### PR TITLE
[AIRFLOW-5850] Capture task logs in DockerSwarmOperator

### DIFF
--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -140,8 +140,8 @@ class TestDockerSwarmOperator(unittest.TestCase):
             operator.execute(None)
         self.assertEqual(str(error.exception), msg)
 
-    @mock.patch('airflow.operators.docker_operator.APIClient')
-    @mock.patch('airflow.contrib.operators.docker_swarm_operator.types')
+    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
+    @mock.patch('airflow.providers.docker.operators.docker_swarm.types')
     def test_logging_with_requests_timeout(self, types_mock, client_class_mock):
 
         mock_obj = mock.Mock()

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -38,7 +38,8 @@ class TestDockerSwarmOperator(unittest.TestCase):
         def _client_tasks_side_effect():
             for _ in range(2):
                 yield [{'Status': {'State': 'pending'}}]
-            yield [{'Status': {'State': 'complete'}}]
+            while True:
+                yield [{'Status': {'State': 'complete'}}]
 
         def _client_service_logs_effect():
             yield b'Testing is awesome.'
@@ -87,7 +88,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         self.assertEqual(csargs, (mock_obj, ))
         self.assertEqual(cskwargs['labels'], {'name': 'airflow__adhoc_airflow__unittest'})
         self.assertTrue(cskwargs['name'].startswith('airflow-'))
-        self.assertEqual(client_mock.tasks.call_count, 3)
+        self.assertEqual(client_mock.tasks.call_count, 5)
         client_mock.remove_service.assert_called_once_with('some_id')
 
     @mock.patch('airflow.providers.docker.operators.docker.APIClient')
@@ -149,7 +150,8 @@ class TestDockerSwarmOperator(unittest.TestCase):
         def _client_tasks_side_effect():
             for _ in range(2):
                 yield [{'Status': {'State': 'pending'}}]
-            yield [{'Status': {'State': 'complete'}}]
+            while True:
+                yield [{'Status': {'State': 'complete'}}]
 
         def _client_service_logs_effect():
             yield b'Testing is awesome.'

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -20,6 +20,7 @@
 import unittest
 
 import mock
+import requests
 from docker import APIClient
 
 from airflow.exceptions import AirflowException
@@ -39,8 +40,12 @@ class TestDockerSwarmOperator(unittest.TestCase):
                 yield [{'Status': {'State': 'pending'}}]
             yield [{'Status': {'State': 'complete'}}]
 
+        def _client_service_logs_effect():
+            yield b'Testing is awesome.'
+
         client_mock = mock.Mock(spec=APIClient)
         client_mock.create_service.return_value = {'ID': 'some_id'}
+        client_mock.service_logs.return_value = _client_service_logs_effect()
         client_mock.images.return_value = []
         client_mock.pull.return_value = [b'{"status":"pull log"}']
         client_mock.tasks.side_effect = _client_tasks_side_effect()
@@ -71,6 +76,10 @@ class TestDockerSwarmOperator(unittest.TestCase):
             base_url='unix://var/run/docker.sock', tls=None, version='1.19'
         )
 
+        client_mock.service_logs.assert_called_once_with(
+            'some_id', follow=True, stdout=True, stderr=True, is_tty=True
+        )
+
         csargs, cskwargs = client_mock.create_service.call_args_list[0]
         self.assertEqual(
             len(csargs), 1, 'create_service called with different number of arguments than expected'
@@ -99,7 +108,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
 
         client_class_mock.return_value = client_mock
 
-        operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest')
+        operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest', enable_logging=False)
         operator.execute(None)
 
         self.assertEqual(
@@ -125,16 +134,55 @@ class TestDockerSwarmOperator(unittest.TestCase):
 
         client_class_mock.return_value = client_mock
 
-        operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest')
+        operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest', enable_logging=False)
         msg = "Service failed: {'ID': 'some_id'}"
         with self.assertRaises(AirflowException) as error:
             operator.execute(None)
         self.assertEqual(str(error.exception), msg)
 
+    @mock.patch('airflow.operators.docker_operator.APIClient')
+    @mock.patch('airflow.contrib.operators.docker_swarm_operator.types')
+    def test_logging_with_requests_timeout(self, types_mock, client_class_mock):
+
+        mock_obj = mock.Mock()
+
+        def _client_tasks_side_effect():
+            for _ in range(2):
+                yield [{'Status': {'State': 'pending'}}]
+            yield [{'Status': {'State': 'complete'}}]
+
+        def _client_service_logs_effect():
+            yield b'Testing is awesome.'
+            raise requests.exceptions.ConnectionError('')
+
+        client_mock = mock.Mock(spec=APIClient)
+        client_mock.create_service.return_value = {'ID': 'some_id'}
+        client_mock.service_logs.return_value = _client_service_logs_effect()
+        client_mock.images.return_value = []
+        client_mock.pull.return_value = [b'{"status":"pull log"}']
+        client_mock.tasks.side_effect = _client_tasks_side_effect()
+        types_mock.TaskTemplate.return_value = mock_obj
+        types_mock.ContainerSpec.return_value = mock_obj
+        types_mock.RestartPolicy.return_value = mock_obj
+        types_mock.Resources.return_value = mock_obj
+
+        client_class_mock.return_value = client_mock
+
+        operator = DockerSwarmOperator(
+            api_version='1.19', command='env', environment={'UNIT': 'TEST'}, image='ubuntu:latest',
+            mem_limit='128m', user='unittest', task_id='unittest', auto_remove=True, tty=True,
+            enable_logging=True
+        )
+        operator.execute(None)
+
+        client_mock.service_logs.assert_called_once_with(
+            'some_id', follow=True, stdout=True, stderr=True, is_tty=True
+        )
+
     def test_on_kill(self):
         client_mock = mock.Mock(spec=APIClient)
 
-        operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest')
+        operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest', enable_logging=False)
         operator.cli = client_mock
         operator.service = {'ID': 'some_id'}
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5850
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit test:
    `test_logging`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
