### PR TITLE
[AIRFLOW-4309] Remove Broken Dag error after Dag is deleted

### DIFF
--- a/airflow/api/common/experimental/delete_dag.py
+++ b/airflow/api/common/experimental/delete_dag.py
@@ -55,4 +55,10 @@ def delete_dag(dag_id: str, keep_records_in_log: bool = True, session=None) -> i
             count += session.query(model).filter(model.dag_id == parent_dag_id,
                                                  model.task_id == task_id).delete()
 
+    # Delete entries in Import Errors table for a deleted DAG
+    # This handles the case when the dag_id is changed in the file
+    session.query(models.ImportError).filter(
+        models.ImportError.filename == dag.fileloc
+    ).delete(synchronize_session='fetch')
+
     return count

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -24,6 +24,7 @@ from airflow.models.dag import DAG, DagModel  # noqa: F401
 from airflow.models.dagbag import DagBag  # noqa: F401
 from airflow.models.dagpickle import DagPickle  # noqa: F401
 from airflow.models.dagrun import DagRun  # noqa: F401
+from airflow.models.errors import ImportError  # noqa: F401, pylint:disable=redefined-builtin
 from airflow.models.kubernetes import KubeWorkerIdentifier, KubeResourceVersion  # noqa: F401
 from airflow.models.log import Log  # noqa: F401
 from airflow.models.pool import Pool  # noqa: F401


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4309

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
If the DAGs have import errors and then if the file is fixed and dag_id is changed without deleting the file, the import error persists. Check Jira for details.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`TestDeleteDAGSuccessfulDelete.test_delete_dag_successful_delete` updated

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
