### PR TITLE
[AIRFLOW-5888] Use psycopg2-binary for postgres operations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ password = [
     'flask-bcrypt>=0.7.1',
 ]
 pinot = ['pinotdb==0.1.1']
-postgres = ['psycopg2>=2.7.4,<2.8']
+postgres = ['psycopg2-binary>=2.7.4']
 qds = ['qds-sdk>=1.10.4']
 rabbitmq = ['librabbitmq>=1.6.1']
 redis = ['redis~=3.2']


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5888
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This requirement was pinned as of #5036, as related to a breaking change with respect to the package namespace. This PR modifies which package to refer to - prior to 2.8 the package was a binary wheel, but with 2.8+ the appropriate installation package is `psycopg2-binary`

### Explanation:
[Full explanation here](http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/)
For most of psycopg2's history, they had distributed pre-compiled binaries (or "wheels") which would get installed when you did `pip install psycopg2` (rather than compiling the source code upon installation). At some point psycopg2 found that there were some segfault issues that were appearing in the pre-compiled versions. Granted, this could be fixed if you installed by explicitly saying you wanted to compile from source rather than retrieve the binary version, but the psycopg2 devs felt that this would be better addressed by publishing a separate package that was the pre-compiled binary, while keeping the original package as compile-from-source only. The upshot of this is that everyone who was used to installing `psycopg2` and getting the pre-compiled binaries was now having to compile the package on install unless they moved over to `psycopg2-binary` instead. The packages are effectively the same, only the pre-compiled versions are usually more optimized, run quicker on the systems they're build for, and don't require compilation dependencies to install. So, in accordance with the warning provided by psycopg2 (`UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead.`), I've swapping this over to psycopg2-binary.

I've also confirmed that `psycopg2-binary` is available from `2.7.4` onwards:

```bash
$ pip install psycopg2-binary==
Collecting psycopg2-binary==
  ERROR: Could not find a version that satisfies the requirement psycopg2-binary== (from versions: 2.7.4, 2.7.5, 2.7.6, 2.7.6.1, 2.7.7, 2.8, 2.8.1, 2.8.2, 2.8.3, 2.8.4)
ERROR: No matching distribution found for psycopg2-binary==
```

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No test changes should need to be made for this requirements change

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
