### PR TITLE
[AIRFLOW-5357] Fix Content-Type for exported variables.json file

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2658,6 +2658,7 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
 
         response = make_response(json.dumps(var_dict, sort_keys=True, indent=4))
         response.headers["Content-Disposition"] = "attachment; filename=variables.json"
+        response.headers["Content-Type"] = "application/json; charset=utf-8"
         return response
 
     def on_form_prefill(self, form, id):

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -2249,6 +2249,7 @@ class VariableModelView(AirflowModelView):
 
         response = make_response(json.dumps(var_dict, sort_keys=True, indent=4))
         response.headers["Content-Disposition"] = "attachment; filename=variables.json"
+        response.headers["Content-Type"] = "application/json; charset=utf-8"
         return response
 
     @expose('/varimport', methods=["POST"])


### PR DESCRIPTION
This PR is targeted to **_v1-10-test_**

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5357

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Same as https://github.com/apache/airflow/pull/5962:

Credits to Anurag Jain for reporting this:
It was observed that the content type is set incorrectly while exporting variables in Apache Airflow.

Steps:

Open the Apache Airflow
Create a new variable at /admin/variable/
Keep the key as and value as
Save this variable
Export this variable using Mozilla Firefox Browser
Observe that the downloaded file is saved as .json.htm instead of .json. This happens since Apache airflow sets Response Content-Type as text/html instead of application/json which causes Browser to interpret it as a HTML

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
