### PR TITLE
[AIRFLOW-5364] Fix missing port numbers for local ci scripts

### DIFF
--- a/breeze
+++ b/breeze
@@ -124,10 +124,6 @@ export SKIP_BUILD_CHECK="false"
 SUPPRESS_CHEATSHEET_FILE="${MY_DIR}/.suppress_cheatsheet"
 SUPPRESS_ASCIIART_FILE="${MY_DIR}/.suppress_asciiart"
 
-export WEBSERVER_HOST_PORT=${WEBSERVER_HOST_PORT:="28080"}
-export POSTGRES_HOST_PORT=${POSTGRES_HOST_PORT:="25433"}
-export MYSQL_HOST_PORT=${MYSQL_HOST_PORT:="23306"}
-
 function print_badge {
     if [[ ! -f "${SUPPRESS_ASCIIART_FILE}" ]]; then
         cat <<EOF

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -72,6 +72,11 @@ fi
 
 export PYTHON_BINARY=${PYTHON_BINARY:=python${PYTHON_VERSION}}
 
+# Default port numbers for forwarded ports
+export WEBSERVER_HOST_PORT=${WEBSERVER_HOST_PORT:="28080"}
+export POSTGRES_HOST_PORT=${POSTGRES_HOST_PORT:="25433"}
+export MYSQL_HOST_PORT=${MYSQL_HOST_PORT:="23306"}
+
 #
 # Sets mounting of host volumes to container for static checks
 # unless AIRFLOW_MOUNT_HOST_VOLUMES_FOR_STATIC_CHECKS is not true


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5264

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When you run local_si_enter_environment, the port numbers are missing. Breeze works fine. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
