### PR TITLE
[AIRFLOW-5350] Fix bug in the num_retires field in BigQueryHook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -56,7 +56,6 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook):
             gcp_conn_id=bigquery_conn_id, delegate_to=delegate_to)
         self.use_legacy_sql = use_legacy_sql
         self.location = location
-        self.num_retries = self._get_field('num_retries', 5) or 5
 
     def get_conn(self):
         """

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -56,7 +56,7 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook):
             gcp_conn_id=bigquery_conn_id, delegate_to=delegate_to)
         self.use_legacy_sql = use_legacy_sql
         self.location = location
-        self.num_retries = self._get_field('num_retries', 5)
+        self.num_retries = self._get_field('num_retries', 5) or 5
 
     def get_conn(self):
         """
@@ -208,7 +208,7 @@ class BigQueryBaseCursor(LoggingMixin):
                  use_legacy_sql=True,
                  api_resource_configs=None,
                  location=None,
-                 num_retries=None):
+                 num_retries=5):
 
         self.service = service
         self.project_id = project_id
@@ -232,7 +232,7 @@ class BigQueryBaseCursor(LoggingMixin):
                            labels=None,
                            view=None,
                            encryption_configuration=None,
-                           num_retries=None):
+                           num_retries=5):
         """
         Creates a new, empty table in the dataset.
         To create a view, which is defined by a SQL query, parse a dictionary to 'view' kwarg
@@ -1970,7 +1970,7 @@ class BigQueryCursor(BigQueryBaseCursor):
     https://github.com/dropbox/PyHive/blob/master/pyhive/common.py
     """
 
-    def __init__(self, service, project_id, use_legacy_sql=True, location=None, num_retries=None):
+    def __init__(self, service, project_id, use_legacy_sql=True, location=None, num_retries=5):
         super().__init__(
             service=service,
             project_id=project_id,

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -172,6 +172,16 @@ class GoogleCloudBaseHook(BaseHook):
         return self._get_field('project')
 
     @property
+    def num_retries(self) -> int:
+        """
+        Returns num_retries from Connection.
+
+        :return: the number of times each API request should be retried
+        :rtype: int
+        """
+        return self._get_field('num_retries') or 5
+
+    @property
     def client_info(self) -> ClientInfo:
         """
         Return client information used to generate a user-agent for API calls.

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -53,7 +53,7 @@ class _DataProcJob(LoggingMixin):
         job: Dict,
         region: str = 'global',
         job_error_states: Iterable[str] = None,
-        num_retries: int = None
+        num_retries: int = 5
     ) -> None:
         self.dataproc_api = dataproc_api
         self.project_id = project_id
@@ -451,7 +451,6 @@ class DataProcHook(GoogleCloudBaseHook):
     ) -> None:
         super().__init__(gcp_conn_id, delegate_to)
         self.api_version = api_version
-        self.num_retries = self._get_field('num_retries', 5)   # type: int
 
     def get_conn(self):
         """

--- a/airflow/gcp/hooks/cloud_build.py
+++ b/airflow/gcp/hooks/cloud_build.py
@@ -58,7 +58,6 @@ class CloudBuildHook(GoogleCloudBaseHook):
     ) -> None:
         super().__init__(gcp_conn_id, delegate_to)
         self.api_version = api_version
-        self.num_retries = self._get_field("num_retries", 5)
 
     def get_conn(self):
         """

--- a/airflow/gcp/hooks/cloud_sql.py
+++ b/airflow/gcp/hooks/cloud_sql.py
@@ -87,7 +87,6 @@ class CloudSqlHook(GoogleCloudBaseHook):
     ) -> None:
         super().__init__(gcp_conn_id, delegate_to)
         self.api_version = api_version
-        self.num_retries = self._get_field('num_retries', 5)  # type: int
         self._conn = None
 
     def get_conn(self):

--- a/airflow/gcp/hooks/cloud_storage_transfer_service.py
+++ b/airflow/gcp/hooks/cloud_storage_transfer_service.py
@@ -115,7 +115,6 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
     ) -> None:
         super().__init__(gcp_conn_id, delegate_to)
         self.api_version = api_version
-        self.num_retries = self._get_field('num_retries', 5)  # type: int
         self._conn = None
 
     def get_conn(self):

--- a/airflow/gcp/hooks/compute.py
+++ b/airflow/gcp/hooks/compute.py
@@ -59,7 +59,6 @@ class GceHook(GoogleCloudBaseHook):
     ) -> None:
         super().__init__(gcp_conn_id, delegate_to)
         self.api_version = api_version
-        self.num_retries = self._get_field('num_retries', 5)  # type: int
 
     def get_conn(self):
         """

--- a/airflow/gcp/hooks/dataflow.py
+++ b/airflow/gcp/hooks/dataflow.py
@@ -301,7 +301,6 @@ class DataFlowHook(GoogleCloudBaseHook):
         poll_sleep: int = 10
     ) -> None:
         self.poll_sleep = poll_sleep
-        self.num_retries = self._get_field('num_retries', 5)  # type: int
         super().__init__(gcp_conn_id, delegate_to)
 
     def get_conn(self):

--- a/airflow/gcp/hooks/datastore.py
+++ b/airflow/gcp/hooks/datastore.py
@@ -46,7 +46,6 @@ class DatastoreHook(GoogleCloudBaseHook):
         super().__init__(datastore_conn_id, delegate_to)
         self.connection = None
         self.api_version = api_version
-        self.num_retries = self._get_field('num_retries', 5)
 
     def get_conn(self):
         """

--- a/airflow/gcp/hooks/functions.py
+++ b/airflow/gcp/hooks/functions.py
@@ -50,7 +50,6 @@ class GcfHook(GoogleCloudBaseHook):
     ) -> None:
         super().__init__(gcp_conn_id, delegate_to)
         self.api_version = api_version
-        self.num_retries = self._get_field('num_retries', 5)  # type: int
 
     @staticmethod
     def _full_location(project_id: str, location: str) -> str:

--- a/airflow/gcp/hooks/gsheets.py
+++ b/airflow/gcp/hooks/gsheets.py
@@ -57,7 +57,6 @@ class GSheetsHook(GoogleCloudBaseHook):
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self.delegate_to = delegate_to
-        self.num_retries = self._get_field('num_retries', 5)
         self._conn = None
 
     def get_conn(self) -> Any:

--- a/airflow/gcp/hooks/kms.py
+++ b/airflow/gcp/hooks/kms.py
@@ -46,7 +46,6 @@ class GoogleCloudKMSHook(GoogleCloudBaseHook):
 
     def __init__(self, gcp_conn_id: str = 'google_cloud_default', delegate_to: str = None) -> None:
         super().__init__(gcp_conn_id, delegate_to=delegate_to)
-        self.num_retries = self._get_field('num_retries', 5)  # type: int
 
     def get_conn(self):
         """

--- a/airflow/gcp/hooks/pubsub.py
+++ b/airflow/gcp/hooks/pubsub.py
@@ -52,7 +52,6 @@ class PubSubHook(GoogleCloudBaseHook):
 
     def __init__(self, gcp_conn_id: str = 'google_cloud_default', delegate_to: str = None) -> None:
         super().__init__(gcp_conn_id, delegate_to=delegate_to)
-        self.num_retries = self._get_field('num_retries', 5)  # type: int
 
     def get_conn(self):
         """

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -1037,6 +1037,19 @@ class TestBigQueryHookRunWithConfiguration(unittest.TestCase):
         )
 
 
+class TestBigQueryHookWithNumRetries(unittest.TestCase):
+    @mock.patch("airflow.contrib.hooks.bigquery_hook.BigQueryHook.get_connection")
+    def test_num_retries_is_not_none_by_default(self, get_con_mock):
+        """
+        Verify that if 'num_retires' in extras is not set, the default value
+        should not be None
+        """
+        keyfile_dict = {"extra__google_cloud_platform__num_retries": None}
+        get_con_mock.return_value.extra_dejson = keyfile_dict
+        bq_hook = hook.BigQueryHook()
+        self.assertEqual(bq_hook.num_retries, 5)
+
+
 class TestBigQueryWithKMS(unittest.TestCase):
     def test_create_empty_table_with_kms(self):
         project_id = "bq-project"

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -1037,19 +1037,6 @@ class TestBigQueryHookRunWithConfiguration(unittest.TestCase):
         )
 
 
-class TestBigQueryHookWithNumRetries(unittest.TestCase):
-    @mock.patch("airflow.contrib.hooks.bigquery_hook.BigQueryHook.get_connection")
-    def test_num_retries_is_not_none_by_default(self, get_con_mock):
-        """
-        Verify that if 'num_retires' in extras is not set, the default value
-        should not be None
-        """
-        keyfile_dict = {"extra__google_cloud_platform__num_retries": None}
-        get_con_mock.return_value.extra_dejson = keyfile_dict
-        bq_hook = hook.BigQueryHook()
-        self.assertEqual(bq_hook.num_retries, 5)
-
-
 class TestBigQueryWithKMS(unittest.TestCase):
     def test_create_empty_table_with_kms(self):
         project_id = "bq-project"

--- a/tests/contrib/hooks/test_gcp_api_base_hook.py
+++ b/tests/contrib/hooks/test_gcp_api_base_hook.py
@@ -327,3 +327,14 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
         self.instance.extras = {'extra__google_cloud_platform__project': default_project}
 
         self.assertEqual(self.instance.scopes, ('https://www.googleapis.com/auth/cloud-platform',))
+
+    @mock.patch("airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.get_connection")
+    def test_num_retries_is_not_none_by_default(self, get_con_mock):
+        """
+        Verify that if 'num_retires' in extras is not set, the default value
+        should not be None
+        """
+        get_con_mock.return_value.extra_dejson = {
+            "extra__google_cloud_platform__num_retries": None
+        }
+        self.assertEqual(self.instance.num_retries, 5)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5350

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The `num_retries` extra is no set in old connections that were created before 1.10.4, for those fields it's value is None which causes the below error:

From the StackOverflow Post:

```
 [2019-08-27 02:49:58,076] {cli.py:516} INFO - Running <TaskInstance: cadastro_remessas_paises2.gcs_to_bq 2019-08-27T02:42:43.970619+00:00 [running]> on host cadastroremessaspaises2gcstobq-78f1ea099c3b4e718ba707cb03ffda1e 
    [2019-08-27 02:49:58,136] {logging_mixin.py:95} INFO - [[34m2019-08-27 02:49:58,136[0m] {[34mdiscovery.py:[0m271} INFO[0m - URL being requested: GET [1mhttps://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest[0m[0m 
    [2019-08-27 02:49:59,259] {logging_mixin.py:95} INFO - [[34m2019-08-27 02:49:59,259[0m] {[34mmy_functions_google.py:[0m2224} INFO[0m - Project not included in [1mdestination_project_dataset_table[0m: [1mcadastro_remessas.paises2[0m; using project "[1mbigdata-staging[0m"[0m 
    [2019-08-27 02:49:59,266] {logging_mixin.py:95} INFO - [[34m2019-08-27 02:49:59,266[0m] {[34mdiscovery.py:[0m867} INFO[0m - URL being requested: POST https://www.googleapis.com/bigquery/v2/projects/bigdata-staging/jobs?alt=json[0m 
    [2019-08-27 02:49:59,266] {taskinstance.py:1047} ERROR - unsupported operand type(s) for +: 'NoneType' and 'int' Traceback (most recent call last):   File "/usr/local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 922, in _run_raw_task
        result = task_copy.execute(context=context)   
        File "/airflow/dags/git/subfolder/my_functions_google.py", line 2502, in execute
        cluster_fields=self.cluster_fields)   
        File "/airflow/dags/git/subfolder/my_functions_google.py", line 1396, in run_load
        return self.run_with_configuration(configuration)   
        File "/airflow/dags/git/subfolder/my_functions_google.py", line 1414, in run_with_configuration
        .execute(num_retries=self.num_retries)   
        File "/usr/local/lib/python3.7/site-packages/googleapiclient/_helpers.py", line 130, in positional_wrapper
        return wrapped(*args, **kwargs)   
        File "/usr/local/lib/python3.7/site-packages/googleapiclient/http.py", line 851, in execute
        method=str(self.method), body=self.body, headers=self.headers)   
        File "/usr/local/lib/python3.7/site-packages/googleapiclient/http.py", line 153, in _retry_request
        for retry_num in range(num_retries + 1): TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* `TestBigQueryHookWithNumRetries.test_num_retries_is_not_none_by_default`
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
