### PR TITLE
[AIRFLOW-5615] Reduce duplicated logic around job heartbeating

### DIFF
--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -147,7 +147,7 @@ class BaseJob(Base, LoggingMixin):
         Callback that is called during heartbeat. This method should be overwritten.
         """
 
-    def heartbeat(self):
+    def heartbeat(self, only_if_necessary=False):
         """
         Heartbeats update the job's entry in the database with a timestamp
         for the latest_heartbeat and allows for the job to be killed
@@ -165,7 +165,18 @@ class BaseJob(Base, LoggingMixin):
         will sleep 50 seconds to complete the 60 seconds and keep a steady
         heart rate. If you go over 60 seconds before calling it, it won't
         sleep at all.
+
+        :param only_if_necessary: If the heartbeat is not yet due then do
+            nothing (don't update column, don't call ``heartbeat_callback``)
+        :type only_if_necessary: boolean
         """
+        seconds_remaining = 0
+        if self.latest_heartbeat:
+            seconds_remaining = self.heartrate - (timezone.utcnow() - self.latest_heartbeat).total_seconds()
+
+        if seconds_remaining > 0 and only_if_necessary:
+            return
+
         previous_heartbeat = self.latest_heartbeat
 
         try:
@@ -215,9 +226,7 @@ class BaseJob(Base, LoggingMixin):
             self.state = State.RUNNING
             session.add(self)
             session.commit()
-            id_ = self.id
             make_transient(self)
-            self.id = id_
 
             try:
                 self._execute()

--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -147,7 +147,7 @@ class BaseJob(Base, LoggingMixin):
         Callback that is called during heartbeat. This method should be overwritten.
         """
 
-    def heartbeat(self, only_if_necessary=False):
+    def heartbeat(self, only_if_necessary: bool = False):
         """
         Heartbeats update the job's entry in the database with a timestamp
         for the latest_heartbeat and allows for the job to be killed

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1615,9 +1615,6 @@ class SchedulerJob(BaseJob):
 
         :rtype: None
         """
-        # Last time that self.heartbeat() was called.
-        last_self_heartbeat_time = timezone.utcnow()
-
         is_unit_test = conf.getboolean('core', 'unit_test_mode')
 
         # For the execute duration, parse and schedule DAGs
@@ -1642,12 +1639,7 @@ class SchedulerJob(BaseJob):
                 continue
 
             # Heartbeat the scheduler periodically
-            time_since_last_heartbeat = (timezone.utcnow() -
-                                         last_self_heartbeat_time).total_seconds()
-            if time_since_last_heartbeat > self.heartrate:
-                self.log.debug("Heartbeating the scheduler")
-                self.heartbeat()
-                last_self_heartbeat_time = timezone.utcnow()
+            self.heartbeat(only_if_necessary=True)
 
             self._emit_pool_metrics()
 


### PR DESCRIPTION
### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-5615

### Description

- [x] Both SchedulerJob and LocalTaskJob have their own timers and decide when
to call heartbeat based upon that. THis makes those jobs harder to
follow, so I've moved the logic to BaseJob

### Tests

- [x] Tests added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release