### PR TITLE
[AIRFLOW-6091] Add flushing in execute method for BigQueryCursor

### DIFF
--- a/airflow/gcp/hooks/bigquery.py
+++ b/airflow/gcp/hooks/bigquery.py
@@ -2119,6 +2119,7 @@ class BigQueryCursor(BigQueryBaseCursor):
         """
         sql = _bind_parameters(operation,
                                parameters) if parameters else operation
+        self.flush_results()
         self.job_id = self.run_query(sql)
 
     def executemany(self, operation: str, seq_of_parameters: List) -> None:
@@ -2133,6 +2134,13 @@ class BigQueryCursor(BigQueryBaseCursor):
         """
         for parameters in seq_of_parameters:
             self.execute(operation, parameters)
+
+    def flush_results(self) -> None:
+        """ Flush results related cursor attributes. """
+        self.page_token = None
+        self.job_id = None
+        self.all_pages_loaded = False
+        self.buffer = []
 
     def fetchone(self) -> Union[List, None]:
         """ Fetch the next row of a query result set. """
@@ -2174,9 +2182,7 @@ class BigQueryCursor(BigQueryBaseCursor):
 
             else:
                 # Reset all state since we've exhausted the results.
-                self.page_token = None
-                self.job_id = None
-                self.page_token = None
+                self.flush_results()
                 return None
 
         return self.buffer.pop(0)


### PR DESCRIPTION
If you execute multiple queries results of old ones will be
flushed allowing to read results of recent execute without
any issues.

Make sure you have checked _all_ steps below.

### Jira

- [x ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6091
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ x] Here are some details about my PR, including screenshots of any UI changes:

My PR addresses issue with results buffer and reading flags not being cleaned in some cases what ends up in returning no data or even data from previous job in case of executing many queries with one cursor.

### Tests

- [ x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

My PR does not add any functionality to test

### Commits

- [ x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
