### PR TITLE
[AIRFLOW-5621] - Failure callback is not triggered when marked Failed on UI

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -163,5 +163,8 @@ class LocalTaskJob(BaseJob):
                 "Taking the poison pill.",
                 ti.state
             )
+            if ti.state == State.FAILED and ti.task.on_failure_callback:
+                context = ti.get_template_context()
+                ti.task.on_failure_callback(context)
             self.task_runner.terminate()
             self.terminating = True

--- a/tests/dags/test_mark_failure.py
+++ b/tests/dags/test_mark_failure.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
+from jobs.test_local_task_job import data
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+
+
+def check_failure(context):
+    data['called'] = True
+
+
+args = {
+    'owner': 'airflow',
+    'start_date': DEFAULT_DATE,
+}
+
+dag = DAG(dag_id='test_mark_success', default_args=args)
+
+task = BashOperator(
+    task_id='task1',
+    bash_command='sleep 600',
+    on_failure_callback=check_failure,
+    dag=dag)

--- a/tests/dags/test_mark_failure.py
+++ b/tests/dags/test_mark_failure.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
+from jobs.test_local_task_job import data
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+
+args = {
+    'owner': 'airflow',
+    'start_date': DEFAULT_DATE,
+}
+
+dag = DAG(dag_id='test_mark_success', default_args=args)
+
+def check_failure(context):
+    data['called'] = True
+
+task = BashOperator(
+    task_id='task1',
+    bash_command='sleep 600',
+    on_failure_callback=check_failure,
+    dag=dag)

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -38,6 +38,7 @@ from tests.executors.test_executor import TestExecutor
 from tests.test_utils.db import clear_db_runs
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+data = {'called': False}
 
 
 class TestLocalTaskJob(unittest.TestCase):
@@ -243,3 +244,44 @@ class TestLocalTaskJob(unittest.TestCase):
         self.assertEqual(ti.state, State.RUNNING)
 
         session.close()
+
+    def test_mark_failure_on_failure_callback(self):
+        """
+        Test that ensures that mark_failure in the UI fails
+        the task, and executes on_failure_callback
+        """
+        dagbag = models.DagBag(
+            dag_folder=TEST_DAG_FOLDER,
+            include_examples=False,
+        )
+        dag = dagbag.dags.get('test_mark_failure')
+        task = dag.get_task('task1')
+
+        session = settings.Session()
+
+        dag.clear()
+        dag.create_dagrun(run_id="test",
+                          state=State.RUNNING,
+                          execution_date=DEFAULT_DATE,
+                          start_date=DEFAULT_DATE,
+                          session=session)
+        ti = TI(task=task, execution_date=DEFAULT_DATE)
+        ti.refresh_from_db()
+        job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
+        process = multiprocessing.Process(target=job1.run)
+        process.start()
+        ti.refresh_from_db()
+        for _ in range(0, 50):
+            if ti.state == State.RUNNING:
+                break
+            time.sleep(0.1)
+            ti.refresh_from_db()
+        self.assertEqual(State.RUNNING, ti.state)
+        ti.state = State.FAILED
+        session.merge(ti)
+        session.commit()
+
+        job1.heartbeat_callback()
+        process.join(timeout=10)
+        self.assertFalse(process.is_alive())
+        self.assertTrue(data['called'])


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5621/) issues and references them in the PR title.

### Description

- [ ] When a task is marked 'Failed' on UI, on_failure_callback on the task is not triggered.

### Tests

- [ ] My PR adds the following unit tests 
      test_mark_failure_on_failure_callback

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

