### PR TITLE
AIRFLOW-5854: Add support for `tty` parameter in Docker related operators

### DIFF
--- a/airflow/contrib/operators/docker_swarm_operator.py
+++ b/airflow/contrib/operators/docker_swarm_operator.py
@@ -86,6 +86,9 @@ class DockerSwarmOperator(DockerOperator):
     :type user: int or str
     :param docker_conn_id: ID of the Airflow connection to use
     :type docker_conn_id: str
+    :param tty: Allocate pseudo-TTY to the container of this service
+        This needs to be set see logs of the Docker container / service.
+    :type tty: bool
     """
 
     @apply_defaults
@@ -108,7 +111,8 @@ class DockerSwarmOperator(DockerOperator):
                     image=self.image,
                     command=self.get_command(),
                     env=self.environment,
-                    user=self.user
+                    user=self.user,
+                    tty=self.tty,
                 ),
                 restart_policy=types.RestartPolicy(condition='none'),
                 resources=types.Resources(mem_limit=self.mem_limit)

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -119,6 +119,9 @@ class DockerOperator(BaseOperator):
     :param shm_size: Size of ``/dev/shm`` in bytes. The size must be
         greater than 0. If omitted uses system default.
     :type shm_size: int
+    :param tty: Allocate pseudo-TTY to the container
+        This needs to be set see logs of the Docker container.
+    :type tty: bool
     """
     template_fields = ('command', 'environment', 'container_name')
     template_ext = ('.sh', '.bash',)
@@ -153,6 +156,7 @@ class DockerOperator(BaseOperator):
             dns_search: Optional[List[str]] = None,
             auto_remove: bool = False,
             shm_size: Optional[int] = None,
+            tty: Optional[bool] = False,
             *args,
             **kwargs) -> None:
 
@@ -183,6 +187,7 @@ class DockerOperator(BaseOperator):
         self.xcom_all = xcom_all
         self.docker_conn_id = docker_conn_id
         self.shm_size = shm_size
+        self.tty = tty
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
@@ -226,7 +231,8 @@ class DockerOperator(BaseOperator):
                     mem_limit=self.mem_limit),
                 image=self.image,
                 user=self.user,
-                working_dir=self.working_dir
+                working_dir=self.working_dir,
+                tty=self.tty,
             )
             self.cli.start(self.container['Id'])
 

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -53,7 +53,8 @@ class TestDockerOperator(unittest.TestCase):
                                   image='ubuntu:latest', network_mode='bridge', owner='unittest',
                                   task_id='unittest', volumes=['/host/path:/container/path'],
                                   working_dir='/container/path', shm_size=1000,
-                                  host_tmp_dir='/host/airflow', container_name='test_container')
+                                  host_tmp_dir='/host/airflow', container_name='test_container',
+                                  tty=True)
         operator.execute(None)
 
         client_class_mock.assert_called_once_with(base_url='unix://var/run/docker.sock', tls=None,
@@ -68,7 +69,8 @@ class TestDockerOperator(unittest.TestCase):
                                                              host_config=host_config,
                                                              image='ubuntu:latest',
                                                              user=None,
-                                                             working_dir='/container/path'
+                                                             working_dir='/container/path',
+                                                             tty=True
                                                              )
         client_mock.create_host_config.assert_called_once_with(binds=['/host/path:/container/path',
                                                                       '/mkdtemp:/tmp/airflow'],

--- a/tests/operators/test_docker_swarm_operator.py
+++ b/tests/operators/test_docker_swarm_operator.py
@@ -53,7 +53,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
 
         operator = DockerSwarmOperator(
             api_version='1.19', command='env', environment={'UNIT': 'TEST'}, image='ubuntu:latest',
-            mem_limit='128m', user='unittest', task_id='unittest', auto_remove=True
+            mem_limit='128m', user='unittest', task_id='unittest', auto_remove=True, tty=True,
         )
         operator.execute(None)
 
@@ -61,7 +61,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             container_spec=mock_obj, restart_policy=mock_obj, resources=mock_obj
         )
         types_mock.ContainerSpec.assert_called_once_with(
-            image='ubuntu:latest', command='env', user='unittest',
+            image='ubuntu:latest', command='env', user='unittest', tty=True,
             env={'UNIT': 'TEST', 'AIRFLOW_TMP_DIR': '/tmp/airflow'}
         )
         types_mock.RestartPolicy.assert_called_once_with(condition='none')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5854

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR updates the unit tests accordingly

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
