### PR TITLE
[AIRFLOW-5448] Handle istio-proxy for Kubernetes Executor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -232,6 +232,7 @@ kerberos = ['pykerberos>=1.1.13',
             'thrift_sasl>=0.2.0',
             'snakebite[kerberos]>=2.7.8']
 kubernetes = ['kubernetes>=3.0.0',
+              'packaging>=19.1',
               'cryptography>=2.0.0']
 ldap = ['ldap3>=2.5.1']
 mssql = ['pymssql>=2.1.1']


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5448) issues and references them in the PR title.

### Description

- [x] Here are some details about my PR:

Istio service mesh is not compatible by default with Kubernetes Jobs. The normal behavior is that a Job will be started, get an istio-proxy sidecar attached to it via the istio mutating webhook, run until completion, then the 'main' container in the pod stops, but istio-proxy hangs around indefinitely. This applies to the Kubernetes Executor.

Very recently, Istio implemented an endpoint that can be called to cleanly exit the proxy, specifically designed for this use case.

explanation: https://github.com/istio/istio/issues/15041
istio PR implementing it: https://github.com/istio/istio/pull/15406
Astronomer will make a contribution to handle cleanly exit the istio-proxy by default. This will help Astronomer and other Airflow users making use of the Kubernetes Executor in combination with Istio.

Here a PR I am closing in favor of contributing to upstream: https://github.com/astronomer/airflow/pull/47

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

 - [x] All the public functions and the classes in the PR contain docstrings that explain what it does
