### PR TITLE
[AIRFLOW-5515] Add stacklevel to GCP deprecation warnings

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -32,5 +32,5 @@ from airflow.gcp.hooks.bigquery import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.bigquery`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/datastore_hook.py
+++ b/airflow/contrib/hooks/datastore_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.datastore import DatastoreHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.datastore`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_bigtable_hook.py
+++ b/airflow/contrib/hooks/gcp_bigtable_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.bigtable import BigtableHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.bigtable`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_cloud_build_hook.py
+++ b/airflow/contrib/hooks/gcp_cloud_build_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.cloud_build import CloudBuildHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.cloud_build`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_compute_hook.py
+++ b/airflow/contrib/hooks/gcp_compute_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.compute import GceHook, GceOperationStatus  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.compute`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_container_hook.py
+++ b/airflow/contrib/hooks/gcp_container_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.kubernetes_engine import GKEClusterHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.container`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -29,5 +29,5 @@ from airflow.gcp.hooks.dataflow import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.dataflow`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.dataproc import DataprocJobStatus, DataProcHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.dataproc`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_dlp_hook.py
+++ b/airflow/contrib/hooks/gcp_dlp_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.dlp import DlpJob, CloudDLPHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.dlp`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_function_hook.py
+++ b/airflow/contrib/hooks/gcp_function_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.functions import GcfHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.functions`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_kms_hook.py
+++ b/airflow/contrib/hooks/gcp_kms_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.kms import GoogleCloudKMSHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.kms`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_mlengine_hook.py
+++ b/airflow/contrib/hooks/gcp_mlengine_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.mlengine import MLEngineHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.mlengine`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_natural_language_hook.py
+++ b/airflow/contrib/hooks/gcp_natural_language_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.natural_language import CloudNaturalLanguageHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.natural_language`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_pubsub_hook.py
+++ b/airflow/contrib/hooks/gcp_pubsub_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.pubsub import PubSubHook, PubSubException  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.pubsub`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_spanner_hook.py
+++ b/airflow/contrib/hooks/gcp_spanner_hook.py
@@ -25,5 +25,5 @@ from airflow.gcp.hooks.spanner import CloudSpannerHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.spanner`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_speech_to_text_hook.py
+++ b/airflow/contrib/hooks/gcp_speech_to_text_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.speech_to_text import GCPSpeechToTextHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.speech_to_text`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.cloud_sql import CloudSqlDatabaseHook, CloudSqlHook  # no
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.cloud_sql`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_tasks_hook.py
+++ b/airflow/contrib/hooks/gcp_tasks_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.tasks import CloudTasksHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.tasks`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_text_to_speech_hook.py
+++ b/airflow/contrib/hooks/gcp_text_to_speech_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.text_to_speech import GCPTextToSpeechHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.text_to_speech`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_transfer_hook.py
+++ b/airflow/contrib/hooks/gcp_transfer_hook.py
@@ -31,5 +31,5 @@ from airflow.gcp.hooks.cloud_storage_transfer_service import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.cloud_storage_transfer_service`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_translate_hook.py
+++ b/airflow/contrib/hooks/gcp_translate_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.translate import CloudTranslateHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.translate`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_video_intelligence_hook.py
+++ b/airflow/contrib/hooks/gcp_video_intelligence_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.video_intelligence import CloudVideoIntelligenceHook  # n
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.video_intelligence`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcp_vision_hook.py
+++ b/airflow/contrib/hooks/gcp_vision_hook.py
@@ -27,5 +27,5 @@ from airflow.gcp.hooks.vision import CloudVisionHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.vision`.",
-    DeprecationWarning
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -26,5 +26,5 @@ from airflow.gcp.hooks.gcs import GoogleCloudStorageHook, _parse_gcs_url  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.gcs`.",
-    DeprecationWarning
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/adls_to_gcs.py
+++ b/airflow/contrib/operators/adls_to_gcs.py
@@ -25,5 +25,5 @@ from airflow.operators.adls_to_gcs import AdlsToGoogleCloudStorageOperator  # no
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.adls_to_gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/bigquery_check_operator.py
+++ b/airflow/contrib/operators/bigquery_check_operator.py
@@ -29,5 +29,5 @@ from airflow.gcp.operators.bigquery import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.bigquery`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/bigquery_get_data.py
+++ b/airflow/contrib/operators/bigquery_get_data.py
@@ -25,5 +25,5 @@ from airflow.gcp.operators.bigquery import BigQueryGetDataOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.bigquery`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -36,5 +36,5 @@ from airflow.gcp.operators.bigquery import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.bigquery`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/bigquery_table_delete_operator.py
+++ b/airflow/contrib/operators/bigquery_table_delete_operator.py
@@ -25,5 +25,5 @@ from airflow.gcp.operators.bigquery import BigQueryTableDeleteOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.bigquery`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/bigquery_to_bigquery.py
+++ b/airflow/contrib/operators/bigquery_to_bigquery.py
@@ -25,5 +25,5 @@ from airflow.operators.bigquery_to_bigquery import BigQueryToBigQueryOperator  #
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.bigquery_to_bigquery`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -25,5 +25,5 @@ from airflow.operators.bigquery_to_gcs import BigQueryToCloudStorageOperator  # 
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.bigquery_to_gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/bigquery_to_mysql_operator.py
+++ b/airflow/contrib/operators/bigquery_to_mysql_operator.py
@@ -25,5 +25,5 @@ from airflow.operators.bigquery_to_mysql import BigQueryToMySqlOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.bigquery_to_mysql`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/cassandra_to_gcs.py
+++ b/airflow/contrib/operators/cassandra_to_gcs.py
@@ -27,5 +27,5 @@ from airflow.operators.cassandra_to_gcs import CassandraToGoogleCloudStorageOper
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.cassandra_to_gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -29,5 +29,5 @@ from airflow.gcp.operators.dataflow import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.dataflow`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -39,5 +39,5 @@ from airflow.gcp.operators.dataproc import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.dataproc`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/datastore_export_operator.py
+++ b/airflow/contrib/operators/datastore_export_operator.py
@@ -25,5 +25,5 @@ from airflow.gcp.operators.datastore import DatastoreExportOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.datastore`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/datastore_import_operator.py
+++ b/airflow/contrib/operators/datastore_import_operator.py
@@ -25,5 +25,5 @@ from airflow.gcp.operators.datastore import DatastoreImportOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.datastore`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/file_to_gcs.py
+++ b/airflow/contrib/operators/file_to_gcs.py
@@ -27,5 +27,5 @@ from airflow.operators.local_to_gcs import FileToGoogleCloudStorageOperator  # n
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.local_to_gcs`,",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_bigtable_operator.py
+++ b/airflow/contrib/operators/gcp_bigtable_operator.py
@@ -37,5 +37,5 @@ from airflow.gcp.sensors.bigtable import BigtableTableWaitForReplicationSensor  
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.bigtable`"
     " or `airflow.gcp.sensors.bigtable`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_cloud_build_operator.py
+++ b/airflow/contrib/operators/gcp_cloud_build_operator.py
@@ -25,5 +25,5 @@ from airflow.gcp.operators.cloud_build import CloudBuildCreateBuildOperator  # n
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_build`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_compute_operator.py
+++ b/airflow/contrib/operators/gcp_compute_operator.py
@@ -34,5 +34,5 @@ from airflow.gcp.operators.compute import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.compute`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_container_operator.py
+++ b/airflow/contrib/operators/gcp_container_operator.py
@@ -31,5 +31,5 @@ from airflow.gcp.operators.kubernetes_engine import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.container`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_dlp_operator.py
+++ b/airflow/contrib/operators/gcp_dlp_operator.py
@@ -56,5 +56,5 @@ from airflow.gcp.operators.dlp import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.dlp`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_function_operator.py
+++ b/airflow/contrib/operators/gcp_function_operator.py
@@ -29,5 +29,5 @@ from airflow.gcp.operators.functions import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.functions`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_natural_language_operator.py
+++ b/airflow/contrib/operators/gcp_natural_language_operator.py
@@ -32,5 +32,5 @@ from airflow.gcp.operators.natural_language import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.natural_language`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_spanner_operator.py
+++ b/airflow/contrib/operators/gcp_spanner_operator.py
@@ -32,5 +32,5 @@ from airflow.gcp.operators.spanner import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.spanner`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_speech_to_text_operator.py
+++ b/airflow/contrib/operators/gcp_speech_to_text_operator.py
@@ -27,5 +27,5 @@ from airflow.gcp.operators.speech_to_text import GcpSpeechToTextRecognizeSpeechO
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.speech_to_text`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_sql_operator.py
+++ b/airflow/contrib/operators/gcp_sql_operator.py
@@ -38,5 +38,5 @@ from airflow.gcp.operators.cloud_sql import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_sql`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_tasks_operator.py
+++ b/airflow/contrib/operators/gcp_tasks_operator.py
@@ -41,5 +41,5 @@ from airflow.gcp.operators.tasks import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.tasks`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_text_to_speech_operator.py
+++ b/airflow/contrib/operators/gcp_text_to_speech_operator.py
@@ -27,5 +27,5 @@ from airflow.gcp.operators.text_to_speech import GcpTextToSpeechSynthesizeOperat
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.text_to_speech`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_transfer_operator.py
+++ b/airflow/contrib/operators/gcp_transfer_operator.py
@@ -39,5 +39,5 @@ from airflow.gcp.operators.cloud_storage_transfer_service import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_transfer_service`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_translate_operator.py
+++ b/airflow/contrib/operators/gcp_translate_operator.py
@@ -27,5 +27,5 @@ from airflow.gcp.operators.translate import CloudTranslateTextOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.translate`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_translate_speech_operator.py
+++ b/airflow/contrib/operators/gcp_translate_speech_operator.py
@@ -25,5 +25,5 @@ from airflow.gcp.operators.translate_speech import GcpTranslateSpeechOperator  #
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.translate_speech`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_video_intelligence_operator.py
+++ b/airflow/contrib/operators/gcp_video_intelligence_operator.py
@@ -31,5 +31,5 @@ from airflow.gcp.operators.video_intelligence import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.video_intelligence`",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcp_vision_operator.py
+++ b/airflow/contrib/operators/gcp_vision_operator.py
@@ -44,5 +44,5 @@ from airflow.gcp.operators.vision import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.vision`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_acl_operator.py
+++ b/airflow/contrib/operators/gcs_acl_operator.py
@@ -30,5 +30,5 @@ from airflow.gcp.operators.gcs import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_delete_operator.py
+++ b/airflow/contrib/operators/gcs_delete_operator.py
@@ -27,5 +27,5 @@ from airflow.gcp.operators.gcs import GoogleCloudStorageDeleteOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -27,5 +27,5 @@ from airflow.gcp.operators.gcs import GoogleCloudStorageDownloadOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -27,5 +27,5 @@ from airflow.gcp.operators.gcs import GoogleCloudStorageListOperator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -27,5 +27,5 @@ from airflow.gcp.operators.gcs import GoogleCloudStorageCreateBucketOperator  # 
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -27,5 +27,5 @@ from airflow.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator  # 
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.gcs_to_bq`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -27,5 +27,5 @@ from airflow.operators.gcs_to_gcs import GoogleCloudStorageToGoogleCloudStorageO
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.gcs_to_gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_to_gcs_transfer_operator.py
+++ b/airflow/contrib/operators/gcs_to_gcs_transfer_operator.py
@@ -29,5 +29,5 @@ from airflow.gcp.operators.cloud_storage_transfer_service import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_transfer_service`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -27,5 +27,5 @@ from airflow.operators.gcs_to_s3 import GoogleCloudStorageToS3Operator  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.gcs_to_s3`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -30,5 +30,5 @@ from airflow.gcp.operators.mlengine import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.mlengine`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/mssql_to_gcs.py
+++ b/airflow/contrib/operators/mssql_to_gcs.py
@@ -25,5 +25,5 @@ from airflow.operators.mssql_to_gcs import MsSqlToGoogleCloudStorageOperator  # 
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.mssql_to_gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -25,5 +25,5 @@ from airflow.operators.mysql_to_gcs import MySqlToGoogleCloudStorageOperator  # 
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.mysql_to_gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -25,5 +25,5 @@ from airflow.operators.postgres_to_gcs import PostgresToGoogleCloudStorageOperat
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.postgres_to_gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/pubsub_operator.py
+++ b/airflow/contrib/operators/pubsub_operator.py
@@ -31,5 +31,5 @@ from airflow.gcp.operators.pubsub import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.pubsub`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/s3_to_gcs_transfer_operator.py
+++ b/airflow/contrib/operators/s3_to_gcs_transfer_operator.py
@@ -28,5 +28,5 @@ from airflow.gcp.operators.cloud_storage_transfer_service import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_transfer_service`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/operators/sql_to_gcs.py
+++ b/airflow/contrib/operators/sql_to_gcs.py
@@ -25,5 +25,5 @@ from airflow.operators.sql_to_gcs import BaseSQLToGoogleCloudStorageOperator  # 
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.operators.sql_to_gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/sensors/bigquery_sensor.py
+++ b/airflow/contrib/sensors/bigquery_sensor.py
@@ -25,5 +25,5 @@ from airflow.gcp.sensors.bigquery import BigQueryTableSensor  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.sensors.bigquery`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/sensors/gcp_transfer_sensor.py
+++ b/airflow/contrib/sensors/gcp_transfer_sensor.py
@@ -27,5 +27,5 @@ from airflow.gcp.sensors.cloud_storage_transfer_service import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.sensors.cloud_storage_transfer_service`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -30,5 +30,5 @@ from airflow.gcp.sensors.gcs import (  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.sensors.gcs`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/sensors/pubsub_sensor.py
+++ b/airflow/contrib/sensors/pubsub_sensor.py
@@ -25,5 +25,5 @@ from airflow.gcp.sensors.pubsub import PubSubPullSensor  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.sensors.pubsub`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/utils/mlengine_operator_utils.py
+++ b/airflow/contrib/utils/mlengine_operator_utils.py
@@ -24,5 +24,5 @@ import warnings
 from airflow.gcp.utils.mlengine_operator_utils import create_evaluate_ops  # noqa
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.utils.mlengine_operator_utils`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )

--- a/airflow/contrib/utils/mlengine_prediction_summary.py
+++ b/airflow/contrib/utils/mlengine_prediction_summary.py
@@ -25,5 +25,5 @@ from airflow.gcp.utils.mlengine_prediction_summary import JsonCoder, run, MakeSu
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.utils.mlengine_prediction_summary`.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] https://issues.apache.org/jira/browse/AIRFLOW-5515


### Description

- [ ] Adding stacklevel to deprecation warnings provides more logic logger information (warning will point out where deprecated module was imported, instead of deprecation warning line in module)