### PR TITLE
[AIRFLOW-5710] Optionally raise exception on unused operator arguments.

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -243,6 +243,7 @@ default_cpus = 1
 default_ram = 512
 default_disk = 512
 default_gpus = 0
+allow_illegal_arguments = True
 
 [hive]
 # Default mapreduce queue for HiveOperator tasks

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -307,6 +307,12 @@ class BaseOperator(LoggingMixin):
 
         if args or kwargs:
             # TODO remove *args and **kwargs in Airflow 2.0
+            if not conf.getboolean('operators', 'ALLOW_ILLEGAL_ARGUMENTS'):
+                raise AirflowException(
+                    "Invalid arguments were passed to {c} (task_id: {t}). Invalid "
+                    "arguments were:\n*args: {a}\n**kwargs: {k}".format(
+                        c=self.__class__.__name__, a=args, k=kwargs, t=task_id),
+                )
             warnings.warn(
                 'Invalid arguments were passed to {c} (task_id: {t}). '
                 'Support for passing such arguments will be dropped in '

--- a/tests/core.py
+++ b/tests/core.py
@@ -455,6 +455,23 @@ class TestCore(unittest.TestCase):
                  '(task_id: test_illegal_args).'),
                 w[0].message.args[0])
 
+    def test_illegal_args_forbidden(self):
+        """
+        Tests that operators raise exceptions on illegal arguments when
+        illegal arguments are not allowed.
+        """
+        with conf_vars({('operators', 'allow_illegal_arguments'): 'False'}):
+            with self.assertRaises(AirflowException) as ctx:
+                BashOperator(
+                    task_id='test_illegal_args',
+                    bash_command='echo success',
+                    dag=self.dag,
+                    illegal_argument_1234='hello?')
+            self.assertIn(
+                ('Invalid arguments were passed to BashOperator '
+                 '(task_id: test_illegal_args).'),
+                str(ctx.exception))
+
     def test_bash_operator(self):
         t = BashOperator(
             task_id='test_bash_operator',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5710
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

My team doesn't always notice warnings for unused operator arguments, and the behavior in airflow 2.0 (raising an exception) would be useful to us. This patch adds an `ALLOW_ILLEGAL_ARGUMENTS` configuration option that defaults to `True`, and if `False` raises an exception on unused arguments.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
