### PR TITLE
[AIRFLOW-5653] Log caught AirflowSkipException in task instance log

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -953,7 +953,7 @@ class TaskInstance(Base, LoggingMixin):
         except AirflowSkipException as e:
             # log only if exception has any arguments to prevent log flooding
             if e.args:
-                self.log.warning(e)
+                self.log.info(e)
             self.refresh_from_db(lock_for_update=True)
             self.state = State.SKIPPED
         except AirflowRescheduleException as reschedule_exception:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -950,7 +950,10 @@ class TaskInstance(Base, LoggingMixin):
                 Stats.incr('ti_successes')
             self.refresh_from_db(lock_for_update=True)
             self.state = State.SUCCESS
-        except AirflowSkipException:
+        except AirflowSkipException as e:
+            # log only if exception has any arguments to prevent log flooding
+            if e.args:
+                self.log.warning(e)
             self.refresh_from_db(lock_for_update=True)
             self.state = State.SKIPPED
         except AirflowRescheduleException as reschedule_exception:


### PR DESCRIPTION
### Jira

- https://issues.apache.org/jira/browse/AIRFLOW-5653

### Description

-  Logging any caught AirflowSkipException with message in models/taskinstance.py
to remove confusion due to no task skipping information being present in the logs

### Tests

- My PR does not needs any new tests since its just adding a single log line

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- No new functionality introduced
