### PR TITLE
Revert "AIRFLOW-5608: Fix bug in SchedulerJob when calling executor.end"

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1314,17 +1314,11 @@ class SchedulerJob(BaseJob):
                                                      async_mode)
 
         try:
-            self.log.debug("Starting executor=%s", self.executor)
-            self.executor.start()
             self._execute_helper()
         except Exception:
             self.log.exception("Exception when executing execute_helper")
         finally:
-            self.log.debug("Calling executor.end()...")
-            self.executor.end()
             self.processor_agent.end()
-            self.log.debug("Calling settings.Session.remove()...")
-            settings.Session.remove()
             self.log.info("Exited execute loop")
 
     def _execute_helper(self):
@@ -1344,6 +1338,8 @@ class SchedulerJob(BaseJob):
 
         :rtype: None
         """
+        self.executor.start()
+
         self.log.info("Resetting orphaned tasks for active dag runs")
         self.reset_state_for_orphaned_tasks()
 
@@ -1456,6 +1452,10 @@ class SchedulerJob(BaseJob):
                 execute_start_time.isoformat()
             )
             models.DAG.deactivate_stale_dags(execute_start_time)
+
+        self.executor.end()
+
+        settings.Session.remove()
 
     def _find_dags_to_process(self, dags: List[DAG], paused_dag_ids: Set[str]):
         """


### PR DESCRIPTION
Reverts apache/airflow#6274

It caused the LocalExecutor to not shutdown when given a SIGINT with this stack trace.

```
^CTraceback (most recent call last):
  File "/Users/ash/code/python/incubator-airflow/airflow/jobs/scheduler_job.py", line 1309, in _execute
    self._execute_helper()
  File "/Users/ash/code/python/incubator-airflow/airflow/jobs/scheduler_job.py", line 1435, in _execute_helper
    sleep(sleep_length)
  File "/Users/ash/code/python/incubator-airflow/airflow/bin/cli.py", line 84, in sigint_handler
    sys.exit(0)
SystemExit: 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ash/.virtualenvs/airflow/bin/airflow", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/ash/code/python/incubator-airflow/airflow/bin/airflow", line 39, in <module>
    args.func(args)
  File "/Users/ash/code/python/incubator-airflow/airflow/utils/cli.py", line 73, in wrapper
    return f(*args, **kwargs)
  File "/Users/ash/code/python/incubator-airflow/airflow/bin/cli.py", line 1124, in scheduler
    job.run()
  File "/Users/ash/code/python/incubator-airflow/airflow/jobs/base_job.py", line 217, in run
    self._execute()
  File "/Users/ash/code/python/incubator-airflow/airflow/jobs/scheduler_job.py", line 1314, in _execute
    self.executor.end()
  File "/Users/ash/code/python/incubator-airflow/airflow/executors/local_executor.py", line 229, in end
    self.impl.end()
  File "/Users/ash/code/python/incubator-airflow/airflow/executors/local_executor.py", line 205, in end
    self.queue.put((None, None))
  File "<string>", line 2, in put
  File "/Users/ash/.homebrew/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/managers.py", line 796, in _callmethod
    kind, result = conn.recv()
  File "/Users/ash/.homebrew/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
  File "/Users/ash/.homebrew/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/connection.py", line 407, in _recv_bytes
    buf = self._recv(4)
  File "/Users/ash/.homebrew/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/connection.py", line 383, in _recv
    raise EOFError
EOFError
```