### PR TITLE
[AIRFLOW-5333] Move init docs to class docs in PubSub

### DIFF
--- a/airflow/gcp/operators/pubsub.py
+++ b/airflow/gcp/operators/pubsub.py
@@ -144,6 +144,30 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
 
     ``topic_project``, ``topic``, ``subscription``, and
     ``subscription`` are templated so you can use variables in them.
+
+    :param topic_project: the GCP project ID where the topic exists
+    :type topic_project: str
+    :param topic: the topic to create. Do not include the
+        full topic path. In other words, instead of
+        ``projects/{project}/topics/{topic}``, provide only
+        ``{topic}``. (templated)
+    :type topic: str
+    :param subscription: the Pub/Sub subscription name. If empty, a random
+        name will be generated using the uuid module
+    :type subscription: str
+    :param subscription_project: the GCP project ID where the subscription
+        will be created. If empty, ``topic_project`` will be used.
+    :type subscription_project: str
+    :param ack_deadline_secs: Number of seconds that a subscriber has to
+        acknowledge each message pulled from the subscription
+    :type ack_deadline_secs: int
+    :param gcp_conn_id: The connection ID to use connecting to
+        Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request
+        must have domain-wide delegation enabled.
+    :type delegate_to: str
     """
     template_fields = ['topic_project', 'topic', 'subscription',
                        'subscription_project']
@@ -162,33 +186,7 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
             delegate_to=None,
             *args,
             **kwargs):
-        """
-        :param topic_project: the GCP project ID where the topic exists
-        :type topic_project: str
-        :param topic: the topic to create. Do not include the
-            full topic path. In other words, instead of
-            ``projects/{project}/topics/{topic}``, provide only
-            ``{topic}``. (templated)
-        :type topic: str
-        :param subscription: the Pub/Sub subscription name. If empty, a random
-            name will be generated using the uuid module
-        :type subscription: str
-        :param subscription_project: the GCP project ID where the subscription
-            will be created. If empty, ``topic_project`` will be used.
-        :type subscription_project: str
-        :param ack_deadline_secs: Number of seconds that a subscriber has to
-            acknowledge each message pulled from the subscription
-        :type ack_deadline_secs: int
-        :param gcp_conn_id: The connection ID to use connecting to
-            Google Cloud Platform.
-        :type gcp_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request
-            must have domain-wide delegation enabled.
-        :type delegate_to: str
-        """
         super().__init__(*args, **kwargs)
-
         self.topic_project = topic_project
         self.topic = topic
         self.subscription = subscription
@@ -233,6 +231,24 @@ class PubSubTopicDeleteOperator(BaseOperator):
 
     Both ``project`` and ``topic`` are templated so you can use
     variables in them.
+
+    :param project: the GCP project ID in which to work (templated)
+    :type project: str
+    :param topic: the topic to delete. Do not include the
+        full topic path. In other words, instead of
+        ``projects/{project}/topics/{topic}``, provide only
+        ``{topic}``. (templated)
+    :type topic: str
+    :param fail_if_not_exists: If True and the topic does not exist, fail
+        the task
+    :type fail_if_not_exists: bool
+    :param gcp_conn_id: The connection ID to use connecting to
+        Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request
+        must have domain-wide delegation enabled.
+    :type delegate_to: str
     """
     template_fields = ['project', 'topic']
     ui_color = '#cb4335'
@@ -247,25 +263,6 @@ class PubSubTopicDeleteOperator(BaseOperator):
             delegate_to=None,
             *args,
             **kwargs):
-        """
-        :param project: the GCP project ID in which to work (templated)
-        :type project: str
-        :param topic: the topic to delete. Do not include the
-            full topic path. In other words, instead of
-            ``projects/{project}/topics/{topic}``, provide only
-            ``{topic}``. (templated)
-        :type topic: str
-        :param fail_if_not_exists: If True and the topic does not exist, fail
-            the task
-        :type fail_if_not_exists: bool
-        :param gcp_conn_id: The connection ID to use connecting to
-            Google Cloud Platform.
-        :type gcp_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request
-            must have domain-wide delegation enabled.
-        :type delegate_to: str
-        """
         super().__init__(*args, **kwargs)
 
         self.project = project
@@ -309,6 +306,24 @@ class PubSubSubscriptionDeleteOperator(BaseOperator):
 
     ``project``, and ``subscription`` are templated so you can use
     variables in them.
+
+    :param project: the GCP project ID in which to work (templated)
+    :type project: str
+    :param subscription: the subscription to delete. Do not include the
+        full subscription path. In other words, instead of
+        ``projects/{project}/subscription/{subscription}``, provide only
+        ``{subscription}``. (templated)
+    :type subscription: str
+    :param fail_if_not_exists: If True and the subscription does not exist,
+        fail the task
+    :type fail_if_not_exists: bool
+    :param gcp_conn_id: The connection ID to use connecting to
+        Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request
+        must have domain-wide delegation enabled.
+    :type delegate_to: str
     """
     template_fields = ['project', 'subscription']
     ui_color = '#cb4335'
@@ -323,25 +338,6 @@ class PubSubSubscriptionDeleteOperator(BaseOperator):
             delegate_to=None,
             *args,
             **kwargs):
-        """
-        :param project: the GCP project ID in which to work (templated)
-        :type project: str
-        :param subscription: the subscription to delete. Do not include the
-            full subscription path. In other words, instead of
-            ``projects/{project}/subscription/{subscription}``, provide only
-            ``{subscription}``. (templated)
-        :type subscription: str
-        :param fail_if_not_exists: If True and the subscription does not exist,
-            fail the task
-        :type fail_if_not_exists: bool
-        :param gcp_conn_id: The connection ID to use connecting to
-            Google Cloud Platform.
-        :type gcp_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request
-            must have domain-wide delegation enabled.
-        :type delegate_to: str
-        """
         super().__init__(*args, **kwargs)
 
         self.project = project
@@ -381,6 +377,30 @@ class PubSubPublishOperator(BaseOperator):
 
     ``project`` , ``topic``, and ``messages`` are templated so you can use
     variables in them.
+
+    :param project: the GCP project ID in which to work (templated)
+    :type project: str
+    :param topic: the topic to which to publish. Do not include the
+        full topic path. In other words, instead of
+        ``projects/{project}/topics/{topic}``, provide only
+        ``{topic}``. (templated)
+    :type topic: str
+    :param messages: a list of messages to be published to the
+        topic. Each message is a dict with one or more of the
+        following keys-value mappings:
+        * 'data': a base64-encoded string
+        * 'attributes': {'key1': 'value1', ...}
+        Each message must contain at least a non-empty 'data' value
+        or an attribute dict with at least one key (templated). See
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
+    :type messages: list
+    :param gcp_conn_id: The connection ID to use connecting to
+        Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request
+        must have domain-wide delegation enabled.
+    :type delegate_to: str
     """
     template_fields = ['project', 'topic', 'messages']
     ui_color = '#0273d4'
@@ -395,31 +415,6 @@ class PubSubPublishOperator(BaseOperator):
             delegate_to=None,
             *args,
             **kwargs):
-        """
-        :param project: the GCP project ID in which to work (templated)
-        :type project: str
-        :param topic: the topic to which to publish. Do not include the
-            full topic path. In other words, instead of
-            ``projects/{project}/topics/{topic}``, provide only
-            ``{topic}``. (templated)
-        :type topic: str
-        :param messages: a list of messages to be published to the
-            topic. Each message is a dict with one or more of the
-            following keys-value mappings:
-            * 'data': a base64-encoded string
-            * 'attributes': {'key1': 'value1', ...}
-            Each message must contain at least a non-empty 'data' value
-            or an attribute dict with at least one key (templated). See
-            https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
-        :type messages: list
-        :param gcp_conn_id: The connection ID to use connecting to
-            Google Cloud Platform.
-        :type gcp_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request
-            must have domain-wide delegation enabled.
-        :type delegate_to: str
-        """
         super().__init__(*args, **kwargs)
 
         self.gcp_conn_id = gcp_conn_id


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5333
### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This PR moves __init__ docstring to class doctstring for better consistency between GCP operators.
 
### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
