### PR TITLE
[AIRFLOW-5674][WIP] rename GoogleCloudKMSHook to CloudKmsHook

### DIFF
--- a/airflow/contrib/hooks/gcp_kms_hook.py
+++ b/airflow/contrib/hooks/gcp_kms_hook.py
@@ -21,7 +21,7 @@
 import warnings
 
 # pylint: disable=unused-import
-from airflow.gcp.hooks.kms import GoogleCloudKMSHook  # noqa
+from airflow.gcp.hooks.kms import CloudKmsHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.kms`.",

--- a/airflow/contrib/hooks/gcp_kms_hook.py
+++ b/airflow/contrib/hooks/gcp_kms_hook.py
@@ -27,3 +27,17 @@ warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.kms`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GoogleCloudKMSHook(CloudKmsHook):
+    """
+    This class is deprecated. Please use `airflow.gcp.hooks.kms.CloudKmsHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This class is deprecated. Please use `airflow.gcp.hooks.kms.CloudKmsHook`.",
+            DeprecationWarning, stacklevel=2
+        )
+
+        super().__init__(*args, **kwargs)

--- a/airflow/gcp/hooks/kms.py
+++ b/airflow/gcp/hooks/kms.py
@@ -42,7 +42,7 @@ def _b64decode(s: str) -> bytes:
 
 
 # noinspection PyAbstractClass
-class GoogleCloudKMSHook(GoogleCloudBaseHook):
+class CloudKmsHook(GoogleCloudBaseHook):
     """
     Hook for Google Cloud Key Management service.
 

--- a/tests/gcp/hooks/test_kms.py
+++ b/tests/gcp/hooks/test_kms.py
@@ -21,7 +21,7 @@ import unittest
 from base64 import b64decode, b64encode
 from collections import namedtuple
 
-from airflow.gcp.hooks.kms import GoogleCloudKMSHook
+from airflow.gcp.hooks.kms import CloudKmsHook
 from tests.compat import mock
 
 Response = namedtuple("Response", ["plaintext", "ciphertext"])
@@ -55,13 +55,13 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
             "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
             new=mock_init,
         ):
-            self.kms_hook = GoogleCloudKMSHook(gcp_conn_id="test")
+            self.kms_hook = CloudKmsHook(gcp_conn_id="test")
 
     @mock.patch(
-        "airflow.gcp.hooks.kms.GoogleCloudKMSHook.client_info",
+        "airflow.gcp.hooks.kms.CloudKmsHook.client_info",
         new_callable=mock.PropertyMock,
     )
-    @mock.patch("airflow.gcp.hooks.kms.GoogleCloudKMSHook._get_credentials")
+    @mock.patch("airflow.gcp.hooks.kms.CloudKmsHook._get_credentials")
     @mock.patch("airflow.gcp.hooks.kms.KeyManagementServiceClient")
     def test_kms_client_creation(self, mock_client, mock_get_creds, mock_client_info):
         result = self.kms_hook.get_conn()
@@ -73,7 +73,7 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
         self.assertEqual(self.kms_hook._conn, result)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.kms.GoogleCloudKMSHook.get_conn",
+        "airflow.gcp.hooks.kms.CloudKmsHook.get_conn",
         **{"return_value.encrypt.return_value": RESPONSE}
     )
     def test_encrypt(self, mock_get_conn):
@@ -90,7 +90,7 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
         self.assertEqual(PLAINTEXT_b64, result)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.kms.GoogleCloudKMSHook.get_conn",
+        "airflow.gcp.hooks.kms.CloudKmsHook.get_conn",
         **{"return_value.encrypt.return_value": RESPONSE}
     )
     def test_encrypt_with_auth_data(self, mock_get_conn):
@@ -107,7 +107,7 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
         self.assertEqual(PLAINTEXT_b64, result)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.kms.GoogleCloudKMSHook.get_conn",
+        "airflow.gcp.hooks.kms.CloudKmsHook.get_conn",
         **{"return_value.decrypt.return_value": RESPONSE}
     )
     def test_decrypt(self, mock_get_conn):
@@ -124,7 +124,7 @@ class TestGoogleCloudKMSHook(unittest.TestCase):
         self.assertEqual(PLAINTEXT, result)
 
     @mock.patch(  # type: ignore
-        "airflow.gcp.hooks.kms.GoogleCloudKMSHook.get_conn",
+        "airflow.gcp.hooks.kms.CloudKmsHook.get_conn",
         **{"return_value.decrypt.return_value": RESPONSE}
     )
     def test_decrypt_with_auth_data(self, mock_get_conn):

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -49,7 +49,7 @@ HOOK = [
         "airflow.contrib.hooks.gcp_function_hook.GcfHook",
     ),
     (
-        "airflow.gcp.hooks.kms.GoogleCloudKMSHook",
+        "airflow.gcp.hooks.kms.CloudKmsHook",
         "airflow.contrib.hooks.gcp_kms_hook.GoogleCloudKMSHook",
     ),
     (


### PR DESCRIPTION
Part of AIP-21

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5674
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
