### PR TITLE
Avoid warning from abc.collections

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -33,7 +33,7 @@ from builtins import input
 from past.builtins import basestring
 from datetime import datetime
 from functools import reduce
-from collections import Iterable
+from collections.abc import Iterable
 import os
 import re
 import signal


### PR DESCRIPTION
Gets rid of warning in py3k