### PR TITLE
AIRFLOW-5126 Read aws_session_token in extra_config of the aws hook

### DIFF
--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -160,7 +160,6 @@ class AwsHook(BaseHook):
                     aws_session_token = credentials['SessionToken']
 
                 endpoint_url = extra_config.get('host')
-                # If there is an external session token use this token
 
             except AirflowException:
                 # No connection found: fallback on boto3 credential strategy

--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -126,17 +126,21 @@ class AwsHook(BaseHook):
                 external_id = extra_config.get('external_id')
                 aws_account_id = extra_config.get('aws_account_id')
                 aws_iam_role = extra_config.get('aws_iam_role')
+                if 'aws_session_token' in extra_config and aws_session_token is None:
+                    aws_session_token = extra_config['aws_session_token']
 
-                if role_arn is None and aws_account_id is not None and \
-                        aws_iam_role is not None:
+                if role_arn is None and aws_account_id is not None and aws_iam_role is not None:
                     role_arn = "arn:aws:iam::{}:role/{}" \
                         .format(aws_account_id, aws_iam_role)
 
                 if role_arn is not None:
+
                     sts_session = boto3.session.Session(
                         aws_access_key_id=aws_access_key_id,
                         aws_secret_access_key=aws_secret_access_key,
-                        region_name=region_name)
+                        region_name=region_name,
+                        aws_session_token=aws_session_token
+                    )
 
                     sts_client = sts_session.client('sts')
 
@@ -156,6 +160,7 @@ class AwsHook(BaseHook):
                     aws_session_token = credentials['SessionToken']
 
                 endpoint_url = extra_config.get('host')
+                # If there is an external session token use this token
 
             except AirflowException:
                 # No connection found: fallback on boto3 credential strategy

--- a/docs/howto/connection/aws.rst
+++ b/docs/howto/connection/aws.rst
@@ -57,6 +57,7 @@ Extra (optional)
     * ``host``: Endpoint URL for the connection
     * ``region_name``: AWS region for the connection
     * ``role_arn``: AWS role ARN for the connection
+    * ``aws_session_token``: AWS session token if you use external credentials. You are responsible for renewing these.
 
     Example "extras" field:
 


### PR DESCRIPTION


### Description

Read a temporary token in case it is present this is important, if you don't manage the session token through `Airflow` but rather you use something like [vault](https://www.vaultproject.io/docs/secrets/aws/index.html) to manage these.

### Tests
adjusted existing test to also parse the session token not other impact.


