### PR TITLE
[AIRFLOW-5417] Fix DB disconnects during webserver startup

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -90,7 +90,6 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     configure_manifest_files(app)
 
     with app.app_context():
-
         from airflow.www.security import AirflowSecurityManager
         security_manager_class = app.config.get('SECURITY_MANAGER_CLASS') or \
             AirflowSecurityManager
@@ -108,6 +107,9 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
 
         def init_views(appbuilder):
             from airflow.www import views
+            # Remove the session from scoped_session registry to avoid
+            # reusing a session with a disconnected connection
+            appbuilder.session.remove()
             appbuilder.add_view_no_menu(views.Airflow())
             appbuilder.add_view_no_menu(views.DagModelView())
             appbuilder.add_view_no_menu(views.ConfigurationView())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5417

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The current workflow of creating an app in views.py is:

1. Create one DB session
2. Assign it to flask-appbuilder, use the session to help initializing the app.
3. Create DagBag
4. **Reuse the same session** to add permission using flask-appbuilder etc.
    - Reason for us reusing the session is because we use the `scoped_session` w/o a scope function, thus made the session a [thread-local scope session](https://docs.sqlalchemy.org/en/13/orm/contextual.html#thread-local-scope), which will be reused until it is removed. Unfortunately flask-appbuilder doesn't remove the session after a query, [e.g. 1](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/security/sqla/manager.py#L371).

Problem with this is that if during step 3, there's a DB disconnect, step 4 will fail because the session is still attached with the disconnected DB connection and not rolled back. It becomes a bigger problem if step 3 regularly takes a long time, more than the DB connection expire time, step 4 will always fail, which is the case for us currently.

Tried to move the import of views.py to the outer scope but that seem to fail multiple tests. The approach here is to remove the session from the registry and the next session call will just create a new one automatically.

Of course the proper way is to fix the session usage in flask-appbuilder but that would be a longer term fix.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Not really changing the behavior.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
