### PR TITLE
[AIRFLOW-5880] Enforce unique task ids

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -95,6 +95,10 @@ class DagFileExists(AirflowBadRequest):
     """Raise when a DAG ID is still in DagBag i.e., DAG file is in DAG folder"""
 
 
+class DuplicateTaskIdFound(AirflowException):
+    """Raise when a Task with duplicate task_id is defined in the same DAG"""
+
+
 class TaskNotFound(AirflowNotFoundException):
     """Raise when a Task is not available in the system"""
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -528,7 +528,7 @@ class BaseOperator(LoggingMixin):
         elif self.has_dag() and self.dag is not dag:
             raise AirflowException(
                 "The DAG assigned to {} can not be changed.".format(self))
-        elif self.task_id not in dag.task_dict:
+        elif self.task_id:
             dag.add_task(self)
 
         self._dag = dag  # pylint: disable=attribute-defined-outside-init

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -34,7 +34,7 @@ from dateutil.relativedelta import relativedelta
 
 from airflow import settings
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, DuplicateTaskIdFound
 from airflow.lineage import DataSet, apply_lineage, prepare_lineage
 from airflow.models.dag import DAG
 from airflow.models.pool import Pool
@@ -528,8 +528,11 @@ class BaseOperator(LoggingMixin):
         elif self.has_dag() and self.dag is not dag:
             raise AirflowException(
                 "The DAG assigned to {} can not be changed.".format(self))
-        elif self.task_id:
+        elif self.task_id not in dag.task_dict:
             dag.add_task(self)
+        elif self.task_id in dag.task_dict and dag.task_dict[self.task_id] != self:
+            raise DuplicateTaskIdFound(
+                "Task id '{}' has already been added to the DAG".format(self.task_id))
 
         self._dag = dag  # pylint: disable=attribute-defined-outside-init
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1170,10 +1170,6 @@ class DAG(BaseDag, LoggingMixin):
         :param task: the task you want to add
         :type task: task
         """
-        # If the task has already been added, so do nothing.
-        if task.task_id in self.task_dict and self.task_dict[task.task_id] == task:
-            return
-
         if not self.start_date and not task.start_date:
             raise AirflowException("Task is missing the start_date parameter")
         # if the task has no start date, assign it the same as the DAG
@@ -1192,7 +1188,7 @@ class DAG(BaseDag, LoggingMixin):
         elif task.end_date and self.end_date:
             task.end_date = min(task.end_date, self.end_date)
 
-        if task.task_id in self.task_dict:
+        if task.task_id in self.task_dict and self.task_dict[task.task_id] != task:
             raise DuplicateTaskIdFound(
                 "Task id '{}' has already been added to the DAG".format(task.task_id))
         else:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -24,7 +24,6 @@ import pickle
 import re
 import sys
 import traceback
-import warnings
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Callable, Dict, FrozenSet, Iterable, List, Optional, Type, Union
@@ -38,7 +37,7 @@ from sqlalchemy import Boolean, Column, Index, Integer, String, Text, func, or_
 from airflow import settings, utils
 from airflow.configuration import conf
 from airflow.dag.base_dag import BaseDag
-from airflow.exceptions import AirflowDagCycleException, AirflowException, DagNotFound
+from airflow.exceptions import AirflowDagCycleException, AirflowException, DagNotFound, DuplicateTaskIdFound
 from airflow.executors import LocalExecutor, get_default_executor
 from airflow.models.base import ID_LEN, Base
 from airflow.models.dagbag import DagBag
@@ -1190,13 +1189,8 @@ class DAG(BaseDag, LoggingMixin):
             task.end_date = min(task.end_date, self.end_date)
 
         if task.task_id in self.task_dict:
-            # TODO: raise an error in Airflow 2.0
-            warnings.warn(
-                'The requested task could not be added to the DAG because a '
-                'task with task_id {} is already in the DAG. Starting in '
-                'Airflow 2.0, trying to overwrite a task will raise an '
-                'exception.'.format(task.task_id),
-                category=PendingDeprecationWarning)
+            raise DuplicateTaskIdFound(
+                "Task id '{}' has already been added to the DAG".format(task.task_id))
         else:
             self.task_dict[task.task_id] = task
             task.dag = self

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1170,6 +1170,10 @@ class DAG(BaseDag, LoggingMixin):
         :param task: the task you want to add
         :type task: task
         """
+        # If the task has already been added, so do nothing.
+        if task.task_id in self.task_dict and self.task_dict[task.task_id] == task:
+            return
+
         if not self.start_date and not task.start_date:
             raise AirflowException("Task is missing the start_date parameter")
         # if the task has no start date, assign it the same as the DAG

--- a/tests/contrib/operators/test_qubole_operator.py
+++ b/tests/contrib/operators/test_qubole_operator.py
@@ -108,7 +108,7 @@ class TestQuboleOperator(unittest.TestCase):
         self.assertEqual(task.get_hook().create_cmd_args({'run_id': 'dummy'})[2], "key2=value2")
 
         cmd = "s3distcp --src s3n://airflow/source_hadoopcmd --dest s3n://airflow/destination_hadoopcmd"
-        task = QuboleOperator(task_id=TASK_ID, command_type='hadoopcmd', dag=dag, sub_command=cmd)
+        task = QuboleOperator(task_id=TASK_ID + "_1", command_type='hadoopcmd', dag=dag, sub_command=cmd)
 
         self.assertEqual(task.get_hook().create_cmd_args({'run_id': 'dummy'})[1],
                          "s3distcp")

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -33,6 +33,7 @@ from airflow import models, settings
 from airflow.configuration import conf
 from airflow.exceptions import AirflowDagCycleException, AirflowException, DuplicateTaskIdFound
 from airflow.models import DAG, DagModel, TaskInstance as TI
+from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils import timezone
@@ -923,5 +924,5 @@ class TestDag(unittest.TestCase):
         ):
             with DAG("test_dag", start_date=DEFAULT_DATE):
                 t1 = DummyOperator(task_id="t1")
-                t2 = DummyOperator(task_id="t1")
+                t2 = BashOperator(task_id="t1", bash_command="sleep 1")
                 t1 >> t2

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -951,8 +951,8 @@ class TestDag(unittest.TestCase):
 
         # Also verify that DAGs with duplicate task_ids don't raise errors
         dag1 = DAG("test_dag_1", start_date=DEFAULT_DATE)
-        t3 = DummyOperator(task_id="t3", dag=dag)
-        t4 = DummyOperator(task_id="t4", dag=dag)
+        t3 = DummyOperator(task_id="t3", dag=dag1)
+        t4 = DummyOperator(task_id="t4", dag=dag1)
         t3 >> t4
 
         self.assertEqual(dag1.task_dict, {t3.task_id: t3, t4.task_id: t4})

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -917,12 +917,54 @@ class TestDag(unittest.TestCase):
             self.assertIn('t2', stdout_lines[1])
             self.assertIn('t3', stdout_lines[2])
 
-    def test_duplicate_task_ids_not_allowed(self):
+    def test_duplicate_task_ids_not_allowed_with_dag_context_manager(self):
         """Verify tasks with Duplicate task_id raises error"""
         with self.assertRaisesRegex(
             DuplicateTaskIdFound, "Task id 't1' has already been added to the DAG"
         ):
-            with DAG("test_dag", start_date=DEFAULT_DATE):
+            with DAG("test_dag", start_date=DEFAULT_DATE) as dag:
                 t1 = DummyOperator(task_id="t1")
                 t2 = BashOperator(task_id="t1", bash_command="sleep 1")
                 t1 >> t2
+
+        self.assertEqual(dag.task_dict, {t1.task_id: t1})
+
+        # Also verify that DAGs with duplicate task_ids don't raise errors
+        with DAG("test_dag_1", start_date=DEFAULT_DATE) as dag1:
+            t3 = DummyOperator(task_id="t3")
+            t4 = BashOperator(task_id="t4", bash_command="sleep 1")
+            t3 >> t4
+
+        self.assertEqual(dag1.task_dict, {t3.task_id: t3, t4.task_id: t4})
+
+    def test_duplicate_task_ids_not_allowed_without_dag_context_manager(self):
+        """Verify tasks with Duplicate task_id raises error"""
+        with self.assertRaisesRegex(
+            DuplicateTaskIdFound, "Task id 't1' has already been added to the DAG"
+        ):
+            dag = DAG("test_dag", start_date=DEFAULT_DATE)
+            t1 = DummyOperator(task_id="t1", dag=dag)
+            t2 = BashOperator(task_id="t1", bash_command="sleep 1", dag=dag)
+            t1 >> t2
+
+        self.assertEqual(dag.task_dict, {t1.task_id: t1})
+
+        # Also verify that DAGs with duplicate task_ids don't raise errors
+        dag1 = DAG("test_dag_1", start_date=DEFAULT_DATE)
+        t3 = DummyOperator(task_id="t3", dag=dag)
+        t4 = DummyOperator(task_id="t4", dag=dag)
+        t3 >> t4
+
+        self.assertEqual(dag1.task_dict, {t3.task_id: t3, t4.task_id: t4})
+
+    def test_duplicate_task_ids_for_same_task_is_allowed(self):
+        """Verify that same tasks with Duplicate task_id do not raise error"""
+        with DAG("test_dag", start_date=DEFAULT_DATE) as dag:
+            t1 = t2 = DummyOperator(task_id="t1")
+            t3 = DummyOperator(task_id="t3")
+            t1 >> t3
+            t2 >> t3
+
+        self.assertEqual(t1, t2)
+        self.assertEqual(dag.task_dict, {t1.task_id: t1, t3.task_id: t3})
+        self.assertEqual(dag.task_dict, {t2.task_id: t2, t3.task_id: t3})


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5880


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Currently, task with equal ids in a DAG simply overwrite each other and the last assigned task is saved. This can lead to unexpected behaviour and an exception should be raised.

We've had a PendingDeprecationWarning on this for 4 years, time to get rid of it: https://github.com/apache/airflow/commit/385add2bf3eb7cd6103cfec0e5516234eeb72443

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
