### PR TITLE
[AIRFLOW-5376] Add coverage package back to devel extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -269,6 +269,8 @@ all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant + druid + 
 devel = [
     'beautifulsoup4~=4.7.1',
     'click==6.7',
+    'contextdecorator;python_version<"3.4"',
+    'coverage',
     'dumb-init>=1.2.2',
     'flake8>=3.6.0',
     'flake8-colors',

--- a/setup.py
+++ b/setup.py
@@ -266,6 +266,11 @@ zendesk = ['zdesk']
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant + druid + pinot + cassandra + mongo
 
+############################################################################################################
+# IMPORTANT NOTE!!!!!!!!!!!!!!!
+# IF you are removing dependencies from this list, please make sure that you also increase
+# DEPENDENCIES_EPOCH_NUMBER in the Dockerfile
+############################################################################################################
 devel = [
     'beautifulsoup4~=4.7.1',
     'click==6.7',
@@ -293,6 +298,11 @@ devel = [
     'requests_mock',
     'yamllint'
 ]
+############################################################################################################
+# IMPORTANT NOTE!!!!!!!!!!!!!!!
+# IF you are removing dependencies from the above list, please make sure that you also increase
+# DEPENDENCIES_EPOCH_NUMBER in the Dockerfile
+############################################################################################################
 
 if PY3:
     devel += ['mypy']
@@ -330,6 +340,11 @@ def do_setup():
         include_package_data=True,
         zip_safe=False,
         scripts=['airflow/bin/airflow'],
+        #####################################################################################################
+        # IMPORTANT NOTE!!!!!!!!!!!!!!!
+        # IF you are removing dependencies from this list, please make sure that you also increase
+        # DEPENDENCIES_EPOCH_NUMBER in the Dockerfile
+        #####################################################################################################
         install_requires=[
             'alembic>=1.0, <2.0',
             'argcomplete~=1.10',
@@ -372,6 +387,11 @@ def do_setup():
             'zope.deprecation>=4.0, <5.0',
             'typing-extensions>=3.7.4;python_version<"3.8"',
         ],
+        #####################################################################################################
+        # IMPORTANT NOTE!!!!!!!!!!!!!!!
+        # IF you are removing dependencies from this list, please make sure that you also increase
+        # DEPENDENCIES_EPOCH_NUMBER in the Dockerfile
+        #####################################################################################################
         setup_requires=[
             'docutils>=0.14, <1.0',
             'gitpython>=2.0.2',


### PR DESCRIPTION
OK. I know what happened exactly. It was my mistake. 

When I moved code coverage reporting with codecov to outside script (where it should be), I removed codecov as dependency (#5732). It also had transitive dependency to coverage package, so when the images got refreshed some time later, the coverage dependency was gone and no coverage information was reported any more.

Adding coverage package should fix it hopefully.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
