### PR TITLE
[AIRFLOW-5531] Replace deprecated log.warn() with log.warning()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -167,6 +167,7 @@ repos:
     rev: v1.4.1
     hooks:
       - id: rst-backticks
+      - id: python-no-log-warn
   - repo: local
     hooks:
       - id: yamllint

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -75,7 +75,7 @@ class HttpHook(BaseHook):
                 try:
                     session.headers.update(conn.extra_dejson)
                 except TypeError:
-                    self.log.warn('Connection to %s has invalid extra field.', conn.host)
+                    self.log.warning('Connection to %s has invalid extra field.', conn.host)
         if headers:
             session.headers.update(headers)
 


### PR DESCRIPTION
- Add pre-commit hook to detect this

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-5531


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
We should replace log.warn which is deprecated with log.warning

Additionally, this PR adds pre-commit to detect this cases.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Add pre-commit hooks

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
