### PR TITLE
[AIRFLOW-5768] GCP cloud sql don't store ephemeral connection in db

### DIFF
--- a/airflow/gcp/operators/cloud_sql.py
+++ b/airflow/gcp/operators/cloud_sql.py
@@ -835,13 +835,10 @@ class CloudSqlQueryOperator(BaseOperator):
                 'extra__google_cloud_platform__project')
         )
         hook.validate_ssl_certs()
-        hook.create_connection()
+        connection = hook.create_connection()
+        hook.validate_socket_path_length()
+        database_hook = hook.get_database_hook(connection=connection)
         try:
-            hook.validate_socket_path_length()
-            database_hook = hook.get_database_hook()
-            try:
-                self._execute_query(hook, database_hook)
-            finally:
-                hook.cleanup_database_hook()
+            self._execute_query(hook, database_hook)
         finally:
-            hook.delete_connection()
+            hook.cleanup_database_hook()

--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -47,6 +47,7 @@ class MySqlHook(DbApiHook):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.schema = kwargs.pop("schema", None)
+        self.connection = kwargs.pop("connection", None)
 
     def set_autocommit(self, conn, autocommit):
         """
@@ -69,7 +70,7 @@ class MySqlHook(DbApiHook):
         """
         Returns a mysql connection object
         """
-        conn = self.get_connection(self.mysql_conn_id)
+        conn = self.connection or self.get_connection(self.mysql_conn_id)
 
         conn_config = {
             "user": conn.login,

--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -56,6 +56,7 @@ class PostgresHook(DbApiHook):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.schema = kwargs.pop("schema", None)
+        self.connection = kwargs.pop("connection", None)
 
     def _get_cursor(self, raw_cursor):
         _cursor = raw_cursor.lower()
@@ -68,8 +69,9 @@ class PostgresHook(DbApiHook):
         raise ValueError('Invalid cursor passed {}'.format(_cursor))
 
     def get_conn(self):
+
         conn_id = getattr(self, self.conn_name_attr)
-        conn = self.get_connection(conn_id)
+        conn = self.connection or self.get_connection(conn_id)
 
         # check for authentication via AWS IAM
         if conn.extra_dejson.get('iam', False):

--- a/tests/hooks/test_mysql_hook.py
+++ b/tests/hooks/test_mysql_hook.py
@@ -62,6 +62,24 @@ class TestMySqlHookConn(unittest.TestCase):
         self.assertEqual(kwargs['db'], 'schema')
 
     @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
+    def test_get_conn_from_connection(self, mock_connect):
+        conn = Connection(login='login-conn', password='password-conn', host='host', schema='schema')
+        hook = MySqlHook(connection=conn)
+        hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user='login-conn', passwd='password-conn', host='host', db='schema', port=3306
+        )
+
+    @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
+    def test_get_conn_from_connection_with_schema(self, mock_connect):
+        conn = Connection(login='login-conn', password='password-conn', host='host', schema='schema')
+        hook = MySqlHook(connection=conn, schema='schema-override')
+        hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user='login-conn', passwd='password-conn', host='host', db='schema-override', port=3306
+        )
+
+    @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
     def test_get_conn_port(self, mock_connect):
         self.connection.port = 3307
         self.db_hook.get_conn()

--- a/tests/hooks/test_postgres_hook.py
+++ b/tests/hooks/test_postgres_hook.py
@@ -77,6 +77,24 @@ class TestPostgresHookConn(unittest.TestCase):
             self.db_hook.get_conn()
 
     @mock.patch('airflow.hooks.postgres_hook.psycopg2.connect')
+    def test_get_conn_from_connection(self, mock_connect):
+        conn = Connection(login='login-conn', password='password-conn', host='host', schema='schema')
+        hook = PostgresHook(connection=conn)
+        hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user='login-conn', password='password-conn', host='host', dbname='schema', port=None
+        )
+
+    @mock.patch('airflow.hooks.postgres_hook.psycopg2.connect')
+    def test_get_conn_from_connection_with_schema(self, mock_connect):
+        conn = Connection(login='login-conn', password='password-conn', host='host', schema='schema')
+        hook = PostgresHook(connection=conn, schema='schema-override')
+        hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user='login-conn', password='password-conn', host='host', dbname='schema-override', port=None
+        )
+
+    @mock.patch('airflow.hooks.postgres_hook.psycopg2.connect')
     @mock.patch('airflow.contrib.hooks.aws_hook.AwsHook.get_client_type')
     def test_get_conn_rds_iam_postgres(self, mock_client, mock_connect):
         self.connection.extra = '{"iam":true}'


### PR DESCRIPTION

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-5768) issues and references them in the PR title. 
  - https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-5768

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

GCP cloud sql operator creates dynamically an ephemeral Connection object. It persists to metastore during execution and deletes afterward.

This behavior has negative impact on our ability to refactor creds management.

By not persisting to database, we can also remove some complexity re ensuring connection is deleted in event of failure, and the tests that go along with that.

This change requires that we add optional param `connection` to both MySqlHook and PostgresHook.

Incidentally, this PR incorporates test simplifications originally in unmerged PR https://github.com/apache/airflow/pull/6390 and will render that PR obsolete.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
