### PR TITLE
[AIRFLOW-5554] Require statsd 3.3.0 for timedelta stat transformation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ mongo = ['pymongo>=3.6.0']
 snowflake = ['snowflake-connector-python>=1.5.2',
              'snowflake-sqlalchemy>=1.1.0']
 ssh = ['paramiko>=2.1.1', 'pysftp>=0.2.9', 'sshtunnel>=0.1.4,<0.2']
-statsd = ['statsd>=3.0.1, <4.0']
+statsd = ['statsd>=3.3.0, <4.0']
 vertica = ['vertica-python>=0.5.1']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']
 winrm = ['pywinrm==0.2.2']


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-5554

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
When statsd is enabled in airflow, there are some calls to the statsd client library that pass timedeltas as the duration for measuring the timing, including dag success and failure durations.

However, handling timedeltas and converting them to millisecond floats is not introduced until statsd 3.3.0. This should be the minimum version required in airflow to avoid a TypeError in these stats.

### Tests

- [x] My PR does not need testing for this extremely good reason:
No code changes introduced, the only behavioral change is inside the statsd library implementation due to the version change.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
