### PR TITLE
[AIRFLOW-5834] Option to skip serve_logs process with workers

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -157,30 +157,30 @@ class TestCLI(unittest.TestCase):
             self.assertEqual(get_num_ready_workers_running(self.gunicorn_master_proc), 0)
 
     @mock.patch('airflow.bin.cli.subprocess.Popen')
-    @mock.patch('celery.platforms.check_privileges')
-    @mock.patch('celery.worker.WorkController.Blueprint.start')
-    def test_serve_logs_on_worker_start(self, mock_run, mock_privil, mock_popen):
+    def test_serve_logs_on_worker_start(self, mock_popen):
         mock_popen.return_value.communicate.return_value = (b'output', b'error')
         mock_popen.return_value.returncode = 0
-        mock_run.return_value.returncode = 0
-        mock_privil.return_value = 0
-
         args = self.parser.parse_args(['worker', '-c', '-1'])
-        cli.worker(args)
-        mock_popen.assert_called_once()
+
+        with patch('celery.platforms.check_privileges') as mock_privil:
+            mock_privil.return_value = 0
+            with patch('celery.worker.WorkController.Blueprint.start') as mock_run:
+                mock_run.return_value.returncode = 0
+                cli.worker(args)
+                mock_popen.assert_called_once()
 
     @mock.patch('airflow.bin.cli.subprocess.Popen')
-    @mock.patch('celery.platforms.check_privileges')
-    @mock.patch('celery.worker.WorkController.Blueprint.start')
-    def test_skip_serve_logs_on_worker_start(self, mock_run, mock_privil, mock_popen):
+    def test_skip_serve_logs_on_worker_start(self, mock_popen):
         mock_popen.return_value.communicate.return_value = (b'output', b'error')
         mock_popen.return_value.returncode = 0
-        mock_run.run.return_value.returncode = 0
-        mock_privil.return_value = 0
-
         args = self.parser.parse_args(['worker', '-c', '-1', '-s'])
-        cli.worker(args)
-        mock_popen.assert_not_called()
+
+        with patch('celery.platforms.check_privileges') as mock_privil:
+            mock_privil.return_value = 0
+            with patch('celery.worker.WorkController.Blueprint.start') as mock_run:
+                mock_run.return_value.returncode = 0
+                cli.worker(args)
+                mock_popen.assert_not_called()
 
     def test_cli_webserver_debug(self):
         env = os.environ.copy()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) 
  - https://issues.apache.org/jira/browse/AIRFLOW-5834

### Description

- [ ] Provide an option to skip serve_logs process along with workers

### Tests

- [ ] Added

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
