### PR TITLE
[AIRFLOW-5682] Allow labels in gcs_to_bq operator

### DIFF
--- a/airflow/operators/gcs_to_bq.py
+++ b/airflow/operators/gcs_to_bq.py
@@ -147,6 +147,8 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key"
             }
     :type encryption_configuration: dict
+    :param labels: a dictionary containing labels for the job/query, passed to BigQuery
+    :type labels: dict
     :param location: [Optional] The geographic location of the job. Required except for US and EU.
         See details at https://cloud.google.com/bigquery/docs/locations#specifying_your_location
     :type location: str
@@ -187,6 +189,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                  cluster_fields=None,
                  autodetect=True,
                  encryption_configuration=None,
+                 labels=None,
                  location=None,
                  *args, **kwargs):
 
@@ -229,6 +232,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.cluster_fields = cluster_fields
         self.autodetect = autodetect
         self.encryption_configuration = encryption_configuration
+        self.labels = labels
         self.location = location
 
     def execute(self, context):
@@ -274,6 +278,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 allow_jagged_rows=self.allow_jagged_rows,
                 encoding=self.encoding,
                 src_fmt_configs=self.src_fmt_configs,
+                labels=self.labels,
                 encryption_configuration=self.encryption_configuration
             )
         else:
@@ -297,6 +302,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 src_fmt_configs=self.src_fmt_configs,
                 time_partitioning=self.time_partitioning,
                 cluster_fields=self.cluster_fields,
+                labels=self.labels,
                 encryption_configuration=self.encryption_configuration)
 
         if self.max_id_key:

--- a/tests/gcp/hooks/test_bigquery.py
+++ b/tests/gcp/hooks/test_bigquery.py
@@ -714,11 +714,12 @@ class TestBigQueryCursor(unittest.TestCase):
 class TestLabelsInRunJob(unittest.TestCase):
     @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
     def test_run_query_with_arg(self, mocked_rwc):
-        project_id = 12345
+        project_id = '12345'
 
         def run_with_config(config):
             self.assertEqual(
-                config['labels'], {'label1': 'test1', 'label2': 'test2'}
+                config['labels'], {'label1': 'test1', 'label2': 'test2',
+                                   'airflow-version': hook._AIRFLOW_VERSION}
             )
         mocked_rwc.side_effect = run_with_config
 
@@ -726,6 +727,29 @@ class TestLabelsInRunJob(unittest.TestCase):
         bq_hook.run_query(
             sql='select 1',
             destination_dataset_table='my_dataset.my_table',
+            labels={'label1': 'test1', 'label2': 'test2'}
+        )
+
+        assert mocked_rwc.call_count == 1
+
+
+class TestLabelsInRunLoad(unittest.TestCase):
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_run_query_with_arg(self, mocked_rwc):
+        project_id = '12345'
+
+        def run_with_config(config):
+            self.assertEqual(
+                config['labels'], {'label1': 'test1', 'label2': 'test2',
+                                   'airflow-version': hook._AIRFLOW_VERSION}
+            )
+        mocked_rwc.side_effect = run_with_config
+
+        bq_hook = hook.BigQueryBaseCursor(mock.Mock(), project_id)
+        bq_hook.run_load(
+            destination_project_dataset_table='my_dataset.my_table',
+            schema_fields=[],
+            source_uris=[],
             labels={'label1': 'test1', 'label2': 'test2'}
         )
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5682) issues and references them in the PR title.

### Description

- [X] Adds support for labels when using the GoogleCloudStorageToBigQuery
operator.

### Tests

- [X] My PR adds the following unit test: `test_bigquery.TestLabelsInRunLoad`

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
