### PR TITLE
[AIRFLOW-5560] Allow no confirmation on reset dags

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -199,7 +199,7 @@ def backfill(args, dag=None):
                 [dag],
                 start_date=args.start_date,
                 end_date=args.end_date,
-                confirm_prompt=True,
+                confirm_prompt=not args.yes,
                 include_subdags=False,
             )
 
@@ -2001,7 +2001,7 @@ class CLIFactory(object):
                     " within the backfill date range.",
             'args': (
                 'dag_id', 'task_regex', 'start_date', 'end_date',
-                'mark_success', 'local', 'donot_pickle',
+                'mark_success', 'local', 'donot_pickle', 'yes',
                 'bf_ignore_dependencies', 'bf_ignore_first_depends_on_past',
                 'subdir', 'pool', 'delay_on_limit', 'dry_run', 'verbose', 'conf',
                 'reset_dag_run', 'rerun_failed_tasks', 'run_backwards'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-5560\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5560

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When using the backfill command with the `--reset_dags` option there is a confirmation prompt and no way to suppress it. I've wired in the `--yes` parameter to do this, note that using `--no_confirm` wasn't an option as thats aliased to '-c' which is used for `--conf` in the backfill sub command.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No tests for command line arguments, tested locally though.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

- Done automatically via argparse