### PR TITLE
[AIRFLOW-5724] Remove side effects from local settings tests

### DIFF
--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -24,14 +24,14 @@ import unittest
 from unittest.mock import MagicMock, call
 
 SETTINGS_FILE_POLICY = """
-def policy(task_instance):
+def test_policy(task_instance):
     task_instance.run_as_user = "myself"
 """
 
 SETTINGS_FILE_POLICY_WITH_DUNDER_ALL = """
-__all__ = ["policy"]
+__all__ = ["test_policy"]
 
-def policy(task_instance):
+def test_policy(task_instance):
     task_instance.run_as_user = "myself"
 
 def not_policy():
@@ -39,7 +39,7 @@ def not_policy():
 """
 
 SETTINGS_FILE_POD_MUTATION_HOOK = """
-def pod_mutation_hook(pod):
+def test_pod_mutation_hook(pod):
     pod.namespace = 'airflow-tests'
 """
 
@@ -109,7 +109,7 @@ class TestLocalSettings(unittest.TestCase):
             settings.import_local_settings()  # pylint: ignore
 
             task_instance = MagicMock()
-            settings.policy(task_instance)
+            settings.test_policy(task_instance)
 
             assert task_instance.run_as_user == "myself"
 
@@ -133,7 +133,7 @@ class TestLocalSettings(unittest.TestCase):
             settings.import_local_settings()  # pylint: ignore
 
             task_instance = MagicMock()
-            settings.policy(task_instance)
+            settings.test_policy(task_instance)
 
             assert task_instance.run_as_user == "myself"
 
@@ -147,6 +147,6 @@ class TestLocalSettings(unittest.TestCase):
             settings.import_local_settings()  # pylint: ignore
 
             pod = MagicMock()
-            settings.pod_mutation_hook(pod)
+            settings.test_pod_mutation_hook(pod)
 
             assert pod.namespace == 'airflow-tests'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5724

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
When running this test with pytest I observed that it creates side effect that resulted in tasks being run by `myself` user. Proposed change avoids overwriting `policy` function but still tests expected behaviour. 

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
