### PR TITLE
[AIRFLOW-5349] Add schedulername option for KubernetesPodOperator

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -122,6 +122,8 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     :type pod_runtime_info_envs: list[airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv]
     :param dnspolicy: dnspolicy for the pod.
     :type dnspolicy: str
+    :param schedulername: Specify a schedulername for the pod
+    :type schedulername: str
     :param full_pod_spec: The complete podSpec
     :type full_pod_spec: kubernetes.client.models.V1Pod
     :param do_xcom_push: If True, the content of the file
@@ -163,6 +165,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  security_context: Optional[Dict] = None,
                  pod_runtime_info_envs: Optional[List[PodRuntimeInfoEnv]] = None,
                  dnspolicy: Optional[str] = None,
+                 schedulername: Optional[str] = None,
                  full_pod_spec: Optional[k8s.V1Pod] = None,
                  *args,
                  **kwargs):
@@ -202,6 +205,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.security_context = security_context or {}
         self.pod_runtime_info_envs = pod_runtime_info_envs or []
         self.dnspolicy = dnspolicy
+        self.schedulername = schedulername
         self.full_pod_spec = full_pod_spec
 
     def execute(self, context):
@@ -239,6 +243,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                 configmaps=self.configmaps,
                 security_context=self.security_context,
                 dnspolicy=self.dnspolicy,
+                schedulername=self.schedulername,
                 pod=self.full_pod_spec,
             ).gen_pod()
 

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -87,6 +87,8 @@ class PodGenerator:
     :type configmaps: List[str]
     :param dnspolicy: Specify a dnspolicy for the pod
     :type dnspolicy: str
+    :param schedulername: Specify a schedulername for the pod
+    :type schedulername: str
     :param pod: The fully specified pod.
     :type pod: kubernetes.client.models.V1Pod
     """
@@ -116,6 +118,7 @@ class PodGenerator:
         security_context=None,
         configmaps=None,
         dnspolicy=None,
+        schedulername=None,
         pod=None,
         extract_xcom=False,
     ):
@@ -167,6 +170,7 @@ class PodGenerator:
         self.spec.security_context = security_context
         self.spec.tolerations = tolerations
         self.spec.dns_policy = dnspolicy
+        self.spec.scheduler_name = schedulername
         self.spec.host_network = hostnetwork
         self.spec.affinity = affinity
         self.spec.service_account_name = service_account_name
@@ -274,6 +278,7 @@ class PodGenerator:
             security_context=namespaced.get('security_context'),
             configmaps=namespaced.get('configmaps'),
             dnspolicy=namespaced.get('dnspolicy'),
+            schedulername=namespaced.get('schedulername'),
             pod=namespaced.get('pod'),
             extract_xcom=namespaced.get('extract_xcom'),
         )

--- a/tests/integration/kubernetes/test_kubernetes_pod_operator.py
+++ b/tests/integration/kubernetes/test_kubernetes_pod_operator.py
@@ -264,6 +264,25 @@ class TestKubernetesPodOperator(unittest.TestCase):
         self.expected_pod['spec']['dnsPolicy'] = dns_policy
         self.assertEqual(self.expected_pod, actual_pod)
 
+    def test_pod_schedulername(self):
+        scheduler_name = "default-scheduler"
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            schedulername=scheduler_name
+        )
+        k.execute(None)
+        actual_pod = self.api_client.sanitize_for_serialization(k.pod)
+        self.expected_pod['spec']['schedulerName'] = scheduler_name
+        self.assertEqual(self.expected_pod, actual_pod)
+
     def test_pod_node_selectors(self):
         node_selectors = {
             'beta.kubernetes.io/os': 'linux'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5349

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Kubernetes PODs might be [specified with explicit scheduler](https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/#specify-schedulers-for-pods). This feature, however, is currently not available from the `KubernetesPodOperator` API.

I am offering simple PR that adds this option via a `schedulername` parameter.

### Tests

- [x] My PR adds the following unit tests:
   - `tests.minikube.test_kubernetes_pod_operator.test_pod_schedulername`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`