### PR TITLE
[AIRFLOW-5947] Make the json backend pluggable for DAG Serialization

### DIFF
--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -23,10 +23,12 @@ import hashlib
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from sqlalchemy import JSON, Column, Index, Integer, String, and_
+import sqlalchemy_jsonfield
+from sqlalchemy import Column, Index, Integer, String, and_
 from sqlalchemy.sql import exists
 
 from airflow.models.base import ID_LEN, Base
+from airflow.settings import json
 from airflow.utils import db, timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.sqlalchemy import UtcDateTime
@@ -63,7 +65,7 @@ class SerializedDagModel(Base):
     fileloc = Column(String(2000), nullable=False)
     # The max length of fileloc exceeds the limit of indexing.
     fileloc_hash = Column(Integer, nullable=False)
-    data = Column(JSON, nullable=False)
+    data = Column(sqlalchemy_jsonfield.JSONField(json=json), nullable=False)
     last_updated = Column(UtcDateTime, nullable=False)
 
     __table_args__ = (

--- a/airflow/serialization/json_schema.py
+++ b/airflow/serialization/json_schema.py
@@ -19,7 +19,6 @@
 
 """jsonschema for validating serialized DAG and operator."""
 
-import json
 import pkgutil
 from typing import Iterable
 
@@ -27,6 +26,7 @@ import jsonschema
 from typing_extensions import Protocol
 
 from airflow.exceptions import AirflowException
+from airflow.settings import json
 
 
 class Validator(Protocol):

--- a/airflow/serialization/serialization.py
+++ b/airflow/serialization/serialization.py
@@ -21,7 +21,6 @@
 
 import datetime
 import enum
-import json
 import logging
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
@@ -34,6 +33,7 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
+from airflow.settings import json
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.www.utils import get_python_source
 

--- a/airflow/serialization/serialized_dag.py
+++ b/airflow/serialization/serialized_dag.py
@@ -36,7 +36,7 @@ class SerializedDAG(DAG, Serialization):
 
     Compared with SimpleDAG: SerializedDAG contains all information for webserver.
     Compared with DagPickle: DagPickle contains all information for worker, but some DAGs are
-    not pickable. SerializedDAG works for all DAGs.
+    not pickle-able. SerializedDAG works for all DAGs.
     """
 
     _decorated_fields = {'schedule_interval', 'default_args'}

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import atexit
+import json
 import logging
 import os
 import sys
@@ -74,6 +75,9 @@ LOGGING_CLASS_PATH = None  # type: Optional[str]
 
 engine = None  # type: Optional[Engine]
 Session = None  # type: Optional[SASession]
+
+# The JSON library to use for DAG Serialization and De-Serialization
+json = json
 
 
 def policy(task_instance):

--- a/docs/dag-serialization.rst
+++ b/docs/dag-serialization.rst
@@ -78,3 +78,15 @@ which is why we said "almost" stateless.
     However, it does not need to Parse the Python file so it is still a small operation.
 *   :doc:`Extra Operator Links <howto/define_extra_link>` for the inbuilt Operators would not no longer work.
     However, you can define your own Operator Links via Airflow plugins.
+
+
+Using a different JSON Library
+------------------------------
+
+To use a different JSON library instead of the standard ``json`` library like ``ujson``, you need to
+define a ``json`` variable in local Airflow settings (``airflow_local_settings.py``) file as follows:
+
+.. code:: python
+
+    import ujson
+    json = ujson

--- a/setup.py
+++ b/setup.py
@@ -389,6 +389,7 @@ def do_setup():
             'requests>=2.20.0, <3',
             'setproctitle>=1.1.8, <2',
             'sqlalchemy~=1.3',
+            'sqlalchemy_jsonfield~=0.9',
             'tabulate>=0.7.5, <0.9',
             'tenacity==4.12.0',
             'termcolor==1.1.0',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-5947

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Allow users the option to choose the JSON library of their choice for DAG Serialization.



### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
