### PR TITLE
[AIRFLOW-6057] Update template_fields of the PythonSensor

### DIFF
--- a/airflow/contrib/sensors/python_sensor.py
+++ b/airflow/contrib/sensors/python_sensor.py
@@ -47,7 +47,7 @@ class PythonSensor(BaseSensorOperator):
     :type templates_dict: dict of str
     """
 
-    template_fields = ('templates_dict',)
+    template_fields = ('templates_dict', 'op_args', 'op_kwargs')
 
     @apply_defaults
     def __init__(

--- a/tests/contrib/sensors/test_python_sensor.py
+++ b/tests/contrib/sensors/test_python_sensor.py
@@ -18,26 +18,19 @@
 # under the License.
 
 
-import unittest
+from collections import namedtuple
+from datetime import date
 
-from airflow import DAG
 from airflow.contrib.sensors.python_sensor import PythonSensor
 from airflow.exceptions import AirflowSensorTimeout
+from airflow.utils.state import State
 from airflow.utils.timezone import datetime
+from tests.operators.test_python_operator import Call, TestPythonBase, build_recording_function
 
 DEFAULT_DATE = datetime(2015, 1, 1)
-TEST_DAG_ID = 'python_sensor_dag'
 
 
-class TestPythonSensor(unittest.TestCase):
-
-    def setUp(self):
-        self.args = {
-            'owner': 'airflow',
-            'start_date': DEFAULT_DATE
-        }
-        dag = DAG(TEST_DAG_ID, default_args=self.args)
-        self.dag = dag
+class TestPythonSensor(TestPythonBase):
 
     def test_python_sensor_true(self):
         op = PythonSensor(
@@ -63,3 +56,84 @@ class TestPythonSensor(unittest.TestCase):
             dag=self.dag)
         with self.assertRaises(ZeroDivisionError):
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+    def test_python_callable_arguments_are_templatized(self):
+        """Test PythonSensor op_args are templatized"""
+        recorded_calls = []
+
+        # Create a named tuple and ensure it is still preserved
+        # after the rendering is done
+        Named = namedtuple('Named', ['var1', 'var2'])
+        named_tuple = Named('{{ ds }}', 'unchanged')
+
+        task = PythonSensor(
+            task_id='python_sensor',
+            timeout=0.01,
+            poke_interval=0.3,
+            # a Mock instance cannot be used as a callable function or test fails with a
+            # TypeError: Object of type Mock is not JSON serializable
+            python_callable=build_recording_function(recorded_calls),
+            op_args=[
+                4,
+                date(2019, 1, 1),
+                "dag {{dag.dag_id}} ran on {{ds}}.",
+                named_tuple
+            ],
+            dag=self.dag)
+
+        self.dag.create_dagrun(
+            run_id='manual__' + DEFAULT_DATE.isoformat(),
+            execution_date=DEFAULT_DATE,
+            start_date=DEFAULT_DATE,
+            state=State.RUNNING
+        )
+        with self.assertRaises(AirflowSensorTimeout):
+            task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        ds_templated = DEFAULT_DATE.date().isoformat()
+        # 2 calls: first: at start, second: before timeout
+        self.assertEqual(2, len(recorded_calls))
+        self._assert_calls_equal(
+            recorded_calls[0],
+            Call(4,
+                 date(2019, 1, 1),
+                 "dag {} ran on {}.".format(self.dag.dag_id, ds_templated),
+                 Named(ds_templated, 'unchanged'))
+        )
+
+    def test_python_callable_keyword_arguments_are_templatized(self):
+        """Test PythonSensor op_kwargs are templatized"""
+        recorded_calls = []
+
+        task = PythonSensor(
+            task_id='python_sensor',
+            timeout=0.01,
+            poke_interval=0.3,
+            # a Mock instance cannot be used as a callable function or test fails with a
+            # TypeError: Object of type Mock is not JSON serializable
+            python_callable=build_recording_function(recorded_calls),
+            op_kwargs={
+                'an_int': 4,
+                'a_date': date(2019, 1, 1),
+                'a_templated_string': "dag {{dag.dag_id}} ran on {{ds}}."
+            },
+            dag=self.dag)
+
+        self.dag.create_dagrun(
+            run_id='manual__' + DEFAULT_DATE.isoformat(),
+            execution_date=DEFAULT_DATE,
+            start_date=DEFAULT_DATE,
+            state=State.RUNNING
+        )
+        with self.assertRaises(AirflowSensorTimeout):
+            task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        # 2 calls: first: at start, second: before timeout
+        self.assertEqual(2, len(recorded_calls))
+        self._assert_calls_equal(
+            recorded_calls[0],
+            Call(an_int=4,
+                 a_date=date(2019, 1, 1),
+                 a_templated_string="dag {} ran on {}.".format(
+                     self.dag.dag_id, DEFAULT_DATE.date().isoformat()))
+        )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6057
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Allow passing Jinja templated arguments to the python_callable of the PythonSensor (just like in PythonOperator) by adding op_args and op_kwargs to the template_fields of the PythonSensor.
Also fix the test_python_callable_keyword_arguments_are_templatized test of the PythonOperator.

### Tests

- [x] My PR adds the following unit tests:
  - test_python_callable_arguments_are_templatized for op_args,
  - test_python_callable_keyword_arguments_are_templatized for op_kwargs

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
