### PR TITLE
[AIRFLOW-5669] Rename GoogleCloudBaseHook to CloudBaseHook

### DIFF
--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -20,7 +20,7 @@
 import warnings
 
 # pylint: disable=unused-import
-from airflow.gcp.hooks.base import GoogleCloudBaseHook  # noqa
+from airflow.gcp.hooks.base import CloudBaseHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.base`.",

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -26,3 +26,17 @@ warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.base`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GoogleCloudBaseHook(CloudBaseHook):
+    """
+    This class is deprecated. Please use `airflow.gcp.hooks.base.CloudBaseHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This class is deprecated. Please use `airflow.gcp.hooks.base.CloudBaseHook`.",
+            DeprecationWarning, stacklevel=2
+        )
+
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/hooks/gdrive_hook.py
+++ b/airflow/contrib/hooks/gdrive_hook.py
@@ -22,11 +22,11 @@ from typing import Any, Optional
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
 # noinspection PyAbstractClass
-class GoogleDriveHook(GoogleCloudBaseHook):
+class GoogleDriveHook(CloudBaseHook):
     """
     Hook for the Google Drive APIs.
 

--- a/airflow/gcp/hooks/automl.py
+++ b/airflow/gcp/hooks/automl.py
@@ -30,10 +30,10 @@ from google.cloud.automl_v1beta1.types import (
     ImageObjectDetectionModelDeploymentMetadata, InputConfig, Model, Operation, PredictResponse, TableSpec,
 )
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class CloudAutoMLHook(GoogleCloudBaseHook):
+class CloudAutoMLHook(CloudBaseHook):
     """
     Google Cloud AutoML hook.
 
@@ -79,8 +79,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
             credentials=self._get_credentials(), client_info=self.client_info
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_model(
         self,
         model: Union[dict, Model],
@@ -122,8 +122,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
             parent=parent, model=model, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def batch_predict(
         self,
         model_id: str,
@@ -184,8 +184,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def predict(
         self,
         model_id: str,
@@ -238,8 +238,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_dataset(
         self,
         dataset: Union[dict, Dataset],
@@ -283,8 +283,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def import_data(
         self,
         dataset_id: str,
@@ -333,8 +333,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def list_column_specs(  # pylint:disable=too-many-arguments
         self,
         dataset_id: str,
@@ -401,8 +401,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def get_model(
         self,
         model_id: str,
@@ -441,8 +441,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_model(
         self,
         model_id: str,
@@ -481,8 +481,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def update_dataset(
         self,
         dataset: Union[dict, Dataset],
@@ -526,8 +526,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def deploy_model(
         self,
         model_id: str,
@@ -640,8 +640,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def list_datasets(
         self,
         location: str,
@@ -680,8 +680,8 @@ class CloudAutoMLHook(GoogleCloudBaseHook):
         )
         return result
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_dataset(
         self,
         dataset_id: str,

--- a/airflow/gcp/hooks/base.py
+++ b/airflow/gcp/hooks/base.py
@@ -100,7 +100,7 @@ class retry_if_temporary_quota(tenacity.retry_if_exception):  # pylint: disable=
 RT = TypeVar('RT')  # pylint: disable=invalid-name
 
 
-class GoogleCloudBaseHook(BaseHook):
+class CloudBaseHook(BaseHook):
     """
     A base hook for Google cloud-related hooks. Google cloud has a shared REST
     API client that is built in the same way no matter which service you use.
@@ -301,7 +301,7 @@ class GoogleCloudBaseHook(BaseHook):
         """
 
         @functools.wraps(func)
-        def wrapper_decorator(self: GoogleCloudBaseHook, *args, **kwargs) -> RT:
+        def wrapper_decorator(self: CloudBaseHook, *args, **kwargs) -> RT:
             try:
                 return func(self, *args, **kwargs)
             except GoogleAPICallError as e:
@@ -334,7 +334,7 @@ class GoogleCloudBaseHook(BaseHook):
         :return: result of the function call
         """
         @functools.wraps(func)
-        def inner_wrapper(self: GoogleCloudBaseHook, *args, **kwargs) -> RT:
+        def inner_wrapper(self: CloudBaseHook, *args, **kwargs) -> RT:
             if args:
                 raise AirflowException(
                     "You must use keyword arguments in this methods rather than"
@@ -361,7 +361,7 @@ class GoogleCloudBaseHook(BaseHook):
         makes it easier to use multiple connection in one function.
         """
         @functools.wraps(func)
-        def wrapper(self: GoogleCloudBaseHook, *args, **kwargs) -> RT:
+        def wrapper(self: CloudBaseHook, *args, **kwargs) -> RT:
             with self.provide_gcp_credential_file_as_context():
                 return func(self, *args, **kwargs)
         return wrapper

--- a/airflow/gcp/hooks/bigquery.py
+++ b/airflow/gcp/hooks/bigquery.py
@@ -37,12 +37,12 @@ from pandas_gbq.gbq import (
 )
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-class BigQueryHook(GoogleCloudBaseHook, DbApiHook):
+class BigQueryHook(CloudBaseHook, DbApiHook):
     """
     Interact with BigQuery. This hook uses the Google Cloud Platform
     connection.

--- a/airflow/gcp/hooks/bigquery_dts.py
+++ b/airflow/gcp/hooks/bigquery_dts.py
@@ -30,7 +30,7 @@ from google.cloud.bigquery_datatransfer_v1.types import (
 )
 from google.protobuf.json_format import MessageToDict, ParseDict
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
 def get_object_id(obj: dict) -> str:
@@ -40,7 +40,7 @@ def get_object_id(obj: dict) -> str:
     return obj["name"].rpartition("/")[-1]
 
 
-class BiqQueryDataTransferServiceHook(GoogleCloudBaseHook):
+class BiqQueryDataTransferServiceHook(CloudBaseHook):
     """
      Hook for Google Bigquery Transfer API.
 
@@ -93,8 +93,8 @@ class BiqQueryDataTransferServiceHook(GoogleCloudBaseHook):
             )
         return self._conn
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_transfer_config(
         self,
         transfer_config: Union[dict, TransferConfig],
@@ -138,8 +138,8 @@ class BiqQueryDataTransferServiceHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_transfer_config(
         self,
         transfer_config_id: str,
@@ -176,8 +176,8 @@ class BiqQueryDataTransferServiceHook(GoogleCloudBaseHook):
             name=name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def start_manual_transfer_runs(
         self,
         transfer_config_id: str,
@@ -233,8 +233,8 @@ class BiqQueryDataTransferServiceHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def get_transfer_run(
         self,
         run_id: str,

--- a/airflow/gcp/hooks/bigtable.py
+++ b/airflow/gcp/hooks/bigtable.py
@@ -28,10 +28,10 @@ from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import ClusterState, Table
 from google.cloud.bigtable_admin_v2 import enums
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class BigtableHook(GoogleCloudBaseHook):
+class BigtableHook(CloudBaseHook):
     """
     Hook for Google Cloud Bigtable APIs.
 
@@ -54,7 +54,7 @@ class BigtableHook(GoogleCloudBaseHook):
             )
         return self._client
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_instance(self, instance_id: str, project_id: Optional[str] = None) -> Instance:
         """
         Retrieves and returns the specified Cloud Bigtable instance if it exists.
@@ -74,7 +74,7 @@ class BigtableHook(GoogleCloudBaseHook):
             return None
         return instance
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_instance(self, instance_id: str, project_id: Optional[str] = None) -> None:
         """
         Deletes the specified Cloud Bigtable instance.
@@ -96,7 +96,7 @@ class BigtableHook(GoogleCloudBaseHook):
             self.log.info("The instance '%s' does not exist in project '%s'. Exiting", instance_id,
                           project_id)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_instance(
         self,
         instance_id: str,
@@ -210,7 +210,7 @@ class BigtableHook(GoogleCloudBaseHook):
         table = Table(table_id, instance)
         table.create(initial_split_keys, column_families)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_table(self, instance_id: str, table_id: str, project_id: Optional[str] = None) -> None:
         """
         Deletes the specified table in Cloud Bigtable.

--- a/airflow/gcp/hooks/cloud_build.py
+++ b/airflow/gcp/hooks/cloud_build.py
@@ -24,14 +24,14 @@ from typing import Any, Dict, Optional
 from googleapiclient.discovery import build
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 # Time to sleep between active checks of the operation results
 TIME_TO_SLEEP_IN_SECONDS = 5
 
 
 # noinspection PyAbstractClass
-class CloudBuildHook(GoogleCloudBaseHook):
+class CloudBuildHook(CloudBaseHook):
     """
     Hook for the Google Cloud Build APIs.
 
@@ -70,7 +70,7 @@ class CloudBuildHook(GoogleCloudBaseHook):
             self._conn = build("cloudbuild", self.api_version, http=http_authorized, cache_discovery=False)
         return self._conn
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_build(self, body: Dict, project_id: Optional[str] = None) -> Dict:
         """
         Starts a build with the specified configuration.

--- a/airflow/gcp/hooks/cloud_memorystore.py
+++ b/airflow/gcp/hooks/cloud_memorystore.py
@@ -29,10 +29,10 @@ from google.cloud.redis_v1.types import FieldMask, InputConfig, Instance, Output
 from google.protobuf.json_format import ParseDict
 
 from airflow import AirflowException, version
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class CloudMemorystoreHook(GoogleCloudBaseHook):
+class CloudMemorystoreHook(CloudBaseHook):
     """
     Hook for Google Cloud Memorystore APIs.
 
@@ -81,7 +81,7 @@ class CloudMemorystoreHook(GoogleCloudBaseHook):
         instance.labels.update({key: val})
         return instance
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_instance(
         self,
         location: str,
@@ -157,7 +157,7 @@ class CloudMemorystoreHook(GoogleCloudBaseHook):
         self.log.info("Instance created.")
         return client.get_instance(name=instance_name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_instance(
         self,
         location: str,
@@ -199,7 +199,7 @@ class CloudMemorystoreHook(GoogleCloudBaseHook):
         result.result()
         self.log.info("Instance deleted: %s", name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def export_instance(
         self,
         location: str,
@@ -245,7 +245,7 @@ class CloudMemorystoreHook(GoogleCloudBaseHook):
         result.result()
         self.log.info("Instance exported: %s", name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def failover_instance(
         self,
         location: str,
@@ -294,7 +294,7 @@ class CloudMemorystoreHook(GoogleCloudBaseHook):
         result.result()
         self.log.info("Instance failovered: %s", name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_instance(
         self,
         location: str,
@@ -329,7 +329,7 @@ class CloudMemorystoreHook(GoogleCloudBaseHook):
         self.log.info("Fetched Instance: %s", name)
         return result
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def import_instance(
         self,
         location: str,
@@ -376,7 +376,7 @@ class CloudMemorystoreHook(GoogleCloudBaseHook):
         result.result()
         self.log.info("Instance imported: %s", name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def list_instances(
         self,
         location: str,
@@ -419,7 +419,7 @@ class CloudMemorystoreHook(GoogleCloudBaseHook):
         self.log.info("Fetched instances")
         return result
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def update_instance(
         self,
         update_mask: Union[Dict, FieldMask],

--- a/airflow/gcp/hooks/cloud_sql.py
+++ b/airflow/gcp/hooks/cloud_sql.py
@@ -44,7 +44,7 @@ from googleapiclient.errors import HttpError
 from sqlalchemy.orm import Session
 
 from airflow import AirflowException, LoggingMixin
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 # Number of retries - used by googleapiclient method calls to perform retries
 # For requests that are "retriable"
 from airflow.hooks.base_hook import BaseHook
@@ -70,7 +70,7 @@ class CloudSqlOperationStatus:
 
 
 # noinspection PyAbstractClass
-class CloudSqlHook(GoogleCloudBaseHook):
+class CloudSqlHook(CloudBaseHook):
     """
     Hook for Google Cloud SQL APIs.
 
@@ -100,7 +100,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
                                http=http_authorized, cache_discovery=False)
         return self._conn
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_instance(self, instance: str, project_id: Optional[str] = None) -> Dict:
         """
         Retrieves a resource containing information about a Cloud SQL instance.
@@ -119,7 +119,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
             instance=instance
         ).execute(num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_instance(self, body: Dict, project_id: Optional[str] = None) -> None:
         """
         Creates a new Cloud SQL instance.
@@ -141,7 +141,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def patch_instance(self, body: Dict, instance: str, project_id: Optional[str] = None) -> None:
         """
         Updates settings of a Cloud SQL instance.
@@ -169,7 +169,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_instance(self, instance: str, project_id: Optional[str] = None) -> None:
         """
         Deletes a Cloud SQL instance.
@@ -190,7 +190,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_database(self, instance: str, database: str, project_id: Optional[str] = None) -> Dict:
         """
         Retrieves a database resource from a Cloud SQL instance.
@@ -213,7 +213,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
             database=database
         ).execute(num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_database(self, instance: str, body: Dict, project_id: Optional[str] = None) -> None:
         """
         Creates a new database inside a Cloud SQL instance.
@@ -238,7 +238,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def patch_database(
         self,
         instance: str,
@@ -275,7 +275,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_database(self, instance: str, database: str, project_id: Optional[str] = None) -> None:
         """
         Deletes a database from a Cloud SQL instance.
@@ -299,7 +299,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def export_instance(self, instance: str, body: Dict, project_id: Optional[str] = None) -> None:
         """
         Exports data from a Cloud SQL instance to a Cloud Storage bucket as a SQL dump
@@ -331,7 +331,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
                 'Exporting instance {} failed: {}'.format(instance, ex.content)
             )
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def import_instance(self, instance: str, body: Dict, project_id: Optional[str] = None) -> None:
         """
         Imports data into a Cloud SQL instance from a SQL dump or CSV file in

--- a/airflow/gcp/hooks/cloud_storage_transfer_service.py
+++ b/airflow/gcp/hooks/cloud_storage_transfer_service.py
@@ -30,7 +30,7 @@ from typing import Dict, List, Optional, Set, Union
 from googleapiclient.discovery import build
 
 from airflow.exceptions import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 # Time to sleep between active checks of the operation results
 TIME_TO_SLEEP_IN_SECONDS = 10
@@ -100,7 +100,7 @@ NEGATIVE_STATUSES = {GcpTransferOperationStatus.FAILED, GcpTransferOperationStat
 
 
 # noinspection PyAbstractClass
-class GCPTransferServiceHook(GoogleCloudBaseHook):
+class GCPTransferServiceHook(CloudBaseHook):
     """
     Hook for Google Storage Transfer Service.
 
@@ -131,7 +131,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
             )
         return self._conn
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def create_transfer_job(self, body: Dict) -> Dict:
         """
         Creates a transfer job that runs periodically.
@@ -148,8 +148,8 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         return self.get_conn().transferJobs().create(body=body).execute(  # pylint: disable=no-member
             num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
     def get_transfer_job(self, job_name: str, project_id: Optional[str] = None) -> Dict:
         """
         Gets the latest state of a long-running operation in Google Storage
@@ -207,7 +207,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
 
         return jobs
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def update_transfer_job(self, job_name: str, body: Dict) -> Dict:
         """
         Updates a transfer job that runs periodically.
@@ -228,8 +228,8 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
             .execute(num_retries=self.num_retries)
         )
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
     def delete_transfer_job(self, job_name: str, project_id: Optional[str] = None) -> None:
         """
         Deletes a transfer job. This is a soft delete. After a transfer job is
@@ -260,7 +260,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
             .execute(num_retries=self.num_retries)
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def cancel_transfer_operation(self, operation_name: str) -> None:
         """
         Cancels an transfer operation in Google Storage Transfer Service.
@@ -273,7 +273,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         self.get_conn().transferOperations().cancel(  # pylint: disable=no-member
             name=operation_name).execute(num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def get_transfer_operation(self, operation_name: str) -> Dict:
         """
         Gets an transfer operation in Google Storage Transfer Service.
@@ -292,7 +292,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
             .execute(num_retries=self.num_retries)
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def list_transfer_operations(self, request_filter: Optional[Dict] = None, **kwargs) -> List[Dict]:
         """
         Gets an transfer operation in Google Storage Transfer Service.
@@ -341,7 +341,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
 
         return operations
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def pause_transfer_operation(self, operation_name: str) -> None:
         """
         Pauses an transfer operation in Google Storage Transfer Service.
@@ -353,7 +353,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         self.get_conn().transferOperations().pause(  # pylint: disable=no-member
             name=operation_name).execute(num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def resume_transfer_operation(self, operation_name: str) -> None:
         """
         Resumes an transfer operation in Google Storage Transfer Service.
@@ -365,7 +365,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         self.get_conn().transferOperations().resume(  # pylint: disable=no-member
             name=operation_name).execute(num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def wait_for_transfer_job(
         self,
         job: Dict,

--- a/airflow/gcp/hooks/compute.py
+++ b/airflow/gcp/hooks/compute.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, Optional
 from googleapiclient.discovery import build
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 # Time to sleep between active checks of the operation results
 TIME_TO_SLEEP_IN_SECONDS = 1
@@ -42,7 +42,7 @@ class GceOperationStatus:
 
 
 # noinspection PyAbstractClass
-class ComputeEngineHook(GoogleCloudBaseHook):
+class ComputeEngineHook(CloudBaseHook):
     """
     Hook for Google Compute Engine APIs.
 
@@ -73,7 +73,7 @@ class ComputeEngineHook(GoogleCloudBaseHook):
                                http=http_authorized, cache_discovery=False)
         return self._conn
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def start_instance(self, zone: str, resource_id: str, project_id: Optional[str] = None) -> None:
         """
         Starts an existing instance defined by project_id, zone and resource_id.
@@ -105,7 +105,7 @@ class ComputeEngineHook(GoogleCloudBaseHook):
                                              operation_name=operation_name,
                                              zone=zone)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def stop_instance(self, zone: str, resource_id: str, project_id: Optional[str] = None) -> None:
         """
         Stops an instance defined by project_id, zone and resource_id
@@ -137,7 +137,7 @@ class ComputeEngineHook(GoogleCloudBaseHook):
                                              operation_name=operation_name,
                                              zone=zone)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def set_machine_type(
         self,
         zone: str,
@@ -186,7 +186,7 @@ class ComputeEngineHook(GoogleCloudBaseHook):
             project=project_id, zone=zone, instance=resource_id, body=body)\
             .execute(num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_instance_template(self, resource_id: str, project_id: Optional[str] = None) -> Dict:
         """
         Retrieves instance template by project_id and resource_id.
@@ -209,7 +209,7 @@ class ComputeEngineHook(GoogleCloudBaseHook):
         ).execute(num_retries=self.num_retries)
         return response
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def insert_instance_template(
         self,
         body: Dict,
@@ -249,7 +249,7 @@ class ComputeEngineHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_instance_group_manager(
         self,
         zone: str,
@@ -280,7 +280,7 @@ class ComputeEngineHook(GoogleCloudBaseHook):
         ).execute(num_retries=self.num_retries)
         return response
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def patch_instance_group_manager(
         self,
         zone: str,

--- a/airflow/gcp/hooks/dataflow.py
+++ b/airflow/gcp/hooks/dataflow.py
@@ -383,7 +383,7 @@ class DataFlowHook(CloudBaseHook):
         return variables
 
     @_fallback_to_project_id_from_variables
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def start_java_dataflow(
         self,
         job_name: str,
@@ -426,7 +426,7 @@ class DataFlowHook(CloudBaseHook):
         self._start_dataflow(variables, name, command_prefix, label_formatter, project_id, multiple_jobs)
 
     @_fallback_to_project_id_from_variables
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def start_template_dataflow(
         self,
         job_name: str,
@@ -460,7 +460,7 @@ class DataFlowHook(CloudBaseHook):
             name, variables, parameters, dataflow_template, project_id)
 
     @_fallback_to_project_id_from_variables
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def start_python_dataflow(
         self,
         job_name: str,
@@ -577,7 +577,7 @@ class DataFlowHook(CloudBaseHook):
         return response
 
     @_fallback_to_project_id_from_variables
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def is_job_dataflow_running(self, name: str, variables: Dict, project_id: Optional[str] = None) -> bool:
         """
         Helper method to check if jos is still running in dataflow

--- a/airflow/gcp/hooks/dataflow.py
+++ b/airflow/gcp/hooks/dataflow.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 from googleapiclient.discovery import build
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 # This is the default location
@@ -325,7 +325,7 @@ class _DataflowRunner(LoggingMixin):
         return job_id
 
 
-class DataFlowHook(GoogleCloudBaseHook):
+class DataFlowHook(CloudBaseHook):
     """
     Hook for Google Dataflow.
 
@@ -350,7 +350,7 @@ class DataFlowHook(GoogleCloudBaseHook):
         return build(
             'dataflow', 'v1b3', http=http_authorized, cache_discovery=False)
 
-    @GoogleCloudBaseHook.provide_gcp_credential_file
+    @CloudBaseHook.provide_gcp_credential_file
     def _start_dataflow(
         self,
         variables: Dict,

--- a/airflow/gcp/hooks/dataproc.py
+++ b/airflow/gcp/hooks/dataproc.py
@@ -29,7 +29,7 @@ from googleapiclient.discovery import build
 from zope.deprecation import deprecation
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.version import version
 
@@ -427,7 +427,7 @@ class _DataProcOperation(LoggingMixin):
                         (self.operation_name, self.operation['error']['message']))
 
 
-class DataprocHook(GoogleCloudBaseHook):
+class DataprocHook(CloudBaseHook):
     """
     Hook for Google Cloud Dataproc APIs.
 

--- a/airflow/gcp/hooks/datastore.py
+++ b/airflow/gcp/hooks/datastore.py
@@ -27,10 +27,10 @@ from typing import Any, Dict, List, Optional, Union
 
 from googleapiclient.discovery import build
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class DatastoreHook(GoogleCloudBaseHook):
+class DatastoreHook(CloudBaseHook):
     """
     Interact with Google Cloud Datastore. This hook uses the Google Cloud Platform connection.
 
@@ -71,7 +71,7 @@ class DatastoreHook(GoogleCloudBaseHook):
 
         return self.connection
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def allocate_ids(self, partial_keys: List, project_id: Optional[str] = None) -> List:
         """
         Allocate IDs for incomplete keys.
@@ -95,7 +95,7 @@ class DatastoreHook(GoogleCloudBaseHook):
 
         return resp['keys']
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def begin_transaction(self, project_id: Optional[str] = None) -> str:
         """
         Begins a new transaction.
@@ -117,7 +117,7 @@ class DatastoreHook(GoogleCloudBaseHook):
 
         return resp['transaction']
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def commit(self, body: Dict, project_id: Optional[str] = None) -> Dict:
         """
         Commit a transaction, optionally creating, deleting or modifying some entities.
@@ -141,7 +141,7 @@ class DatastoreHook(GoogleCloudBaseHook):
 
         return resp
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def lookup(self,
                keys: List,
                read_consistency: Optional[str] = None,
@@ -179,7 +179,7 @@ class DatastoreHook(GoogleCloudBaseHook):
 
         return resp
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def rollback(self, transaction: str, project_id: Optional[str] = None) -> Any:
         """
         Roll back a transaction.
@@ -198,7 +198,7 @@ class DatastoreHook(GoogleCloudBaseHook):
             projectId=project_id, body={'transaction': transaction}
         ).execute(num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def run_query(self, body: Dict, project_id: Optional[str] = None) -> Dict:
         """
         Run a query for entities.
@@ -288,7 +288,7 @@ class DatastoreHook(GoogleCloudBaseHook):
             else:
                 return result
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def export_to_storage_bucket(self,
                                  bucket: str,
                                  namespace: Optional[str] = None,
@@ -336,7 +336,7 @@ class DatastoreHook(GoogleCloudBaseHook):
 
         return resp
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def import_from_storage_bucket(self,
                                    bucket: str,
                                    file: str,

--- a/airflow/gcp/hooks/discovery_api.py
+++ b/airflow/gcp/hooks/discovery_api.py
@@ -24,10 +24,10 @@ from typing import Dict, Optional
 
 from googleapiclient.discovery import build
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class GoogleDiscoveryApiHook(GoogleCloudBaseHook):
+class GoogleDiscoveryApiHook(CloudBaseHook):
     """
     A hook to use the Google API Discovery Service.
 

--- a/airflow/gcp/hooks/dlp.py
+++ b/airflow/gcp/hooks/dlp.py
@@ -36,7 +36,7 @@ from google.cloud.dlp_v2.types import (
 )
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 DLP_JOB_PATH_PATTERN = "^projects/[^/]+/dlpJobs/(?P<job>.*?)$"
 # Time to sleep between active checks of the operation results
@@ -44,7 +44,7 @@ TIME_TO_SLEEP_IN_SECONDS = 1
 
 
 # pylint: disable=R0904, C0302
-class CloudDLPHook(GoogleCloudBaseHook):
+class CloudDLPHook(CloudBaseHook):
     """
     Hook for Google Cloud Data Loss Prevention (DLP) APIs.
     Cloud DLP allows clients to detect the presence of Personally Identifiable
@@ -76,8 +76,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
             self._client = DlpServiceClient(credentials=self._get_credentials(), client_info=self.client_info)
         return self._client
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def cancel_dlp_job(
         self,
         dlp_job_id: str,
@@ -114,7 +114,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
         name = DlpServiceClient.dlp_job_path(project_id, dlp_job_id)
         client.cancel_dlp_job(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def create_deidentify_template(
         self,
         organization_id: Optional[str] = None,
@@ -172,8 +172,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_dlp_job(
         self,
         project_id: Optional[str] = None,
@@ -255,7 +255,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
                 )
         return job
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def create_inspect_template(
         self,
         organization_id: Optional[str] = None,
@@ -314,8 +314,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_job_trigger(
         self,
         project_id: Optional[str] = None,
@@ -361,7 +361,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def create_stored_info_type(
         self,
         organization_id: Optional[str] = None,
@@ -419,8 +419,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def deidentify_content(
         self,
         project_id: Optional[str] = None,
@@ -484,7 +484,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def delete_deidentify_template(
         self, template_id, organization_id=None, project_id=None, retry=None, timeout=None, metadata=None
     ) -> None:
@@ -528,8 +528,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
 
         client.delete_deidentify_template(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_dlp_job(
         self,
         dlp_job_id: str,
@@ -567,7 +567,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
         name = DlpServiceClient.dlp_job_path(project_id, dlp_job_id)
         client.delete_dlp_job(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def delete_inspect_template(
         self,
         template_id: str,
@@ -617,8 +617,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
 
         client.delete_inspect_template(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_job_trigger(
         self,
         job_trigger_id: str,
@@ -655,7 +655,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
         name = DlpServiceClient.project_job_trigger_path(project_id, job_trigger_id)
         client.delete_job_trigger(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def delete_stored_info_type(
         self,
         stored_info_type_id: str,
@@ -705,7 +705,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
 
         client.delete_stored_info_type(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def get_deidentify_template(
         self,
         template_id: str,
@@ -756,8 +756,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
 
         return client.get_deidentify_template(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def get_dlp_job(
         self,
         dlp_job_id: str,
@@ -795,7 +795,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
         name = DlpServiceClient.dlp_job_path(project_id, dlp_job_id)
         return client.get_dlp_job(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def get_inspect_template(
         self,
         template_id: str,
@@ -846,8 +846,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
 
         return client.get_inspect_template(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def get_job_trigger(
         self,
         job_trigger_id: str,
@@ -885,7 +885,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
         name = DlpServiceClient.project_job_trigger_path(project_id, job_trigger_id)
         return client.get_job_trigger(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def get_stored_info_type(
         self,
         stored_info_type_id: str,
@@ -936,8 +936,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
 
         return client.get_stored_info_type(name=name, retry=retry, timeout=timeout, metadata=metadata)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def inspect_content(
         self,
         project_id: Optional[str] = None,
@@ -989,7 +989,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def list_deidentify_templates(
         self,
         organization_id: Optional[str] = None,
@@ -1051,8 +1051,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
 
         return list(results)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def list_dlp_jobs(
         self,
         project_id: Optional[str] = None,
@@ -1108,7 +1108,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
         )
         return list(results)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def list_info_types(
         self,
         language_code: Optional[str] = None,
@@ -1148,7 +1148,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def list_inspect_templates(
         self,
         organization_id: Optional[str] = None,
@@ -1209,8 +1209,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
         )
         return list(results)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def list_job_triggers(
         self,
         project_id: Optional[str] = None,
@@ -1262,7 +1262,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
         )
         return list(results)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def list_stored_info_types(
         self,
         organization_id: Optional[str] = None,
@@ -1323,8 +1323,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
         )
         return list(results)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def redact_image(
         self,
         project_id: Optional[str] = None,
@@ -1384,8 +1384,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def reidentify_content(
         self,
         project_id: Optional[str] = None,
@@ -1446,7 +1446,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def update_deidentify_template(
         self,
         template_id: str,
@@ -1510,7 +1510,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def update_inspect_template(
         self,
         template_id: str,
@@ -1573,8 +1573,8 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def update_job_trigger(
         self,
         job_trigger_id: str,
@@ -1625,7 +1625,7 @@ class CloudDLPHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def update_stored_info_type(
         self,
         stored_info_type_id: str,

--- a/airflow/gcp/hooks/functions.py
+++ b/airflow/gcp/hooks/functions.py
@@ -26,14 +26,14 @@ import requests
 from googleapiclient.discovery import build
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 # Time to sleep between active checks of the operation results
 TIME_TO_SLEEP_IN_SECONDS = 1
 
 
 # noinspection PyAbstractClass
-class CloudFunctionsHook(GoogleCloudBaseHook):
+class CloudFunctionsHook(CloudBaseHook):
     """
     Hook for the Google Cloud Functions APIs.
 
@@ -90,7 +90,7 @@ class CloudFunctionsHook(GoogleCloudBaseHook):
         return self.get_conn().projects().locations().functions().get(  # pylint: disable=no-member
             name=name).execute(num_retries=self.num_retries)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_new_function(self, location: str, body: Dict, project_id: Optional[str] = None) -> None:
         """
         Creates a new function in Cloud Function in the location specified in the body.
@@ -132,7 +132,7 @@ class CloudFunctionsHook(GoogleCloudBaseHook):
         operation_name = response["name"]
         self._wait_for_operation_to_complete(operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def upload_function_zip(self, location: str, zip_path: str, project_id: Optional[str] = None) -> str:
         """
         Uploads zip file with sources.
@@ -181,7 +181,7 @@ class CloudFunctionsHook(GoogleCloudBaseHook):
         operation_name = response["name"]
         self._wait_for_operation_to_complete(operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def call_function(
             self,
             function_id: str,

--- a/airflow/gcp/hooks/gcs.py
+++ b/airflow/gcp/hooks/gcs.py
@@ -32,11 +32,11 @@ from urllib.parse import urlparse
 from google.cloud import storage
 
 from airflow.exceptions import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 from airflow.version import version
 
 
-class GoogleCloudStorageHook(GoogleCloudBaseHook):
+class GoogleCloudStorageHook(CloudBaseHook):
     """
     Interact with Google Cloud Storage. This hook uses the Google Cloud Platform
     connection.
@@ -429,8 +429,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         self.log.info('The md5Hash of %s is %s', object_name, blob_md5hash)
         return blob_md5hash
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_bucket(self,
                       bucket_name,
                       resource=None,

--- a/airflow/gcp/hooks/gsheets.py
+++ b/airflow/gcp/hooks/gsheets.py
@@ -26,10 +26,10 @@ from typing import Any, Dict, List, Optional
 from googleapiclient.discovery import build
 
 from airflow.exceptions import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class GSheetsHook(GoogleCloudBaseHook):
+class GSheetsHook(CloudBaseHook):
     """
     Interact with Google Sheets via GCP connection
     Reading and writing cells in Google Sheet:
@@ -74,7 +74,7 @@ class GSheetsHook(GoogleCloudBaseHook):
 
         return self._conn
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def get_values(
         self,
         range_: str,
@@ -111,7 +111,7 @@ class GSheetsHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def batch_get_values(
         self,
         ranges: List,
@@ -148,7 +148,7 @@ class GSheetsHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def update_values(
         self,
         range_: str,
@@ -203,7 +203,7 @@ class GSheetsHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def batch_update_values(
         self,
         ranges: List,
@@ -268,7 +268,7 @@ class GSheetsHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def append_values(
         self,
         range_: str,
@@ -328,7 +328,7 @@ class GSheetsHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def clear(self, range_: str) -> Dict:
         """
         Clear values from Google Sheet from a single range
@@ -347,7 +347,7 @@ class GSheetsHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def batch_clear(self, ranges: List) -> Dict:
         """
         Clear values from Google Sheet from a list of ranges

--- a/airflow/gcp/hooks/kms.py
+++ b/airflow/gcp/hooks/kms.py
@@ -28,7 +28,7 @@ from typing import Optional, Sequence, Tuple
 from google.api_core.retry import Retry
 from google.cloud.kms_v1 import KeyManagementServiceClient
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
 def _b64encode(s: bytes) -> str:
@@ -42,7 +42,7 @@ def _b64decode(s: str) -> bytes:
 
 
 # noinspection PyAbstractClass
-class GoogleCloudKMSHook(GoogleCloudBaseHook):
+class GoogleCloudKMSHook(CloudBaseHook):
     """
     Hook for Google Cloud Key Management service.
 

--- a/airflow/gcp/hooks/kubernetes_engine.py
+++ b/airflow/gcp/hooks/kubernetes_engine.py
@@ -34,12 +34,12 @@ from google.cloud.container_v1.types import Cluster
 from google.protobuf.json_format import ParseDict
 
 from airflow import AirflowException, version
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 OPERATIONAL_POLL_INTERVAL = 15
 
 
-class GKEClusterHook(GoogleCloudBaseHook):
+class GKEClusterHook(CloudBaseHook):
     """
     Hook for Google Kubernetes Engine APIs.
 
@@ -138,7 +138,7 @@ class GKEClusterHook(GoogleCloudBaseHook):
         cluster_proto.resource_labels.update({key: val})
         return cluster_proto
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_cluster(
         self,
         name: str,
@@ -185,7 +185,7 @@ class GKEClusterHook(GoogleCloudBaseHook):
             self.log.info('Assuming Success: %s', error.message)
             return None
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_cluster(
         self,
         cluster: Union[Dict, Cluster],
@@ -243,7 +243,7 @@ class GKEClusterHook(GoogleCloudBaseHook):
             self.log.info('Assuming Success: %s', error.message)
             return self.get_cluster(name=cluster.name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_cluster(
         self,
         name: str,

--- a/airflow/gcp/hooks/mlengine.py
+++ b/airflow/gcp/hooks/mlengine.py
@@ -26,7 +26,7 @@ from typing import Callable, Dict, List, Optional
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.version import version as airflow_version
 
@@ -58,7 +58,7 @@ def _poll_with_exponential_delay(request, max_n, is_done_func, is_error_func):
     raise ValueError('Connection could not be established after {} retries.'.format(max_n))
 
 
-class MLEngineHook(GoogleCloudBaseHook):
+class MLEngineHook(CloudBaseHook):
     """
     Hook for Google ML Engine APIs.
 
@@ -74,7 +74,7 @@ class MLEngineHook(GoogleCloudBaseHook):
         authed_http = self._authorize()
         return build('ml', 'v1', http=authed_http, cache_discovery=False)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_job(
         self,
         job: Dict,
@@ -198,7 +198,7 @@ class MLEngineHook(GoogleCloudBaseHook):
                 return job
             time.sleep(interval)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_version(
         self,
         model_name: str,
@@ -238,7 +238,7 @@ class MLEngineHook(GoogleCloudBaseHook):
             is_done_func=lambda resp: resp.get('done', False),
             is_error_func=lambda resp: resp.get('error', None) is not None)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def set_default_version(
         self,
         model_name: str,
@@ -275,7 +275,7 @@ class MLEngineHook(GoogleCloudBaseHook):
             self.log.error('Something went wrong: %s', e)
             raise
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def list_versions(
         self,
         model_name: str,
@@ -311,7 +311,7 @@ class MLEngineHook(GoogleCloudBaseHook):
             time.sleep(5)
         return result
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_version(
         self,
         model_name: str,
@@ -348,7 +348,7 @@ class MLEngineHook(GoogleCloudBaseHook):
             is_done_func=lambda resp: resp.get('done', False),
             is_error_func=lambda resp: resp.get('error', None) is not None)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_model(
         self,
         model: Dict,
@@ -379,7 +379,7 @@ class MLEngineHook(GoogleCloudBaseHook):
             parent=project, body=model)
         return request.execute()
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_model(
         self,
         model_name: str,
@@ -413,7 +413,7 @@ class MLEngineHook(GoogleCloudBaseHook):
                 return None
             raise
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_model(
         self,
         model_name: str,

--- a/airflow/gcp/hooks/spanner.py
+++ b/airflow/gcp/hooks/spanner.py
@@ -29,10 +29,10 @@ from google.cloud.spanner_v1.transaction import Transaction
 from google.longrunning.operations_grpc_pb2 import Operation  # noqa: F401
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class SpannerHook(GoogleCloudBaseHook):
+class SpannerHook(CloudBaseHook):
     """
     Hook for Google Cloud Spanner APIs.
 
@@ -61,7 +61,7 @@ class SpannerHook(GoogleCloudBaseHook):
             )
         return self._client
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_instance(
         self,
         instance_id: str,
@@ -126,7 +126,7 @@ class SpannerHook(GoogleCloudBaseHook):
             result = operation.result()
             self.log.info(result)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_instance(
         self,
         instance_id: str,
@@ -160,7 +160,7 @@ class SpannerHook(GoogleCloudBaseHook):
         self._apply_to_instance(project_id, instance_id, configuration_name,
                                 node_count, display_name, lambda x: x.create())
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def update_instance(
         self,
         instance_id: str,
@@ -194,7 +194,7 @@ class SpannerHook(GoogleCloudBaseHook):
         self._apply_to_instance(project_id, instance_id, configuration_name,
                                 node_count, display_name, lambda x: x.update())
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_instance(self, instance_id: str, project_id: Optional[str] = None) -> None:
         """
         Deletes an existing Cloud Spanner instance.
@@ -215,7 +215,7 @@ class SpannerHook(GoogleCloudBaseHook):
             self.log.error('An error occurred: %s. Exiting.', e.message)
             raise e
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def get_database(
         self,
         instance_id: str,
@@ -249,7 +249,7 @@ class SpannerHook(GoogleCloudBaseHook):
 
         return database
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_database(
         self,
         instance_id: str,
@@ -290,7 +290,7 @@ class SpannerHook(GoogleCloudBaseHook):
             result = operation.result()
             self.log.info(result)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def update_database(
         self,
         instance_id: str,
@@ -340,7 +340,7 @@ class SpannerHook(GoogleCloudBaseHook):
             self.log.error('An error occurred: %s. Exiting.', e.message)
             raise e
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_database(self, instance_id: str, database_id, project_id: Optional[str] = None) -> bool:
         """
         Drops a database in Cloud Spanner.
@@ -377,7 +377,7 @@ class SpannerHook(GoogleCloudBaseHook):
 
         return True
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def execute_dml(
         self,
         instance_id: str,

--- a/airflow/gcp/hooks/speech_to_text.py
+++ b/airflow/gcp/hooks/speech_to_text.py
@@ -25,10 +25,10 @@ from google.api_core.retry import Retry
 from google.cloud.speech_v1 import SpeechClient
 from google.cloud.speech_v1.types import RecognitionAudio, RecognitionConfig
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class CloudSpeechToTextHook(GoogleCloudBaseHook):
+class CloudSpeechToTextHook(CloudBaseHook):
     """
     Hook for Google Cloud Speech API.
 
@@ -55,7 +55,7 @@ class CloudSpeechToTextHook(GoogleCloudBaseHook):
             self._client = SpeechClient(credentials=self._get_credentials(), client_info=self.client_info)
         return self._client
 
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.quota_retry()
     def recognize_speech(
         self,
         config: Union[Dict, RecognitionConfig],

--- a/airflow/gcp/hooks/tasks.py
+++ b/airflow/gcp/hooks/tasks.py
@@ -29,10 +29,10 @@ from google.cloud.tasks_v2 import CloudTasksClient, enums
 from google.cloud.tasks_v2.types import FieldMask, Queue, Task
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class CloudTasksHook(GoogleCloudBaseHook):
+class CloudTasksHook(CloudBaseHook):
     """
     Hook for Google Cloud Tasks APIs. Cloud Tasks allows developers to manage
     the execution of background work in their applications.
@@ -66,8 +66,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             )
         return self._client
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_queue(
         self,
         location: str,
@@ -124,8 +124,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def update_queue(
         self,
         task_queue: Queue,
@@ -187,8 +187,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def get_queue(
         self,
         location: str,
@@ -227,8 +227,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def list_queues(
         self,
         location: str,
@@ -277,8 +277,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
         )
         return list(queues)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_queue(
         self,
         location: str,
@@ -316,8 +316,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def purge_queue(
         self,
         location: str,
@@ -356,8 +356,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def pause_queue(
         self,
         location: str,
@@ -396,8 +396,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def resume_queue(
         self,
         location: str,
@@ -436,8 +436,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_task(
         self,
         location: str,
@@ -503,8 +503,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def get_task(
         self,
         location: str,
@@ -554,8 +554,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def list_tasks(
         self,
         location: str,
@@ -607,8 +607,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
         )
         return list(tasks)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_task(
         self,
         location: str,
@@ -649,8 +649,8 @@ class CloudTasksHook(GoogleCloudBaseHook):
             name=full_task_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def run_task(
         self,
         location: str,

--- a/airflow/gcp/hooks/text_to_speech.py
+++ b/airflow/gcp/hooks/text_to_speech.py
@@ -27,10 +27,10 @@ from google.cloud.texttospeech_v1.types import (
     AudioConfig, SynthesisInput, SynthesizeSpeechResponse, VoiceSelectionParams,
 )
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class CloudTextToSpeechHook(GoogleCloudBaseHook):
+class CloudTextToSpeechHook(CloudBaseHook):
     """
     Hook for Google Cloud Text to Speech API.
 
@@ -64,7 +64,7 @@ class CloudTextToSpeechHook(GoogleCloudBaseHook):
 
         return self._client
 
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.quota_retry()
     def synthesize_speech(
         self,
         input_data: Union[Dict, SynthesisInput],

--- a/airflow/gcp/hooks/translate.py
+++ b/airflow/gcp/hooks/translate.py
@@ -23,10 +23,10 @@ from typing import Dict, List, Optional, Union
 
 from google.cloud.translate_v2 import Client
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class CloudTranslateHook(GoogleCloudBaseHook):
+class CloudTranslateHook(CloudBaseHook):
     """
     Hook for Google Cloud translate APIs.
 
@@ -49,7 +49,7 @@ class CloudTranslateHook(GoogleCloudBaseHook):
             self._client = Client(credentials=self._get_credentials(), client_info=self.client_info)
         return self._client
 
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.quota_retry()
     def translate(
         self,
         values: Union[str, List[str]],

--- a/airflow/gcp/hooks/video_intelligence.py
+++ b/airflow/gcp/hooks/video_intelligence.py
@@ -26,10 +26,10 @@ from google.api_core.retry import Retry
 from google.cloud.videointelligence_v1 import VideoIntelligenceServiceClient
 from google.cloud.videointelligence_v1.types import VideoContext
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class CloudVideoIntelligenceHook(GoogleCloudBaseHook):
+class CloudVideoIntelligenceHook(CloudBaseHook):
     """
     Hook for Google Cloud Video Intelligence APIs.
 
@@ -61,7 +61,7 @@ class CloudVideoIntelligenceHook(GoogleCloudBaseHook):
             )
         return self._conn
 
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.quota_retry()
     def annotate_video(
         self,
         input_uri: Optional[str] = None,

--- a/airflow/gcp/operators/kubernetes_engine.py
+++ b/airflow/gcp/operators/kubernetes_engine.py
@@ -30,7 +30,7 @@ from google.cloud.container_v1.types import Cluster
 
 from airflow import AirflowException
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 from airflow.gcp.hooks.kubernetes_engine import GKEClusterHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
@@ -245,7 +245,7 @@ class GKEPodOperator(KubernetesPodOperator):
             )
 
     def execute(self, context):
-        hook = GoogleCloudBaseHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudBaseHook(gcp_conn_id=self.gcp_conn_id)
         self.project_id = self.project_id or hook.project_id
 
         if not self.project_id:

--- a/airflow/providers/google/cloud/hooks/natural_language.py
+++ b/airflow/providers/google/cloud/hooks/natural_language.py
@@ -28,11 +28,11 @@ from google.cloud.language_v1.types import (
     AnnotateTextRequest, AnnotateTextResponse, ClassifyTextResponse, Document,
 )
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
 # noinspection PyAbstractClass
-class CloudNaturalLanguageHook(GoogleCloudBaseHook):
+class CloudNaturalLanguageHook(CloudBaseHook):
     """
     Hook for Google Cloud Natural Language Service.
 
@@ -62,8 +62,8 @@ class CloudNaturalLanguageHook(GoogleCloudBaseHook):
             )
         return self._conn
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def analyze_entities(
         self,
         document: Union[Dict, Document],
@@ -97,8 +97,8 @@ class CloudNaturalLanguageHook(GoogleCloudBaseHook):
             document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def analyze_entity_sentiment(
         self,
         document: Union[Dict, Document],
@@ -132,8 +132,8 @@ class CloudNaturalLanguageHook(GoogleCloudBaseHook):
             document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def analyze_sentiment(
         self,
         document: Union[Dict, Document],
@@ -166,8 +166,8 @@ class CloudNaturalLanguageHook(GoogleCloudBaseHook):
             document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def analyze_syntax(
         self,
         document: Union[Dict, Document],
@@ -201,8 +201,8 @@ class CloudNaturalLanguageHook(GoogleCloudBaseHook):
             document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def annotate_text(
         self,
         document: Union[Dict, Document],
@@ -245,8 +245,8 @@ class CloudNaturalLanguageHook(GoogleCloudBaseHook):
             metadata=metadata,
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def classify_text(
         self,
         document: Union[Dict, Document],

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -32,7 +32,7 @@ from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from google.cloud.pubsub_v1.types import Duration, MessageStoragePolicy, PushConfig
 from googleapiclient.errors import HttpError
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 from airflow.version import version
 
 
@@ -43,7 +43,7 @@ class PubSubException(Exception):
 
 
 # noinspection PyAbstractClass
-class PubSubHook(GoogleCloudBaseHook):
+class PubSubHook(CloudBaseHook):
     """
     Hook for accessing Google Pub/Sub.
 
@@ -82,7 +82,7 @@ class PubSubHook(GoogleCloudBaseHook):
             client_info=self.client_info
         )
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def publish(
         self,
         topic: str,
@@ -149,7 +149,7 @@ class PubSubHook(GoogleCloudBaseHook):
                     "Wrong message. If 'data' is not provided 'attributes' must be a non empty dictionary.")
 
     # pylint: disable=too-many-arguments
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_topic(
         self,
         topic: str,
@@ -227,7 +227,7 @@ class PubSubHook(GoogleCloudBaseHook):
 
         self.log.info("Created topic (path) %s", topic_path)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_topic(
         self,
         topic: str,
@@ -281,7 +281,7 @@ class PubSubHook(GoogleCloudBaseHook):
         self.log.info("Deleted topic (path) %s", topic_path)
 
     # pylint: disable=too-many-arguments
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def create_subscription(
         self,
         topic: str,
@@ -392,7 +392,7 @@ class PubSubHook(GoogleCloudBaseHook):
         self.log.info("Created subscription (path) %s for topic (path) %s", subscription_path, topic_path)
         return subscription
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_subscription(
         self,
         subscription: str,
@@ -446,7 +446,7 @@ class PubSubHook(GoogleCloudBaseHook):
 
         self.log.info("Deleted subscription (path) %s", subscription_path)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def pull(
         self,
         subscription: str,
@@ -508,7 +508,7 @@ class PubSubHook(GoogleCloudBaseHook):
         except (HttpError, GoogleAPICallError) as e:
             raise PubSubException('Error pulling messages from subscription {}'.format(subscription_path), e)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.fallback_to_default_project_id
     def acknowledge(
         self,
         subscription: str,

--- a/airflow/providers/google/cloud/hooks/vision.py
+++ b/airflow/providers/google/cloud/hooks/vision.py
@@ -32,7 +32,7 @@ from google.cloud.vision_v1.types import (
 from google.protobuf.json_format import MessageToDict
 
 from airflow import AirflowException
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 ERR_DIFF_NAMES = \
     """The {label} name provided in the object ({explicit_name}) is different than the name created
@@ -117,7 +117,7 @@ class NameDeterminer:
             )
 
 
-class CloudVisionHook(GoogleCloudBaseHook):
+class CloudVisionHook(CloudBaseHook):
     """
     Hook for Google Cloud Vision APIs.
 
@@ -163,8 +163,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         if "error" in response:
             raise AirflowException(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_product_set(
         self,
         location: str,
@@ -201,8 +201,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return product_set_id
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def get_product_set(
         self,
         location: str,
@@ -224,8 +224,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('ProductSet retrieved:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def update_product_set(
         self,
         product_set: Union[dict, ProductSet],
@@ -254,8 +254,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('ProductSet updated:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_product_set(
         self,
         location: str,
@@ -276,8 +276,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         client.delete_product_set(name=name, retry=retry, timeout=timeout, metadata=metadata)
         self.log.info('ProductSet with the name [%s] deleted.', name)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_product(
         self,
         location: str,
@@ -314,8 +314,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return product_id
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def get_product(
         self,
         location: str,
@@ -338,8 +338,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('Product retrieved:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def update_product(
         self,
         product: Union[dict, Product],
@@ -366,8 +366,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('Product updated:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_product(
         self,
         location: str,
@@ -388,8 +388,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         client.delete_product(name=name, retry=retry, timeout=timeout, metadata=metadata)
         self.log.info('Product with the name [%s] deleted:', name)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def create_reference_image(
         self,
         location: str,
@@ -431,8 +431,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return reference_image_id
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def delete_reference_image(
         self,
         location: str,
@@ -461,8 +461,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.info('ReferenceImage with the name [%s] deleted.', name)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def add_product_to_product_set(
         self,
         product_set_id: str,
@@ -491,8 +491,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         self.log.info('Product added to Product Set')
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.fallback_to_default_project_id
     def remove_product_from_product_set(
         self,
         product_set_id: str,
@@ -521,7 +521,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         self.log.info('Product removed from Product Set')
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @CloudBaseHook.catch_http_exception
     def annotate_image(
         self,
         request: Union[dict, AnnotateImageRequest],
@@ -543,8 +543,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def batch_annotate_images(
         self,
         requests: Union[List[dict], List[AnnotateImageRequest]],
@@ -567,8 +567,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def text_detection(
         self,
         image: Union[Dict, Image],
@@ -598,8 +598,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def document_text_detection(
         self,
         image: Union[Dict, Image],
@@ -629,8 +629,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def label_detection(
         self,
         image: Union[Dict, Image],
@@ -660,8 +660,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return response
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.quota_retry()
+    @CloudBaseHook.catch_http_exception
+    @CloudBaseHook.quota_retry()
     def safe_search_detection(
         self,
         image: Union[Dict, Image],

--- a/airflow/providers/google/marketing_platform/hooks/campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/hooks/campaign_manager.py
@@ -24,10 +24,10 @@ from typing import Any, Dict, List, Optional
 from googleapiclient import http
 from googleapiclient.discovery import Resource, build
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class GoogleCampaignManagerHook(GoogleCloudBaseHook):
+class GoogleCampaignManagerHook(CloudBaseHook):
     """
     Hook for Google Campaign Manager.
     """

--- a/airflow/providers/google/marketing_platform/hooks/display_video.py
+++ b/airflow/providers/google/marketing_platform/hooks/display_video.py
@@ -23,10 +23,10 @@ from typing import Any, Dict, List, Optional
 
 from googleapiclient.discovery import Resource, build
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class GoogleDisplayVideo360Hook(GoogleCloudBaseHook):
+class GoogleDisplayVideo360Hook(CloudBaseHook):
     """
     Hook for Google Display & Video 360.
     """

--- a/airflow/providers/google/marketing_platform/hooks/search_ads.py
+++ b/airflow/providers/google/marketing_platform/hooks/search_ads.py
@@ -23,10 +23,10 @@ from typing import Any, Dict, Optional
 
 from googleapiclient.discovery import build
 
-from airflow.gcp.hooks.base import GoogleCloudBaseHook
+from airflow.gcp.hooks.base import CloudBaseHook
 
 
-class GoogleSearchAdsHook(GoogleCloudBaseHook):
+class GoogleSearchAdsHook(CloudBaseHook):
     """
     Hook for Google Search Ads 360.
     """

--- a/tests/contrib/hooks/test_gdrive_hook.py
+++ b/tests/contrib/hooks/test_gdrive_hook.py
@@ -37,7 +37,7 @@ class TestGoogleDriveHook(unittest.TestCase):
         self.patcher_get_connections.stop()
 
     @mock.patch(
-        "airflow.gcp.hooks.base.GoogleCloudBaseHook._authorize", return_value="AUTHORIZE"
+        "airflow.gcp.hooks.base.CloudBaseHook._authorize", return_value="AUTHORIZE"
     )
     @mock.patch("airflow.contrib.hooks.gdrive_hook.build")
     def test_get_conn(self, mock_discovery_build, mock_authorize):

--- a/tests/gcp/hooks/test_automl.py
+++ b/tests/gcp/hooks/test_automl.py
@@ -53,7 +53,7 @@ MASK = {"field": "mask"}
 class TestAuoMLHook(unittest.TestCase):
     def setUp(self) -> None:
         with mock.patch(
-            "airflow.gcp.hooks.automl.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.automl.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.hook = CloudAutoMLHook()
@@ -62,7 +62,7 @@ class TestAuoMLHook(unittest.TestCase):
             )
 
     @mock.patch(
-        "airflow.gcp.hooks.automl.GoogleCloudBaseHook.client_info",
+        "airflow.gcp.hooks.automl.CloudBaseHook.client_info",
         new_callable=lambda: CLIENT_INFO,
     )
     @mock.patch("airflow.gcp.hooks.automl.AutoMlClient")
@@ -73,7 +73,7 @@ class TestAuoMLHook(unittest.TestCase):
         )
 
     @mock.patch(
-        "airflow.gcp.hooks.automl.GoogleCloudBaseHook.client_info",
+        "airflow.gcp.hooks.automl.CloudBaseHook.client_info",
         new_callable=lambda: CLIENT_INFO,
     )
     @mock.patch("airflow.gcp.hooks.automl.PredictionServiceClient")

--- a/tests/gcp/hooks/test_base.py
+++ b/tests/gcp/hooks/test_base.py
@@ -66,7 +66,7 @@ class NoForbiddenAfterCount:
         return True
 
 
-@hook.GoogleCloudBaseHook.quota_retry(wait=tenacity.wait_none())
+@hook.CloudBaseHook.quota_retry(wait=tenacity.wait_none())
 def _retryable_test_with_temporary_quota_retry(thing):
     return thing()
 
@@ -129,7 +129,7 @@ class TestCatchHttpException(unittest.TestCase):
         self.called = False  # pylint:disable=attribute-defined-outside-init
 
         class FixtureClass(base_class):
-            @hook.GoogleCloudBaseHook.catch_http_exception
+            @hook.CloudBaseHook.catch_http_exception
             def test_fixture(*args, **kwargs):  # pylint:disable=unused-argument,no-method-argument
                 self.called = True  # pylint:disable=attribute-defined-outside-init
                 if exception is not None:
@@ -148,7 +148,7 @@ class FallbackToDefaultProjectIdFixtureClass:
         self.mock = mock.Mock()
         self.fixture_project_id = project_id
 
-    @hook.GoogleCloudBaseHook.fallback_to_default_project_id
+    @hook.CloudBaseHook.fallback_to_default_project_id
     def method(self, project_id=None):
         self.mock(project_id=project_id)
 
@@ -198,16 +198,16 @@ ENV_VALUE = "/tmp/a"
 class TestProvideGcpCredentialFile(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            MODULE_NAME + '.GoogleCloudBaseHook.__init__',
+            MODULE_NAME + '.CloudBaseHook.__init__',
             new=mock_base_gcp_hook_default_project_id,
         ):
-            self.instance = hook.GoogleCloudBaseHook(gcp_conn_id="google-cloud-default")
+            self.instance = hook.CloudBaseHook(gcp_conn_id="google-cloud-default")
 
     def test_provide_gcp_credential_file_decorator_key_path(self):
         key_path = '/test/key-path'
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
-        @hook.GoogleCloudBaseHook.provide_gcp_credential_file
+        @hook.CloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(_):
             self.assertEqual(os.environ[CREDENTIALS], key_path)
 
@@ -223,7 +223,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         mock_file_handler.name = file_name
         mock_file_handler.write = string_file.write
 
-        @hook.GoogleCloudBaseHook.provide_gcp_credential_file
+        @hook.CloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(_):
             self.assertEqual(os.environ[CREDENTIALS], file_name)
             self.assertEqual(file_content, string_file.getvalue())
@@ -235,7 +235,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         key_path = '/test/key-path'
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
-        @hook.GoogleCloudBaseHook.provide_gcp_credential_file
+        @hook.CloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(_):
             self.assertEqual(os.environ[CREDENTIALS], key_path)
 
@@ -247,7 +247,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         key_path = '/test/key-path'
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
-        @hook.GoogleCloudBaseHook.provide_gcp_credential_file
+        @hook.CloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(_):
             raise Exception()
 
@@ -261,7 +261,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         key_path = '/test/key-path'
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
-        @hook.GoogleCloudBaseHook.provide_gcp_credential_file
+        @hook.CloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(_):
             self.assertEqual(os.environ[CREDENTIALS], key_path)
 
@@ -273,7 +273,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         key_path = '/test/key-path'
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
-        @hook.GoogleCloudBaseHook.provide_gcp_credential_file
+        @hook.CloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(_):
             raise Exception()
 
@@ -286,10 +286,10 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
 class TestProvideGcpCredentialFileAsContext(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+            'airflow.contrib.hooks.gcp_api_base_hook.CloudBaseHook.__init__',
             new=mock_base_gcp_hook_default_project_id,
         ):
-            self.instance = hook.GoogleCloudBaseHook(gcp_conn_id="google-cloud-default")
+            self.instance = hook.CloudBaseHook(gcp_conn_id="google-cloud-default")
 
     def test_provide_gcp_credential_file_decorator_key_path(self):
         key_path = '/test/key-path'
@@ -357,7 +357,7 @@ class TestProvideGcpCredentialFileAsContext(unittest.TestCase):
 
 class TestGoogleCloudBaseHook(unittest.TestCase):
     def setUp(self):
-        self.instance = hook.GoogleCloudBaseHook()
+        self.instance = hook.CloudBaseHook()
 
     @mock.patch(MODULE_NAME + '.google.auth.default', return_value=("CREDENTIALS", "PROJECT_ID"))
     def test_get_credentials_and_project_id_with_default_auth(self, mock_auth_default):
@@ -489,7 +489,7 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
         key_path = '/test/key-path'
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
-        @hook.GoogleCloudBaseHook.provide_gcp_credential_file
+        @hook.CloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(hook_instance):  # pylint:disable=unused-argument
             self.assertEqual(os.environ[CREDENTIALS],
                              key_path)
@@ -508,7 +508,7 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
         mock_file_handler.name = file_name
         mock_file_handler.write = string_file.write
 
-        @hook.GoogleCloudBaseHook.provide_gcp_credential_file
+        @hook.CloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(hook_instance):  # pylint:disable=unused-argument
             self.assertEqual(os.environ[CREDENTIALS],
                              file_name)
@@ -542,7 +542,7 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
 
         self.assertEqual(self.instance.scopes, ('https://www.googleapis.com/auth/cloud-platform',))
 
-    @mock.patch("airflow.gcp.hooks.base.GoogleCloudBaseHook.get_connection")
+    @mock.patch("airflow.gcp.hooks.base.CloudBaseHook.get_connection")
     def test_num_retries_is_not_none_by_default(self, get_con_mock):
         """
         Verify that if 'num_retires' in extras is not set, the default value

--- a/tests/gcp/hooks/test_bigquery.py
+++ b/tests/gcp/hooks/test_bigquery.py
@@ -65,7 +65,7 @@ class TestBigQueryHookConnection(unittest.TestCase):
 
 class TestPandasGbqCredentials(unittest.TestCase):
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook._get_credentials_and_project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook._get_credentials_and_project_id',
         return_value=("CREDENTIALS", "PROJECT_ID",)
     )
     @mock.patch('airflow.gcp.hooks.bigquery.read_gbq')
@@ -84,7 +84,7 @@ class TestBigQueryDataframeResults(unittest.TestCase):
         self.instance = hook.BigQueryHook()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=mock.PropertyMock,
         return_value=None
     )
@@ -95,7 +95,7 @@ class TestBigQueryDataframeResults(unittest.TestCase):
         self.assertIsInstance(df, pd.DataFrame)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=mock.PropertyMock,
         return_value=None
     )
@@ -106,7 +106,7 @@ class TestBigQueryDataframeResults(unittest.TestCase):
         self.assertIn('Reason: ', str(context.exception), "")
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=mock.PropertyMock,
         return_value=None
     )
@@ -116,7 +116,7 @@ class TestBigQueryDataframeResults(unittest.TestCase):
         self.assertEqual(df.iloc(0)[0][0], 1)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=mock.PropertyMock,
         return_value=None
     )
@@ -127,7 +127,7 @@ class TestBigQueryDataframeResults(unittest.TestCase):
         self.assertEqual(df.iloc(0)[0][0], 1)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=mock.PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_bigquery_dts.py
+++ b/tests/gcp/hooks/test_bigquery_dts.py
@@ -57,7 +57,7 @@ TRANSFER_CONFIG_ID = "id1234"
 class BigQueryDataTransferHookTestCase(unittest.TestCase):
     def setUp(self) -> None:
         with mock.patch(
-            "airflow.gcp.hooks.bigquery_dts.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.bigquery_dts.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.hook = BiqQueryDataTransferServiceHook(  # type: ignore

--- a/tests/gcp/hooks/test_bigtable.py
+++ b/tests/gcp/hooks/test_bigtable.py
@@ -40,7 +40,7 @@ CBT_TABLE = 'table'
 class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_no_default_project_id):
             self.bigtable_hook_no_default_project_id = BigtableHook(gcp_conn_id='test')
 
@@ -59,7 +59,7 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         self.assertEqual(self.bigtable_hook_no_default_project_id._client, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -89,7 +89,7 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         self.assertIsNotNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -122,7 +122,7 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -158,7 +158,7 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         self.assertEqual(res.instance_id, 'instance')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -196,7 +196,7 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
 class TestBigtableHookDefaultProjectId(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
             self.bigtable_hook_default_project_id = BigtableHook(gcp_conn_id='test')
 
@@ -215,7 +215,7 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         self.assertEqual(self.bigtable_hook_default_project_id._client, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -245,7 +245,7 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         self.assertIsNotNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -262,7 +262,7 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -295,7 +295,7 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -313,7 +313,7 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         get_client.assert_called_once_with(project_id='example-project')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -347,7 +347,7 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         self.assertEqual(res.instance_id, 'instance')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )

--- a/tests/gcp/hooks/test_cloud_build.py
+++ b/tests/gcp/hooks/test_cloud_build.py
@@ -51,7 +51,7 @@ class TestCloudBuildHookWithPassedProjectId(unittest.TestCase):
 
     def setUp(self):
         with mock.patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
@@ -115,7 +115,7 @@ class TestCloudBuildHookWithPassedProjectId(unittest.TestCase):
         self.assertEqual(result, TEST_BUILD)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -139,7 +139,7 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
 
     def setUp(self):
         with mock.patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
@@ -155,7 +155,7 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
         self.assertEqual(self.hook._conn, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -182,7 +182,7 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
         self.assertEqual(result, TEST_BUILD)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -209,7 +209,7 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
         self.assertEqual(result, TEST_BUILD)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -233,7 +233,7 @@ class TestCloudBuildHookWithoutProjectId(unittest.TestCase):
 
     def setUp(self):
         with mock.patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
@@ -249,7 +249,7 @@ class TestCloudBuildHookWithoutProjectId(unittest.TestCase):
         self.assertEqual(self.hook._conn, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_cloud_memorystore.py
+++ b/tests/gcp/hooks/test_cloud_memorystore.py
@@ -60,7 +60,7 @@ class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
             self.hook = CloudMemorystoreHook(gcp_conn_id="test")
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -83,7 +83,7 @@ class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
         self.assertEqual(Instance(name=TEST_NAME), result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -124,7 +124,7 @@ class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
         self.assertEqual(Instance(name=TEST_NAME), result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -144,7 +144,7 @@ class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -164,7 +164,7 @@ class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -188,7 +188,7 @@ class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -292,7 +292,7 @@ class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
         self.assertEqual(Instance(name=TEST_NAME), result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -328,7 +328,7 @@ class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -363,7 +363,7 @@ class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -402,7 +402,7 @@ class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -441,7 +441,7 @@ class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_cloud_sql.py
+++ b/tests/gcp/hooks/test_cloud_sql.py
@@ -38,7 +38,7 @@ from tests.gcp.utils.base_gcp_mock import (
 class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
             self.cloudsql_hook = CloudSqlHook(api_version='v1', gcp_conn_id='test')
 
@@ -421,12 +421,12 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
 
 class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_no_default_project_id):
             self.cloudsql_hook_no_default_project_id = CloudSqlHook(api_version='v1', gcp_conn_id='test')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -450,7 +450,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
                                                                operation_name='operation_id')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -474,7 +474,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -498,7 +498,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
                                                                operation_name='operation_id')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -522,7 +522,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -545,7 +545,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -568,7 +568,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -592,7 +592,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -615,7 +615,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -640,7 +640,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -664,7 +664,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -688,7 +688,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -711,7 +711,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -737,7 +737,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -761,7 +761,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -786,7 +786,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -810,7 +810,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -839,7 +839,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -864,7 +864,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -891,7 +891,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -67,7 +67,7 @@ def _without_key(body, key):
 class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            'airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+            'airflow.gcp.hooks.base.CloudBaseHook.__init__',
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
@@ -83,7 +83,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         self.assertEqual(self.gct_hook._conn, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -109,7 +109,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -134,7 +134,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         list_execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -189,7 +189,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -232,7 +232,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -257,7 +257,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         mock_sleep.assert_called_once_with(TIME_TO_SLEEP_IN_SECONDS)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -281,7 +281,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
             self.assertTrue(list_method.called)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -375,7 +375,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
 class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            'airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+            'airflow.gcp.hooks.base.CloudBaseHook.__init__',
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
@@ -391,7 +391,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         self.assertEqual(self.gct_hook._conn, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -406,7 +406,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -422,7 +422,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -450,7 +450,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         list_execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -506,7 +506,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -549,7 +549,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
 class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            'airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+            'airflow.gcp.hooks.base.CloudBaseHook.__init__',
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
@@ -565,7 +565,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         self.assertEqual(self.gct_hook._conn, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -584,7 +584,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -603,7 +603,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -627,7 +627,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -646,7 +646,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         self.assertEqual(res, [TEST_TRANSFER_OPERATION] * 4)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -667,7 +667,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -684,7 +684,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_dataflow.py
+++ b/tests/gcp/hooks/test_dataflow.py
@@ -145,7 +145,7 @@ def mock_init(self, gcp_conn_id, delegate_to=None):  # pylint: disable=unused-ar
 class TestDataFlowHook(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch(BASE_STRING.format('GoogleCloudBaseHook.__init__'),
+        with mock.patch(BASE_STRING.format('CloudBaseHook.__init__'),
                         new=mock_init):
             self.dataflow_hook = DataFlowHook(gcp_conn_id='test')
 
@@ -297,7 +297,7 @@ class TestDataFlowHook(unittest.TestCase):
 class TestDataFlowTemplateHook(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch(BASE_STRING.format('GoogleCloudBaseHook.__init__'),
+        with mock.patch(BASE_STRING.format('CloudBaseHook.__init__'),
                         new=mock_init):
             self.dataflow_hook = DataFlowHook(gcp_conn_id='test')
 

--- a/tests/gcp/hooks/test_dataproc.py
+++ b/tests/gcp/hooks/test_dataproc.py
@@ -40,7 +40,7 @@ def mock_init(self, gcp_conn_id, delegate_to=None):  # pylint: disable=unused-ar
 
 class TestDataProcHook(unittest.TestCase):
     def setUp(self):
-        with mock.patch(BASE_STRING.format('GoogleCloudBaseHook.__init__'),
+        with mock.patch(BASE_STRING.format('CloudBaseHook.__init__'),
                         new=mock_init):
             self.dataproc_hook = DataprocHook()
 

--- a/tests/gcp/hooks/test_datastore.py
+++ b/tests/gcp/hooks/test_datastore.py
@@ -34,7 +34,7 @@ def mock_init(self, gcp_conn_id, delegate_to=None):  # pylint: disable=unused-ar
 
 class TestDatastoreHook(unittest.TestCase):
     def setUp(self):
-        with patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__', new=mock_init):
+        with patch('airflow.gcp.hooks.base.CloudBaseHook.__init__', new=mock_init):
             self.datastore_hook = DatastoreHook()
 
     @patch('airflow.gcp.hooks.datastore.DatastoreHook._authorize')

--- a/tests/gcp/hooks/test_dlp.py
+++ b/tests/gcp/hooks/test_dlp.py
@@ -67,7 +67,7 @@ JOB_TRIGGER_PATH = "projects/{}/jobTriggers/{}".format(PROJECT_ID, TRIGGER_ID)
 class TestCloudDLPHook(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.hook = CloudDLPHook(gcp_conn_id="test")
@@ -102,7 +102,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.cancel_dlp_job(dlp_job_id=None, project_id=PROJECT_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -114,7 +114,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.cancel_dlp_job(dlp_job_id=DLP_JOB_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -157,7 +157,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -189,7 +189,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -216,7 +216,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -259,7 +259,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -290,7 +290,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -302,7 +302,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.create_job_trigger()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -345,7 +345,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -379,7 +379,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -391,7 +391,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.deidentify_content()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -433,7 +433,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.delete_deidentify_template(template_id=None)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -462,7 +462,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.delete_dlp_job(dlp_job_id=None, project_id=PROJECT_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -474,7 +474,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.delete_dlp_job(dlp_job_id=DLP_JOB_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -516,7 +516,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.delete_inspect_template(template_id=None)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -545,7 +545,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.delete_job_trigger(job_trigger_id=None, project_id=PROJECT_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -557,7 +557,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.delete_job_trigger(job_trigger_id=TRIGGER_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -599,7 +599,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.delete_stored_info_type(stored_info_type_id=None)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -611,7 +611,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.delete_stored_info_type(stored_info_type_id=STORED_INFO_TYPE_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -661,7 +661,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.get_deidentify_template(template_id=None)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -692,7 +692,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.get_dlp_job(dlp_job_id=None, project_id=PROJECT_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -704,7 +704,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.get_dlp_job(dlp_job_id=DLP_JOB_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -754,7 +754,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.get_inspect_template(template_id=None)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -787,7 +787,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.get_job_trigger(job_trigger_id=None, project_id=PROJECT_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -799,7 +799,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.get_job_trigger(job_trigger_id=TRIGGER_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -849,7 +849,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.get_stored_info_type(stored_info_type_id=None)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -879,7 +879,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -891,7 +891,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.inspect_content()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -928,7 +928,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -958,7 +958,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -982,7 +982,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1019,7 +1019,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1048,7 +1048,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1060,7 +1060,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.list_job_triggers()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1097,7 +1097,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1128,7 +1128,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1162,7 +1162,7 @@ class TestCloudDLPHook(unittest.TestCase):
         )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1174,7 +1174,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.reidentify_content()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1230,7 +1230,7 @@ class TestCloudDLPHook(unittest.TestCase):
             )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1242,7 +1242,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.update_deidentify_template(template_id=TEMPLATE_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1298,7 +1298,7 @@ class TestCloudDLPHook(unittest.TestCase):
             )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1338,7 +1338,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.update_job_trigger(job_trigger_id=None, project_id=PROJECT_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1350,7 +1350,7 @@ class TestCloudDLPHook(unittest.TestCase):
             self.hook.update_job_trigger(job_trigger_id=TRIGGER_ID)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1406,7 +1406,7 @@ class TestCloudDLPHook(unittest.TestCase):
             )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_functions.py
+++ b/tests/gcp/hooks/test_functions.py
@@ -34,7 +34,7 @@ GCF_FUNCTION = 'function'
 class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_no_default_project_id):
             self.gcf_function_hook_no_project_id = CloudFunctionsHook(gcp_conn_id='test', api_version='v1')
 
@@ -49,7 +49,7 @@ class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
         self.assertEqual(self.gcf_function_hook_no_project_id._conn, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -94,7 +94,7 @@ class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -150,7 +150,7 @@ class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
 
 class TestFunctionHookDefaultProjectId(unittest.TestCase):
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
             self.gcf_function_hook = CloudFunctionsHook(gcp_conn_id='test', api_version='v1')
 
@@ -165,7 +165,7 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
         self.assertEqual(self.gcf_function_hook._conn, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -258,7 +258,7 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )

--- a/tests/gcp/hooks/test_gcp_compute_hook.py
+++ b/tests/gcp/hooks/test_gcp_compute_hook.py
@@ -39,7 +39,7 @@ GCE_INSTANCE_GROUP_MANAGER = 'instance_group_manager'
 class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_no_default_project_id):
             self.gce_hook_no_project_id = ComputeEngineHook(gcp_conn_id='test')
 
@@ -71,7 +71,7 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                zone='zone')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -111,7 +111,7 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                zone='zone')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -153,7 +153,7 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                zone='zone')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -192,7 +192,7 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -234,7 +234,7 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                operation_name='operation_id')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -278,7 +278,7 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -331,7 +331,7 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                zone='zone')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -360,12 +360,12 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
 
 class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
             self.gce_hook = ComputeEngineHook(gcp_conn_id='test')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -405,7 +405,7 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
                                                                zone='zone')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -445,7 +445,7 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
                                                                zone='zone')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -483,7 +483,7 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
                                                                zone='zone')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -517,7 +517,7 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -557,7 +557,7 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
                                                                operation_name='operation_id')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -599,7 +599,7 @@ class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )

--- a/tests/gcp/hooks/test_gcs.py
+++ b/tests/gcp/hooks/test_gcs.py
@@ -68,22 +68,22 @@ class TestGCSHookHelperFunctions(unittest.TestCase):
 class TestGoogleCloudStorageHook(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            GCS_STRING.format('GoogleCloudBaseHook.__init__'),
+            GCS_STRING.format('CloudBaseHook.__init__'),
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.gcs_hook = gcs.GoogleCloudStorageHook(
                 google_cloud_storage_conn_id='test')
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.client_info',
+        'airflow.gcp.hooks.base.CloudBaseHook.client_info',
         new_callable=mock.PropertyMock,
         return_value="CLIENT_INFO"
     )
     @mock.patch(
-        BASE_STRING.format("GoogleCloudBaseHook._get_credentials_and_project_id"),
+        BASE_STRING.format("CloudBaseHook._get_credentials_and_project_id"),
         return_value=("CREDENTIALS", "PROJECT_ID")
     )
-    @mock.patch(GCS_STRING.format('GoogleCloudBaseHook.get_connection'))
+    @mock.patch(GCS_STRING.format('CloudBaseHook.get_connection'))
     @mock.patch('google.cloud.storage.Client')
     def test_storage_client_creation(self,
                                      mock_client,
@@ -571,7 +571,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
 
 class TestGoogleCloudStorageHookUpload(unittest.TestCase):
     def setUp(self):
-        with mock.patch(BASE_STRING.format('GoogleCloudBaseHook.__init__')):
+        with mock.patch(BASE_STRING.format('CloudBaseHook.__init__')):
             self.gcs_hook = gcs.GoogleCloudStorageHook(
                 google_cloud_storage_conn_id='test'
             )
@@ -720,7 +720,7 @@ class TestGoogleCloudStorageHookUpload(unittest.TestCase):
 class TestSyncGcsHook(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            GCS_STRING.format("GoogleCloudBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
+            GCS_STRING.format("CloudBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
             self.gcs_hook = gcs.GoogleCloudStorageHook(google_cloud_storage_conn_id="test")
 

--- a/tests/gcp/hooks/test_gsheets.py
+++ b/tests/gcp/hooks/test_gsheets.py
@@ -46,7 +46,7 @@ API_RESPONSE = {'test': 'repsonse'}
 
 class TestGSheetsHook(unittest.TestCase):
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
             self.hook = GSheetsHook(gcp_conn_id=GCP_CONN_ID, spreadsheet_id=SPREADHSEET_ID)
 

--- a/tests/gcp/hooks/test_kms.py
+++ b/tests/gcp/hooks/test_kms.py
@@ -52,7 +52,7 @@ def mock_init(self, gcp_conn_id, delegate_to=None):  # pylint: disable=unused-ar
 class TestGoogleCloudKMSHook(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_init,
         ):
             self.kms_hook = GoogleCloudKMSHook(gcp_conn_id="test")

--- a/tests/gcp/hooks/test_kubernetes_engine.py
+++ b/tests/gcp/hooks/test_kubernetes_engine.py
@@ -58,7 +58,7 @@ class TestGKEClusterHookDelete(unittest.TestCase):
         self.gke_hook._client = mock.Mock()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -83,7 +83,7 @@ class TestGKEClusterHookDelete(unittest.TestCase):
         convert_mock.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -104,7 +104,7 @@ class TestGKEClusterHookDelete(unittest.TestCase):
         log_mock.info.assert_any_call("Assuming Success: %s", message)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -127,7 +127,7 @@ class TestGKEClusterHookCreate(unittest.TestCase):
         self.gke_hook._client = mock.Mock()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -155,7 +155,7 @@ class TestGKEClusterHookCreate(unittest.TestCase):
         convert_mock.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_mlengine.py
+++ b/tests/gcp/hooks/test_mlengine.py
@@ -693,7 +693,7 @@ class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
             self.hook = hook.MLEngineHook()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -735,7 +735,7 @@ class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
         ], any_order=True)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -770,7 +770,7 @@ class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
         ], any_order=True)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -813,7 +813,7 @@ class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
         ], any_order=True)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -859,7 +859,7 @@ class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
         ], any_order=True)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -888,7 +888,7 @@ class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
         ])
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -915,7 +915,7 @@ class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
         ])
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -940,7 +940,7 @@ class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
         ])
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -998,7 +998,7 @@ class TestMLEngineHookWithoutProjectId(unittest.TestCase):
             self.hook = hook.MLEngineHook()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1015,7 +1015,7 @@ class TestMLEngineHookWithoutProjectId(unittest.TestCase):
             )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1031,7 +1031,7 @@ class TestMLEngineHookWithoutProjectId(unittest.TestCase):
             )
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1044,7 +1044,7 @@ class TestMLEngineHookWithoutProjectId(unittest.TestCase):
             self.hook.list_versions(model_name=model_name)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1057,7 +1057,7 @@ class TestMLEngineHookWithoutProjectId(unittest.TestCase):
             self.hook.delete_version(model_name=model_name, version_name=version_name)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1072,7 +1072,7 @@ class TestMLEngineHookWithoutProjectId(unittest.TestCase):
             self.hook.create_model(model=model)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1083,7 +1083,7 @@ class TestMLEngineHookWithoutProjectId(unittest.TestCase):
             self.hook.get_model(model_name=model_name)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -1095,7 +1095,7 @@ class TestMLEngineHookWithoutProjectId(unittest.TestCase):
             self.hook.delete_model(model_name=model_name)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_spanner.py
+++ b/tests/gcp/hooks/test_spanner.py
@@ -35,7 +35,7 @@ SPANNER_DATABASE = 'database-name'
 class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_default_project_id):
             self.spanner_hook_default_project_id = SpannerHook(gcp_conn_id='test')
 
@@ -75,7 +75,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         self.assertIsNotNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -117,7 +117,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -161,7 +161,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -197,7 +197,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -237,7 +237,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         self.assertIsNotNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -277,7 +277,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -317,7 +317,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -361,7 +361,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         self.assertTrue(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
@@ -404,7 +404,7 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
 class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch('airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__',
+        with mock.patch('airflow.gcp.hooks.base.CloudBaseHook.__init__',
                         new=mock_base_gcp_hook_no_default_project_id):
             self.spanner_hook_no_default_project_id = SpannerHook(gcp_conn_id='test')
 
@@ -428,7 +428,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         self.assertEqual(self.spanner_hook_no_default_project_id._client, result)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -468,7 +468,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -510,7 +510,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -554,7 +554,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -591,7 +591,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -632,7 +632,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         self.assertIsNotNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -674,7 +674,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -735,7 +735,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         self.assertIsNone(res)
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )
@@ -800,7 +800,7 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         database_drop_method.assert_not_called()
 
     @mock.patch(
-        'airflow.gcp.hooks.base.GoogleCloudBaseHook.project_id',
+        'airflow.gcp.hooks.base.CloudBaseHook.project_id',
         new_callable=PropertyMock,
         return_value=None
     )

--- a/tests/gcp/hooks/test_speech_to_text.py
+++ b/tests/gcp/hooks/test_speech_to_text.py
@@ -32,7 +32,7 @@ AUDIO = {"uri": "gs://bucket/object"}
 class TestTextToSpeechOperator(unittest.TestCase):
     def setUp(self):
         with patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.gcp_speech_to_text_hook = CloudSpeechToTextHook(gcp_conn_id="test")

--- a/tests/gcp/hooks/test_tasks.py
+++ b/tests/gcp/hooks/test_tasks.py
@@ -41,7 +41,7 @@ FULL_TASK_PATH = (
 class TestCloudTasksHook(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.hook = CloudTasksHook(gcp_conn_id="test")

--- a/tests/gcp/hooks/test_text_to_speech.py
+++ b/tests/gcp/hooks/test_text_to_speech.py
@@ -32,7 +32,7 @@ AUDIO_CONFIG = {"audio_encoding": "MP3"}
 class TestTextToSpeechHook(unittest.TestCase):
     def setUp(self):
         with patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.gcp_text_to_speech_hook = CloudTextToSpeechHook(gcp_conn_id="test")

--- a/tests/providers/google/cloud/hooks/test_natural_language.py
+++ b/tests/providers/google/cloud/hooks/test_natural_language.py
@@ -36,7 +36,7 @@ ENCODING_TYPE = "UTF32"
 class TestCloudNaturalLanguageHook(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            "airflow.contrib.hooks." "gcp_api_base_hook.GoogleCloudBaseHook.__init__",
+            "airflow.contrib.hooks." "gcp_api_base_hook.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
         ):
             self.hook = CloudNaturalLanguageHook(gcp_conn_id="test")

--- a/tests/providers/google/cloud/hooks/test_pubsub.py
+++ b/tests/providers/google/cloud/hooks/test_pubsub.py
@@ -55,7 +55,7 @@ def mock_init(self, gcp_conn_id, delegate_to=None):  # pylint: disable=unused-ar
 
 class TestPubSubHook(unittest.TestCase):
     def setUp(self):
-        with mock.patch(BASE_STRING.format('GoogleCloudBaseHook.__init__'),
+        with mock.patch(BASE_STRING.format('CloudBaseHook.__init__'),
                         new=mock_init):
             self.pubsub_hook = PubSubHook(gcp_conn_id='test')
 

--- a/tests/providers/google/marketing_platform/hooks/test_campaign_manager.py
+++ b/tests/providers/google/marketing_platform/hooks/test_campaign_manager.py
@@ -28,7 +28,7 @@ GCP_CONN_ID = "google_cloud_default"
 class TestGoogleCampaignManagerHook(TestCase):
     def setUp(self):
         with mock.patch(
-            "airflow.gcp.hooks.base.GoogleCloudBaseHook.__init__",
+            "airflow.gcp.hooks.base.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.hook = GoogleCampaignManagerHook(
@@ -59,7 +59,7 @@ class TestGoogleCampaignManagerHook(TestCase):
     )
     @mock.patch(
         "airflow.providers.google.marketing_platform.hooks."
-        "campaign_manager.GoogleCloudBaseHook.__init__"
+        "campaign_manager.CloudBaseHook.__init__"
     )
     def test_delete_report(self, mock_base_hook, get_conn_mock):
         profile_id = "PROFILE_ID"
@@ -84,7 +84,7 @@ class TestGoogleCampaignManagerHook(TestCase):
     )
     @mock.patch(
         "airflow.providers.google.marketing_platform.hooks."
-        "campaign_manager.GoogleCloudBaseHook.__init__"
+        "campaign_manager.CloudBaseHook.__init__"
     )
     def test_get_report(self, mock_base_hook, get_conn_mock):
         profile_id = "PROFILE_ID"
@@ -111,7 +111,7 @@ class TestGoogleCampaignManagerHook(TestCase):
     )
     @mock.patch(
         "airflow.providers.google.marketing_platform.hooks."
-        "campaign_manager.GoogleCloudBaseHook.__init__"
+        "campaign_manager.CloudBaseHook.__init__"
     )
     def test_get_report_file(self, mock_base_hook, get_conn_mock):
         profile_id = "PROFILE_ID"
@@ -139,7 +139,7 @@ class TestGoogleCampaignManagerHook(TestCase):
     )
     @mock.patch(
         "airflow.providers.google.marketing_platform.hooks."
-        "campaign_manager.GoogleCloudBaseHook.__init__"
+        "campaign_manager.CloudBaseHook.__init__"
     )
     def test_insert_report(self, mock_base_hook, get_conn_mock):
         profile_id = "PROFILE_ID"
@@ -164,7 +164,7 @@ class TestGoogleCampaignManagerHook(TestCase):
     )
     @mock.patch(
         "airflow.providers.google.marketing_platform.hooks."
-        "campaign_manager.GoogleCloudBaseHook.__init__"
+        "campaign_manager.CloudBaseHook.__init__"
     )
     def test_list_reports(self, mock_base_hook, get_conn_mock):
         profile_id = "PROFILE_ID"
@@ -211,7 +211,7 @@ class TestGoogleCampaignManagerHook(TestCase):
     )
     @mock.patch(
         "airflow.providers.google.marketing_platform.hooks."
-        "campaign_manager.GoogleCloudBaseHook.__init__"
+        "campaign_manager.CloudBaseHook.__init__"
     )
     def test_patch_report(self, mock_base_hook, get_conn_mock):
         profile_id = "PROFILE_ID"
@@ -239,7 +239,7 @@ class TestGoogleCampaignManagerHook(TestCase):
     )
     @mock.patch(
         "airflow.providers.google.marketing_platform.hooks."
-        "campaign_manager.GoogleCloudBaseHook.__init__"
+        "campaign_manager.CloudBaseHook.__init__"
     )
     def test_run_report(self, mock_base_hook, get_conn_mock):
         profile_id = "PROFILE_ID"
@@ -267,7 +267,7 @@ class TestGoogleCampaignManagerHook(TestCase):
     )
     @mock.patch(
         "airflow.providers.google.marketing_platform.hooks."
-        "campaign_manager.GoogleCloudBaseHook.__init__"
+        "campaign_manager.CloudBaseHook.__init__"
     )
     def test_update_report(self, mock_base_hook, get_conn_mock):
         profile_id = "PROFILE_ID"

--- a/tests/providers/google/marketing_platform/hooks/test_display_video.py
+++ b/tests/providers/google/marketing_platform/hooks/test_display_video.py
@@ -28,7 +28,7 @@ GCP_CONN_ID = "google_cloud_default"
 class TestGoogleDisplayVideo360Hook(TestCase):
     def setUp(self):
         with mock.patch(
-            "airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__",
+            "airflow.contrib.hooks.gcp_api_base_hook.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.hook = GoogleDisplayVideo360Hook(gcp_conn_id=GCP_CONN_ID)

--- a/tests/providers/google/marketing_platform/hooks/test_search_ads.py
+++ b/tests/providers/google/marketing_platform/hooks/test_search_ads.py
@@ -28,7 +28,7 @@ GCP_CONN_ID = "google_cloud_default"
 class TestSearchAdsHook(TestCase):
     def setUp(self):
         with mock.patch(
-            "airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__",
+            "airflow.contrib.hooks.gcp_api_base_hook.CloudBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.hook = GoogleSearchAdsHook(gcp_conn_id=GCP_CONN_ID)

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -29,7 +29,7 @@ HOOK = [
         "airflow.contrib.hooks.gcp_compute_hook.GceHook",
     ),
     (
-        "airflow.gcp.hooks.base.GoogleCloudBaseHook",
+        "airflow.gcp.hooks.base.CloudBaseHook",
         "airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook",
     ),
     (


### PR DESCRIPTION
Part of AIP-21

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5669
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
