### PR TITLE
[AIRFLOW-5793] add test to detect multiple alembic revision heads

### DIFF
--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -20,7 +20,9 @@
 import unittest
 
 from alembic.autogenerate import compare_metadata
+from alembic.config import Config
 from alembic.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from sqlalchemy import MetaData
 
 from airflow.models import Base as airflow_base
@@ -97,3 +99,12 @@ class TestDb(unittest.TestCase):
             diff,
             'Database schema and SQLAlchemy model are not in sync: ' + str(diff)
         )
+
+    def test_only_single_head_revision_in_migrations(self):
+        config = Config()
+        config.set_main_option("script_location", "airflow:migrations")
+        script = ScriptDirectory.from_config(config)
+
+        # This will raise if there are multiple heads
+        # To resolve, use the command `alembic merge`
+        script.get_current_head()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-5793)
  - https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-5793

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Depending on the timing of merges with migrations, we can end up with two revision heads that need to be merged.

This adds a test to detect when multiple heads are present.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
