### PR TITLE
[AIRFLOW-5425] Use logging not printing in LoggingCommandExecutor

### DIFF
--- a/tests/contrib/utils/logging_command_executor.py
+++ b/tests/contrib/utils/logging_command_executor.py
@@ -39,7 +39,7 @@ class LoggingCommandExecutor(LoggingMixin):
             self.log.info("Stdout: {}".format(output))
             self.log.info("Stderr: {}".format(err))
             if retcode:
-                print("Error when executing '{}'".format(" ".join(cmd)))
+                self.log.warning("Error when executing %s", " ".join(cmd))
             return retcode
 
     def check_output(self, cmd):


### PR DESCRIPTION
This will show proper message in log (yellow color) which will be harder to miss.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5425

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
