### PR TITLE
[AIRFLOW-5740] Fix Transient failure in Slack test

### DIFF
--- a/tests/contrib/hooks/test_slack_webhook_hook.py
+++ b/tests/contrib/hooks/test_slack_webhook_hook.py
@@ -105,7 +105,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         message = hook._build_slack_message()
 
         # Then
-        self.assertCountEqual(self.expected_message, message)
+        self.assertEqual(self.expected_message_dict, json.loads(message))
 
     @mock.patch('requests.Session')
     @mock.patch('requests.Request')

--- a/tests/contrib/hooks/test_slack_webhook_hook.py
+++ b/tests/contrib/hooks/test_slack_webhook_hook.py
@@ -105,7 +105,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         message = hook._build_slack_message()
 
         # Then
-        self.assertEqual(self.expected_message, message)
+        self.assertCountEqual(self.expected_message, message)
 
     @mock.patch('requests.Session')
     @mock.patch('requests.Request')


### PR DESCRIPTION
The transient failure is caused by Dict Ordering

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-5740


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Change Slack test so that it does Equality check regardless of order

```
7) FAIL: test_build_slack_message (tests.contrib.hooks.test_slack_webhook_hook.TestSlackWebhookHook)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/airflow/tests/contrib/hooks/test_slack_webhook_hook.py", line 109, in test_build_slack_message
    self.assertEqual(self.expected_message, message)
AssertionError: '{"ic[188 chars]k", "channel": "#general", "blocks": [{"type":[109 chars]: 1}' != '{"ic[188 chars]k", "username": "SlackMcSlackFace", "blocks": [109 chars]: 1}'
- {"icon_emoji": ":hankey:", "icon_url": "https://airflow.apache.org/_images/pin_large.png", "attachments": [{"fallback": "Required plain-text summary"}], "text": "Awesome message to put on Slack", "channel": "#general", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "*bold text*"}}], "username": "SlackMcSlackFace", "link_names": 1}
?                                                                                                                                                                                                      ^^^^^^^^^^^^^^^^^^^^^                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ {"icon_emoji": ":hankey:", "icon_url": "https://airflow.apache.org/_images/pin_large.png", "attachments": [{"fallback": "Required plain-text summary"}], "text": "Awesome message to put on Slack", "username": "SlackMcSlackFace", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "*bold text*"}}], "channel": "#general", "link_names": 1}
?                    
```

Changing from using assertEqual to [assertCountEqual](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertCountEqual). THe backport should contain `assertItemsEqual` (for Py2)

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
