### PR TITLE
[AIRFLOW-5824] Added AWS DataSync Hook and Operator

### DIFF
--- a/airflow/contrib/hooks/aws_datasync_hook.py
+++ b/airflow/contrib/hooks/aws_datasync_hook.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.hooks.datasync`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.hooks.datasync import AWSDataSyncHook  # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.hooks.datasync`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/airflow/providers/amazon/aws/hooks/datasync.py
+++ b/airflow/providers/amazon/aws/hooks/datasync.py
@@ -1,0 +1,308 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Interact with AWS DataSync, using the AWS ``boto3`` library.
+"""
+
+import time
+
+from airflow.contrib.hooks.aws_hook import AwsHook
+from airflow.exceptions import AirflowBadRequest, AirflowException, AirflowTaskTimeout
+
+
+class AWSDataSyncHook(AwsHook):
+    """
+    Interact with AWS DataSync.
+
+    :param str aws_conn_id: AWS connection to use.
+    :param int wait_for_task_execution: Time to wait between two
+        consecutive calls to check TaskExecution status.
+    :raises ValueError: If wait_interval_seconds is not between 0 and 15*60 seconds.
+    """
+
+    TASK_EXECUTION_INTERMEDIATE_STATES = (
+        'INITIALIZING',
+        'QUEUED', 'LAUNCHING',
+        'PREPARING', 'TRANSFERRING', 'VERIFYING')
+    TASK_EXECUTION_FAILURE_STATES = ('ERROR',)
+    TASK_EXECUTION_SUCCESS_STATES = ('SUCCESS', )
+
+    def __init__(self,
+                 aws_conn_id='aws_default',
+                 wait_interval_seconds=30,
+                 *args, **kwargs):
+        super().__init__(aws_conn_id, *args, **kwargs)
+        self.conn = None
+        self.locations = list()
+        self.tasks = list()
+        # wait_interval_seconds = 0 is used during unit tests
+        if wait_interval_seconds < 0 or wait_interval_seconds > 15 * 60:
+            raise ValueError(
+                'Invalid wait_interval_seconds %s' % wait_interval_seconds)
+        self.wait_interval_seconds = wait_interval_seconds
+
+    def get_conn(self):
+        """Sets and returns AWS DataSync client.
+
+        :return: A boto3 client for AWS DataSync.
+        """
+        if not self.conn:
+            self.conn = self.get_client_type('datasync')
+        return self.conn
+
+    def create_location(self, location_uri, **create_location_kwargs):
+        r"""Creates a new location.
+
+        :param str location_uri: Location URI used to determine the location type (S3, SMB, NFS, EFS).
+        :param \**create_location_kwargs: Passed to ``boto.create_location_xyz()``.
+            See AWS boto3 datasync documentation.
+        :return str: LocationArn of the created Location.
+        :raises AirflowException: If location type (prefix from ``location_uri``) is invalid.
+        """
+        typ = location_uri.split(':')[0]
+        if typ == 'smb':
+            location = self.get_conn().create_location_smb(**create_location_kwargs)
+        elif typ == 's3':
+            location = self.get_conn().create_location_s3(**create_location_kwargs)
+        elif typ == 'nfs':
+            location = self.get_conn().create_loction_nfs(**create_location_kwargs)
+        elif typ == 'efs':
+            location = self.get_conn().create_loction_efs(**create_location_kwargs)
+        else:
+            raise AirflowException('Invalid location type: {0}'.format(typ))
+        self._refresh_locations()
+        return location['LocationArn']
+
+    def get_location_arns(self, location_uri, case_sensitive=True):
+        """
+        Return all LocationArns which match a LocationUri.
+
+        :param str location_uri: Location URI to search for, eg ``s3://mybucket/mypath``
+        :param bool case_sensitive: Do a case sensitive search for location URI.
+        :return: List of LocationArns.
+        :rtype: list(str)
+        :raises AirflowBadRequest: if ``location_uri`` is empty
+        """
+        if not location_uri:
+            raise AirflowBadRequest('location_uri not specified')
+        if not self.locations:
+            self._refresh_locations()
+        result = list()
+
+        for location in self.locations:
+            match = False
+            if case_sensitive:
+                match = location['LocationUri'] == location_uri
+            else:
+                match = location['LocationUri'].lower() == location_uri.lower()
+            if match:
+                result.append(location['LocationArn'])
+        return result
+
+    def _refresh_locations(self):
+        """Refresh the local list of Locations."""
+        self.locations = list()
+        next_token = None
+        while True:
+            if next_token:
+                locations = self.get_conn().list_locations(NextToken=next_token)
+            else:
+                locations = self.get_conn().list_locations()
+            self.locations.extend(locations['Locations'])
+            if 'NextToken' not in locations:
+                break
+            next_token = locations['NextToken']
+
+    def create_task(
+            self,
+            source_location_arn,
+            destination_location_arn,
+            **create_task_kwargs):
+        r"""Create a Task between the specified source and destination LocationArns.
+
+        :param str source_location_arn: Source LocationArn. Must exist already.
+        :param str destination_location_arn: Destination LocationArn. Must exist already.
+        :param \**create_task_kwargs: Passed to ``boto.create_task()``. See AWS boto3 datasync documentation.
+        :return: TaskArn of the created Task
+        :rtype: str
+        """
+        task = self.get_conn().create_task(
+            SourceLocationArn=source_location_arn,
+            DestinationLocationArn=destination_location_arn,
+            **create_task_kwargs
+        )
+        self._refresh_tasks()
+        return task['TaskArn']
+
+    def update_task(self, task_arn, **update_task_kwargs):
+        r"""Update a Task.
+
+        :param str task_arn: The TaskArn to update.
+        :param \**update_task_kwargs: Passed to ``boto.update_task()``, See AWS boto3 datasync documentation.
+        """
+        self.get_conn().update_task(
+            TaskArn=task_arn,
+            **update_task_kwargs
+        )
+
+    def delete_task(self, task_arn):
+        r"""Delete a Task.
+
+        :param str task_arn: The TaskArn to delete.
+        """
+        self.get_conn().delete_task(
+            TaskArn=task_arn
+        )
+
+    def _refresh_tasks(self):
+        """Refreshes the local list of Tasks"""
+        self.tasks = list()
+        next_token = None
+        while True:
+            if next_token:
+                tasks = self.get_conn().list_tasks(NextToken=next_token)
+            else:
+                tasks = self.get_conn().list_tasks()
+            self.tasks.extend(tasks['Tasks'])
+            if 'NextToken' not in tasks:
+                break
+            next_token = tasks['NextToken']
+
+    def get_task_arns_for_location_arns(self, source_location_arns, destination_location_arns):
+        """
+        Return list of TaskArns for which use any one of the specified
+        source LocationArns and any one of the specified destination LocationArns.
+
+        :param list source_location_arns: List of source LocationArns.
+        :param list destination_location_arns: List of destination LocationArns.
+        :return: list
+        :rtype: List of TaskArns.
+        :raises AirflowBadRequest: if ``source_location_arns`` or ``destination_location_arns`` are empty.
+        """
+        if not source_location_arns:
+            raise AirflowBadRequest('source_location_arns not specified')
+        if not destination_location_arns:
+            raise AirflowBadRequest('destination_location_arns not specified')
+        if not self.tasks:
+            self._refresh_tasks()
+
+        result = list()
+        for task in self.tasks:
+            task_arn = task['TaskArn']
+            task_description = self.get_task_description(task_arn)
+            if (task_description['SourceLocationArn'] in source_location_arns and
+                    task_description['DestinationLocationArn'] in destination_location_arns):
+                result.append(task_arn)
+        return result
+
+    def start_task_execution(self, task_arn, **kwargs):
+        r'''
+        Start a TaskExecution for the specified task_arn.
+        Each task can have at most one TaskExecution.
+
+        :param str task_arn: TaskArn
+        :return: TaskExecutionArn
+        :param \**kwargs: kwargs sent to ``boto3.start_task_execution()``
+        :rtype: str
+        :raises ClientError: If a TaskExecution is already busy running for this ``task_arn``.
+        :raises AirflowBadRequest: If ``task_arn`` is empty.
+        '''
+        if not task_arn:
+            raise AirflowBadRequest('task_arn not specified')
+        task_execution = self.get_conn().start_task_execution(TaskArn=task_arn, **kwargs)
+        return task_execution['TaskExecutionArn']
+
+    def cancel_task_execution(self, task_execution_arn):
+        '''
+        Cancel a TaskExecution for the specified ``task_execution_arn``.
+
+        :param str task_execution_arn: TaskExecutionArn.
+        :raises AirflowBadRequest: If ``task_execution_arn`` is empty.
+        '''
+        if not task_execution_arn:
+            raise AirflowBadRequest('task_execution_arn not specified')
+        self.get_conn().cancel_task_execution(TaskExecutionArn=task_execution_arn)
+
+    def get_task_description(self, task_arn):
+        '''
+        Get description for the specified ``task_arn``.
+
+        :param str task_arn: TaskArn
+        :return: AWS metadata about a task.
+        :rtype: dict
+        :raises AirflowBadRequest: If ``task_arn`` is empty.
+        '''
+        if not task_arn:
+            raise AirflowBadRequest('task_arn not specified')
+        return self.get_conn().describe_task(TaskArn=task_arn)
+
+    def get_current_task_execution_arn(self, task_arn):
+        '''
+        Get current TaskExecutionArn (if one exists) for the specified ``task_arn``.
+
+        :param str task_arn: TaskArn
+        :return: CurrentTaskExecutionArn for this ``task_arn`` or None.
+        :rtype: str
+        :raises AirflowBadRequest: if ``task_arn`` is empty.
+        '''
+        if not task_arn:
+            raise AirflowBadRequest('task_arn not specified')
+        task_description = self.get_task_description(task_arn)
+        if 'CurrentTaskExecutionArn' in task_description:
+            return task_description['CurrentTaskExecutionArn']
+        return None
+
+    def wait_for_task_execution(self, task_execution_arn, max_iterations=2 * 180):
+        '''
+        Wait for Task Execution status to be complete (SUCCESS/ERROR).
+        The ``task_execution_arn`` must exist, or a boto3 ClientError will be raised.
+
+        :param str task_execution_arn: TaskExecutionArn
+        :param int max_iterations: Maximum number of iterations before timing out.
+        :return: Result of task execution.
+        :rtype: bool
+        :raises AirflowTaskTimeout: If maximum iterations is exceeded.
+        :raises AirflowBadRequest: If ``task_execution_arn`` is empty.
+        '''
+        if not task_execution_arn:
+            raise AirflowBadRequest('task_execution_arn not specified')
+
+        status = None
+        iterations = max_iterations
+        while status is None or status in self.TASK_EXECUTION_INTERMEDIATE_STATES:
+            task_execution = self.get_conn().describe_task_execution(
+                TaskExecutionArn=task_execution_arn)
+            status = task_execution['Status']
+            self.log.info('status=%s', status)
+            iterations = iterations - 1
+            if (status in self.TASK_EXECUTION_FAILURE_STATES or
+                    status in self.TASK_EXECUTION_SUCCESS_STATES or
+                    iterations <= 0):
+                break
+            time.sleep(self.wait_interval_seconds)
+
+        if status in self.TASK_EXECUTION_SUCCESS_STATES:
+            return True
+        if status in self.TASK_EXECUTION_FAILURE_STATES:
+            return False
+        if iterations <= 0:
+            raise AirflowTaskTimeout('Max iterations exceeded!')
+        raise AirflowException('Unknown status: %s' %
+                               status)  # Should never happen

--- a/airflow/providers/amazon/aws/operators/datasync.py
+++ b/airflow/providers/amazon/aws/operators/datasync.py
@@ -1,0 +1,498 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Get, Create, Update, Delete and execute an AWS DataSync Task.
+"""
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.datasync import AWSDataSyncHook
+from airflow.utils.decorators import apply_defaults
+
+
+class AWSDataSyncCreateTaskOperator(BaseOperator):
+    r"""Create an AWS DataSync Task.
+
+    If there are existing Locations which match the specified
+    source and destination URIs then these will be used for the Task.
+    Otherwise, new Locations can be created automatically,
+    depending on input parameters.
+
+    If ``do_xcom_push`` is True, the TaskArn which is created
+    will be pushed to an XCom.
+
+    :param str aws_conn_id: AWS connection to use.
+    :param str source_location_uri: Source location URI.
+        Example: ``smb://server/subdir``
+    :param str destination_location_uri: Destination location URI.
+        Example: ``s3://airflow_bucket/stuff``
+    :param bool case_sensitive_location_search: Whether or not to do a
+        case-sensitive search for each Location URI.
+    :param dict create_task_kwargs: If no suitable TaskArn is found,
+        it will be created if ``create_task_kwargs`` is defined.
+        ``create_task_kwargs`` is then used internally like this:
+        ``boto3.create_task(**create_task_kwargs)``
+        Example:  ``{'Name': 'xyz', 'Options': ..., 'Excludes': ..., 'Tags': ...}``
+    :param dict create_source_location_kwargs: If no suitable LocationArn is found,
+        a Location will be created if ``create_source_location_kwargs`` is defined.
+        ``create_source_location_kwargs`` is then used internally like this:
+        ``boto3.create_location_xyz(**create_source_location_kwargs)``
+        The xyz is determined from the prefix of source_location_uri, eg ``smb:/...`` or ``s3:/...``
+        Example:  ``{'Subdirectory': ..., 'ServerHostname': ..., ...}``
+    :param dict create_destination_location_kwargs: If no suitable LocationArn is found,
+        a Location will be created if ``create_destination_location_kwargs`` is defined.
+        ``create_destination_location_kwargs`` is used internally like this:
+        ``boto3.create_location_xyz(**create_destination_location_kwargs)``
+        The xyz is determined from the prefix of destination_location_uri, eg ``smb:/...` or ``s3:/...``
+        Example:  ``{'S3BucketArn': ..., 'S3Config': {'BucketAccessRoleArn': ...}, ...}``
+
+    :raises AirflowException: If neither ``source_location_uri`` nor
+        ``destination_location_uri`` were specified.
+    :raises AirflowException: If source or destination Location weren't found
+        and could not be created.
+    :raises AirflowException: If Task creation fails.
+    """
+    template_fields = ('source_location_uri',
+                       'destination_location_uri')
+    ui_color = '#44b5e2'
+
+    @apply_defaults
+    def __init__(
+        self,
+        aws_conn_id='aws_default',
+        source_location_uri=None,
+        destination_location_uri=None,
+        case_sensitive_location_search=True,
+        create_task_kwargs=None,
+        create_source_location_kwargs=None,
+        create_destination_location_kwargs=None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+
+        # Assignments
+        self.aws_conn_id = aws_conn_id
+        self.source_location_uri = source_location_uri
+        self.destination_location_uri = destination_location_uri
+        self.case_sensitive_location_search = case_sensitive_location_search
+        if create_task_kwargs:
+            self.create_task_kwargs = create_task_kwargs
+        else:
+            self.create_task_kwargs = dict()
+        if create_source_location_kwargs:
+            self.create_source_location_kwargs = create_source_location_kwargs
+        else:
+            self.create_source_location_kwargs = dict()
+        if create_destination_location_kwargs:
+            self.create_destination_location_kwargs = create_destination_location_kwargs
+        else:
+            self.create_destination_location_kwargs = dict()
+
+        # Validations
+        if not (self.source_location_uri and self.destination_location_uri):
+            raise AirflowException(
+                'Specify both source_location_uri and destination_location_uri')
+
+        # Others
+        self.hook = None
+        self.source_location_arn = None
+        self.destination_location_arn = None
+        self.task_arn = None
+
+    def get_hook(self):
+        """Create and return AWSDataSyncHook.
+
+        :return AWSDataSyncHook: An AWSDataSyncHook instance.
+        """
+        if not self.hook:
+            self.hook = AWSDataSyncHook(
+                aws_conn_id=self.aws_conn_id
+            )
+        return self.hook
+
+    def _create_or_get_location_arn(
+            self,
+            location_uri,
+            **create_location_kwargs):
+        location_arns = self.get_hook().get_location_arns(
+            location_uri,
+            self.case_sensitive_location_search)
+        if not location_arns:
+            self.log.info('Creating location for LocationUri %s',
+                          location_uri)
+            return self.get_hook().create_location(
+                location_uri,
+                **create_location_kwargs)
+        else:
+            self.log.info('Found LocationArns %s for LocationUri %s',
+                          location_arns, location_uri)
+            if len(location_arns) != 1:
+                raise AirflowException(
+                    'More than 1 LocationArn was found for LocationUri %s' % location_uri)
+            return location_arns[0]
+
+    def execute(self, context):
+        """Create a new Task (and Locations) if necessary."""
+        hook = self.get_hook()
+
+        self.source_location_arn = self._create_or_get_location_arn(
+            self.source_location_uri,
+            **self.create_source_location_kwargs
+        )
+
+        self.destination_location_arn = self._create_or_get_location_arn(
+            self.destination_location_uri,
+            **self.create_destination_location_kwargs
+        )
+
+        self.log.info('Creating a Task.')
+        self.task_arn = hook.create_task(
+            self.source_location_arn,
+            self.destination_location_arn,
+            **self.create_task_kwargs
+        )
+        if not self.task_arn:
+            raise AirflowException('Task could not be created')
+        return self.task_arn
+
+
+class AWSDataSyncGetTasksOperator(BaseOperator):
+    r"""Get AWS DataSync Tasks.
+
+    Finds AWS DataSync Tasks which have a source and destination
+    location corresponding to the specified source and destination
+    URIs.
+
+    If ``do_xcom_push`` is True, the TaskArns which are found
+    will be pushed to an XCom.
+
+    note:: There may be 0, 1, or many matching Tasks. The calling
+        application will need to deal with these scenarios.
+
+    :param str aws_conn_id: AWS connection to use.
+    :param str source_location_uri: Source location URI.
+        Example: ``smb://server/subdir``
+    :param str destination_location_uri: Destination location URI.
+        Example: ``s3://airflow_bucket/stuff``
+    :param bool case_sensitive_location_search: Whether or not to do a
+        case-sensitive search for each Location URI.
+
+    :raises AirflowException: If neither ``source_location_uri`` nor
+        ``destination_location_uri`` were specified.
+    """
+    template_fields = ('source_location_uri',
+                       'destination_location_uri')
+    ui_color = '#44b5e2'
+
+    @apply_defaults
+    def __init__(
+        self,
+        aws_conn_id='aws_default',
+        source_location_uri=None,
+        destination_location_uri=None,
+        case_sensitive_location_search=True,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+
+        # Assignments
+        self.aws_conn_id = aws_conn_id
+        self.source_location_uri = source_location_uri
+        self.destination_location_uri = destination_location_uri
+        self.case_sensitive_location_search = case_sensitive_location_search
+
+        # Validations
+        if not (self.source_location_uri and self.destination_location_uri):
+            raise AirflowException(
+                'Specify both source_location_uri and destination_location_uri')
+
+        # Others
+        self.hook = None
+        self.source_location_arns = None
+        self.destination_location_arns = None
+        self.task_arns = None
+
+    def get_hook(self):
+        """Create and return AWSDataSyncHook.
+
+        :return AWSDataSyncHook: An AWSDataSyncHook instance.
+        """
+        if not self.hook:
+            self.hook = AWSDataSyncHook(
+                aws_conn_id=self.aws_conn_id
+            )
+        return self.hook
+
+    def _get_location_arns(
+            self, location_uri
+    ):
+        location_arns = self.get_hook().get_location_arns(
+            location_uri,
+            self.case_sensitive_location_search)
+        self.log.info('Found LocationArns %s for LocationUri %s',
+                      location_arns, location_uri)
+        return location_arns
+
+    def execute(self, context):
+        """Create a new Task (and Locations) if necessary."""
+        hook = self.get_hook()
+
+        self.source_location_arns = self._get_location_arns(
+            self.source_location_uri
+        )
+
+        self.destination_location_arns = self._get_location_arns(
+            self.destination_location_uri
+        )
+
+        if not (self.source_location_arns and self.destination_location_arns):
+            self.log.info('Insufficient Locations to search for Task')
+            return []
+
+        self.log.info('Searching for TaskArns')
+        self.task_arns = hook.get_task_arns_for_location_arns(
+            self.source_location_arns,
+            self.destination_location_arns)
+        self.log.info('Found %s matching TaskArns', len(self.task_arns))
+        return self.task_arns
+
+
+class AWSDataSyncUpdateTaskOperator(BaseOperator):
+    """
+    Update an AWS DataSyncTask
+
+    If ``do_xcom_push`` is True, the TaskArns which were updated
+    will be pushed to an XCom.
+
+    :param str aws_conn_id: AWS connection to use.
+    :param str task_arn: The TaskArn to update. If ``None``, the operator will
+        look in xcom_pull for a TaskArn.
+    :param dict update_task_kwargs: The TaskArn will be updated with ``update_task_kwargs``.
+        ``update_task_kwargs`` is used internally like this:
+        ``boto3.update_task(TaskArn=task_arn, **update_task_kwargs)``
+        Example:  ``{'Name': 'xyz', 'Options': ..., 'Excludes': ...}``
+    :raises AirflowException: If ``task_arn`` is None.
+    :raises AirflowException: If ``update_task_kwargs`` is None.
+    """
+    template_fields = ('task_arn',)
+    ui_color = '#44b5e2'
+
+    @apply_defaults
+    def __init__(
+        self,
+        aws_conn_id='aws_default',
+        task_arn=None,
+        update_task_kwargs=None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+
+        # Assignments
+        self.aws_conn_id = aws_conn_id
+        self.task_arn = task_arn
+        self.update_task_kwargs = update_task_kwargs
+
+        # Validations
+        if not self.task_arn:
+            raise AirflowException(
+                'task_arn must be specified')
+
+        if not self.update_task_kwargs:
+            raise AirflowException(
+                'update_task_kwargs must be specified')
+
+        # Others
+        self.hook = None
+
+    def get_hook(self):
+        """Create and return AWSDataSyncHook.
+
+        :return AWSDataSyncHook: An AWSDataSyncHook instance.
+        """
+        if not self.hook:
+            self.hook = AWSDataSyncHook(
+                aws_conn_id=self.aws_conn_id,
+            )
+        return self.hook
+
+    def execute(self, context):
+        hook = self.get_hook()
+        self.log.info('Updating TaskArn %s', self.task_arn)
+        hook.update_task(self.task_arn, **self.update_task_kwargs)
+        self.log.info('Updated TaskArn %s', self.task_arn)
+        return self.task_arn
+
+
+class AWSDataSyncTaskOperator(BaseOperator):
+    r"""
+    An operator that starts an AWS DataSync TaskExecution for a Task.
+
+    If ``do_xcom_push`` is True, the TaskExecutionArn used
+    will be pushed to an XCom when it successfuly completes.
+
+    :param str aws_conn_id: AWS connection to use.
+    :param int wait_interval_seconds: Time to wait between two consecutive calls
+        to check TaskExecution status.
+    :param str task_arn: The TaskArn to start. If ``None``, the operator will
+        look in xcom_pull for a TaskArn.
+        Example: ``arn:aws:datasync:eu-west-1:111122233444:task/task-0dfafff11dc43f1ab``
+
+    :raises AirflowException: If neither ``task_arn`` nor
+        (``source_location_uri`` and ``destination_location_uri``) is specified.
+    :raises AirflowException: If ``task_arn`` is None.
+    :raises AirflowException: If ``task_arn`` is None and TaskArn was not found in xcom_pull.
+    :raises AirflowException: If TaskExecution fails.
+    """
+
+    template_fields = ('task_arn',)
+    ui_color = '#44b5e2'
+
+    @apply_defaults
+    def __init__(
+        self,
+        aws_conn_id='aws_default',
+        wait_interval_seconds=30,
+        task_arn=None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+
+        # Assignments
+        self.aws_conn_id = aws_conn_id
+        self.wait_interval_seconds = wait_interval_seconds
+        self.task_arn = task_arn
+
+        # Validations
+        if not self.task_arn:
+            raise AirflowException(
+                'task_arn must be specified')
+
+        # Others
+        self.hook = None
+        self.task_execution_arn = None
+
+    def get_hook(self):
+        """Create and return AWSDataSyncHook.
+
+        :return AWSDataSyncHook: An AWSDataSyncHook instance.
+        """
+        if not self.hook:
+            self.hook = AWSDataSyncHook(
+                aws_conn_id=self.aws_conn_id,
+                wait_interval_seconds=self.wait_interval_seconds
+            )
+        return self.hook
+
+    def execute(self, context):
+        """Create and monitor an AWSDataSync TaskExecution for a Task."""
+        hook = self.get_hook()
+
+        # Create a task execution:
+        self.log.info('Starting execution for TaskArn %s', self.task_arn)
+        self.task_execution_arn = hook.start_task_execution(self.task_arn)
+        self.log.info('Started TaskExecutionArn %s', self.task_execution_arn)
+
+        # Wait for task execution to complete
+        self.log.info('Waiting for TaskExecutionArn %s',
+                      self.task_execution_arn)
+        result = hook.wait_for_task_execution(self.task_execution_arn)
+        self.log.info('Completed TaskExecutionArn %s', self.task_execution_arn)
+        if not result:
+            raise AirflowException(
+                'Failed TaskExecutionArn %s' % self.task_execution_arn)
+        return self.task_execution_arn
+
+    def on_kill(self):
+        """Cancel the submitted DataSync task."""
+        hook = self.get_hook()
+        if self.task_execution_arn:
+            self.log.info('Cancelling TaskExecutionArn %s',
+                          self.task_execution_arn)
+            hook.cancel_task_execution(
+                task_execution_arn=self.task_execution_arn)
+            self.log.info('Cancelled TaskExecutionArn %s',
+                          self.task_execution_arn)
+
+
+class AWSDataSyncDeleteTaskOperator(BaseOperator):
+    r"""
+    An operator that deletes an AWS DataSync Task.
+
+    If ``do_xcom_push`` is True, the TaskArn used
+    will be pushed to an XCom when it successfuly completes.
+
+    :param str aws_conn_id: AWS connection to use.
+    :param str task_arn: The TaskArn to start. If ``None``, the operator will
+        look in xcom_pull for a TaskArn.
+        Example: ``arn:aws:datasync:eu-west-1:111122233444:task/task-0dfafff11dc43f1ab``
+
+    :raises AirflowException: If ``task_arn`` is None.
+    :raises AirflowException: If ``task_arn`` is None and TaskArn was not found in xcom_pull.
+    :raises AirflowException: If Task deletion fails.
+    """
+
+    template_fields = ('task_arn',)
+    ui_color = '#44b5e2'
+
+    @apply_defaults
+    def __init__(
+        self,
+        aws_conn_id='aws_default',
+        task_arn=None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+
+        # Assignments
+        self.aws_conn_id = aws_conn_id
+        self.task_arn = task_arn
+
+        # Validations
+        if not self.task_arn:
+            raise AirflowException(
+                'task_arn must be specified')
+
+        # Others
+        self.hook = None
+
+    def get_hook(self):
+        """Create and return AWSDataSyncHook.
+
+        :return AWSDataSyncHook: An AWSDataSyncHook instance.
+        """
+        if not self.hook:
+            self.hook = AWSDataSyncHook(
+                aws_conn_id=self.aws_conn_id,
+            )
+        return self.hook
+
+    def execute(self, context):
+        """Deletes an AWS DataSync Task."""
+        hook = self.get_hook()
+        # Delete task:
+        self.log.info('Deleting Task with TaskArn %s', self.task_arn)
+        hook.delete_task(self.task_arn)
+        self.log.info('Task Deleted')
+        return self.task_arn

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -319,6 +319,11 @@ These integrations allow you to perform various operations within the Amazon Web
      -
      -
 
+   * - `AWS DataSync <https://aws.amazon.com/datasync/>`__
+     - :mod:`airflow.providers.amazon.aws.hooks.datasync`
+     - :mod:`airflow.providers.amazon.aws.operators.datasync`
+     - 
+
    * - `Amazon DynamoDB <https://aws.amazon.com/dynamodb/>`__
      - :mod:`airflow.contrib.hooks.aws_dynamodb_hook`
      -
@@ -438,6 +443,11 @@ These integrations allow you to copy data from/to Amazon Web Services.
      - `Amazon Redshift <https://aws.amazon.com/redshift/>`__
      -
      - :mod:`airflow.operators.s3_to_redshift_operator`
+
+   * - `On-premises NFS or SMB using Amazon DataSync <https://aws.amazon.com/datasync/>`__
+     - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
+     -
+     - :mod:`airflow.providers.amazon.aws.operators.datasync`
 
    * - `Amazon DynamoDB <https://aws.amazon.com/dynamodb/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_

--- a/tests/providers/amazon/aws/hooks/test_datasync.py
+++ b/tests/providers/amazon/aws/hooks/test_datasync.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import unittest
+
+import boto3
+
+from airflow.exceptions import AirflowTaskTimeout
+from airflow.providers.amazon.aws.hooks.datasync import AWSDataSyncHook
+from tests.compat import mock
+
+
+def no_datasync(x):
+    return x
+
+
+try:
+    from moto import mock_datasync
+except ImportError:
+    mock_datasync = no_datasync
+
+
+@mock_datasync
+@unittest.skipIf(mock_datasync == no_datasync, 'moto datasync package missing')  # pylint: disable=W0143
+class TestAwsDataSyncHook(unittest.TestCase):
+    def test_get_conn(self):
+        hook = AWSDataSyncHook(aws_conn_id='aws_default')
+        self.assertIsNotNone(hook.get_conn())
+
+# Explanation of: @mock.patch.object(AWSDataSyncHook, 'get_conn')
+# aws_hook.py fiddles with config files and changes the region
+# If you have any ~/.credentials then aws_hook uses it for the region
+# This region might not match us-east-1 used for the mocked self.client
+
+# Once patched, the AWSDataSyncHook.get_conn method is mocked and passed to the test as
+# mock_get_conn. We then override it to just return the locally created self.client instead of
+# the one created by the AWS self.hook.
+
+# Unfortunately this means we cant test the get_conn method - which is why we have it in a
+# separate class above
+
+
+@mock_datasync
+@mock.patch.object(AWSDataSyncHook, 'get_conn')
+@unittest.skipIf(mock_datasync == no_datasync, 'moto datasync package missing')  # pylint: disable=W0143
+class TestAWSDataSyncHookMocked(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.source_server_hostname = 'host'
+        self.source_subdirectory = 'somewhere'
+        self.destination_bucket_name = 'my_bucket'
+        self.destination_bucket_dir = 'dir'
+
+        self.client = None
+        self.hook = None
+        self.source_location_arn = None
+        self.destination_location_arn = None
+        self.task_arn = None
+
+    def setUp(self):
+        self.client = boto3.client("datasync", region_name="us-east-1")
+        self.hook = AWSDataSyncHook(aws_conn_id='aws_default', wait_interval_seconds=0)
+
+        # Create default locations and tasks
+        self.source_location_arn = self.client.create_location_smb(
+            ServerHostname=self.source_server_hostname,
+            Subdirectory=self.source_subdirectory,
+            User='',
+            Password='',
+            AgentArns=['stuff']
+        )['LocationArn']
+        self.destination_location_arn = self.client.create_location_s3(
+            S3BucketArn='arn:aws:s3:::{0}'.format(
+                self.destination_bucket_name),
+            Subdirectory=self.destination_bucket_dir,
+            S3Config={'BucketAccessRoleArn': 'role'}
+        )['LocationArn']
+        self.task_arn = self.client.create_task(
+            SourceLocationArn=self.source_location_arn,
+            DestinationLocationArn=self.destination_location_arn
+        )['TaskArn']
+
+    def tearDown(self):
+        # Delete all tasks:
+        tasks = self.client.list_tasks()
+        for task in tasks['Tasks']:
+            self.client.delete_task(TaskArn=task['TaskArn'])
+        # Delete all locations:
+        locations = self.client.list_locations()
+        for location in locations['Locations']:
+            self.client.delete_location(LocationArn=location['LocationArn'])
+        self.client = None
+
+    def test_init(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.assertIsNone(self.hook.conn)
+        self.assertFalse(self.hook.locations)
+        self.assertFalse(self.hook.tasks)
+        self.assertEqual(self.hook.wait_interval_seconds, 0)
+
+    def test_create_location_smb(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        locations = self.hook.get_conn().list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        server_hostname = 'my.hostname'
+        subdirectory = 'my_dir'
+        agent_arns = ['stuff']
+        user = 'username123'
+        domain = 'COMPANY.DOMAIN'
+        mount_options = {'Version': 'SMB2'}
+
+        location_uri = 'smb://{0}/{1}'.format(server_hostname, subdirectory)
+
+        create_location_kwargs = {
+            'ServerHostname': server_hostname,
+            'Subdirectory': subdirectory,
+            'User': user,
+            'Password': 'password',
+            'Domain': domain,
+            'AgentArns': agent_arns,
+            'MountOptions': mount_options
+        }
+        location_arn = self.hook.create_location(
+            location_uri, **create_location_kwargs)
+        self.assertIsNotNone(location_arn)
+
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 3)
+
+        location_desc = self.client.describe_location_smb(LocationArn=location_arn)
+        self.assertEqual(location_desc['LocationArn'], location_arn)
+        self.assertEqual(location_desc['LocationUri'], location_uri)
+        self.assertEqual(location_desc['AgentArns'], agent_arns)
+        self.assertEqual(location_desc['User'], user)
+        self.assertEqual(location_desc['Domain'], domain)
+        self.assertEqual(location_desc['MountOptions'], mount_options)
+
+    def test_create_location_s3(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        locations = self.hook.get_conn().list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        s3_bucket_arn = 'some_s3_arn'
+        subdirectory = 'my_subdir'
+        s3_config = {'BucketAccessRoleArn': 'myrole'}
+
+        location_uri = 's3://{0}/{1}'.format(s3_bucket_arn, subdirectory)
+
+        create_location_kwargs = {
+            'S3BucketArn': s3_bucket_arn,
+            'Subdirectory': subdirectory,
+            'S3Config': s3_config
+        }
+        location_arn = self.hook.create_location(
+            location_uri, **create_location_kwargs)
+        self.assertIsNotNone(location_arn)
+
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 3)
+
+        location_desc = self.client.describe_location_s3(LocationArn=location_arn)
+        self.assertEqual(location_desc['LocationArn'], location_arn)
+        self.assertEqual(location_desc['LocationUri'], location_uri)
+        self.assertEqual(location_desc['S3Config'], s3_config)
+
+    def test_create_task(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        log_group_arn = 'cloudwatcharn123'
+        name = 'my_task'
+
+        options = {  # Random options
+            'VerifyMode': 'NONE',
+            'Atime': 'NONE',
+            'Mtime': 'NONE',
+            'Uid': 'BOTH',
+            'Gid': 'INT_VALUE',
+            'PreserveDeletedFiles': 'PRESERVE',
+            'PreserveDevices': 'PRESERVE',
+            'PosixPermissions': 'BEST_EFFORT',
+            'BytesPerSecond': 123,
+        }
+
+        create_task_kwargs = {
+            'CloudWatchLogGroupArn': log_group_arn,
+            'Name': name,
+            'Options': options
+        }
+
+        task_arn = self.hook.create_task(
+            source_location_arn=self.source_location_arn,
+            destination_location_arn=self.destination_location_arn,
+            **create_task_kwargs
+        )
+
+        task = self.client.describe_task(TaskArn=task_arn)
+        self.assertEqual(task['TaskArn'], task_arn)
+        self.assertEqual(task['Name'], name)
+        self.assertEqual(task['CloudWatchLogGroupArn'], log_group_arn)
+        self.assertEqual(task['Options'], options)
+
+    def test_update_task(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task_arn = self.task_arn
+
+        task = self.client.describe_task(TaskArn=task_arn)
+        self.assertNotIn('Name', task)
+
+        update_task_kwargs = {'Name': 'xyz'}
+        self.hook.update_task(task_arn, **update_task_kwargs)
+
+        task = self.client.describe_task(TaskArn=task_arn)
+        self.assertEqual(task['Name'], 'xyz')
+
+    def test_delete_task(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task_arn = self.task_arn
+
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 1)
+
+        self.hook.delete_task(task_arn)
+
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 0)
+
+    def test_get_location_arns(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        # Get true location_arn from boto/moto self.client
+        location_uri = 'smb://{0}/{1}'.format(
+            self.source_server_hostname, self.source_subdirectory)
+        locations = self.client.list_locations()
+        for location in locations['Locations']:
+            if location['LocationUri'] == location_uri:
+                location_arn = location['LocationArn']
+
+        # Verify our self.hook gets the same
+        location_arns = self.hook.get_location_arns(location_uri)
+
+        self.assertEqual(len(location_arns), 1)
+        self.assertEqual(location_arns[0], location_arn)
+
+    def test_get_task_arns_for_location_arns(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task_arns = self.hook.get_task_arns_for_location_arns(
+            [self.source_location_arn],
+            [self.destination_location_arn]
+        )
+        self.assertEqual(len(task_arns), 1)
+        self.assertEqual(task_arns[0], self.task_arn)
+
+        task_arns = self.hook.get_task_arns_for_location_arns(
+            ['foo'], ['bar']
+        )
+        self.assertEqual(len(task_arns), 0)
+
+    def test_start_task_execution(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task = self.client.describe_task(TaskArn=self.task_arn)
+        self.assertNotIn('CurrentTaskExecutionArn', task)
+
+        task_execution_arn = self.hook.start_task_execution(self.task_arn)
+        self.assertIsNotNone(task_execution_arn)
+
+        task = self.client.describe_task(TaskArn=self.task_arn)
+        self.assertIn('CurrentTaskExecutionArn', task)
+        self.assertEqual(task['CurrentTaskExecutionArn'], task_execution_arn)
+
+        task_execution = self.client.describe_task_execution(
+            TaskExecutionArn=task_execution_arn)
+        self.assertIn('Status', task_execution)
+
+    def test_cancel_task_execution(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task_execution_arn = self.hook.start_task_execution(self.task_arn)
+        self.assertIsNotNone(task_execution_arn)
+
+        self.hook.cancel_task_execution(task_execution_arn=task_execution_arn)
+
+        task = self.client.describe_task(TaskArn=self.task_arn)
+        self.assertNotIn('CurrentTaskExecutionArn', task)
+
+    def test_get_task_description(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task = self.client.describe_task(TaskArn=self.task_arn)
+        self.assertIn('TaskArn', task)
+        self.assertIn('Status', task)
+        self.assertIn('SourceLocationArn', task)
+        self.assertIn('DestinationLocationArn', task)
+        self.assertNotIn('CurrentTaskExecutionArn', task)
+
+    def test_get_current_task_execution_arn(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task_execution_arn = self.hook.start_task_execution(self.task_arn)
+
+        current_task_execution = self.hook.get_current_task_execution_arn(
+            self.task_arn)
+        self.assertEqual(current_task_execution, task_execution_arn)
+
+    def test_wait_for_task_execution(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task_execution_arn = self.hook.start_task_execution(self.task_arn)
+        result = self.hook.wait_for_task_execution(
+            task_execution_arn, max_iterations=20)
+
+        self.assertIsNotNone(result)
+
+    def test_wait_for_task_execution_timeout(self, mock_get_conn):
+        # ### Configure mock:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        task_execution_arn = self.hook.start_task_execution(self.task_arn)
+        with self.assertRaises(AirflowTaskTimeout):
+            result = self.hook.wait_for_task_execution(
+                task_execution_arn, max_iterations=1)
+            self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/providers/amazon/aws/operators/test_datasync.py
+++ b/tests/providers/amazon/aws/operators/test_datasync.py
@@ -1,0 +1,739 @@
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest import mock
+
+import boto3
+
+from airflow.exceptions import AirflowException
+from airflow.models import DAG, TaskInstance
+from airflow.providers.amazon.aws.hooks.datasync import AWSDataSyncHook
+from airflow.providers.amazon.aws.operators.datasync import (
+    AWSDataSyncCreateTaskOperator, AWSDataSyncDeleteTaskOperator, AWSDataSyncGetTasksOperator,
+    AWSDataSyncTaskOperator, AWSDataSyncUpdateTaskOperator,
+)
+from airflow.utils import timezone
+from airflow.utils.timezone import datetime
+
+
+def no_datasync(x):
+    return x
+
+
+try:
+    from moto import mock_datasync
+except ImportError:
+    mock_datasync = no_datasync
+
+TEST_DAG_ID = 'unit_tests'
+DEFAULT_DATE = datetime(2018, 1, 1)
+
+SOURCE_HOST_NAME = 'airflow.host'
+SOURCE_SUBDIR = 'airflow_subdir'
+DESTINATION_BUCKET_NAME = 'airflow_bucket'
+
+SOURCE_LOCATION_URI = 'smb://{0}/{1}'.format(SOURCE_HOST_NAME, SOURCE_SUBDIR)
+DESTINATION_LOCATION_URI = 's3://{0}'.format(DESTINATION_BUCKET_NAME)
+DESTINATION_LOCATION_ARN = 'arn:aws:s3:::{0}'.format(DESTINATION_BUCKET_NAME)
+CREATE_TASK_KWARGS = {'Options': {'VerifyMode': 'NONE', 'Atime': 'NONE'}}
+UPDATE_TASK_KWARGS = {'Options': {
+    'VerifyMode': 'BEST_EFFORT', 'Atime': 'NONE'}}
+
+MOCK_DATA = {
+    'task_id': 'test_aws_datasync_task_operator',
+    'create_task_id': 'test_aws_datasync_create_task_operator',
+    'get_task_id': 'test_aws_datasync_get_tasks_operator',
+    'update_task_id': 'test_aws_datasync_update_task_operator',
+    'delete_task_id': 'test_aws_datasync_delete_task_operator',
+    'source_location_uri': SOURCE_LOCATION_URI,
+    'destination_location_uri': DESTINATION_LOCATION_URI,
+    'case_sensitive_location_search': True,
+    'create_task_kwargs': CREATE_TASK_KWARGS,
+    'update_task_kwargs': UPDATE_TASK_KWARGS,
+    'create_source_location_kwargs': {
+        'Subdirectory': SOURCE_SUBDIR,
+        'ServerHostname': SOURCE_HOST_NAME,
+        'User': 'airflow',
+        'Password': 'airflow_password',
+        'AgentArns': ['some_agent']
+    },
+    'create_destination_location_kwargs': {
+        'S3BucketArn': DESTINATION_LOCATION_ARN,
+        'S3Config': {'BucketAccessRoleArn': 'myrole'}
+    },
+}
+
+
+@mock_datasync
+@mock.patch.object(AWSDataSyncHook, 'get_conn')
+@unittest.skipIf(mock_datasync == no_datasync, 'moto datasync package missing')  # pylint: disable=W0143
+class AWSDataSyncTestCase(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.datasync = None
+
+    # Runs once for each test
+    def setUp(self):
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE,
+        }
+
+        self.dag = DAG(TEST_DAG_ID + 'test_schedule_dag_once',
+                       default_args=args,
+                       schedule_interval='@once')
+
+        self.client = boto3.client("datasync", region_name="us-east-1")
+
+        self.source_location_arn = self.client.create_location_smb(
+            **MOCK_DATA['create_source_location_kwargs']
+        )['LocationArn']
+        self.destination_location_arn = self.client.create_location_s3(
+            **MOCK_DATA['create_destination_location_kwargs']
+        )['LocationArn']
+        self.task_arn = self.client.create_task(
+            SourceLocationArn=self.source_location_arn,
+            DestinationLocationArn=self.destination_location_arn
+        )['TaskArn']
+
+    def tearDown(self):
+        # Delete all tasks:
+        tasks = self.client.list_tasks()
+        for task in tasks['Tasks']:
+            self.client.delete_task(TaskArn=task['TaskArn'])
+        # Delete all locations:
+        locations = self.client.list_locations()
+        for location in locations['Locations']:
+            self.client.delete_location(LocationArn=location['LocationArn'])
+        self.client = None
+
+
+@mock_datasync
+@mock.patch.object(AWSDataSyncHook, 'get_conn')
+@unittest.skipIf(mock_datasync == no_datasync, 'moto datasync package missing')  # pylint: disable=W0143
+class TestAWSDataSyncCreateTaskOperator(AWSDataSyncTestCase):
+
+    def set_up_operator(
+        self,
+        source_location_uri=SOURCE_LOCATION_URI,
+        destination_location_uri=DESTINATION_LOCATION_URI
+    ):
+        # Create operator
+        self.datasync = AWSDataSyncCreateTaskOperator(
+            task_id='test_aws_datasync_create_task_operator',
+            dag=self.dag,
+            source_location_uri=source_location_uri,
+            destination_location_uri=destination_location_uri,
+            case_sensitive_location_search=True,
+            create_task_kwargs={'Options': {
+                'VerifyMode': 'NONE', 'Atime': 'NONE'}},
+            create_source_location_kwargs={
+                'Subdirectory': SOURCE_SUBDIR,
+                'ServerHostname': SOURCE_HOST_NAME,
+                'User': 'airflow',
+                'Password': 'airflow_password',
+                'AgentArns': ['some_agent']
+            },
+            create_destination_location_kwargs={
+                'S3BucketArn': DESTINATION_LOCATION_ARN,
+                'S3Config': {'BucketAccessRoleArn': 'myrole'},
+            }
+        )
+
+    def test_init(self, mock_get_conn):
+        self.set_up_operator()
+        # Airflow built-ins
+        self.assertEqual(self.datasync.task_id, MOCK_DATA['create_task_id'])
+        # Defaults
+        self.assertEqual(self.datasync.aws_conn_id, 'aws_default')
+        # Assignments
+        self.assertEqual(self.datasync.source_location_uri,
+                         MOCK_DATA['source_location_uri'])
+        self.assertEqual(self.datasync.destination_location_uri,
+                         MOCK_DATA['destination_location_uri'])
+        self.assertEqual(self.datasync.case_sensitive_location_search,
+                         MOCK_DATA['case_sensitive_location_search'])
+        self.assertEqual(self.datasync.create_task_kwargs,
+                         MOCK_DATA['create_task_kwargs'])
+        self.assertEqual(self.datasync.create_source_location_kwargs,
+                         MOCK_DATA['create_source_location_kwargs'])
+        self.assertEqual(self.datasync.create_destination_location_kwargs,
+                         MOCK_DATA['create_destination_location_kwargs'])
+
+    def test_init_fails(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(source_location_uri=None)
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(destination_location_uri=None)
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(
+                source_location_uri=None, destination_location_uri=None)
+
+    def test_create_task(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        # Delete all tasks:
+        tasks = self.client.list_tasks()
+        for task in tasks['Tasks']:
+            self.client.delete_task(TaskArn=task['TaskArn'])
+
+        # Check how many tasks and locations we have
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 0)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+        task_arn = result
+
+        # Assert 1 additional task and 0 additional locations
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 1)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        # Check task metadata
+        task = self.client.describe_task(TaskArn=task_arn)
+        self.assertEqual(task['Options'], CREATE_TASK_KWARGS['Options'])
+
+    def test_create_task_even_if_one_exists(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+
+        # Check how many tasks and locations we have
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 1)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+        task_arn = result
+
+        # Assert 1 additional task and 0 additional locations
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 2)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        # Check task metadata
+        task = self.client.describe_task(TaskArn=task_arn)
+        self.assertEqual(task['Options'], CREATE_TASK_KWARGS['Options'])
+
+    def test_create_task_and_location(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        # Delete all tasks:
+        tasks = self.client.list_tasks()
+        for task in tasks['Tasks']:
+            self.client.delete_task(TaskArn=task['TaskArn'])
+        # Delete all locations:
+        locations = self.client.list_locations()
+        for location in locations['Locations']:
+            self.client.delete_location(LocationArn=location['LocationArn'])
+
+        # Check how many tasks and locations we have
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 0)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 0)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+
+        # Assert 1 additional task and 2 additional locations
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 1)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+    def test_xcom_push(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        ti = TaskInstance(task=self.datasync, execution_date=timezone.utcnow())
+        ti.run()
+        xcom_result = ti.xcom_pull(
+            task_ids=self.datasync.task_id, key='return_value')
+        self.assertIsNotNone(xcom_result)
+
+
+@mock_datasync
+@mock.patch.object(AWSDataSyncHook, 'get_conn')
+@unittest.skipIf(mock_datasync == no_datasync, 'moto datasync package missing')  # pylint: disable=W0143
+class TestAWSDataSyncGetTasksOperator(AWSDataSyncTestCase):
+
+    def set_up_operator(
+        self,
+        source_location_uri=SOURCE_LOCATION_URI,
+        destination_location_uri=DESTINATION_LOCATION_URI
+    ):
+        # Create operator
+        self.datasync = AWSDataSyncGetTasksOperator(
+            task_id='test_aws_datasync_get_tasks_operator',
+            dag=self.dag,
+            source_location_uri=source_location_uri,
+            destination_location_uri=destination_location_uri,
+            case_sensitive_location_search=True
+        )
+
+    def test_init(self, mock_get_conn):
+        self.set_up_operator()
+        # Airflow built-ins
+        self.assertEqual(self.datasync.task_id, MOCK_DATA['get_task_id'])
+        # Defaults
+        self.assertEqual(self.datasync.aws_conn_id, 'aws_default')
+        # Assignments
+        self.assertEqual(self.datasync.source_location_uri,
+                         MOCK_DATA['source_location_uri'])
+        self.assertEqual(self.datasync.destination_location_uri,
+                         MOCK_DATA['destination_location_uri'])
+        self.assertEqual(self.datasync.case_sensitive_location_search,
+                         MOCK_DATA['case_sensitive_location_search'])
+
+    def test_init_fails(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(source_location_uri=None)
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(destination_location_uri=None)
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(
+                source_location_uri=None, destination_location_uri=None)
+
+    def test_get_no_location(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        locations = self.client.list_locations()
+        for location in locations['Locations']:
+            self.client.delete_location(LocationArn=location['LocationArn'])
+
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 0)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+        self.assertFalse(result)
+
+    def test_get_no_tasks2(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        tasks = self.client.list_tasks()
+        for task in tasks['Tasks']:
+            self.client.delete_task(TaskArn=task['TaskArn'])
+
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 0)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+        self.assertFalse(result)
+
+    def test_get_one_task(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        # Make sure we dont cheat
+        self.set_up_operator()
+        self.assertEqual(self.datasync.task_arns, None)
+
+        # Check how many tasks and locations we have
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 1)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+
+        task_arns = result
+        self.assertIsNotNone(task_arns)
+        self.assertTrue(task_arns)
+        self.assertEqual(len(task_arns), 1)
+        self.assertEqual(task_arns[0], self.task_arn)
+
+        # Assert 0 additional task and 0 additional locations
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 1)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+    def test_get_many_tasks(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+
+        self.client.create_task(
+            SourceLocationArn=self.source_location_arn,
+            DestinationLocationArn=self.destination_location_arn
+        )
+
+        # Check how many tasks and locations we have
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 2)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+
+        task_arns = result
+        self.assertIsNotNone(task_arns)
+        self.assertTrue(task_arns)
+        self.assertEqual(len(task_arns), 2)
+
+        # Assert 0 additional task and 0 additional locations
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 2)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+    def test_xcom_push(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        ti = TaskInstance(task=self.datasync, execution_date=timezone.utcnow())
+        ti.run()
+        self.assertEqual(
+            ti.xcom_pull(task_ids=self.datasync.task_id, key='return_value'),
+            [self.task_arn])
+
+
+@mock_datasync
+@mock.patch.object(AWSDataSyncHook, 'get_conn')
+@unittest.skipIf(mock_datasync == no_datasync, 'moto datasync package missing')  # pylint: disable=W0143
+class TestAWSDataSyncUpdateTaskOperator(AWSDataSyncTestCase):
+
+    def __init(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.datasync = None
+
+    def set_up_operator(
+        self,
+        task_arn='self',
+        update_task_kwargs='default'
+    ):
+        if task_arn == 'self':
+            task_arn = self.task_arn
+        if update_task_kwargs == 'default':
+            update_task_kwargs = {'Options': {
+                'VerifyMode': 'BEST_EFFORT', 'Atime': 'NONE'}}
+        # Create operator
+        self.datasync = AWSDataSyncUpdateTaskOperator(
+            task_id='test_aws_datasync_update_task_operator',
+            dag=self.dag,
+            task_arn=task_arn,
+            update_task_kwargs=update_task_kwargs,
+        )
+
+    def test_init(self, mock_get_conn):
+        self.set_up_operator()
+        # Airflow built-ins
+        self.assertEqual(self.datasync.task_id, MOCK_DATA['update_task_id'])
+        # Defaults
+        self.assertEqual(self.datasync.aws_conn_id, 'aws_default')
+        # Assignments
+        self.assertEqual(self.datasync.task_arn, self.task_arn)
+        self.assertEqual(self.datasync.update_task_kwargs,
+                         MOCK_DATA['update_task_kwargs'])
+
+    def test_init_fails(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(task_arn=None)
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(update_task_kwargs=None)
+
+    def test_update_task(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+
+        # Check task before update
+        task = self.client.describe_task(TaskArn=self.task_arn)
+        self.assertNotIn('Options', task)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result, self.task_arn)
+
+        self.assertIsNotNone(self.datasync.task_arn)
+        # Check it was updated
+        task = self.client.describe_task(TaskArn=self.task_arn)
+        self.assertEqual(task['Options'], UPDATE_TASK_KWARGS['Options'])
+
+    def test_xcom_push(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        ti = TaskInstance(task=self.datasync, execution_date=timezone.utcnow())
+        ti.run()
+        self.assertEqual(
+            ti.xcom_pull(task_ids=self.datasync.task_id, key='return_value'),
+            self.task_arn)
+
+
+@mock_datasync
+@mock.patch.object(AWSDataSyncHook, 'get_conn')
+@unittest.skipIf(mock_datasync == no_datasync, 'moto datasync package missing')  # pylint: disable=W0143
+class TestAWSDataSyncTaskOperator(AWSDataSyncTestCase):
+
+    def set_up_operator(
+        self,
+        task_arn='self'
+    ):
+        if task_arn == 'self':
+            task_arn = self.task_arn
+        # Create operator
+        self.datasync = AWSDataSyncTaskOperator(
+            task_id='test_aws_datasync_task_operator',
+            dag=self.dag,
+            wait_interval_seconds=0,
+            task_arn=task_arn
+        )
+
+    def test_init(self, mock_get_conn):
+        self.set_up_operator()
+        # Airflow built-ins
+        self.assertEqual(self.datasync.task_id, MOCK_DATA['task_id'])
+        # Defaults
+        self.assertEqual(self.datasync.aws_conn_id, 'aws_default')
+        self.assertEqual(self.datasync.wait_interval_seconds, 0)
+        # Assignments
+        self.assertEqual(self.datasync.task_arn, self.task_arn)
+
+    def test_init_fails(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(task_arn=None)
+
+    def test_execute_task(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        # Configure the Operator with the specific task_arn
+        self.set_up_operator()
+        self.assertEqual(self.datasync.task_arn, self.task_arn)
+
+        # Check how many tasks and locations we have
+        tasks = self.client.list_tasks()
+        len_tasks_before = len(tasks['Tasks'])
+        locations = self.client.list_locations()
+        len_locations_before = len(locations['Locations'])
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+        task_execution_arn = result
+        self.assertIsNotNone(task_execution_arn)
+
+        # Assert 0 additional task and 0 additional locations
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), len_tasks_before)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), len_locations_before)
+
+        # Check with the DataSync client what happened
+        task_execution = self.client.describe_task_execution(
+            TaskExecutionArn=task_execution_arn)
+        self.assertEqual(task_execution['Status'], 'SUCCESS')
+
+        # Insist that this specific task was executed, not anything else
+        task_execution_arn = task_execution['TaskExecutionArn']
+        # format of task_execution_arn:
+        # arn:aws:datasync:us-east-1:111222333444:task/task-00000000000000003/execution/exec-00000000000000004
+        # format of task_arn:
+        # arn:aws:datasync:us-east-1:111222333444:task/task-00000000000000003
+        self.assertEqual(
+            '/'.join(task_execution_arn.split('/')[:2]), self.task_arn)
+
+    @mock.patch.object(AWSDataSyncHook, 'wait_for_task_execution')
+    def test_failed_task(self, mock_wait, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        mock_wait.return_value = False
+        # ### Begin tests:
+
+        self.set_up_operator()
+
+        # Execute the task
+        with self.assertRaises(AirflowException):
+            self.datasync.execute(None)
+
+    @mock.patch.object(AWSDataSyncHook, 'wait_for_task_execution')
+    def test_killed_task(self, mock_wait, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        # Kill the task when doing wait_for_task_execution
+        def kill_task(*args):
+            self.datasync.on_kill()
+            return True
+        mock_wait.side_effect = kill_task
+
+        self.set_up_operator()
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+
+        task_execution_arn = result
+        self.assertIsNotNone(task_execution_arn)
+
+        # Verify the task was killed
+        task = self.client.describe_task(TaskArn=self.task_arn)
+        self.assertEqual(task['Status'], 'AVAILABLE')
+        task_execution = self.client.describe_task_execution(
+            TaskExecutionArn=task_execution_arn)
+        self.assertEqual(task_execution['Status'], 'ERROR')
+
+    def test_xcom_push(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        ti = TaskInstance(task=self.datasync, execution_date=timezone.utcnow())
+        ti.run()
+        xcom_result = ti.xcom_pull(
+            task_ids=self.datasync.task_id, key='return_value')
+        self.assertIsNotNone(xcom_result)
+
+
+@mock_datasync
+@mock.patch.object(AWSDataSyncHook, 'get_conn')
+@unittest.skipIf(mock_datasync == no_datasync, 'moto datasync package missing')  # pylint: disable=W0143
+class TestAWSDataSyncDeleteTaskOperator(AWSDataSyncTestCase):
+
+    def set_up_operator(
+        self,
+        task_arn='self'
+    ):
+        if task_arn == 'self':
+            task_arn = self.task_arn
+        # Create operator
+        self.datasync = AWSDataSyncDeleteTaskOperator(
+            task_id='test_aws_datasync_delete_task_operator',
+            dag=self.dag,
+            task_arn=task_arn
+        )
+
+    def test_init(self, mock_get_conn):
+        self.set_up_operator()
+        # Airflow built-ins
+        self.assertEqual(self.datasync.task_id, MOCK_DATA['delete_task_id'])
+        # Defaults
+        self.assertEqual(self.datasync.aws_conn_id, 'aws_default')
+        # Assignments
+        self.assertEqual(self.datasync.task_arn, self.task_arn)
+
+    def test_init_fails(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        with self.assertRaises(AirflowException):
+            self.set_up_operator(task_arn=None)
+
+    def test_delete_task(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+
+        # Check how many tasks and locations we have
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 1)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+        # Execute the task
+        result = self.datasync.execute(None)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, self.task_arn)
+
+        # Assert -1 additional task and 0 additional locations
+        tasks = self.client.list_tasks()
+        self.assertEqual(len(tasks['Tasks']), 0)
+        locations = self.client.list_locations()
+        self.assertEqual(len(locations['Locations']), 2)
+
+    def test_xcom_push(self, mock_get_conn):
+        # ### Set up mocks:
+        mock_get_conn.return_value = self.client
+        # ### Begin tests:
+
+        self.set_up_operator()
+        ti = TaskInstance(task=self.datasync, execution_date=timezone.utcnow())
+        ti.run()
+        self.assertEqual(
+            ti.xcom_pull(task_ids=self.datasync.task_id, key='return_value'),
+            self.task_arn)

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -133,6 +133,10 @@ HOOK = [
         "airflow.contrib.hooks.aws_athena_hook.AWSAthenaHook",
     ),
     (
+        "airflow.providers.amazon.aws.hooks.datasync.AWSDataSyncHook",
+        "airflow.contrib.hooks.aws_datasync_hook.AWSDataSyncHook",
+    ),
+    (
         "airflow.providers.amazon.aws.hooks.s3.S3Hook",
         "airflow.hooks.S3_hook.S3Hook",
     ),


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira
- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  
### Description
- [x] Here are some details about my PR:

Added AWS DataSync Hook and Operator, along with appropriate tests and documentation.

### Tests
- [x] My PR adds the following unit tests:

Tests added for both new components (DataSync hook + operator).

The tests require the moto Python library, specifically moto_datasync. 
I only recently added moto_datasync to moto, so the Airflow tests for AWS DataSync will be skipped if moto_datasync is not present. 
However all tests pass on my local copy of moto which includes moto_datasync


### Commits
- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
