### PR TITLE
[AIRFLOW-5731] Make output format from list commands configurable

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -1104,6 +1104,10 @@ class TestCli(unittest.TestCase):
         for i in range(0, 3):
             self.assertIn('user{}'.format(i), stdout)
 
+    def test_cli_list_users_with_args(self):
+        cli.users_list(self.parser.parse_args(['users', 'list',
+                                               '--output', 'tsv']))
+
     def test_cli_import_users(self):
         def assertUserInRoles(email, roles):
             for role in roles:
@@ -1330,6 +1334,10 @@ class TestCli(unittest.TestCase):
         self.assertIn('FakeTeamA', stdout)
         self.assertIn('FakeTeamB', stdout)
 
+    def test_cli_list_roles_with_args(self):
+        cli.roles_list(self.parser.parse_args(['roles', 'list',
+                                               '--output', 'tsv']))
+
     def test_cli_list_tasks(self):
         for dag_id in self.dagbag.dags.keys():
             args = self.parser.parse_args(['tasks', 'list', dag_id])
@@ -1347,7 +1355,8 @@ class TestCli(unittest.TestCase):
         args = self.parser.parse_args(['dags', 'list_jobs', '--dag_id',
                                        'example_bash_operator',
                                        '--state', 'success',
-                                       '--limit', '100'])
+                                       '--limit', '100',
+                                       '--output', 'tsv'])
         cli.list_jobs(args)
 
     @mock.patch("airflow.bin.cli.db.initdb")
@@ -1381,6 +1390,11 @@ class TestCli(unittest.TestCase):
         self.assertIn(['postgres_default', 'postgres'], conns)
         self.assertIn(['wasb_default', 'wasb'], conns)
         self.assertIn(['segment_default', 'segment'], conns)
+
+    def test_cli_connections_list_with_args(self):
+        args = self.parser.parse_args(['connections', 'list',
+                                       '--output', 'tsv'])
+        cli.connections_list(args)
 
     def test_cli_connections_list_redirect(self):
         cmd = ['airflow', 'connections', 'list']
@@ -1646,6 +1660,17 @@ class TestCli(unittest.TestCase):
             cli.delete_dag(self.parser.parse_args([
                 'dags', 'delete', key, '--yes']))
             self.assertEqual(session.query(DM).filter_by(dag_id=key).count(), 0)
+
+    def test_pool_list(self):
+        cli.pool_set(self.parser.parse_args(['pools', 'set', 'foo', '1', 'test']))
+        with mock.patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            cli.pool_list(self.parser.parse_args(['pools', 'list']))
+            stdout = mock_stdout.getvalue()
+        self.assertIn('foo', stdout)
+
+    def test_pool_list_with_args(self):
+        cli.pool_list(self.parser.parse_args(['pools', 'list',
+                                              '--output', 'tsv']))
 
     def test_pool_create(self):
         cli.pool_set(self.parser.parse_args(['pools', 'set', 'foo', '1', 'test']))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5731
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, list commands such as `airflow connections list` and `airflow users list` display prettily formatted tables, but they are not so suitable for parsing and processing. With this PR, users can get easier-to-parse output, as follows:

```
$ airflow connections list --tablefmt=simple 2>/dev/null | head
Conn Id                         Conn Type                    Host                       Port    Is Encrypted    Is Extra Encrypted    Extra
------------------------------  ---------------------------  -------------------------  ------  --------------  --------------------  ------------------------------
'airflow_db'                    'mysql'                      'mysql'                    None    False           False                 None
'local_mysql'                   'mysql'                      'localhost'                None    True            False                 None
'presto_default'                'presto'                     'localhost'                3400    False           False                 None
'google_cloud_default'          'google_cloud_platform'      None                       None    False           False                 None
'hive_cli_default'              'hive_cli'                   'localhost'                10000   False           True                  'gAAAAABdrxCP...jMAQ6LknDM8pc'
'pig_cli_default'               'pig_cli'                    None                       None    False           False                 None
'hiveserver2_default'           'hiveserver2'                'localhost'                10000   False           False                 None
'metastore_default'             'hive_metastore'             'localhost'                9083    False           True                  'gAAAAABdrxCP...ABWevIJL-Dto='

$ airflow connections list --tablefmt=tsv 2>/dev/null | head
Conn Id                       	Conn Type                  	Host                     	Port  	Is Encrypted  	Is Extra Encrypted  	Extra
'airflow_db'                  	'mysql'                    	'mysql'                  	None  	False         	False               	None
'local_mysql'                 	'mysql'                    	'localhost'              	None  	True          	False               	None
'presto_default'              	'presto'                   	'localhost'              	3400  	False         	False               	None
'google_cloud_default'        	'google_cloud_platform'    	None                     	None  	False         	False               	None
'hive_cli_default'            	'hive_cli'                 	'localhost'              	10000 	False         	True                	'gAAAAABdrxCP...jMAQ6LknDM8pc'
'pig_cli_default'             	'pig_cli'                  	None                     	None  	False         	False               	None
'hiveserver2_default'         	'hiveserver2'              	'localhost'              	10000 	False         	False               	None
'metastore_default'           	'hive_metastore'           	'localhost'              	9083  	False         	True                	'gAAAAABdrxCP...ABWevIJL-Dto='
'mongo_default'               	'mongo'                    	'mongo'                  	27017 	False         	False               	None
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

test_cli_list_users_with_args
test_cli_list_roles_with_args
test_cli_list_jobs_with_args (added arguments to the existing test)
test_cli_connections_list_with_args
test_pool_list
test_pool_list_with_args

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
