### PR TITLE
[AIRFLOW-6045] Error on failed execution of compile_assets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ class CompileAssets(Command):
     # noinspection PyMethodMayBeStatic
     def run(self):
         """Run a command to compile and build assets."""
-        subprocess.call('./airflow/www/compile_assets.sh')
+        subprocess.check_call('./airflow/www/compile_assets.sh')
 
 
 def git_version(version_: str) -> str:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AIRFLOW-6045

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-6045


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Currently, if someone runs `python setup.py compile_assets sdist` and if they don't have npm install or if for some reason the script called by compile_assets function fail, the function does nothing as it uses `subprocess.call`. We should use `subprocess.check_call` to fix it



### Tests

- [] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
