### PR TITLE
[AIRFLOW-5827] Move build to later stage in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,21 +21,6 @@ default_language_version:
   python: python3
 minimum_pre_commit_version: "1.20.0"
 repos:
-  - repo: local
-    hooks:
-      - id: build
-        name: Check if image build is needed
-        entry: ./scripts/ci/local_ci_build.sh
-        language: system
-        always_run: true
-        pass_filenames: false
-      - id: check-apache-license
-        name: Check if licenses are OK for Apache
-        entry: "./scripts/ci/pre_commit_check_license.sh"
-        language: system
-        files: ^.*LICENSE.*$|^.*LICENCE.*$
-        pass_filenames: false
-        require_serial: true
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.7
     hooks:
@@ -190,11 +175,32 @@ repos:
         entry: "./scripts/ci/pre_commit_lint_dockerfile.sh"
         files: ^Dockerfile.*$
         pass_filenames: true
+      - id: isort
+        name: Run isort to sort imports
+        language: python
+        entry: isort
+        files: \.py$
+        # To keep consistent with the global isort skip config defined in setup.cfg
+        exclude: ^airflow/_vendor/.*$|^build/.*$|^.tox/.*$|^venv/.*$
+        additional_dependencies: ['isort']
       - id: update-breeze-file
         name: Update output of breeze command in BREEZE.rst
         entry: "./scripts/ci/pre_commit_breeze_cmd_line.sh"
         language: system
         files: ^BREEZE.rst$|^breeze$|^breeze-complete$
+        pass_filenames: false
+        require_serial: true
+      - id: build
+        name: Check if image build is needed
+        entry: ./scripts/ci/local_ci_build.sh
+        language: system
+        always_run: true
+        pass_filenames: false
+      - id: check-apache-license
+        name: Check if licenses are OK for Apache
+        entry: "./scripts/ci/pre_commit_check_license.sh"
+        language: system
+        files: ^.*LICENSE.*$|^.*LICENCE.*$
         pass_filenames: false
         require_serial: true
       - id: mypy
@@ -217,14 +223,6 @@ repos:
         entry: "./scripts/ci/pre_commit_pylint_tests.sh"
         files: ^tests/.*\.py$
         pass_filenames: true
-      - id: isort
-        name: Run isort to sort imports
-        language: python
-        entry: isort
-        files: \.py$
-        # To keep consistent with the global isort skip config defined in setup.cfg
-        exclude: ^airflow/_vendor/.*$|^build/.*$|^.tox/.*$|^venv/.*$
-        additional_dependencies: ['isort']
       - id: flake8
         name: Run flake8
         language: system


### PR DESCRIPTION
This change is to move build stage of pre-commit as late as possible in pre-commit
chain. This is useful if you do not want to rebuild the docker images needed
to run pylint/mypy/flake8 - and still see the result of other checks immediately
after you run commit.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5827
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
