### PR TITLE
AIRFLOW-5608: Fix bug in SchedulerJob when calling executor.end

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1304,11 +1304,17 @@ class SchedulerJob(BaseJob):
                                                      async_mode)
 
         try:
+            self.log.debug("Starting executor=%s", self.executor)
+            self.executor.start()
             self._execute_helper()
         except Exception:
             self.log.exception("Exception when executing execute_helper")
         finally:
+            self.log.debug("Calling executor.end()...")
+            self.executor.end()
             self.processor_agent.end()
+            self.log.debug("Calling settings.Session.remove()...")
+            settings.Session.remove()
             self.log.info("Exited execute loop")
 
     def _execute_helper(self):
@@ -1328,8 +1334,6 @@ class SchedulerJob(BaseJob):
 
         :rtype: None
         """
-        self.executor.start()
-
         self.log.info("Resetting orphaned tasks for active dag runs")
         self.reset_state_for_orphaned_tasks()
 
@@ -1442,10 +1446,6 @@ class SchedulerJob(BaseJob):
                 execute_start_time.isoformat()
             )
             models.DAG.deactivate_stale_dags(execute_start_time)
-
-        self.executor.end()
-
-        settings.Session.remove()
 
     def _find_dags_to_process(self, dags: List[DAG], paused_dag_ids: Set[str]):
         """


### PR DESCRIPTION
Fix bug in SchedulerJob when calling executor.end

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR:
  - https://issues.apache.org/jira/browse/AIRFLOW-5608

### Description

- [x] Scheduler bug fix to call executor.end properly.

### Tests

- [x] It does not have tests.
