### PR TITLE
[AIRFLOW-5408] Fix env variable name in Kubernetes template

### DIFF
--- a/scripts/ci/kubernetes/kube/templates/airflow.template.yaml
+++ b/scripts/ci/kubernetes/kube/templates/airflow.template.yaml
@@ -74,7 +74,7 @@ spec:
           containerPort: 8080
         args: ["webserver"]
         env:
-        - name: AIRFLOW_KUBE_NAMESPACE
+        - name: AIRFLOW__KUBERNETES__NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -96,7 +96,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["scheduler"]
         env:
-        - name: AIRFLOW_KUBE_NAMESPACE
+        - name: AIRFLOW__KUBERNETES__NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5408

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

I fix a variable name in https://github.com/apache/airflow/blob/master/scripts/ci/kubernetes/kube/templates/airflow.template.yaml to match the name of the configuration value, it had no impact before.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
