### PR TITLE
[AIRFLOW-5102] Worker jobs should terminate themselves if they can't heartbeat

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -27,6 +27,7 @@ from airflow.exceptions import AirflowException
 from airflow.jobs.base_job import BaseJob
 from airflow.stats import Stats
 from airflow.task.task_runner import get_task_runner
+from airflow.utils import timezone
 from airflow.utils.db import provide_session
 from airflow.utils.net import get_hostname
 from airflow.utils.state import State
@@ -98,14 +99,12 @@ class LocalTaskJob(BaseJob):
                     self.log.info("Task exited with return code %s", return_code)
                     return
 
-                # Periodically heartbeat so that the scheduler doesn't think this
-                # is a zombie
-                last_heartbeat_time = time.time()
                 self.heartbeat()
 
                 # If it's been too long since we've heartbeat, then it's possible that
                 # the scheduler rescheduled this task, so kill launched processes.
-                time_since_last_heartbeat = time.time() - last_heartbeat_time
+                # This can only really happen if the worker can't readh the DB for a long time
+                time_since_last_heartbeat = (timezone.utcnow() - self.latest_heartbeat).total_seconds()
                 if time_since_last_heartbeat > heartbeat_time_limit:
                     Stats.incr('local_task_job_prolonged_heartbeat_failure', 1, 1)
                     self.log.error("Heartbeat time limited exceeded!")

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -21,10 +21,13 @@
 import datetime
 import unittest
 
+from sqlalchemy.exc import OperationalError
+
 from airflow.jobs import BaseJob
 from airflow.utils import timezone
 from airflow.utils.db import create_session
 from airflow.utils.state import State
+from tests.compat import Mock, patch
 
 
 class TestBaseJob(unittest.TestCase):
@@ -96,3 +99,19 @@ class TestBaseJob(unittest.TestCase):
         job.state = State.SUCCESS
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
         self.assertFalse(job.is_alive(), "Completed jobs even with recent heartbeat should not be alive")
+
+    @patch('airflow.jobs.base_job.create_session')
+    def test_heartbeat_failed(self, mock_create_session):
+        when = timezone.utcnow() - datetime.timedelta(seconds=60)
+        with create_session() as session:
+            mock_session = Mock(spec_set=session, name="MockSession")
+            mock_create_session.return_value.__enter__.return_value = mock_session
+
+            job = self.TestJob(None, heartrate=10, state=State.RUNNING)
+            job.latest_heartbeat = when
+
+            mock_session.commit.side_effect = OperationalError("Force fail", {}, None)
+
+            job.heartbeat()
+
+            self.assertEqual(job.latest_heartbeat, when, "attriubte not updated when heartbeat fails")

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -111,8 +111,7 @@ class TestLocalTaskJob(unittest.TestCase):
         session.merge(ti)
         session.commit()
 
-        ret = job1.heartbeat_callback()
-        self.assertEqual(ret, None)
+        job1.heartbeat_callback()
 
         mock_pid.return_value = 2
         self.assertRaises(AirflowException, job1.heartbeat_callback)
@@ -126,7 +125,7 @@ class TestLocalTaskJob(unittest.TestCase):
 
         heartbeat_records = []
 
-        def heartbeat_recorder():
+        def heartbeat_recorder(**kwargs):
             heartbeat_records.append(timezone.utcnow())
 
         with create_session() as session:
@@ -153,7 +152,7 @@ class TestLocalTaskJob(unittest.TestCase):
 
             job = LocalTaskJob(task_instance=ti, executor=TestExecutor(do_update=False))
             job.heartrate = 2
-            job.heartbeat = heartbeat_recorder
+            job.heartbeat_callback = heartbeat_recorder
             job._execute()
             self.assertGreater(len(heartbeat_records), 1)
             for i in range(1, len(heartbeat_records)):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-5102

### Description

- [x] If a LocalTaskJob fails to heartbeat for scheduler_zombie_task_threshold, it should shut itself down.

  However, at some point, a change was made to catch exceptions inside the heartbeat, so the LocalTaskJob thought it had managed to heartbeat successfully.

  This effectively means that zombie tasks don't shut themselves down. When the scheduler reschedules the job, this means we could have two instances of the task running concurrently.

### Tests

- [x] I have added tests to ensure that `self.latest_heartbeat` is only updated when the DB is updated.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] None