### PR TITLE
[AIRFLOW-XXX] Fix typo and format error

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -916,7 +916,7 @@ There are three images that we currently manage:
 
 * **Slim CI** image that is used for static code checks (size around 500MB) - tag follows the pattern
   of ``<BRANCH>-python<PYTHON_VERSION>-ci-slim`` (for example ``apache/airflow:master-python3.6-ci-slim``).
-  The image is built using the [Dockerfile](Dockerfile) dockerfile.
+  The image is built using the `<Dockerfile>`_ dockerfile.
 * **Full CI image*** that is used for testing - containing a lot more test-related installed software
   (size around 1GB)  - tag follows the pattern of ``<BRANCH>-python<PYTHON_VERSION>-ci``
   (for example ``apache/airflow:master-python3.6-ci``). The image is built using the

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV AIRFLOW_VERSION=$AIRFLOW_VERSION
 RUN echo "Base image: ${PYTHON_BASE_IMAGE}"
 RUN echo "Airflow version: ${AIRFLOW_VERSION}"
 
-# Make sure noninteractie debian install is used and language variables set
+# Make sure noninteractive debian install is used and language variables set
 ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
 

--- a/scripts/ci/docker_build/ci_build_install_deps.sh
+++ b/scripts/ci/docker_build/ci_build_install_deps.sh
@@ -20,7 +20,7 @@
 set -euxo pipefail
 
 # TODO: We should think about removing those and moving them into docker-compose dependencies.
-# TODO: We might come up with just ine airflow CI image not the SLIM/CI versions. That would simplify a lot.
+# TODO: We might come up with just one airflow CI image not the SLIM/CI versions. That would simplify a lot.
 # TODO: We could likely get rid of the multi-staging approach. It introduces a number of limitations
 # TODO: As long as we decrease the size of the CI image, we should be fine with using single CI image for
 # TODO: everything. Currently the CI image is about 1GB where CI_SLIM is around 0.5 GB.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
