### PR TITLE
[AIRFLOW-5519] Fix sql_to_gcs operator missing multi-level default args by adding apply_defaults decorator 

### DIFF
--- a/airflow/operators/sql_to_gcs.py
+++ b/airflow/operators/sql_to_gcs.py
@@ -29,6 +29,7 @@ import unicodecsv as csv
 
 from airflow.gcp.hooks.gcs import GoogleCloudStorageHook
 from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
 
 
 class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
@@ -78,6 +79,7 @@ class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
     template_ext = ('.sql',)
     ui_color = '#a0e08c'
 
+    @apply_defaults
     def __init__(self,  # pylint: disable=too-many-arguments
                  sql,
                  bucket,

--- a/airflow/operators/sql_to_gcs.py
+++ b/airflow/operators/sql_to_gcs.py
@@ -29,7 +29,6 @@ import unicodecsv as csv
 
 from airflow.gcp.hooks.gcs import GoogleCloudStorageHook
 from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
 
 
 class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
@@ -78,7 +77,7 @@ class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
     template_fields = ('sql', 'bucket', 'filename', 'schema_filename', 'schema', 'parameters')
     template_ext = ('.sql',)
     ui_color = '#a0e08c'
-    @apply_defaults
+
     def __init__(self,  # pylint: disable=too-many-arguments
                  sql,
                  bucket,

--- a/airflow/operators/sql_to_gcs.py
+++ b/airflow/operators/sql_to_gcs.py
@@ -29,6 +29,7 @@ import unicodecsv as csv
 
 from airflow.gcp.hooks.gcs import GoogleCloudStorageHook
 from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
 
 
 class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
@@ -77,7 +78,7 @@ class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
     template_fields = ('sql', 'bucket', 'filename', 'schema_filename', 'schema', 'parameters')
     template_ext = ('.sql',)
     ui_color = '#a0e08c'
-
+    @apply_defaults
     def __init__(self,  # pylint: disable=too-many-arguments
                  sql,
                  bucket,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-5519

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
The apply_defaults decorator is missing in sql_to_gcs operator (BaseSQLToGoogleCloudStorageOperator), which will cause missing multi-level default args such as google_cloud_storage_conn_id. 


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
