### PR TITLE
[AIRFLOW-6027] Disable API access by default

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -41,6 +41,14 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### API access disabled by default
+
+In previous versions, the default configuration contains a dangerous configuration that allows access
+to the API without authorization.
+
+This behavior must now be intentionally configured, but the default behavior allows unauthorized access to
+the API.
+
 ### Remove serve_logs command from CLI
 
 The ``serve_logs`` command has been deleted. This command should be run only by internal application mechanisms

--- a/airflow/api/auth/backend/__init__.py
+++ b/airflow/api/auth/backend/__init__.py
@@ -16,3 +16,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing_extensions import Protocol
+
+
+class ClientAuthProtocol(Protocol):
+    """
+    Protocol type for CLIENT_AUTH
+    """
+    def handle_response(self, _):
+        """
+        CLIENT_AUTH.handle_response method
+        """
+        ...

--- a/airflow/api/auth/backend/allow_all.py
+++ b/airflow/api/auth/backend/allow_all.py
@@ -16,25 +16,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Default authentication backend - everything is allowed"""
+"""Everything is allowed"""
 from functools import wraps
 from typing import Optional
 
-from airflow.typing_compat import Protocol
+from airflow.api.auth.backend import ClientAuthProtocol
 
-
-class ClientAuthProtocol(Protocol):
-    """
-    Protocol type for CLIENT_AUTH
-    """
-    def handle_response(self, _):
-        """
-        CLIENT_AUTH.handle_response method
-        """
-        ...
-
-
-CLIENT_AUTH = None  # type: Optional[ClientAuthProtocol]
+CLIENT_AUTH: Optional[ClientAuthProtocol] = None
 
 
 def init_app(_):

--- a/airflow/api/auth/backend/deny_all.py
+++ b/airflow/api/auth/backend/deny_all.py
@@ -22,9 +22,9 @@ from typing import Optional
 
 from flask import Response
 
-from airflow.api.auth.backend.default import ClientAuthProtocol
+from airflow.api.auth.backend import ClientAuthProtocol
 
-CLIENT_AUTH = None  # type: Optional[ClientAuthProtocol]
+CLIENT_AUTH: Optional[ClientAuthProtocol] = None
 
 
 def init_app(_):

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -239,7 +239,7 @@ fail_fast = False
 
 [api]
 # How to authenticate users of the API
-auth_backend = airflow.api.auth.backend.default
+auth_backend = airflow.api.auth.backend.deny_all
 
 [lineage]
 # what lineage backend to use

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -113,27 +113,33 @@ alter the content and make it part of the ``PYTHONPATH`` and configure it as a b
 API Authentication
 ------------------
 
-Authentication for the API is handled separately to the Web Authentication. The default is to not
-require any authentication on the API i.e. wide open by default. This is not recommended if your
-Airflow webserver is publicly accessible, and you should probably use the ``deny all`` backend:
+Authentication for the API is handled separately to the Web Authentication. By default, access to it is
+blocked, because the authorization configuration is configured as follows.
 
 .. code-block:: ini
 
     [api]
     auth_backend = airflow.api.auth.backend.deny_all
 
-Two "real" methods for authentication are currently supported for the API.
+Three "real" backend for authentication are currently supported for the API.
 
-To enabled Password authentication, set the following in the configuration:
+To allow access to the API **without authentication**, set the following in the configuration:
+
+.. code-block:: ini
+
+    [api]
+    auth_backend = airflow.api.auth.backend.allow_all
+
+To enable **password authentication**, set the following in the configuration:
 
 .. code-block:: ini
 
     [api]
     auth_backend = airflow.contrib.auth.backends.password_auth
 
-It's usage is similar to the Password Authentication used for the Web interface.
+It's usage is similar to the password authentication used for the Web interface.
 
-To enable Kerberos authentication, set the following in the configuration:
+To enable **Kerberos authentication**, set the following in the configuration:
 
 .. code-block:: ini
 


### PR DESCRIPTION
Default configuration should be secure, so open unsecured API is a big problem.  A lot of Airflow instances may not change the default configuration and therefore be vulnerable to third party attacks.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6027
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
