### PR TITLE
[AIRFLOW-5243] Make airflow/configuration pylint compatible

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -20,6 +20,7 @@
 # Note: Any AirflowException raised is expected to cause the TaskInstance
 #       to be marked in an ERROR state
 """Exceptions used by Airflow"""
+# pylint: disable=invalid-name
 
 
 class AirflowException(Exception):


### PR DESCRIPTION
[AIRFLOW-5243](https://issues.apache.org/jira/browse/AIRFLOW-5243) config and exceptions pylint compliance

### Notes:
```
airflow/configuration.py:199:4: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
airflow/configuration.py:205:4: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
airflow/configuration.py:213:4: R0911: Too many return statements (7/6) (too-many-return-statements)
```

- These 3 errors still remain and I'm not sure how to fix them, too many return statements would require some refactoring but I'm unsure about exactly what is happening in that function.
- I couldn't figure out how to fix the other two

### Description
- As part of [AIRFLOW-4364 Integrate Pylint](https://issues.apache.org/jira/browse/AIRFLOW-4364)

### Tests
- No code changes
