### PR TITLE
[AIRFLOW-5437] Do not override python when you rebuild ci_slim image

### DIFF
--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -454,7 +454,9 @@ function rebuild_ci_slim_image_if_needed() {
     export AIRFLOW_CONTAINER_SKIP_CI_IMAGE="true"
     export AIRFLOW_CONTAINER_SKIP_CHECKLICENCE_IMAGE="true"
 
-    export PYTHON_VERSION=3.5  # Always use python version 3.5 for static checks
+    # Temporary force python version 3.5 for static checks
+    export OLD_PYTHON_VERSION=${PYTHON_VERSION=""}
+    export PYTHON_VERSION=3.5
 
     export THE_IMAGE_TYPE="SLIM_CI"
 
@@ -462,6 +464,8 @@ function rebuild_ci_slim_image_if_needed() {
 
     AIRFLOW_SLIM_CI_IMAGE=$(cat "${BUILD_CACHE_DIR}/.AIRFLOW_SLIM_CI_IMAGE") || true 2>/dev/null
     export AIRFLOW_SLIM_CI_IMAGE
+    export PYTHON_VERSION=${OLD_PYTHON_VERSION}
+
 }
 
 #


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

Yet another issue with overriding python version for breeze. I made it resilient to such errors.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5437

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
