### PR TITLE
[AIRFLOW-5517] Remove default value spark_binary

### DIFF
--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -117,7 +117,7 @@ class SparkSubmitOperator(BaseOperator):
                  application_args=None,
                  env_vars=None,
                  verbose=False,
-                 spark_binary="spark-submit",
+                 spark_binary=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Remove default value of spark_binary because it's better managed on spark hook.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-6086](https://issues.apache.org/jira/browse/AIRFLOW-6086/) issue

