### PR TITLE
[AIRFLOW-5322] Fix flaky gcp transfer hook test

### DIFF
--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -228,7 +228,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
             mock.call(request_filter={FILTER_PROJECT_ID: TEST_PROJECT_ID, FILTER_JOB_NAMES: [job_name]}),
             mock.call(request_filter={FILTER_PROJECT_ID: TEST_PROJECT_ID, FILTER_JOB_NAMES: [job_name]})
         ]
-        mock_list.assert_has_calls(calls)
+        mock_list.assert_has_calls(calls, any_order=True)
 
         mock_sleep.assert_called_once_with(TIME_TO_SLEEP_IN_SECONDS)
 

--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -225,8 +225,8 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         self.gct_hook.wait_for_transfer_job({PROJECT_ID: TEST_PROJECT_ID, 'name': job_name})
 
         calls = [
-            mock.call(request_filter={'project_id': TEST_PROJECT_ID, 'job_names': [job_name]}),
-            mock.call(request_filter={'project_id': TEST_PROJECT_ID, 'job_names': [job_name]})
+            mock.call(request_filter={FILTER_PROJECT_ID: TEST_PROJECT_ID, FILTER_JOB_NAMES: [job_name]}),
+            mock.call(request_filter={FILTER_PROJECT_ID: TEST_PROJECT_ID, FILTER_JOB_NAMES: [job_name]})
         ]
         mock_list.assert_has_calls(calls)
 

--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -213,38 +213,22 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch('time.sleep')
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
-    def test_wait_for_transfer_job(self, get_conn, mock_sleep):
-        list_method = get_conn.return_value.transferOperations.return_value.list
-        list_execute_method = list_method.return_value.execute
-        list_execute_method.side_effect = [
-            {OPERATIONS: [{METADATA: {STATUS: GcpTransferOperationStatus.IN_PROGRESS}}]},
-            {OPERATIONS: [{METADATA: {STATUS: GcpTransferOperationStatus.SUCCESS}}]},
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.'
+                'GCPTransferServiceHook.list_transfer_operations')
+    def test_wait_for_transfer_job(self, mock_list, mock_sleep):
+        mock_list.side_effect = [
+            [{METADATA: {STATUS: GcpTransferOperationStatus.IN_PROGRESS}}],
+            [{METADATA: {STATUS: GcpTransferOperationStatus.SUCCESS}}],
         ]
-        get_conn.return_value.transferOperations.return_value.list_next.return_value = None
 
         job_name = 'transferJobs/test-job'
         self.gct_hook.wait_for_transfer_job({PROJECT_ID: TEST_PROJECT_ID, 'name': job_name})
-        self.assertTrue(list_method.called)
 
         calls = [
-            mock.call(
-                filter=json.dumps({"project_id": TEST_PROJECT_ID, "job_names": [job_name]}),
-                name='transferOperations'
-            ),
-            mock.call().execute(num_retries=5),
-            mock.call(
-                filter=json.dumps({"project_id": TEST_PROJECT_ID, "job_names": [job_name]}),
-                name='transferOperations'
-            ),
-            mock.call().execute(num_retries=5)
+            mock.call(request_filter={'project_id': TEST_PROJECT_ID, 'job_names': [job_name]}),
+            mock.call(request_filter={'project_id': TEST_PROJECT_ID, 'job_names': [job_name]})
         ]
-        list_method.assert_has_calls(calls)
-        args, kwargs = list_method.call_args_list[0]
-        self.assertEqual(
-            json.loads(kwargs['filter']),
-            {FILTER_PROJECT_ID: TEST_PROJECT_ID, FILTER_JOB_NAMES: ["transferJobs/test-job"]},
-        )
+        mock_list.assert_has_calls(calls)
 
         mock_sleep.assert_called_once_with(TIME_TO_SLEEP_IN_SECONDS)
 


### PR DESCRIPTION
This commit fixes flaky test (occured in python 3.5). I am not yet sure what was the
reason but I simplified the mocking and everything seems to be ok. The error seems to be introduced in this PR https://github.com/apache/airflow/pull/5912

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5322

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This commit fixes flaky test (occured in python 3.5). I am not yet sure what was the
reason but I simplified the mocking and everything seems to be ok. The error seems to be introduced in this PR https://github.com/apache/airflow/pull/5912

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
