### PR TITLE
[AIRFLOW-6044] Standardize the Code Structure in kube_pod_operator.py

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -122,6 +122,79 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     """
     template_fields = ('cmds', 'arguments', 'env_vars', 'config_file')
 
+    @apply_defaults
+    def __init__(self,  # pylint: disable=too-many-arguments,too-many-locals
+                 namespace,
+                 image,
+                 name,
+                 cmds=None,
+                 arguments=None,
+                 ports=None,
+                 volume_mounts=None,
+                 volumes=None,
+                 env_vars=None,
+                 secrets=None,
+                 in_cluster=True,
+                 cluster_context=None,
+                 labels=None,
+                 startup_timeout_seconds=120,
+                 get_logs=True,
+                 image_pull_policy='IfNotPresent',
+                 annotations=None,
+                 resources=None,
+                 affinity=None,
+                 config_file=None,
+                 node_selectors=None,
+                 image_pull_secrets=None,
+                 service_account_name='default',
+                 is_delete_operator_pod=False,
+                 hostnetwork=False,
+                 tolerations=None,
+                 configmaps=None,
+                 security_context=None,
+                 pod_runtime_info_envs=None,
+                 dnspolicy=None,
+                 full_pod_spec=None,
+                 *args,
+                 **kwargs):
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException("'xcom_push' was deprecated, use 'do_xcom_push' instead")
+        super().__init__(*args, resources=None, **kwargs)
+
+        self.pod = None
+
+        self.image = image
+        self.namespace = namespace
+        self.cmds = cmds or []
+        self.arguments = arguments or []
+        self.labels = labels or {}
+        self.startup_timeout_seconds = startup_timeout_seconds
+        self.name = self._set_name(name)
+        self.env_vars = env_vars or {}
+        self.ports = ports or []
+        self.volume_mounts = volume_mounts or []
+        self.volumes = volumes or []
+        self.secrets = secrets or []
+        self.in_cluster = in_cluster
+        self.cluster_context = cluster_context
+        self.get_logs = get_logs
+        self.image_pull_policy = image_pull_policy
+        self.node_selectors = node_selectors or {}
+        self.annotations = annotations or {}
+        self.affinity = affinity or {}
+        self.resources = self._set_resources(resources)
+        self.config_file = config_file
+        self.image_pull_secrets = image_pull_secrets
+        self.service_account_name = service_account_name
+        self.is_delete_operator_pod = is_delete_operator_pod
+        self.hostnetwork = hostnetwork
+        self.tolerations = tolerations or []
+        self.configmaps = configmaps or []
+        self.security_context = security_context or {}
+        self.pod_runtime_info_envs = pod_runtime_info_envs or []
+        self.dnspolicy = dnspolicy
+        self.full_pod_spec = full_pod_spec
+
     def execute(self, context):
         try:
             client = kube_client.get_kube_client(in_cluster=self.in_cluster,
@@ -199,76 +272,3 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     def _set_name(self, name):
         validate_key(name, max_length=63)
         return re.sub(r'[^a-z0-9.-]+', '-', name.lower())
-
-    @apply_defaults
-    def __init__(self,  # pylint: disable=too-many-arguments,too-many-locals
-                 namespace,
-                 image,
-                 name,
-                 cmds=None,
-                 arguments=None,
-                 ports=None,
-                 volume_mounts=None,
-                 volumes=None,
-                 env_vars=None,
-                 secrets=None,
-                 in_cluster=True,
-                 cluster_context=None,
-                 labels=None,
-                 startup_timeout_seconds=120,
-                 get_logs=True,
-                 image_pull_policy='IfNotPresent',
-                 annotations=None,
-                 resources=None,
-                 affinity=None,
-                 config_file=None,
-                 node_selectors=None,
-                 image_pull_secrets=None,
-                 service_account_name='default',
-                 is_delete_operator_pod=False,
-                 hostnetwork=False,
-                 tolerations=None,
-                 configmaps=None,
-                 security_context=None,
-                 pod_runtime_info_envs=None,
-                 dnspolicy=None,
-                 full_pod_spec=None,
-                 *args,
-                 **kwargs):
-        if kwargs.get('xcom_push') is not None:
-            raise AirflowException("'xcom_push' was deprecated, use 'do_xcom_push' instead")
-        super().__init__(*args, resources=None, **kwargs)
-
-        self.pod = None
-
-        self.image = image
-        self.namespace = namespace
-        self.cmds = cmds or []
-        self.arguments = arguments or []
-        self.labels = labels or {}
-        self.startup_timeout_seconds = startup_timeout_seconds
-        self.name = self._set_name(name)
-        self.env_vars = env_vars or {}
-        self.ports = ports or []
-        self.volume_mounts = volume_mounts or []
-        self.volumes = volumes or []
-        self.secrets = secrets or []
-        self.in_cluster = in_cluster
-        self.cluster_context = cluster_context
-        self.get_logs = get_logs
-        self.image_pull_policy = image_pull_policy
-        self.node_selectors = node_selectors or {}
-        self.annotations = annotations or {}
-        self.affinity = affinity or {}
-        self.resources = self._set_resources(resources)
-        self.config_file = config_file
-        self.image_pull_secrets = image_pull_secrets
-        self.service_account_name = service_account_name
-        self.is_delete_operator_pod = is_delete_operator_pod
-        self.hostnetwork = hostnetwork
-        self.tolerations = tolerations or []
-        self.configmaps = configmaps or []
-        self.security_context = security_context or {}
-        self.pod_runtime_info_envs = pod_runtime_info_envs or []
-        self.dnspolicy = dnspolicy
-        self.full_pod_spec = full_pod_spec


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AIRFLOW-6044

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6044


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The `execute` method is before `_init_`. The order doesn't matter but for the sake of consistency across Airflow codebase, it would be ideal to standardize this.



### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Already covered

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
