### PR TITLE
[AIRFLOW-5168] Fix Dataproc Operators & add tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,6 @@ repos:
         name: Check if licences are OK for Apache
         entry: ./scripts/ci/ci_check_license.sh
         language: system
-        always_run: true
         files: ^\.pre-commit-config\.yaml$
         pass_filenames: true
   - repo: https://github.com/potiuk/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
         name: Check if licences are OK for Apache
         entry: ./scripts/ci/ci_check_license.sh
         language: system
+        always_run: true
         files: ^\.pre-commit-config\.yaml$
         pass_filenames: true
   - repo: https://github.com/potiuk/pre-commit-hooks

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -631,10 +631,6 @@ class DataProcJobBaseOperator(BaseOperator):
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
-    :param labels: The labels to associate with this job. Label keys must contain 1 to 63 characters,
-        and must conform to RFC 1035. Label values may be empty, but, if present, must contain 1 to 63
-        characters, and must conform to RFC 1035. No more than 32 labels can be associated with a job.
-    :type labels: dict
     :param region: The specified region where the dataproc cluster is created.
     :type region: str
     :param job_error_states: Job states that should be considered error states.
@@ -660,7 +656,6 @@ class DataProcJobBaseOperator(BaseOperator):
                  dataproc_jars=None,
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,
-                 labels=None,
                  region='global',
                  job_error_states=None,
                  *args,
@@ -668,7 +663,6 @@ class DataProcJobBaseOperator(BaseOperator):
         super(DataProcJobBaseOperator, self).__init__(*args, **kwargs)
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
-        self.labels = labels
         self.job_name = job_name
         self.cluster_name = cluster_name
         self.dataproc_properties = dataproc_properties
@@ -690,7 +684,6 @@ class DataProcJobBaseOperator(BaseOperator):
                                                           self.dataproc_properties)
         self.job_template.set_job_name(self.job_name)
         self.job_template.add_jar_file_uris(self.dataproc_jars)
-        self.job_template.add_labels(self.labels)
 
     def execute(self, context):
         """
@@ -992,7 +985,7 @@ class DataProcHadoopOperator(DataProcJobBaseOperator):
         default arguments (tempplated)
     :type dataproc_hadoop_properties: dict
     :param dataproc_hadoop_jars: Jar file URIs to add to the CLASSPATHs of the Hadoop driver and
-        tasks. (tempplated)
+        tasks. (templated)
     :type dataproc_hadoop_jars: list
     """
 

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -25,6 +25,9 @@ from typing import Dict
 
 import time
 
+from airflow.contrib.hooks.gcp_dataproc_hook import _DataProcJobBuilder
+from airflow.models.taskinstance import TaskInstance
+
 from airflow import DAG, AirflowException
 from airflow.contrib.operators.dataproc_operator import \
     DataprocClusterCreateOperator, \
@@ -47,11 +50,15 @@ from copy import deepcopy
 from mock import MagicMock, Mock
 from mock import patch
 
+DAG_ID = 'test_dag'
 TASK_ID = 'test-dataproc-operator'
-CLUSTER_NAME = 'test-cluster-name'
+CLUSTER_NAME = 'airflow_{}_cluster'.format(DAG_ID)
+CLUSTER_NAME_TEMPLATED = 'airflow_{{ dag.dag_id }}_cluster'
 GCP_PROJECT_ID = 'test-project-id'
+GCP_PROJECT_TEMPLATED = "{{  ['test', 'project', 'id'] | join('-') }}"
 NUM_WORKERS = 123
 GCE_ZONE = 'us-central1-a'
+GCE_ZONE_TEMPLATED = "{{ 'US-CENTRAL1-A' | lower }}"
 SCALING_POLICY = 'test-scaling-policy'
 NETWORK_URI = '/projects/project_id/regions/global/net'
 SUBNETWORK_URI = '/projects/project_id/regions/global/subnet'
@@ -78,7 +85,8 @@ IDLE_DELETE_TTL = 321
 AUTO_DELETE_TIME = datetime.datetime(2017, 6, 7)
 AUTO_DELETE_TTL = 654
 DEFAULT_DATE = datetime.datetime(2017, 6, 6)
-GCP_REGION = 'test-region'
+GCP_REGION = 'us-central1'
+GCP_REGION_TEMPLATED = "{{ 'US-CENTRAL1' | lower }}"
 MAIN_URI = 'test-uri'
 TEMPLATE_ID = 'template-id'
 
@@ -143,7 +151,7 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                 )
             )
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
@@ -385,7 +393,7 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                 requestId=mock.ANY,
                 body={
                     'projectId': 'test-project-id',
-                    'clusterName': 'test-cluster-name',
+                    'clusterName': CLUSTER_NAME,
                     'config': {
                         'gceClusterConfig':
                             {'zoneUri': zone_uri},
@@ -429,6 +437,28 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "Set internal_ip_only to true only when you pass a subnetwork_uri.")
 
+    def test_render_template(self):
+        task = DataprocClusterCreateOperator(
+            task_id=TASK_ID,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            project_id=GCP_PROJECT_TEMPLATED,
+            num_workers=NUM_WORKERS,
+            zone=GCE_ZONE_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dag=self.dag,
+        )
+
+        self.assertEqual(task.template_fields,
+                         ['cluster_name', 'project_id', 'zone', 'region'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.project_id, GCP_PROJECT_ID)
+        self.assertEqual(task.zone, GCE_ZONE)
+        self.assertEqual(task.region, GCP_REGION)
+
 
 class DataprocClusterScaleOperatorTest(unittest.TestCase):
     # Unit test for the DataprocClusterScaleOperator
@@ -448,7 +478,7 @@ class DataprocClusterScaleOperatorTest(unittest.TestCase):
         self.mock_conn.projects.return_value = self.mock_projects
 
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
@@ -492,6 +522,27 @@ class DataprocClusterScaleOperatorTest(unittest.TestCase):
                 })
             hook.wait.assert_called_once_with(self.operation)
 
+    def test_render_template(self):
+        task = DataprocClusterScaleOperator(
+                task_id=TASK_ID,
+                region=GCP_REGION_TEMPLATED,
+                project_id=GCP_PROJECT_TEMPLATED,
+                cluster_name=CLUSTER_NAME_TEMPLATED,
+                num_workers=NUM_WORKERS,
+                num_preemptible_workers=NUM_PREEMPTIBLE_WORKERS,
+                dag=self.dag
+            )
+
+        self.assertEqual(task.template_fields,
+                         ['cluster_name', 'project_id', 'region'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.project_id, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+
 
 class DataprocClusterDeleteOperatorTest(unittest.TestCase):
     # Unit test for the DataprocClusterDeleteOperator
@@ -511,7 +562,7 @@ class DataprocClusterDeleteOperatorTest(unittest.TestCase):
         self.mock_conn.projects.return_value = self.mock_projects
 
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
@@ -541,17 +592,48 @@ class DataprocClusterDeleteOperatorTest(unittest.TestCase):
                 requestId=mock.ANY)
             hook.wait.assert_called_once_with(self.operation)
 
+    def test_render_template(self):
+        task = DataprocClusterDeleteOperator(
+            task_id=TASK_ID,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            project_id=GCP_PROJECT_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dag=self.dag,
+        )
+
+        self.assertEqual(task.template_fields,
+                         ['cluster_name', 'project_id', 'region'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.project_id, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+
 
 class DataProcJobBaseOperatorTest(unittest.TestCase):
 
     def setUp(self):
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
             },
             schedule_interval='@daily')
+
+    def test_dataproc_job_base(self):
+        task = DataProcJobBaseOperator(
+            task_id=TASK_ID,
+            cluster_name="cluster-1",
+            region=GCP_REGION,
+            dag=self.dag
+        )
+        task.create_job_template()
+
+        self.assertIsInstance(task.job_template, _DataProcJobBuilder)
+        self.assertEqual({'clusterName': task.cluster_name}, task.job_template.build()['job']['placement'])
 
     def test_timeout_kills_job(self):
         def submit_side_effect(_1, _2, _3, _4):
@@ -568,7 +650,6 @@ class DataProcJobBaseOperatorTest(unittest.TestCase):
                 execution_timeout=datetime.timedelta(seconds=1),
                 dag=self.dag
             )
-            task.create_job_template()
 
             with self.assertRaises(AirflowTaskTimeout):
                 task.run(start_date=make_aware(DEFAULT_DATE), end_date=make_aware(DEFAULT_DATE))
@@ -577,6 +658,16 @@ class DataProcJobBaseOperatorTest(unittest.TestCase):
 
 class DataProcHadoopOperatorTest(unittest.TestCase):
     # Unit test for the DataProcHadoopOperator
+
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -600,9 +691,46 @@ class DataProcHadoopOperatorTest(unittest.TestCase):
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
 
+    def test_render_template(self):
+        task = DataProcHadoopOperator(
+            task_id=TASK_ID,
+            main_jar='file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
+            arguments=['{{ ds }}', 'gs://pub/shakespeare/rose.txt'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dataproc_hadoop_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            dataproc_hadoop_properties={},
+            dag=self.dag,
+        )
+
+        self.assertEqual(task.template_fields,
+                         ['arguments', 'job_name', 'cluster_name',
+                          'region', 'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.arguments, [DEFAULT_DATE.date().isoformat(), 'gs://pub/shakespeare/rose.txt'])
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
 
 class DataProcHiveOperatorTest(unittest.TestCase):
     # Unit test for the DataProcHiveOperator
+
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -626,8 +754,48 @@ class DataProcHiveOperatorTest(unittest.TestCase):
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
 
+    def test_template_fields(self):
+        self.assertEqual(self.batch.template_fields, ('job_name', 'overrides',))
+
+    def test_render_template(self):
+        task = DataProcHiveOperator(
+            task_id=TASK_ID,
+            query="select * from {{ dag.dag_id }}",
+            variables={},
+            dataproc_hive_properties={},
+            dataproc_hive_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dag=self.dag,
+        )
+
+        self.assertEqual(
+            task.template_fields, ['query', 'variables', 'job_name', 'cluster_name', 'region',
+                                   'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.query, "select * from {}".format(DAG_ID))
+        self.assertEqual(task.variables, {})
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
 
 class DataProcPigOperatorTest(unittest.TestCase):
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -655,9 +823,46 @@ class DataProcPigOperatorTest(unittest.TestCase):
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
 
+    def test_render_template(self):
+        task = DataProcPigOperator(
+            task_id=TASK_ID,
+            query="select * from {{ dag.dag_id }}",
+            variables={},
+            dataproc_pig_properties={},
+            dataproc_pig_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dag=self.dag,
+        )
+
+        self.assertEqual(
+            task.template_fields, ['query', 'variables', 'job_name', 'cluster_name', 'region',
+                                   'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.query, "select * from {}".format(DAG_ID))
+        self.assertEqual(task.variables, {})
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
 
 class DataProcPySparkOperatorTest(unittest.TestCase):
     # Unit test for the DataProcPySparkOperator
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -683,9 +888,47 @@ class DataProcPySparkOperatorTest(unittest.TestCase):
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
 
+    def test_render_template(self):
+        task = DataProcPySparkOperator(
+            task_id=TASK_ID,
+            main='file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
+            arguments=['{{ ds }}', 'gs://pub/shakespeare/rose.txt'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dataproc_pyspark_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            dataproc_pyspark_properties={},
+            dag=self.dag,
+        )
+
+        task.create_job_template()
+
+        self.assertEqual(
+            task.template_fields, ['arguments', 'job_name', 'cluster_name',
+                                   'region', 'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.arguments, [DEFAULT_DATE.date().isoformat(), 'gs://pub/shakespeare/rose.txt'])
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
 
 class DataProcSparkOperatorTest(unittest.TestCase):
     # Unit test for the DataProcSparkOperator
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -708,6 +951,33 @@ class DataProcSparkOperatorTest(unittest.TestCase):
             )
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
+
+    def test_render_template(self):
+        task = DataProcSparkOperator(
+            task_id=TASK_ID,
+            main_jar='file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
+            arguments=['{{ ds }}', 'gs://pub/shakespeare/rose.txt'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dataproc_spark_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            dataproc_spark_properties={},
+            dag=self.dag,
+        )
+
+        self.assertEqual(
+            task.template_fields, ['arguments', 'job_name', 'cluster_name', 'region',
+                                   'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.arguments, [DEFAULT_DATE.date().isoformat(), 'gs://pub/shakespeare/rose.txt'])
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
 
 
 class DataprocWorkflowTemplateInstantiateOperatorTest(unittest.TestCase):

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -658,6 +658,8 @@ class DataProcJobBaseOperatorTest(unittest.TestCase):
                 dag=self.dag
             )
 
+            task.create_job_template()
+
             with self.assertRaises(AirflowTaskTimeout):
                 task.run(start_date=make_aware(DEFAULT_DATE), end_date=make_aware(DEFAULT_DATE))
             mock_hook.cancel.assert_called_once_with(mock.ANY, job_id, GCP_REGION)
@@ -1021,8 +1023,8 @@ class DataprocWorkflowTemplateInstantiateOperatorTest(unittest.TestCase):
 
             dataproc_task.execute(None)
             template_name = (
-                'projects/test-project-id/regions/test-region/'
-                'workflowTemplates/template-id')
+                'projects/test-project-id/regions/{}/'
+                'workflowTemplates/template-id'.format(GCP_REGION))
             self.mock_workflows.instantiate.assert_called_once_with(
                 name=template_name,
                 body=mock.ANY)
@@ -1089,7 +1091,7 @@ class DataprocWorkflowTemplateInstantiateInlineOperatorTest(unittest.TestCase):
 
             dataproc_task.execute(None)
             self.mock_workflows.instantiateInline.assert_called_once_with(
-                parent='projects/test-project-id/regions/test-region',
+                parent='projects/test-project-id/regions/{}'.format(GCP_REGION),
                 requestId=mock.ANY,
                 body=template)
             hook.wait.assert_called_once_with(self.operation)


### PR DESCRIPTION
PR targeted to 1.10.4. Creating new PR for master

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5168

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

2 issues in 1.10.4

(1) Invalid template field. It was resolved by https://github.com/apache/airflow/pull/5751
(2) An issue with `add_labels` field expained below:

There is a commit to master which adds label support, this has a change in the hook & base operator: https://github.com/apache/airflow/commit/4d58f36df3b533edfce873799dc161ee34571d63#diff-bc55ad8b749b7a136f51ffabfdbaf13dL684

Then in the 1.10.4 branch there is a massive commit for GCP DLP: https://github.com/apache/airflow/commit/222c6ac45de54ed0398645c1d456a592e194325b

This seems to have leaked the operator part of the label change only: https://github.com/apache/airflow/commit/222c6ac45de54ed0398645c1d456a592e194325b#diff-bc55ad8b749b7a136f51ffabfdbaf13dR693

This then manifests as this error when trying to execute a Dataproc job: [2019-08-09 14:32:02,971] {taskinstance.py:1047} ERROR - _DataProcJobBuilder instance has no attribute 'add_labels'


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Add tests to cover both issues

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
