### PR TITLE
AIRFLOW-6083 - Custom Lambda client parameters

### DIFF
--- a/airflow/providers/amazon/aws/hooks/lambda_function.py
+++ b/airflow/providers/amazon/aws/hooks/lambda_function.py
@@ -37,21 +37,25 @@ class AwsLambdaHook(AwsHook):
     :type qualifier: str
     :param invocation_type: AWS Lambda Invocation Type (RequestResponse, Event etc)
     :type invocation_type: str
+    :param config: Configuration for botocore client.
+        (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html)
+    :type config: botocore.client.Config
     """
 
     def __init__(self, function_name, region_name=None,
                  log_type='None', qualifier='$LATEST',
-                 invocation_type='RequestResponse', *args, **kwargs):
+                 invocation_type='RequestResponse', config=None, *args, **kwargs):
         self.function_name = function_name
         self.region_name = region_name
         self.log_type = log_type
         self.invocation_type = invocation_type
         self.qualifier = qualifier
         self.conn = None
+        self.config = config
         super().__init__(*args, **kwargs)
 
     def get_conn(self):
-        self.conn = self.get_client_type('lambda', self.region_name)
+        self.conn = self.get_client_type('lambda', self.region_name, config=self.config)
         return self.conn
 
     def invoke_lambda(self, payload):

--- a/airflow/providers/amazon/aws/hooks/lambda_function.py
+++ b/airflow/providers/amazon/aws/hooks/lambda_function.py
@@ -37,6 +37,9 @@ class AwsLambdaHook(AwsHook):
     :type qualifier: str
     :param invocation_type: AWS Lambda Invocation Type (RequestResponse, Event etc)
     :type invocation_type: str
+    :param config: Configuration for botocore client.
+        (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html)
+    :type config: botocore.client.Config
     """
 
     def __init__(self, function_name, region_name=None,

--- a/airflow/providers/amazon/aws/hooks/lambda_function.py
+++ b/airflow/providers/amazon/aws/hooks/lambda_function.py
@@ -41,17 +41,18 @@ class AwsLambdaHook(AwsHook):
 
     def __init__(self, function_name, region_name=None,
                  log_type='None', qualifier='$LATEST',
-                 invocation_type='RequestResponse', *args, **kwargs):
+                 invocation_type='RequestResponse', config=None, *args, **kwargs):
         self.function_name = function_name
         self.region_name = region_name
         self.log_type = log_type
         self.invocation_type = invocation_type
         self.qualifier = qualifier
         self.conn = None
+        self.config = config
         super().__init__(*args, **kwargs)
 
     def get_conn(self):
-        self.conn = self.get_client_type('lambda', self.region_name)
+        self.conn = self.get_client_type('lambda', self.region_name, config=self.config)
         return self.conn
 
     def invoke_lambda(self, payload):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-6083) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6083
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
My PR adds ability to provide Lambda client with custom configuration.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: 
It does not need testing as the functionality that was already implemented in function get_client_type was defaulting config param to None, which I also do in case no config is provided to AwsLambdaHook constructor. If config is provided, then the only thing I do is pass it to the client creation function, which already has everything else implemented.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
