### PR TITLE
[AIRFLOW-5522] BQ list dataset tables operator

### DIFF
--- a/airflow/gcp/example_dags/example_bigquery.py
+++ b/airflow/gcp/example_dags/example_bigquery.py
@@ -36,6 +36,7 @@ from airflow.gcp.operators.bigquery import (
     BigQueryCreateExternalTableOperator,
     BigQueryGetDataOperator,
     BigQueryTableDeleteOperator,
+    BigQueryGetDatasetTablesOperator
 )
 
 from airflow.operators.bigquery_to_bigquery import BigQueryToBigQueryOperator
@@ -203,6 +204,16 @@ with models.DAG(
         ],
     )
 
+    get_empty_dataset_tables = BigQueryGetDatasetTablesOperator(
+        task_id="get_empty_dataset_tables",
+        dataset_id=DATASET_NAME
+    )
+
+    get_dataset_tables = BigQueryGetDatasetTablesOperator(
+        task_id="get_dataset_tables",
+        dataset_id=DATASET_NAME
+    )
+
     delete_table = BigQueryTableDeleteOperator(
         task_id="delete-table", deletion_dataset_table="{}.test_table".format(DATASET_NAME)
     )
@@ -235,7 +246,7 @@ with models.DAG(
     )
 
     create_dataset >> execute_query_save >> delete_dataset
-    create_dataset >> create_table >> delete_dataset
+    create_dataset >> get_empty_dataset_tables >> create_table >> get_dataset_tables >> delete_dataset
     create_dataset >> get_dataset >> delete_dataset
     create_dataset >> patch_dataset >> update_dataset >> delete_dataset
     execute_query_save >> get_data >> get_dataset_result

--- a/airflow/gcp/hooks/bigquery.py
+++ b/airflow/gcp/hooks/bigquery.py
@@ -1439,6 +1439,39 @@ class BigQueryBaseCursor(LoggingMixin):
                               self.running_job_id)
                 time.sleep(5)
 
+    def get_dataset_tables(self, dataset_id: str, project_id: Optional[str] = None,
+                           max_results: Optional[int] = None,
+                           page_token: Optional[str] = None) -> Dict[str, Union[str, int, List]]:
+        """
+        Get the list of tables for a given dataset.
+        .. seealso:: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
+
+        :param dataset_id: the dataset ID of the requested dataset.
+        :type dataset_id: str
+        :param project_id: (Optional) the project of the requested dataset. If None,
+            self.project_id will be used.
+        :type project_id: str
+        :param max_results: (Optional) the maximum number of tables to return.
+        :type max_results: int
+        :param page_token: (Optional) page token, returned from a previous call,
+            identifying the result set.
+        :type page_token: str
+
+        :return: map containing the list of tables + metadata.
+        """
+        optional_params = {}  # type: Dict[str, Union[str, int]]
+        if max_results:
+            optional_params['maxResults'] = max_results
+        if page_token:
+            optional_params['pageToken'] = page_token
+
+        dataset_project_id = project_id or self.project_id
+
+        return (self.service.tables().list(
+            projectId=dataset_project_id,
+            datasetId=dataset_id,
+            **optional_params).execute(num_retries=self.num_retries))
+
     def get_schema(self, dataset_id: str, table_id: str) -> Dict:
         """
         Get the schema for a given datset.table.

--- a/tests/gcp/hooks/test_bigquery.py
+++ b/tests/gcp/hooks/test_bigquery.py
@@ -657,6 +657,50 @@ class TestTableOperations(unittest.TestCase):
         with self.assertRaises(Exception):
             cursor.create_empty_table(project_id, dataset_id, table_id)
 
+    def test_get_tables_list(self):
+        expected_result = {
+            "kind": "bigquery#tableList",
+            "etag": "N/b12GSqMasEfwBOXofGQ==",
+            "tables": [
+                {
+                    "kind": "bigquery#table",
+                    "id": "your-project:your_dataset.table1",
+                    "tableReference": {
+                        "projectId": "your-project",
+                        "datasetId": "your_dataset",
+                        "tableId": "table1"
+                    },
+                    "type": "TABLE",
+                    "creationTime": "1565781859261"
+                },
+                {
+                    "kind": "bigquery#table",
+                    "id": "your-project:your_dataset.table2",
+                    "tableReference": {
+                        "projectId": "your-project",
+                        "datasetId": "your_dataset",
+                        "tableId": "table2"
+                    },
+                    "type": "TABLE",
+                    "creationTime": "1565782713480"
+                }
+            ],
+            "totalItems": 2
+        }
+
+        project_id = 'your-project'
+        dataset_id = 'your_dataset'
+
+        mock_service = mock.Mock()
+        with mock.patch.object(hook.BigQueryBaseCursor(mock_service, dataset_id).service,
+                               'tables') as MockService:
+            MockService.return_value.list(
+                dataset_id=dataset_id).execute.return_value = expected_result
+            result = hook.BigQueryBaseCursor(
+                mock_service, project_id).get_dataset_tables(
+                dataset_id=dataset_id)
+            self.assertEqual(result, expected_result)
+
 
 class TestBigQueryCursor(unittest.TestCase):
     @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')

--- a/tests/gcp/operators/test_bigquery.py
+++ b/tests/gcp/operators/test_bigquery.py
@@ -33,15 +33,15 @@ from airflow.gcp.operators.bigquery import (
     BigQueryPatchDatasetOperator,
     BigQueryUpdateDatasetOperator,
     BigQueryTableDeleteOperator,
-    BigQueryGetDataOperator
-)
+    BigQueryGetDataOperator,
+    BigQueryGetDatasetTablesOperator)
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, TaskFail, TaskInstance, XCom
 from airflow.settings import Session
 from airflow.utils.db import provide_session
 from tests.compat import mock
 
-TASK_ID = 'test-bq-create-table-operator'
+TASK_ID = 'test-bq-generic-operator'
 TEST_DATASET = 'test-dataset'
 TEST_DATASET_LOCATION = 'EU'
 TEST_GCP_PROJECT_ID = 'test-project'
@@ -565,4 +565,27 @@ class TestBigQueryTableDeleteOperator(unittest.TestCase):
             .assert_called_once_with(
                 deletion_dataset_table=deletion_dataset_table,
                 ignore_if_missing=ignore_if_missing
+            )
+
+
+class TestBigQueryGetDatasetTablesOperator(unittest.TestCase):
+    @mock.patch('airflow.gcp.operators.bigquery.BigQueryHook')
+    def test_execute(self, mock_hook):
+        operator = BigQueryGetDatasetTablesOperator(
+            task_id=TASK_ID,
+            dataset_id=TEST_DATASET,
+            project_id=TEST_GCP_PROJECT_ID,
+            max_results=2
+        )
+
+        operator.execute(None)
+        mock_hook.return_value \
+            .get_conn.return_value \
+            .cursor.return_value \
+            .get_dataset_tables \
+            .assert_called_once_with(
+                dataset_id=TEST_DATASET,
+                project_id=TEST_GCP_PROJECT_ID,
+                max_results=2,
+                page_token=None
             )


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5522) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5522

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This operator will fetch the tables of the specified dataset. Currently it will return the entire BQ return object ([reference](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list#response-body)) but we might think of extracting fewer parts.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
