### PR TITLE
[AIRFLOW-5412] Add get_conn/get_client to hooks tests

### DIFF
--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -37,7 +37,6 @@ except GoogleAuthError:
     bq_available = False
 
 
-
 class TestBigQueryHookConnection(unittest.TestCase):
     hook = None  # type: Optional[hook.BigQueryHook]
 

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -20,7 +20,7 @@
 
 import unittest
 from unittest import mock
-from typing import List
+from typing import List, Optional
 
 from google.auth.exceptions import GoogleAuthError
 from googleapiclient.errors import HttpError
@@ -35,6 +35,31 @@ try:
     hook.BigQueryHook().get_service()
 except GoogleAuthError:
     bq_available = False
+
+
+
+class TestBigQueryHookConnection(unittest.TestCase):
+    hook = None  # type: Optional[hook.BigQueryHook]
+
+    def setUp(self):
+        self.hook = hook.BigQueryHook()
+
+    @mock.patch("airflow.contrib.hooks.bigquery_hook.BigQueryConnection")
+    @mock.patch("airflow.contrib.hooks.bigquery_hook.BigQueryHook._authorize")
+    @mock.patch("airflow.contrib.hooks.bigquery_hook.build")
+    def test_bigquery_client_creation(self, mock_build, mock_authorize, mock_bigquery_connection):
+        result = self.hook.get_conn()
+        mock_build.assert_called_once_with(
+            'bigquery', 'v2', http=mock_authorize.return_value, cache_discovery=False
+        )
+        mock_bigquery_connection.assert_called_once_with(
+            service=mock_build.return_value,
+            project_id=self.hook.project_id,
+            use_legacy_sql=self.hook.use_legacy_sql,
+            location=self.hook.location,
+            num_retries=self.hook.num_retries
+        )
+        self.assertEqual(mock_bigquery_connection.return_value, result)
 
 
 class TestPandasGbqCredentials(unittest.TestCase):

--- a/tests/contrib/utils/base_gcp_mock.py
+++ b/tests/contrib/utils/base_gcp_mock.py
@@ -28,13 +28,16 @@ def mock_base_gcp_hook_default_project_id(self, gcp_conn_id, delegate_to=None):
     }
     self._conn = gcp_conn_id
     self.delegate_to = delegate_to
+    self._client = None
+    self._conn = None
 
 
 def mock_base_gcp_hook_no_default_project_id(self, gcp_conn_id, delegate_to=None):
-    self.extras = {
-    }
+    self.extras = {}
     self._conn = gcp_conn_id
     self.delegate_to = delegate_to
+    self._client = None
+    self._conn = None
 
 
 def get_open_mock():

--- a/tests/gcp/hooks/test_bigtable.py
+++ b/tests/gcp/hooks/test_bigtable.py
@@ -214,7 +214,6 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         self.assertEqual(mock_client.return_value, result)
         self.assertEqual(self.bigtable_hook_default_project_id._client, result)
 
-
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
         new_callable=PropertyMock,

--- a/tests/gcp/hooks/test_bigtable.py
+++ b/tests/gcp/hooks/test_bigtable.py
@@ -44,6 +44,20 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
                         new=mock_base_gcp_hook_no_default_project_id):
             self.bigtable_hook_no_default_project_id = BigtableHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.bigtable.BigtableHook.client_info", new_callable=mock.PropertyMock)
+    @mock.patch("airflow.gcp.hooks.bigtable.BigtableHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.bigtable.Client")
+    def test_bigtable_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.bigtable_hook_no_default_project_id._get_client(GCP_PROJECT_ID_HOOK_UNIT_TEST)
+        mock_client.assert_called_once_with(
+            project=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value,
+            admin=True
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.bigtable_hook_no_default_project_id._client, result)
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
         new_callable=PropertyMock,
@@ -185,6 +199,21 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
             self.bigtable_hook_default_project_id = BigtableHook(gcp_conn_id='test')
+
+    @mock.patch("airflow.gcp.hooks.bigtable.BigtableHook.client_info", new_callable=mock.PropertyMock)
+    @mock.patch("airflow.gcp.hooks.bigtable.BigtableHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.bigtable.Client")
+    def test_bigtable_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.bigtable_hook_default_project_id._get_client(GCP_PROJECT_ID_HOOK_UNIT_TEST)
+        mock_client.assert_called_once_with(
+            project=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value,
+            admin=True
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.bigtable_hook_default_project_id._client, result)
+
 
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',

--- a/tests/gcp/hooks/test_cloud_build.py
+++ b/tests/gcp/hooks/test_cloud_build.py
@@ -57,6 +57,16 @@ class TestCloudBuildHookWithPassedProjectId(unittest.TestCase):
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
 
+    @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_build.build")
+    def test_cloud_build_client_creation(self, mock_build, mock_authorize):
+        result = self.hook.get_conn()
+        mock_build.assert_called_once_with(
+            'cloudbuild', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+        self.assertEqual(self.hook._conn, result)
+
     @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook.get_conn")
     def test_build_immediately_complete(self, get_conn_mock):
         service_mock = get_conn_mock.return_value
@@ -134,6 +144,16 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
+
+    @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_build.build")
+    def test_cloud_build_client_creation(self, mock_build, mock_authorize):
+        result = self.hook.get_conn()
+        mock_build.assert_called_once_with(
+            'cloudbuild', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+        self.assertEqual(self.hook._conn, result)
 
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
@@ -218,6 +238,16 @@ class TestCloudBuildHookWithoutProjectId(unittest.TestCase):
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
+
+    @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_build.build")
+    def test_cloud_build_client_creation(self, mock_build, mock_authorize):
+        result = self.hook.get_conn()
+        mock_build.assert_called_once_with(
+            'cloudbuild', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+        self.assertEqual(self.hook._conn, result)
 
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',

--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -83,6 +83,16 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         ):
             self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.build")
+    def test_gct_client_creation(self, mock_build, mock_authorize):
+        result = self.gct_hook.get_conn()
+        mock_build.assert_called_once_with(
+            'storagetransfer', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+        self.assertEqual(self.gct_hook._conn, result)
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
         new_callable=PropertyMock,
@@ -381,6 +391,16 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         ):
             self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.build")
+    def test_gct_client_creation(self, mock_build, mock_authorize):
+        result = self.gct_hook.get_conn()
+        mock_build.assert_called_once_with(
+            'storagetransfer', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+        self.assertEqual(self.gct_hook._conn, result)
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
         new_callable=PropertyMock,
@@ -544,6 +564,16 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
+
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.build")
+    def test_gct_client_creation(self, mock_build, mock_authorize):
+        result = self.gct_hook.get_conn()
+        mock_build.assert_called_once_with(
+            'storagetransfer', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+        self.assertEqual(self.gct_hook._conn, result)
 
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',

--- a/tests/gcp/hooks/test_dataflow.py
+++ b/tests/gcp/hooks/test_dataflow.py
@@ -87,6 +87,15 @@ class TestDataFlowHook(unittest.TestCase):
                         new=mock_init):
             self.dataflow_hook = DataFlowHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.dataflow.DataFlowHook._authorize")
+    @mock.patch("airflow.gcp.hooks.dataflow.build")
+    def test_dataflow_client_creation(self, mock_build, mock_authorize):
+        result = self.dataflow_hook.get_conn()
+        mock_build.assert_called_once_with(
+            'dataflow', 'v1b3', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+
     @mock.patch(DATAFLOW_STRING.format('uuid.uuid4'))
     @mock.patch(DATAFLOW_STRING.format('_DataflowJob'))
     @mock.patch(DATAFLOW_STRING.format('_Dataflow'))

--- a/tests/gcp/hooks/test_dataproc.py
+++ b/tests/gcp/hooks/test_dataproc.py
@@ -44,6 +44,15 @@ class TestDataProcHook(unittest.TestCase):
                         new=mock_init):
             self.dataproc_hook = DataProcHook()
 
+    @mock.patch("airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook._authorize")
+    @mock.patch("airflow.contrib.hooks.gcp_dataproc_hook.build")
+    def test_dataproc_client_creation(self, mock_build, mock_authorize):
+        result = self.dataproc_hook.get_conn()
+        mock_build.assert_called_once_with(
+            'dataproc', 'v1beta2', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+
     @mock.patch(DATAPROC_STRING.format('_DataProcJob'))
     def test_submit(self, job_mock):
         with mock.patch(DATAPROC_STRING.format('DataProcHook.get_conn',

--- a/tests/gcp/hooks/test_dataproc.py
+++ b/tests/gcp/hooks/test_dataproc.py
@@ -44,8 +44,8 @@ class TestDataProcHook(unittest.TestCase):
                         new=mock_init):
             self.dataproc_hook = DataProcHook()
 
-    @mock.patch("airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook._authorize")
-    @mock.patch("airflow.contrib.hooks.gcp_dataproc_hook.build")
+    @mock.patch("airflow.gcp.hooks.dataproc.DataProcHook._authorize")
+    @mock.patch("airflow.gcp.hooks.dataproc.build")
     def test_dataproc_client_creation(self, mock_build, mock_authorize):
         result = self.dataproc_hook.get_conn()
         mock_build.assert_called_once_with(

--- a/tests/gcp/hooks/test_dlp.py
+++ b/tests/gcp/hooks/test_dlp.py
@@ -71,6 +71,18 @@ class TestCloudDLPHook(unittest.TestCase):
         ):
             self.hook = CloudDLPHook(gcp_conn_id="test")
 
+    @mock.patch("airflow.gcp.hooks.dlp.CloudDLPHook.client_info", new_callable=mock.PropertyMock)
+    @mock.patch("airflow.gcp.hooks.dlp.CloudDLPHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.dlp.DlpServiceClient")
+    def test_dlp_service_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.hook.get_conn()
+        mock_client.assert_called_once_with(
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.hook._client, result)
+
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )

--- a/tests/gcp/hooks/test_functions.py
+++ b/tests/gcp/hooks/test_functions.py
@@ -37,6 +37,16 @@ class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
                         new=mock_base_gcp_hook_no_default_project_id):
             self.gcf_function_hook_no_project_id = GcfHook(gcp_conn_id='test', api_version='v1')
 
+    @mock.patch("airflow.gcp.hooks.functions.GcfHook._authorize")
+    @mock.patch("airflow.gcp.hooks.functions.build")
+    def test_gcf_client_creation(self, mock_build, mock_authorize):
+        result = self.gcf_function_hook_no_project_id.get_conn()
+        mock_build.assert_called_once_with(
+            'cloudfunctions', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+        self.assertEqual(self.gcf_function_hook_no_project_id._conn, result)
+
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
         new_callable=PropertyMock,
@@ -142,6 +152,16 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
         with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
             self.gcf_function_hook = GcfHook(gcp_conn_id='test', api_version='v1')
+
+    @mock.patch("airflow.gcp.hooks.functions.GcfHook._authorize")
+    @mock.patch("airflow.gcp.hooks.functions.build")
+    def test_gcf_client_creation(self, mock_build, mock_authorize):
+        result = self.gcf_function_hook.get_conn()
+        mock_build.assert_called_once_with(
+            'cloudfunctions', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+        self.assertEqual(self.gcf_function_hook._conn, result)
 
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',

--- a/tests/gcp/hooks/test_gcp_compute_hook.py
+++ b/tests/gcp/hooks/test_gcp_compute_hook.py
@@ -42,6 +42,15 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                         new=mock_base_gcp_hook_no_default_project_id):
             self.gce_hook_no_project_id = GceHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.compute.GceHook._authorize")
+    @mock.patch("airflow.gcp.hooks.compute.build")
+    def test_gce_client_creation(self, mock_build, mock_authorize):
+        result = self.gce_hook_no_project_id.get_conn()
+        mock_build.assert_called_once_with(
+            'compute', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
     def test_start_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):

--- a/tests/gcp/hooks/test_gsheets.py
+++ b/tests/gcp/hooks/test_gsheets.py
@@ -51,6 +51,15 @@ class TestGSheetsHook(unittest.TestCase):
                         new=mock_base_gcp_hook_default_project_id):
             self.hook = GSheetsHook(gcp_conn_id=GCP_CONN_ID, spreadsheet_id=SPREADHSEET_ID)
 
+    @mock.patch("airflow.gcp.hooks.gsheets.GSheetsHook._authorize")
+    @mock.patch("airflow.gcp.hooks.gsheets.build")
+    def test_gsheets_client_creation(self, mock_build, mock_authorize):
+        result = self.hook.get_conn()
+        mock_build.assert_called_once_with(
+            'sheets', 'v4', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+
     @mock.patch("airflow.gcp.hooks.gsheets.GSheetsHook.get_conn")
     def test_get_values(self, get_conn):
         get_method = get_conn.return_value.spreadsheets.return_value.values.return_value.get

--- a/tests/gcp/hooks/test_kms.py
+++ b/tests/gcp/hooks/test_kms.py
@@ -45,6 +45,15 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
                         new=mock_init):
             self.kms_hook = GoogleCloudKMSHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.kms.GoogleCloudKMSHook._authorize")
+    @mock.patch("airflow.gcp.hooks.kms.build")
+    def test_kms_client_creation(self, mock_build, mock_authorize):
+        result = self.kms_hook.get_conn()
+        mock_build.assert_called_once_with(
+            'cloudkms', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+
     @mock.patch(KMS_STRING.format('GoogleCloudKMSHook.get_conn'))
     def test_encrypt(self, mock_service):
         plaintext = b'Test plaintext'

--- a/tests/gcp/hooks/test_kubernetes_engine.py
+++ b/tests/gcp/hooks/test_kubernetes_engine.py
@@ -31,6 +31,27 @@ TEST_GCP_PROJECT_ID = 'test-project'
 GKE_ZONE = 'test-zone'
 
 
+class TestGKEClusterHookClient(unittest.TestCase):
+    def setUp(self):
+        self.gke_hook = GKEClusterHook(location=GKE_ZONE)
+
+    @mock.patch(
+        "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.client_info",
+        new_callable=mock.PropertyMock
+    )
+    @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.kubernetes_engine.container_v1.ClusterManagerClient")
+    def test_gke_cluster_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+
+        result = self.gke_hook.get_client()
+        mock_client.assert_called_once_with(
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.gke_hook._client, result)
+
+
 class TestGKEClusterHookDelete(unittest.TestCase):
     def setUp(self):
         self.gke_hook = GKEClusterHook(location=GKE_ZONE)

--- a/tests/gcp/hooks/test_mlengine.py
+++ b/tests/gcp/hooks/test_mlengine.py
@@ -103,6 +103,16 @@ class TestMLEngineHook(unittest.TestCase):
 
     _SERVICE_URI_PREFIX = 'https://ml.googleapis.com/v1/'
 
+    @mock.patch("airflow.gcp.hooks.mlengine.MLEngineHook._authorize")
+    @mock.patch("airflow.gcp.hooks.mlengine.build")
+    def test_mle_engine_client_creation(self, mock_build, mock_authorize):
+        mle_engine_hook = hook.MLEngineHook()
+        result = mle_engine_hook.get_conn()
+        mock_build.assert_called_with(
+            'ml', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+
     @_SKIP_IF
     def test_create_version(self):
         project = 'test-project'

--- a/tests/gcp/hooks/test_natural_language.py
+++ b/tests/gcp/hooks/test_natural_language.py
@@ -42,6 +42,21 @@ class TestCloudNaturalLanguageHook(unittest.TestCase):
         ):
             self.hook = CloudNaturalLanguageHook(gcp_conn_id="test")
 
+    @mock.patch(
+        "airflow.gcp.hooks.natural_language.CloudNaturalLanguageHook.client_info",
+        new_callable=mock.PropertyMock
+    )
+    @mock.patch("airflow.gcp.hooks.natural_language.CloudNaturalLanguageHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.natural_language.LanguageServiceClient")
+    def test_language_service_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.hook.get_conn()
+        mock_client.assert_called_once_with(
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.hook._conn, result)
+
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.natural_language.CloudNaturalLanguageHook.get_conn",
         **{"return_value.analyze_entities.return_value": API_RESPONSE}  # type: ignore
@@ -49,7 +64,7 @@ class TestCloudNaturalLanguageHook(unittest.TestCase):
     def test_analyze_entities(self, get_conn):
         result = self.hook.analyze_entities(document=DOCUMENT, encoding_type=ENCODING_TYPE)
 
-        self.assertIs(result, API_RESPONSE)
+        self.assertEqual(result, API_RESPONSE)
 
         get_conn.return_value.analyze_entities.assert_called_once_with(
             document=DOCUMENT, encoding_type=ENCODING_TYPE, retry=None, timeout=None, metadata=None
@@ -62,7 +77,7 @@ class TestCloudNaturalLanguageHook(unittest.TestCase):
     def test_analyze_entity_sentiment(self, get_conn):
         result = self.hook.analyze_entity_sentiment(document=DOCUMENT, encoding_type=ENCODING_TYPE)
 
-        self.assertIs(result, API_RESPONSE)
+        self.assertEqual(result, API_RESPONSE)
 
         get_conn.return_value.analyze_entity_sentiment.assert_called_once_with(
             document=DOCUMENT, encoding_type=ENCODING_TYPE, retry=None, timeout=None, metadata=None
@@ -75,7 +90,7 @@ class TestCloudNaturalLanguageHook(unittest.TestCase):
     def test_analyze_sentiment(self, get_conn):
         result = self.hook.analyze_sentiment(document=DOCUMENT, encoding_type=ENCODING_TYPE)
 
-        self.assertIs(result, API_RESPONSE)
+        self.assertEqual(result, API_RESPONSE)
 
         get_conn.return_value.analyze_sentiment.assert_called_once_with(
             document=DOCUMENT, encoding_type=ENCODING_TYPE, retry=None, timeout=None, metadata=None
@@ -88,7 +103,7 @@ class TestCloudNaturalLanguageHook(unittest.TestCase):
     def test_analyze_syntax(self, get_conn):
         result = self.hook.analyze_syntax(document=DOCUMENT, encoding_type=ENCODING_TYPE)
 
-        self.assertIs(result, API_RESPONSE)
+        self.assertEqual(result, API_RESPONSE)
 
         get_conn.return_value.analyze_syntax.assert_called_once_with(
             document=DOCUMENT, encoding_type=ENCODING_TYPE, retry=None, timeout=None, metadata=None
@@ -101,7 +116,7 @@ class TestCloudNaturalLanguageHook(unittest.TestCase):
     def test_annotate_text(self, get_conn):
         result = self.hook.annotate_text(document=DOCUMENT, encoding_type=ENCODING_TYPE, features=None)
 
-        self.assertIs(result, API_RESPONSE)
+        self.assertEqual(result, API_RESPONSE)
 
         get_conn.return_value.annotate_text.assert_called_once_with(
             document=DOCUMENT,
@@ -119,7 +134,7 @@ class TestCloudNaturalLanguageHook(unittest.TestCase):
     def test_classify_text(self, get_conn):
         result = self.hook.classify_text(document=DOCUMENT)
 
-        self.assertIs(result, API_RESPONSE)
+        self.assertEqual(result, API_RESPONSE)
 
         get_conn.return_value.classify_text.assert_called_once_with(
             document=DOCUMENT, retry=None, timeout=None, metadata=None

--- a/tests/gcp/hooks/test_pubsub.py
+++ b/tests/gcp/hooks/test_pubsub.py
@@ -56,6 +56,15 @@ class TestPubSubHook(unittest.TestCase):
                         new=mock_init):
             self.pubsub_hook = PubSubHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.pubsub.PubSubHook._authorize")
+    @mock.patch("airflow.gcp.hooks.pubsub.build")
+    def test_pubsub_client_creation(self, mock_build, mock_authorize):
+        result = self.pubsub_hook.get_conn()
+        mock_build.assert_called_once_with(
+            'pubsub', 'v1', http=mock_authorize.return_value, cache_discovery=False
+        )
+        self.assertEqual(mock_build.return_value, result)
+
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_create_nonexistent_topic(self, mock_service):
         self.pubsub_hook.create_topic(TEST_PROJECT, TEST_TOPIC)

--- a/tests/gcp/hooks/test_spanner.py
+++ b/tests/gcp/hooks/test_spanner.py
@@ -37,6 +37,19 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
                         new=mock_base_gcp_hook_default_project_id):
             self.spanner_hook_default_project_id = CloudSpannerHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.spanner.CloudSpannerHook.client_info", new_callable=mock.PropertyMock)
+    @mock.patch("airflow.gcp.hooks.spanner.CloudSpannerHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.spanner.Client")
+    def test_spanner_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.spanner_hook_default_project_id._get_client(GCP_PROJECT_ID_HOOK_UNIT_TEST)
+        mock_client.assert_called_once_with(
+            project=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.spanner_hook_default_project_id._client, result)
+
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
     def test_get_existing_instance(self, get_client):
         instance_method = get_client.return_value.instance
@@ -392,6 +405,25 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
                         new=mock_base_gcp_hook_no_default_project_id):
             self.spanner_hook_no_default_project_id = CloudSpannerHook(gcp_conn_id='test')
+
+    @mock.patch(
+        "airflow.gcp.hooks.spanner.CloudSpannerHook.client_info",
+        new_callable=mock.PropertyMock
+    )
+    @mock.patch(
+        "airflow.gcp.hooks.spanner.CloudSpannerHook._get_credentials",
+        return_value="CREDENTIALS"
+    )
+    @mock.patch("airflow.gcp.hooks.spanner.Client")
+    def test_spanner_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.spanner_hook_no_default_project_id._get_client(GCP_PROJECT_ID_HOOK_UNIT_TEST)
+        mock_client.assert_called_once_with(
+            project=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.spanner_hook_no_default_project_id._client, result)
 
     @mock.patch(
         'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',

--- a/tests/gcp/hooks/test_tasks.py
+++ b/tests/gcp/hooks/test_tasks.py
@@ -47,6 +47,18 @@ class TestCloudTasksHook(unittest.TestCase):
         ):
             self.hook = CloudTasksHook(gcp_conn_id="test")
 
+    @mock.patch("airflow.gcp.hooks.tasks.CloudTasksHook.client_info", new_callable=mock.PropertyMock)
+    @mock.patch("airflow.gcp.hooks.tasks.CloudTasksHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.tasks.CloudTasksClient")
+    def test_cloud_tasks_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.hook.get_conn()
+        mock_client.assert_called_once_with(
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.hook._client, result)
+
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.tasks.CloudTasksHook.get_conn",
         **{"return_value.create_queue.return_value": API_RESPONSE},  # type: ignore

--- a/tests/gcp/hooks/test_translate.py
+++ b/tests/gcp/hooks/test_translate.py
@@ -34,6 +34,18 @@ class TestCloudTranslateHook(unittest.TestCase):
         ):
             self.hook = CloudTranslateHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.translate.CloudTranslateHook.client_info", new_callable=mock.PropertyMock)
+    @mock.patch("airflow.gcp.hooks.translate.CloudTranslateHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.translate.Client")
+    def test_translate_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.hook.get_conn()
+        mock_client.assert_called_once_with(
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.hook._client, result)
+
     @mock.patch('airflow.gcp.hooks.translate.CloudTranslateHook.get_conn')
     def test_translate_called(self, get_conn):
         # Given

--- a/tests/gcp/hooks/test_video_intelligence.py
+++ b/tests/gcp/hooks/test_video_intelligence.py
@@ -42,6 +42,21 @@ class TestCloudVideoIntelligenceHook(unittest.TestCase):
         ):
             self.hook = CloudVideoIntelligenceHook(gcp_conn_id="test")
 
+    @mock.patch(
+        "airflow.gcp.hooks.video_intelligence.CloudVideoIntelligenceHook.client_info",
+        new_callable=mock.PropertyMock
+    )
+    @mock.patch("airflow.gcp.hooks.video_intelligence.CloudVideoIntelligenceHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.video_intelligence.VideoIntelligenceServiceClient")
+    def test_video_intelligence_service_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.hook.get_conn()
+        mock_client.assert_called_once_with(
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.hook._conn, result)
+
     @mock.patch("airflow.gcp.hooks.video_intelligence.CloudVideoIntelligenceHook.get_conn")
     def test_annotate_video(self, get_conn):
         # Given

--- a/tests/gcp/hooks/test_vision.py
+++ b/tests/gcp/hooks/test_vision.py
@@ -82,6 +82,18 @@ class TestGcpVisionHook(unittest.TestCase):
         ):
             self.hook = CloudVisionHook(gcp_conn_id='test')
 
+    @mock.patch("airflow.gcp.hooks.vision.CloudVisionHook.client_info", new_callable=mock.PropertyMock)
+    @mock.patch("airflow.gcp.hooks.vision.CloudVisionHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.vision.ProductSearchClient")
+    def test_product_search_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+        result = self.hook.get_conn()
+        mock_client.assert_called_once_with(
+            credentials=mock_get_creds.return_value,
+            client_info=mock_client_info.return_value
+        )
+        self.assertEqual(mock_client.return_value, result)
+        self.assertEqual(self.hook._client, result)
+
     @mock.patch('airflow.gcp.hooks.vision.CloudVisionHook.get_conn')
     def test_create_productset_explicit_id(self, get_conn):
         # Given


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5412
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
