### PR TITLE
[AIRFLOW-6088] pass DAG processing runtime as duration to stats

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -25,7 +25,7 @@ import sys
 import textwrap
 import zipfile
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from croniter import CroniterBadCronError, CroniterBadDateError, CroniterNotAlphaError, croniter
 
@@ -477,7 +477,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         stats = self.dagbag_stats
         return report.format(
             dag_folder=self.dag_folder,
-            duration=sum([o.duration for o in stats]),
+            duration=sum([o.duration for o in stats], timedelta()).total_seconds(),
             dag_num=sum([o.dag_num for o in stats]),
             task_num=sum([o.task_num for o in stats]),
             table=pprinttable(stats),

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -419,8 +419,6 @@ class DagBag(BaseDagBag, LoggingMixin):
                 dag_id_names = str(dag_ids)
 
                 td = timezone.utcnow() - ts
-                td = td.total_seconds() + (
-                    float(td.microseconds) / 1000000)
                 stats.append(FileLoadStat(
                     filepath.replace(settings.DAGS_FOLDER, ''),
                     td,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -306,7 +306,7 @@ class DagRun(Base, LoggingMixin):
                     no_dependencies_met = False
                     break
 
-        duration = (timezone.utcnow() - start_dttm).total_seconds() * 1000
+        duration = (timezone.utcnow() - start_dttm)
         Stats.timing("dagrun.dependency-check.{}".format(self.dag_id), duration)
 
         leaf_tis = [ti for ti in tis if ti.task_id in {t.task_id for t in dag.leaves}]

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -971,7 +971,7 @@ class DagFileProcessorManager(LoggingMixin):
 
             processor_pid = self.get_pid(file_path)
             processor_start_time = self.get_start_time(file_path)
-            runtime = ((now - processor_start_time).total_seconds() if processor_start_time else None)
+            runtime = ((now - processor_start_time) if processor_start_time else None)
             last_run = self.get_last_finish_time(file_path)
             if last_run:
                 seconds_ago = (now - last_run).total_seconds()
@@ -996,7 +996,7 @@ class DagFileProcessorManager(LoggingMixin):
         for file_path, pid, runtime, num_dags, num_errors, last_runtime, last_run in rows:
             formatted_rows.append((file_path,
                                    pid,
-                                   "{:.2f}s".format(runtime) if runtime else None,
+                                   "{:.2f}s".format(runtime.total_seconds()) if runtime else None,
                                    num_dags,
                                    num_errors,
                                    "{:.2f}s".format(last_runtime) if last_runtime else None,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-6088

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
runtime var is now a duration object, not a float

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
