### PR TITLE
[AIRFLOW-5388] Add airflow version label to newly created buckets

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -31,6 +31,7 @@ from google.cloud import storage
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.exceptions import AirflowException
+from airflow.version import version
 
 
 class GoogleCloudStorageHook(GoogleCloudBaseHook):
@@ -439,6 +440,10 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         self.log.info('Creating Bucket: %s; Location: %s; Storage Class: %s',
                       bucket_name, location, storage_class)
 
+        # Add airflow-version label to the bucket
+        labels = {} or labels
+        labels['airflow-version'] = 'v' + version.replace('.', '-').replace('+', '-')
+
         client = self.get_conn()
         bucket = client.bucket(bucket_name=bucket_name)
         bucket_resource = resource or {}
@@ -448,7 +453,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 bucket._patch_property(name=item, value=resource[item])  # pylint: disable=protected-access
 
         bucket.storage_class = storage_class
-        bucket.labels = labels or {}
+        bucket.labels = labels
         bucket.create(project=project_id, location=location)
         return bucket.id
 

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -24,7 +24,6 @@ import warnings
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from airflow.version import version
 
 
 class GoogleCloudStorageCreateBucketOperator(BaseOperator):
@@ -125,11 +124,6 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
         self.delegate_to = delegate_to
 
     def execute(self, context):
-        if self.labels is not None:
-            self.labels.update(
-                {'airflow-version': 'v' + version.replace('.', '-').replace('+', '-')}
-            )
-
         hook = GoogleCloudStorageHook(
             google_cloud_storage_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to

--- a/tests/contrib/operators/test_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_operator.py
@@ -20,7 +20,6 @@
 import unittest
 
 from airflow.contrib.operators.gcs_operator import GoogleCloudStorageCreateBucketOperator
-from airflow.version import version
 from tests.compat import mock
 
 TASK_ID = 'test-gcs-operator'
@@ -45,9 +44,7 @@ class TestGoogleCloudStorageCreateBucket(unittest.TestCase):
         operator.execute(None)
         mock_hook.return_value.create_bucket.assert_called_once_with(
             bucket_name=TEST_BUCKET, storage_class='MULTI_REGIONAL',
-            location='EU', labels={
-                'airflow-version': 'v' + version.replace('.', '-').replace('+', '-'),
-                'env': 'prod'
-            }, project_id=TEST_PROJECT,
+            location='EU', labels={'env': 'prod'},
+            project_id=TEST_PROJECT,
             resource={'lifecycle': {'rule': [{'action': {'type': 'Delete'}, 'condition': {'age': 7}}]}}
         )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5388

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
To tag and track GCP resources spawned from Airflow, we have been adding airflow specific label(s) to GCP API service calls whenever possible and applicable.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`