### PR TITLE
AIRFLOW-6132 - Allow to pass in tags

### DIFF
--- a/airflow/contrib/operators/azure_container_instances_operator.py
+++ b/airflow/contrib/operators/azure_container_instances_operator.py
@@ -87,6 +87,8 @@ class AzureContainerInstancesOperator(BaseOperator):
     :param container_timeout: max time allowed for the execution of
         the container instance.
     :type container_timeout: datetime.timedelta
+    :param tags: azure tags as dict of str:str
+    :type tags: dict[str, str]
 
     **Example**::
 
@@ -135,6 +137,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                  command=None,
                  remove_on_error=True,
                  fail_if_exists=True,
+                 tags=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -155,6 +158,7 @@ class AzureContainerInstancesOperator(BaseOperator):
         self.remove_on_error = remove_on_error
         self.fail_if_exists = fail_if_exists
         self._ci_hook = None
+        self.tags = tags
 
     def execute(self, context):
         # Check name again in case it was templated.
@@ -222,7 +226,8 @@ class AzureContainerInstancesOperator(BaseOperator):
                 image_registry_credentials=image_registry_credentials,
                 volumes=volumes,
                 restart_policy='Never',
-                os_type='Linux')
+                os_type='Linux',
+                tags=self.tags)
 
             self._ci_hook.create_or_update(self.resource_group, self.name, container_group)
 

--- a/tests/contrib/operators/test_azure_container_instances_operator.py
+++ b/tests/contrib/operators/test_azure_container_instances_operator.py
@@ -111,7 +111,7 @@ class TestACIOperator(unittest.TestCase):
     def test_execute_with_tags(self, aci_mock):
         expected_c_state = ContainerState(state='Terminated', exit_code=0, detail_status='test')
         expected_cg = make_mock_cg(expected_c_state)
-        tags = {"testKey":"testValue"}
+        tags = {"testKey": "testValue"}
 
         aci_mock.return_value.get_state.return_value = expected_cg
         aci_mock.return_value.exists.return_value = False

--- a/tests/contrib/operators/test_azure_container_instances_operator.py
+++ b/tests/contrib/operators/test_azure_container_instances_operator.py
@@ -108,6 +108,45 @@ class TestACIOperator(unittest.TestCase):
 
     @mock.patch("airflow.contrib.operators."
                 "azure_container_instances_operator.AzureContainerInstanceHook")
+    def test_execute_with_tags(self, aci_mock):
+        expected_c_state = ContainerState(state='Terminated', exit_code=0, detail_status='test')
+        expected_cg = make_mock_cg(expected_c_state)
+        tags = {"testKey":"testValue"}
+
+        aci_mock.return_value.get_state.return_value = expected_cg
+        aci_mock.return_value.exists.return_value = False
+
+        aci = AzureContainerInstancesOperator(ci_conn_id=None,
+                                              registry_conn_id=None,
+                                              resource_group='resource-group',
+                                              name='container-name',
+                                              image='container-image',
+                                              region='region',
+                                              task_id='task',
+                                              tags=tags)
+        aci.execute(None)
+
+        self.assertEqual(aci_mock.return_value.create_or_update.call_count, 1)
+        (called_rg, called_cn, called_cg), _ = \
+            aci_mock.return_value.create_or_update.call_args
+
+        self.assertEqual(called_rg, 'resource-group')
+        self.assertEqual(called_cn, 'container-name')
+
+        self.assertEqual(called_cg.location, 'region')
+        self.assertEqual(called_cg.image_registry_credentials, None)
+        self.assertEqual(called_cg.restart_policy, 'Never')
+        self.assertEqual(called_cg.os_type, 'Linux')
+        self.assertEqual(called_cg.tags, tags)
+
+        called_cg_container = called_cg.containers[0]
+        self.assertEqual(called_cg_container.name, 'container-name')
+        self.assertEqual(called_cg_container.image, 'container-image')
+
+        self.assertEqual(aci_mock.return_value.delete.call_count, 1)
+
+    @mock.patch("airflow.contrib.operators."
+                "azure_container_instances_operator.AzureContainerInstanceHook")
     def test_execute_with_messages_logs(self, aci_mock):
         events = [Event(message="test"), Event(message="messages")]
         expected_c_state1 = ContainerState(state='Running', exit_code=0, detail_status='test')


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [[AIRFLOW-6132](https://issues.apache.org/jira/browse/AIRFLOW-6132)]

### Description

Small change to allow pass in tags for the azure cloud

### Documentation

added python docs
