### PR TITLE
[AIRFLOW-5343] Add pool_pre_ping to SQLAlchemy

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -122,6 +122,11 @@ sql_alchemy_max_overflow = 10
 # a lower config value will allow the system to recover faster.
 sql_alchemy_pool_recycle = 1800
 
+# Check connection at the start of each connection pool checkout.
+# Typically, this is a simple statement like “SELECT 1”.
+# More information here: https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
+sql_alchemy_pool_pre_ping = False
+
 # How many seconds to retry re-establishing a DB connection after
 # disconnects. Setting this to 0 disables retries.
 sql_alchemy_reconnect_timeout = 300

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -144,10 +144,7 @@ def configure_orm(disable_connection_pool=False):
         # Pool size engine args not supported by sqlite.
         # If no config value is defined for the pool size, select a reasonable value.
         # 0 means no limit, which could lead to exceeding the Database connection limit.
-        try:
-            pool_size = conf.getint('core', 'SQL_ALCHEMY_POOL_SIZE')
-        except conf.AirflowConfigException:
-            pool_size = 5
+        pool_size = conf.getint('core', 'SQL_ALCHEMY_POOL_SIZE', fallback=5)
 
         # The maximum overflow size of the pool.
         # When the number of checked-out connections reaches the size set in pool_size,
@@ -159,29 +156,20 @@ def configure_orm(disable_connection_pool=False):
         # max_overflow can be set to -1 to indicate no overflow limit;
         # no limit will be placed on the total number
         # of concurrent connections. Defaults to 10.
-        try:
-            max_overflow = conf.getint('core', 'SQL_ALCHEMY_MAX_OVERFLOW')
-        except conf.AirflowConfigException:
-            max_overflow = 10
+        max_overflow = conf.getint('core', 'SQL_ALCHEMY_MAX_OVERFLOW', fallback=10)
 
         # The DB server already has a value for wait_timeout (number of seconds after
         # which an idle sleeping connection should be killed). Since other DBs may
         # co-exist on the same server, SQLAlchemy should set its
         # pool_recycle to an equal or smaller value.
-        try:
-            pool_recycle = conf.getint('core', 'SQL_ALCHEMY_POOL_RECYCLE')
-        except conf.AirflowConfigException:
-            pool_recycle = 1800
+        pool_recycle = conf.getint('core', 'SQL_ALCHEMY_POOL_RECYCLE', fallback=1800)
 
         # Check connection at the start of each connection pool checkout.
         # Typically, this is a simple statement like “SELECT 1”, but may also make use
         # of some DBAPI-specific method to test the connection for liveness.
         # More information here:
         # https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
-        try:
-            pool_pre_ping = conf.getboolean('core', 'SQL_ALCHEMY_POOL_PRE_PING')
-        except conf.AirflowConfigException:
-            pool_pre_ping = False
+        pool_pre_ping = conf.getboolean('core', 'SQL_ALCHEMY_POOL_PRE_PING', fallback=False)
 
         log.info("settings.configure_orm(): Using pool settings. pool_size={}, max_overflow={}, "
                  "pool_recycle={}, pid={}".format(pool_size, max_overflow, pool_recycle, os.getpid()))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5343
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

SQLalchemy supports connection check while returning it from the pool. There is a need to allow this parameter (pool_pre_ping) while creating the connection to database.
More info here: https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It's kinda integration layer with database and not really coverable with unit tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
