### PR TITLE
[AIRFLOW-XXX] Fix Documentation for adding extra Operator Links

### DIFF
--- a/docs/howto/define_extra_link.rst
+++ b/docs/howto/define_extra_link.rst
@@ -36,15 +36,16 @@ The following code shows how to add extra links to an operator:
 
 
     class GoogleLink(BaseOperatorLink):
+        name = 'Google'
 
         def get_link(self, operator, dttm):
             return "https://www.google.com"
 
     class MyFirstOperator(BaseOperator):
 
-        operator_extra_link_dict = {
-            "Google": GoogleLink(),
-        }
+        operator_extra_links = (
+            GoogleLink(),
+        )
 
         @apply_defaults
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
https://github.com/apache/airflow/pull/5094 updated the code but maybe forgot to update this docs


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Doc change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
