### PR TITLE
[AIRFLOW-5817] Improve BigQuery operators idempotency

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -41,6 +41,11 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Idempotency in BigQuery operators
+Idempotency was added to `BigQueryCreateEmptyTableOperator` and `BigQueryCreateEmptyDatasetOperator`. 
+But to achieve that try / except clause was removed from `create_empty_dataset` and `create_empty_table` 
+methods of `BigQueryHook`. 
+
 ### Migration of AWS components
 
 All AWS components (hooks, operators, sensors, example DAGs) will be grouped together as decided in

--- a/airflow/gcp/hooks/bigquery.py
+++ b/airflow/gcp/hooks/bigquery.py
@@ -329,16 +329,10 @@ class BigQueryBaseCursor(LoggingMixin):
 
         num_retries = num_retries if num_retries else self.num_retries
 
-        self.log.info('Creating Table %s:%s.%s',
-                      project_id, dataset_id, table_id)
-
         self.service.tables().insert(
             projectId=project_id,
             datasetId=dataset_id,
             body=table_resource).execute(num_retries=num_retries)
-
-        self.log.info('Table created successfully: %s:%s.%s',
-                      project_id, dataset_id, table_id)
 
     def create_external_table(self,  # pylint: disable=too-many-locals,too-many-arguments
                               external_project_dataset_table: str,
@@ -1736,14 +1730,9 @@ class BigQueryBaseCursor(LoggingMixin):
         dataset_id = dataset_reference.get("datasetReference").get("datasetId")  # type: ignore
         dataset_project_id = dataset_reference.get("datasetReference").get("projectId")  # type: ignore
 
-        self.log.info('Creating Dataset: %s in project: %s ', dataset_id,
-                      dataset_project_id)
-
         self.service.datasets().insert(
             projectId=dataset_project_id,
             body=dataset_reference).execute(num_retries=self.num_retries)
-        self.log.info('Dataset created successfully: In project %s '
-                      'Dataset %s', dataset_project_id, dataset_id)
 
     def delete_dataset(self, project_id: str, dataset_id: str, delete_contents: bool = False) -> None:
         """

--- a/airflow/gcp/hooks/bigquery.py
+++ b/airflow/gcp/hooks/bigquery.py
@@ -332,19 +332,13 @@ class BigQueryBaseCursor(LoggingMixin):
         self.log.info('Creating Table %s:%s.%s',
                       project_id, dataset_id, table_id)
 
-        try:
-            self.service.tables().insert(
-                projectId=project_id,
-                datasetId=dataset_id,
-                body=table_resource).execute(num_retries=num_retries)
+        self.service.tables().insert(
+            projectId=project_id,
+            datasetId=dataset_id,
+            body=table_resource).execute(num_retries=num_retries)
 
-            self.log.info('Table created successfully: %s:%s.%s',
-                          project_id, dataset_id, table_id)
-
-        except HttpError as err:
-            raise AirflowException(
-                'BigQuery job failed. Error was: {}'.format(err.content)
-            )
+        self.log.info('Table created successfully: %s:%s.%s',
+                      project_id, dataset_id, table_id)
 
     def create_external_table(self,  # pylint: disable=too-many-locals,too-many-arguments
                               external_project_dataset_table: str,
@@ -540,20 +534,14 @@ class BigQueryBaseCursor(LoggingMixin):
         if encryption_configuration:
             table_resource["encryptionConfiguration"] = encryption_configuration
 
-        try:
-            self.service.tables().insert(
-                projectId=project_id,
-                datasetId=dataset_id,
-                body=table_resource
-            ).execute(num_retries=self.num_retries)
+        self.service.tables().insert(
+            projectId=project_id,
+            datasetId=dataset_id,
+            body=table_resource
+        ).execute(num_retries=self.num_retries)
 
-            self.log.info('External table created successfully: %s',
-                          external_project_dataset_table)
-
-        except HttpError as err:
-            raise Exception(
-                'BigQuery job failed. Error was: {}'.format(err.content)
-            )
+        self.log.info('External table created successfully: %s',
+                      external_project_dataset_table)
 
     def patch_table(self,  # pylint: disable=too-many-arguments
                     dataset_id: str,
@@ -1751,17 +1739,11 @@ class BigQueryBaseCursor(LoggingMixin):
         self.log.info('Creating Dataset: %s in project: %s ', dataset_id,
                       dataset_project_id)
 
-        try:
-            self.service.datasets().insert(
-                projectId=dataset_project_id,
-                body=dataset_reference).execute(num_retries=self.num_retries)
-            self.log.info('Dataset created successfully: In project %s '
-                          'Dataset %s', dataset_project_id, dataset_id)
-
-        except HttpError as err:
-            raise AirflowException(
-                'BigQuery job failed. Error was: {}'.format(err.content)
-            )
+        self.service.datasets().insert(
+            projectId=dataset_project_id,
+            body=dataset_reference).execute(num_retries=self.num_retries)
+        self.log.info('Dataset created successfully: In project %s '
+                      'Dataset %s', dataset_project_id, dataset_id)
 
     def delete_dataset(self, project_id: str, dataset_id: str, delete_contents: bool = False) -> None:
         """

--- a/airflow/gcp/operators/bigquery.py
+++ b/airflow/gcp/operators/bigquery.py
@@ -750,6 +750,8 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         cursor = conn.cursor()
 
         try:
+            self.log.info('Creating Table %s:%s.%s',
+                          self.project_id, self.dataset_id, self.table_id)
             cursor.create_empty_table(
                 project_id=self.project_id,
                 dataset_id=self.dataset_id,
@@ -759,9 +761,14 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                 labels=self.labels,
                 encryption_configuration=self.encryption_configuration
             )
+            self.log.info('Table created successfully: %s:%s.%s',
+                          self.project_id, self.dataset_id, self.table_id)
         except HttpError as err:
             if err.resp.status != 409:
                 raise
+            else:
+                self.log.info('Table %s:%s.%s already exists.', self.project_id,
+                              self.dataset_id, self.table_id)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -1095,14 +1102,17 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
         cursor = conn.cursor()
 
         try:
+            self.log.info('Creating Dataset: %s in project: %s ', self.dataset_id, self.project_id)
             cursor.create_empty_dataset(
                 project_id=self.project_id,
                 dataset_id=self.dataset_id,
                 dataset_reference=self.dataset_reference,
                 location=self.location)
+            self.log.info('Dataset created successfully.')
         except HttpError as err:
             if err.resp.status != 409:
                 raise
+            self.log.info('Dataset %s already exists.', self.dataset_id)
 
 
 class BigQueryGetDatasetOperator(BaseOperator):

--- a/airflow/gcp/operators/bigquery.py
+++ b/airflow/gcp/operators/bigquery.py
@@ -26,6 +26,8 @@ import json
 import warnings
 from typing import Any, Dict, Iterable, List, Optional, SupportsAbs, Union
 
+from googleapiclient.errors import HttpError
+
 from airflow.exceptions import AirflowException
 from airflow.gcp.hooks.bigquery import BigQueryHook
 from airflow.gcp.hooks.gcs import GoogleCloudStorageHook, _parse_gcs_url
@@ -362,7 +364,8 @@ class BigQueryConsoleIndexableLink(BaseOperatorLink):
 # pylint: disable=too-many-instance-attributes
 class BigQueryOperator(BaseOperator):
     """
-    Executes BigQuery SQL queries in a specific BigQuery database
+    Executes BigQuery SQL queries in a specific BigQuery database.
+    This operator does not assert idempotency.
 
     :param sql: the sql code to be executed (templated)
     :type sql: Can receive a str representing a sql statement,
@@ -746,15 +749,19 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 
-        cursor.create_empty_table(
-            project_id=self.project_id,
-            dataset_id=self.dataset_id,
-            table_id=self.table_id,
-            schema_fields=schema_fields,
-            time_partitioning=self.time_partitioning,
-            labels=self.labels,
-            encryption_configuration=self.encryption_configuration
-        )
+        try:
+            cursor.create_empty_table(
+                project_id=self.project_id,
+                dataset_id=self.dataset_id,
+                table_id=self.table_id,
+                schema_fields=schema_fields,
+                time_partitioning=self.time_partitioning,
+                labels=self.labels,
+                encryption_configuration=self.encryption_configuration
+            )
+        except HttpError as err:
+            if err.resp.status != 409:
+                raise
 
 
 # pylint: disable=too-many-instance-attributes
@@ -917,22 +924,26 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 
-        cursor.create_external_table(
-            external_project_dataset_table=self.destination_project_dataset_table,
-            schema_fields=schema_fields,
-            source_uris=source_uris,
-            source_format=self.source_format,
-            compression=self.compression,
-            skip_leading_rows=self.skip_leading_rows,
-            field_delimiter=self.field_delimiter,
-            max_bad_records=self.max_bad_records,
-            quote_character=self.quote_character,
-            allow_quoted_newlines=self.allow_quoted_newlines,
-            allow_jagged_rows=self.allow_jagged_rows,
-            src_fmt_configs=self.src_fmt_configs,
-            labels=self.labels,
-            encryption_configuration=self.encryption_configuration
-        )
+        try:
+            cursor.create_external_table(
+                external_project_dataset_table=self.destination_project_dataset_table,
+                schema_fields=schema_fields,
+                source_uris=source_uris,
+                source_format=self.source_format,
+                compression=self.compression,
+                skip_leading_rows=self.skip_leading_rows,
+                field_delimiter=self.field_delimiter,
+                max_bad_records=self.max_bad_records,
+                quote_character=self.quote_character,
+                allow_quoted_newlines=self.allow_quoted_newlines,
+                allow_jagged_rows=self.allow_jagged_rows,
+                src_fmt_configs=self.src_fmt_configs,
+                labels=self.labels,
+                encryption_configuration=self.encryption_configuration
+            )
+        except HttpError as err:
+            if err.resp.status != 409:
+                raise
 
 
 class BigQueryDeleteDatasetOperator(BaseOperator):
@@ -1083,11 +1094,15 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 
-        cursor.create_empty_dataset(
-            project_id=self.project_id,
-            dataset_id=self.dataset_id,
-            dataset_reference=self.dataset_reference,
-            location=self.location)
+        try:
+            cursor.create_empty_dataset(
+                project_id=self.project_id,
+                dataset_id=self.dataset_id,
+                dataset_reference=self.dataset_reference,
+                location=self.location)
+        except HttpError as err:
+            if err.resp.status != 409:
+                raise
 
 
 class BigQueryGetDatasetOperator(BaseOperator):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5817

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The PR adds idempotency to ` BigQueryCreateEmptyTableOperator` and `BigQueryCreateEmptyDatasetOperator`. I added also comment to `BigQueryOperator` that it does not have to be idempotent. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
