### PR TITLE
[AIRFLOW-5873] KubernetesPodOperator fixes and test

### DIFF
--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -40,6 +40,8 @@ class Resources(K8SModel):
     :param limit_gpu: Limits for GPU used
     :type limit_gpu: int
     """
+    __slots__ = ('request_memory', 'request_cpu', 'limit_memory', 'limit_cpu', 'limit_gpu')
+
     def __init__(
             self,
             request_memory=None,
@@ -82,6 +84,8 @@ class Resources(K8SModel):
 
 class Port(K8SModel):
     """POD port"""
+    __slots__ = ('name', 'container_port')
+
     def __init__(
             self,
             name=None,

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -238,7 +238,6 @@ class PodGenerator:
             requests = {
                 'cpu': namespaced.get('request_cpu'),
                 'memory': namespaced.get('request_memory')
-
             }
             limits = {
                 'cpu': namespaced.get('limit_cpu'),

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -44,7 +44,7 @@ DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM = conf.getint(
     'core', 'KILLED_TASK_CLEANUP_TIME'
 )
 
-KEY_REGEX = re.compile(r'^[\w\-\.]+$')
+KEY_REGEX = re.compile(r'^[\w.-]+$')
 
 
 def validate_key(k, max_length=250):

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -863,7 +863,9 @@ function build_image_on_ci() {
     echo "Finding changed file names ${TRAVIS_BRANCH}...HEAD"
     echo
 
-    CHANGED_FILE_NAMES=$(git diff --name-only "${TRAVIS_BRANCH}...HEAD")
+    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    git fetch origin "${TRAVIS_BRANCH}"
+    CHANGED_FILE_NAMES=$(git diff --name-only "remotes/origin/${TRAVIS_BRANCH}...HEAD")
     echo
     echo "Changed file names in this commit"
     echo "${CHANGED_FILE_NAMES}"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-5873

### Description

This PR implements the same as #6523 but is adapted to `master` branch:

- `KubernetesPodOperator` kwarg `resources` is erroneously passed to `base_operator`, instead should only go to `PodGenerator`. The two have different syntax. (both on `master` and `v1-10-test` branches)
- `resources` passed to PodGenerator [should be `k8s.V1ResourceRequirements`](https://github.com/kubernetes-client/python/blob/c4883541465fe6a276365bb3e3dfee34c4e0c296/kubernetes/client/models/v1_container.py#L45), which is now handled in `KubernetesPodOperator`
- `kubernetes/pod.py`: `Resources` does not have `__slots__` so accepts arbitrary values in `setattr` (not present on either branch https://github.com/apache/airflow/blame/50343040ff4679e32e01f138ead80bc4bcef4b47/airflow/contrib/operators/kubernetes_pod_operator.py#L166-L171)
- `KubernetesPodOperator` kwarg `in_cluster` erroneously defaults to False in comparison to `default_args.py`, also default `do_xcom_push` was overwritten to False in contradiction to `BaseOperator`
- Reduce amount of times the pod object is copied before execution
- `v1-10-test` is behind `master` with KubernetesPodOperator fixes and refactors **(will not be addressed in this PR,)**
  - e.g. ~~move kubernetes folder one level up from `/contrib`~~ https://github.com/apache/airflow/blame/4dd24a2c595d4042ffe745aed947eaaea6abb652/airflow/contrib/operators/kubernetes_pod_operator.py#L21
  - ~~fix `xcom_push` to `do_xcom_push`~~ https://github.com/apache/airflow/blame/4dd24a2c595d4042ffe745aed947eaaea6abb652/airflow/contrib/operators/kubernetes_pod_operator.py#L90

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`contrib/operators/test_kubernetes_pod_operator.py`

<!-- ### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release -->
