### PR TITLE
Revert "[AIRFLOW-5490] Fix incorrect None comparison"

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -340,8 +340,8 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         pvms = (
             sesh.query(sqla_models.PermissionView)
             .filter(or_(
-                sqla_models.PermissionView.permission is None,  # noqa pylint: disable=singleton-comparison
-                sqla_models.PermissionView.view_menu is None,  # noqa pylint: disable=singleton-comparison
+                sqla_models.PermissionView.permission == None,  # noqa pylint: disable=singleton-comparison
+                sqla_models.PermissionView.view_menu == None,  # noqa pylint: disable=singleton-comparison
             ))
         )
         # Since FAB doesn't define ON DELETE CASCADE on these tables, we need


### PR DESCRIPTION
Reverts apache/airflow#6109 as this breaks the query.

```
In [5]: type(TI.state is None)
Out[5]: bool

In [6]: type(TI.state == None)
Out[6]: sqlalchemy.sql.elements.BinaryExpression

In [7]: type(TI.state.is_(None))
Out[7]: sqlalchemy.sql.elements.BinaryExpression
```