### PR TITLE
[AIRFLOW-5549] Extended BQ GetDataOperator to handle query params

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -40,6 +40,29 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Changes to BigQueryGetDataOperator
+`max_results` parameter type changed from `str` to `int` to reflect the correct data type 
+and `location` parameter removed as it is redundant.
+
+Data structure pushed to XCOM by the operator changed from a `list` to a `dict`.
+
+Old format:
+```json
+[["Tony", "10"], ["Mike", "20"], ["Steve", "15"]]
+```
+
+New format:
+```json
+{
+    "totalRows": 20,
+    "pageToken": "BHSHJT3DRAFSSIAICAFCACSB77777777757SUAA=",
+    "rows": [["Tony", "10"], ["Mike", "20"], ["Steve", "15"]]
+}
+```
+
+For more information please check the 
+[BigQuery tabledata documentation](https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/list).
+
 ### Changes to `aws_default` Connection's default region
 
 The region of Airflow's default connection to AWS (`aws_default`) was previously

--- a/airflow/gcp/hooks/bigquery.py
+++ b/airflow/gcp/hooks/bigquery.py
@@ -1488,10 +1488,10 @@ class BigQueryBaseCursor(LoggingMixin):
 
     def get_tabledata(self, dataset_id: str, table_id: str,
                       max_results: Optional[int] = None, selected_fields: Optional[str] = None,
-                      page_token: Optional[str] = None, start_index: Optional[int] = None) -> Dict:
+                      page_token: Optional[str] = None, start_index: Optional[str] = None) -> Dict:
         """
         Get the data of a given dataset.table and optionally with selected columns.
-        see https://cloud.google.com/bigquery/docs/reference/v2/tabledata/list
+        .. seealso:: https://cloud.google.com/bigquery/docs/reference/v2/tabledata/list
 
         :param dataset_id: the dataset ID of the requested table.
         :param table_id: the table ID of the requested table.
@@ -1501,7 +1501,7 @@ class BigQueryBaseCursor(LoggingMixin):
         :param page_token: page token, returned from a previous call,
             identifying the result set.
         :param start_index: zero based index of the starting row to read.
-        :return: map containing the requested rows.
+        :return: map containing the requested rows + metadata.
         """
         optional_params = {}  # type: Dict[str, Any]
         if self.location:

--- a/tests/gcp/operators/test_bigquery.py
+++ b/tests/gcp/operators/test_bigquery.py
@@ -524,7 +524,7 @@ class TestBigQueryGetDataOperator(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.bigquery.BigQueryHook')
     def test_execute(self, mock_hook):
 
-        max_results = '100'
+        max_results = 100
         selected_fields = 'DATE'
         operator = BigQueryGetDataOperator(task_id=TASK_ID,
                                            dataset_id=TEST_DATASET,
@@ -540,7 +540,9 @@ class TestBigQueryGetDataOperator(unittest.TestCase):
             .assert_called_once_with(
                 dataset_id=TEST_DATASET,
                 table_id=TEST_TABLE_ID,
+                start_index=None,
                 max_results=max_results,
+                page_token=None,
                 selected_fields=selected_fields,
             )
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5549) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5549

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently the BigQueryGetDataOperator returns a list of rows only and not the total number of rows available and the page token to navigate to the next page. It also does not handle pagination (to request the next set of rows). The operator will now return the total number of rows and the next page token as well as handling start_index and page_token parameters.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
