### PR TITLE
[AIRFLOW-5753] Add DailyLatestOnlyOperator

### DIFF
--- a/airflow/contrib/operators/daily_latest_only_operator.py
+++ b/airflow/contrib/operators/daily_latest_only_operator.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This module contains DailyLatestOnlyOperator"""
+
+import pendulum
+
+from airflow.models import BaseOperator, SkipMixin
+
+
+class DailyLatestOnlyOperator(BaseOperator, SkipMixin):
+    """
+    Allows a workflow to skip tasks that are not running during the most
+    recent daily schedule interval.
+
+    If the task is run outside of the daily latest schedule interval, all
+    directly downstream tasks will be skipped.
+
+    Note that downstream tasks are never skipped if the given DAG_Run is
+    marked as externally triggered.
+    """
+
+    ui_color = '#f5dbff'  # light purple
+
+    def execute(self, context):
+        # If the DAG Run is externally triggered, then return without
+        # skipping downstream tasks
+        if context['dag_run'] and context['dag_run'].external_trigger:
+            self.log.info('Externally triggered DAG_Run: allowing execution to proceed.')
+            return
+
+        now = pendulum.utcnow()
+        left_window = context['dag'].following_schedule(
+            context['execution_date'])
+        right_window = context['dag'].following_schedule(left_window)
+        self.log.info(
+            'Checking latest only with left_window: %s right_window: %s now: %s',
+            left_window, right_window, now
+        )
+
+        if not left_window < now <= right_window:
+            if context['execution_date'].day != left_window.day:
+                self.log.info('Not latest execution, but last daily '
+                              'execution. Proceed.')
+            else:
+                self.log.info('Not latest execution, skipping downstream.')
+
+                downstream_tasks = context['task'].get_flat_relatives(upstream=False)
+                self.log.debug('Downstream task_ids %s', downstream_tasks)
+
+                if downstream_tasks:
+                    self.skip(context['dag_run'],
+                              context['ti'].execution_date,
+                              downstream_tasks)
+
+                self.log.info('Done.')
+        else:
+            self.log.info('Latest, allowing execution to proceed.')

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -39,6 +39,7 @@ Fundamentals
 * :mod:`airflow.operators.branch_operator`
 * :mod:`airflow.operators.check_operator`
 * :mod:`airflow.operators.dagrun_operator`
+* :mod:`airflow.contrib.operators.daily_latest_only_operator`
 * :mod:`airflow.operators.dummy_operator`
 * :mod:`airflow.operators.generic_transfer`
 * :mod:`airflow.operators.latest_only_operator`

--- a/tests/contrib/operators/test_daily_latest_only_operator.py
+++ b/tests/contrib/operators/test_daily_latest_only_operator.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime
+import unittest
+
+from freezegun import freeze_time
+
+from airflow import DAG, settings
+from airflow.contrib.operators.daily_latest_only_operator import DailyLatestOnlyOperator
+from airflow.models import TaskInstance
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils import timezone
+from airflow.utils.state import State
+
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+END_DATE = timezone.datetime(2016, 1, 2)
+INTERVAL = datetime.timedelta(hours=12)
+FROZEN_NOW = timezone.datetime(2016, 1, 2, 12, 1, 1)
+
+
+def get_task_instances(task_id):
+    session = settings.Session()
+    return session \
+        .query(TaskInstance) \
+        .filter(TaskInstance.task_id == task_id) \
+        .order_by(TaskInstance.execution_date) \
+        .all()
+
+
+class DailyLatestOnlyOperatorTest(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.dag = DAG(
+            'test_dag',
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE},
+            schedule_interval=INTERVAL)
+        self.addCleanup(self.dag.clear)
+        freezer = freeze_time(FROZEN_NOW)
+        freezer.start()
+        self.addCleanup(freezer.stop)
+
+    def test_run(self):
+        task = DailyLatestOnlyOperator(
+            task_id='daily_latest',
+            dag=self.dag)
+        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+    def test_skipping(self):
+        latest_task = DailyLatestOnlyOperator(
+            task_id='daily_latest',
+            dag=self.dag)
+        downstream_task = DummyOperator(
+            task_id='downstream',
+            dag=self.dag)
+        downstream_task2 = DummyOperator(
+            task_id='downstream_2',
+            dag=self.dag)
+
+        downstream_task.set_upstream(latest_task)
+        downstream_task2.set_upstream(downstream_task)
+
+        latest_task.run(start_date=DEFAULT_DATE, end_date=END_DATE)
+        downstream_task.run(start_date=DEFAULT_DATE, end_date=END_DATE)
+        downstream_task2.run(start_date=DEFAULT_DATE, end_date=END_DATE)
+
+        latest_instances = get_task_instances('daily_latest')
+        exec_date_to_latest_state = {
+            ti.execution_date: ti.state for ti in latest_instances}
+        self.assertEqual({
+            timezone.datetime(2016, 1, 1): 'success',
+            timezone.datetime(2016, 1, 1, 12): 'success',
+            timezone.datetime(2016, 1, 2): 'success', },
+            exec_date_to_latest_state)
+
+        downstream_instances = get_task_instances('downstream')
+        exec_date_to_downstream_state = {
+            ti.execution_date: ti.state for ti in downstream_instances}
+        self.assertEqual({
+            timezone.datetime(2016, 1, 1): 'skipped',
+            timezone.datetime(2016, 1, 1, 12): 'success',
+            timezone.datetime(2016, 1, 2): 'success', },
+            exec_date_to_downstream_state)
+
+        downstream_instances = get_task_instances('downstream_2')
+        exec_date_to_downstream_state = {
+            ti.execution_date: ti.state for ti in downstream_instances}
+        self.assertEqual({
+            timezone.datetime(2016, 1, 1): 'skipped',
+            timezone.datetime(2016, 1, 1, 12): 'success',
+            timezone.datetime(2016, 1, 2): 'success', },
+            exec_date_to_downstream_state)
+
+    def test_skipping_dagrun(self):
+        latest_task = DailyLatestOnlyOperator(
+            task_id='daily_latest',
+            dag=self.dag)
+        downstream_task = DummyOperator(
+            task_id='downstream',
+            dag=self.dag)
+        downstream_task2 = DummyOperator(
+            task_id='downstream_2',
+            dag=self.dag)
+
+        downstream_task.set_upstream(latest_task)
+        downstream_task2.set_upstream(downstream_task)
+
+        self.dag.create_dagrun(
+            run_id='manual__1',
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING
+        )
+
+        self.dag.create_dagrun(
+            run_id='manual__2',
+            start_date=timezone.utcnow(),
+            execution_date=timezone.datetime(2016, 1, 1, 12),
+            state=State.RUNNING
+        )
+
+        self.dag.create_dagrun(
+            run_id='manual__3',
+            start_date=timezone.utcnow(),
+            execution_date=END_DATE,
+            state=State.RUNNING
+        )
+
+        latest_task.run(start_date=DEFAULT_DATE, end_date=END_DATE)
+        downstream_task.run(start_date=DEFAULT_DATE, end_date=END_DATE)
+        downstream_task2.run(start_date=DEFAULT_DATE, end_date=END_DATE)
+
+        latest_instances = get_task_instances('daily_latest')
+        exec_date_to_latest_state = {
+            ti.execution_date: ti.state for ti in latest_instances}
+        self.assertEqual({
+            timezone.datetime(2016, 1, 1): 'success',
+            timezone.datetime(2016, 1, 1, 12): 'success',
+            timezone.datetime(2016, 1, 2): 'success', },
+            exec_date_to_latest_state)
+
+        downstream_instances = get_task_instances('downstream')
+        exec_date_to_downstream_state = {
+            ti.execution_date: ti.state for ti in downstream_instances}
+        self.assertEqual({
+            timezone.datetime(2016, 1, 1): 'skipped',
+            timezone.datetime(2016, 1, 1, 12): 'success',
+            timezone.datetime(2016, 1, 2): 'success', },
+            exec_date_to_downstream_state)
+
+        downstream_instances = get_task_instances('downstream_2')
+        exec_date_to_downstream_state = {
+            ti.execution_date: ti.state for ti in downstream_instances}
+        self.assertEqual({
+            timezone.datetime(2016, 1, 1): 'skipped',
+            timezone.datetime(2016, 1, 1, 12): 'success',
+            timezone.datetime(2016, 1, 2): 'success', },
+            exec_date_to_downstream_state)


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5753
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In addition to LatestOnlyOperator, DailyLatestOnlyOperator is for cases that we need to run only the latest run in the series of task run, but to ensure that the task is run at least once in a day.

This is useful when we scrape external data from third-parties on an hourly basis/for multiple times in a day to keep data up-to-date. If the DAG is paused for several days, we want to avoid multiple runs in a day, but still want to ensure data is filled in every daily window.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`test_daily_latest_only_operator.py` added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
