### PR TITLE
[AIRFLOW-6025] Add label to uniquely identify creator of Pod

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -25,6 +25,7 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.helpers import validate_key
 from airflow.utils.state import State
+from airflow.version import version as airflow_version
 
 
 class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
@@ -126,6 +127,15 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
             client = kube_client.get_kube_client(in_cluster=self.in_cluster,
                                                  cluster_context=self.cluster_context,
                                                  config_file=self.config_file)
+
+            # Add Airflow Version to the label
+            # And a label to identify that pod is launched by KubernetesPodOperator
+            self.labels.update(
+                {
+                    'airflow_version': airflow_version.replace('+', '-'),
+                    'kubernetes_pod_operator': 'True',
+                }
+            )
 
             pod = pod_generator.PodGenerator(
                 image=self.image,

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -25,6 +25,7 @@ from airflow.kubernetes.k8s_model import append_to_pod
 from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.kubernetes.secret import Secret
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.version import version as airflow_version
 
 
 class WorkerConfiguration(LoggingMixin):
@@ -375,6 +376,8 @@ class WorkerConfiguration(LoggingMixin):
                 'task_id': task_id,
                 'execution_date': execution_date,
                 'try_number': str(try_number),
+                'airflow_version': airflow_version.replace('+', '-'),
+                'kubernetes_executor': 'True',
             },
             cmds=airflow_command,
             volumes=self._get_volumes(),

--- a/tests/integration/kubernetes/test_kubernetes_pod_operator.py
+++ b/tests/integration/kubernetes/test_kubernetes_pod_operator.py
@@ -35,6 +35,7 @@ from airflow.kubernetes.pod_launcher import PodLauncher
 from airflow.kubernetes.secret import Secret
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
+from airflow.version import version as airflow_version
 
 try:
     check_call(["/usr/local/bin/kubectl", "get", "pods"])
@@ -61,7 +62,10 @@ class TestKubernetesPodOperator(unittest.TestCase):
                 'namespace': 'default',
                 'name': ANY,
                 'annotations': {},
-                'labels': {'foo': 'bar'}
+                'labels': {
+                    'foo': 'bar', 'kubernetes_pod_operator': 'True',
+                    'airflow_version': airflow_version.replace('+', '-')
+                }
             },
             'spec': {
                 'affinity': {},

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -30,6 +30,7 @@ try:
     from airflow.kubernetes.pod_generator import PodGenerator
     from airflow.exceptions import AirflowConfigException
     from airflow.kubernetes.secret import Secret
+    from airflow.version import version as airflow_version
     import kubernetes.client.models as k8s
     from kubernetes.client.api_client import ApiClient
 except ImportError:
@@ -640,5 +641,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.assertEqual({
             'my_label': 'label_id',
             'dag_id': 'override_dag_id',
-            'my_kube_executor_label': 'kubernetes'
+            'my_kube_executor_label': 'kubernetes',
+            'kubernetes_executor': 'True',
+            'airflow_version': airflow_version.replace('+', '-'),
         }, labels)

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -350,6 +350,24 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
 
         self.assertEqual(0, pod.spec.security_context.run_as_user)
 
+    def test_make_pod_assert_labels(self):
+        # Tests the pod created has all the expected labels set
+        self.kube_config.dags_folder = 'dags'
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        pod = worker_config.make_pod("default", "sample-uuid", "test_pod_id", "test_dag_id",
+                                     "test_task_id", "2019-11-21 11:08:22.920875", 1, "bash -c 'ls /'")
+        expected_labels = {
+            'airflow-worker': 'sample-uuid',
+            'airflow_version': airflow_version.replace('+', '-'),
+            'dag_id': 'test_dag_id',
+            'execution_date': '2019-11-21 11:08:22.920875',
+            'kubernetes_executor': 'True',
+            'task_id': 'test_task_id',
+            'try_number': '1'
+        }
+        self.assertEqual(pod.metadata.labels, expected_labels)
+
     def test_make_pod_git_sync_ssh_without_known_hosts(self):
         # Tests the pod created with git-sync SSH authentication option is correct without known hosts
         self.kube_config.airflow_configmap = 'airflow-configmap'
@@ -642,6 +660,4 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
             'my_label': 'label_id',
             'dag_id': 'override_dag_id',
             'my_kube_executor_label': 'kubernetes',
-            'kubernetes_executor': 'True',
-            'airflow_version': airflow_version.replace('+', '-'),
         }, labels)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6025


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
2 Components natively create Kubernetes Pods.

1) KubernetesPodOperator
2) KubernetesExecutor

It would be ideal to add a label that identifies which of the two launches pod.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
