### PR TITLE
[AIRFLOW-5465] Fix deprecated imports in examples

### DIFF
--- a/airflow/gcp/example_dags/example_cloud_memorystore.py
+++ b/airflow/gcp/example_dags/example_cloud_memorystore.py
@@ -25,7 +25,7 @@ from urllib.parse import urlparse
 from google.cloud.redis_v1.gapic.enums import Instance, FailoverInstanceRequest
 
 from airflow import models
-from airflow.contrib.operators.gcs_acl_operator import GoogleCloudStorageBucketCreateAclEntryOperator
+from airflow.gcp.operators.gcs import GoogleCloudStorageBucketCreateAclEntryOperator
 from airflow.gcp.operators.cloud_memorystore import (
     CloudMemorystoreCreateInstanceOperator,
     CloudMemorystoreDeleteInstanceOperator,

--- a/airflow/gcp/example_dags/example_cloud_sql.py
+++ b/airflow/gcp/example_dags/example_cloud_sql.py
@@ -38,7 +38,7 @@ from airflow.gcp.operators.cloud_sql import CloudSqlInstanceCreateOperator, \
     CloudSqlInstanceDatabaseCreateOperator, CloudSqlInstanceDatabasePatchOperator, \
     CloudSqlInstanceDatabaseDeleteOperator, CloudSqlInstanceExportOperator, \
     CloudSqlInstanceImportOperator
-from airflow.contrib.operators.gcs_acl_operator import \
+from airflow.gcp.operators.gcs import \
     GoogleCloudStorageBucketCreateAclEntryOperator, \
     GoogleCloudStorageObjectCreateAclEntryOperator
 

--- a/airflow/gcp/operators/dataproc.py
+++ b/airflow/gcp/operators/dataproc.py
@@ -30,7 +30,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import List, Dict, Set, Optional
 
-from airflow.contrib.hooks.gcp_dataproc_hook import DataProcHook
+from airflow.gcp.hooks.dataproc import DataProcHook
 from airflow.gcp.hooks.gcs import GoogleCloudStorageHook
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5465

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
