### PR TITLE
[AIRFLOW-5659] - Add support for ephemeral storage on KubernetesPodOp…

### DIFF
--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -33,12 +33,16 @@ class Resources(K8SModel):
     :type request_memory: str
     :param request_cpu: requested CPU number
     :type request_cpu: float | str
+    :param request_ephemeral_storage: requested ephermeral storage
+    :type request_ephemeral_storage: str
     :param limit_memory: limit for memory usage
     :type limit_memory: str
     :param limit_cpu: Limit for CPU used
     :type limit_cpu: float | str
     :param limit_gpu: Limits for GPU used
     :type limit_gpu: int
+    :param limit_ephemeral_storage: Limit for ephermeral storage
+    :type limit_ephemeral_storage: float | str
     """
     __slots__ = ('request_memory', 'request_cpu', 'limit_memory', 'limit_cpu', 'limit_gpu')
 
@@ -46,14 +50,18 @@ class Resources(K8SModel):
             self,
             request_memory=None,
             request_cpu=None,
+            request_ephemeral_storage=None,
             limit_memory=None,
             limit_cpu=None,
-            limit_gpu=None):
+            limit_gpu=None,
+            limit_ephemeral_storage=None):
         self.request_memory = request_memory
         self.request_cpu = request_cpu
+        self.request_ephemeral_storage = request_ephemeral_storage
         self.limit_memory = limit_memory
         self.limit_cpu = limit_cpu
         self.limit_gpu = limit_gpu
+        self.limit_ephemeral_storage = limit_ephemeral_storage
 
     def is_empty_resource_request(self):
         """Whether resource is empty"""
@@ -61,17 +69,30 @@ class Resources(K8SModel):
 
     def has_limits(self):
         """Whether resource has limits"""
-        return self.limit_cpu is not None or self.limit_memory is not None or self.limit_gpu is not None
+        return self.limit_cpu is not None or \
+            self.limit_memory is not None or \
+            self.limit_gpu is not None or \
+            self.limit_ephemeral_storage is not None
 
     def has_requests(self):
         """Whether resource has requests"""
-        return self.request_cpu is not None or self.request_memory is not None
+        return self.request_cpu is not None or \
+            self.request_memory is not None or \
+            self.request_ephemeral_storage is not None
 
     def to_k8s_client_obj(self) -> k8s.V1ResourceRequirements:
         """Converts to k8s client object"""
         return k8s.V1ResourceRequirements(
-            limits={'cpu': self.limit_cpu, 'memory': self.limit_memory, 'nvidia.com/gpu': self.limit_gpu},
-            requests={'cpu': self.request_cpu, 'memory': self.request_memory}
+            limits={
+                'cpu': self.limit_cpu,
+                'memory': self.limit_memory,
+                'nvidia.com/gpu': self.limit_gpu,
+                'ephemeral-storage': self.limit_ephemeral_storage
+            },
+            requests={
+                'cpu': self.request_cpu,
+                'memory': self.request_memory,
+                'ephemeral-storage': self.request_ephemeral_storage}
         )
 
     def attach_to_pod(self, pod: k8s.V1Pod) -> k8s.V1Pod:

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -286,11 +286,13 @@ class PodGenerator:
         if resources is None:
             requests = {
                 'cpu': namespaced.get('request_cpu'),
-                'memory': namespaced.get('request_memory')
+                'memory': namespaced.get('request_memory'),
+                'ephemeral-storage': namespaced.get('ephemeral-storage')
             }
             limits = {
                 'cpu': namespaced.get('limit_cpu'),
-                'memory': namespaced.get('limit_memory')
+                'memory': namespaced.get('limit_memory'),
+                'ephemeral-storage': namespaced.get('ephemeral-storage')
             }
             all_resources = list(requests.values()) + list(limits.values())
             if all(r is None for r in all_resources):

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -44,6 +44,7 @@ class TestPodGenerator(unittest.TestCase):
             # This should produce a single secret mounted in env
             Secret('env', 'TARGET', 'secret_b', 'source_b'),
         ]
+
         self.labels = {
             'airflow-worker': 'uuid',
             'dag_id': 'dag_id',
@@ -59,7 +60,7 @@ class TestPodGenerator(unittest.TestCase):
             'namespace': 'namespace'
         }
 
-        self.resources = Resources('1Gi', 1, '2Gi', 2, 1)
+        self.resources = Resources('1Gi', 1, '2Gi', '2Gi', 2, 1, '4Gi')
         self.k8s_client = ApiClient()
         self.expected = {
             'apiVersion': 'v1',
@@ -109,12 +110,14 @@ class TestPodGenerator(unittest.TestCase):
                     'resources': {
                         'requests': {
                             'memory': '1Gi',
-                            'cpu': 1
+                            'cpu': 1,
+                            'ephemeral-storage': '2Gi'
                         },
                         'limits': {
                             'memory': '2Gi',
                             'cpu': 2,
-                            'nvidia.com/gpu': 1
+                            'nvidia.com/gpu': 1,
+                            'ephemeral-storage': '4Gi'
                         },
                     },
                     'ports': [{'name': 'foo', 'containerPort': 1234}],

--- a/tests/runtime/kubernetes/test_kubernetes_pod_operator.py
+++ b/tests/runtime/kubernetes/test_kubernetes_pod_operator.py
@@ -312,8 +312,10 @@ class TestKubernetesPodOperator(unittest.TestCase):
         resources = {
             'limit_cpu': 0.25,
             'limit_memory': '64Mi',
+            'limit_ephemeral_storage': '2Gi',
             'request_cpu': '250m',
             'request_memory': '64Mi',
+            'request_ephemeral_storage': '1Gi',
         }
         k = KubernetesPodOperator(
             namespace='default',
@@ -332,12 +334,14 @@ class TestKubernetesPodOperator(unittest.TestCase):
         self.expected_pod['spec']['containers'][0]['resources'] = {
             'requests': {
                 'memory': '64Mi',
-                'cpu': '250m'
+                'cpu': '250m',
+                'ephemeral-storage': '1Gi'
             },
             'limits': {
                 'memory': '64Mi',
                 'cpu': 0.25,
-                'nvidia.com/gpu': None
+                'nvidia.com/gpu': None,
+                'ephemeral-storage': '2Gi'
             }
         }
         self.assertEqual(self.expected_pod, actual_pod)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5659) issues and references them in the PR title.

### Description

- [X] Add support for specifying requests and limits on ephemeral-storage for KubernetesPodOperator.

### Tests

- [X] My PR adds check on unit tests: test_gen_pod and test_gen_pod_extract_xcom

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
