### PR TITLE
[AIRFLOW-5444] Fix action_logging so that request.form for POST is logged

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -43,13 +43,13 @@ def action_logging(f):
                 event=f.__name__,
                 task_instance=None,
                 owner=user,
-                extra=str(list(request.args.items())),
-                task_id=request.args.get('task_id'),
-                dag_id=request.args.get('dag_id'))
+                extra=str(list(request.values.items())),
+                task_id=request.values.get('task_id'),
+                dag_id=request.values.get('dag_id'))
 
-            if 'execution_date' in request.args:
+            if 'execution_date' in request.values:
                 log.execution_date = pendulum.parse(
-                    request.args.get('execution_date'))
+                    request.values.get('execution_date'))
 
             session.add(log)
 


### PR DESCRIPTION
- Log request.form when request.method is POST
- Add a test for action_logging

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues
  - https://issues.apache.org/jira/browse/AIRFLOW-5444

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
When user performs actions such as "clear", "success" or "failed" on the WebUI, important parameters such as dag_id, task_id and execution_date are not logged by action_logging because the values are in request.form rather than request.args. This PR fixes the issue.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added tests.www.test_views:TestDecorators to check for the scenario where request.method is GET and POST.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
