### PR TITLE
[AIRFLOW-5323] Fix teething proglems breeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ dmypy.json
 # Needed for CI Dockerfile build system
 .build
 /tmp
+/files
 
 /hive_scratch_dir/
 /.bash_aliases

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,6 @@ repos:
         name: Check if licences are OK for Apache
         entry: ./scripts/ci/ci_check_license.sh
         language: system
-        always_run: true
         files: ^\.pre-commit-config\.yaml$
         pass_filenames: true
   - repo: https://github.com/potiuk/pre-commit-hooks

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -183,13 +183,13 @@ For example, in order to just execute the "core" unit tests, run the following:
 
 .. code-block:: bash
 
-   run-tests tests.core:CoreTest -- -s --logging-level=DEBUG
+   run-tests tests.core:TestCore -- -s --logging-level=DEBUG
 
 or a single test method:
 
 .. code-block:: bash
 
-   run-tests tests.core:CoreTest.test_check_operators -- -s --logging-level=DEBUG
+   run-tests tests.core:TestCore.test_check_operators -- -s --logging-level=DEBUG
 
 
 The tests will run ``airflow db reset`` and ``airflow db init`` the first time you
@@ -203,7 +203,7 @@ the database.
 
 .. code-block:: bash
 
-   run-tests --with-db-init tests.core:CoreTest.test_check_operators -- -s --logging-level=DEBUG
+   run-tests --with-db-init tests.core:TestCore.test_check_operators -- -s --logging-level=DEBUG
 
 Debugging with ipdb
 -------------------
@@ -477,7 +477,7 @@ You can also specify individual tests or group of tests:
 
 .. code-block:: bash
 
-    ./breeze --test-target tests.core:CoreTest
+    ./breeze --test-target tests.core:TestCore
 
 Running commands inside Docker
 ------------------------------

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -217,6 +217,10 @@ embedded in the container - and changes to those sources will not be persistent.
 
 Once you enter the environment you are dropped into bash shell and you can run tests immediately.
 
+After you run Breeze for the first time you will have an empty directory ``files`` in your source code
+that will be mapped to ``/files`` in your docker container. You can pass any files there you need
+to configure and run docker and they will not be removed between docker runs.
+
 Running tests in Airflow Breeze
 -------------------------------
 

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -25,6 +25,7 @@ Table of Contents
 
 * `Airflow Breeze <#airflow-breeze>`_
 * `Installation <#installation>`_
+* `Resource usage <#resource-usage>`_
 * `Setting up autocomplete <#setting-up-autocomplete>`_
 * `Using the Airflow Breeze environment <#using-the-airflow-breeze-environment>`_
     - `Entering the environment <#entering-the-environment>`_
@@ -80,15 +81,34 @@ Prerequisites for the installation:
 *
   If you are on MacOS you need gnu ``getopt`` and ``gstat`` to get Airflow Breeze running. Typically
   you need to run ``brew install gnu-getopt coreutils`` and then follow instructions (you need
-  to link the gnu getopt version to become first on the PATH).
+  to link the gnu getopt version to become first on the PATH). Make sure to re-login after you
+  make the suggested changes.
 
 *
   Latest stable Docker Community Edition installed and on the PATH. It should be
-  configured to be able to run ``docker`` commands directly and not only via root user
+  configured to be able to run ``docker`` commands directly and not only via root user. You user
+  should be in the ``docker`` group. See `Docker installation guide <https://docs.docker.com/install/>`_
 
 
-  * your user should be in ``docker`` group.
-    See `Docker installation guide <https://docs.docker.com/install/>`_
+*
+  When you develop on Mac OS you usually have not enough disk space for Docker if you start using it
+  seriously. You should increase disk space available before starting to work with the environment.
+  Usually you have weird problems of docker containers when you run out of Disk space. It might not be
+  obvious that space is an issue.
+
+  If you get into weird behaviour try
+  `Cleaning Up Docker <CONTRIBUTING.md#cleaning-up-cached-docker-imagescontainers>`_
+
+  See `Docker for Mac - Space <https://docs.docker.com/docker-for-mac/space>`_ for details of increasing
+  disk space available for Docker on Mac.
+
+  At least 128 GB of Disk space is recommended. You can also get by with smaller space but you should more
+  often clean the docker disk space periodically.
+
+*
+  On MacOS, the default 2GB of RAM available for your docker containers, but more memory is recommended
+  (4GB should be comfortable). For details see
+  `Docker for Mac - Advanced tab <https://docs.docker.com/v17.12/docker-for-mac/#advanced-tab>`_
 
 *
   Latest stable Docker Compose installed and on the PATH. It should be
@@ -108,6 +128,31 @@ It will pull latest Airflow CI images from `Apache Airflow DockerHub <https://hu
 and use them to build your local docker images. It will use latest sources from your source code.
 Further on ``breeze`` uses md5sum calculation and Docker caching mechanisms to only rebuild what is needed.
 Airflow Breeze will detect if Docker images need to be rebuilt and ask you for confirmation.
+
+Resource usage
+==============
+
+You can choose environment when you run Breeze with ``--env`` flag.
+Running the default ``docker`` environment takes considerable amount of resources. You can run a slimmed-down
+version of the environment - just the Apache Airflow container - by choosing ``bare`` environment instead.
+
+The following environments are available:
+
+ * The ``docker`` environment (default): starts all dependencies required by full integration test-suite
+   (postgres, mysql, celery, etc.). This option is resource intensive so do not forget to
+   [Stop environment](#stopping-the-environment) when you are finished. This option is also RAM intensive
+   and can slow down your machine.
+ * The ``kubernetes`` environment: Runs airflow tests within a kubernetes cluster (requires
+   ``KUBERNETES_VERSION`` and ``KUBERNETES_MODE`` variables).
+ * The ``bare`` environment:  runs airflow in docker without any external dependencies.
+   It will only work for non-dependent tests. You can only run it with sqlite backend.
+
+After starting up, the environment runs in the background and takes resources. You can always stop
+it via
+
+.. code-block:: bash
+
+    breeze --stop-environment
 
 Setting up autocomplete
 =======================

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -523,7 +523,7 @@ KUBERNETES_VERSION==v1.13.0 KUBERNETES_MODE=persistent_mode BACKEND=postgres ENV
   ./scripts/ci/local_ci_run_airflow_testing.sh
 ```
 
-* PYTHON_VERSION might be one of 3.5/3.6
+* PYTHON_VERSION might be one of 3.5/3.6/3.7
 * BACKEND might be one of postgres/sqlite/mysql
 * ENV might be one of docker/kubernetes/bare
 * KUBERNETES_VERSION - required for Kubernetes tests - currently KUBERNETES_VERSION=v1.13.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,13 +246,13 @@ For example, in order to just execute the "core" unit tests and add ipdb set_tra
 run the following command:
 
 ```bash
-./run-tests tests.core:CoreTest --nocapture --verbose
+./run-tests tests.core:TestCore --nocapture --verbose
 ```
 
 or a single test method without colors or debug logs:
 
 ```bash
-./run-tests tests.core:CoreTest.test_check_operators
+./run-tests tests.core:TestCore.test_check_operators
 ```
 Note that `./run_tests` script runs tests but the first time it runs, it performs database initialisation.
 If you run further tests without leaving the environment, the database will not be initialized, but you

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,8 +290,8 @@ IMPORTANT!!! : Mac OS Docker default Disk size settings
 
 When you develop on Mac OS you usually have not enough disk space for Docker if you start using it seriously.
 You should increase disk space available before starting to work with the environment. Usually you have weird
-stops of docker containers when you run out of Disk space. It might not be obvious that space is an issue.
-If you get into weird behaviour try [Cleaning Up Docker](#cleaning-up-cached-docker-imagescontainers)
+problems with docker containers when you run out of Disk space. It might not be obvious that space is an
+issue. If you get into weird behaviour try [Cleaning Up Docker](#cleaning-up-cached-docker-imagescontainers)
 
 See [Docker for Mac - Space](https://docs.docker.com/docker-for-mac/space/) for details of increasing
 disk space available for Docker on Mac.
@@ -531,13 +531,13 @@ KUBERNETES_VERSION==v1.13.0 KUBERNETES_MODE=persistent_mode BACKEND=postgres ENV
 
 The following environments are possible:
 
- * The "docker" environment (default): starts all dependencies required by full integration test-suite
+ * The `docker` environment (default): starts all dependencies required by full integration test-suite
    (postgres, mysql, celery, etc.). This option is resource intensive so do not forget to
    [Stop environment](#stopping-the-environment) when you are finished. This option is also RAM intensive
    and can slow down your machine.
- * The "kubernetes" environment: Runs airflow tests within a kubernetes cluster (requires KUBERNETES_VERSION
+ * The `kubernetes` environment: Runs airflow tests within a kubernetes cluster (requires KUBERNETES_VERSION
    and KUBERNETES_MODE variables).
- * The "bare" environment:  runs airflow in docker without any external dependencies.
+ * The `bare` environment:  runs airflow in docker without any external dependencies.
    It will only work for non-dependent tests. You can only run it with sqlite backend. You can only
    enter the bare environment with `local_ci_enter_environment.sh` and run tests manually, you cannot execute
    `local_ci_run_airflow_testing.sh` with it.

--- a/breeze
+++ b/breeze
@@ -679,8 +679,12 @@ if ! PYTHON_BIN=$(command -v python3); then
 fi
 
 BUILD_CACHE_DIR="${MY_DIR}/.build"
+FILES_DIR="${MY_DIR}/files"
+TMP_DIR="${MY_DIR}/tmp"
 
 mkdir -pv "${BUILD_CACHE_DIR}"
+mkdir -pv "${TMP_DIR}"
+mkdir -pv "${FILES_DIR}"
 
 CMDNAME="$(basename -- "$0")"
 

--- a/hooks/build
+++ b/hooks/build
@@ -260,7 +260,7 @@ AIRFLOW_CONTAINER_USE_PULLED_IMAGES_CACHE=${AIRFLOW_CONTAINER_USE_PULLED_IMAGES_
 
 pwd
 # Determine version of the Airflow from version.py
-AIRFLOW_VERSION=$(cat airflow/version.py - << EOF | ${PYTHON_BINARY}
+AIRFLOW_VERSION=$(cat airflow/version.py - << EOF | python
 print(version.replace("+",""))
 EOF
 )

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -63,11 +63,10 @@ export PYTHON_VERSION
 
 if [[ ${PYTHON_VERSION} == 2.* ]]; then
     echo 2>&1
-    echo 2>&1 " Warning! You have python 2.7 as default on your path"
-    echo 2>&1 " Switching to python 3"
+    echo 2>&1 " You have python 2.7 on your path but python 2 is not supported any more."
+    echo 2>&1 " Switching to python 3.5"
     echo 2>&1
-    PYTHON_VERSION=$(python3 -c \
-        'import sys; print("%s.%s" % (sys.version_info.major, sys.version_info.minor))')
+    PYTHON_VERSION=3.5
     export PYTHON_VERSION
 fi
 
@@ -373,10 +372,11 @@ function rebuild_image_if_needed() {
     export PYTHON_VERSION
     if [[ ${PYTHON_VERSION} == 2.* ]]; then
         echo 2>&1
-        echo 2>&1 " Warning! You have python 2.7 on your path"
-        echo 2>&1 " Switching to python 3.6"
+        echo 2>&1 " You have python 2.7 on your path but python 2 is not supported any more."
+        echo 2>&1 " Switching to python 3.5"
         echo 2>&1
-        export PYTHON_VERSION=3.6
+        PYTHON_VERSION=3.5
+        export PYTHON_VERSION
     fi
 
     AIRFLOW_VERSION=$(cat airflow/version.py - << EOF | python

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -117,6 +117,7 @@ if [[ ${AIRFLOW_MOUNT_HOST_VOLUMES_FOR_STATIC_CHECKS} == "true" ]]; then
       "-v" "${AIRFLOW_SOURCES}/.rat-excludes:/opt/airflow/.rat-excludes:cached" \
       "-v" "${AIRFLOW_SOURCES}/logs:/opt/airflow/logs:cached" \
       "-v" "${AIRFLOW_SOURCES}/logs:/root/logs:cached" \
+      "-v" "${AIRFLOW_SOURCES}/files:/files:cached" \
       "-v" "${AIRFLOW_SOURCES}/tmp:/opt/airflow/tmp:cached" \
       "--env" "PYTHONDONTWRITEBYTECODE" \
     )

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -104,6 +104,10 @@ if [[ ${AIRFLOW_MOUNT_HOST_VOLUMES_FOR_STATIC_CHECKS} == "true" ]]; then
       "-v" "${AIRFLOW_SOURCES}/dev:/opt/airflow/dev:cached" \
       "-v" "${AIRFLOW_SOURCES}/docs:/opt/airflow/docs:cached" \
       "-v" "${AIRFLOW_SOURCES}/scripts:/opt/airflow/scripts:cached" \
+      "-v" "${AIRFLOW_SOURCES}/.bash_history:/root/.bash_history:cached" \
+      "-v" "${AIRFLOW_SOURCES}/.bash_aliases:/root/.bash_aliases:cached" \
+      "-v" "${AIRFLOW_SOURCES}/.inputrc:/root/.inputrc:cached" \
+      "-v" "${AIRFLOW_SOURCES}/.bash_completion.d:/root/.bash_completion.d:cached" \
       "-v" "${AIRFLOW_SOURCES}/tmp:/opt/airflow/tmp:cached" \
       "-v" "${AIRFLOW_SOURCES}/tests:/opt/airflow/tests:cached" \
       "-v" "${AIRFLOW_SOURCES}/.flake8:/opt/airflow/.flake8:cached" \

--- a/scripts/ci/docker-compose-local.yml
+++ b/scripts/ci/docker-compose-local.yml
@@ -45,6 +45,10 @@ services:
       - ../../NOTICE:/opt/airflow/NOTICE:cached
       - ../../CHANGELOG.txt:/opt/airflow/CHANGELOG:cached
       - ../../.github:/opt/airflow/.github:cached
+      - ../../.bash_completion.d:/root/.bash_completion.d:cached
+      - ../../.bash_history:/root/.bash_history:cached
+      - ../../.bash_aliases:/root/.bash_aliases:cached
+      - ../../.inputrc:/root/.inputrc:cached
       - ../../.flake8:/opt/airflow/.flake8:cached
       - ../../pylintrc:/opt/airflow/pylintrc:cached
       - ../../.rat-excludes:/opt/airflow/.rat-excludes:cached

--- a/scripts/ci/docker-compose-local.yml
+++ b/scripts/ci/docker-compose-local.yml
@@ -54,8 +54,8 @@ services:
       - ../../.rat-excludes:/opt/airflow/.rat-excludes:cached
       - ../../run-tests:/opt/airflow/run-tests:cached
       - ../../logs:/root/airflow/logs:cached
-      - ../../logs:/opt/airflow/logs:cached
       - ../../tmp:/opt/airflow/tmp:cached
+      - ../../files:/files:cached
     environment:
       - HOST_USER_ID
       - HOST_GROUP_ID


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
Those are for issues solved in 5 separate commits (all found during first Breeze workshop)

  - https://issues.apache.org/jira/browse/AIRFLOW-5323
  - https://issues.apache.org/jira/browse/AIRFLOW-5324
  - https://issues.apache.org/jira/browse/AIRFLOW-5325
  - https://issues.apache.org/jira/browse/AIRFLOW-5326
  - https://issues.apache.org/jira/browse/AIRFLOW-5327
  - https://issues.apache.org/jira/browse/AIRFLOW-5329
  - better documentation about resources usage for Breeze

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Issues discovered during first Breeze workshop (AKA Teething problems).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
