### PR TITLE
[AIRFLOW-5897] Allow setting -1 as pool slots value in webserver

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2174,7 +2174,7 @@ class PoolModelView(AirflowModelView):
 
     validators_columns = {
         'pool': [validators.DataRequired()],
-        'slots': [validators.NumberRange(min=0)]
+        'slots': [validators.NumberRange(min=-1)]
     }
 
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5897) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5897

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Given https://github.com/apache/airflow/pull/6520, we should also allow -1 as pool slots value in the webserver.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Too minor a change to add unit test. Tested locally.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"
