### PR TITLE
[AIRFLOW-5541] Exclude example DAGs from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,7 +21,11 @@ omit =
     tests/*
     scripts/*
     dev/*
+    dags/*
     airflow/migrations/*
     airflow/www/node_modules/**
     airflow/www_rbac/node_modules/**
     airflow/_vendor/*
+    airflow/example_dags/*
+    airflow/gcp/example_dags/*
+    airflow/contrib/example_dags/*


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5541

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
There is no need to include example dags in tests coverage.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
