### PR TITLE
[AIRFLOW-5335] Update GCSHook methods so they need min IAM perms

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -91,9 +91,9 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             raise ValueError('source_bucket and source_object cannot be empty.')
 
         client = self.get_conn()
-        source_bucket = client.get_bucket(source_bucket)
+        source_bucket = client.bucket(source_bucket)
         source_object = source_bucket.blob(source_object)
-        destination_bucket = client.get_bucket(destination_bucket)
+        destination_bucket = client.bucket(destination_bucket)
         destination_object = source_bucket.copy_blob(
             blob=source_object,
             destination_bucket=destination_bucket,
@@ -133,9 +133,9 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             raise ValueError('source_bucket and source_object cannot be empty.')
 
         client = self.get_conn()
-        source_bucket = client.get_bucket(source_bucket)
+        source_bucket = client.bucket(source_bucket)
         source_object = source_bucket.blob(blob_name=source_object)
-        destination_bucket = client.get_bucket(destination_bucket)
+        destination_bucket = client.bucket(destination_bucket)
 
         token, bytes_rewritten, total_bytes = destination_bucket.blob(
             blob_name=destination_object).rewrite(
@@ -169,7 +169,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         :type filename: str
         """
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
         blob = bucket.blob(blob_name=object_name)
 
         if filename:
@@ -204,7 +204,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                     filename = filename_gz
 
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
         blob = bucket.blob(blob_name=object_name)
         blob.upload_from_filename(filename=filename,
                                   content_type=mime_type)
@@ -224,7 +224,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         :type object_name: str
         """
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
         blob = bucket.blob(blob_name=object_name)
         return blob.exists()
 
@@ -241,9 +241,12 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         :type ts: datetime.datetime
         """
         client = self.get_conn()
-        bucket = storage.Bucket(client=client, name=bucket_name)
+        bucket = client.bucket(bucket_name)
         blob = bucket.get_blob(blob_name=object_name)
-        blob.reload()
+
+        if blob is None:
+            raise ValueError("Object ({}) not found in Bucket ({})".format(
+                object_name, bucket_name))
 
         blob_update_time = blob.updated
 
@@ -270,7 +273,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         :type object_name: str
         """
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
         blob = bucket.blob(blob_name=object_name)
         blob.delete()
 
@@ -294,7 +297,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         :return: a stream of object names matching the filtering criteria
         """
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
 
         ids = []
         page_token = None
@@ -338,9 +341,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                       object_name,
                       bucket_name)
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
         blob = bucket.get_blob(blob_name=object_name)
-        blob.reload()
         blob_size = blob.size
         self.log.info('The file size of %s is %s bytes.', object_name, blob_size)
         return blob_size
@@ -358,9 +360,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         self.log.info('Retrieving the crc32c checksum of '
                       'object_name: %s in bucket_name: %s', object_name, bucket_name)
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
         blob = bucket.get_blob(blob_name=object_name)
-        blob.reload()
         blob_crc32c = blob.crc32c
         self.log.info('The crc32c checksum of %s is %s', object_name, blob_crc32c)
         return blob_crc32c
@@ -378,9 +379,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         self.log.info('Retrieving the MD5 hash of '
                       'object: %s in bucket: %s', object_name, bucket_name)
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
         blob = bucket.get_blob(blob_name=object_name)
-        blob.reload()
         blob_md5hash = blob.md5_hash
         self.log.info('The md5Hash of %s is %s', object_name, blob_md5hash)
         return blob_md5hash
@@ -550,7 +550,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         self.log.info("Composing %s to %s in the bucket %s",
                       source_objects, destination_object, bucket_name)
         client = self.get_conn()
-        bucket = client.get_bucket(bucket_name)
+        bucket = client.bucket(bucket_name)
         destination_blob = bucket.blob(destination_object)
         destination_blob.compose(
             sources=[

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -69,14 +69,25 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
             self.gcs_hook = gcs_hook.GoogleCloudStorageHook(
                 google_cloud_storage_conn_id='test')
 
+    def test_storage_client_creation(self):
+        with mock.patch('google.cloud.storage.Client') as mock_client:
+            gcs_hook_1 = gcs_hook.GoogleCloudStorageHook()
+            gcs_hook_1.get_conn()
+
+            # test that Storage Client is called with required arguments
+            mock_client.assert_called_once_with(
+                client_info=mock.ANY,
+                credentials=mock.ANY,
+                project=mock.ANY)
+
     @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
     def test_exists(self, mock_service):
         test_bucket = 'test_bucket'
         test_object = 'test_object'
 
         # Given
-        get_bucket_mock = mock_service.return_value.get_bucket
-        blob_object = get_bucket_mock.return_value.blob
+        bucket_mock = mock_service.return_value.bucket
+        blob_object = bucket_mock.return_value.blob
         exists_method = blob_object.return_value.exists
         exists_method.return_value = True
 
@@ -85,7 +96,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
 
         # Then
         self.assertTrue(response)
-        get_bucket_mock.assert_called_once_with(test_bucket)
+        bucket_mock.assert_called_once_with(test_bucket)
         blob_object.assert_called_once_with(blob_name=test_object)
         exists_method.assert_called_once_with()
 
@@ -95,8 +106,8 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         test_object = 'test_object'
 
         # Given
-        get_bucket_mock = mock_service.return_value.get_bucket
-        blob_object = get_bucket_mock.return_value.blob
+        bucket_mock = mock_service.return_value.bucket
+        blob_object = bucket_mock.return_value.blob
         exists_method = blob_object.return_value.exists
         exists_method.return_value = False
 
@@ -121,9 +132,9 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
             name=destination_object)
 
         # Given
-        get_bucket_mock = mock_service.return_value.get_bucket
-        get_bucket_mock.return_value = mock_bucket
-        copy_method = get_bucket_mock.return_value.copy_blob
+        bucket_mock = mock_service.return_value.bucket
+        bucket_mock.return_value = mock_bucket
+        copy_method = bucket_mock.return_value.copy_blob
         copy_method.return_value = destination_blob
 
         # When
@@ -206,9 +217,9 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         source_blob = mock_bucket.blob(source_object)
 
         # Given
-        get_bucket_mock = mock_service.return_value.get_bucket
-        get_bucket_mock.return_value = mock_bucket
-        get_blob_method = get_bucket_mock.return_value.blob
+        bucket_mock = mock_service.return_value.bucket
+        bucket_mock.return_value = mock_bucket
+        get_blob_method = bucket_mock.return_value.blob
         rewrite_method = get_blob_method.return_value.rewrite
         rewrite_method.side_effect = [(None, mock.ANY, mock.ANY), (mock.ANY, mock.ANY, mock.ANY)]
 
@@ -280,8 +291,8 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         test_bucket = 'test_bucket'
         test_object = 'test_object'
 
-        get_bucket_method = mock_service.return_value.get_bucket
-        blob = get_bucket_method.return_value.blob
+        bucket_method = mock_service.return_value.bucket
+        blob = bucket_method.return_value.blob
         delete_method = blob.return_value.delete
         delete_method.side_effect = exceptions.NotFound(message="Not Found")
 
@@ -294,15 +305,14 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         test_object = 'test_object'
         returned_file_size = 1200
 
-        get_bucket_method = mock_service.return_value.get_bucket
-        get_blob_method = get_bucket_method.return_value.get_blob
+        bucket_method = mock_service.return_value.bucket
+        get_blob_method = bucket_method.return_value.get_blob
         get_blob_method.return_value.size = returned_file_size
 
         response = self.gcs_hook.get_size(bucket_name=test_bucket,
                                           object_name=test_object)
 
         self.assertEqual(response, returned_file_size)
-        get_blob_method.return_value.reload.assert_called_once_with()
 
     @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
     def test_object_get_crc32c(self, mock_service):
@@ -310,8 +320,8 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         test_object = 'test_object'
         returned_file_crc32c = "xgdNfQ=="
 
-        get_bucket_method = mock_service.return_value.get_bucket
-        get_blob_method = get_bucket_method.return_value.get_blob
+        bucket_method = mock_service.return_value.bucket
+        get_blob_method = bucket_method.return_value.get_blob
         get_blob_method.return_value.crc32c = returned_file_crc32c
 
         response = self.gcs_hook.get_crc32c(bucket_name=test_bucket,
@@ -319,26 +329,20 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
 
         self.assertEqual(response, returned_file_crc32c)
 
-        # Check that reload method is called
-        get_blob_method.return_value.reload.assert_called_once_with()
-
     @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
     def test_object_get_md5hash(self, mock_service):
         test_bucket = 'test_bucket'
         test_object = 'test_object'
         returned_file_md5hash = "leYUJBUWrRtks1UeUFONJQ=="
 
-        get_bucket_method = mock_service.return_value.get_bucket
-        get_blob_method = get_bucket_method.return_value.get_blob
+        bucket_method = mock_service.return_value.bucket
+        get_blob_method = bucket_method.return_value.get_blob
         get_blob_method.return_value.md5_hash = returned_file_md5hash
 
         response = self.gcs_hook.get_md5hash(bucket_name=test_bucket,
                                              object_name=test_object)
 
         self.assertEqual(response, returned_file_md5hash)
-
-        # Check that reload method is called
-        get_blob_method.return_value.reload.assert_called_once_with()
 
     @mock.patch('google.cloud.storage.Bucket')
     @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
@@ -416,9 +420,9 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         test_source_objects = ['test_object_1', 'test_object_2', 'test_object_3']
         test_destination_object = 'test_object_composed'
 
-        mock_service.return_value.get_bucket.return_value\
+        mock_service.return_value.bucket.return_value\
             .blob.return_value = mock_blob(blob_name=mock.ANY)
-        method = mock_service.return_value.get_bucket.return_value.blob\
+        method = mock_service.return_value.bucket.return_value.blob\
             .return_value.compose
 
         self.gcs_hook.compose(
@@ -492,7 +496,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         test_object = 'test_object'
         test_object_bytes = io.BytesIO(b"input")
 
-        download_method = mock_service.return_value.get_bucket.return_value \
+        download_method = mock_service.return_value.bucket.return_value \
             .blob.return_value.download_as_string
         download_method.return_value = test_object_bytes
 
@@ -510,11 +514,11 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         test_object_bytes = io.BytesIO(b"input")
         test_file = 'test_file'
 
-        download_filename_method = mock_service.return_value.get_bucket.return_value \
+        download_filename_method = mock_service.return_value.bucket.return_value \
             .blob.return_value.download_to_filename
         download_filename_method.return_value = None
 
-        download_as_a_string_method = mock_service.return_value.get_bucket.return_value \
+        download_as_a_string_method = mock_service.return_value.bucket.return_value \
             .blob.return_value.download_as_string
         download_as_a_string_method.return_value = test_object_bytes
 
@@ -546,7 +550,7 @@ class TestGoogleCloudStorageHookUpload(unittest.TestCase):
         test_bucket = 'test_bucket'
         test_object = 'test_object'
 
-        upload_method = mock_service.return_value.get_bucket.return_value\
+        upload_method = mock_service.return_value.bucket.return_value\
             .blob.return_value.upload_from_filename
         upload_method.return_value = None
 

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -20,7 +20,9 @@ import io
 import os
 import tempfile
 import unittest
+from datetime import datetime
 
+import dateutil
 from google.cloud import storage
 from google.cloud import exceptions
 
@@ -116,6 +118,24 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
 
         # Then
         self.assertFalse(response)
+
+    @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
+    def test_is_updated_after(self, mock_service):
+        test_bucket = 'test_bucket'
+        test_object = 'test_object'
+
+        # Given
+        mock_service.return_value.bucket.return_value.get_blob\
+            .return_value.updated = datetime(2019, 8, 28, 14, 7, 20, 700000, dateutil.tz.tzutc())
+
+        # When
+        response = self.gcs_hook.is_updated_after(
+            bucket_name=test_bucket, object_name=test_object,
+            ts=datetime(2018, 1, 1, 1, 1, 1)
+        )
+
+        # Then
+        self.assertTrue(response)
 
     @mock.patch('google.cloud.storage.Bucket')
     @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5335


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
After we refactored to using Storage client in GCS, we need more IAM permissions.

This is because we use `get_bucket` method which requires `storage.bucket.list` permission. Instead of that if we use `bucket` method that creates Bucket object we don't need the above permission.

This restores the behavior (IAM perms needed) of  **Airflow <=1.10.3** 


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tests updated

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
