### PR TITLE
[AIRFLOW-6034] Fix Deprecated Elasticsearch configs on Master

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -113,13 +113,13 @@ class AirflowConfigParser(ConfigParser):
     # DeprecationWarning will be issued and the old name will be used instead
     deprecated_options = {
         'elasticsearch': {
-            'elasticsearch_host': 'host',
-            'elasticsearch_log_id_template': 'log_id_template',
-            'elasticsearch_end_of_log_mark': 'end_of_log_mark',
-            'elasticsearch_frontend': 'frontend',
-            'elasticsearch_write_stdout': 'write_stdout',
-            'elasticsearch_json_format': 'json_format',
-            'elasticsearch_json_fields': 'json_fields'
+            'host': 'elasticsearch_host',
+            'log_id_template': 'elasticsearch_log_id_template',
+            'end_of_log_mark': 'elasticsearch_end_of_log_mark',
+            'frontend': 'elasticsearch_frontend',
+            'write_stdout': 'elasticsearch_write_stdout',
+            'json_format': 'elasticsearch_json_format',
+            'json_fields': 'elasticsearch_json_fields'
         }
     }
 


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6034


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This was already fixed in v1-10-* branches

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
