### PR TITLE
[AIRFLOW-6055] Option for exponential backoff in Sensors

### DIFF
--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -21,6 +21,7 @@
 from datetime import timedelta
 from time import sleep
 from typing import Dict, Iterable
+import hashlib
 
 from airflow.exceptions import (
     AirflowException, AirflowRescheduleException, AirflowSensorTimeout, AirflowSkipException,
@@ -68,6 +69,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                  timeout: float = 60 * 60 * 24 * 7,
                  soft_fail: bool = False,
                  mode: str = 'poke',
+                 exponential_backoff: bool = False,
                  *args,
                  **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -75,6 +77,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         self.soft_fail = soft_fail
         self.timeout = timeout
         self.mode = mode
+        self.exponential_backoff = exponential_backoff
         self._validate_input_values()
 
     def _validate_input_values(self) -> None:
@@ -101,11 +104,13 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
 
     def execute(self, context: Dict) -> None:
         started_at = timezone.utcnow()
+        try_number = 1
         if self.reschedule:
             # If reschedule, use first start date of current try
             task_reschedules = TaskReschedule.find_for_task_instance(context['ti'])
             if task_reschedules:
                 started_at = task_reschedules[0].start_date
+                try_number = len(task_reschedules) + 1
         while not self.poke(context):
             if (timezone.utcnow() - started_at).total_seconds() > self.timeout:
                 # If sensor is in soft fail mode but will be retried then
@@ -118,10 +123,11 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                     raise AirflowSensorTimeout('Snap. Time is OUT.')
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
-                    seconds=self.poke_interval)
+                    seconds=self._get_next_poke_interval(started_at, try_number))
                 raise AirflowRescheduleException(reschedule_date)
             else:
-                sleep(self.poke_interval)
+                sleep(self._get_next_poke_interval(started_at, try_number))
+                try_number += 1
         self.log.info("Success criteria met. Exiting.")
 
     def _do_skip_downstream_tasks(self, context: Dict) -> None:
@@ -129,6 +135,28 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         self.log.debug("Downstream task_ids %s", downstream_tasks)
         if downstream_tasks:
             self.skip(context['dag_run'], context['ti'].execution_date, downstream_tasks)
+
+    def _get_next_poke_interval(self, started_at, try_number):
+        if self.exponential_backoff:
+            min_backoff = int(self.poke_interval * (2 ** (try_number - 2)))
+            current_time = timezone.utcnow()
+
+            hash = int(hashlib.sha1("{}#{}#{}#{}".format(self.dag_id,
+                                                         self.task_id,
+                                                         started_at,
+                                                         try_number)
+                                    .encode('utf-8')).hexdigest(), 16)
+            modded_hash = min_backoff + hash % min_backoff
+
+            delay_backoff_in_seconds = min(
+                modded_hash,
+                timedelta.max.total_seconds() - 1
+            )
+            new_interval = min(self.timeout - int((current_time - started_at).total_seconds()), delay_backoff_in_seconds)
+            self.log.info("new {} interval is {}".format(self.mode, new_interval))
+            return new_interval
+        else:
+            return self.poke_interval
 
     @property
     def reschedule(self):

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -17,11 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
+import hashlib
 from datetime import timedelta
 from time import sleep
 from typing import Dict, Iterable
-import hashlib
 
 from airflow.exceptions import (
     AirflowException, AirflowRescheduleException, AirflowSensorTimeout, AirflowSkipException,

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -502,3 +502,30 @@ class TestBaseSensor(unittest.TestCase):
             return_value=None,
             poke_interval=10,
             timeout=positive_timeout)
+
+    def test_sensor_with_exponential_backoff_off(self):
+        sensor = self._make_sensor(
+            return_value=None,
+            poke_interval=5,
+            timeout=60,
+            exponential_backoff=False)
+
+        started_at = timezone.utcnow() - timedelta(seconds=10)
+        self.assertEqual(sensor._get_next_poke_interval(started_at, 1), sensor.poke_interval)
+        self.assertEqual(sensor._get_next_poke_interval(started_at, 2), sensor.poke_interval)
+
+
+    def test_sensor_with_exponential_backoff_on(self):
+        sensor = self._make_sensor(
+            return_value=None,
+            poke_interval=5,
+            timeout=60,
+            exponential_backoff=True)
+
+        started_at = timezone.utcnow() - timedelta(seconds=10)
+
+        interval1 = sensor._get_next_poke_interval(started_at, 1)
+        interval2 = sensor._get_next_poke_interval(started_at, 2)
+
+        self.assertTrue(interval2 >= sensor.poke_interval >= interval1)
+

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -514,7 +514,6 @@ class TestBaseSensor(unittest.TestCase):
         self.assertEqual(sensor._get_next_poke_interval(started_at, 1), sensor.poke_interval)
         self.assertEqual(sensor._get_next_poke_interval(started_at, 2), sensor.poke_interval)
 
-
     def test_sensor_with_exponential_backoff_on(self):
         sensor = self._make_sensor(
             return_value=None,
@@ -528,4 +527,3 @@ class TestBaseSensor(unittest.TestCase):
         interval2 = sensor._get_next_poke_interval(started_at, 2)
 
         self.assertTrue(interval2 >= sensor.poke_interval >= interval1)
-


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issue https://issues.apache.org/jira/browse/AIRFLOW-6055

### Description

- [ ] Adding an option in sensors to do exponential backoff before poke or schedule again.

### Tests

- [ ] Added a couple of unit tests around the new function

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
