### PR TITLE
[AIRFLOW-5663] Switch to real-time logging in PythonVirtualenvOperator

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -339,7 +339,7 @@ class PythonVirtualenvOperator(PythonOperator):
         self.log.info("Got output\n")
         with self._sp.stdout:
             for line in iter(self._sp.stdout.readline, b''):
-                self.log.info(line)
+                self.log.info("%s", line)
 
         returncode = self._sp.wait()
         if returncode:

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -342,7 +342,7 @@ class PythonVirtualenvOperator(PythonOperator):
                 self.log.info("%s", line)
 
         returncode = self._sp.wait()
-        if returncode:
+        if returncode != 0:
             raise subprocess.CalledProcessError(returncode, cmd)
 
     def _write_string_args(self, filename):

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -339,7 +339,7 @@ class PythonVirtualenvOperator(PythonOperator):
         self.log.info("Got output")
         with self._sp.stdout:
             for line in iter(self._sp.stdout.readline, b''):
-                self.log.info("%s", line)
+                self.log.info("%s", line.decode().rstrip())
 
         returncode = self._sp.wait()
         if returncode != 0:

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -336,7 +336,7 @@ class PythonVirtualenvOperator(PythonOperator):
                                     stderr=subprocess.STDOUT,
                                     bufsize=0,
                                     close_fds=True)
-        self.log.info("Got output\n")
+        self.log.info("Got output")
         with self._sp.stdout:
             for line in iter(self._sp.stdout.readline, b''):
                 self.log.info("%s", line)

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -330,16 +330,20 @@ class PythonVirtualenvOperator(PythonOperator):
         return len(self.op_args) + len(self.op_kwargs) > 0
 
     def _execute_in_subprocess(self, cmd):
-        try:
-            self.log.info("Executing cmd\n%s", cmd)
-            output = subprocess.check_output(cmd,
-                                             stderr=subprocess.STDOUT,
-                                             close_fds=True)
-            if output:
-                self.log.info("Got output\n%s", output)
-        except subprocess.CalledProcessError as e:
-            self.log.info("Got error output\n%s", e.output)
-            raise
+        self.log.info("Executing cmd\n{}".format(cmd))
+        self._sp = subprocess.Popen(cmd,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT,
+                                    bufsize=0,
+                                    close_fds=True)
+        self.log.info("Got output\n")
+        with self._sp.stdout:
+            for line in iter(self._sp.stdout.readline, b''):
+                self.log.info(line)
+
+        returncode = self._sp.wait()
+        if returncode:
+            raise subprocess.CalledProcessError(returncode, cmd)
 
     def _write_string_args(self, filename):
         # writes string_args to a file, which are read line by line


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5663

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Allow us to see the logs while the operator is running.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing 19 unit tests passed.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
