### PR TITLE
[AIRFLOW-5578] Adding the ability to define custom IndexView

### DIFF
--- a/airflow/config_templates/default_webserver_config.py
+++ b/airflow/config_templates/default_webserver_config.py
@@ -61,6 +61,9 @@ AUTH_TYPE = AUTH_DB
 # The default user self registration role
 # AUTH_USER_REGISTRATION_ROLE = "Public"
 
+# Set your custom IndexView class here to override the default
+# INDEX_VIEW_CLASS =
+
 # When using OAuth Auth, uncomment to setup provider(s) info
 # Google OAuth example:
 # OAUTH_PROVIDERS = [{

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -99,10 +99,19 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
                 """Your CUSTOM_SECURITY_MANAGER must now extend AirflowSecurityManager,
                  not FAB's security manager.""")
 
+        from airflow.www.blueprints import AirflowIndexView
+        from flask_appbuilder import IndexView
+        index_view_class = app.config.get('INDEX_VIEW_CLASS') or \
+            AirflowIndexView
+
+        if not issubclass(index_view_class, IndexView):
+            raise Exception("Your INDEX_VIEW_CLASS must extend flask_appbuilder.IndexView")
+
         appbuilder = AppBuilder(
             app,
             db.session if not session else session,
             security_manager_class=security_manager_class,
+            indexview=index_view_class,
             base_template='appbuilder/baselayout.html')
 
         def init_views(appbuilder):

--- a/airflow/www/blueprints.py
+++ b/airflow/www/blueprints.py
@@ -18,10 +18,19 @@
 # under the License.
 #
 from flask import Blueprint, redirect, url_for
+from flask_appbuilder import IndexView, expose
 
 routes = Blueprint('routes', __name__)
 
+# Place any Flask Blueprint routes (non Flask-Appbuilder ones) here
 
-@routes.route('/')
-def index():
-    return redirect(url_for('Airflow.index'))
+# We can't put this into airflow.www.views because then we would have to import the views module
+# inside airflow.www.app prior to the appbuilder object being set up.
+# This would break other code in views not using the cached_appbuilder() function.
+
+
+class AirflowIndexView(IndexView):
+    """Redirection to /home using IndexView from Flask-Appbuilder."""
+    @expose('/')
+    def index(self):
+        return redirect(url_for('Airflow.index'))


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Jira Issue](https://issues.apache.org/jira/browse/AIRFLOW-5578)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
* The route that simply redirects to "/home" in airflow.www.blueprints has been replaced with an IndexView version from Flask-Appbuilder.
* This IndexView is used as the default and should behave in exactly the same way as before.
* I have added config option for defining your own IndexView class in default_webserver_config.py
* The either the default IndexView or the one defined in default_webserver_config.py is used by the indexview keyword in the appbuilder setup in app.py
* So now a user can define a custom IndexView and choose to do something else instead of a simple redirection.

### Tests

- [x] My PR adds no unit tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits (closely) follow the guidelines.

### Documentation

- [x] The config file contains a description of what to do. And the IndexView class has a basic docstring.
