### PR TITLE
[AIRFLOW-5393] UI crashes in the Ad Hoc Query menu (PULL REQUEST FIX)

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2314,7 +2314,7 @@ class QueryView(wwwutils.DataProfilingMixin, AirflowViewMixin, BaseView):
         if not has_data and error:
             flash('No data', 'error')
 
-        if csv:
+        if csv and not error:
             return Response(
                 response=df.to_csv(index=False),
                 status=200,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5393


### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

There was a crash in the Airflow Ad Hoc Query menu when you hit the ".csv" button to obtain a csv file of the query if the query is empty. This happened due to a "**_df variable referenced before assigment_**", the "**_df_**" variable is catched inside a try / except block and "**_df_**" is never assigned, instead there is an "**_error_**" variable which can be used to detect when the query was empty or the connection could not be stablished.

In the screenshot it fails in line 2295 and the "**_error_**" variable will be True.

In line 2317 you can see the proposed change adding "**and not error**"

![alt text](https://i.imgur.com/KnK43hk.png)


### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

  - I didn't know exactly how to unit test this, if you have any advice I will do a test for it. Other than that, I did test checking that the behaviour was as expected:
    
    - [X] Querying with blank text and unset connection works with an error message
    - [X]  Querying with blank text and set connection works with an error message
    - [X] Querying with text and set connection works returning the .csv file
    - [X] Querying with text and unset connection works returning an error message


### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
