### PR TITLE
[AIRFLOW-5582] AutoCommit in jdbc is missing get_autocommit

### DIFF
--- a/airflow/hooks/jdbc_hook.py
+++ b/airflow/hooks/jdbc_hook.py
@@ -53,8 +53,10 @@ class JdbcHook(DbApiHook):
         """
         Enable or disable autocommit for the given connection.
 
-        :param conn: The connection
-        :return:
+        :param conn: The connection.
+        :type conn: connection object
+        :param autocommit: The connection's autocommit setting.
+        :type autocommit: bool
         """
         conn.jconn.setAutoCommit(autocommit)
 
@@ -64,7 +66,8 @@ class JdbcHook(DbApiHook):
         Return True if conn.autocommit is set to True.
         Return False if conn.autocommit is not set or set to False
 
-        :param conn: The connection
+        :param conn: The connection.
+        :type conn: connection object
         :return: connection autocommit setting.
         :rtype: bool
         """

--- a/airflow/hooks/jdbc_hook.py
+++ b/airflow/hooks/jdbc_hook.py
@@ -57,3 +57,16 @@ class JdbcHook(DbApiHook):
         :return:
         """
         conn.jconn.setAutoCommit(autocommit)
+
+    def get_autocommit(self, conn):
+        """
+        Get autocommit setting for the provided connection.
+        Return True if conn.autocommit is set to True.
+        Return False if conn.autocommit is not set or set to False
+
+        :param conn: The connection
+        :return: connection autocommit setting.
+        :rtype: bool
+        """
+
+        return conn.jconn.getAutoCommit()

--- a/tests/contrib/hooks/test_jdbc_hook.py
+++ b/tests/contrib/hooks/test_jdbc_hook.py
@@ -54,14 +54,14 @@ class TestJdbcHook(unittest.TestCase):
         jdbc_hook = JdbcHook()
         jdbc_conn = jdbc_hook.get_conn()
         jdbc_hook.set_autocommit(jdbc_conn, False)
-        jdbc_conn.jconn.setAutoCommit.assert_called_with(False)
+        jdbc_conn.jconn.setAutoCommit.assert_called_once_with(False)
 
     @patch("airflow.hooks.jdbc_hook.jaydebeapi.connect")
     def test_jdbc_conn_get_autocommit(self, _):
         jdbc_hook = JdbcHook()
         jdbc_conn = jdbc_hook.get_conn()
         jdbc_hook.get_autocommit(jdbc_conn)
-        self.assertTrue(jdbc_conn.jconn.getAutoCommit.called)
+        jdbc_conn.jconn.getAutoCommit.assert_called_once_with()
 
 
 if __name__ == '__main__':

--- a/tests/contrib/hooks/test_jdbc_hook.py
+++ b/tests/contrib/hooks/test_jdbc_hook.py
@@ -49,11 +49,17 @@ class TestJdbcHook(unittest.TestCase):
         self.assertIsInstance(jdbc_conn, Mock)
         self.assertEqual(jdbc_conn.name, jdbc_mock.return_value.name)  # pylint: disable=no-member
 
-        # Set autocommit
+    @patch("airflow.hooks.jdbc_hook.jaydebeapi.connect")
+    def test_jdbc_conn_set_autocommit(self, _):
+        jdbc_hook = JdbcHook()
+        jdbc_conn = jdbc_hook.get_conn()
         jdbc_hook.set_autocommit(jdbc_conn, False)
         jdbc_conn.jconn.setAutoCommit.assert_called_with(False)
 
-        # Get autocommit
+    @patch("airflow.hooks.jdbc_hook.jaydebeapi.connect")
+    def test_jdbc_conn_get_autocommit(self, _):
+        jdbc_hook = JdbcHook()
+        jdbc_conn = jdbc_hook.get_conn()
         jdbc_hook.get_autocommit(jdbc_conn)
         self.assertTrue(jdbc_conn.jconn.getAutoCommit.called)
 

--- a/tests/contrib/hooks/test_jdbc_hook.py
+++ b/tests/contrib/hooks/test_jdbc_hook.py
@@ -49,6 +49,14 @@ class TestJdbcHook(unittest.TestCase):
         self.assertIsInstance(jdbc_conn, Mock)
         self.assertEqual(jdbc_conn.name, jdbc_mock.return_value.name)  # pylint: disable=no-member
 
+        # Set autocommit
+        jdbc_hook.set_autocommit(jdbc_conn, False)
+        jdbc_conn.jconn.setAutoCommit.assert_called_with(False)
+
+        # Get autocommit
+        jdbc_hook.get_autocommit(jdbc_conn)
+        self.assertTrue(jdbc_conn.jconn.getAutoCommit.called)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues
  - https://issues.apache.org/jira/browse/AIRFLOW-5582

### Description

- [ ] Some of JDBC driver does not support autoCommit=false, such as org.apache.hive.jdbc.HiveDrive.
JdbcHook.set_autocommit update by conn.jconn.setAutoCommit, DbApiHook.get_autocommit retrieve by conn.autocommit.
After DbApiHook.execute(sql), conn.commit() will throws exception.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"