### PR TITLE
[AIRFLOW-5532] Fix imagePullSecrets in pod created from k8s executor

### DIFF
--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -219,13 +219,6 @@ class WorkerConfiguration(LoggingMixin):
 
         return worker_secrets
 
-    def _get_image_pull_secrets(self) -> List[k8s.V1LocalObjectReference]:
-        """Extracts any image pull secrets for fetching container(s)"""
-        if not self.kube_config.image_pull_secrets:
-            return []
-        pull_secrets = self.kube_config.image_pull_secrets.split(',')
-        return list(map(k8s.V1LocalObjectReference, pull_secrets))
-
     def _get_security_context(self) -> k8s.V1PodSecurityContext:
         """Defines the security context"""
 
@@ -368,6 +361,7 @@ class WorkerConfiguration(LoggingMixin):
             name=pod_id,
             image=self.kube_config.kube_image,
             image_pull_policy=self.kube_config.kube_image_pull_policy,
+            image_pull_secrets=self.kube_config.image_pull_secrets,
             labels={
                 'airflow-worker': worker_uuid,
                 'dag_id': dag_id,
@@ -391,6 +385,5 @@ class WorkerConfiguration(LoggingMixin):
         pod.spec.containers[0].env_from = pod.spec.containers[0].env_from or []
         pod.spec.containers[0].env_from.extend(self._get_env_from())
         pod.spec.security_context = self._get_security_context()
-        pod.spec.image_pull_secrets = self._get_image_pull_secrets()
 
         return append_to_pod(pod, self._get_secrets())

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -391,5 +391,6 @@ class WorkerConfiguration(LoggingMixin):
         pod.spec.containers[0].env_from = pod.spec.containers[0].env_from or []
         pod.spec.containers[0].env_from.extend(self._get_env_from())
         pod.spec.security_context = self._get_security_context()
+        pod.spec.image_pull_secrets = self._get_image_pull_secrets()
 
         return append_to_pod(pod, self._get_secrets())

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -625,3 +625,19 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
             'dag_id': 'override_dag_id',
             'my_kube_executor_label': 'kubernetes'
         }, labels)
+
+    def test_make_pod_with_image_pull_secrets(self):
+        # Tests the pod created with image_pull_secrets actually gets that in it's config
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_volume_host = None
+        self.kube_config.dags_in_image = None
+        self.kube_config.git_dags_folder_mount_point = 'dags'
+        self.kube_config.git_sync_dest = 'repo'
+        self.kube_config.git_subpath = 'path'
+        self.kube_config.image_pull_secrets = 'image_pull_secret1,image_pull_secret2'
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        pod = worker_config.make_pod("default", str(uuid.uuid4()), "test_pod_id", "test_dag_id",
+                                     "test_task_id", str(datetime.utcnow()), 1, "bash -c 'ls /'")
+
+        self.assertEqual(2, len(pod.spec.image_pull_secrets))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5532

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
   bug fix for supporting pulling private container image.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   `tests.kubernetes.TestKubernetesWorkerConfiguration.test_make_pod_with_image_pull_secrets()`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
  no new functionality.