### PR TITLE
[AIRFLOW-5342] Fix MSSQL breaking task_instance db migration

### DIFF
--- a/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
+++ b/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
@@ -33,13 +33,11 @@ from sqlalchemy.ext.declarative import declarative_base
 from airflow.utils.db import create_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
-
 # revision identifiers, used by Alembic.
 revision = '6e96a59344a4'
 down_revision = '939bb1e647c8'
 branch_labels = None
 depends_on = None
-
 
 Base = declarative_base()
 ID_LEN = 250
@@ -87,11 +85,15 @@ def upgrade():
     Make TaskInstance.pool field not nullable.
     """
     with create_session() as session:
-        session.query(TaskInstance)\
-            .filter(TaskInstance.pool.is_(None))\
+        session.query(TaskInstance) \
+            .filter(TaskInstance.pool.is_(None)) \
             .update({TaskInstance.pool: 'default_pool'},
                     synchronize_session=False)  # Avoid select updated rows
         session.commit()
+
+    conn = op.get_bind()
+    if conn.dialect.name == "mssql":
+        op.drop_index('ti_pool', table_name='task_instance')
 
     # use batch_alter_table to support SQLite workaround
     with op.batch_alter_table('task_instance') as batch_op:
@@ -101,11 +103,19 @@ def upgrade():
             nullable=False,
         )
 
+    if conn.dialect.name == "mssql":
+        op.create_index('ti_pool', 'task_instance', ['pool', 'state', 'priority_weight'])
+
 
 def downgrade():
     """
     Make TaskInstance.pool field nullable.
     """
+
+    conn = op.get_bind()
+    if conn.dialect.name == "mssql":
+        op.drop_index('ti_pool', table_name='task_instance')
+
     # use batch_alter_table to support SQLite workaround
     with op.batch_alter_table('task_instance') as batch_op:
         batch_op.alter_column(
@@ -114,9 +124,12 @@ def downgrade():
             nullable=True,
         )
 
+    if conn.dialect.name == "mssql":
+        op.create_index('ti_pool', 'task_instance', ['pool', 'state', 'priority_weight'])
+
     with create_session() as session:
-        session.query(TaskInstance)\
-            .filter(TaskInstance.pool == 'default_pool')\
+        session.query(TaskInstance) \
+            .filter(TaskInstance.pool == 'default_pool') \
             .update({TaskInstance.pool: None},
                     synchronize_session=False)  # Avoid select updated rows
         session.commit()


### PR DESCRIPTION
MSSQL does not allow altering columns to NOT NULL when the column
is used in an index. Therefore we drop the ti_pool index and recreate
it after modifying the column.

Co-authored-by: mattinbits <3765307+mattinbits@users.noreply.github.com>
Co-authored-by: sirVir <sirVir@users.noreply.github.com>

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5342) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5342
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

AIRFLOW-4591 introduced a breaking migration script on MSSQL server. This change fixes this.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

MSSQL testing is not officially supported and is not part of the CICD pipeline. Migrations script changes have been tested on MSSQL locally.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
