### PR TITLE
[AIRFLOW-5566] Fix false positive deprecation warning

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -303,6 +303,14 @@ class AirflowConfigParser(ConfigParser):
         except (NoOptionError, NoSectionError):
             return False
 
+    def file_has_option(self, section, option):
+        """
+        Check that the config file itself has the specified option.
+        This bypasses the overwritten 'has_option' in this class, which also
+        checks whether the option is in the environment variables
+        """
+        return super().has_option(section, option)
+
     def remove_option(self, section, option, remove_default=True):
         """
         Remove an option if it exists in config from a file or
@@ -548,7 +556,7 @@ conf = AirflowConfigParser(default_config=parameterized_config(DEFAULT_CONFIG))
 
 conf.read(AIRFLOW_CONFIG)
 
-if conf.has_option('core', 'AIRFLOW_HOME'):
+if conf.file_has_option('core', 'AIRFLOW_HOME'):
     msg = (
         'Specifying both AIRFLOW_HOME environment variable and airflow_home '
         'in the config file is deprecated. Please use only the AIRFLOW_HOME '


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes the following issue:

[This deprecation warning](https://github.com/apache/airflow/blob/4d4fda75333b1e6ae4e99b407ab2b1edc0d139d8/airflow/configuration.py#L551-L568) is run regardless of whether an 'airflow_home' entry exists in the config file when the 'AIRFLOW_HOME' environment variables are set.

Traceback:
[config entry check](https://github.com/apache/airflow/blob/4d4fda75333b1e6ae4e99b407ab2b1edc0d139d8/airflow/configuration.py#L551) -> [config.has_option(...)](https://github.com/apache/airflow/blob/4d4fda75333b1e6ae4e99b407ab2b1edc0d139d8/airflow/configuration.py#L296-L304) -> [get(...)]( https://github.com/apache/airflow/blob/4d4fda75333b1e6ae4e99b407ab2b1edc0d139d8/airflow/configuration.py#L214-L267)
in get:
```
        option = self._get_env_var_option(section, key)
        if option is not None:
            return option
```
'get' returns True, then 'has_option' returns True, which triggers the warning

This PR adds an additional `file_has_option` method to the `AirflowConfigParser` that does not check the environment variables for the specified option.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The additional method in this PR simply provides a way to access Python's `ConfigParser` `has_option` method, which was overwritten in the `AirflowConfigParser` class. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
