### PR TITLE
[AIRFLOW-XXX] Fix incorrect units in docs for metrics using Timers

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -82,11 +82,11 @@ Timers
 ================================= =================================================
 Name                              Description
 ================================= =================================================
-dagrun.dependency-check.<dag_id>  Seconds taken to check DAG dependencies
-dag.<dag_id>.<task_id>.duration   Seconds taken to finish a task
-dag.loading-duration.<dag_file>   Seconds taken to load the given DAG file
-dagrun.duration.success.<dag_id>  Seconds taken for a DagRun to reach success state
-dagrun.duration.failed.<dag_id>   Seconds taken for a DagRun to reach failed state
-dagrun.schedule_delay.<dag_id>    Seconds of delay between the scheduled DagRun
+dagrun.dependency-check.<dag_id>  Milliseconds taken to check DAG dependencies
+dag.<dag_id>.<task_id>.duration   Milliseconds taken to finish a task
+dag.loading-duration.<dag_file>   Milliseconds taken to load the given DAG file
+dagrun.duration.success.<dag_id>  Milliseconds taken for a DagRun to reach success state
+dagrun.duration.failed.<dag_id>   Milliseconds taken for a DagRun to reach failed state
+dagrun.schedule_delay.<dag_id>    Milliseconds of delay between the scheduled DagRun
                                   start date and the actual DagRun start date
 ================================= =================================================


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

https://statsd.readthedocs.io/en/v2.1.2/timing.html - Stats timers would emit time in milliseconds. 


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
n/a - doc change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
