### PR TITLE
[AIRFLOW-4833] Allow to set Jinja env options in DAG declaration

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -205,6 +205,7 @@ class DAG(BaseDag, LoggingMixin):
         params: Optional[Dict] = None,
         access_control: Optional[Dict] = None,
         is_paused_upon_creation: Optional[bool] = None,
+        jinja_environment_kwargs: Optional[Dict] = None
     ):
         self.user_defined_macros = user_defined_macros
         self.user_defined_filters = user_defined_filters
@@ -292,6 +293,8 @@ class DAG(BaseDag, LoggingMixin):
         self._old_context_manager_dags = []  # type: Iterable[DAG]
         self._access_control = access_control
         self.is_paused_upon_creation = is_paused_upon_creation
+
+        self.jinja_environment_kwargs = jinja_environment_kwargs
 
     def __repr__(self):
         return "<DAG: {self.dag_id}>".format(self=self)
@@ -727,12 +730,17 @@ class DAG(BaseDag, LoggingMixin):
         if self.template_searchpath:
             searchpath += self.template_searchpath
 
-        env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(searchpath),
-            undefined=self.template_undefined,
-            extensions=["jinja2.ext.do"],
-            cache_size=0,
-        )
+        # Default values (for backward compatibility)
+        jinja_env_options = {
+            'loader': jinja2.FileSystemLoader(searchpath),
+            'undefined': self.template_undefined,
+            'extensions': ["jinja2.ext.do"],
+            'cache_size': 0
+        }
+        if self.jinja_environment_kwargs:
+            jinja_env_options.update(self.jinja_environment_kwargs)
+
+        env = jinja2.Environment(**jinja_env_options)  # type: ignore
 
         # Add any user defined items. Safe to edit globals as long as no templates are rendered yet.
         # http://jinja.pocoo.org/docs/2.10/api/#jinja2.Environment.globals

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -166,6 +166,22 @@ class DAG(BaseDag, LoggingMixin):
         If the dag exists already, this flag will be ignored. If this optional parameter
         is not specified, the global config setting will be used.
     :type is_paused_upon_creation: bool or None
+    :param jinja_environment_kwargs: additional configuration options to be passed to Jinja
+        ``Environment`` for template rendering
+
+        **Example**: to avoid Jinja from removing a trailing newline from template strings ::
+
+            DAG(dag_id='my-dag',
+                jinja_environment_kwargs={
+                    'keep_trailing_newline': True,
+                    # some other jinja2 Environment options here
+                }
+            )
+
+        **See**: `Jinja Environment documentation
+        <https://jinja.palletsprojects.com/en/master/api/#jinja2.Environment>`_
+
+    :type jinja_environment_kwargs: dict
     """
 
     _comps = {

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1091,6 +1091,21 @@ You can use Jinja templating with every parameter that is marked as "templated"
 in the documentation. Template substitution occurs just before the pre_execute
 function of your operator is called.
 
+You can pass custom options to the Jinja ``Environment`` when creating your DAG.
+One common usage is to avoid Jinja from dropping a trailing newline from a
+template string:
+
+.. code:: python
+
+  my_dag = DAG(dag_id='my-dag',
+               jinja_environment_kwargs={
+                    'keep_trailing_newline': True,
+                    # some other jinja2 Environment options here
+               })
+
+See `Jinja documentation <https://jinja.palletsprojects.com/en/master/api/#jinja2.Environment>`_
+to find all available options.
+
 Packaged DAGs
 '''''''''''''
 While often you will specify DAGs in a single ``.py`` file it might sometimes

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -72,6 +72,8 @@ class TestBaseOperator(unittest.TestCase):
             (datetime.datetime(2018, 12, 6, 10, 55), {"foo": "bar"}, datetime.datetime(2018, 12, 6, 10, 55)),
             (TestNamedTuple("{{ foo }}_1", "{{ foo }}_2"), {"foo": "bar"}, TestNamedTuple("bar_1", "bar_2")),
             ({"{{ foo }}_1", "{{ foo }}_2"}, {"foo": "bar"}, {"bar_1", "bar_2"}),
+            # By default, Jinja2 drops one (single) trailing newline
+            ("{{ foo }}\n\n", {"foo": "bar"}, "bar\n"),
         ]
     )
     def test_render_template(self, content, context, expected_output):
@@ -141,3 +143,23 @@ class TestBaseOperator(unittest.TestCase):
 
         task.render_template_fields(context={"foo": "whatever", "bar": "whatever"})
         self.assertEqual(mock_jinja_env.call_count, 1)
+
+    def test_set_jinja_env_additional_option(self):
+        """Test render_template given various input types."""
+        with DAG("test-dag",
+                 start_date=DEFAULT_DATE,
+                 jinja_environment_kwargs={'keep_trailing_newline': True}):
+            task = DummyOperator(task_id="op1")
+
+        result = task.render_template("{{ foo }}\n\n", {"foo": "bar"})
+        self.assertEqual(result, "bar\n\n")
+
+    def test_override_jinja_env_option(self):
+        """Test render_template given various input types."""
+        with DAG("test-dag",
+                 start_date=DEFAULT_DATE,
+                 jinja_environment_kwargs={'cache_size': 50}):
+            task = DummyOperator(task_id="op1")
+
+        result = task.render_template("{{ foo }}", {"foo": "bar"})
+        self.assertEqual(result, "bar")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ x ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4833) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4833
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ x ]
- Issue was : a trailing newline in a template string is dropped by Jinja2 (default behavior)
- This is fixed by allowing to set options to `jinja2.Environment` object by defining these options at the DAG level (see [AIRFLOW-4833](https://issues.apache.org/jira/browse/AIRFLOW-4833) for more information)

### Tests

- [ x ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ x ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ x ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ x ] Passes `flake8`
