### PR TITLE
[AIRFLOW-5168] Add tests for Dataproc{*} Operators

### DIFF
--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -21,17 +21,16 @@
 
 import datetime
 import re
-import unittest
-from unittest.mock import MagicMock, Mock, patch
-from typing import Dict
-
 import time
-
+import unittest
 from copy import deepcopy
+from typing import Dict
+from unittest.mock import MagicMock, Mock, patch
 
 from mock import PropertyMock
 
 from airflow import DAG, AirflowException
+from airflow.contrib.hooks.gcp_dataproc_hook import _DataProcJobBuilder
 from airflow.contrib.operators.dataproc_operator import \
     DataprocClusterCreateOperator, \
     DataprocClusterDeleteOperator, \
@@ -44,16 +43,20 @@ from airflow.contrib.operators.dataproc_operator import \
     DataprocWorkflowTemplateInstantiateOperator, \
     DataprocClusterScaleOperator, DataProcJobBaseOperator
 from airflow.exceptions import AirflowTaskTimeout
+from airflow.models.taskinstance import TaskInstance
 from airflow.utils.timezone import make_aware
 from airflow.version import version
 from tests.compat import mock
 
-
+DAG_ID = 'test_dag'
 TASK_ID = 'test-dataproc-operator'
-CLUSTER_NAME = 'test-cluster-name'
+CLUSTER_NAME = 'airflow_{}_cluster'.format(DAG_ID)
+CLUSTER_NAME_TEMPLATED = 'airflow_{{ dag.dag_id }}_cluster'
 GCP_PROJECT_ID = 'test-project-id'
+GCP_PROJECT_TEMPLATED = "{{  ['test', 'project', 'id'] | join('-') }}"
 NUM_WORKERS = 123
 GCE_ZONE = 'us-central1-a'
+GCE_ZONE_TEMPLATED = "{{ 'US-CENTRAL1-A' | lower }}"
 SCALING_POLICY = 'test-scaling-policy'
 NETWORK_URI = '/projects/project_id/regions/global/net'
 SUBNETWORK_URI = '/projects/project_id/regions/global/subnet'
@@ -81,7 +84,8 @@ IDLE_DELETE_TTL = 321
 AUTO_DELETE_TIME = datetime.datetime(2017, 6, 7)
 AUTO_DELETE_TTL = 654
 DEFAULT_DATE = datetime.datetime(2017, 6, 6)
-GCP_REGION = 'test-region'
+GCP_REGION = 'us-central1'
+GCP_REGION_TEMPLATED = "{{ 'US-CENTRAL1' | lower }}"
 MAIN_URI = 'test-uri'
 TEMPLATE_ID = 'template-id'
 
@@ -153,7 +157,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
                 )
             )
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
@@ -419,7 +423,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
                 requestId=mock.ANY,
                 body={
                     'projectId': 'test-project-id',
-                    'clusterName': 'test-cluster-name',
+                    'clusterName': CLUSTER_NAME,
                     'config': {
                         'gceClusterConfig':
                             {'zoneUri': zone_uri},
@@ -530,6 +534,28 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "Set internal_ip_only to true only when you pass a subnetwork_uri.")
 
+    def test_render_template(self):
+        task = DataprocClusterCreateOperator(
+            task_id=TASK_ID,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            project_id=GCP_PROJECT_TEMPLATED,
+            num_workers=NUM_WORKERS,
+            zone=GCE_ZONE_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dag=self.dag,
+        )
+
+        self.assertEqual(task.template_fields,
+                         ['cluster_name', 'project_id', 'zone', 'region'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.project_id, GCP_PROJECT_ID)
+        self.assertEqual(task.zone, GCE_ZONE)
+        self.assertEqual(task.region, GCP_REGION)
+
 
 class TestDataprocClusterScaleOperator(unittest.TestCase):
     # Unit test for the DataprocClusterScaleOperator
@@ -549,7 +575,7 @@ class TestDataprocClusterScaleOperator(unittest.TestCase):
         self.mock_conn.projects.return_value = self.mock_projects
 
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
@@ -593,6 +619,27 @@ class TestDataprocClusterScaleOperator(unittest.TestCase):
                 })
             hook.wait.assert_called_once_with(self.operation)
 
+    def test_render_template(self):
+        task = DataprocClusterScaleOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION_TEMPLATED,
+            project_id=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            num_workers=NUM_WORKERS,
+            num_preemptible_workers=NUM_PREEMPTIBLE_WORKERS,
+            dag=self.dag
+        )
+
+        self.assertEqual(task.template_fields,
+                         ['cluster_name', 'project_id', 'region'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.project_id, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+
 
 class TestDataprocClusterDeleteOperator(unittest.TestCase):
     # Unit test for the DataprocClusterDeleteOperator
@@ -612,7 +659,7 @@ class TestDataprocClusterDeleteOperator(unittest.TestCase):
         self.mock_conn.projects.return_value = self.mock_projects
 
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
@@ -642,12 +689,31 @@ class TestDataprocClusterDeleteOperator(unittest.TestCase):
                 requestId=mock.ANY)
             hook.wait.assert_called_once_with(self.operation)
 
+    def test_render_template(self):
+        task = DataprocClusterDeleteOperator(
+            task_id=TASK_ID,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            project_id=GCP_PROJECT_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dag=self.dag,
+        )
+
+        self.assertEqual(task.template_fields,
+                         ['cluster_name', 'project_id', 'region'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.project_id, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+
 
 class TestDataProcJobBaseOperator(unittest.TestCase):
 
     def setUp(self):
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
@@ -681,9 +747,31 @@ class TestDataProcJobBaseOperator(unittest.TestCase):
                 task.run(start_date=make_aware(DEFAULT_DATE), end_date=make_aware(DEFAULT_DATE))
             mock_hook.cancel.assert_called_once_with(mock.ANY, job_id, GCP_REGION)
 
+    def test_dataproc_job_base(self):
+        task = DataProcJobBaseOperator(
+            task_id=TASK_ID,
+            cluster_name="cluster-1",
+            region=GCP_REGION,
+            dag=self.dag
+        )
+        task.create_job_template()
+
+        self.assertIsInstance(task.job_template, _DataProcJobBuilder)
+        self.assertEqual({'clusterName': task.cluster_name}, task.job_template.build()['job']['placement'])
+
 
 class TestDataProcHadoopOperator(unittest.TestCase):
     # Unit test for the DataProcHadoopOperator
+
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
         new_callable=PropertyMock,
@@ -730,9 +818,45 @@ class TestDataProcHadoopOperator(unittest.TestCase):
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
 
+    def test_render_template(self):
+        task = DataProcHadoopOperator(
+            task_id=TASK_ID,
+            main_jar='file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
+            arguments=['{{ ds }}', 'gs://pub/shakespeare/rose.txt'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dataproc_hadoop_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            dataproc_hadoop_properties={},
+            dag=self.dag,
+        )
+
+        self.assertEqual(task.template_fields,
+                         ['arguments', 'job_name', 'cluster_name',
+                          'region', 'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.arguments, [DEFAULT_DATE.date().isoformat(), 'gs://pub/shakespeare/rose.txt'])
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
 
 class TestDataProcHiveOperator(unittest.TestCase):
     # Unit test for the DataProcHiveOperator
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
         new_callable=PropertyMock,
@@ -779,8 +903,45 @@ class TestDataProcHiveOperator(unittest.TestCase):
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
 
+    def test_render_template(self):
+        task = DataProcHiveOperator(
+            task_id=TASK_ID,
+            query="select * from {{ dag.dag_id }}",
+            variables={},
+            dataproc_hive_properties={},
+            dataproc_hive_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dag=self.dag,
+        )
+
+        self.assertEqual(
+            task.template_fields, ['query', 'variables', 'job_name', 'cluster_name', 'region',
+                                   'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.query, "select * from {}".format(DAG_ID))
+        self.assertEqual(task.variables, {})
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
 
 class TestDataProcPigOperator(unittest.TestCase):
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
         new_callable=PropertyMock,
@@ -820,6 +981,34 @@ class TestDataProcPigOperator(unittest.TestCase):
         mock_hook.return_value.submit.assert_called_once_with(mock.ANY, mock.ANY,
                                                               GCP_REGION, mock.ANY)
 
+    def test_render_template(self):
+        task = DataProcPigOperator(
+            task_id=TASK_ID,
+            query="select * from {{ dag.dag_id }}",
+            variables={},
+            dataproc_pig_properties={},
+            dataproc_pig_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dag=self.dag,
+        )
+
+        self.assertEqual(
+            task.template_fields, ['query', 'variables', 'job_name', 'cluster_name', 'region',
+                                   'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.query, "select * from {}".format(DAG_ID))
+        self.assertEqual(task.variables, {})
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
     @staticmethod
     def test_dataproc_job_id_is_set():
         with patch(HOOK) as mock_hook:
@@ -834,6 +1023,15 @@ class TestDataProcPigOperator(unittest.TestCase):
 
 class TestDataProcPySparkOperator(unittest.TestCase):
     # Unit test for the DataProcPySparkOperator
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
         new_callable=PropertyMock,
@@ -883,9 +1081,47 @@ class TestDataProcPySparkOperator(unittest.TestCase):
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
 
+    def test_render_template(self):
+        task = DataProcPySparkOperator(
+            task_id=TASK_ID,
+            main='file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
+            arguments=['{{ ds }}', 'gs://pub/shakespeare/rose.txt'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dataproc_pyspark_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            dataproc_pyspark_properties={},
+            dag=self.dag,
+        )
+
+        task.create_job_template()
+
+        self.assertEqual(
+            task.template_fields, ['arguments', 'job_name', 'cluster_name',
+                                   'region', 'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.arguments, [DEFAULT_DATE.date().isoformat(), 'gs://pub/shakespeare/rose.txt'])
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
 
 class TestDataProcSparkOperator(unittest.TestCase):
     # Unit test for the DataProcSparkOperator
+    def setUp(self):
+        self.dag = DAG(
+            DAG_ID,
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
         new_callable=PropertyMock,
@@ -933,6 +1169,33 @@ class TestDataProcSparkOperator(unittest.TestCase):
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)
 
+    def test_render_template(self):
+        task = DataProcSparkOperator(
+            task_id=TASK_ID,
+            main_jar='file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
+            arguments=['{{ ds }}', 'gs://pub/shakespeare/rose.txt'],
+            job_name=GCP_PROJECT_TEMPLATED,
+            cluster_name=CLUSTER_NAME_TEMPLATED,
+            region=GCP_REGION_TEMPLATED,
+            dataproc_spark_jars=['gs://test-bucket/{{ dag.dag_id }}/test.jar'],
+            dataproc_spark_properties={},
+            dag=self.dag,
+        )
+
+        self.assertEqual(
+            task.template_fields, ['arguments', 'job_name', 'cluster_name', 'region',
+                                   'dataproc_jars', 'dataproc_properties'])
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.arguments, [DEFAULT_DATE.date().isoformat(), 'gs://pub/shakespeare/rose.txt'])
+        self.assertEqual(task.cluster_name, CLUSTER_NAME)
+        self.assertEqual(task.job_name, GCP_PROJECT_ID)
+        self.assertEqual(task.region, GCP_REGION)
+        self.assertEqual(task.dataproc_jars, ['gs://test-bucket/{}/test.jar'.format(DAG_ID)])
+        self.assertEqual(task.dataproc_properties, {})
+
 
 class TestDataprocWorkflowTemplateInstantiateOperator(unittest.TestCase):
     def setUp(self):
@@ -949,7 +1212,7 @@ class TestDataprocWorkflowTemplateInstantiateOperator(unittest.TestCase):
         self.mock_conn = Mock()
         self.mock_conn.projects.return_value = self.mock_projects
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
@@ -997,7 +1260,7 @@ class TestDataprocWorkflowTemplateInstantiateInlineOperator(unittest.TestCase):
         self.mock_conn = Mock()
         self.mock_conn.projects.return_value = self.mock_projects
         self.dag = DAG(
-            'test_dag',
+            DAG_ID,
             default_args={
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -21,11 +21,12 @@
 
 import datetime
 import re
-import time
 import unittest
-from copy import deepcopy
-from typing import Dict
 from unittest.mock import MagicMock, Mock, patch
+from typing import Dict
+
+import time
+from copy import deepcopy
 
 from mock import PropertyMock
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5168

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
