### PR TITLE
[AIRFLOW-3877] -Changing full file path in scheduler

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -25,7 +25,6 @@ import signal
 import sys
 import threading
 import time
-import re
 from collections import defaultdict
 from datetime import timedelta
 from time import sleep
@@ -1084,7 +1083,7 @@ class SchedulerJob(BaseJob):
         TI = models.TaskInstance
 
         def change_file_path(full_filepath):
-            return re.sub(DAGS_FOLDER, 'DAGS_FOLDER', full_filepath)
+            return full_filepath.replace(DAGS_FOLDER, 'DAGS_FOLDER', 1)
 
         # actually enqueue them
         for simple_task_instance in simple_task_instances:

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -57,6 +57,7 @@ from airflow.utils.state import State
 
 DAGS_FOLDER = settings.DAGS_FOLDER
 
+
 class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
     """Helps call SchedulerJob.process_file() in a separate process.
 
@@ -321,15 +322,15 @@ class SchedulerJob(BaseJob):
     heartrate = conf.getint('scheduler', 'SCHEDULER_HEARTBEAT_SEC')
 
     def __init__(
-            self,
-            dag_id=None,
-            dag_ids=None,
-            subdir=settings.DAGS_FOLDER,
-            num_runs=conf.getint('scheduler', 'num_runs'),
-            processor_poll_interval=conf.getfloat('scheduler', 'processor_poll_interval'),
-            do_pickle=False,
-            log=None,
-            *args, **kwargs):
+        self,
+        dag_id=None,
+        dag_ids=None,
+        subdir=settings.DAGS_FOLDER,
+        num_runs=conf.getint('scheduler', 'num_runs'),
+        processor_poll_interval=conf.getfloat('scheduler', 'processor_poll_interval'),
+        do_pickle=False,
+        log=None,
+        *args, **kwargs):
         # for BaseJob compatibility
         self.dag_id = dag_id
         self.dag_ids = [dag_id] if dag_id else []
@@ -405,16 +406,16 @@ class SchedulerJob(BaseJob):
         TI = models.TaskInstance
         sq = (
             session
-            .query(
+                .query(
                 TI.task_id,
                 func.max(TI.execution_date).label('max_ti'))
-            .with_hint(TI, 'USE INDEX (PRIMARY)', dialect_name='mysql')
-            .filter(TI.dag_id == dag.dag_id)
-            .filter(or_(
+                .with_hint(TI, 'USE INDEX (PRIMARY)', dialect_name='mysql')
+                .filter(TI.dag_id == dag.dag_id)
+                .filter(or_(
                 TI.state == State.SUCCESS,
                 TI.state == State.SKIPPED))
-            .filter(TI.task_id.in_(dag.task_ids))
-            .group_by(TI.task_id).subquery('sq')
+                .filter(TI.task_id.in_(dag.task_ids))
+                .group_by(TI.task_id).subquery('sq')
         )
 
         max_tis = session.query(TI).filter(
@@ -442,17 +443,18 @@ class SchedulerJob(BaseJob):
 
         slas = (
             session
-            .query(SlaMiss)
-            .filter(SlaMiss.notification_sent == False, SlaMiss.dag_id == dag.dag_id)  # noqa pylint: disable=singleton-comparison
-            .all()
+                .query(SlaMiss)
+                .filter(SlaMiss.notification_sent == False,
+                        SlaMiss.dag_id == dag.dag_id)  # noqa pylint: disable=singleton-comparison
+                .all()
         )
 
         if slas:
             sla_dates = [sla.execution_date for sla in slas]
             qry = (
                 session
-                .query(TI)
-                .filter(
+                    .query(TI)
+                    .filter(
                     TI.state != State.SUCCESS,
                     TI.execution_date.in_(sla_dates),
                     TI.dag_id == dag.dag_id
@@ -568,8 +570,8 @@ class SchedulerJob(BaseJob):
             timedout_runs = 0
             for dr in active_runs:
                 if (
-                        dr.start_date and dag.dagrun_timeout and
-                        dr.start_date < timezone.utcnow() - dag.dagrun_timeout):
+                    dr.start_date and dag.dagrun_timeout and
+                    dr.start_date < timezone.utcnow() - dag.dagrun_timeout):
                     dr.state = State.FAILED
                     dr.end_date = timezone.utcnow()
                     dag.handle_callback(dr, success=False, reason='dagrun_timeout',
@@ -582,8 +584,8 @@ class SchedulerJob(BaseJob):
             # this query should be replaced by find dagrun
             qry = (
                 session.query(func.max(DagRun.execution_date))
-                .filter_by(dag_id=dag.dag_id)
-                .filter(or_(
+                    .filter_by(dag_id=dag.dag_id)
+                    .filter(or_(
                     DagRun.external_trigger == False,  # noqa: E712 pylint: disable=singleton-comparison
                     # add % as a wildcard for the like query
                     DagRun.run_id.like(DagRun.ID_PREFIX + '%')
@@ -731,8 +733,8 @@ class SchedulerJob(BaseJob):
                 ti.task = task
 
                 if ti.are_dependencies_met(
-                        dep_context=DepContext(flag_upstream_failed=True),
-                        session=session):
+                    dep_context=DepContext(flag_upstream_failed=True),
+                    session=session):
                     self.log.debug('Queuing task: %s', ti)
                     task_instances_list.append(ti.key)
 
@@ -761,13 +763,13 @@ class SchedulerJob(BaseJob):
         query = session \
             .query(models.TaskInstance) \
             .outerjoin(models.DagRun, and_(
-                models.TaskInstance.dag_id == models.DagRun.dag_id,
-                models.TaskInstance.execution_date == models.DagRun.execution_date)) \
+            models.TaskInstance.dag_id == models.DagRun.dag_id,
+            models.TaskInstance.execution_date == models.DagRun.execution_date)) \
             .filter(models.TaskInstance.dag_id.in_(simple_dag_bag.dag_ids)) \
             .filter(models.TaskInstance.state.in_(old_states)) \
             .filter(or_(
-                models.DagRun.state != State.RUNNING,
-                models.DagRun.state.is_(None)))
+            models.DagRun.state != State.RUNNING,
+            models.DagRun.state.is_(None)))
         if self.using_sqlite:
             tis_to_change = query \
                 .with_for_update() \
@@ -780,10 +782,10 @@ class SchedulerJob(BaseJob):
             tis_changed = session \
                 .query(models.TaskInstance) \
                 .filter(and_(
-                    models.TaskInstance.dag_id == subq.c.dag_id,
-                    models.TaskInstance.task_id == subq.c.task_id,
-                    models.TaskInstance.execution_date ==
-                    subq.c.execution_date)) \
+                models.TaskInstance.dag_id == subq.c.dag_id,
+                models.TaskInstance.task_id == subq.c.task_id,
+                models.TaskInstance.execution_date ==
+                subq.c.execution_date)) \
                 .update({models.TaskInstance.state: new_state},
                         synchronize_session=False)
             session.commit()
@@ -810,9 +812,9 @@ class SchedulerJob(BaseJob):
         TI = models.TaskInstance
         ti_concurrency_query = (
             session
-            .query(TI.task_id, TI.dag_id, func.count('*'))
-            .filter(TI.state.in_(states))
-            .group_by(TI.task_id, TI.dag_id)
+                .query(TI.task_id, TI.dag_id, func.count('*'))
+                .filter(TI.state.in_(states))
+                .group_by(TI.task_id, TI.dag_id)
         ).all()
         dag_map = defaultdict(int)
         task_map = defaultdict(int)
@@ -848,17 +850,17 @@ class SchedulerJob(BaseJob):
         DM = models.DagModel
         ti_query = (
             session
-            .query(TI)
-            .filter(TI.dag_id.in_(simple_dag_bag.dag_ids))
-            .outerjoin(
+                .query(TI)
+                .filter(TI.dag_id.in_(simple_dag_bag.dag_ids))
+                .outerjoin(
                 DR,
                 and_(DR.dag_id == TI.dag_id, DR.execution_date == TI.execution_date)
             )
-            .filter(or_(DR.run_id == None,  # noqa: E711 pylint: disable=singleton-comparison
-                    not_(DR.run_id.like(BackfillJob.ID_PREFIX + '%'))))
-            .outerjoin(DM, DM.dag_id == TI.dag_id)
-            .filter(or_(DM.dag_id == None,  # noqa: E711 pylint: disable=singleton-comparison
-                    not_(DM.is_paused)))
+                .filter(or_(DR.run_id == None,  # noqa: E711 pylint: disable=singleton-comparison
+                            not_(DR.run_id.like(BackfillJob.ID_PREFIX + '%'))))
+                .outerjoin(DM, DM.dag_id == TI.dag_id)
+                .filter(or_(DM.dag_id == None,  # noqa: E711 pylint: disable=singleton-comparison
+                            not_(DM.is_paused)))
         )
 
         # Additional filters on task instance state
@@ -1027,8 +1029,8 @@ class SchedulerJob(BaseJob):
                 for ti in task_instances])
         ti_query = (
             session
-            .query(TI)
-            .filter(or_(*filter_for_ti_state_change)))
+                .query(TI)
+                .filter(or_(*filter_for_ti_state_change)))
 
         if None in acceptable_states:
             ti_query = ti_query.filter(
@@ -1039,8 +1041,8 @@ class SchedulerJob(BaseJob):
 
         tis_to_set_to_queued = (
             ti_query
-            .with_for_update()
-            .all())
+                .with_for_update()
+                .all())
 
         if len(tis_to_set_to_queued) == 0:
             self.log.info("No tasks were able to have their state changed to queued.")
@@ -1286,7 +1288,7 @@ class SchedulerJob(BaseJob):
         # DAGs can be pickled for easier remote execution by some executors
         pickle_dags = False
         if self.do_pickle and self.executor.__class__ not in \
-                (executors.LocalExecutor, executors.SequentialExecutor):
+            (executors.LocalExecutor, executors.SequentialExecutor):
             pickle_dags = True
 
         self.log.info("Processing each file at most %s times", self.num_runs)
@@ -1438,7 +1440,7 @@ class SchedulerJob(BaseJob):
                 sleep_length = 1 - loop_duration
                 self.log.debug(
                     "Sleeping for {0:.2f} seconds to prevent excessive logging"
-                    .format(sleep_length))
+                        .format(sleep_length))
                 sleep(sleep_length)
 
         # Stop any processors
@@ -1559,9 +1561,9 @@ class SchedulerJob(BaseJob):
             # a task that recently got its state changed to RUNNING from somewhere
             # other than the scheduler from getting its state overwritten.
             if ti.are_dependencies_met(
-                    dep_context=dep_context,
-                    session=session,
-                    verbose=True):
+                dep_context=dep_context,
+                session=session,
+                verbose=True):
                 # Task starts out in the scheduled state. All tasks in the
                 # scheduled state will be sent to the executor
                 ti.state = State.SCHEDULED

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -57,6 +57,7 @@ from airflow.utils.state import State
 
 DAGS_FOLDER = settings.DAGS_FOLDER
 
+
 class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
     """Helps call SchedulerJob.process_file() in a separate process.
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2740,7 +2740,7 @@ class TestSchedulerJob(unittest.TestCase):
 
     def test_change_filepath_in_enqueue_task_instances_with_queued_state(self):
         dag_id = 'test_change_full_filepath'
-        task_id_1 = 'dummyTask1'
+        task_id_1 = 'dummyTask'
         dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE,
                   full_filepath=os.path.join(DAGS_FOLDER, TEMP_DAG_FILENAME))
         task1 = DummyOperator(dag=dag, task_id=task_id_1)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2741,7 +2741,8 @@ class TestSchedulerJob(unittest.TestCase):
     def test_change_filepath_in_enqueue_task_instances_with_queued_state(self):
         dag_id = 'test_change_full_filepath'
         task_id_1 = 'dummyTask1'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, full_filepath=os.path.join(DAGS_FOLDER, TEMP_DAG_FILENAME))
+        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE,
+                  full_filepath=os.path.join(DAGS_FOLDER, TEMP_DAG_FILENAME))
         task1 = DummyOperator(dag=dag, task_id=task_id_1)
         dagbag = self._make_simple_dag_bag([dag])
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2756,8 +2756,8 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler._enqueue_task_instances_with_queued_state(dagbag, [ti1])
 
         for value in scheduler.executor.queued_tasks.values():
-            command = value[0]
             try:
+                command = value[0]
                 assert (command[command.index('-sd') + 1].startswith('DAGS_FOLDER'))
-            except:
+            except ValueError:
                 assert False

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -63,6 +63,7 @@ UNPARSEABLE_DAG_FILE_CONTENTS = 'airflow DAG'
 TEMP_DAG_FILENAME = "temp_dag.py"
 DAGS_FOLDER = settings.DAGS_FOLDER
 
+
 class TestSchedulerJob(unittest.TestCase):
 
     def setUp(self):
@@ -2738,7 +2739,7 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertNotIn(dag, dags)
 
     def test_change_filepath_in_enqueue_task_instances_with_queued_state(self):
-        dag_id = 'SchedulerJobTest.test_change_filepath_in_enqueue_task_instances_with_queued_state'
+        dag_id = 'test_change_filepath_in_enqueue_task_instances_with_queued_state'
         task_id_1 = 'dummyTask1'
         dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, full_filepath=os.path.join(DAGS_FOLDER, TEMP_DAG_FILENAME))
         task1 = DummyOperator(dag=dag, task_id=task_id_1)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3877

### Description

- [x] When the dag is picked up by scheduler and sent to the workers the full file path is sent. If scheduler and worker are running on different hosts as different users it gives error as the file path of dags on scheduler doesn't match with file path on workers.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
