### PR TITLE
[AIRFLOW-5447] Scheduler stalls because second watcher thread in default args

### DIFF
--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -77,11 +77,11 @@ class BaseJob(Base, LoggingMixin):
 
     def __init__(
             self,
-            executor=executors.get_default_executor(),
+            executor=None,
             heartrate=None,
             *args, **kwargs):
         self.hostname = get_hostname()
-        self.executor = executor
+        self.executor = executor or executors.get_default_executor()
         self.executor_class = executor.__class__.__name__
         self.start_date = timezone.utcnow()
         self.latest_heartbeat = timezone.utcnow()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5447
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Starting in 1.10.4, and continuing in 1.10.5, when using the KubernetesExecutor, with the webserver and scheduler running in the kubernetes cluster, tasks are scheduled, but when added to the task queue, the executor process hangs indefinitely. Based on log messages, it appears to be stuck at this line https://github.com/apache/airflow/blob/v1-10-stable/airflow/contrib/executors/kubernetes_executor.py#L761

"The call to get a default executor was being executed at module import time. If this module is imported by a DAG, it can lead to two executors running in the scheduler, which in the case of the KubernetesExecutor can cause a deadlock. This defers creating the default executor to initialization" @cwegrzyn
### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
