### PR TITLE
[AIRFLOW-5266] Allow aws_athena_hook to get all query results

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_athena.py
+++ b/tests/providers/amazon/aws/hooks/test_athena.py
@@ -1,0 +1,172 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import unittest
+from unittest import mock
+
+from airflow.providers.amazon.aws.hooks.athena import AWSAthenaHook
+
+MOCK_DATA = {
+    'query': 'SELECT * FROM TEST_TABLE',
+    'database': 'TEST_DATABASE',
+    'outputLocation': 's3://test_s3_bucket/',
+    'client_request_token': 'eac427d0-1c6d-4dfb-96aa-2835d3ac6595',
+    'workgroup': 'primary',
+    'query_execution_id': 'eac427d0-1c6d-4dfb-96aa-2835d3ac6595',
+    'next_token_id': 'eac427d0-1c6d-4dfb-96aa-2835d3ac6595',
+    'max_items': 1000
+}
+
+mock_query_context = {
+    'Database': MOCK_DATA['database']
+}
+mock_result_configuration = {
+    'OutputLocation': MOCK_DATA['outputLocation']
+}
+
+MOCK_RUNNING_QUERY_EXECUTION = {'QueryExecution': {'Status': {'State': 'RUNNING'}}}
+MOCK_SUCCEEDED_QUERY_EXECUTION = {'QueryExecution': {'Status': {'State': 'SUCCEEDED'}}}
+
+MOCK_QUERY_EXECUTION = {'QueryExecutionId': MOCK_DATA['query_execution_id']}
+
+
+class TestAWSAthenaHook(unittest.TestCase):
+
+    def setUp(self):
+        self.athena = AWSAthenaHook(sleep_time=0)
+
+    def test_init(self):
+        self.assertEqual(self.athena.aws_conn_id, 'aws_default')
+        self.assertEqual(self.athena.sleep_time, 0)
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_run_query_without_token(self, mock_conn):
+        mock_conn.return_value.start_query_execution.return_value = MOCK_QUERY_EXECUTION
+        result = self.athena.run_query(query=MOCK_DATA['query'],
+                                       query_context=mock_query_context,
+                                       result_configuration=mock_result_configuration)
+        expected_call_params = {
+            'QueryString': MOCK_DATA['query'],
+            'QueryExecutionContext': mock_query_context,
+            'ResultConfiguration': mock_result_configuration,
+            'WorkGroup': MOCK_DATA['workgroup']
+        }
+        mock_conn.return_value.start_query_execution.assert_called_with(**expected_call_params)
+        self.assertEqual(result, MOCK_DATA['query_execution_id'])
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_run_query_with_token(self, mock_conn):
+        mock_conn.return_value.start_query_execution.return_value = MOCK_QUERY_EXECUTION
+        result = self.athena.run_query(query=MOCK_DATA['query'],
+                                       query_context=mock_query_context,
+                                       result_configuration=mock_result_configuration,
+                                       client_request_token=MOCK_DATA['client_request_token'])
+        expected_call_params = {
+            'QueryString': MOCK_DATA['query'],
+            'QueryExecutionContext': mock_query_context,
+            'ResultConfiguration': mock_result_configuration,
+            'ClientRequestToken': MOCK_DATA['client_request_token'],
+            'WorkGroup': MOCK_DATA['workgroup']
+        }
+        mock_conn.return_value.start_query_execution.assert_called_with(**expected_call_params)
+        self.assertEqual(result, MOCK_DATA['query_execution_id'])
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_get_query_results_with_non_succeeded_query(self, mock_conn):
+        mock_conn.return_value.get_query_execution.return_value = MOCK_RUNNING_QUERY_EXECUTION
+        result = self.athena.get_query_results(query_execution_id=MOCK_DATA['query_execution_id'])
+        self.assertIsNone(result)
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_get_query_results_with_default_params(self, mock_conn):
+        mock_conn.return_value.get_query_execution.return_value = MOCK_SUCCEEDED_QUERY_EXECUTION
+        self.athena.get_query_results(query_execution_id=MOCK_DATA['query_execution_id'])
+        expected_call_params = {
+            'QueryExecutionId': MOCK_DATA['query_execution_id'],
+            'MaxResults': 1000
+        }
+        mock_conn.return_value.get_query_results.assert_called_with(**expected_call_params)
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_get_query_results_with_next_token(self, mock_conn):
+        mock_conn.return_value.get_query_execution.return_value = MOCK_SUCCEEDED_QUERY_EXECUTION
+        self.athena.get_query_results(query_execution_id=MOCK_DATA['query_execution_id'],
+                                      next_token_id=MOCK_DATA['next_token_id'])
+        expected_call_params = {
+            'QueryExecutionId': MOCK_DATA['query_execution_id'],
+            'NextToken': MOCK_DATA['next_token_id'],
+            'MaxResults': 1000
+        }
+        mock_conn.return_value.get_query_results.assert_called_with(**expected_call_params)
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_get_paginator_with_non_succeeded_query(self, mock_conn):
+        mock_conn.return_value.get_query_execution.return_value = MOCK_RUNNING_QUERY_EXECUTION
+        result = self.athena.get_query_results_paginator(query_execution_id=MOCK_DATA['query_execution_id'])
+        self.assertIsNone(result)
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_get_paginator_with_default_params(self, mock_conn):
+        mock_conn.return_value.get_query_execution.return_value = MOCK_SUCCEEDED_QUERY_EXECUTION
+        self.athena.get_query_results_paginator(query_execution_id=MOCK_DATA['query_execution_id'])
+        expected_call_params = {
+            'QueryExecutionId': MOCK_DATA['query_execution_id'],
+            'PaginationConfig': {
+                'MaxItems': None,
+                'PageSize': None,
+                'StartingToken': None
+
+            }
+        }
+        mock_conn.return_value.get_paginator.return_value.paginate.assert_called_with(**expected_call_params)
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_get_paginator_with_pagination_config(self, mock_conn):
+        mock_conn.return_value.get_query_execution.return_value = MOCK_SUCCEEDED_QUERY_EXECUTION
+        self.athena.get_query_results_paginator(query_execution_id=MOCK_DATA['query_execution_id'],
+                                                max_items=MOCK_DATA['max_items'],
+                                                page_size=MOCK_DATA['max_items'],
+                                                starting_token=MOCK_DATA['next_token_id'])
+        expected_call_params = {
+            'QueryExecutionId': MOCK_DATA['query_execution_id'],
+            'PaginationConfig': {
+                'MaxItems': MOCK_DATA['max_items'],
+                'PageSize': MOCK_DATA['max_items'],
+                'StartingToken': MOCK_DATA['next_token_id']
+
+            }
+        }
+        mock_conn.return_value.get_paginator.return_value.paginate.assert_called_with(**expected_call_params)
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_poll_query_when_final(self, mock_conn):
+        mock_conn.return_value.get_query_execution.return_value = MOCK_SUCCEEDED_QUERY_EXECUTION
+        result = self.athena.poll_query_status(query_execution_id=MOCK_DATA['query_execution_id'])
+        mock_conn.return_value.get_query_execution.assert_called_once()
+        self.assertEqual(result, 'SUCCEEDED')
+
+    @mock.patch.object(AWSAthenaHook, 'get_conn')
+    def test_hook_poll_query_with_timeout(self, mock_conn):
+        mock_conn.return_value.get_query_execution.return_value = MOCK_RUNNING_QUERY_EXECUTION
+        result = self.athena.poll_query_status(query_execution_id=MOCK_DATA['query_execution_id'],
+                                               max_tries=1)
+        mock_conn.return_value.get_query_execution.assert_called_once()
+        self.assertEqual(result, 'RUNNING')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -28,7 +28,6 @@ ROOT_FOLDER = os.path.realpath(
 )
 
 MISSING_TEST_FILES = {
-    'tests/providers/amazon/aws/hooks/test_athena.py',
     'tests/providers/apache/cassandra/sensors/test_record.py',
     'tests/providers/apache/cassandra/sensors/test_table.py',
     'tests/providers/apache/hdfs/sensors/test_web_hdfs.py',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5266#Athena.Client.get_query_results%5D) issues and references them in the PR title. 

### Description

- [x] The previous version of the hook returned up to 1000 results. The update allows the user to set the max results (default and max constrained by the api is 1000) and also the NextTokenId.  
- [x] The client request token in the run_query function is now truly optional. Boto3 doesn't allow you to send in parameters that are set to None.
- [x] Another function was added to return a paginator for the query results. 

### Tests

- [x] My PR adds the following unit tests:
tests/providers/amazon/aws/hooks/test_athena.py 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
