### PR TITLE
[AIRFLOW-6099] Add host name to task runner log

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -25,6 +25,7 @@ import threading
 from airflow.configuration import conf
 from airflow.utils.configuration import tmp_configuration_copy
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.net import get_hostname
 
 PYTHONPATH_VAR = 'PYTHONPATH'
 
@@ -121,6 +122,7 @@ class BaseTaskRunner(LoggingMixin):
         run_with = run_with or []
         full_cmd = run_with + self._command
 
+        self.log.info("Running on host: %s", get_hostname())
         self.log.info('Running: %s', full_cmd)
         proc = subprocess.Popen(
             full_cmd,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6099

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
It would be great to be able to look at log at web UI and see on what host the task was running. This is very helpful especially with celery executor using multiple workers.
 
```
[2019-11-29 10:10:41,214] {taskinstance.py:846} INFO - Executing <Task(PubSubTopicCreateOperator): create_topic> on 2019-11-28T00:00:00+00:00
[2019-11-29 10:10:41,215] {base_task_runner.py:125} INFO - Running on host: airflow-worker-75887d4878-4rcx2@-@{"workflow": "example_gcp_pubsub", "task-id": "create_topic", "execution-date": "2019-11-28T00:00:00+00:00"}
[2019-11-29 10:10:41,216] {base_task_runner.py:126} INFO - Running: ['airflow', 'tasks', 'run', 'example_gcp_pubsub', 'create_topic', '2019-11-28T00:00:00+00:00', '--job_id', '2', '--pool', 'default_pool', '--raw', '-sd', '/opt/airflow/airflow/providers/google/cloud/example_dags/example_pubsub.py', '--cfg_path', '/tmp/tmpwrwdlsdv']
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
