### PR TITLE
[AIRFLOW-XXX] Clarify daylight savings time behaviour

### DIFF
--- a/docs/timezone.rst
+++ b/docs/timezone.rst
@@ -147,18 +147,20 @@ It is left up to the DAG to handle this.
     local_tz = pendulum.timezone("Europe/Amsterdam")
     local_tz.convert(execution_date)
 
-
 Cron schedules
 ''''''''''''''
 
-In case you set a cron schedule, Airflow assumes you will always want to run at the exact same time. It will
-then ignore day light savings time. Thus, if you have a schedule that says
-run at the end of interval every day at 08:00 GMT+1 it will always run at the end of interval 08:00 GMT+1,
-regardless if day light savings time is in place.
-
+Time zone aware DAGs that use cron schedules respect daylight savings
+time. For example, a DAG with a start date in the ``US/Eastern`` time zone
+with a schedule of ``0 0 * * *`` will run daily at 04:00 UTC during
+daylight savings time and at 05:00 otherwise.
 
 Time deltas
 '''''''''''
-For schedules with time deltas Airflow assumes you always will want to run with the specified interval. So if you
-specify a ``timedelta(hours=2)`` you will always want to run two hours later. In this case day light savings time will
-be taken into account.
+
+Time zone aware DAGs that use ``timedelta`` or ``relativedelta`` schedules
+respect daylight savings time for the start date but do not adjust for
+daylight savings time when scheduling subsequent runs. For example, a
+DAG with a start date of ``pendulum.create(2020, 1, 1, tz="US/Eastern")``
+and a schedule interval of ``timedelta(days=1)`` will run daily at 05:00
+UTC regardless of daylight savings time.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
