### PR TITLE
[AIRFLOW-5482] Deprecate Schedule Interval on task level

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -249,7 +249,6 @@ class BaseOperator(LoggingMixin):
         'retry_exponential_backoff',
         'max_retry_delay',
         'start_date',
-        'schedule_interval',
         'depends_on_past',
         'wait_for_downstream',
         'priority_weight',
@@ -275,7 +274,6 @@ class BaseOperator(LoggingMixin):
         max_retry_delay: Optional[datetime] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
-        schedule_interval: Optional[ScheduleInterval] = None,  # not hooked as of now
         depends_on_past: bool = False,
         wait_for_downstream: bool = False,
         dag: Optional[DAG] = None,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -343,14 +343,6 @@ class BaseOperator(LoggingMixin):
         if wait_for_downstream:
             self.depends_on_past = True
 
-        if schedule_interval:
-            self.log.warning(
-                "schedule_interval is used for %s, though it has "
-                "been deprecated as a task parameter, you need to "
-                "specify it as a DAG parameter instead",
-                self
-            )
-        self._schedule_interval = schedule_interval
         self.retries = retries if retries is not None else \
             conf.getint('core', 'default_task_retries', fallback=0)
         self.queue = queue
@@ -542,18 +534,6 @@ class BaseOperator(LoggingMixin):
             PrevDagrunDep(),
             TriggerRuleDep(),
         }
-
-    @property
-    def schedule_interval(self):
-        """
-        The schedule interval of the DAG always wins over individual tasks so
-        that tasks within a DAG always line up. The task still needs a
-        schedule_interval as it may not be attached to a DAG.
-        """
-        if self.has_dag():
-            return self.dag._schedule_interval
-        else:
-            return self._schedule_interval
 
     @property
     def priority_weight_total(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5482


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

It has been 4 years since it was deprecated. https://github.com/apache/airflow/commit/3e8bb2abf18c3a130c52288e25f5f7d114e407ad



### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
