### PR TITLE
[AIRFLOW-5651] Replace GCP deprecated imports

### DIFF
--- a/airflow/gcp/operators/kubernetes_engine.py
+++ b/airflow/gcp/operators/kubernetes_engine.py
@@ -29,8 +29,8 @@ from typing import Dict, Optional, Union
 from google.cloud.container_v1.types import Cluster
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.gcp.hooks.base import GoogleCloudBaseHook
 from airflow.gcp.hooks.kubernetes_engine import GKEClusterHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults

--- a/airflow/operators/gcs_to_s3.py
+++ b/airflow/operators/gcs_to_s3.py
@@ -21,8 +21,8 @@ This module contains Google Cloud Storage to S3 operator.
 """
 import warnings
 
-from airflow.contrib.operators.gcs_list_operator import GoogleCloudStorageListOperator
 from airflow.gcp.hooks.gcs import GoogleCloudStorageHook
+from airflow.gcp.operators.gcs import GoogleCloudStorageListOperator
 from airflow.hooks.S3_hook import S3Hook
 from airflow.utils.decorators import apply_defaults
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5651
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
