### PR TITLE
[AIRFLOW-5441] Ownership of package*.json file group write is fixed

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -572,7 +572,10 @@ if  [[ "${AIRFLOW_FIX_PERMISSIONS}" == "all" || "${AIRFLOW_FIX_PERMISSIONS}" == 
             ${AIRFLOW_ROOT}/setup.cfg \
             ${AIRFLOW_ROOT}/airflow/version.py \
             ${AIRFLOW_ROOT}/airflow/__init__.py \
-            ${AIRFLOW_ROOT}/airflow/bin/airflow"
+            ${AIRFLOW_ROOT}/airflow/bin/airflow \
+            ${AIRFLOW_ROOT}/airflow/www/package.json \
+            ${AIRFLOW_ROOT}/airflow/www/package-lock.json \
+            "
     fi
     STAT_BIN=stat
     if [[ "${OSTYPE}" == "darwin"* ]]; then


### PR DESCRIPTION
When you use Breeze and you specify "--force-pull" flag, the latest image from
DockerHub is pulled before you attempt to rebuild the image. Currently in
breeze we used an optimised version of "fix-permission" script that only fixes
permissions of several files in the context (the workaround for different
roup write umask setting in DockerHub). However we did not have package.json
and package-lock.json on the list so those files were always seen as "changed"
and npm was reinstalled for the first time (and only the first time) when the
image was force pulled.

After fixing this, the of --force-pull breeze commands will be much faster -
skipping the whole npm package reinstallation. Depending on your network speed,
this might be between 20 seconds to several minutes as npm ci command wipes out
everything and downloads a lot of packages.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5441

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
