### PR TITLE
[AIRFLOW-5597] Linkify urls in task instance log

### DIFF
--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -121,10 +121,18 @@
           if (res.message) {
             // Auto scroll window to the end if current window location is near the end.
             if(auto_tailing && checkAutoTailingCondition()) {
-              var should_scroll = true
+              var should_scroll = true;
             }
             // The message may contain HTML, so either have to escape it or write it as text.
-            document.getElementById(`try-${try_number}`).textContent += res.message + "\n";
+            var escaped_message = escapeHtml(res.message);
+
+            // Detect urls
+            var url_regex = /http(s)?:\/\/[\w\.\-]+(\.?:[\w\.\-]+)*([\/?#][\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=\.%]+)?/g;
+            var linkified_message = escaped_message.replace(url_regex, function(url) {
+              return "<a href=\"" + url + "\" target=\"_blank\">" + url + "</a>";
+            });
+
+            document.getElementById(`try-${try_number}`).innerHTML += linkified_message + "<br/>";
             // Auto scroll window to the end if current window location is near the end.
             if(should_scroll) {
               scrollBottom();


### PR DESCRIPTION
#6070 # Jira

- [x] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-5597

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Very often we have urls in our task instances' logs. This change allows these urls to be rendered as clickable links, so users no longer have to copy and paste these urls manually.
![image](https://user-images.githubusercontent.com/1507278/66247175-ddc77a80-e6ce-11e9-9bc8-3ec2e8baa55d.png)

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just a simple JS change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.