### PR TITLE
[AIRFLOW-6068] Make args of KubernetesPodOperator to get dict type

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -280,7 +280,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         def _set_instance(_class, _args):
             try:
                 return _class(**_args)
-            except Exception:
+            except TypeError:
                 return None
 
         if _args_list and isinstance(_args_list, list):

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -280,7 +280,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         def _set_instance(_class, _args):
             try:
                 return _class(**_args)
-            except Exception: 
+            except Exception:
                 return None
 
         if _args_list and isinstance(_args_list, list):

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -276,14 +276,13 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
             raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
 
     @staticmethod
-    def _set_instance(_class, _args):
-        try:
-            return _class(**_args)
-        except:
-            return None
-
-    @staticmethod
     def _set_instances(_class, _args_list):
+        def _set_instance(_class, _args):
+            try:
+                return _class(**_args)
+            except Exception: 
+                return None
+
         if _args_list and isinstance(_args_list, list):
             ret = [_set_instance(_class, _args) for _args in _args_list]
             return [x for x in ret if x]

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -280,12 +280,11 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         def _set_instance(_class, _args):
             try:
                 return _class(**_args)
-            except TypeError:
-                return None
+            except TypeError as err:
+                raise TypeError("{} class {}".format(_class.__name__, err))
 
-        if _args_list and isinstance(_args_list, list):
-            ret = [_set_instance(_class, _args) for _args in _args_list]
-            return [x for x in ret if x]
+        if _args_list:
+            return [_set_instance(_class, _args) for _args in _args_list]
         return []
 
     @staticmethod


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6068

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
