### PR TITLE
[AIRFLOW-5672][WIP] Rename CloudDLPHook to CloudDlpHook

### DIFF
--- a/airflow/contrib/hooks/gcp_dlp_hook.py
+++ b/airflow/contrib/hooks/gcp_dlp_hook.py
@@ -21,7 +21,7 @@
 import warnings
 
 # pylint: disable=unused-import
-from airflow.gcp.hooks.dlp import CloudDLPHook, DlpJob  # noqa
+from airflow.gcp.hooks.dlp import CloudDlpHook, DlpJob  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.dlp`.",

--- a/airflow/contrib/hooks/gcp_dlp_hook.py
+++ b/airflow/contrib/hooks/gcp_dlp_hook.py
@@ -27,3 +27,17 @@ warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.dlp`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class CloudDLPHook(CloudDlpHook):
+    """
+    This class is deprecated. Please use `airflow.gcp.hooks.dlp.CloudDlpHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This class is deprecated. Please use `airflow.gcp.hooks.dlp.CloudDlpHook`.",
+            DeprecationWarning, stacklevel=2
+        )
+
+        super().__init__(*args, **kwargs)

--- a/airflow/gcp/hooks/dlp.py
+++ b/airflow/gcp/hooks/dlp.py
@@ -18,7 +18,7 @@
 # under the License.
 
 """
-This module contains a CloudDLPHook
+This module contains a CloudDlpHook
 which allows you to connect to GCP Cloud DLP service.
 """
 
@@ -44,7 +44,7 @@ TIME_TO_SLEEP_IN_SECONDS = 1
 
 
 # pylint: disable=R0904, C0302
-class CloudDLPHook(GoogleCloudBaseHook):
+class CloudDlpHook(GoogleCloudBaseHook):
     """
     Hook for Google Cloud Data Loss Prevention (DLP) APIs.
     Cloud DLP allows clients to detect the presence of Personally Identifiable

--- a/airflow/gcp/operators/dlp.py
+++ b/airflow/gcp/operators/dlp.py
@@ -32,7 +32,7 @@ from google.cloud.dlp_v2.types import (
     StoredInfoTypeConfig,
 )
 
-from airflow.gcp.hooks.dlp import CloudDLPHook
+from airflow.gcp.hooks.dlp import CloudDlpHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
@@ -83,7 +83,7 @@ class CloudDLPCancelDLPJobOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         hook.cancel_dlp_job(
             dlp_job_id=self.dlp_job_id,
             project_id=self.project_id,
@@ -156,7 +156,7 @@ class CloudDLPCreateDeidentifyTemplateOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.create_deidentify_template(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -228,7 +228,7 @@ class CloudDLPCreateDLPJobOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.create_dlp_job(
             project_id=self.project_id,
             inspect_job=self.inspect_job,
@@ -304,7 +304,7 @@ class CloudDLPCreateInspectTemplateOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.create_inspect_template(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -368,7 +368,7 @@ class CloudDLPCreateJobTriggerOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.create_job_trigger(
             project_id=self.project_id,
             job_trigger=self.job_trigger,
@@ -441,7 +441,7 @@ class CloudDLPCreateStoredInfoTypeOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.create_stored_info_type(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -531,7 +531,7 @@ class CloudDLPDeidentifyContentOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.deidentify_content(
             project_id=self.project_id,
             deidentify_config=self.deidentify_config,
@@ -596,7 +596,7 @@ class CloudDLPDeleteDeidentifyTemplateOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         hook.delete_deidentify_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -654,7 +654,7 @@ class CloudDLPDeleteDlpJobOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         hook.delete_dlp_job(
             dlp_job_id=self.dlp_job_id,
             project_id=self.project_id,
@@ -715,7 +715,7 @@ class CloudDLPDeleteInspectTemplateOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         hook.delete_inspect_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -772,7 +772,7 @@ class CloudDLPDeleteJobTriggerOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         hook.delete_job_trigger(
             job_trigger_id=self.job_trigger_id,
             project_id=self.project_id,
@@ -838,7 +838,7 @@ class CloudDLPDeleteStoredInfoTypeOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         hook.delete_stored_info_type(
             stored_info_type_id=self.stored_info_type_id,
             organization_id=self.organization_id,
@@ -901,7 +901,7 @@ class CloudDLPGetDeidentifyTemplateOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.get_deidentify_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -959,7 +959,7 @@ class CloudDLPGetDlpJobOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.get_dlp_job(
             dlp_job_id=self.dlp_job_id,
             project_id=self.project_id,
@@ -1021,7 +1021,7 @@ class CloudDLPGetInspectTemplateOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.get_inspect_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -1079,7 +1079,7 @@ class CloudDLPGetJobTripperOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.get_job_trigger(
             job_trigger_id=self.job_trigger_id,
             project_id=self.project_id,
@@ -1146,7 +1146,7 @@ class CloudDLPGetStoredInfoTypeOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.get_stored_info_type(
             stored_info_type_id=self.stored_info_type_id,
             organization_id=self.organization_id,
@@ -1221,7 +1221,7 @@ class CloudDLPInspectContentOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.inspect_content(
             project_id=self.project_id,
             inspect_config=self.inspect_config,
@@ -1291,7 +1291,7 @@ class CloudDLPListDeidentifyTemplatesOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.list_deidentify_templates(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -1364,7 +1364,7 @@ class CloudDLPListDlpJobsOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.list_dlp_jobs(
             project_id=self.project_id,
             results_filter=self.results_filter,
@@ -1424,7 +1424,7 @@ class CloudDLPListInfoTypesOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.list_info_types(
             language_code=self.language_code,
             results_filter=self.results_filter,
@@ -1492,7 +1492,7 @@ class CloudDLPListInspectTemplatesOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.list_inspect_templates(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -1561,7 +1561,7 @@ class CloudDLPListJobTriggersOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.list_job_triggers(
             project_id=self.project_id,
             page_size=self.page_size,
@@ -1631,7 +1631,7 @@ class CloudDLPListStoredInfoTypesOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.list_stored_info_types(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -1714,7 +1714,7 @@ class CloudDLPRedactImageOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.redact_image(
             project_id=self.project_id,
             inspect_config=self.inspect_config,
@@ -1802,7 +1802,7 @@ class CloudDLPReidentifyContentOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.reidentify_content(
             project_id=self.project_id,
             reidentify_config=self.reidentify_config,
@@ -1883,7 +1883,7 @@ class CloudDLPUpdateDeidentifyTemplateOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.update_deidentify_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -1963,7 +1963,7 @@ class CloudDLPUpdateInspectTemplateOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.update_inspect_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -2037,7 +2037,7 @@ class CloudDLPUpdateJobTriggerOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.update_job_trigger(
             job_trigger_id=self.job_trigger_id,
             project_id=self.project_id,
@@ -2117,7 +2117,7 @@ class CloudDLPUpdateStoredInfoTypeOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDlpHook(gcp_conn_id=self.gcp_conn_id)
         return hook.update_stored_info_type(
             stored_info_type_id=self.stored_info_type_id,
             organization_id=self.organization_id,

--- a/tests/gcp/hooks/test_dlp.py
+++ b/tests/gcp/hooks/test_dlp.py
@@ -20,7 +20,7 @@
 # pylint: disable=R0904, C0111, C0302
 """
 This module contains various unit tests for
-functions in CloudDLPHook
+functions in CloudDlpHook
 """
 
 import unittest
@@ -29,7 +29,7 @@ from typing import Any, Dict
 from google.cloud.dlp_v2.types import DlpJob
 
 from airflow import AirflowException
-from airflow.gcp.hooks.dlp import CloudDLPHook
+from airflow.gcp.hooks.dlp import CloudDlpHook
 from tests.compat import PropertyMock, mock
 from tests.gcp.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 
@@ -70,10 +70,10 @@ class TestCloudDLPHook(unittest.TestCase):
             "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
         ):
-            self.hook = CloudDLPHook(gcp_conn_id="test")
+            self.hook = CloudDlpHook(gcp_conn_id="test")
 
-    @mock.patch("airflow.gcp.hooks.dlp.CloudDLPHook.client_info", new_callable=mock.PropertyMock)
-    @mock.patch("airflow.gcp.hooks.dlp.CloudDLPHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.dlp.CloudDlpHook.client_info", new_callable=mock.PropertyMock)
+    @mock.patch("airflow.gcp.hooks.dlp.CloudDlpHook._get_credentials")
     @mock.patch("airflow.gcp.hooks.dlp.DlpServiceClient")
     def test_dlp_service_client_creation(self, mock_client, mock_get_creds, mock_client_info):
         result = self.hook.get_conn()
@@ -85,7 +85,7 @@ class TestCloudDLPHook(unittest.TestCase):
         self.assertEqual(self.hook._client, result)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_cancel_dlp_job(self, get_conn):
         self.hook.cancel_dlp_job(dlp_job_id=DLP_JOB_ID, project_id=PROJECT_ID)
@@ -95,7 +95,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_cancel_dlp_job_without_dlp_job_id(self, _):
         with self.assertRaises(AirflowException):
@@ -107,7 +107,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_cancel_dlp_job_without_parent(self, _, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -119,7 +119,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.create_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -138,7 +138,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.create_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -162,14 +162,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_create_deidentify_template_without_parent(self, _, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_deidentify_template()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{"return_value.create_dlp_job.return_value": API_RESPONSE},  # type: ignore
     )
     def test_create_dlp_job(self, get_conn):
@@ -194,14 +194,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_create_dlp_job_without_project_id(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_dlp_job()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_create_dlp_job_with_wait_until_finished(self, get_conn):
         job_for_create = DlpJob(name=DLP_JOB_PATH, state=DlpJob.JobState.PENDING)
@@ -221,7 +221,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.create_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -240,7 +240,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.create_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -264,14 +264,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_create_inspect_template_without_parent(self, _, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_inspect_template()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.create_job_trigger.return_value": API_RESPONSE
         },  # type: ignore
@@ -295,7 +295,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_create_job_trigger_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -307,7 +307,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.create_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
@@ -326,7 +326,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.create_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
@@ -350,14 +350,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_create_stored_info_type_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_stored_info_type()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.deidentify_content.return_value": API_RESPONSE
         },  # type: ignore
@@ -384,7 +384,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_deidentify_content_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -396,7 +396,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_deidentify_template_with_org_id(self, get_conn, mock_project_id):
         self.hook.delete_deidentify_template(
@@ -411,7 +411,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_deidentify_template_with_project_id(self, get_conn):
         self.hook.delete_deidentify_template(
@@ -426,7 +426,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_deidentify_template_without_template_id(self, _):
         with self.assertRaises(AirflowException):
@@ -438,14 +438,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_deidentify_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.delete_deidentify_template(template_id=TEMPLATE_ID)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_dlp_job(self, get_conn):
         self.hook.delete_dlp_job(dlp_job_id=DLP_JOB_ID, project_id=PROJECT_ID)
@@ -455,7 +455,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_dlp_job_without_dlp_job_id(self, _):
         with self.assertRaises(AirflowException):
@@ -467,7 +467,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_dlp_job_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -479,7 +479,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_inspect_template_with_org_id(self, get_conn, mock_project_id):
         self.hook.delete_inspect_template(
@@ -494,7 +494,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_inspect_template_with_project_id(self, get_conn):
         self.hook.delete_inspect_template(
@@ -509,7 +509,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_inspect_template_without_template_id(self, _):
         with self.assertRaises(AirflowException):
@@ -521,14 +521,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_inspect_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.delete_inspect_template(template_id=TEMPLATE_ID)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_job_trigger(self, get_conn):
         self.hook.delete_job_trigger(job_trigger_id=TRIGGER_ID, project_id=PROJECT_ID)
@@ -538,7 +538,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_job_trigger_without_trigger_id(self, _):
         with self.assertRaises(AirflowException):
@@ -550,7 +550,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_job_trigger_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -562,7 +562,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_stored_info_type_with_org_id(self, get_conn, mock_project_id):
         self.hook.delete_stored_info_type(
@@ -577,7 +577,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_stored_info_type_with_project_id(self, get_conn):
         self.hook.delete_stored_info_type(
@@ -592,7 +592,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_stored_info_type_without_stored_info_type_id(self, _):
         with self.assertRaises(AirflowException):
@@ -604,7 +604,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_delete_stored_info_type_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -616,7 +616,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.get_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -635,7 +635,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.get_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -654,7 +654,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_deidentify_template_without_template_id(self, _):
         with self.assertRaises(AirflowException):
@@ -666,14 +666,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_deidentify_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.get_deidentify_template(template_id=TEMPLATE_ID)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{"return_value.get_dlp_job.return_value": API_RESPONSE},  # type: ignore
     )
     def test_get_dlp_job(self, get_conn):
@@ -685,7 +685,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_dlp_job_without_dlp_job_id(self, _):
         with self.assertRaises(AirflowException):
@@ -697,7 +697,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_dlp_job_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -709,7 +709,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.get_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -728,7 +728,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.get_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -747,7 +747,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_inspect_template_without_template_id(self, _):
         with self.assertRaises(AirflowException):
@@ -759,14 +759,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_inspect_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.get_inspect_template(template_id=TEMPLATE_ID)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{"return_value.get_job_trigger.return_value": API_RESPONSE},  # type: ignore
     )
     def test_get_job_trigger(self, get_conn):
@@ -780,7 +780,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_job_trigger_without_trigger_id(self, _):
         with self.assertRaises(AirflowException):
@@ -792,7 +792,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_job_trigger_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -804,7 +804,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.get_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
@@ -823,7 +823,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.get_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
@@ -842,7 +842,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_stored_info_type_without_stored_info_type_id(self, _):
         with self.assertRaises(AirflowException):
@@ -854,14 +854,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_get_stored_info_type_without_parent(self, mock_get_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.get_stored_info_type(stored_info_type_id=STORED_INFO_TYPE_ID)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{"return_value.inspect_content.return_value": API_RESPONSE},  # type: ignore
     )
     def test_inspect_content(self, get_conn):
@@ -884,7 +884,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_inspect_content_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -896,7 +896,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_deidentify_templates_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.list_deidentify_templates(organization_id=ORGANIZATION_ID)
@@ -912,7 +912,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_deidentify_templates_with_project_id(self, get_conn):
         result = self.hook.list_deidentify_templates(project_id=PROJECT_ID)
@@ -933,14 +933,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_deidentify_templates_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_deidentify_templates()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_dlp_jobs(self, get_conn):
         result = self.hook.list_dlp_jobs(project_id=PROJECT_ID)
@@ -963,14 +963,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_dlp_jobs_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_dlp_jobs()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{"return_value.list_info_types.return_value": API_RESPONSE},  # type: ignore
     )
     def test_list_info_types(self, get_conn):
@@ -987,7 +987,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_inspect_templates_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.list_inspect_templates(organization_id=ORGANIZATION_ID)
@@ -1003,7 +1003,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_inspect_templates_with_project_id(self, get_conn):
         result = self.hook.list_inspect_templates(project_id=PROJECT_ID)
@@ -1024,14 +1024,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_inspect_templates_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_inspect_templates()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_job_triggers(self, get_conn):
         result = self.hook.list_job_triggers(project_id=PROJECT_ID)
@@ -1053,7 +1053,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_job_triggers_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -1065,7 +1065,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_stored_info_types_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.list_stored_info_types(organization_id=ORGANIZATION_ID)
@@ -1081,7 +1081,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_stored_info_types_with_project_id(self, get_conn):
         result = self.hook.list_stored_info_types(project_id=PROJECT_ID)
@@ -1102,14 +1102,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_list_stored_info_types_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_stored_info_types()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{"return_value.redact_image.return_value": API_RESPONSE},  # type: ignore
     )
     def test_redact_image(self, get_conn):
@@ -1133,14 +1133,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_redact_image_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.redact_image()
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.reidentify_content.return_value": API_RESPONSE
         },  # type: ignore
@@ -1167,7 +1167,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_reidentify_content_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -1179,7 +1179,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.update_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -1200,7 +1200,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.update_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -1221,7 +1221,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_update_deidentify_template_without_template_id(self, _):
         with self.assertRaises(AirflowException):
@@ -1235,7 +1235,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_update_deidentify_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -1247,7 +1247,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.update_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -1268,7 +1268,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.update_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
@@ -1289,7 +1289,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_update_inspect_template_without_template_id(self, _):
         with self.assertRaises(AirflowException):
@@ -1303,14 +1303,14 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_update_inspect_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.update_inspect_template(template_id=TEMPLATE_ID)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.update_job_trigger.return_value": API_RESPONSE
         },  # type: ignore
@@ -1331,7 +1331,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_update_job_trigger_without_job_trigger_id(self, _):
         with self.assertRaises(AirflowException):
@@ -1343,7 +1343,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_update_job_trigger_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
@@ -1355,7 +1355,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.update_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
@@ -1376,7 +1376,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn",
         **{
             "return_value.update_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
@@ -1397,7 +1397,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_update_stored_info_type_without_stored_info_type_id(self, _):
         with self.assertRaises(AirflowException):
@@ -1411,7 +1411,7 @@ class TestCloudDLPHook(unittest.TestCase):
         return_value=None
     )
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
+        "airflow.gcp.hooks.dlp.CloudDlpHook.get_conn"
     )
     def test_update_stored_info_type_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):

--- a/tests/gcp/operators/test_dlp.py
+++ b/tests/gcp/operators/test_dlp.py
@@ -50,7 +50,7 @@ TRIGGER_ID = "trigger123"
 
 
 class TestCloudDLPCancelDLPJobOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_cancel_dlp_job(self, mock_hook):
         mock_hook.return_value.cancel_dlp_job.return_value = {}
         operator = CloudDLPCancelDLPJobOperator(dlp_job_id=DLP_JOB_ID, task_id="id")
@@ -66,7 +66,7 @@ class TestCloudDLPCancelDLPJobOperator(unittest.TestCase):
 
 
 class TestCloudDLPCreateDeidentifyTemplateOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_create_deidentify_template(self, mock_hook):
         mock_hook.return_value.create_deidentify_template.return_value = {}
         operator = CloudDLPCreateDeidentifyTemplateOperator(
@@ -86,7 +86,7 @@ class TestCloudDLPCreateDeidentifyTemplateOperator(unittest.TestCase):
 
 
 class TestCloudDLPCreateDLPJobOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_create_dlp_job(self, mock_hook):
         mock_hook.return_value.create_dlp_job.return_value = {}
         operator = CloudDLPCreateDLPJobOperator(project_id=PROJECT_ID, task_id="id")
@@ -105,7 +105,7 @@ class TestCloudDLPCreateDLPJobOperator(unittest.TestCase):
 
 
 class TestCloudDLPCreateInspectTemplateOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_create_inspect_template(self, mock_hook):
         mock_hook.return_value.create_inspect_template.return_value = {}
         operator = CloudDLPCreateInspectTemplateOperator(
@@ -125,7 +125,7 @@ class TestCloudDLPCreateInspectTemplateOperator(unittest.TestCase):
 
 
 class TestCloudDLPCreateJobTriggerOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_create_job_trigger(self, mock_hook):
         mock_hook.return_value.create_job_trigger.return_value = {}
         operator = CloudDLPCreateJobTriggerOperator(project_id=PROJECT_ID, task_id="id")
@@ -142,7 +142,7 @@ class TestCloudDLPCreateJobTriggerOperator(unittest.TestCase):
 
 
 class TestCloudDLPCreateStoredInfoTypeOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_create_stored_info_type(self, mock_hook):
         mock_hook.return_value.create_stored_info_type.return_value = {}
         operator = CloudDLPCreateStoredInfoTypeOperator(
@@ -162,7 +162,7 @@ class TestCloudDLPCreateStoredInfoTypeOperator(unittest.TestCase):
 
 
 class TestCloudDLPDeidentifyContentOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_deidentify_content(self, mock_hook):
         mock_hook.return_value.deidentify_content.return_value = {}
         operator = CloudDLPDeidentifyContentOperator(
@@ -184,7 +184,7 @@ class TestCloudDLPDeidentifyContentOperator(unittest.TestCase):
 
 
 class TestCloudDLPDeleteDeidentifyTemplateOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_delete_deidentify_template(self, mock_hook):
         mock_hook.return_value.delete_deidentify_template.return_value = {}
         operator = CloudDLPDeleteDeidentifyTemplateOperator(
@@ -203,7 +203,7 @@ class TestCloudDLPDeleteDeidentifyTemplateOperator(unittest.TestCase):
 
 
 class TestCloudDLPDeleteDlpJobOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_delete_dlp_job(self, mock_hook):
         mock_hook.return_value.delete_dlp_job.return_value = {}
         operator = CloudDLPDeleteDlpJobOperator(
@@ -221,7 +221,7 @@ class TestCloudDLPDeleteDlpJobOperator(unittest.TestCase):
 
 
 class TestCloudDLPDeleteInspectTemplateOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_delete_inspect_template(self, mock_hook):
         mock_hook.return_value.delete_inspect_template.return_value = {}
         operator = CloudDLPDeleteInspectTemplateOperator(
@@ -240,7 +240,7 @@ class TestCloudDLPDeleteInspectTemplateOperator(unittest.TestCase):
 
 
 class TestCloudDLPDeleteJobTriggerOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_delete_job_trigger(self, mock_hook):
         mock_hook.return_value.delete_job_trigger.return_value = {}
         operator = CloudDLPDeleteJobTriggerOperator(
@@ -258,7 +258,7 @@ class TestCloudDLPDeleteJobTriggerOperator(unittest.TestCase):
 
 
 class TestCloudDLPDeleteStoredInfoTypeOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_delete_stored_info_type(self, mock_hook):
         mock_hook.return_value.delete_stored_info_type.return_value = {}
         operator = CloudDLPDeleteStoredInfoTypeOperator(
@@ -279,7 +279,7 @@ class TestCloudDLPDeleteStoredInfoTypeOperator(unittest.TestCase):
 
 
 class TestCloudDLPGetDeidentifyTemplateOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_get_deidentify_template(self, mock_hook):
         mock_hook.return_value.get_deidentify_template.return_value = {}
         operator = CloudDLPGetDeidentifyTemplateOperator(
@@ -298,7 +298,7 @@ class TestCloudDLPGetDeidentifyTemplateOperator(unittest.TestCase):
 
 
 class TestCloudDLPGetDlpJobOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_get_dlp_job(self, mock_hook):
         mock_hook.return_value.get_dlp_job.return_value = {}
         operator = CloudDLPGetDlpJobOperator(
@@ -316,7 +316,7 @@ class TestCloudDLPGetDlpJobOperator(unittest.TestCase):
 
 
 class TestCloudDLPGetInspectTemplateOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_get_inspect_template(self, mock_hook):
         mock_hook.return_value.get_inspect_template.return_value = {}
         operator = CloudDLPGetInspectTemplateOperator(
@@ -335,7 +335,7 @@ class TestCloudDLPGetInspectTemplateOperator(unittest.TestCase):
 
 
 class TestCloudDLPGetJobTripperOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_get_job_trigger(self, mock_hook):
         mock_hook.return_value.get_job_trigger.return_value = {}
         operator = CloudDLPGetJobTripperOperator(
@@ -353,7 +353,7 @@ class TestCloudDLPGetJobTripperOperator(unittest.TestCase):
 
 
 class TestCloudDLPGetStoredInfoTypeOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_get_stored_info_type(self, mock_hook):
         mock_hook.return_value.get_stored_info_type.return_value = {}
         operator = CloudDLPGetStoredInfoTypeOperator(
@@ -374,7 +374,7 @@ class TestCloudDLPGetStoredInfoTypeOperator(unittest.TestCase):
 
 
 class TestCloudDLPInspectContentOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_inspect_content(self, mock_hook):
         mock_hook.return_value.inspect_content.return_value = {}
         operator = CloudDLPInspectContentOperator(project_id=PROJECT_ID, task_id="id")
@@ -392,7 +392,7 @@ class TestCloudDLPInspectContentOperator(unittest.TestCase):
 
 
 class TestCloudDLPListDeidentifyTemplatesOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_list_deidentify_templates(self, mock_hook):
         mock_hook.return_value.list_deidentify_templates.return_value = {}
         operator = CloudDLPListDeidentifyTemplatesOperator(
@@ -412,7 +412,7 @@ class TestCloudDLPListDeidentifyTemplatesOperator(unittest.TestCase):
 
 
 class TestCloudDLPListDlpJobsOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_list_dlp_jobs(self, mock_hook):
         mock_hook.return_value.list_dlp_jobs.return_value = {}
         operator = CloudDLPListDlpJobsOperator(project_id=PROJECT_ID, task_id="id")
@@ -431,7 +431,7 @@ class TestCloudDLPListDlpJobsOperator(unittest.TestCase):
 
 
 class TestCloudDLPListInfoTypesOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_list_info_types(self, mock_hook):
         mock_hook.return_value.list_info_types.return_value = {}
         operator = CloudDLPListInfoTypesOperator(task_id="id")
@@ -447,7 +447,7 @@ class TestCloudDLPListInfoTypesOperator(unittest.TestCase):
 
 
 class TestCloudDLPListInspectTemplatesOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_list_inspect_templates(self, mock_hook):
         mock_hook.return_value.list_inspect_templates.return_value = {}
         operator = CloudDLPListInspectTemplatesOperator(
@@ -467,7 +467,7 @@ class TestCloudDLPListInspectTemplatesOperator(unittest.TestCase):
 
 
 class TestCloudDLPListJobTriggersOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_list_job_triggers(self, mock_hook):
         mock_hook.return_value.list_job_triggers.return_value = {}
         operator = CloudDLPListJobTriggersOperator(project_id=PROJECT_ID, task_id="id")
@@ -485,7 +485,7 @@ class TestCloudDLPListJobTriggersOperator(unittest.TestCase):
 
 
 class TestCloudDLPListStoredInfoTypesOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_list_stored_info_types(self, mock_hook):
         mock_hook.return_value.list_stored_info_types.return_value = {}
         operator = CloudDLPListStoredInfoTypesOperator(
@@ -505,7 +505,7 @@ class TestCloudDLPListStoredInfoTypesOperator(unittest.TestCase):
 
 
 class TestCloudDLPRedactImageOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_redact_image(self, mock_hook):
         mock_hook.return_value.redact_image.return_value = {}
         operator = CloudDLPRedactImageOperator(project_id=PROJECT_ID, task_id="id")
@@ -524,7 +524,7 @@ class TestCloudDLPRedactImageOperator(unittest.TestCase):
 
 
 class TestCloudDLPReidentifyContentOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_reidentify_content(self, mock_hook):
         mock_hook.return_value.reidentify_content.return_value = {}
         operator = CloudDLPReidentifyContentOperator(
@@ -546,7 +546,7 @@ class TestCloudDLPReidentifyContentOperator(unittest.TestCase):
 
 
 class TestCloudDLPUpdateDeidentifyTemplateOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_update_deidentify_template(self, mock_hook):
         mock_hook.return_value.update_deidentify_template.return_value = {}
         operator = CloudDLPUpdateDeidentifyTemplateOperator(
@@ -567,7 +567,7 @@ class TestCloudDLPUpdateDeidentifyTemplateOperator(unittest.TestCase):
 
 
 class TestCloudDLPUpdateInspectTemplateOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_update_inspect_template(self, mock_hook):
         mock_hook.return_value.update_inspect_template.return_value = {}
         operator = CloudDLPUpdateInspectTemplateOperator(
@@ -588,7 +588,7 @@ class TestCloudDLPUpdateInspectTemplateOperator(unittest.TestCase):
 
 
 class TestCloudDLPUpdateJobTriggerOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_update_job_trigger(self, mock_hook):
         mock_hook.return_value.update_job_trigger.return_value = {}
         operator = CloudDLPUpdateJobTriggerOperator(
@@ -608,7 +608,7 @@ class TestCloudDLPUpdateJobTriggerOperator(unittest.TestCase):
 
 
 class TestCloudDLPUpdateStoredInfoTypeOperator(unittest.TestCase):
-    @mock.patch("airflow.gcp.operators.dlp.CloudDLPHook")
+    @mock.patch("airflow.gcp.operators.dlp.CloudDlpHook")
     def test_update_stored_info_type(self, mock_hook):
         mock_hook.return_value.update_stored_info_type.return_value = {}
         operator = CloudDLPUpdateStoredInfoTypeOperator(

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -41,7 +41,7 @@ HOOK = [
         "airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook",
     ),
     (
-        "airflow.gcp.hooks.dlp.CloudDLPHook",
+        "airflow.gcp.hooks.dlp.CloudDlpHook",
         "airflow.contrib.hooks.gcp_dlp_hook.CloudDLPHook",
     ),
     (


### PR DESCRIPTION
Part of AIP-21

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5672
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
