### PR TITLE
[AIRFLOW-4574] SSHHook private_key may only be supplied in extras

### DIFF
--- a/tests/contrib/hooks/test_ssh_hook.py
+++ b/tests/contrib/hooks/test_ssh_hook.py
@@ -54,15 +54,39 @@ TEST_PRIVATE_KEY = generate_key_string(pkey=TEST_PKEY)
 
 class TestSSHHook(unittest.TestCase):
     CONN_SSH_WITH_PRIVATE_KEY_EXTRA = 'ssh_with_private_key_extra'
+    CONN_SSH_WITH_EXTRA = 'ssh_with_extra'
 
-    def tearDown(self) -> None:
+    @classmethod
+    def tearDownClass(cls) -> None:
         with create_session() as session:
             conns_to_reset = [
-                self.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
+                cls.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
             ]
             connections = session.query(Connection).filter(Connection.conn_id.in_(conns_to_reset))
             connections.delete(synchronize_session=False)
             session.commit()
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        db.merge_conn(
+            Connection(
+                conn_id=cls.CONN_SSH_WITH_EXTRA,
+                host='localhost',
+                conn_type='ssh',
+                extra='{"compress" : true, "no_host_key_check" : "true", '
+                      '"allow_host_key_change": false}'
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=cls.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
+                host='localhost',
+                conn_type='ssh',
+                extra=json.dumps({
+                    "private_key": TEST_PRIVATE_KEY,
+                })
+            )
+        )
 
     @mock.patch('airflow.contrib.hooks.ssh_hook.paramiko.SSHClient')
     def test_ssh_connection_with_password(self, ssh_mock):
@@ -144,19 +168,31 @@ class TestSSHHook(unittest.TestCase):
                                              logger=hook.log)
 
     def test_conn_with_extra_parameters(self):
-        db.merge_conn(
-            Connection(
-                conn_id='ssh_with_extra',
-                host='localhost',
-                conn_type='ssh',
-                extra='{"compress" : true, "no_host_key_check" : "true", '
-                      '"allow_host_key_change": false}'
-            )
-        )
-        ssh_hook = SSHHook(ssh_conn_id='ssh_with_extra')
+        ssh_hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_EXTRA)
         self.assertEqual(ssh_hook.compress, True)
         self.assertEqual(ssh_hook.no_host_key_check, True)
         self.assertEqual(ssh_hook.allow_host_key_change, False)
+
+    @mock.patch('airflow.contrib.hooks.ssh_hook.SSHTunnelForwarder')
+    def test_tunnel_with_private_key(self, ssh_mock):
+        hook = SSHHook(
+            ssh_conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
+            remote_host='remote_host',
+            port='port',
+            username='username',
+            timeout=10,
+        )
+
+        with hook.get_tunnel(1234):
+            ssh_mock.assert_called_once_with('remote_host',
+                                             ssh_port='port',
+                                             ssh_username='username',
+                                             ssh_pkey=TEST_PKEY,
+                                             ssh_proxy=None,
+                                             local_bind_address=('localhost',),
+                                             remote_bind_address=('localhost', 1234),
+                                             host_pkey_directories=[],
+                                             logger=hook.log)
 
     def test_ssh_connection(self):
         hook = SSHHook(ssh_conn_id='ssh_default')
@@ -176,11 +212,13 @@ class TestSSHHook(unittest.TestCase):
         import subprocess
         import socket
 
-        server_handle = subprocess.Popen(["python", "-c", HELLO_SERVER_CMD],
-                                         stdout=subprocess.PIPE)
-        with hook.create_tunnel(2135, 2134):
+        subprocess_kwargs = dict(
+            args=["python", "-c", HELLO_SERVER_CMD],
+            stdout=subprocess.PIPE,
+        )
+        with subprocess.Popen(**subprocess_kwargs) as server_handle, hook.create_tunnel(2135, 2134):
             server_output = server_handle.stdout.read(5)
-            self.assertEqual(server_output, b"ready")
+            self.assertEqual(b"ready", server_output)
             socket = socket.socket()
             socket.connect(("localhost", 2135))
             response = socket.recv(5)
@@ -190,37 +228,7 @@ class TestSSHHook(unittest.TestCase):
             self.assertEqual(server_handle.returncode, 0)
 
     @mock.patch('airflow.contrib.hooks.ssh_hook.paramiko.SSHClient')
-    def test_ssh_connection_with_private_key(self, ssh_mock):
-        hook = SSHHook(remote_host='remote_host',
-                       port='port',
-                       username='username',
-                       timeout=10,
-                       private_key=TEST_PRIVATE_KEY)
-
-        with hook.get_conn():
-            ssh_mock.return_value.connect.assert_called_once_with(
-                hostname='remote_host',
-                username='username',
-                pkey=TEST_PKEY,
-                timeout=10,
-                compress=True,
-                port='port',
-                sock=None
-            )
-
-    @mock.patch('airflow.contrib.hooks.ssh_hook.paramiko.SSHClient')
     def test_ssh_connection_with_private_key_extra(self, ssh_mock):
-        db.merge_conn(
-            Connection(
-                conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
-                host='localhost',
-                conn_type='ssh',
-                extra=json.dumps({
-                    "private_key": TEST_PRIVATE_KEY,
-                })
-            )
-        )
-
         hook = SSHHook(
             ssh_conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
             remote_host='remote_host',


### PR DESCRIPTION
Summary:
* discussion on original PR suggested removing private_key option as init param
* with this PR, can still provide through extras, but not as init param
* also add support for private_key in tunnel -- missing in original PR for this issue
* remove test related to private_key init param
* use context manager to auto-close socket listener so tests can be re-run

Notes:
@mik-laj @pgagnon @kaxil
In this PR I attempt to address concerns raised by @pgagnon after the merge of original PR for this issue (#6104 ).  

Namely, I set out to remove private_key as an init param to SSHHook.  

While doing so, I noticed that original PR did not extend support for `private_key` to the get_tunnel hook method, because it doesn't use `get_conn` but connects independently.  

This PR rectifies this oversight by adding this capability.

I did not create new jira because this feels like continuation of same issue -- just more completely fulfilling its goal, and hopefully in a way that everyone can be happy with.

There were some minor tweaks that I made to testing.  
* In test, The `HELLO_SERVER_CMD` was not executed in context manager, so it left the socket listener running, which meant you could not rerun the tests without manually killing the listener process.  I use context manager.  I think this makes sense in same PR because it actively interfered with my ability to test my change.
* In test, I also moved connection creation / destruction to setUpClass / tearDownClass so they are created and destroyed only once for the ssh hook test suite.  Made sense to do this because in adding tunnel test I had to use the connection in more than one place.




Make sure you have checked _all_ steps below.

### Jira

- [ x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4574
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
