### PR TITLE
[AIRFLOW-6073] Move Qubole Operator Link class to qubole_operator.py

### DIFF
--- a/airflow/contrib/hooks/qubole_hook.py
+++ b/airflow/contrib/hooks/qubole_hook.py
@@ -21,7 +21,6 @@
 import datetime
 import os
 import pathlib
-import re
 import time
 
 from qds_sdk.commands import (
@@ -33,7 +32,6 @@ from qds_sdk.qubole import Qubole
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.models import TaskInstance
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
 
@@ -220,26 +218,6 @@ class QuboleHook(BaseHook):
         if self.cmd is None:
             cmd_id = ti.xcom_pull(key="qbol_cmd_id", task_ids=self.task_id)
         Command.get_jobs_id(cmd_id)
-
-    # noinspection PyMethodMayBeStatic
-    def get_extra_links(self, operator, dttm):
-        """
-        Get link to qubole command result page.
-
-        :param operator: operator
-        :param dttm: datetime
-        :return: url link
-        """
-        conn = BaseHook.get_connection(operator.kwargs['qubole_conn_id'])
-        if conn and conn.host:
-            host = re.sub(r'api$', 'v2/analyze?command_id=', conn.host)
-        else:
-            host = 'https://api.qubole.com/v2/analyze?command_id='
-
-        ti = TaskInstance(task=operator, execution_date=dttm)
-        qds_command_id = ti.xcom_pull(task_ids=operator.task_id, key='qbol_cmd_id')
-        url = host + str(qds_command_id) if qds_command_id else ''
-        return url
 
     def create_cmd_args(self, context):
         """Creates command arguments"""

--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -17,13 +17,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """Qubole operator"""
-
+import re
 from typing import Iterable
 
 from airflow.contrib.hooks.qubole_hook import (
     COMMAND_ARGS, HYPHEN_ARGS, POSITIONAL_ARGS, QuboleHook, flatten_list,
 )
+from airflow.hooks.base_hook import BaseHook
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+from airflow.models.taskinstance import TaskInstance
 from airflow.utils.decorators import apply_defaults
 
 
@@ -32,7 +34,22 @@ class QDSLink(BaseOperatorLink):
     name = 'Go to QDS'
 
     def get_link(self, operator, dttm):
-        return operator.get_hook().get_extra_links(operator, dttm)
+        """
+        Get link to qubole command result page.
+
+        :param operator: operator
+        :param dttm: datetime
+        :return: url link
+        """
+        ti = TaskInstance(task=operator, execution_date=dttm)
+        conn = BaseHook.get_connection(operator.kwargs['qubole_conn_id'])
+        if conn and conn.host:
+            host = re.sub(r'api$', 'v2/analyze?command_id=', conn.host)
+        else:
+            host = 'https://api.qubole.com/v2/analyze?command_id='
+        qds_command_id = ti.xcom_pull(task_ids=operator.task_id, key='qbol_cmd_id')
+        url = host + str(qds_command_id) if qds_command_id else ''
+        return url
 
 
 class QuboleOperator(BaseOperator):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-6073


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The OperatorLink should be in the file where Operator is defined for consistency



### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Current tests cover it

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
