### PR TITLE
[AIRFLOW-XXX] Improve linking

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -826,7 +826,7 @@ For example a ``html_content_template`` file could look like this:
   Log file: {{ti.log_filepath}}<br>
   Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>
 
-.. _contepts/trigger_rule:
+.. _concepts/trigger_rule:
 
 Trigger Rules
 =============

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -826,6 +826,8 @@ For example a ``html_content_template`` file could look like this:
   Log file: {{ti.log_filepath}}<br>
   Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>
 
+.. _contepts/trigger_rule:
+
 Trigger Rules
 =============
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -84,14 +84,12 @@ sure you fully understand how it proceeds.
 How do I trigger tasks based on another task's failure?
 -------------------------------------------------------
 
-Check out the ``Trigger Rule`` section in the Concepts section of the
-documentation.
+Check out the :ref:`contepts/trigger_rule`.
 
 Why are connection passwords still not encrypted in the metadata db after I installed airflow[crypto]?
 ------------------------------------------------------------------------------------------------------
 
-Check out the ``Securing Connections`` section in the How-to Guides section of the
-documentation.
+Check out the :doc:`howto/secure-connections`.
 
 What's the deal with ``start_date``?
 ------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -84,7 +84,7 @@ sure you fully understand how it proceeds.
 How do I trigger tasks based on another task's failure?
 -------------------------------------------------------
 
-Check out the :ref:`contepts/trigger_rule`.
+Check out the :ref:`concepts/trigger_rule`.
 
 Why are connection passwords still not encrypted in the metadata db after I installed airflow[crypto]?
 ------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
