### PR TITLE
[AIRFLOW-5895] Move HDFS stuff from tests/core.py

### DIFF
--- a/tests/contrib/sensors/test_hdfs_sensor.py
+++ b/tests/contrib/sensors/test_hdfs_sensor.py
@@ -21,10 +21,9 @@ import re
 import unittest
 from datetime import timedelta
 
-from tests.test_utils.hdfs_utils import FakeHDFSHook
-
 from airflow.contrib.sensors.hdfs_sensor import HdfsSensorFolder, HdfsSensorRegex
 from airflow.exceptions import AirflowSensorTimeout
+from tests.test_utils.hdfs_utils import FakeHDFSHook
 
 
 class TestHdfsSensorFolder(unittest.TestCase):

--- a/tests/contrib/sensors/test_hdfs_sensor.py
+++ b/tests/contrib/sensors/test_hdfs_sensor.py
@@ -21,13 +21,14 @@ import re
 import unittest
 from datetime import timedelta
 
+from tests.test_utils.hdfs_utils import FakeHDFSHook
+
 from airflow.contrib.sensors.hdfs_sensor import HdfsSensorFolder, HdfsSensorRegex
 from airflow.exceptions import AirflowSensorTimeout
 
 
 class TestHdfsSensorFolder(unittest.TestCase):
     def setUp(self):
-        from tests.core import FakeHDFSHook
         self.hook = FakeHDFSHook
         self.log = logging.getLogger()
         self.log.setLevel(logging.DEBUG)
@@ -123,7 +124,6 @@ class TestHdfsSensorFolder(unittest.TestCase):
 
 class TestHdfsSensorRegex(unittest.TestCase):
     def setUp(self):
-        from tests.core import FakeHDFSHook
         self.hook = FakeHDFSHook
         self.log = logging.getLogger()
         self.log.setLevel(logging.DEBUG)

--- a/tests/core.py
+++ b/tests/core.py
@@ -30,7 +30,6 @@ import unittest
 from datetime import timedelta
 from tempfile import NamedTemporaryFile
 from time import sleep
-from typing import Optional
 from unittest import mock
 
 import sqlalchemy
@@ -38,12 +37,13 @@ from dateutil.relativedelta import relativedelta
 from numpy.testing import assert_array_almost_equal
 from pendulum import utcnow
 
+from tests.test_utils.config import conf_vars
+
 from airflow import DAG, configuration, exceptions, jobs, models, settings, utils
 from airflow.bin import cli
 from airflow.configuration import AirflowConfigException, conf, run_command
 from airflow.exceptions import AirflowException
 from airflow.executors import SequentialExecutor
-from airflow.hooks import hdfs_hook
 from airflow.hooks.base_hook import BaseHook
 from airflow.hooks.sqlite_hook import SqliteHook
 from airflow.models import BaseOperator, Connection, DagBag, DagRun, Pool, TaskFail, TaskInstance, Variable
@@ -57,7 +57,6 @@ from airflow.utils.dates import days_ago, infer_time_unit, round_time, scale_tim
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.version import version
-from tests.test_utils.config import conf_vars
 
 DEV_NULL = '/dev/null'
 TEST_DAG_FOLDER = os.path.join(
@@ -1806,170 +1805,6 @@ class TestCli(unittest.TestCase):
         self.assertEqual(e.exception.code, 1)
 
 
-class FakeWebHDFSHook:
-    def __init__(self, conn_id):
-        self.conn_id = conn_id
-
-    def get_conn(self):
-        return self.conn_id
-
-    def check_for_path(self, hdfs_path):
-        return hdfs_path
-
-
-class FakeSnakeBiteClientException(Exception):
-    pass
-
-
-class FakeSnakeBiteClient:
-
-    def __init__(self):
-        self.started = True
-
-    def ls(self, path, include_toplevel=False):
-        """
-        the fake snakebite client
-
-        :param path: the array of path to test
-        :param include_toplevel: to return the toplevel directory info
-        :return: a list for path for the matching queries
-        """
-        if path[0] == '/datadirectory/empty_directory' and not include_toplevel:
-            return []
-        elif path[0] == '/datadirectory/datafile':
-            return [{
-                'group': 'supergroup',
-                'permission': 420,
-                'file_type': 'f',
-                'access_time': 1481122343796,
-                'block_replication': 3,
-                'modification_time': 1481122343862,
-                'length': 0,
-                'blocksize': 134217728,
-                'owner': 'hdfs',
-                'path': '/datadirectory/datafile'
-            }]
-        elif path[0] == '/datadirectory/empty_directory' and include_toplevel:
-            return [{
-                'group': 'supergroup',
-                'permission': 493,
-                'file_type': 'd',
-                'access_time': 0,
-                'block_replication': 0,
-                'modification_time': 1481132141540,
-                'length': 0,
-                'blocksize': 0,
-                'owner': 'hdfs',
-                'path': '/datadirectory/empty_directory'
-            }]
-        elif path[0] == '/datadirectory/not_empty_directory' and include_toplevel:
-            return [{
-                'group': 'supergroup',
-                'permission': 493,
-                'file_type': 'd',
-                'access_time': 0,
-                'block_replication': 0,
-                'modification_time': 1481132141540,
-                'length': 0,
-                'blocksize': 0,
-                'owner': 'hdfs',
-                'path': '/datadirectory/empty_directory'
-            }, {
-                'group': 'supergroup',
-                'permission': 420,
-                'file_type': 'f',
-                'access_time': 1481122343796,
-                'block_replication': 3,
-                'modification_time': 1481122343862,
-                'length': 0,
-                'blocksize': 134217728,
-                'owner': 'hdfs',
-                'path': '/datadirectory/not_empty_directory/test_file'
-            }]
-        elif path[0] == '/datadirectory/not_empty_directory':
-            return [{
-                'group': 'supergroup',
-                'permission': 420,
-                'file_type': 'f',
-                'access_time': 1481122343796,
-                'block_replication': 3,
-                'modification_time': 1481122343862,
-                'length': 0,
-                'blocksize': 134217728,
-                'owner': 'hdfs',
-                'path': '/datadirectory/not_empty_directory/test_file'
-            }]
-        elif path[0] == '/datadirectory/not_existing_file_or_directory':
-            raise FakeSnakeBiteClientException
-        elif path[0] == '/datadirectory/regex_dir':
-            return [{
-                'group': 'supergroup',
-                'permission': 420,
-                'file_type': 'f',
-                'access_time': 1481122343796,
-                'block_replication': 3,
-                'modification_time': 1481122343862, 'length': 12582912,
-                'blocksize': 134217728,
-                'owner': 'hdfs',
-                'path': '/datadirectory/regex_dir/test1file'
-            }, {
-                'group': 'supergroup',
-                'permission': 420,
-                'file_type': 'f',
-                'access_time': 1481122343796,
-                'block_replication': 3,
-                'modification_time': 1481122343862,
-                'length': 12582912,
-                'blocksize': 134217728,
-                'owner': 'hdfs',
-                'path': '/datadirectory/regex_dir/test2file'
-            }, {
-                'group': 'supergroup',
-                'permission': 420,
-                'file_type': 'f',
-                'access_time': 1481122343796,
-                'block_replication': 3,
-                'modification_time': 1481122343862,
-                'length': 12582912,
-                'blocksize': 134217728,
-                'owner': 'hdfs',
-                'path': '/datadirectory/regex_dir/test3file'
-            }, {
-                'group': 'supergroup',
-                'permission': 420,
-                'file_type': 'f',
-                'access_time': 1481122343796,
-                'block_replication': 3,
-                'modification_time': 1481122343862,
-                'length': 12582912,
-                'blocksize': 134217728,
-                'owner': 'hdfs',
-                'path': '/datadirectory/regex_dir/copying_file_1.txt._COPYING_'
-            }, {
-                'group': 'supergroup',
-                'permission': 420,
-                'file_type': 'f',
-                'access_time': 1481122343796,
-                'block_replication': 3,
-                'modification_time': 1481122343862,
-                'length': 12582912,
-                'blocksize': 134217728,
-                'owner': 'hdfs',
-                'path': '/datadirectory/regex_dir/copying_file_3.txt.sftp'
-            }]
-        else:
-            raise FakeSnakeBiteClientException
-
-
-class FakeHDFSHook:
-    def __init__(self, conn_id=None):
-        self.conn_id = conn_id
-
-    def get_conn(self):
-        client = FakeSnakeBiteClient()
-        return client
-
-
 class TestConnection(unittest.TestCase):
     def setUp(self):
         utils.db.initdb()
@@ -2055,70 +1890,6 @@ class TestConnection(unittest.TestCase):
         assert conns[0].login == 'username'
         assert conns[0].password == 'password'
         assert conns[0].port == 5432
-
-
-class TestWebHDFSHook(unittest.TestCase):
-    def test_simple_init(self):
-        from airflow.hooks.webhdfs_hook import WebHDFSHook
-        c = WebHDFSHook()
-        self.assertIsNone(c.proxy_user)
-
-    def test_init_proxy_user(self):
-        from airflow.hooks.webhdfs_hook import WebHDFSHook
-        c = WebHDFSHook(proxy_user='someone')
-        self.assertEqual('someone', c.proxy_user)
-
-
-HDFSHook = None  # type: Optional[hdfs_hook.HDFSHook]
-snakebite = None  # type: None
-
-
-@unittest.skipIf(HDFSHook is None,
-                 "Skipping test because HDFSHook is not installed")
-class TestHDFSHook(unittest.TestCase):
-    @unittest.mock.patch.dict('os.environ', {
-        'AIRFLOW_CONN_HDFS_DEFAULT': 'hdfs://localhost:8020',
-    })
-    def test_get_client(self):
-        client = HDFSHook(proxy_user='foo').get_conn()
-        self.assertIsInstance(client, snakebite.client.Client)
-        self.assertEqual('localhost', client.host)
-        self.assertEqual(8020, client.port)
-        self.assertEqual('foo', client.service.channel.effective_user)
-
-    @unittest.mock.patch.dict('os.environ', {
-        'AIRFLOW_CONN_HDFS_DEFAULT': 'hdfs://localhost:8020',
-    })
-    @mock.patch('airflow.hooks.hdfs_hook.AutoConfigClient')
-    @mock.patch('airflow.hooks.hdfs_hook.HDFSHook.get_connections')
-    def test_get_autoconfig_client(self, mock_get_connections,
-                                   MockAutoConfigClient):
-        c = Connection(conn_id='hdfs', conn_type='hdfs',
-                       host='localhost', port=8020, login='foo',
-                       extra=json.dumps({'autoconfig': True}))
-        mock_get_connections.return_value = [c]
-        HDFSHook(hdfs_conn_id='hdfs').get_conn()
-        MockAutoConfigClient.assert_called_once_with(effective_user='foo',
-                                                     use_sasl=False)
-
-    @unittest.mock.patch.dict('os.environ', {
-        'AIRFLOW_CONN_HDFS_DEFAULT': 'hdfs://localhost:8020',
-    })
-    @mock.patch('airflow.hooks.hdfs_hook.AutoConfigClient')
-    def test_get_autoconfig_client_no_conn(self, MockAutoConfigClient):
-        HDFSHook(hdfs_conn_id='hdfs_missing', autoconfig=True).get_conn()
-        MockAutoConfigClient.assert_called_once_with(effective_user=None,
-                                                     use_sasl=False)
-
-    @mock.patch('airflow.hooks.hdfs_hook.HDFSHook.get_connections')
-    def test_get_ha_client(self, mock_get_connections):
-        c1 = Connection(conn_id='hdfs_default', conn_type='hdfs',
-                        host='localhost', port=8020)
-        c2 = Connection(conn_id='hdfs_default', conn_type='hdfs',
-                        host='localhost2', port=8020)
-        mock_get_connections.return_value = [c1, c2]
-        client = HDFSHook().get_conn()
-        self.assertIsInstance(client, snakebite.client.HAClient)
 
 
 if __name__ == '__main__':

--- a/tests/core.py
+++ b/tests/core.py
@@ -37,8 +37,6 @@ from dateutil.relativedelta import relativedelta
 from numpy.testing import assert_array_almost_equal
 from pendulum import utcnow
 
-from tests.test_utils.config import conf_vars
-
 from airflow import DAG, configuration, exceptions, jobs, models, settings, utils
 from airflow.bin import cli
 from airflow.configuration import AirflowConfigException, conf, run_command
@@ -57,6 +55,7 @@ from airflow.utils.dates import days_ago, infer_time_unit, round_time, scale_tim
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.version import version
+from tests.test_utils.config import conf_vars
 
 DEV_NULL = '/dev/null'
 TEST_DAG_FOLDER = os.path.join(

--- a/tests/hooks/test_hdfs_hook.py
+++ b/tests/hooks/test_hdfs_hook.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import unittest
+from unittest import mock
+
+from airflow.hooks.hdfs_hook import HDFSHook
+from airflow.models import Connection
+
+try:
+    import snakebite
+    snakebite_loaded = True
+except ImportError:
+    snakebite_loaded = False
+
+if not snakebite_loaded:
+    raise unittest.SkipTest(
+        "Skipping test because HDFSHook is not installed"
+    )
+
+
+class TestHDFSHook(unittest.TestCase):
+    @mock.patch.dict('os.environ', {
+        'AIRFLOW_CONN_HDFS_DEFAULT': 'hdfs://localhost:8020',
+    })
+    def test_get_client(self):
+        client = HDFSHook(proxy_user='foo').get_conn()
+        self.assertIsInstance(client, snakebite.client.Client)
+        self.assertEqual('localhost', client.host)
+        self.assertEqual(8020, client.port)
+        self.assertEqual('foo', client.service.channel.effective_user)
+
+    @mock.patch.dict('os.environ', {
+        'AIRFLOW_CONN_HDFS_DEFAULT': 'hdfs://localhost:8020',
+    })
+    @mock.patch('airflow.hooks.hdfs_hook.AutoConfigClient')
+    @mock.patch('airflow.hooks.hdfs_hook.HDFSHook.get_connections')
+    def test_get_autoconfig_client(self, mock_get_connections,
+                                   MockAutoConfigClient):
+        c = Connection(conn_id='hdfs', conn_type='hdfs',
+                       host='localhost', port=8020, login='foo',
+                       extra=json.dumps({'autoconfig': True}))
+        mock_get_connections.return_value = [c]
+        HDFSHook(hdfs_conn_id='hdfs').get_conn()
+        MockAutoConfigClient.assert_called_once_with(effective_user='foo',
+                                                     use_sasl=False)
+
+    @mock.patch.dict('os.environ', {
+        'AIRFLOW_CONN_HDFS_DEFAULT': 'hdfs://localhost:8020',
+    })
+    @mock.patch('airflow.hooks.hdfs_hook.AutoConfigClient')
+    def test_get_autoconfig_client_no_conn(self, MockAutoConfigClient):
+        HDFSHook(hdfs_conn_id='hdfs_missing', autoconfig=True).get_conn()
+        MockAutoConfigClient.assert_called_once_with(effective_user=None,
+                                                     use_sasl=False)
+
+    @mock.patch('airflow.hooks.hdfs_hook.HDFSHook.get_connections')
+    def test_get_ha_client(self, mock_get_connections):
+        c1 = Connection(conn_id='hdfs_default', conn_type='hdfs',
+                        host='localhost', port=8020)
+        c2 = Connection(conn_id='hdfs_default', conn_type='hdfs',
+                        host='localhost2', port=8020)
+        mock_get_connections.return_value = [c1, c2]
+        client = HDFSHook().get_conn()
+        self.assertIsInstance(client, snakebite.client.HAClient)

--- a/tests/hooks/test_hdfs_hook.py
+++ b/tests/hooks/test_hdfs_hook.py
@@ -63,8 +63,7 @@ class TestHDFSHook(unittest.TestCase):
         )
         mock_get_connections.return_value = [conn]
         HDFSHook(hdfs_conn_id='hdfs').get_conn()
-        mock_client.assert_called_once_with(effective_user='foo',
-                                                     use_sasl=False)
+        mock_client.assert_called_once_with(effective_user='foo', use_sasl=False)
 
     @mock.patch.dict('os.environ', {
         'AIRFLOW_CONN_HDFS_DEFAULT': 'hdfs://localhost:8020',
@@ -72,8 +71,7 @@ class TestHDFSHook(unittest.TestCase):
     @mock.patch('airflow.hooks.hdfs_hook.AutoConfigClient')
     def test_get_autoconfig_client_no_conn(self, mock_client):
         HDFSHook(hdfs_conn_id='hdfs_missing', autoconfig=True).get_conn()
-        mock_client.assert_called_once_with(effective_user=None,
-                                                     use_sasl=False)
+        mock_client.assert_called_once_with(effective_user=None, use_sasl=False)
 
     @mock.patch('airflow.hooks.hdfs_hook.HDFSHook.get_connections')
     def test_get_ha_client(self, mock_get_connections):

--- a/tests/hooks/test_webhdfs_hook.py
+++ b/tests/hooks/test_webhdfs_hook.py
@@ -95,3 +95,11 @@ class TestWebHDFSHook(unittest.TestCase):
             overwrite=True,
             n_threads=1
         )
+
+    def test_simple_init(self):
+        c = WebHDFSHook()
+        self.assertIsNone(c.proxy_user)
+
+    def test_init_proxy_user(self):
+        c = WebHDFSHook(proxy_user='someone')
+        self.assertEqual('someone', c.proxy_user)

--- a/tests/sensors/test_hdfs_sensor.py
+++ b/tests/sensors/test_hdfs_sensor.py
@@ -19,10 +19,11 @@
 import unittest
 from datetime import timedelta
 
+from tests.test_utils.hdfs_utils import FakeHDFSHook
+
 from airflow.exceptions import AirflowSensorTimeout
 from airflow.sensors.hdfs_sensor import HdfsSensor
 from airflow.utils.timezone import datetime
-from tests.core import FakeHDFSHook
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_dag'

--- a/tests/sensors/test_hdfs_sensor.py
+++ b/tests/sensors/test_hdfs_sensor.py
@@ -19,11 +19,10 @@
 import unittest
 from datetime import timedelta
 
-from tests.test_utils.hdfs_utils import FakeHDFSHook
-
 from airflow.exceptions import AirflowSensorTimeout
 from airflow.sensors.hdfs_sensor import HdfsSensor
 from airflow.utils.timezone import datetime
+from tests.test_utils.hdfs_utils import FakeHDFSHook
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_dag'

--- a/tests/test_utils/hdfs_utils.py
+++ b/tests/test_utils/hdfs_utils.py
@@ -38,7 +38,7 @@ class FakeSnakeBiteClient:
     def __init__(self):
         self.started = True
 
-    def ls(self, path, include_toplevel=False):
+    def ls(self, path, include_toplevel=False):  # pylint: disable=invalid-name
         """
         the fake snakebite client
 

--- a/tests/test_utils/hdfs_utils.py
+++ b/tests/test_utils/hdfs_utils.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class FakeWebHDFSHook:
+    def __init__(self, conn_id):
+        self.conn_id = conn_id
+
+    def get_conn(self):
+        return self.conn_id
+
+    def check_for_path(self, hdfs_path):
+        return hdfs_path
+
+
+class FakeSnakeBiteClientException(Exception):
+    pass
+
+
+class FakeSnakeBiteClient:
+
+    def __init__(self):
+        self.started = True
+
+    def ls(self, path, include_toplevel=False):
+        """
+        the fake snakebite client
+
+        :param path: the array of path to test
+        :param include_toplevel: to return the toplevel directory info
+        :return: a list for path for the matching queries
+        """
+        if path[0] == '/datadirectory/empty_directory' and not include_toplevel:
+            return []
+        elif path[0] == '/datadirectory/datafile':
+            return [{
+                'group': 'supergroup',
+                'permission': 420,
+                'file_type': 'f',
+                'access_time': 1481122343796,
+                'block_replication': 3,
+                'modification_time': 1481122343862,
+                'length': 0,
+                'blocksize': 134217728,
+                'owner': 'hdfs',
+                'path': '/datadirectory/datafile'
+            }]
+        elif path[0] == '/datadirectory/empty_directory' and include_toplevel:
+            return [{
+                'group': 'supergroup',
+                'permission': 493,
+                'file_type': 'd',
+                'access_time': 0,
+                'block_replication': 0,
+                'modification_time': 1481132141540,
+                'length': 0,
+                'blocksize': 0,
+                'owner': 'hdfs',
+                'path': '/datadirectory/empty_directory'
+            }]
+        elif path[0] == '/datadirectory/not_empty_directory' and include_toplevel:
+            return [{
+                'group': 'supergroup',
+                'permission': 493,
+                'file_type': 'd',
+                'access_time': 0,
+                'block_replication': 0,
+                'modification_time': 1481132141540,
+                'length': 0,
+                'blocksize': 0,
+                'owner': 'hdfs',
+                'path': '/datadirectory/empty_directory'
+            }, {
+                'group': 'supergroup',
+                'permission': 420,
+                'file_type': 'f',
+                'access_time': 1481122343796,
+                'block_replication': 3,
+                'modification_time': 1481122343862,
+                'length': 0,
+                'blocksize': 134217728,
+                'owner': 'hdfs',
+                'path': '/datadirectory/not_empty_directory/test_file'
+            }]
+        elif path[0] == '/datadirectory/not_empty_directory':
+            return [{
+                'group': 'supergroup',
+                'permission': 420,
+                'file_type': 'f',
+                'access_time': 1481122343796,
+                'block_replication': 3,
+                'modification_time': 1481122343862,
+                'length': 0,
+                'blocksize': 134217728,
+                'owner': 'hdfs',
+                'path': '/datadirectory/not_empty_directory/test_file'
+            }]
+        elif path[0] == '/datadirectory/not_existing_file_or_directory':
+            raise FakeSnakeBiteClientException
+        elif path[0] == '/datadirectory/regex_dir':
+            return [{
+                'group': 'supergroup',
+                'permission': 420,
+                'file_type': 'f',
+                'access_time': 1481122343796,
+                'block_replication': 3,
+                'modification_time': 1481122343862, 'length': 12582912,
+                'blocksize': 134217728,
+                'owner': 'hdfs',
+                'path': '/datadirectory/regex_dir/test1file'
+            }, {
+                'group': 'supergroup',
+                'permission': 420,
+                'file_type': 'f',
+                'access_time': 1481122343796,
+                'block_replication': 3,
+                'modification_time': 1481122343862,
+                'length': 12582912,
+                'blocksize': 134217728,
+                'owner': 'hdfs',
+                'path': '/datadirectory/regex_dir/test2file'
+            }, {
+                'group': 'supergroup',
+                'permission': 420,
+                'file_type': 'f',
+                'access_time': 1481122343796,
+                'block_replication': 3,
+                'modification_time': 1481122343862,
+                'length': 12582912,
+                'blocksize': 134217728,
+                'owner': 'hdfs',
+                'path': '/datadirectory/regex_dir/test3file'
+            }, {
+                'group': 'supergroup',
+                'permission': 420,
+                'file_type': 'f',
+                'access_time': 1481122343796,
+                'block_replication': 3,
+                'modification_time': 1481122343862,
+                'length': 12582912,
+                'blocksize': 134217728,
+                'owner': 'hdfs',
+                'path': '/datadirectory/regex_dir/copying_file_1.txt._COPYING_'
+            }, {
+                'group': 'supergroup',
+                'permission': 420,
+                'file_type': 'f',
+                'access_time': 1481122343796,
+                'block_replication': 3,
+                'modification_time': 1481122343862,
+                'length': 12582912,
+                'blocksize': 134217728,
+                'owner': 'hdfs',
+                'path': '/datadirectory/regex_dir/copying_file_3.txt.sftp'
+            }]
+        else:
+            raise FakeSnakeBiteClientException
+
+
+class FakeHDFSHook:
+    def __init__(self, conn_id=None):
+        self.conn_id = conn_id
+
+    def get_conn(self):
+        client = FakeSnakeBiteClient()
+        return client


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5895
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
