### PR TITLE
Dags filter by owner in RBAC

### DIFF
--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -230,10 +230,15 @@ class Airflow(AirflowBaseView):
         else:
             hide_paused = hide_paused_dags_by_default
 
-        # read orm_dags from the db
-        query = session.query(DM).filter(
-            ~DM.is_subdag, DM.is_active
-        )
+        # read orm_dags from the db filter by owner, if the user is not admin
+        if ({'Admin'} & roles):
+            query = session.query(DM).filter(
+               ~DM.is_subdag, DM.is_active
+            )
+        else:
+            query = session.query(DM).filter(
+               ~DM.is_subdag, DM.is_active, DM.owners == current_user.username
+           )
 
         # optionally filter out "paused" dags
         if hide_paused:

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -229,18 +229,17 @@ class Airflow(AirflowBaseView):
             hide_paused = False
         else:
             hide_paused = hide_paused_dags_by_default
-
         current_user = appbuilder.sm.get_user()
         roles = {role.name for role in current_user.roles}
         # read orm_dags from the db filter by owner, if the user is not admin
         if ({'Admin'} & roles):
             query = session.query(DM).filter(
-               ~DM.is_subdag, DM.is_active
+                ~DM.is_subdag, DM.is_active
             )
         else:
             query = session.query(DM).filter(
-               ~DM.is_subdag, DM.is_active, DM.owners == current_user.username
-           )
+                ~DM.is_subdag, DM.is_active, DM.owners == current_user.username
+            )
 
         # optionally filter out "paused" dags
         if hide_paused:

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -230,6 +230,7 @@ class Airflow(AirflowBaseView):
         else:
             hide_paused = hide_paused_dags_by_default
 
+        current_user = appbuilder.sm.get_user()
         roles = {role.name for role in current_user.roles}
         # read orm_dags from the db filter by owner, if the user is not admin
         if ({'Admin'} & roles):

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -230,6 +230,7 @@ class Airflow(AirflowBaseView):
         else:
             hide_paused = hide_paused_dags_by_default
 
+        roles = {role.name for role in current_user.roles}
         # read orm_dags from the db filter by owner, if the user is not admin
         if ({'Admin'} & roles):
             query = session.query(DM).filter(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5577
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-5577\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
