### PR TITLE
[AIRFLOW-5348] Escape chart Label when set via JS

### DIFF
--- a/airflow/www/templates/airflow/nvd3.html
+++ b/airflow/www/templates/airflow/nvd3.html
@@ -164,7 +164,7 @@ body {
           $('#chart_body').html('<div class="alert alert-danger">' + payload.error + '</div>');
         }
         $("#sql_panel_body").html(payload.sql_html);
-        $("#label").html(payload.label);
+        $("#label").text(payload.label);
         if (payload.state == "SUCCESS") {
           {% if chart.chart_type != "datatable" %}
             $('#chart_body').css('width', '100%');


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] https://issues.apache.org/jira/browse/AIRFLOW-5348


### Description
- [x] Escape chart label when set via JS


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `flake8`