### PR TITLE
[AIRFLOW-5634] Don't allow disabled fields to be edited in DagModelView

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3200,7 +3200,7 @@ class ConfigurationView(wwwutils.SuperUserMixin, AirflowViewMixin, BaseView):
 
 class DagModelView(wwwutils.SuperUserMixin, ModelView):
     column_list = ('dag_id', 'owners')
-    column_editable_list = ('is_paused',)
+    column_editable_list = ('is_paused', 'description', 'default_view')
     form_excluded_columns = ('is_subdag', 'is_active')
     column_searchable_list = ('dag_id',)
     column_filters = (
@@ -3245,3 +3245,15 @@ class DagModelView(wwwutils.SuperUserMixin, ModelView):
             .get_count_query()\
             .filter(models.DagModel.is_active)\
             .filter(~models.DagModel.is_subdag)
+
+    def edit_form(self, obj=None):
+        # Ensure that disabled fields aren't overwritten
+        form = super(DagModelView, self).edit_form(obj)
+
+        if not obj:
+            return obj
+
+        for fld in form:
+            if self.form_widget_args.get(fld.name, {}).get('disabled'):
+                fld.data = getattr(obj, fld.name)
+        return form

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1046,5 +1046,34 @@ class TestConnectionModelView(unittest.TestCase):
         self.assertIsNone(conn.extra_dejson['extra__google_cloud_platform__num_retries'])
 
 
+class TestDagModelView(unittest.TestCase):
+    EDIT_URL = '/admin/dagmodel/edit/?id=example_bash_operator'
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestDagModelView, cls).setUpClass()
+        app = application.create_app(testing=True)
+        app.config['WTF_CSRF_METHODS'] = []
+        cls.app = app.test_client()
+
+    def test_edit_disabled_fields(self):
+        response = self.app.post(
+            self.EDIT_URL,
+            data={
+                "fileloc": "/etc/passwd",
+                "description": "Set in tests",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        session = Session()
+        DM = models.DagModel
+        dm = session.query(DM).filter(DM.dag_id == 'example_bash_operator').one()
+        session.close()
+
+        self.assertEqual(dm.description, "Set in tests")
+        self.assertNotEqual(dm.fileloc, "/etc/passwd", "Disabled fields shouldn't be updated")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-5634

### Description

- [x] If someone plays silly games and edits the HTML (or crafts a request) to
the DAG model it is possible to edit fields that aren't meant to be
edited, leading to odd to debug behaviour

  Against v1-10-stable as this only applies to the classic UI. Separate PR coming for RBAC UI (where I will just disable the ability to edit the DagModel. I could do the same here )

### Tests

- [x] Tests added

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
