### PR TITLE
[AIRFLOW-5870] Allow -1 for infinite pool size

### DIFF
--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy import Column, Integer, String, Text, func
 
 from airflow.models.base import Base
 from airflow.ti_deps.deps.pool_slots_available_dep import STATES_TO_COUNT_AS_RUNNING
@@ -30,6 +30,7 @@ class Pool(Base):
 
     id = Column(Integer, primary_key=True)
     pool = Column(String(50), unique=True)
+    # -1 for infinite
     slots = Column(Integer, default=0)
     description = Column(Text)
 
@@ -64,10 +65,10 @@ class Pool(Base):
         from airflow.models.taskinstance import TaskInstance  # Avoid circular import
         return (
             session
-            .query(TaskInstance)
+            .query(func.count())
             .filter(TaskInstance.pool == self.pool)
             .filter(TaskInstance.state.in_(STATES_TO_COUNT_AS_RUNNING))
-            .count()
+            .scalar()
         )
 
     @provide_session
@@ -79,10 +80,10 @@ class Pool(Base):
 
         running = (
             session
-            .query(TaskInstance)
+            .query(func.count())
             .filter(TaskInstance.pool == self.pool)
             .filter(TaskInstance.state == State.RUNNING)
-            .count()
+            .scalar()
         )
         return running
 
@@ -95,10 +96,10 @@ class Pool(Base):
 
         return (
             session
-            .query(TaskInstance)
+            .query(func.count())
             .filter(TaskInstance.pool == self.pool)
             .filter(TaskInstance.state == State.QUEUED)
-            .count()
+            .scalar()
         )
 
     @provide_session
@@ -106,4 +107,7 @@ class Pool(Base):
         """
         Returns the number of slots open at the moment
         """
-        return self.slots - self.occupied_slots(session)
+        if self.slots == -1:
+            return float('inf')
+        else:
+            return self.slots - self.occupied_slots(session)

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -65,6 +65,30 @@ class TestPool(unittest.TestCase):
         self.assertEqual(1, pool.queued_slots())
         self.assertEqual(2, pool.occupied_slots())
 
+    def test_infinite_slots(self):
+        pool = Pool(pool='test_pool', slots=-1)
+        dag = DAG(
+            dag_id='test_infinite_slots',
+            start_date=DEFAULT_DATE, )
+        t1 = DummyOperator(task_id='dummy1', dag=dag, pool='test_pool')
+        t2 = DummyOperator(task_id='dummy2', dag=dag, pool='test_pool')
+        ti1 = TI(task=t1, execution_date=DEFAULT_DATE)
+        ti2 = TI(task=t2, execution_date=DEFAULT_DATE)
+        ti1.state = State.RUNNING
+        ti2.state = State.QUEUED
+
+        session = settings.Session
+        session.add(pool)
+        session.add(ti1)
+        session.add(ti2)
+        session.commit()
+        session.close()
+
+        self.assertEqual(float('inf'), pool.open_slots())
+        self.assertEqual(1, pool.used_slots())
+        self.assertEqual(1, pool.queued_slots())
+        self.assertEqual(2, pool.occupied_slots())
+
     def test_default_pool_open_slots(self):
         set_default_pool_slots(5)
         self.assertEqual(5, Pool.get_default_pool().open_slots())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5870
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description
Adds the ability to create pools with size=-1, allowing infinite task usage, and allowing the used_slots to return without a db query.

To contextualize this change, we saw spiky DB queries since this has to query all RUNNING task instances, and each task instance that starts running needs to run this query, leading to an n^2 problem. 
- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: add test_infinite_slots

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
