### PR TITLE
[AIRFLOW-5419] - Use `sudo` to kill cleared tasks when running with impersonation

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -306,7 +306,8 @@ def reap_process_group(pid, log, sig=signal.SIGTERM,
     except OSError as err:
         if err.errno == errno.ESRCH:
             return
-        # If operation not permitted error is thrown due to run_as_user, use sudo -n(--non-interactive) to kill the process
+        # If operation not permitted error is thrown due to run_as_user,
+        # use sudo -n(--non-interactive) to kill the process
         if err.errno == errno.EPERM:
             subprocess.check_call(["sudo", "-n", "-" + str(sig), str(os.getpgid(pid))])
         raise

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -305,6 +305,9 @@ def reap_process_group(pid, log, sig=signal.SIGTERM,
     except OSError as err:
         if err.errno == errno.ESRCH:
             return
+        # If operation not permitted error is thrown due to run_as_user, use sudo to kill the process
+        if err.errno == errno.EPERM:
+            os.system('sudo kill -' + str(sig) + ' ' + str(os.getpgid(pid)))
         raise
 
     _, alive = psutil.wait_procs(children, timeout=timeout, callback=on_terminate)

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -308,7 +308,7 @@ def reap_process_group(pid, log, sig=signal.SIGTERM,
             return
         # If operation not permitted error is thrown due to run_as_user, use sudo to kill the process
         if err.errno == errno.EPERM:
-            subprocess.call('sudo -i kill -' + str(sig) + ' ' + str(os.getpgid(pid)), shell=True)
+            subprocess.check_call(["sudo", "-n", "-" + str(sig), str(os.getpgid(pid))])
         raise
 
     _, alive = psutil.wait_procs(children, timeout=timeout, callback=on_terminate)

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -32,6 +32,7 @@ except ImportError:
 import os
 import re
 import signal
+import subprocess
 
 from jinja2 import Template
 
@@ -307,7 +308,7 @@ def reap_process_group(pid, log, sig=signal.SIGTERM,
             return
         # If operation not permitted error is thrown due to run_as_user, use sudo to kill the process
         if err.errno == errno.EPERM:
-            os.system('sudo kill -' + str(sig) + ' ' + str(os.getpgid(pid)))
+            subprocess.call('sudo -i kill -' + str(sig) + ' ' + str(os.getpgid(pid)), shell=True)
         raise
 
     _, alive = psutil.wait_procs(children, timeout=timeout, callback=on_terminate)

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -306,7 +306,7 @@ def reap_process_group(pid, log, sig=signal.SIGTERM,
     except OSError as err:
         if err.errno == errno.ESRCH:
             return
-        # If operation not permitted error is thrown due to run_as_user, use sudo to kill the process
+        # If operation not permitted error is thrown due to run_as_user, use sudo -n(--non-interactive) to kill the process
         if err.errno == errno.EPERM:
             subprocess.check_call(["sudo", "-n", "-" + str(sig), str(os.getpgid(pid))])
         raise


### PR DESCRIPTION
Marking task failed doesn't kill task, when it is run through impersonation(run_as_user)

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5419) issues and references them in the PR title. 

### Description

- [ ] When a dag is run through impersonation 'run_as_user'. Tasks won't get killed when a SIGTERM is issued either by marking it failed explicitly or by scheduler.

### Tests

- [ ] Existing test cases should take care as it is already covered and this is more of linux process level defect

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] 
