### PR TITLE
[AIRFLOW-5336] Add ability to make updating FAB perms on webserver in…

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -341,6 +341,10 @@ default_wrap = False
 # analytics_tool = # choose from google_analytics, segment, or metarouter
 # analytics_id = XXXXXXXXXXX
 
+# Update FAB permissions and sync security manager roles
+# on webserver startup
+update_fab_perms = True
+
 [email]
 email_backend = airflow.utils.email.send_email_smtp
 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -104,7 +104,8 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
             app,
             db.session if not session else session,
             security_manager_class=security_manager_class,
-            base_template='appbuilder/baselayout.html')
+            base_template='appbuilder/baselayout.html',
+            update_perms=conf.getboolean('webserver', 'UPDATE_FAB_PERMS'))
 
         def init_views(appbuilder):
             from airflow.www import views
@@ -190,8 +191,9 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
         init_views(appbuilder)
         init_plugin_blueprints(app)
 
-        security_manager = appbuilder.sm
-        security_manager.sync_roles()
+        if conf.getboolean('webserver', 'UPDATE_FAB_PERMS'):
+            security_manager = appbuilder.sm
+            security_manager.sync_roles()
 
         from airflow.www.api.experimental import endpoints as e
         # required for testing purposes otherwise the module retains

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -222,7 +222,7 @@ Why next_ds or prev_ds might not contain expected values?
   the ``next_ds``, ``next_ds_nodash``, ``prev_ds``, ``prev_ds_nodash`` valueS will be set to ``None``.
 - When manually triggering DAG, the schedule will be ignored, and ``prev_ds == next_ds == ds``
 
-I am running multiple webserver processes, how can I solve records in the ``ab_permission_view`` with ``null`` ``permission_id``?
+How do I stop the sync perms happening multiple times per webserver?
 ------------------------------------------------
 
-Set the value of ``update_fab_perms`` configuration in ``airflow.cfg`` to ``False`` and have a process that runs the ``sync_perm`` CLI command instead.
+Set the value of ``update_fab_perms`` configuration in ``airflow.cfg`` to ``False``.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -223,6 +223,6 @@ Why next_ds or prev_ds might not contain expected values?
 - When manually triggering DAG, the schedule will be ignored, and ``prev_ds == next_ds == ds``
 
 How do I stop the sync perms happening multiple times per webserver?
-------------------------------------------------
+-------------------------------------------------------------------
 
 Set the value of ``update_fab_perms`` configuration in ``airflow.cfg`` to ``False``.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -221,3 +221,8 @@ Why next_ds or prev_ds might not contain expected values?
   ``execution_date`` and ``schedule_interval``. If you set ``schedule_interval`` as ``None`` or ``@once``,
   the ``next_ds``, ``next_ds_nodash``, ``prev_ds``, ``prev_ds_nodash`` valueS will be set to ``None``.
 - When manually triggering DAG, the schedule will be ignored, and ``prev_ds == next_ds == ds``
+
+I am running multiple webserver processes, how can I solve records in the ``ab_permission_view`` with ``null`` ``permission_id``?
+------------------------------------------------
+
+Set the value of ``update_fab_perms`` configuration in ``airflow.cfg`` to ``False`` and have a process that runs the ``sync_perm`` CLI command instead.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -223,6 +223,6 @@ Why next_ds or prev_ds might not contain expected values?
 - When manually triggering DAG, the schedule will be ignored, and ``prev_ds == next_ds == ds``
 
 How do I stop the sync perms happening multiple times per webserver?
--------------------------------------------------------------------
+--------------------------------------------------------------------
 
 Set the value of ``update_fab_perms`` configuration in ``airflow.cfg`` to ``False``.


### PR DESCRIPTION
…it optional

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

https://issues.apache.org/jira/browse/AIRFLOW-5336

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add ability to make updating perms and other syncs on webserver init optional similar to https://github.com/dpgaspar/Flask-AppBuilder/pull/625
I am running into issues where multiple webserver processes are running what I believe is the sync_perm and it causes there to be records in the ab_permission_view with null permission_id (ultimately resulting in both processes crashing until I either manually clean them up or recreate the table). I envision being able to shut it off on the webserver init and use a one-off run that I am currently using, that handles it as part of deployment via the sync_perm CLI command.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Not sure if testing is needed here. If it is, let me know where to look.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
