### PR TITLE
[WIP][AIRFLOW-XXX] GCS SFTP

### DIFF
--- a/airflow/operators/gcs_to_sftp.py
+++ b/airflow/operators/gcs_to_sftp.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This module contains Google Cloud Storage to SFTP operator.
+"""
+from tempfile import NamedTemporaryFile
+from typing import Optional
+
+from airflow.contrib.hooks.ssh_hook import SSHHook
+from airflow.gcp.hooks.gcs import GoogleCloudStorageHook
+from airflow.gcp.operators.gcs import GoogleCloudStorageListOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class GoogleCloudStorageToSFTPOperator(GoogleCloudStorageListOperator):
+    """
+    Transfer files from a Google Cloud Storage bucket to SFTP server.
+
+    :param bucket: The Google Cloud Storage bucket to find the objects. (templated)
+    :type bucket: str
+    :param sftp_path: The sftp remote path. This is the specified file path for
+        uploading file to the SFTP server.
+    :type sftp_path: str
+    :param prefix: Prefix string which filters objects whose name begin with
+        this prefix. (templated)
+    :type prefix: str
+    :param delimiter: The delimiter by which you want to filter the objects. (templated)
+        For e.g to lists the CSV files from in a directory in GCS you would use
+        delimiter='.csv'.
+    :type delimiter: str
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param sftp_conn_id: The sftp connection id. The name or identifier for
+        establishing a connection to the SFTP server.
+    :type sftp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+
+    template_fields = ("bucket", "prefix", "delimiter", "sftp_path")
+    ui_color = "#f0eee4"
+
+    # pylint: disable=too-many-arguments
+    @apply_defaults
+    def __init__(
+        self,
+        bucket: str,
+        sftp_path: str,
+        prefix: Optional[str] = None,
+        delimiter: Optional[str] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        sftp_conn_id: str = "ssh_default",
+        delegate_to: Optional[str] = None,
+        *args,
+        **kwargs
+    ) -> None:
+
+        super().__init__(
+            bucket=bucket,
+            prefix=prefix,
+            delimiter=delimiter,
+            gcp_conn_id=gcp_conn_id,
+            delegate_to=delegate_to,
+            *args,
+            **kwargs
+        )
+
+        self.sftp_path = sftp_path
+        self.sftp_conn_id = sftp_conn_id
+
+    def execute(self, context):
+        # use the super to list all files in an Google Cloud Storage bucket
+        files = super().execute(context) or []
+
+        if files:
+
+            gcs_hook = GoogleCloudStorageHook(
+                google_cloud_storage_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+            )
+
+            ssh_hook = SSHHook(ssh_conn_id=self.sftp_conn_id)
+            sftp_client = ssh_hook.get_conn().open_sftp()
+
+            for file in files:
+                with NamedTemporaryFile("w") as tmp:
+                    gcs_hook.download(self.bucket, file, tmp.name)
+                    sftp_client.put(tmp.name, self.sftp_path)
+
+            self.log.info("All done, uploaded %d files to STPS", len(files))
+        else:
+            self.log.info("No files in bucket.")
+
+        return files

--- a/airflow/operators/sftp_to_gcs.py
+++ b/airflow/operators/sftp_to_gcs.py
@@ -1,0 +1,102 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This module contains SFTP to Google Cloud Storage operator.
+"""
+from tempfile import NamedTemporaryFile
+from typing import Optional
+
+from airflow.contrib.hooks.ssh_hook import SSHHook
+from airflow.gcp.hooks.gcs import GoogleCloudStorageHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class SFTPToGoogleCloudStorageOperator(BaseOperator):
+    """
+    Transfer files to Google Cloud Storage from SFTP server.
+
+    :param sftp_path: The sftp remote path. This is the specified file path
+        for downloading the file from the SFTP server.
+    :type sftp_path: str
+    :param destination_path: Destination path within the specified bucket, it must be the full file path
+        to destination object on GCS, including GCS object (ex. `path/to/file.txt`) (templated)
+    :type destination_path: str
+    :param bucket: The bucket to upload to. (templated)
+    :type bucket: str
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
+    :type google_cloud_storage_conn_id: str
+    :param mime_type: The mime-type string
+    :type mime_type: str
+    :param delegate_to: The account to impersonate, if any
+    :type delegate_to: str
+    :param gzip: Allows for file to be compressed and uploaded as gzip
+    :type gzip: bool
+    :param sftp_conn_id: The sftp connection id. The name or identifier for
+        establishing a connection to the SFTP server.
+    :type sftp_conn_id: str
+    """
+
+    template_fields = ("sftp_path", "dst", "bucket")
+
+    @apply_defaults
+    def __init__(
+        self,
+        sftp_path: str,
+        destination_path: str,
+        bucket: str,
+        gcp_conn_id: str = "google_cloud_default",
+        mime_type: str = "application/octet-stream",
+        delegate_to: Optional[str] = None,
+        gzip: bool = False,
+        sftp_conn_id: str = "ssh_default",
+        *args,
+        **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.sftp_path = sftp_path
+        self.destination_path = destination_path
+        self.bucket = bucket
+        self.gcp_conn_id = gcp_conn_id
+        self.mime_type = mime_type
+        self.delegate_to = delegate_to
+        self.gzip = gzip
+        self.sftp_conn_id = sftp_conn_id
+
+    def execute(self, context):
+        gcs_hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to
+        )
+
+        ssh_hook = SSHHook(ssh_conn_id=self.sftp_conn_id)
+        sftp_client = ssh_hook.get_conn().open_sftp()
+
+        with NamedTemporaryFile("w") as f:
+            sftp_client.get(self.sftp_path, f.name)
+
+            gcs_hook.upload(
+                bucket_name=self.bucket,
+                object_name=self.destination_path,
+                mime_type=self.mime_type,
+                filename=f.name,
+                gzip=self.gzip,
+            )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
