### PR TITLE
[AIRFLOW-5661] Fix create_cluster method of GKEClusterHook

### DIFF
--- a/airflow/gcp/hooks/kubernetes_engine.py
+++ b/airflow/gcp/hooks/kubernetes_engine.py
@@ -241,7 +241,7 @@ class GKEClusterHook(GoogleCloudBaseHook):
             return resource.target_link
         except AlreadyExists as error:
             self.log.info('Assuming Success: %s', error.message)
-            return self.get_cluster(name=cluster.name).self_link
+            return self.get_cluster(name=cluster.name)
 
     @GoogleCloudBaseHook.fallback_to_default_project_id
     def get_cluster(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5661

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This PR fixes `create_cluster` method of `GKEClusterHook`. The method uses `get_cluster` which already returns a string, so calling `self_link` once more rises error. 

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
