### PR TITLE
[AIRFLOW-5451] SparkSubmitHook don't set default namespace

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -175,7 +175,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                      'deploy_mode': None,
                      'spark_home': None,
                      'spark_binary': self._spark_binary or "spark-submit",
-                     'namespace': 'default'}
+                     'namespace': None}
 
         try:
             # Master can be local, yarn, spark://HOST:PORT, mesos://HOST:PORT and
@@ -193,7 +193,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             conn_data['spark_home'] = extra.get('spark-home', None)
             conn_data['spark_binary'] = self._spark_binary or  \
                 extra.get('spark-binary', "spark-submit")
-            conn_data['namespace'] = extra.get('namespace', 'default')
+            conn_data['namespace'] = extra.get('namespace')
         except AirflowException:
             self.log.info(
                 "Could not load connection string %s, defaulting to %s",
@@ -246,7 +246,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         elif self._env_vars and self._connection['deploy_mode'] == "cluster":
             raise AirflowException(
                 "SparkSubmitHook env_vars is not supported in standalone-cluster mode.")
-        if self._is_kubernetes:
+        if self._is_kubernetes and self._connection['namespace']:
             connection_cmd += ["--conf", "spark.kubernetes.namespace={}".format(
                 self._connection['namespace'])]
         if self._files:

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -244,7 +244,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": None,
                                      "spark_home": None,
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(dict_cmd["--master"], "yarn")
 
@@ -263,7 +263,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": "root.default",
                                      "spark_home": None,
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(dict_cmd["--master"], "yarn")
         self.assertEqual(dict_cmd["--queue"], "root.default")
@@ -283,7 +283,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": None,
                                      "spark_home": None,
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(dict_cmd["--master"], "mesos://host:5050")
 
@@ -302,7 +302,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": "cluster",
                                      "queue": "root.etl",
                                      "spark_home": None,
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(dict_cmd["--master"], "yarn://yarn-master")
         self.assertEqual(dict_cmd["--queue"], "root.etl")
@@ -342,7 +342,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": None,
                                      "spark_home": "/opt/myspark",
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(cmd[0], '/opt/myspark/bin/spark-submit')
 
@@ -360,7 +360,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": None,
                                      "spark_home": None,
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(cmd[0], 'spark-submit')
 
@@ -378,7 +378,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": None,
                                      "spark_home": None,
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(cmd[0], 'custom-spark-submit')
 
@@ -397,7 +397,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": None,
                                      "spark_home": None,
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(cmd[0], 'another-custom-spark-submit')
 
@@ -415,7 +415,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": 'root.default',
                                      "spark_home": None,
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(cmd[0], 'spark-submit')
 
@@ -433,7 +433,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": None,
                                      "queue": None,
                                      "spark_home": "/path/to/spark_home",
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(cmd[0], '/path/to/spark_home/bin/custom-spark-submit')
 
@@ -451,7 +451,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                                      "deploy_mode": "cluster",
                                      "queue": None,
                                      "spark_home": "/path/to/spark_home",
-                                     "namespace": 'default'}
+                                     "namespace": None}
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(cmd[0], '/path/to/spark_home/bin/spark-submit')
 


### PR DESCRIPTION
We only want to set the namespace if it isn't `default`. The default is already set by Spark: https://spark.apache.org/docs/latest/running-on-kubernetes.html#configuration. This also allows us to pass the namespace over the `_conf` dict. Otherwise, the namespace would be set twice. From a behavioral perspective this makes also more sense, if the namespace is omitted in the connection, we also omit it from the command line arguments.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
