### PR TITLE
[AIRFLOW-5474] Add Basic auth to Druid hook

### DIFF
--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -31,6 +31,9 @@ class DruidHook(BaseHook):
     """
     Connection to Druid overlord for ingestion
 
+    To connect to a Druid cluster that is secured with the druid-basic-security
+    extension, add the username and password to the druid ingestion connection.
+
     :param druid_ingest_conn_id: The connection id to the Druid overlord machine
                                  which accepts index jobs
     :type druid_ingest_conn_id: str
@@ -65,6 +68,11 @@ class DruidHook(BaseHook):
             conn_type=conn_type, host=host, port=port, endpoint=endpoint)
 
     def get_auth(self):
+        """
+        Return username and password from connections tab as requests.auth.HTTPBasicAuth object.
+
+        If these details have not been set then returns None.
+        """
         conn = self.get_connection(self.druid_ingest_conn_id)
         user = conn.login
         password = conn.password

--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -64,11 +64,20 @@ class DruidHook(BaseHook):
         return "{conn_type}://{host}:{port}/{endpoint}".format(
             conn_type=conn_type, host=host, port=port, endpoint=endpoint)
 
+    def get_auth(self):
+        conn = self.get_connection(self.druid_ingest_conn_id)
+        user = conn.login
+        password = conn.password
+        if user is not None and password is not None:
+            return requests.auth.HTTPBasicAuth(user, password)
+        else:
+            return None
+
     def submit_indexing_job(self, json_index_spec):
         url = self.get_conn_url()
 
         self.log.info("Druid ingestion spec: %s", json_index_spec)
-        req_index = requests.post(url, json=json_index_spec, headers=self.header)
+        req_index = requests.post(url, json=json_index_spec, headers=self.header, auth=self.get_auth())
         if req_index.status_code != 200:
             raise AirflowException('Did not get 200 when '
                                    'submitting the Druid job to {}'.format(url))
@@ -82,13 +91,13 @@ class DruidHook(BaseHook):
 
         sec = 0
         while running:
-            req_status = requests.get("{0}/{1}/status".format(url, druid_task_id))
+            req_status = requests.get("{0}/{1}/status".format(url, druid_task_id), auth=self.get_auth())
 
             self.log.info("Job still running for %s seconds...", sec)
 
             if self.max_ingestion_time and sec > self.max_ingestion_time:
                 # ensure that the job gets killed if the max ingestion time is exceeded
-                requests.post("{0}/{1}/shutdown".format(url, druid_task_id))
+                requests.post("{0}/{1}/shutdown".format(url, druid_task_id), auth=self.get_auth())
                 raise AirflowException('Druid ingestion took more than '
                                        '%s seconds', self.max_ingestion_time)
 

--- a/tests/hooks/test_druid_hook.py
+++ b/tests/hooks/test_druid_hook.py
@@ -134,6 +134,39 @@ class TestDruidHook(unittest.TestCase):
         hook = DruidHook(timeout=1, max_ingestion_time=5)
         self.assertEqual(hook.get_conn_url(), 'https://test_host:1/ingest')
 
+    @patch('airflow.hooks.druid_hook.DruidHook.get_connection')
+    def test_get_auth(self, mock_get_connection):
+        get_conn_value = MagicMock()
+        get_conn_value.login = 'airflow'
+        get_conn_value.password = 'password'
+        mock_get_connection.return_value = get_conn_value
+        expected = requests.auth.HTTPBasicAuth('airflow', 'password')
+        self.assertEqual(self.db_hook.get_auth(), expected)
+
+    @patch('airflow.hooks.druid_hook.DruidHook.get_connection')
+    def test_get_auth_with_no_user(self, mock_get_connection):
+        get_conn_value = MagicMock()
+        get_conn_value.login = None
+        get_conn_value.password = 'password'
+        mock_get_connection.return_value = get_conn_value
+        self.assertEqual(self.db_hook.get_auth(), None)
+
+    @patch('airflow.hooks.druid_hook.DruidHook.get_connection')
+    def test_get_auth_with_no_password(self, mock_get_connection):
+        get_conn_value = MagicMock()
+        get_conn_value.login = 'airflow'
+        get_conn_value.password = None
+        mock_get_connection.return_value = get_conn_value
+        self.assertEqual(self.db_hook.get_auth(), None)
+
+    @patch('airflow.hooks.druid_hook.DruidHook.get_connection')
+    def test_get_auth_with_no_user_and_password(self, mock_get_connection):
+        get_conn_value = MagicMock()
+        get_conn_value.login = None
+        get_conn_value.password = None
+        mock_get_connection.return_value = get_conn_value
+        self.assertEqual(self.db_hook.get_auth(), None)
+
 
 class TestDruidDbApiHook(unittest.TestCase):
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5474) issues and references them in the PR title.
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds Basic HTTP auth to the druid hook using the login and password credentials from the druid ingestion connection. This allows Airflow to send ingestion tasks to a Druid cluster that has the druid-basic-security extension enabled. If the login and/or password is left blank then the druid hook will continue to work as before.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added tests which passed after running this command `./breeze --test-target tests/hooks/test_druid_hook.py -- --logging-level=DEBUG`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
