### PR TITLE
[AIRFLOW-5341] Use more precise mock of time.sleep

### DIFF
--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -212,7 +212,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         resume_method.assert_called_once_with(name=TEST_TRANSFER_OPERATION_NAME)
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('time.sleep')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.time.sleep')
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.'
                 'GCPTransferServiceHook.list_transfer_operations')
     def test_wait_for_transfer_job(self, mock_list, mock_sleep):
@@ -232,7 +232,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
 
         mock_sleep.assert_called_once_with(TIME_TO_SLEEP_IN_SECONDS)
 
-    @mock.patch('time.sleep')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.time.sleep')
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
     def test_wait_for_transfer_job_failed(self, get_conn, mock_sleep):  # pylint: disable=unused-argument
         list_method = get_conn.return_value.transferOperations.return_value.list
@@ -249,7 +249,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
             self.gct_hook.wait_for_transfer_job({PROJECT_ID: TEST_PROJECT_ID, NAME: 'transferJobs/test-job'})
             self.assertTrue(list_method.called)
 
-    @mock.patch('time.sleep')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.time.sleep')
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
     def test_wait_for_transfer_job_expect_failed(self,
                                                  get_conn,

--- a/tests/gcp/hooks/test_kubernetes_engine.py
+++ b/tests/gcp/hooks/test_kubernetes_engine.py
@@ -224,7 +224,7 @@ class TestGKEClusterHook(unittest.TestCase):
         self.gke_hook._append_label(mock_proto, key, val)
         mock_proto.resource_labels.update.assert_called_once_with({key: 'test-val-this'})
 
-    @mock.patch("time.sleep")
+    @mock.patch("airflow.gcp.hooks.kubernetes_engine.time.sleep")
     def test_wait_for_response_done(self, time_mock):
         from google.cloud.container_v1.gapic.enums import Operation
         mock_op = mock.Mock()
@@ -232,7 +232,7 @@ class TestGKEClusterHook(unittest.TestCase):
         self.gke_hook.wait_for_operation(mock_op)
         self.assertEqual(time_mock.call_count, 1)
 
-    @mock.patch("time.sleep")
+    @mock.patch("airflow.gcp.hooks.kubernetes_engine.time.sleep")
     def test_wait_for_response_exception(self, time_mock):
         from google.cloud.container_v1.gapic.enums import Operation
         from google.cloud.exceptions import GoogleCloudError
@@ -245,7 +245,7 @@ class TestGKEClusterHook(unittest.TestCase):
             self.assertEqual(time_mock.call_count, 1)
 
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.get_operation")
-    @mock.patch("time.sleep")
+    @mock.patch("airflow.gcp.hooks.kubernetes_engine.time.sleep")
     def test_wait_for_response_running(self, time_mock, operation_mock):
         from google.cloud.container_v1.gapic.enums import Operation
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5341

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Some tests were mocking `time.sleep` instead of using more precise `airflow.module.path.time.sleep` mock.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
