### PR TITLE
[AIRFLOW-3804] Extend MySQL to GCS operator tests

### DIFF
--- a/tests/operators/test_mysql_to_gcs.py
+++ b/tests/operators/test_mysql_to_gcs.py
@@ -23,6 +23,8 @@ import unittest
 
 from parameterized import parameterized
 
+from _mysql_exceptions import ProgrammingError
+
 from airflow.operators.mysql_to_gcs import \
     MySqlToGoogleCloudStorageOperator
 from tests.compat import mock
@@ -292,3 +294,31 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
 
         # once for the file and once for the schema
         self.assertEqual(2, gcs_hook_mock.upload.call_count)
+
+    @mock.patch('airflow.operators.mysql_to_gcs.MySqlHook')
+    @mock.patch('airflow.operators.sql_to_gcs.GoogleCloudStorageHook')
+    def test_query_with_error(self, mock_gcs_hook, mock_mysql_hook):
+        mock_mysql_hook.return_value.get_conn.\
+            return_value.cursor.return_value.execute.side_effect = ProgrammingError
+        op = MySqlToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=JSON_FILENAME,
+            schema_filename=SCHEMA_FILENAME)
+        with self.assertRaises(ProgrammingError):
+            op.query()
+
+    @mock.patch('airflow.operators.mysql_to_gcs.MySqlHook')
+    @mock.patch('airflow.operators.sql_to_gcs.GoogleCloudStorageHook')
+    def test_execute_with_query_error(self, mock_gcs_hook, mock_mysql_hook):
+        mock_mysql_hook.return_value.get_conn.\
+            return_value.cursor.return_value.execute.side_effect = ProgrammingError
+        op = MySqlToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=JSON_FILENAME,
+            schema_filename=SCHEMA_FILENAME)
+        with self.assertRaises(ProgrammingError):
+            op.execute(None)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3804

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This commit adds additional test related to problem mentioned in initial issue https://issues.apache.org/jira/browse/AIRFLOW-3804
I was not able to reproduce the mentioned behaviour but I think it's go to have these tests.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
