### PR TITLE
[AIRFLOW-XXX] Add logo info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Use Airflow to author workflows as directed acyclic graphs (DAGs) of tasks. The 
 - [Contributing](#contributing)
 - [Who uses Apache Airflow?](#who-uses-apache-airflow)
 - [Who Maintains Apache Airflow?](#who-maintains-apache-airflow)
+- [Can I use the Apache Airflow logo in my presentation?](#can-i-use-the-apache-airflow-logo-in-my-presentation)
 - [Links](#links)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -440,6 +441,10 @@ but the [core committers/maintainers](https://people.apache.org/committers-by-pr
 are responsible for reviewing and merging PRs as well as steering conversation around new feature requests.
 If you would like to become a maintainer, please review the Apache Airflow
 [committer requirements](https://cwiki.apache.org/confluence/display/AIRFLOW/Committers).
+
+## Can I use the Apache Airflow logo in my presentation?
+
+Yes! Be sure to abide by the Apache Foundation [trademark policies](https://www.apache.org/foundation/marks/#books) and the Apache Airflow [Brandbook](https://cwiki.apache.org/confluence/display/AIRFLOW/Brandbook). The most up to date logos are found in [this repo](/docs/img/logos) and on the Apache Software Foundation [website](https://www.apache.org/logos/about.html).
 
 ## Links
 


### PR DESCRIPTION
I added info about logo usage to the README! One thing I wasn't sure is if line 48 needs to be included in the README - I autogenerated it when I built the docs locally, but if I should remove it because it will be generated as part of the build, let me know. 

If needed, I can also add a README to the docs/img/logos folder - I didn't do that yet because I was unsure how it would affect other generated docs