### PR TITLE
[AIRFLOW-5869] BugFix: Creating DagRuns fails for Deserialized tasks …

### DIFF
--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -82,6 +82,7 @@
         "max_active_runs": { "type" : "number"},
         "default_args": { "$ref": "#/definitions/dict" },
         "start_date": { "$ref": "#/definitions/datetime" },
+        "end_date": { "$ref": "#/definitions/datetime" },
         "dagrun_timeout": { "$ref": "#/definitions/timedelta" },
         "doc_md": { "type" : "string"}
       },

--- a/airflow/serialization/serialized_dag.py
+++ b/airflow/serialization/serialized_dag.py
@@ -120,6 +120,11 @@ class SerializedDAG(DAG, Serialization):
         for task in dag.task_dict.values():
             task.dag = dag
             task = cast(SerializedBaseOperator, task)
+
+            for date_attr in ["start_date", "end_date"]:
+                if getattr(task, date_attr) is None:
+                    setattr(task, date_attr, getattr(dag, date_attr))
+
             if task.subdag is not None:
                 setattr(task.subdag, 'parent_dag', dag)
                 task.subdag.is_subdag = True


### PR DESCRIPTION
…with no start_date

Make sure you have checked _all_ steps below.

### Jira
  - https://issues.apache.org/jira/browse/AIRFLOW-5869


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Deserialized operators do not always have start_date set.

That, for instance, breaks triggering dags.

See the code from DAG.create_dagrun():
```
        run = DagRun(...)
        session.add(run)
        session.commit()

        run.dag = self
        run.verify_integrity(session=session) # this validation fails because run assumes that all operators have start_date set
        run.refresh_from_db()
```
One of the optimisation (https://github.com/coufon/airflow/commit/b5ee858f44f55818c589cf2c8bf3866fa5d50e30) we did as part of DAG Serialization was to not store dates in tasks if they have a matching date (start_date or end_date) in DAG. Unfortunately, when triggering DAG containing such tasks, it fails on DagRun.run.verify_integrity.

The fix is to add the start_date when deserializing the operator.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* `test_deserialization_start_date`
* `test_deserialization_end_date `
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
