### PR TITLE
[AIRFLOW-5396] - Add button Auto Refresh

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -627,7 +627,7 @@ function updateQueryStringParameter(uri, key, value) {
     setInterval(()=>{
         if (isAutoRefreshEnabled())
             location.reload()
-    }, 1500);
+    }, 3000);
 
     function toggleAutoRefreshBtnLabel() {
       if (isAutoRefreshEnabled())

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -115,6 +115,12 @@
         </a>
       </li>
       <li>
+        <a href="javascript: void();" title="Auto Refresh" onclick="toggleAutoRefresh(); return false" id="btn-auto-refresh">
+          <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
+          <span id="label-auto-refresh">Auto Refresh</span>
+        </a>
+      </li>
+      <li>
         <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}"
           onclick="return confirmDeleteDag(this, '{{ dag.safe_dag_id }}')">
           <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true"></span>
@@ -358,6 +364,8 @@ function updateQueryStringParameter(uri, key, value) {
     $(document).ready(function () {
       $('a[href*="' + this.location.pathname + '"]').parent().addClass('active');
       $('.never_active').removeClass('active');
+
+      toggleAutoRefreshBtnLabel();
     });
 
     var id = '';
@@ -573,5 +581,59 @@ function updateQueryStringParameter(uri, key, value) {
       $.post(url);
     });
 
+    // AutoRefresh
+    AUTO_REFRESH_COOKIE_NAME = 'airflow_auto_refresh_enabled'
+
+    setCookie = (cname, cvalue, exdays) => {
+    var d = new Date();
+      d.setTime(d.getTime() + (exdays*24*60*60*1000));
+      var expires = "expires="+ d.toUTCString();
+      document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+    }
+
+    getCookie = (cname)=> {
+      var name = cname + "=";
+      var decodedCookie = decodeURIComponent(document.cookie);
+      var ca = decodedCookie.split(';');
+      for(var i = 0; i <ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+          c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+          return c.substring(name.length, c.length);
+        }
+      }
+      return "";
+    }
+
+    rmCookie = (cname)=>{
+      setCookie(cname, '', 0)
+    }
+
+    isAutoRefreshEnabled = ()=>{
+        return getCookie(AUTO_REFRESH_COOKIE_NAME)==1
+    }
+
+    toggleAutoRefresh = ()=>{
+      if(isAutoRefreshEnabled()){
+        $('#label-auto-refresh').html('Auto Refresh')
+        rmCookie(AUTO_REFRESH_COOKIE_NAME)
+      }else{
+        setCookie(AUTO_REFRESH_COOKIE_NAME, 1)
+      }
+    }
+
+    setInterval(()=>{
+        if (isAutoRefreshEnabled())
+            location.reload()
+    }, 1500);
+
+    function toggleAutoRefreshBtnLabel() {
+      if (isAutoRefreshEnabled())
+        $('#label-auto-refresh').html('Turn Off')
+      else
+        $('#label-auto-refresh').html('Auto Refresh')
+    }
   </script>
 {% endblock %}


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5396) issues and references them in the PR title.
"\[AIRFLOW-5396\] Add button to Auto Refresh Airflow UI"
  - https://issues.apache.org/jira/browse/AIRFLOW-5396


### Description

Currently, to follow up the tasks running on Airflow UI (mainly when we are at development) we should click at button "Refresh". When we need to know the finishing of a task we have to click many times at this button.

It would be useful to have a new button "Auto Refresh" which we could click and just wait the UI showing us the status while Airflow executes.

We can do another thing meanwhile and just return to the UI screen when it's finished.

So this button should:
- when clicked start an auto refresh 
- when clicked again stop the auto refresh

Auto Refresh disabled / initial state
![image](https://user-images.githubusercontent.com/13151948/64216116-eccbca80-ce8d-11e9-802c-5eff32b2dc5f.png)

Auto Refresh Enabled
![image](https://user-images.githubusercontent.com/13151948/64216120-f1907e80-ce8d-11e9-954e-2ebe34026a92.png)


### Tests

As it's a front/UI related PR we currently don't have unit tests then I have tested the functionality on the UI.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue.

### Code Quality

- [x] Passes `flake8`
