### PR TITLE
[AIRFLOW-6046] Fix Alembic migrations & sync it to 1.10.*

### DIFF
--- a/airflow/migrations/versions/4ebbffe0a39a_merge_heads.py
+++ b/airflow/migrations/versions/4ebbffe0a39a_merge_heads.py
@@ -19,14 +19,14 @@
 """Merge heads
 
 Revision ID: 4ebbffe0a39a
-Revises: dd4ecb8fbee3, cf5dc11e79ad, a56c9515abdc
+Revises: dd4ecb8fbee3, cf5dc11e79ad
 Create Date: 2019-02-04 20:19:50.628137
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '4ebbffe0a39a'
-down_revision = ('dd4ecb8fbee3', 'cf5dc11e79ad', 'a56c9515abdc')
+down_revision = ('dd4ecb8fbee3', 'cf5dc11e79ad')
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/74effc47d867_change_datetime_to_datetime2_6_on_mssql_.py
+++ b/airflow/migrations/versions/74effc47d867_change_datetime_to_datetime2_6_on_mssql_.py
@@ -31,7 +31,7 @@ from sqlalchemy.dialects import mssql
 
 # revision identifiers, used by Alembic.
 revision = '74effc47d867'
-down_revision = 'b3b105409875'
+down_revision = '6e96a59344a4'
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/b0125267960b_merge_heads.py
+++ b/airflow/migrations/versions/b0125267960b_merge_heads.py
@@ -16,38 +16,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""increase queue name size limit
+"""merge multiple heads
 
-Revision ID: 004c1210f153
-Revises: 939bb1e647c8
-Create Date: 2019-06-07 07:46:04.262275
+Revision ID: 08364691d074
+Revises: a56c9515abdc, 74effc47d867, b3b105409875, bbf4a7ad0465
+Create Date: 2019-11-19 22:05:11.752222
 
 """
 
-import sqlalchemy as sa
-from alembic import op
-
 # revision identifiers, used by Alembic.
-revision = '004c1210f153'
-down_revision = '939bb1e647c8'
+revision = '08364691d074'
+down_revision = ('a56c9515abdc', '74effc47d867', 'b3b105409875', 'bbf4a7ad0465')
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    """
-    Increase column size from 50 to 256 characters, closing AIRFLOW-4737 caused
-    by broker backends that might use unusually large queue names.
-    """
-    # use batch_alter_table to support SQLite workaround
-    with op.batch_alter_table('task_instance') as batch_op:
-        batch_op.alter_column('queue', type_=sa.String(256))
+    pass
 
 
 def downgrade():
-    """
-    Revert column size from 256 to 50 characters, might result in data loss.
-    """
-    # use batch_alter_table to support SQLite workaround
-    with op.batch_alter_table('task_instance') as batch_op:
-        batch_op.alter_column('queue', type_=sa.String(50))
+    pass


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6046

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
From https://github.com/apache/airflow/pull/6442#issuecomment-557574440

just tried doing an upgrade to 1.10.6 followed by an upgrade to master:

```
git checkout 1.10.6

alembic upgrade heads
git checkout master
alembic upgrade heads
```

Result is

```
ERROR [alembic.util.messaging] Requested revision 74effc47d867 overlaps with other requested 
revisions 004c1210f153
  FAILED: Requested revision 74effc47d867 overlaps with other requested revisions 004c1210f153
```


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release