### PR TITLE
[AIRFLOW-5399] Add invoke operator for GCP Functions

### DIFF
--- a/airflow/gcp/example_dags/example_functions.py
+++ b/airflow/gcp/example_dags/example_functions.py
@@ -45,7 +45,7 @@ import os
 
 from airflow import models
 from airflow.gcp.operators.functions \
-    import GcfFunctionDeployOperator, GcfFunctionDeleteOperator
+    import GcfFunctionDeployOperator, GcfFunctionDeleteOperator, GcfFunctionInvokeOperator
 from airflow.utils import dates
 
 # [START howto_operator_gcf_common_variables]
@@ -124,10 +124,19 @@ with models.DAG(
         validate_body=GCP_VALIDATE_BODY
     )
     # [END howto_operator_gcf_deploy_no_project_id]
+    # [START howto_operator_gcf_invoke_function]
+    invoke_task = GcfFunctionInvokeOperator(
+        task_id="invoke_task",
+        project_id=GCP_PROJECT_ID,
+        location=GCP_LOCATION,
+        input_data={},
+        function_id=GCF_SHORT_FUNCTION_NAME
+    )
+    # [END howto_operator_gcf_invoke_function]
     # [START howto_operator_gcf_delete]
     delete_task = GcfFunctionDeleteOperator(
         task_id="gcf_delete_task",
         name=FUNCTION_NAME
     )
     # [END howto_operator_gcf_delete]
-    deploy_task >> deploy2_task >> delete_task
+    deploy_task >> deploy2_task >> invoke_task >> delete_task

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -487,6 +487,9 @@ Cloud Functions
 :class:`airflow.gcp.operators.functions.GcfFunctionDeleteOperator`
     delete Google Cloud Function in Google Cloud Platform
 
+:class:`airflow.gcp.operators.functions.GcfFunctionInvokeOperator`
+    invoke Google Cloud Function in Google Cloud Platform
+
 
 They also use :class:`airflow.gcp.hooks.functions.GcfHook` to communicate with Google Cloud Platform.
 

--- a/tests/gcp/operators/test_functions.py
+++ b/tests/gcp/operators/test_functions.py
@@ -25,7 +25,8 @@ from googleapiclient.errors import HttpError
 from parameterized import parameterized
 
 from airflow.gcp.operators.functions import \
-    GcfFunctionDeployOperator, GcfFunctionDeleteOperator, FUNCTION_NAME_PATTERN
+    GcfFunctionDeployOperator, GcfFunctionDeleteOperator, \
+    FUNCTION_NAME_PATTERN, GcfFunctionInvokeOperator
 from airflow import AirflowException
 from airflow.version import version
 from tests.compat import mock
@@ -634,4 +635,45 @@ class TestGcfFunctionDelete(unittest.TestCase):
                                           gcp_conn_id='google_cloud_default')
         mock_hook.return_value.delete_function.assert_called_once_with(
             'projects/project_name/locations/project_location/functions/function_name'
+        )
+
+
+class TestGcfFunctionInvokeOperator(unittest.TestCase):
+    @mock.patch("airflow.gcp.operators.functions.BaseOperator.xcom_push")
+    @mock.patch("airflow.gcp.operators.functions.GcfHook")
+    def test_execute(self, mock_gcf_hook, mock_xcom):
+        exec_id = 'exec_id'
+        mock_gcf_hook.return_value.call_function.return_value = {'executionId': exec_id}
+
+        function_id = "test_function"
+        payload = {'key': 'value'}
+        api_version = 'test'
+        gcp_conn_id = 'test_conn'
+
+        op = GcfFunctionInvokeOperator(
+            task_id='test',
+            function_id=function_id,
+            input_data=payload,
+            location=GCP_LOCATION,
+            project_id=GCP_PROJECT_ID,
+            api_version=api_version,
+            gcp_conn_id=gcp_conn_id
+        )
+        op.execute(None)
+        mock_gcf_hook.assert_called_once_with(
+            api_version=api_version,
+            gcp_conn_id=gcp_conn_id
+        )
+
+        mock_gcf_hook.return_value.call_function.assert_called_once_with(
+            function_id=function_id,
+            input_data=payload,
+            location=GCP_LOCATION,
+            project_id=GCP_PROJECT_ID
+        )
+
+        mock_xcom.assert_called_once_with(
+            context=None,
+            key='execution_id',
+            value=exec_id
         )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5399
### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This PR adds `GcfFunctionInvokeOperator` for invoking a function on Google Cloud Functions.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`