### PR TITLE
[AIRFLOW-5683] Add propagate_skipped_state to SubDagOperator

### DIFF
--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -189,7 +189,6 @@
 ./airflow/operators/s3_to_redshift_operator.py
 ./airflow/operators/slack_operator.py
 ./airflow/operators/sqlite_operator.py
-./airflow/operators/subdag_operator.py
 ./airflow/plugins_manager.py
 ./airflow/providers/aws/operators/athena.py
 ./airflow/providers/aws/sensors/athena.py

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -18,13 +18,16 @@
 # under the License.
 
 import unittest
+from unittest import mock
 from unittest.mock import Mock
+
+from parameterized import parameterized
 
 import airflow
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.subdag_operator import SubDagOperator
+from airflow.operators.subdag_operator import SkippedStatePropagationOptions, SubDagOperator
 from airflow.utils.db import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
@@ -237,3 +240,66 @@ class TestSubDagOperator(unittest.TestCase):
 
         sub_dagrun.refresh_from_db()
         self.assertEqual(sub_dagrun.state, State.RUNNING)
+
+    @parameterized.expand([
+        (SkippedStatePropagationOptions.ALL_LEAVES, [State.SKIPPED, State.SKIPPED], True),
+        (SkippedStatePropagationOptions.ALL_LEAVES, [State.SKIPPED, State.SUCCESS], False),
+        (SkippedStatePropagationOptions.ANY_LEAF, [State.SKIPPED, State.SUCCESS], True),
+        (SkippedStatePropagationOptions.ANY_LEAF, [State.FAILED, State.SKIPPED], True),
+        (None, [State.SKIPPED, State.SKIPPED], False),
+    ])
+    @mock.patch('airflow.operators.subdag_operator.SubDagOperator.skip')
+    @mock.patch('airflow.operators.subdag_operator.get_task_instance')
+    def test_subdag_with_propagate_skipped_state(
+        self,
+        propagate_option,
+        states,
+        skip_parent,
+        mock_get_task_instance,
+        mock_skip
+    ):
+        """
+        Tests that skipped state of leaf tasks propagates to the parent dag.
+        Note that the skipped state propagation only takes affect when the dagrun's state is SUCCESS.
+        """
+        dag = DAG('parent', default_args=default_args)
+        subdag = DAG('parent.test', default_args=default_args)
+        subdag_task = SubDagOperator(
+            task_id='test',
+            subdag=subdag,
+            dag=dag,
+            poke_interval=1,
+            propagate_skipped_state=propagate_option
+        )
+        dummy_subdag_tasks = [
+            DummyOperator(task_id='dummy_subdag_{}'.format(i), dag=subdag)
+            for i in range(len(states))
+        ]
+        dummy_dag_task = DummyOperator(task_id='dummy_dag', dag=dag)
+        subdag_task >> dummy_dag_task
+
+        subdag_task._get_dagrun = Mock()
+        subdag_task._get_dagrun.return_value = self.dag_run_success
+        mock_get_task_instance.side_effect = [
+            TaskInstance(
+                task=task,
+                execution_date=DEFAULT_DATE,
+                state=state
+            ) for task, state in zip(dummy_subdag_tasks, states)
+        ]
+
+        context = {
+            'execution_date': DEFAULT_DATE,
+            'dag_run': DagRun(),
+            'task': subdag_task
+        }
+        subdag_task.post_execute(context)
+
+        if skip_parent:
+            mock_skip.assert_called_once_with(
+                context['dag_run'],
+                context['execution_date'],
+                [dummy_dag_task]
+            )
+        else:
+            mock_skip.assert_not_called()


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-5683

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently there is no way of telling the parent dag of a sub dag that an _essential_ task has been **skipped**. This PR addresses this issue by adding a new `propagate_skipped_state` option to the SubDagOperator.

_Background story:_ https://lists.apache.org/thread.html/0eefd459a502c5100d792416f8ba720302aa49a8906fe6ea4ec8fca4@%3Cdev.airflow.apache.org%3E

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
