### PR TITLE
[AIRFLOW-3753] Replace Flask-OAuthlib with Authlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,9 +216,7 @@ gcp = [
 ]
 grpc = ['grpcio>=1.15.0']
 flask_oauth = [
-    'Flask-OAuthlib>=0.9.1',
-    'oauthlib!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0,>=1.1.2',
-    'requests-oauthlib==1.1.0'
+    'Authlib>=0.12.1,<1.0.0',
 ]
 hdfs = ['snakebite>=2.7.8']
 hive = [


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3753

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Flask-OAuthlib is deprecated, use Authlib instead. Updated Google and GitHub Enterprise OAuth backends.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
