### PR TITLE
[AIRFLOW-5401] Add support for project_id from connection in GKE

### DIFF
--- a/airflow/gcp/hooks/kubernetes_engine.py
+++ b/airflow/gcp/hooks/kubernetes_engine.py
@@ -131,6 +131,7 @@ class GKEClusterHook(GoogleCloudBaseHook):
         cluster_proto.resource_labels.update({key: val})
         return cluster_proto
 
+    @GoogleCloudBaseHook.fallback_to_default_project_id
     def delete_cluster(
         self,
         name: str,
@@ -177,6 +178,7 @@ class GKEClusterHook(GoogleCloudBaseHook):
             self.log.info('Assuming Success: %s', error.message)
             return None
 
+    @GoogleCloudBaseHook.fallback_to_default_project_id
     def create_cluster(
         self,
         cluster: Union[Dict, Cluster],
@@ -234,6 +236,7 @@ class GKEClusterHook(GoogleCloudBaseHook):
             self.log.info('Assuming Success: %s', error.message)
             return self.get_cluster(name=cluster.name).self_link
 
+    @GoogleCloudBaseHook.fallback_to_default_project_id
     def get_cluster(
         self,
         name: str,

--- a/airflow/gcp/operators/kubernetes_engine.py
+++ b/airflow/gcp/operators/kubernetes_engine.py
@@ -71,9 +71,9 @@ class GKEClusterDeleteOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id: str,
                  name: str,
                  location: str,
+                 project_id: str = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v2',
                  *args,
@@ -146,9 +146,9 @@ class GKEClusterCreateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id: str,
                  location: str,
                  body: Optional[Union[Dict, Cluster]],
+                 project_id: str = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v2',
                  *args,

--- a/tests/gcp/hooks/test_kubernetes_engine.py
+++ b/tests/gcp/hooks/test_kubernetes_engine.py
@@ -98,7 +98,7 @@ class TestGKEClusterHookDelete(unittest.TestCase):
         message = 'Not Found'
         self.gke_hook._client.delete_cluster.side_effect = NotFound(message=message)
 
-        self.gke_hook.delete_cluster('not-existing')
+        self.gke_hook.delete_cluster(name='not-existing', project_id=TEST_GCP_PROJECT_ID)
         wait_mock.assert_not_called()
         convert_mock.assert_not_called()
         log_mock.info.assert_any_call("Assuming Success: %s", message)
@@ -116,7 +116,7 @@ class TestGKEClusterHookDelete(unittest.TestCase):
         self.gke_hook._client.delete_cluster.side_effect = AirflowException('400')
 
         with self.assertRaises(AirflowException):
-            self.gke_hook.delete_cluster('a-cluster')
+            self.gke_hook.delete_cluster(name='a-cluster')
             wait_mock.assert_not_called()
             convert_mock.assert_not_called()
 
@@ -142,7 +142,7 @@ class TestGKEClusterHookCreate(unittest.TestCase):
 
         client_create = self.gke_hook._client.create_cluster = mock.Mock()
 
-        self.gke_hook.create_cluster(mock_cluster_proto,
+        self.gke_hook.create_cluster(cluster=mock_cluster_proto,
                                      project_id=TEST_GCP_PROJECT_ID,
                                      retry=retry_mock,
                                      timeout=timeout_mock)
@@ -169,7 +169,7 @@ class TestGKEClusterHookCreate(unittest.TestCase):
         client_create = self.gke_hook._client.create_cluster = mock.Mock()
         proto_mock = convert_mock.return_value = mock.Mock()
 
-        self.gke_hook.create_cluster(mock_cluster_dict,
+        self.gke_hook.create_cluster(cluster=mock_cluster_dict,
                                      project_id=TEST_GCP_PROJECT_ID,
                                      retry=retry_mock,
                                      timeout=timeout_mock)
@@ -197,22 +197,17 @@ class TestGKEClusterHookCreate(unittest.TestCase):
             convert_mock.assert_not_called()
 
     @mock.patch(
-        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
-        new_callable=PropertyMock,
-        return_value=None
-    )
-    @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.log")
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.ParseDict")
     @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.wait_for_operation")
-    def test_create_cluster_already_exists(self, wait_mock, convert_mock, log_mock, mock_project_id):
+    def test_create_cluster_already_exists(self, wait_mock, convert_mock, log_mock):
         from google.api_core.exceptions import AlreadyExists
         # To force an error
         message = 'Already Exists'
         self.gke_hook._client.create_cluster.side_effect = AlreadyExists(message=message)
 
-        self.gke_hook.create_cluster({})
+        self.gke_hook.create_cluster(cluster={}, project_id=TEST_GCP_PROJECT_ID)
         wait_mock.assert_not_called()
         self.assertEqual(convert_mock.call_count, 1)
         log_mock.info.assert_any_call("Assuming Success: %s", message)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5401

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This change adds support for reading project_id value from connection configuration GKE operators.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
