### PR TITLE
[AIRFLOW-5751] add get_uri method to Connection

### DIFF
--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import json
 import unittest
 from collections import namedtuple
 
@@ -27,6 +27,29 @@ from airflow.models import Connection, crypto
 from tests.test_utils.config import conf_vars
 
 ConnectionParts = namedtuple("ConnectionParts", ["conn_type", "login", "password", "host", "port", "schema"])
+
+
+class UriTestCaseConfig:
+    def __init__(
+        self,
+        test_conn_uri: str,
+        test_conn_attributes: dict,
+        description: str,
+    ):
+        """
+
+        :param test_conn_uri: URI that we use to create connection
+        :param test_conn_attributes: we expect a connection object created with `test_uri` to have these
+        attributes
+        :param description: human-friendly name appended to parameterized test
+        """
+        self.test_uri = test_conn_uri
+        self.test_conn_attributes = test_conn_attributes
+        self.description = description
+
+    @staticmethod
+    def uri_test_name(func, num, param):
+        return "{}_{}_{}".format(func.__name__, num, param.args[0].description.replace(' ', '_'))
 
 
 class TestConnection(unittest.TestCase):
@@ -80,132 +103,253 @@ class TestConnection(unittest.TestCase):
             self.assertEqual(test_connection.extra, 'testextra')
             self.assertEqual(Fernet(key2).decrypt(test_connection._extra.encode()), b'testextra')
 
-    def test_connection_from_uri_without_extras(self):
-        uri = 'scheme://user:password@host%2flocation:1234/schema'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host/location')
-        self.assertEqual(connection.schema, 'schema')
-        self.assertEqual(connection.login, 'user')
-        self.assertEqual(connection.password, 'password')
-        self.assertEqual(connection.port, 1234)
-        self.assertIsNone(connection.extra)
+    test_from_uri_params = [
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location',
+                schema='schema',
+                login='user',
+                password='password',
+                port=1234,
+                extra=None,
+            ),
+            description='without extras',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
+                          'extra1=a%20value&extra2=%2Fpath%2F',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location',
+                schema='schema',
+                login='user',
+                password='password',
+                port=1234,
+                extra_dejson={'extra1': 'a value', 'extra2': '/path/'}
+            ),
+            description='with extras'
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?extra1=a%20value&extra2=',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location',
+                schema='schema',
+                login='user',
+                password='password',
+                port=1234,
+                extra_dejson={'extra1': 'a value', 'extra2': ''}
+            ),
+            description='with empty extras'
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password@host%2Flocation%3Ax%3Ay:1234/schema?'
+                          'extra1=a%20value&extra2=%2Fpath%2F',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location:x:y',
+                schema='schema',
+                login='user',
+                password='password',
+                port=1234,
+                extra_dejson={'extra1': 'a value', 'extra2': '/path/'},
+            ),
+            description='with colon in hostname'
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password%20with%20space@host%2Flocation%3Ax%3Ay:1234/schema',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location:x:y',
+                schema='schema',
+                login='user',
+                password='password with space',
+                port=1234,
+            ),
+            description='with encoded password'
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://domain%2Fuser:password@host%2Flocation%3Ax%3Ay:1234/schema',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location:x:y',
+                schema='schema',
+                login='domain/user',
+                password='password',
+                port=1234,
+            ),
+            description='with encoded user',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password%20with%20space@host:1234/schema%2Ftest',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host',
+                schema='schema/test',
+                login='user',
+                password='password with space',
+                port=1234,
+            ),
+            description='with encoded schema'
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password%20with%20space@host:1234',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host',
+                schema='',
+                login='user',
+                password='password with space',
+                port=1234,
+            ),
+            description='no schema'
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='google-cloud-platform://?extra__google_cloud_platform__key_'
+            'path=%2Fkeys%2Fkey.json&extra__google_cloud_platform__scope='
+            'https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform&extra'
+            '__google_cloud_platform__project=airflow',
+            test_conn_attributes=dict(
+                conn_type='google_cloud_platform',
+                host='',
+                schema='',
+                login=None,
+                password=None,
+                port=None,
+                extra_dejson=dict(
+                    extra__google_cloud_platform__key_path='/keys/key.json',
+                    extra__google_cloud_platform__scope='https://www.googleapis.com/auth/cloud-platform',
+                    extra__google_cloud_platform__project='airflow',
+                )
+            ),
+            description='with underscore',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://host:1234',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host',
+                schema='',
+                login=None,
+                password=None,
+                port=1234,
+            ),
+            description='without auth info'
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://%2FTmP%2F:1234',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='/TmP/',
+                schema='',
+                login=None,
+                password=None,
+                port=1234,
+            ),
+            description='with path',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme:///airflow',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                schema='airflow',
+            ),
+            description='schema only',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://@:1234',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                port=1234,
+            ),
+            description='port only',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://:password%2F%21%40%23%24%25%5E%26%2A%28%29%7B%7D@',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                password='password/!@#$%^&*(){}',
+            ),
+            description='password only',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://login%2F%21%40%23%24%25%5E%26%2A%28%29%7B%7D@',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                login='login/!@#$%^&*(){}',
+            ),
+            description='login only',
+        ),
+    ]
 
-    def test_connection_from_uri_with_extras(self):
-        uri = 'scheme://user:password@host%2flocation:1234/schema?' \
-              'extra1=a%20value&extra2=%2fpath%2f'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host/location')
-        self.assertEqual(connection.schema, 'schema')
-        self.assertEqual(connection.login, 'user')
-        self.assertEqual(connection.password, 'password')
-        self.assertEqual(connection.port, 1234)
-        self.assertDictEqual(connection.extra_dejson, {'extra1': 'a value',
-                                                       'extra2': '/path/'})
+    # pylint: disable=undefined-variable
+    @parameterized.expand([(x,) for x in test_from_uri_params], UriTestCaseConfig.uri_test_name)
+    def test_connection_from_uri(self, test_config: UriTestCaseConfig):
 
-    def test_connection_from_uri_with_empty_extras(self):
-        uri = 'scheme://user:password@host%2flocation:1234/schema?' \
-              'extra1=a%20value&extra2='
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host/location')
-        self.assertEqual(connection.schema, 'schema')
-        self.assertEqual(connection.login, 'user')
-        self.assertEqual(connection.password, 'password')
-        self.assertEqual(connection.port, 1234)
-        self.assertDictEqual(connection.extra_dejson, {'extra1': 'a value',
-                                                       'extra2': ''})
+        connection = Connection(uri=test_config.test_uri)
+        for conn_attr, expected_val in test_config.test_conn_attributes.items():
+            actual_val = getattr(connection, conn_attr)
+            if expected_val is None:
+                self.assertIsNone(expected_val)
+            if isinstance(expected_val, dict):
+                self.assertDictEqual(expected_val, actual_val)
+            else:
+                self.assertEqual(expected_val, actual_val)
 
-    def test_connection_from_uri_with_colon_in_hostname(self):
-        uri = 'scheme://user:password@host%2flocation%3ax%3ay:1234/schema?' \
-              'extra1=a%20value&extra2=%2fpath%2f'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host/location:x:y')
-        self.assertEqual(connection.schema, 'schema')
-        self.assertEqual(connection.login, 'user')
-        self.assertEqual(connection.password, 'password')
-        self.assertEqual(connection.port, 1234)
-        self.assertDictEqual(connection.extra_dejson, {'extra1': 'a value',
-                                                       'extra2': '/path/'})
+    # pylint: disable=undefined-variable
+    @parameterized.expand([(x,) for x in test_from_uri_params], UriTestCaseConfig.uri_test_name)
+    def test_connection_get_uri_from_uri(self, test_config: UriTestCaseConfig):
+        """
+        This test verifies that when we create a conn_1 from URI, and we generate a URI from that conn, that
+        when we create a conn_2 from the generated URI, we get an equivalent conn.
+        1. Parse URI to create `Connection` object, `connection`.
+        2. Using this connection, generate URI `generated_uri`..
+        3. Using this`generated_uri`, parse and create new Connection `new_conn`.
+        4. Verify that `new_conn` has same attributes as `connection`.
+        """
+        connection = Connection(uri=test_config.test_uri)
+        generated_uri = connection.get_uri()
+        new_conn = Connection(uri=generated_uri)
+        self.assertEqual(connection.conn_type, new_conn.conn_type)
+        self.assertEqual(connection.login, new_conn.login)
+        self.assertEqual(connection.password, new_conn.password)
+        self.assertEqual(connection.host, new_conn.host)
+        self.assertEqual(connection.port, new_conn.port)
+        self.assertEqual(connection.schema, new_conn.schema)
+        self.assertDictEqual(connection.extra_dejson, new_conn.extra_dejson)
 
-    def test_connection_from_uri_with_encoded_password(self):
-        uri = 'scheme://user:password%20with%20space@host%2flocation%3ax%3ay:1234/schema'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host/location:x:y')
-        self.assertEqual(connection.schema, 'schema')
-        self.assertEqual(connection.login, 'user')
-        self.assertEqual(connection.password, 'password with space')
-        self.assertEqual(connection.port, 1234)
+    # pylint: disable=undefined-variable
+    @parameterized.expand([(x,) for x in test_from_uri_params], UriTestCaseConfig.uri_test_name)
+    def test_connection_get_uri_from_conn(self, test_config: UriTestCaseConfig):
+        """
+        This test verifies that if we create conn_1 from attributes (rather than from URI), and we generate a
+        URI, that when we create conn_2 from this URI, we get an equivalent conn.
+        1. Build conn init params using `test_conn_attributes` and store in `conn_kwargs`
+        2. Instantiate conn `connection` from `conn_kwargs`.
+        3. Generate uri `get_uri` from this conn.
+        4. Create conn `new_conn` from this uri.
+        5. Verify `new_conn` has same attributes as `connection`.
+        """
+        conn_kwargs = {}
+        for k, v in test_config.test_conn_attributes.items():
+            if k == 'extra_dejson':
+                conn_kwargs.update({'extra': json.dumps(v)})
+            else:
+                conn_kwargs.update({k: v})
 
-    def test_connection_from_uri_with_encoded_user(self):
-        uri = 'scheme://domain%2fuser:password@host%2flocation%3ax%3ay:1234/schema'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host/location:x:y')
-        self.assertEqual(connection.schema, 'schema')
-        self.assertEqual(connection.login, 'domain/user')
-        self.assertEqual(connection.password, 'password')
-        self.assertEqual(connection.port, 1234)
-
-    def test_connection_from_uri_with_encoded_schema(self):
-        uri = 'scheme://user:password%20with%20space@host:1234/schema%2ftest'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host')
-        self.assertEqual(connection.schema, 'schema/test')
-        self.assertEqual(connection.login, 'user')
-        self.assertEqual(connection.password, 'password with space')
-        self.assertEqual(connection.port, 1234)
-
-    def test_connection_from_uri_no_schema(self):
-        uri = 'scheme://user:password%20with%20space@host:1234'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host')
-        self.assertEqual(connection.schema, '')
-        self.assertEqual(connection.login, 'user')
-        self.assertEqual(connection.password, 'password with space')
-        self.assertEqual(connection.port, 1234)
-
-    def test_connection_from_uri_with_underscore(self):
-        uri = 'google-cloud-platform://?extra__google_cloud_platform__key_' \
-              'path=%2Fkeys%2Fkey.json&extra__google_cloud_platform__scope=' \
-              'https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform&extra' \
-              '__google_cloud_platform__project=airflow'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'google_cloud_platform')
-        self.assertEqual(connection.host, '')
-        self.assertEqual(connection.schema, '')
-        self.assertEqual(connection.login, None)
-        self.assertEqual(connection.password, None)
-        self.assertEqual(connection.extra_dejson, dict(
-            extra__google_cloud_platform__key_path='/keys/key.json',
-            extra__google_cloud_platform__project='airflow',
-            extra__google_cloud_platform__scope='https://www.googleapis.com/'
-                                                'auth/cloud-platform'))
-
-    def test_connection_from_uri_without_authinfo(self):
-        uri = 'scheme://host:1234'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, 'host')
-        self.assertEqual(connection.schema, '')
-        self.assertEqual(connection.login, None)
-        self.assertEqual(connection.password, None)
-        self.assertEqual(connection.port, 1234)
-
-    def test_connection_from_uri_with_path(self):
-        uri = 'scheme://%2FTmP%2F:1234'
-        connection = Connection(uri=uri)
-        self.assertEqual(connection.conn_type, 'scheme')
-        self.assertEqual(connection.host, '/TmP/')
-        self.assertEqual(connection.schema, '')
-        self.assertEqual(connection.login, None)
-        self.assertEqual(connection.password, None)
-        self.assertEqual(connection.port, 1234)
+        connection = Connection(conn_id='test_conn', **conn_kwargs)
+        gen_uri = connection.get_uri()
+        new_conn = Connection(conn_id='test_conn', uri=gen_uri)
+        for conn_attr, expected_val in test_config.test_conn_attributes.items():
+            actual_val = getattr(new_conn, conn_attr)
+            if expected_val is None:
+                self.assertIsNone(expected_val)
+            if isinstance(expected_val, dict):
+                self.assertDictEqual(expected_val, actual_val)
+            else:
+                self.assertEqual(expected_val, actual_val)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
* Add a convenience method `get_uri` on `Connection` object to generate the URI for a connection.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5751) issues and references them in the PR title. For example, "\[AIRFLOW-5751\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5751


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Building URI for use in connection env var can be a nuisance.  This is a convenience method that will do it for you, given a connection object.  

So if you have created one in UI, you could do BaseHook.get_connection(conn_id).get_uri().

Or build using init params on `Connection` object and call `get_uri()`.

I think it could also be nice if each hook had a `get_uri` method that would take all relevant params and produce a correctly encoded URI.  If that were implemented, it could use this function for that purpose. 

I added tests to verify that generated URIs, when parsed again, produce the same connection object.  For this I used the same URIs we were already testing.  And as part of this there was an efficiency in refactoring the existing from_uri test.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
