### PR TITLE
[AIRFLOW-XXX] Ignore FAB's db tables when auto-generating migrations

### DIFF
--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -23,6 +23,16 @@ from logging.config import fileConfig
 from airflow import settings
 from airflow import models
 
+
+def include_object(_, name, type_, *args):
+    """Filter objects for autogenerating revisions"""
+    # Ignore _anything_ to do with Flask AppBuilder's tables
+    if type_ == "table" and name.startswith("ab_"):
+        return False
+    else:
+        return True
+
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
@@ -80,6 +90,7 @@ def run_migrations_online():
             transaction_per_migration=True,
             target_metadata=target_metadata,
             compare_type=COMPARE_TYPE,
+            include_object=include_object,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
## Jira

- [x] No Jira


## Description

- [x] Make `alembic revision --autogenerate` ignore any table starting with
  `ab_` as that is what Flask-AppBuilder uses and we don't manage those tables.