### PR TITLE
[AIRFLOW-5372] Apache license check runs locally on LICENCE changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,8 +32,9 @@ repos:
         name: Check if licences are OK for Apache
         entry: ./scripts/ci/ci_check_license.sh
         language: system
-        files: ^\.pre-commit-config\.yaml$
-        pass_filenames: true
+        files: ^.*LICENSE.*$|^.*LICENCE.*$
+        pass_filenames: false
+        require_serial: true
   - repo: https://github.com/potiuk/pre-commit-hooks
     rev: d5bee8590ea3405a299825e68dbfa0e1b951a2be
     hooks:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5372


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Licence check for RAT runs too often (every time pre-commit is modified) and it
should only be run (locally) when any of *LICEN[S|C]E* files change. We anyhow
run full check on CI so this is local optimisation (it runs too long while you
play with .pre-commit-config.yaml - and we will probably be able to detect some
problems locally as well when new modules are added.
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
