### PR TITLE
[AIRFLOW-XXX] Add clarity to gcs_download_operator params

### DIFF
--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -39,12 +39,13 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
     set the ``store_to_xcom_key`` parameter to True push the file content into xcom. When the file size
     exceeds the maximum size for xcom it is recommended to write to a file.
 
-    :param bucket: The Google cloud storage bucket where the object is. (templated)
+    :param bucket: The Google cloud storage bucket where the object is.
+        Must not contain 'gs://' prefix. (templated)
     :type bucket: str
     :param object: The name of the object to download in the Google cloud
         storage bucket. (templated)
     :type object: str
-    :param filename: The file path on the local file system (where the
+    :param filename: The file path, including filename,  on the local file system (where the
         operator is being executed) that the file should be downloaded to. (templated)
         If no filename passed, the downloaded data will not be stored on the local file
         system.


### PR DESCRIPTION
Small docs change to add clarity to the gcs_download_operator parameters