### PR TITLE
[AIRFLOW-XXX] Add render_template changes to UPDATING.md

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -41,6 +41,19 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### BaseOperator::render_template function signature changed
+
+Previous versions of the `BaseOperator::render_template` function required an `attr` argument as the first
+positional argument, along with `content` and `context`. This function signature was changed in 1.10.6 and
+the `attr` argument is no longer required (or accepted).
+
+In order to use this function in subclasses of the `BaseOperator`, the `attr` argument must be removed:
+```python
+result = self.render_template('myattr', self.myattr, context)  # Pre-1.10.6 call
+...
+result = self.render_template(self.myattr, context)  # Post-1.10.6 call
+```
+
 ### Idempotency in BigQuery operators
 Idempotency was added to `BigQueryCreateEmptyTableOperator` and `BigQueryCreateEmptyDatasetOperator`. 
 But to achieve that try / except clause was removed from `create_empty_dataset` and `create_empty_table` 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

We recently encountered some errors in 1.10.6 that related to a specific change to the `BaseOperator::render_template` function. This appears to be a new change since 1.10.5:
- 1.10.5: https://github.com/apache/airflow/blob/1.10.5/airflow/models/baseoperator.py#L667
- 1.10.6: https://github.com/apache/airflow/blob/1.10.6/airflow/models/baseoperator.py#L699

We had upgraded from 1.10.4 to 1.10.6, and I was surprised when I first looked at the code at both of those tags that it _appeared_ as though this change was a part of 1.10.4 (even though our DAGs had been running fine in 1.10.4 but broke in 1.10.6).
Here's the code at the 1.10.4 git tag: https://github.com/apache/airflow/blob/1.10.4/airflow/models/baseoperator.py#L699-L702
Here's the code at the 1.10.6 git tag: https://github.com/apache/airflow/blob/1.10.6/airflow/models/baseoperator.py#L699

It would appear as though the 1.10.4 tag might be incorrect. It looks like 1.10.4b2 has the more accurate version of the code: https://github.com/apache/airflow/blob/1.10.4b2/airflow/models/baseoperator.py#L660

I'm not sure how that might be resolved, but it's a separate problem from this docs change.

I wasn't sure where to put this in the document, but it looked like it was "most recent at the top" so I followed that. Additionally, should a new section be made for 1.10.6 that's separate from `Airflow Master`? I can do that as part of this PR too if it's desired.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This is just a docs change

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
