### PR TITLE
[AIRFLOW-6023] Remove deprecated Celery configs

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -102,8 +102,6 @@ class AirflowConfigParser(ConfigParser):
         ('core', 'fernet_key'),
         ('celery', 'broker_url'),
         ('celery', 'result_backend'),
-        # Todo: remove this in Airflow 1.11
-        ('celery', 'celery_result_backend'),
         ('atlas', 'password'),
         ('smtp', 'smtp_password'),
         ('ldap', 'bind_password'),
@@ -114,14 +112,7 @@ class AirflowConfigParser(ConfigParser):
     # new_name, the old_name will be checked to see if it exists. If it does a
     # DeprecationWarning will be issued and the old name will be used instead
     deprecated_options = {
-        'celery': {
-            # Remove these keys in Airflow 1.11
-            'worker_concurrency': 'celeryd_concurrency',
-            'result_backend': 'celery_result_backend',
-            'broker_url': 'celery_broker_url',
-            'ssl_active': 'celery_ssl_active',
-            'ssl_cert': 'celery_ssl_cert',
-            'ssl_key': 'celery_ssl_key',
+        'elasticsearch': {
             'elasticsearch_host': 'host',
             'elasticsearch_log_id_template': 'log_id_template',
             'elasticsearch_end_of_log_mark': 'end_of_log_mark',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6023

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Some of the celery configs have been deprecated since 1.10 https://github.com/apache/airflow/blob/master/UPDATING.md#celery-config

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
