### PR TITLE
[AIRFLOW-5634] Don't allow editing of DagModelView

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2555,7 +2555,7 @@ class DagModelView(AirflowModelView):
 
     datamodel = AirflowModelView.CustomSQLAInterface(models.DagModel)
 
-    base_permissions = ['can_list', 'can_show', 'can_edit']
+    base_permissions = ['can_list', 'can_show']
 
     list_columns = ['dag_id', 'is_paused', 'last_scheduler_run',
                     'last_expired', 'scheduler_lock', 'fileloc', 'owners']

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -446,15 +446,6 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.get(url, follow_redirects=True)
         self.check_content_in_response('XCom', resp)
 
-    def test_edit_dagrun_page(self):
-        resp = self.client.get('dagmodel/edit/example_bash_operator', follow_redirects=False)
-        self.assertEqual(resp.status_code, 200)
-
-    def test_edit_dagrun_url(self):
-        with self.app.test_request_context():
-            url = url_for('DagModelView.edit', pk='example_bash_operator')
-            self.assertEqual(url, '/dagmodel/edit/example_bash_operator')
-
     def test_rendered(self):
         url = ('rendered?task_id=runme_0&dag_id=example_bash_operator&execution_date={}'
                .format(self.percent_encode(self.EXAMPLE_DAG_DEFAULT_DATE)))


### PR DESCRIPTION
### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-5634

### Description

- [x] Most/all of these fields are not fur user editing, with the exception of
Pause which is set in other ways, and if a user edits these it will just
confuse the system.

  So lets disable the FAB edit form.

  (Not to mention that the form was broken because it didn't accept the
last_scheduler_run as filled out.)

  If anyone feels this is worth keeping I can make the it work but not allow editing of most/all fields