### PR TITLE
[AIRFLOW-5356] Fix GCP Datastore unit tests

### DIFF
--- a/tests/gcp/hooks/test_datastore.py
+++ b/tests/gcp/hooks/test_datastore.py
@@ -64,8 +64,10 @@ class TestDatastoreHook(unittest.TestCase):
         execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(keys, execute.return_value['keys'])
 
+    @patch('airflow.gcp.hooks.datastore.DatastoreHook.project_id',
+           new_callable=mock.PropertyMock, return_value=None)
     @patch('airflow.gcp.hooks.datastore.DatastoreHook.get_conn')
-    def test_allocate_ids_no_project_id(self, mock_get_conn):
+    def test_allocate_ids_no_project_id(self, mock_get_conn, mock_project_id):
         self.datastore_hook.connection = mock_get_conn.return_value
         partial_keys = []
 
@@ -87,8 +89,10 @@ class TestDatastoreHook(unittest.TestCase):
         execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(transaction, execute.return_value['transaction'])
 
+    @patch('airflow.gcp.hooks.datastore.DatastoreHook.project_id',
+           new_callable=mock.PropertyMock, return_value=None)
     @patch('airflow.gcp.hooks.datastore.DatastoreHook.get_conn')
-    def test_begin_transaction_no_project_id(self, mock_get_conn):
+    def test_begin_transaction_no_project_id(self, mock_get_conn, mock_project_id):
         self.datastore_hook.connection = mock_get_conn.return_value
         with self.assertRaises(AirflowException) as err:
             self.datastore_hook.begin_transaction()
@@ -109,8 +113,10 @@ class TestDatastoreHook(unittest.TestCase):
         execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(resp, execute.return_value)
 
+    @patch('airflow.gcp.hooks.datastore.DatastoreHook.project_id',
+           new_callable=mock.PropertyMock, return_value=None)
     @patch('airflow.gcp.hooks.datastore.DatastoreHook.get_conn')
-    def test_commit_no_project_id(self, mock_get_conn):
+    def test_commit_no_project_id(self, mock_get_conn, mock_project_id):
         self.datastore_hook.connection = mock_get_conn.return_value
         body = {'item': 'a'}
 
@@ -144,8 +150,10 @@ class TestDatastoreHook(unittest.TestCase):
         execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(resp, execute.return_value)
 
+    @patch('airflow.gcp.hooks.datastore.DatastoreHook.project_id',
+           new_callable=mock.PropertyMock, return_value=None)
     @patch('airflow.gcp.hooks.datastore.DatastoreHook.get_conn')
-    def test_lookup_no_project_id(self, mock_get_conn):
+    def test_lookup_no_project_id(self, mock_get_conn, mock_project_id):
         self.datastore_hook.connection = mock_get_conn.return_value
         keys = []
         read_consistency = 'ENUM'
@@ -173,8 +181,10 @@ class TestDatastoreHook(unittest.TestCase):
         execute = rollback.return_value.execute
         execute.assert_called_once_with(num_retries=mock.ANY)
 
+    @patch('airflow.gcp.hooks.datastore.DatastoreHook.project_id',
+           new_callable=mock.PropertyMock, return_value=None)
     @patch('airflow.gcp.hooks.datastore.DatastoreHook.get_conn')
-    def test_rollback_no_project_id(self, mock_get_conn):
+    def test_rollback_no_project_id(self, mock_get_conn, mock_project_id):
         self.datastore_hook.connection = mock_get_conn.return_value
         transaction = 'transaction'
 
@@ -197,8 +207,10 @@ class TestDatastoreHook(unittest.TestCase):
         execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(resp, execute.return_value['batch'])
 
+    @patch('airflow.gcp.hooks.datastore.DatastoreHook.project_id',
+           new_callable=mock.PropertyMock, return_value=None)
     @patch('airflow.gcp.hooks.datastore.DatastoreHook.get_conn')
-    def test_run_query_no_project_id(self, mock_get_conn):
+    def test_run_query_no_project_id(self, mock_get_conn, mock_project_id):
         self.datastore_hook.connection = mock_get_conn.return_value
         body = {'item': 'a'}
 
@@ -286,8 +298,10 @@ class TestDatastoreHook(unittest.TestCase):
         execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(resp, execute.return_value)
 
+    @patch('airflow.gcp.hooks.datastore.DatastoreHook.project_id',
+           new_callable=mock.PropertyMock, return_value=None)
     @patch('airflow.gcp.hooks.datastore.DatastoreHook.get_conn')
-    def test_export_to_storage_bucket_no_project_id(self, mock_get_conn):
+    def test_export_to_storage_bucket_no_project_id(self, mock_get_conn, mock_project_id):
         self.datastore_hook.admin_connection = mock_get_conn.return_value
         bucket = 'bucket'
         namespace = None
@@ -334,8 +348,10 @@ class TestDatastoreHook(unittest.TestCase):
         execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(resp, execute.return_value)
 
+    @patch('airflow.gcp.hooks.datastore.DatastoreHook.project_id',
+           new_callable=mock.PropertyMock, return_value=None)
     @patch('airflow.gcp.hooks.datastore.DatastoreHook.get_conn')
-    def test_import_from_storage_bucket_no_project_id(self, mock_get_conn):
+    def test_import_from_storage_bucket_no_project_id(self, mock_get_conn, mock_project_id):
         self.datastore_hook.admin_connection = mock_get_conn.return_value
         bucket = 'bucket'
         file = 'file'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5356

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This commit adds additional mocking for Datastore tests which tests fallback_to_default_project_id decorator.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
