### PR TITLE
[AIRFLOW-3489] Improve json data handling in PostgresToGcs operator

### DIFF
--- a/airflow/example_dags/example_postgres_to_gcs.py
+++ b/airflow/example_dags/example_postgres_to_gcs.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example DAG using PostgresToGoogleCloudStorageOperator.
+"""
+import airflow
+from airflow import models
+from airflow.operators.postgres_to_gcs import PostgresToGoogleCloudStorageOperator
+
+GCS_BUCKET = "postgres_to_gcs_example"
+FILENAME = "test_file"
+SQL_QUERY = "select * from test_table;"
+
+default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+
+with models.DAG(
+    dag_id='example_postgres_to_gcs',
+    default_args=default_args,
+    schedule_interval=None,  # Override to match your needs
+) as dag:
+    upload_data = PostgresToGoogleCloudStorageOperator(
+        task_id="get_data",
+        sql=SQL_QUERY,
+        bucket=GCS_BUCKET,
+        filename=FILENAME,
+        gzip=False
+    )

--- a/airflow/operators/postgres_to_gcs.py
+++ b/airflow/operators/postgres_to_gcs.py
@@ -21,6 +21,7 @@ PostgreSQL to GCS operator.
 """
 
 import datetime
+import json
 import time
 from decimal import Decimal
 
@@ -95,6 +96,8 @@ class PostgresToGoogleCloudStorageOperator(BaseSQLToGoogleCloudStorageOperator):
                 hours=formated_time.tm_hour,
                 minutes=formated_time.tm_min,
                 seconds=formated_time.tm_sec).seconds
+        if isinstance(value, dict):
+            return json.dumps(value)
         if isinstance(value, Decimal):
             return float(value)
         return value

--- a/tests/operators/test_postgres_to_gcs_system.py
+++ b/tests/operators/test_postgres_to_gcs_system.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from psycopg2 import ProgrammingError
+
+from airflow.hooks.postgres_hook import PostgresHook
+from tests.contrib.utils.logging_command_executor import LoggingCommandExecutor
+from tests.gcp.utils.gcp_authenticator import GCP_GCS_KEY
+from tests.test_utils.gcp_system_helpers import provide_gcp_context, skip_gcp_system
+from tests.test_utils.system_tests_class import SystemTest
+
+GCS_BUCKET = "postgres_to_gcs_example"
+CREATE_QUERY = """
+CREATE TABLE public.test_table
+(
+    id integer,
+    params json
+)
+WITH (
+    OIDS = FALSE
+)
+TABLESPACE pg_default;
+
+ALTER TABLE public.test_table
+    OWNER to postgres;
+"""
+
+LOAD_QUERY = """
+INSERT INTO test_table (id, params)
+VALUES
+   (
+      1, '{ "customer": "Lily Bush", "items": {"product": "Diaper","qty": 24}}'
+   ),
+   (
+      2, '{ "customer": "Josh William", "items": {"product": "Toy Car","qty": 1}}'
+   ),
+   (
+      3, '{ "customer": "Mary Clark", "items": {"product": "Toy Train","qty": 2}}'
+   );
+"""
+DELETE_QUERY = "DROP TABLE public.test_table;"
+
+
+class GcsHelper(LoggingCommandExecutor):
+    @staticmethod
+    def init_db():
+        try:
+            hook = PostgresHook()
+            hook.run(CREATE_QUERY)
+            hook.run(LOAD_QUERY)
+        except ProgrammingError:
+            pass
+
+    @staticmethod
+    def drop_db():
+        hook = PostgresHook()
+        hook.run(DELETE_QUERY)
+
+    def create_bucket(self):
+        """Create a bucket."""
+        self.execute_cmd(["gsutil", "mb", "gs://{}".format(GCS_BUCKET)])
+
+    def delete_bucket(self):
+        """Delete bucket in Google Cloud Storage service"""
+        self.execute_cmd(["gsutil", "-m", "rm", "-r", "gs://{}".format(GCS_BUCKET)])
+
+
+@skip_gcp_system(GCP_GCS_KEY, require_local_executor=True)
+class PostgresToGCSSystemTest(SystemTest):
+    helper = GcsHelper()
+
+    @provide_gcp_context(GCP_GCS_KEY)
+    def setUp(self):
+        super().setUp()
+        self.helper.create_bucket()
+        self.helper.init_db()
+
+    @provide_gcp_context(GCP_GCS_KEY)
+    def test_run_example_dag(self):
+        self.run_dag('example_postgres_to_gcs', 'airflow/example_dags')
+
+    @provide_gcp_context(GCP_GCS_KEY)
+    def tearDown(self):
+        self.helper.delete_bucket()
+        self.helper.drop_db()
+        super().tearDown()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3489

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
According to the issue, `PostgresToGoogleCloudStorageOperator` had a problem with handling postgres json data type in way that would allow to import the exported file into BigQuery. So I've added a simple check and `json.dumps`. I've checked if after that the data could be easily transferred to BQ (using data transfer service) and everything worked. I've added also a system test.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
