### PR TITLE
[AIRFLOW-6020] fix python 3 KubernetesExecutor iteritems exception

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -20,10 +20,10 @@ import hashlib
 import json
 import multiprocessing
 import re
+import sys
 from queue import Empty
 from typing import Union
 from uuid import uuid4
-from six import iteritems
 
 import kubernetes
 from dateutil import parser
@@ -45,6 +45,13 @@ from airflow.utils.state import State
 
 MAX_POD_ID_LEN = 253
 MAX_LABEL_LEN = 63
+
+
+def iteritems(d):
+    if sys.version_info[0] == 2:
+        return d.iteritems()
+    else:
+        return d.items()
 
 
 class KubeConfig:  # pylint: disable=too-many-instance-attributes

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -20,7 +20,6 @@ import hashlib
 import json
 import multiprocessing
 import re
-import sys
 from queue import Empty
 from typing import Union
 from uuid import uuid4
@@ -45,13 +44,6 @@ from airflow.utils.state import State
 
 MAX_POD_ID_LEN = 253
 MAX_LABEL_LEN = 63
-
-
-def iteritems(d):
-    if sys.version_info[0] == 2:
-        return d.iteritems()
-    else:
-        return d.items()
 
 
 class KubeConfig:  # pylint: disable=too-many-instance-attributes
@@ -282,7 +274,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         if resource_version:
             kwargs['resource_version'] = resource_version
         if kube_config.kube_client_request_args:
-            for key, value in iteritems(kube_config.kube_client_request_args):
+            for key, value in kube_config.kube_client_request_args.items():
                 kwargs[key] = value
 
         last_resource_version = None
@@ -660,7 +652,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
             # pylint: enable=protected-access
             kwargs = dict(label_selector=dict_string)
             if self.kube_config.kube_client_request_args:
-                for key, value in iteritems(self.kube_config.kube_client_request_args):
+                for key, value in self.kube_config.kube_client_request_args.items():
                     kwargs[key] = value
             pod_list = self.kube_client.list_namespaced_pod(
                 self.kube_config.kube_namespace, **kwargs)

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -23,6 +23,7 @@ import re
 from queue import Empty
 from typing import Union
 from uuid import uuid4
+from six import iteritems
 
 import kubernetes
 from dateutil import parser
@@ -274,7 +275,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         if resource_version:
             kwargs['resource_version'] = resource_version
         if kube_config.kube_client_request_args:
-            for key, value in kube_config.kube_client_request_args.iteritems():
+            for key, value in iteritems(kube_config.kube_client_request_args):
                 kwargs[key] = value
 
         last_resource_version = None
@@ -652,7 +653,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
             # pylint: enable=protected-access
             kwargs = dict(label_selector=dict_string)
             if self.kube_config.kube_client_request_args:
-                for key, value in self.kube_config.kube_client_request_args.iteritems():
+                for key, value in iteritems(self.kube_config.kube_client_request_args):
                     kwargs[key] = value
             pod_list = self.kube_client.list_namespaced_pod(
                 self.kube_config.kube_namespace, **kwargs)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6020
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:  
`kubernetes_executor.py` didn't support Python 3 cause of `dict.iteritems()` using.
It has been fixed by changing `iteritems()` for just `items()`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"
