### PR TITLE
[AIRFLOW-XXX] Don't trust python-requests.org to run a valid HTTPS server

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -241,7 +241,7 @@ intersphinx_mapping = {
     'mongodb': ('https://api.mongodb.com/python/current/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/3/', None),
-    'requests': ('http://docs.python-requests.org/en/master/', None),
+    'requests': ('https://requests.readthedocs.io/en/master/', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/latest/', None),
     'hdfs': ('https://hdfscli.readthedocs.io/en/latest/', None),
     # google-cloud-python


### PR DESCRIPTION
This is the 3rd or 4th time we've had a problem with the docs from
requests causing the docs step of our build to fail. So lets switch to
RTD.io instead as they are much better at this.