### PR TITLE
[AIRFLOW-5882] Add ti_dep for not being in the RUNNING state

### DIFF
--- a/airflow/ti_deps/dep_context.py
+++ b/airflow/ti_deps/dep_context.py
@@ -25,6 +25,7 @@ from airflow.ti_deps.deps.exec_date_after_start_date_dep import ExecDateAfterSta
 from airflow.ti_deps.deps.pool_slots_available_dep import PoolSlotsAvailableDep
 from airflow.ti_deps.deps.runnable_exec_date_dep import RunnableExecDateDep
 from airflow.ti_deps.deps.task_concurrency_dep import TaskConcurrencyDep
+from airflow.ti_deps.deps.task_not_running_dep import TaskNotRunningDep
 from airflow.ti_deps.deps.valid_state_dep import ValidStateDep
 from airflow.utils.state import State
 
@@ -121,6 +122,7 @@ BACKFILL_QUEUEABLE_STATES = {
 SCHEDULED_DEPS = {
     RunnableExecDateDep(),
     ValidStateDep(SCHEDULEABLE_STATES),
+    TaskNotRunningDep(),
 }
 
 # Dependencies that if met, task instance should be re-queued.
@@ -137,12 +139,14 @@ RUNNING_DEPS = {
     DagTISlotsAvailableDep(),
     TaskConcurrencyDep(),
     PoolSlotsAvailableDep(),
+    TaskNotRunningDep(),
 }
 
 BACKFILL_QUEUED_DEPS = {
     RunnableExecDateDep(),
     ValidStateDep(BACKFILL_QUEUEABLE_STATES),
     DagrunRunningDep(),
+    TaskNotRunningDep(),
 }
 
 # TODO(aoen): SCHEDULER_QUEUED_DEPS is not coupled to actual scheduling/execution
@@ -169,4 +173,5 @@ SCHEDULER_QUEUED_DEPS = {
     DagrunIdDep(),
     DagUnpausedDep(),
     ExecDateAfterStartDateDep(),
+    TaskNotRunningDep(),
 }

--- a/tests/ti_deps/deps/test_task_not_running_dep.py
+++ b/tests/ti_deps/deps/test_task_not_running_dep.py
@@ -16,6 +16,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-Implementation of specific dependencies for tasks.
-"""
+
+import unittest
+from datetime import datetime
+from unittest.mock import Mock
+
+from airflow.ti_deps.deps.task_not_running_dep import TaskNotRunningDep
+from airflow.utils.state import State
+
+
+class TestTaskNotRunningDep(unittest.TestCase):
+
+    def test_not_running_state(self):
+        ti = Mock(state=State.QUEUED, end_date=datetime(2016, 1, 1))
+        self.assertTrue(TaskNotRunningDep().is_met(ti=ti))
+
+    def test_running_state(self):
+        ti = Mock(state=State.RUNNING, end_date=datetime(2016, 1, 1))
+        self.assertFalse(TaskNotRunningDep().is_met(ti=ti))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5882
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This ti_state dep should not be ignoreable as it would allow double-run in the "ideal" situation and in the current situation it causes both tasks to die. Due to celery visibility timeout, the task will always kill itself eventually
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
will fix existing unit tests if they exist
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
