### PR TITLE
[AIRFLOW-XXX] Fix incorrect backticks in BREEZE.rst

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -292,7 +292,7 @@ It is as easy as copy&pasting this line into your code:
 
 Once you hit the line you will be dropped into interactive ipdb  debugger where you have colors
 and auto-completion to guide your debugging. This works from the console where you started your program.
-Note that in case of ``nosetest`` you need to provide `--nocapture` flag to avoid nosetests
+Note that in case of ``nosetest`` you need to provide ``--nocapture`` flag to avoid nosetests
 capturing the stdout of your process.
 
 Airflow directory structure inside Docker
@@ -928,7 +928,7 @@ There are three images that we currently manage:
   the checklicence image.
 
 We also use a very small `<Dockerfile-context>`_ dockerfile in order to fix file permissions
-for an obscure permission problem with Docker caching but it is not stored in `apache/airflow` registry.
+for an obscure permission problem with Docker caching but it is not stored in ``apache/airflow`` registry.
 
 Before you run tests or enter environment or run local static checks, the necessary local images should be
 pulled and built from DockerHub. This happens automatically for the test environment but you need to
@@ -959,7 +959,7 @@ For automation scripts, you can export one of the three variables to control the
 
   export FORCE_ANSWER_TO_QUESTIONS="yes"
 
-If ``FORCE_ANSWER_TO_QUESTIONS` is set to ``yes``, the images will automatically rebuild when needed.
+If ``FORCE_ANSWER_TO_QUESTIONS`` is set to ``yes``, the images will automatically rebuild when needed.
 Images are deleted without asking.
 
 .. code-block::


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
Doc change

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Fix incorrect backticks in BREEZE.rst

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Doc change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
