### PR TITLE
[AIRFLOW-5371] Remove yamllint as prerequisite to run pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -158,6 +158,7 @@ repos:
         name: Check yaml files with yamllint
         entry: yamllint -c yamllint-config.yml
         language: python
+        additional_dependencies: ['yamllint']
         types: [yaml]
         exclude: ^.*init_git_sync\.template\.yaml$|^.*airflow\.template\.yaml$
       - id: shellcheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -712,7 +712,6 @@ In Linux you typically install them with `sudo apt install` on MacOS with `brew 
 The current list of prerequisites:
 
 * xmllint: Linux - install via `sudo apt install xmllint`, MacOS - install via `brew install xmllint`
-* yamllint: install via `pip install yamllint`
 
 ## Pre-commit hooks installed
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5371

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

No yamllint needs to be installed in host to run pre-commits.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
