### PR TITLE
[AIRFLOW-5873] KubernetesPodOperator fixes and test

### DIFF
--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -17,6 +17,8 @@
 
 
 class Resources:
+    __slots__ = ('request_memory', 'request_cpu', 'limit_memory', 'limit_cpu', 'limit_gpu')
+
     def __init__(
             self,
             request_memory=None,

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -15,11 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """Executes task in a Kubernetes POD"""
+import re
+import warnings
+
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.contrib.kubernetes import kube_client, pod_generator, pod_launcher
 from airflow.contrib.kubernetes.pod import Resources
+from airflow.utils.helpers import validate_key
 from airflow.utils.state import State
 
 
@@ -27,79 +31,84 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     """
     Execute a task in a Kubernetes Pod
 
-    :param image: Docker image you wish to launch. Defaults to dockerhub.io,
-        but fully qualified URLS will point to custom repositories
+    :param image: Docker image you wish to launch. Defaults to hub.docker.com,
+        but fully qualified URLS will point to custom repositories.
     :type image: str
-    :param namespace: the namespace to run within kubernetes
+    :param namespace: the namespace to run within kubernetes.
     :type namespace: str
     :param cmds: entrypoint of the container. (templated)
-        The docker images's entrypoint is used if this is not provide.
+        The docker images's entrypoint is used if this is not provided.
     :type cmds: list[str]
     :param arguments: arguments of the entrypoint. (templated)
         The docker image's CMD is used if this is not provided.
     :type arguments: list[str]
-    :param image_pull_policy: Specify a policy to cache or always pull an image
+    :param image_pull_policy: Specify a policy to cache or always pull an image.
     :type image_pull_policy: str
     :param image_pull_secrets: Any image pull secrets to be given to the pod.
                                If more than one secret is required, provide a
                                comma separated list: secret_a,secret_b
     :type image_pull_secrets: str
-    :param ports: ports for launched pod
+    :param ports: ports for launched pod.
     :type ports: list[airflow.contrib.kubernetes.pod.Port]
-    :param volume_mounts: volumeMounts for launched pod
+    :param volume_mounts: volumeMounts for launched pod.
     :type volume_mounts: list[airflow.contrib.kubernetes.volume_mount.VolumeMount]
-    :param volumes: volumes for launched pod. Includes ConfigMaps and PersistentVolumes
+    :param volumes: volumes for launched pod. Includes ConfigMaps and PersistentVolumes.
     :type volumes: list[airflow.contrib.kubernetes.volume.Volume]
-    :param labels: labels to apply to the Pod
+    :param labels: labels to apply to the Pod.
     :type labels: dict
-    :param startup_timeout_seconds: timeout in seconds to startup the pod
+    :param startup_timeout_seconds: timeout in seconds to startup the pod.
     :type startup_timeout_seconds: int
-    :param name: name of the task you want to run,
-        will be used to generate a pod id
+    :param name: name of the pod in which the task will run, will be used to
+        generate a pod id (DNS-1123 subdomain, containing only [a-z0-9.-]).
     :type name: str
     :param env_vars: Environment variables initialized in the container. (templated)
     :type env_vars: dict
-    :param secrets: Kubernetes secrets to inject in the container,
-        They can be exposed as environment vars or files in a volume.
+    :param secrets: Kubernetes secrets to inject in the container.
+        They can be exposed as environment vars or files in a volume
     :type secrets: list[airflow.contrib.kubernetes.secret.Secret]
-    :param in_cluster: run kubernetes client with in_cluster configuration
+    :param in_cluster: run kubernetes client with in_cluster configuration.
     :type in_cluster: bool
     :param cluster_context: context that points to kubernetes cluster.
         Ignored when in_cluster is True. If None, current-context is used.
     :type cluster_context: str
-    :param get_logs: get the stdout of the container as logs of the tasks
+    :param get_logs: get the stdout of the container as logs of the tasks.
     :type get_logs: bool
     :param annotations: non-identifying metadata you can attach to the Pod.
                         Can be a large range of data, and can include characters
                         that are not permitted by labels.
     :type annotations: dict
-    :param resources: A dict containing a group of resources requests and limits
+    :param resources: A dict containing resources requests and limits.
+        Possible keys are request_memory, request_cpu, limit_memory, limit_cpu,
+        and limit_gpu, which will be used to generate airflow.kubernetes.pod.Resources.
+        See also kubernetes.io/docs/concepts/configuration/manage-compute-resources-container
     :type resources: dict
-    :param affinity: A dict containing a group of affinity scheduling rules
+    :param affinity: A dict containing a group of affinity scheduling rules.
     :type affinity: dict
-    :param node_selectors: A dict containing a group of scheduling rules
+    :param node_selectors: A dict containing a group of scheduling rules.
     :type node_selectors: dict
-    :param config_file: The path to the Kubernetes config file
+    :param config_file: The path to the Kubernetes config file. (templated)
     :type config_file: str
-    :param xcom_push: If xcom_push is True, the content of the file
+    :param do_xcom_push: If do_xcom_push is True, the content of the file
         /airflow/xcom/return.json in the container will also be pushed to an
         XCom when the container completes.
-    :type xcom_push: bool
+    :type do_xcom_push: bool
     :param is_delete_operator_pod: What to do when the pod reaches its final
         state, or the execution is interrupted.
         If False (default): do nothing, If True: delete the pod
     :type is_delete_operator_pod: bool
-    :param hostnetwork: If True enable host networking on the pod
+    :param hostnetwork: If True enable host networking on the pod.
     :type hostnetwork: bool
-    :param tolerations: A list of kubernetes tolerations
+    :param tolerations: A list of kubernetes tolerations.
     :type tolerations: list tolerations
     :param configmaps: A list of configmap names objects that we
-        want mount as env variables
+        want mount as env variables.
     :type configmaps: list[str]
     :param pod_runtime_info_envs: environment variables about
-                                  pod runtime information (ip, namespace, nodeName, podName)
+                                  pod runtime information (ip, namespace, nodeName, podName).
     :type pod_runtime_info_envs: list[PodRuntimeEnv]
-    :param dnspolicy: Specify a dnspolicy for the pod
+    :param security_context: security options the pod should run with (PodSecurityContext).
+    :type security_context: dict
+    :param dnspolicy: dnspolicy for the pod.
     :type dnspolicy: str
     """
     template_fields = ('cmds', 'arguments', 'env_vars', 'config_file')
@@ -144,7 +153,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
             pod.dnspolicy = self.dnspolicy
 
             launcher = pod_launcher.PodLauncher(kube_client=client,
-                                                extract_xcom=self.xcom_push)
+                                                extract_xcom=self.do_xcom_push)
             try:
                 (final_state, result) = launcher.run_pod(
                     pod,
@@ -158,17 +167,17 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                 raise AirflowException(
                     'Pod returned a failure: {state}'.format(state=final_state)
                 )
-            if self.xcom_push:
+            if self.do_xcom_push:
                 return result
         except AirflowException as ex:
             raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
 
     def _set_resources(self, resources):
-        inputResource = Resources()
-        if resources:
-            for item in resources.keys():
-                setattr(inputResource, item, resources[item])
-        return inputResource
+        return Resources(**resources) if resources else Resources()
+
+    def _set_name(self, name):
+        validate_key(name, max_length=63)
+        return re.sub(r'[^a-z0-9.-]+', '-', name.lower())
 
     @apply_defaults
     def __init__(self,  # pylint: disable=too-many-arguments,too-many-locals
@@ -182,7 +191,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  volumes=None,
                  env_vars=None,
                  secrets=None,
-                 in_cluster=False,
+                 in_cluster=True,
                  cluster_context=None,
                  labels=None,
                  startup_timeout_seconds=120,
@@ -192,10 +201,9 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  resources=None,
                  affinity=None,
                  config_file=None,
-                 xcom_push=False,
                  node_selectors=None,
                  image_pull_secrets=None,
-                 service_account_name="default",
+                 service_account_name='default',
                  is_delete_operator_pod=False,
                  hostnetwork=False,
                  tolerations=None,
@@ -205,14 +213,21 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  dnspolicy=None,
                  *args,
                  **kwargs):
-        super(KubernetesPodOperator, self).__init__(*args, **kwargs)
+        # https://github.com/apache/airflow/blob/2d0eff4ee4fafcf8c7978ac287a8fb968e56605f/UPDATING.md#unification-of-do_xcom_push-flag
+        if kwargs.get('xcom_push') is not None:
+            kwargs['do_xcom_push'] = kwargs.pop('xcom_push')
+            warnings.warn(
+                "`xcom_push` will be deprecated. Use `do_xcom_push` instead.",
+                DeprecationWarning, stacklevel=2
+            )
+        super(KubernetesPodOperator, self).__init__(*args, resources=None, **kwargs)
         self.image = image
         self.namespace = namespace
         self.cmds = cmds or []
         self.arguments = arguments or []
         self.labels = labels or {}
         self.startup_timeout_seconds = startup_timeout_seconds
-        self.name = name
+        self.name = self._set_name(name)
         self.env_vars = env_vars or {}
         self.ports = ports or []
         self.volume_mounts = volume_mounts or []
@@ -225,7 +240,6 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.node_selectors = node_selectors or {}
         self.annotations = annotations or {}
         self.affinity = affinity or {}
-        self.xcom_push = xcom_push
         self.resources = self._set_resources(resources)
         self.config_file = config_file
         self.image_pull_secrets = image_pull_secrets

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -385,7 +385,7 @@ class BaseOperator(LoggingMixin):
                         d=dag.dag_id if dag else "", t=task_id, tr=weight_rule))
         self.weight_rule = weight_rule
 
-        self.resources = Resources(*resources) if resources is not None else None
+        self.resources = Resources(**resources) if resources is not None else None
         self.run_as_user = run_as_user
         self.task_concurrency = task_concurrency
         self.executor_config = executor_config or {}

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -50,7 +50,7 @@ DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM = conf.getint(
     'core', 'KILLED_TASK_CLEANUP_TIME'
 )
 
-KEY_REGEX = re.compile(r'^[\w\-\.]+$')
+KEY_REGEX = re.compile(r'^[\w.-]+$')
 
 
 def validate_key(k, max_length=250):

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -777,7 +777,9 @@ function build_image_on_ci() {
     echo "Finding changed file names ${TRAVIS_BRANCH}...HEAD"
     echo
 
-    CHANGED_FILE_NAMES=$(git diff --name-only "${TRAVIS_BRANCH}...HEAD")
+    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    git fetch origin "${TRAVIS_BRANCH}"
+    CHANGED_FILE_NAMES=$(git diff --name-only "remotes/origin/${TRAVIS_BRANCH}...HEAD")
     echo
     echo "Changed file names in this commit"
     echo "${CHANGED_FILE_NAMES}"

--- a/tests/integration/kubernetes/test_kubernetes_pod_operator.py
+++ b/tests/integration/kubernetes/test_kubernetes_pod_operator.py
@@ -97,7 +97,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
-            config_file=new_config_path
+            in_cluster=False,
+            do_xcom_push=False,
+            config_file=new_config_path,
         )
         k.execute(None)
 
@@ -117,7 +119,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             task_id="task",
             config_file=file_path,
             in_cluster=False,
-            cluster_context='default'
+            do_xcom_push=False,
+            cluster_context='default',
         )
         launcher_mock.return_value = (State.SUCCESS, None)
         k.execute(None)
@@ -143,7 +146,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             task_id="task",
             image_pull_secrets=fake_pull_secrets,
             in_cluster=False,
-            cluster_context='default'
+            do_xcom_push=False,
+            cluster_context='default',
         )
         mock_launcher.return_value = (State.SUCCESS, None)
         k.execute(None)
@@ -163,8 +167,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
             name="test",
             task_id="task",
             in_cluster=False,
+            do_xcom_push=False,
             cluster_context='default',
-            is_delete_operator_pod=True
+            is_delete_operator_pod=True,
         )
         run_pod_mock.side_effect = AirflowException('fake failure')
         with self.assertRaises(AirflowException):
@@ -179,7 +184,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task"
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
         )
         k.execute(None)
 
@@ -192,7 +199,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
-            is_delete_operator_pod=True
+            is_delete_operator_pod=True,
+            in_cluster=False,
+            do_xcom_push=False,
         )
         k.execute(None)
 
@@ -205,7 +214,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
-            hostnetwork=True
+            in_cluster=False,
+            do_xcom_push=False,
+            hostnetwork=True,
         )
         k.execute(None)
 
@@ -219,8 +230,10 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             hostnetwork=True,
-            dnspolicy=dns_policy
+            dnspolicy=dns_policy,
         )
         k.execute(None)
 
@@ -236,20 +249,18 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             node_selectors=node_selectors,
         )
         k.execute(None)
 
     def test_pod_resources(self):
         resources = {
-            'limits': {
-                'cpu': '250m',
-                'memory': '64Mi',
-            },
-            'requests': {
-                'cpu': '250m',
-                'memory': '64Mi',
-            }
+            'limit_cpu': 0.25,
+            'limit_memory': '64Mi',
+            'request_cpu': '250m',
+            'request_memory': '64Mi',
         }
         k = KubernetesPodOperator(
             namespace='default',
@@ -259,6 +270,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             resources=resources,
         )
         k.execute(None)
@@ -289,6 +302,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             affinity=affinity,
         )
         k.execute(None)
@@ -304,7 +319,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
-            ports=[port]
+            in_cluster=False,
+            do_xcom_push=False,
+            ports=[port],
         )
         k.execute(None)
 
@@ -332,7 +349,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
                 volume_mounts=[volume_mount],
                 volumes=[volume],
                 name="test",
-                task_id="task"
+                task_id="task",
+                in_cluster=False,
+                do_xcom_push=False,
             )
             k.execute(None)
             mock_logger.info.assert_any_call(b"retrieved from mount\n")
@@ -351,6 +370,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             security_context=security_context,
         )
         k.execute(None)
@@ -370,6 +391,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             security_context=security_context,
         )
         k.execute(None)
@@ -389,6 +412,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             security_context=security_context,
         )
         k.execute(None)
@@ -403,6 +428,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             startup_timeout_seconds=5
         )
         with self.assertRaises(AirflowException):
@@ -418,6 +445,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             startup_timeout_seconds=5,
             service_account_name=bad_service_account_name
         )
@@ -436,7 +465,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
             arguments=bad_internal_command,
             labels={"foo": "bar"},
             name="test",
-            task_id="task"
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
         )
         with self.assertRaises(AirflowException):
             k.execute(None)
@@ -452,7 +483,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
-            xcom_push=True
+            in_cluster=False,
+            do_xcom_push=True,
         )
         self.assertEqual(k.execute(None), json.loads(return_value))
 
@@ -471,6 +503,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
             configmaps=configmaps
         )
         # THEN
@@ -495,6 +529,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             labels={"foo": "bar"},
             name="test",
             task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
         )
         # THEN
         mock_launcher.return_value = (State.SUCCESS, None)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-5873

### Description

- `KubernetesPodOperator` kwarg `resources` is erroneously passed to `base_operator`, instead should only go to `PodGenerator`. The two have different syntax. (both on `master` and `v1-10-test` branches)
- `kubernetes/pod.py`: `Resources` does not have `__slots__` so accepts arbitrary values in `setattr` (present on `v1-10-test` branch https://github.com/apache/airflow/blame/50343040ff4679e32e01f138ead80bc4bcef4b47/airflow/contrib/operators/kubernetes_pod_operator.py#L166-L171)
- `KubernetesPodOperator` kwarg `in_cluster` erroneously defaults to False in comparison to `default_args.py`, also default `do_xcom_push` was overwritten to False in contradiction to `BaseOperator`
- `v1-10-test` is behind `master` with KubernetesPodOperator fixes and refactors **(will not be addressed in this PR,)**
  - e.g. ~~move kubernetes folder one level up from `/contrib`~~ https://github.com/apache/airflow/blame/4dd24a2c595d4042ffe745aed947eaaea6abb652/airflow/contrib/operators/kubernetes_pod_operator.py#L21
  - ~~fix `xcom_push` to `do_xcom_push`~~ https://github.com/apache/airflow/blame/4dd24a2c595d4042ffe745aed947eaaea6abb652/airflow/contrib/operators/kubernetes_pod_operator.py#L90

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`contrib/operators/test_kubernetes_pod_operator.py`

<!-- ### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release -->
