### PR TITLE
[AIRFLOW-5343] Remove legacy way of pessimistic disconnect handling

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -125,11 +125,7 @@ sql_alchemy_pool_recycle = 1800
 # Check connection at the start of each connection pool checkout.
 # Typically, this is a simple statement like “SELECT 1”.
 # More information here: https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
-sql_alchemy_pool_pre_ping = False
-
-# How many seconds to retry re-establishing a DB connection after
-# disconnects. Setting this to 0 disables retries.
-sql_alchemy_reconnect_timeout = 300
+sql_alchemy_pool_pre_ping = True
 
 # The schema to use for the metadata database
 # SqlAlchemy supports databases with the concept of multiple schemas.

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -169,7 +169,7 @@ def configure_orm(disable_connection_pool=False):
         # of some DBAPI-specific method to test the connection for liveness.
         # More information here:
         # https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
-        pool_pre_ping = conf.getboolean('core', 'SQL_ALCHEMY_POOL_PRE_PING', fallback=False)
+        pool_pre_ping = conf.getboolean('core', 'SQL_ALCHEMY_POOL_PRE_PING', fallback=True)
 
         log.info("settings.configure_orm(): Using pool settings. pool_size={}, max_overflow={}, "
                  "pool_recycle={}, pid={}".format(pool_size, max_overflow, pool_recycle, os.getpid()))
@@ -186,8 +186,7 @@ def configure_orm(disable_connection_pool=False):
     engine_args['encoding'] = engine_args['encoding'].__str__()
 
     engine = create_engine(SQL_ALCHEMY_CONN, **engine_args)
-    reconnect_timeout = conf.getint('core', 'SQL_ALCHEMY_RECONNECT_TIMEOUT')
-    setup_event_handlers(engine, reconnect_timeout)
+    setup_event_handlers(engine)
 
     Session = scoped_session(
         sessionmaker(autocommit=False,

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -21,11 +21,9 @@ import datetime
 import os
 import json
 import pendulum
-import time
-import random
 
 from dateutil import relativedelta
-from sqlalchemy import event, exc, select
+from sqlalchemy import event, exc
 from sqlalchemy.types import Text, DateTime, TypeDecorator
 
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -34,73 +32,7 @@ log = LoggingMixin().log
 utc = pendulum.timezone('UTC')
 
 
-def setup_event_handlers(engine,
-                         reconnect_timeout_seconds,
-                         initial_backoff_seconds=0.2,
-                         max_backoff_seconds=120):
-    @event.listens_for(engine, "engine_connect")
-    def ping_connection(connection, branch):  # pylint: disable=unused-variable
-        """
-        Pessimistic SQLAlchemy disconnect handling. Ensures that each
-        connection returned from the pool is properly connected to the database.
-
-        http://docs.sqlalchemy.org/en/rel_1_1/core/pooling.html#disconnect-handling-pessimistic
-        """
-        if branch:
-            # "branch" refers to a sub-connection of a connection,
-            # we don't want to bother pinging on these.
-            return
-
-        start = time.time()
-        backoff = initial_backoff_seconds
-
-        # turn off "close with result".  This flag is only used with
-        # "connectionless" execution, otherwise will be False in any case
-        save_should_close_with_result = connection.should_close_with_result
-
-        while True:
-            connection.should_close_with_result = False
-
-            try:
-                connection.scalar(select([1]))
-                # If we made it here then the connection appears to be healthy
-                break
-            except exc.DBAPIError as err:
-                if time.time() - start >= reconnect_timeout_seconds:
-                    log.error(
-                        "Failed to re-establish DB connection within %s secs: %s",
-                        reconnect_timeout_seconds,
-                        err)
-                    raise
-                if err.connection_invalidated:
-                    # Don't log the first time -- this happens a lot and unless
-                    # there is a problem reconnecting is not a sign of a
-                    # problem
-                    if backoff > initial_backoff_seconds:
-                        log.warning("DB connection invalidated. Reconnecting...")
-                    else:
-                        log.debug("DB connection invalidated. Initial reconnect")
-
-                    # Use a truncated binary exponential backoff. Also includes
-                    # a jitter to prevent the thundering herd problem of
-                    # simultaneous client reconnects
-                    backoff += backoff * random.random()
-                    time.sleep(min(backoff, max_backoff_seconds))
-
-                    # run the same SELECT again - the connection will re-validate
-                    # itself and establish a new connection.  The disconnect detection
-                    # here also causes the whole connection pool to be invalidated
-                    # so that all stale connections are discarded.
-                    continue
-                else:
-                    log.error(
-                        "Unknown database connection error. Not retrying: %s",
-                        err)
-                    raise
-            finally:
-                # restore "close with result"
-                connection.should_close_with_result = save_should_close_with_result
-
+def setup_event_handlers(engine):
     @event.listens_for(engine, "connect")
     def connect(dbapi_connection, connection_record):  # pylint: disable=unused-variable
         connection_record.info['pid'] = os.getpid()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5343
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Based on discussions in https://github.com/apache/airflow/pull/5949 it was figured out that there is already pessimistic disconnect timeout handling. So instead of hand-written one only SQLAlchemy embedded way should be used.

'sqlalchemy~=1.3' is in `setup.py` requirements and `pool_pre_ping` appeared in SQLAlchemy 1.2.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

It's quite an edge case for integrated environment. I'm not quite sure how to test it.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
