### PR TITLE
[AIRFLOW-5340] Fix GCP DLP example

### DIFF
--- a/airflow/gcp/example_dags/example_gcp_dlp_operator.py
+++ b/airflow/gcp/example_dags/example_gcp_dlp_operator.py
@@ -60,7 +60,7 @@ with DAG("example_gcp_dlp", default_args=default_args, schedule_interval=None) a
         inspect_template=INSPECT_TEMPLATE,
         template_id=TEMPLATE_ID,
         task_id="create_template",
-        xcom_push=True,
+        do_xcom_push=True,
         dag=dag,
     )
 


### PR DESCRIPTION
Use `do_xcom_push` instead of deprecated `xcom_push`.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5340

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Use `do_xcom_push` instead of deprecated `xcom_push`.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
