### PR TITLE
[AIRFLOW-6069] Python host version in travis is set to 3.6 always

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ stages:
 jobs:
   include:
     - name: "Static checks"
-      python: "3.6"
       stage: pre-test
       script: ./scripts/ci/ci_run_all_static_tests.sh
       env: >-
@@ -42,7 +41,6 @@ jobs:
     - name: "Build documentation"
       env: >-
         PYTHON_VERSION=3.6
-      python: "3.6"
       stage: pre-test
       script: ./scripts/ci/ci_docs.sh
     - name: "Tests postgres python 3.6"
@@ -50,21 +48,18 @@ jobs:
         BACKEND=postgres
         ENV=docker
         PYTHON_VERSION=3.6
-      python: "3.6"
       stage: test
     - name: "Tests sqlite python 3.6"
       env:
         BACKEND=sqlite
         ENV=docker
         PYTHON_VERSION=3.6
-      python: "3.6"
       stage: test
     - name: "Tests mysql python 3.7"
       env:
         BACKEND=mysql
         ENV=docker
         PYTHON_VERSION=3.7
-      python: "3.7"
       stage: test
     - name: "Tests postgres kubernetes python 3.6 (persistent)"
       env: >-
@@ -73,7 +68,6 @@ jobs:
         KUBERNETES_VERSION=v1.15.0
         KUBERNETES_MODE=persistent_mode
         PYTHON_VERSION=3.6
-      python: "3.6"
       stage: test
       script: travis_wait 30 "./scripts/ci/ci_run_airflow_testing.sh"
     - name: "Tests postgres kubernetes python 3.6 (git)"
@@ -83,7 +77,6 @@ jobs:
         KUBERNETES_VERSION=v1.15.0
         KUBERNETES_MODE=git_mode
         PYTHON_VERSION=3.6
-      python: "3.6"
       stage: test
       script: travis_wait 30 "./scripts/ci/ci_run_airflow_testing.sh"
   services:


### PR DESCRIPTION
This will make the scripts more "stable" - no problems with
features missing in 3.5 for host scripts.

Python version for all tests in container is controlled via
PYTHON_VERSION variable.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6069

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
