### PR TITLE
[AIRFLOW-5562] Skip grant single DAG permissions for Admin role.

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -453,7 +453,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
     def update_admin_perm_view(self):
         """
-        Admin should have all the permission-views, except the dag views.
+        Admin should has all the permission-views, except the dag views.
         because Admin have already have all_dags permission.
         Add the missing ones to the table for admin.
 

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -21,7 +21,7 @@
 from flask import g
 from flask_appbuilder.security.sqla import models as sqla_models
 from flask_appbuilder.security.sqla.manager import SecurityManager
-from sqlalchemy import or_
+from sqlalchemy import or_, and_
 
 from airflow import models
 from airflow.exceptions import AirflowException
@@ -453,12 +453,19 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
     def update_admin_perm_view(self):
         """
-        Admin should have all the permission-views.
+        Admin should have all the permission-views, except the dag views.
+        because Admin have already have all_dags permission.
         Add the missing ones to the table for admin.
 
         :return: None.
         """
-        pvms = self.get_session.query(sqla_models.PermissionView).all()
+        all_dag_view = self.find_view_menu('all_dags')
+        dag_perm_ids = [self.find_permission('can_dag_edit').id, self.find_permission('can_dag_read').id]
+        pvms = self.get_session.query(sqla_models.PermissionView).filter(~and_(
+            sqla_models.PermissionView.permission_id.in_(dag_perm_ids),
+            sqla_models.PermissionView.view_menu_id != all_dag_view.id)
+        ).all()
+
         pvms = [p for p in pvms if p.permission and p.view_menu]
 
         admin = self.find_role('Admin')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-5562

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR is aim to improve airflow security logic, it skip granting DAG permissions to Admin role when refresh dag or restart Airflow. As Admin role has the access to all_dags, we don't need grant the permission to it.
Besides, too many permissions will cause WebUI full of text and some performance issues in DB.

### Tests

- [X] My PR adds does not need testing for this extremely good reason: The function didn't have test case before.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
