### PR TITLE
[AIRFLOW-4858] Deprecate "Historical convenience functions" in airflow.configuration

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -34,7 +34,8 @@ __version__ = version.version
 import sys
 
 # flake8: noqa: F401
-from airflow import settings, configuration as conf
+from airflow import settings
+from airflow.configuration import conf
 from airflow.models import DAG
 from airflow.exceptions import AirflowException
 

--- a/airflow/config_templates/default_webserver_config.py
+++ b/airflow/config_templates/default_webserver_config.py
@@ -24,7 +24,7 @@ from flask_appbuilder.security.manager import AUTH_DB
 # from flask_appbuilder.security.manager import AUTH_OID
 # from flask_appbuilder.security.manager import AUTH_REMOTE_USER
 
-from airflow import configuration as conf
+from airflow.configuration import conf
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4858

### Description

- [x] These places were missed in the original PR (#5495)