### PR TITLE
[AIRFLOW-5749] Support the "blocks" component for the Slack operators

### DIFF
--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -39,8 +39,11 @@ class SlackWebhookOperator(SimpleHttpOperator):
     :param message: The message you want to send on Slack
     :type message: str
     :param attachments: The attachments to send on Slack. Should be a list of
-                        dictionaries representing Slack attachments.
+        dictionaries representing Slack attachments.
     :type attachments: list
+    :param blocks: The blocks to send on Slack. Should be a list of
+        dictionaries representing Slack blocks.
+    :type blocks: list
     :param channel: The channel the message should be posted to
     :type channel: str
     :param username: The username to post to slack with
@@ -50,13 +53,13 @@ class SlackWebhookOperator(SimpleHttpOperator):
     :param icon_url: The icon image URL string to use in place of the default icon.
     :type icon_url: str
     :param link_names: Whether or not to find and link channel and usernames in your
-                       message
+        message
     :type link_names: bool
     :param proxy: Proxy to use to make the Slack webhook call
     :type proxy: str
     """
 
-    template_fields = ['webhook_token', 'message', 'attachments', 'channel',
+    template_fields = ['webhook_token', 'message', 'attachments', 'blocks', 'channel',
                        'username', 'proxy', ]
 
     @apply_defaults
@@ -65,6 +68,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
                  webhook_token=None,
                  message="",
                  attachments=None,
+                 blocks=None,
                  channel=None,
                  username=None,
                  icon_emoji=None,
@@ -80,6 +84,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
         self.webhook_token = webhook_token
         self.message = message
         self.attachments = attachments
+        self.blocks = blocks
         self.channel = channel
         self.username = username
         self.icon_emoji = icon_emoji
@@ -97,6 +102,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
             self.webhook_token,
             self.message,
             self.attachments,
+            self.blocks,
             self.channel,
             self.username,
             self.icon_emoji,

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -102,9 +102,12 @@ class SlackAPIPostOperator(SlackAPIOperator):
     :param attachments: extra formatting details. (templated)
         - see https://api.slack.com/docs/attachments.
     :type attachments: list of hashes
+    :param blocks: extra block layouts. (templated)
+        - see https://api.slack.com/reference/block-kit/blocks.
+    :type blocks: list of hashes
     """
 
-    template_fields = ('username', 'text', 'attachments', 'channel')
+    template_fields = ('username', 'text', 'attachments', 'blocks', 'channel')
     ui_color = '#FFBA40'
 
     @apply_defaults
@@ -117,6 +120,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
                  icon_url: str = 'https://raw.githubusercontent.com/apache/'
                                  'airflow/master/airflow/www/static/pin_100.png',
                  attachments: Optional[List] = None,
+                 blocks: Optional[List] = None,
                  *args, **kwargs):
         self.method = 'chat.postMessage'
         self.channel = channel
@@ -124,6 +128,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
         self.text = text
         self.icon_url = icon_url
         self.attachments = attachments
+        self.blocks = blocks
         super().__init__(method=self.method,
                          *args, **kwargs)
 
@@ -134,4 +139,5 @@ class SlackAPIPostOperator(SlackAPIOperator):
             'text': self.text,
             'icon_url': self.icon_url,
             'attachments': json.dumps(self.attachments),
+            'blocks': json.dumps(self.blocks),
         }

--- a/tests/contrib/operators/test_slack_webhook_operator.py
+++ b/tests/contrib/operators/test_slack_webhook_operator.py
@@ -76,7 +76,8 @@ class TestSlackWebhookOperator(unittest.TestCase):
             **self._config
         )
 
-        template_fields = ['webhook_token', 'message', 'attachments', 'blocks', 'channel', 'username', 'proxy']
+        template_fields = ['webhook_token', 'message', 'attachments', 'blocks', 'channel',
+                           'username', 'proxy']
 
         self.assertEqual(operator.template_fields, template_fields)
 

--- a/tests/contrib/operators/test_slack_webhook_operator.py
+++ b/tests/contrib/operators/test_slack_webhook_operator.py
@@ -33,6 +33,7 @@ class TestSlackWebhookOperator(unittest.TestCase):
         'webhook_token': 'manual_token',
         'message': 'your message here',
         'attachments': [{'fallback': 'Required plain-text summary'}],
+        'blocks': [{'type': 'section', 'text': {'type': 'mrkdwn', 'text': '*bold text*'}}],
         'channel': '#general',
         'username': 'SlackMcSlackFace',
         'icon_emoji': ':hankey',
@@ -60,6 +61,7 @@ class TestSlackWebhookOperator(unittest.TestCase):
         self.assertEqual(self._config['webhook_token'], operator.webhook_token)
         self.assertEqual(self._config['message'], operator.message)
         self.assertEqual(self._config['attachments'], operator.attachments)
+        self.assertEqual(self._config['blocks'], operator.blocks)
         self.assertEqual(self._config['channel'], operator.channel)
         self.assertEqual(self._config['username'], operator.username)
         self.assertEqual(self._config['icon_emoji'], operator.icon_emoji)
@@ -74,7 +76,7 @@ class TestSlackWebhookOperator(unittest.TestCase):
             **self._config
         )
 
-        template_fields = ['webhook_token', 'message', 'attachments', 'channel', 'username', 'proxy']
+        template_fields = ['webhook_token', 'message', 'attachments', 'blocks', 'channel', 'username', 'proxy']
 
         self.assertEqual(operator.template_fields, template_fields)
 

--- a/tests/operators/test_slack_operator.py
+++ b/tests/operators/test_slack_operator.py
@@ -56,7 +56,28 @@ class TestSlackAPIPostOperator(unittest.TestCase):
                 "ts": 123456789
             }
         ]
+        self.test_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "text": "A message *with some bold text* and _some italicized text_.",
+                    "type": "mrkdwn"
+                },
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "High"
+                    },
+                    {
+                        "type": "plain_text",
+                        "emoji": True,
+                        "text": "String"
+                    }
+                ]
+            }
+        ]
         self.test_attachments_in_json = json.dumps(self.test_attachments)
+        self.test_blocks_in_json = json.dumps(self.test_blocks)
         self.test_api_params = {'key': 'value'}
         self.test_kwarg = 'test_kwarg'
 
@@ -67,6 +88,7 @@ class TestSlackAPIPostOperator(unittest.TestCase):
             'text': self.test_text,
             'icon_url': self.test_icon_url,
             'attachments': self.test_attachments_in_json,
+            'blocks': self.test_blocks_in_json,
         }
 
     def __construct_operator(self, test_token, test_slack_conn_id, test_api_params=None):
@@ -79,6 +101,7 @@ class TestSlackAPIPostOperator(unittest.TestCase):
             text=self.test_text,
             icon_url=self.test_icon_url,
             attachments=self.test_attachments,
+            blocks=self.test_blocks,
             api_params=test_api_params,
             kwarg=self.test_kwarg
         )
@@ -143,6 +166,7 @@ class TestSlackAPIPostOperator(unittest.TestCase):
         self.assertEqual(slack_api_post_operator.username, self.test_username)
         self.assertEqual(slack_api_post_operator.icon_url, self.test_icon_url)
         self.assertEqual(slack_api_post_operator.attachments, self.test_attachments)
+        self.assertEqual(slack_api_post_operator.blocks, self.test_blocks)
 
         slack_api_post_operator = self.__construct_operator(None, test_slack_conn_id)
         self.assertEqual(slack_api_post_operator.token, None)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

Slack clients v1.x.x also does support "blocks".