### PR TITLE
[AIRFLOW-6084] Add info endpoint to experimental api

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -30,6 +30,7 @@ from airflow.exceptions import AirflowException
 from airflow.utils import timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.strings import to_boolean
+from airflow.version import version
 from airflow.www.app import csrf
 
 _log = LoggingMixin().log
@@ -138,6 +139,12 @@ def dag_runs(dag_id):
 @requires_authentication
 def test():
     return jsonify(status='OK')
+
+
+@api_experimental.route('/info', methods=['GET'])
+@requires_authentication
+def info():
+    return jsonify(version=version)
 
 
 @api_experimental.route('/dags/<string:dag_id>/code', methods=['GET'])

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -27,6 +27,7 @@ from airflow.api.common.experimental.trigger_dag import trigger_dag
 from airflow.models import DagBag, DagRun, Pool, TaskInstance
 from airflow.settings import Session
 from airflow.utils.timezone import datetime, parse as parse_datetime, utcnow
+from airflow.version import version
 from airflow.www import app as application
 from tests.test_utils.db import clear_db_pools
 
@@ -65,6 +66,14 @@ class TestApiExperimental(TestBase):
         session.commit()
         session.close()
         super().tearDown()
+
+    def test_info(self):
+        url = '/api/experimental/info'
+
+        resp_raw = self.client.get(url)
+        resp = json.loads(resp_raw.data.decode('utf-8'))
+
+        self.assertEqual(version, resp['version'])
 
     def test_task_info(self):
         url_template = '/api/experimental/dags/{}/tasks/{}'


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-6084

### Description

Add version info endpoint to experimental api

Use case: version info is useful for audit/monitoring purpose.

### Tests

Tests included.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release


cc @bolkedebruin 
