### PR TITLE
[AIRFLOW-6133] Make Hive transfer operators pylint compatible

### DIFF
--- a/airflow/contrib/operators/hive_to_dynamodb.py
+++ b/airflow/contrib/operators/hive_to_dynamodb.py
@@ -17,6 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+This module contains operator to move data from Hive to DynamoDB.
+"""
+
 import json
 
 from airflow.contrib.hooks.aws_dynamodb_hook import AwsDynamoDBHook
@@ -58,7 +62,7 @@ class HiveToDynamoDBTransferOperator(BaseOperator):
     ui_color = '#a0e08c'
 
     @apply_defaults
-    def __init__(
+    def __init__(  # pylint:disable=too-many-arguments
             self,
             sql,
             table_name,

--- a/airflow/contrib/operators/vertica_to_hive.py
+++ b/airflow/contrib/operators/vertica_to_hive.py
@@ -98,7 +98,7 @@ class VerticaToHiveTransfer(BaseOperator):
     @classmethod
     def type_map(cls, vertica_type):
         """
-        Vertica-python datatype.py donot provied the full type mapping access.
+        Vertica-python datatype.py does not provide the full type mapping access.
         Manual hack. Reference:
         https://github.com/uber/vertica-python/blob/master/vertica_python/vertica/column.py
         """

--- a/airflow/contrib/operators/vertica_to_hive.py
+++ b/airflow/contrib/operators/vertica_to_hive.py
@@ -17,6 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+This module contains operator to move data from Vertica to Hive.
+"""
+
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
@@ -93,11 +97,12 @@ class VerticaToHiveTransfer(BaseOperator):
 
     @classmethod
     def type_map(cls, vertica_type):
-        # vertica-python datatype.py donot provied the full type mapping access.
-        # Manual hack.
-        # Reference:
-        # https://github.com/uber/vertica-python/blob/master/vertica_python/vertica/column.py
-        d = {
+        """
+        Vertica-python datatype.py donot provied the full type mapping access.
+        Manual hack. Reference:
+        https://github.com/uber/vertica-python/blob/master/vertica_python/vertica/column.py
+        """
+        type_map = {
             5: 'BOOLEAN',
             6: 'INT',
             7: 'FLOAT',
@@ -105,7 +110,7 @@ class VerticaToHiveTransfer(BaseOperator):
             9: 'STRING',
             16: 'FLOAT',
         }
-        return d[vertica_type] if vertica_type in d else 'STRING'
+        return type_map.get(vertica_type, 'STRING')
 
     def execute(self, context):
         hive = HiveCliHook(hive_cli_conn_id=self.hive_cli_conn_id)

--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -16,6 +16,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+"""
+This module contains operator to move data from Hive to Druid.
+"""
+
 from typing import Dict, List, Optional
 
 from airflow.hooks.druid_hook import DruidHook
@@ -79,7 +84,7 @@ class HiveToDruidTransfer(BaseOperator):
     template_ext = ('.sql',)
 
     @apply_defaults
-    def __init__(
+    def __init__(  # pylint:disable=too-many-arguments
             self,
             sql: str,
             druid_datasource: str,
@@ -124,7 +129,7 @@ class HiveToDruidTransfer(BaseOperator):
         tblproperties = ''.join([", '{}' = '{}'"
                                 .format(k, v)
                                  for k, v in self.hive_tblproperties.items()])
-        hql = """\
+        hql = f"""\
         SET mapred.output.compress=false;
         SET hive.exec.compress.output=false;
         DROP TABLE IF EXISTS {hive_table};
@@ -134,18 +139,18 @@ class HiveToDruidTransfer(BaseOperator):
         TBLPROPERTIES ('serialization.null.format' = ''{tblproperties})
         AS
         {sql}
-        """.format(hive_table=hive_table, tblproperties=tblproperties, sql=sql)
+        """
         self.log.info("Running command:\n %s", hql)
         hive.run_cli(hql)
 
-        m = HiveMetastoreHook(self.metastore_conn_id)
+        meta_hook = HiveMetastoreHook(self.metastore_conn_id)
 
         # Get the Hive table and extract the columns
-        t = m.get_table(hive_table)
-        columns = [col.name for col in t.sd.cols]
+        table = meta_hook.get_table(hive_table)
+        columns = [col.name for col in table.sd.cols]
 
         # Get the path on hdfs
-        static_path = m.get_table(hive_table).sd.location
+        static_path = meta_hook.get_table(hive_table).sd.location
 
         druid = DruidHook(druid_ingest_conn_id=self.druid_ingest_conn_id)
 

--- a/airflow/operators/hive_to_mysql.py
+++ b/airflow/operators/hive_to_mysql.py
@@ -17,6 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+This module contains operator to move data from Hive to MySQL.
+"""
 from tempfile import NamedTemporaryFile
 from typing import Dict, Optional
 

--- a/airflow/operators/hive_to_samba_operator.py
+++ b/airflow/operators/hive_to_samba_operator.py
@@ -17,6 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+This module contains operator to move data from Hive to Samba.
+"""
+
 from tempfile import NamedTemporaryFile
 
 from airflow.hooks.hive_hooks import HiveServer2Hook

--- a/airflow/operators/mssql_to_hive.py
+++ b/airflow/operators/mssql_to_hive.py
@@ -17,6 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+This module contains operator to move data from MSSQL to Hive.
+"""
+
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 from typing import Dict, Optional
@@ -97,15 +101,18 @@ class MsSqlToHiveTransfer(BaseOperator):
         self.tblproperties = tblproperties
 
     @classmethod
-    def type_map(cls, mssql_type):
+    def type_map(cls, mssql_type: int) -> str:
+        """
+        Maps MsSQL type to Hive type.
+        """
         map_dict = {
             pymssql.BINARY.value: 'INT',
             pymssql.DECIMAL.value: 'FLOAT',
             pymssql.NUMBER.value: 'INT',
         }
-        return map_dict[mssql_type] if mssql_type in map_dict else 'STRING'
+        return map_dict.get(mssql_type, 'STRING')
 
-    def execute(self, context):
+    def execute(self, context: Dict[str, str]):
         mssql = MsSqlHook(mssql_conn_id=self.mssql_conn_id)
         self.log.info("Dumping Microsoft SQL Server query results to local file")
         with mssql.get_conn() as conn:
@@ -113,7 +120,7 @@ class MsSqlToHiveTransfer(BaseOperator):
                 cursor.execute(self.sql)
                 with NamedTemporaryFile("w") as tmp_file:
                     csv_writer = csv.writer(tmp_file, delimiter=self.delimiter, encoding='utf-8')
-                    field_dict = OrderedDict()
+                    field_dict = OrderedDict()  # type:ignore
                     col_count = 0
                     for field in cursor.description:
                         col_count += 1

--- a/airflow/operators/s3_to_hive_operator.py
+++ b/airflow/operators/s3_to_hive_operator.py
@@ -17,6 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+This module contains operator to move data from Hive to S3 bucket.
+"""
+
 import bz2
 import gzip
 import os
@@ -33,7 +37,7 @@ from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
 
 
-class S3ToHiveTransfer(BaseOperator):
+class S3ToHiveTransfer(BaseOperator):  # pylint:disable=too-many-instance-attributes
     """
     Moves data from S3 to Hive. The operator downloads a file from S3,
     stores the file locally before loading it into a Hive table.
@@ -104,7 +108,7 @@ class S3ToHiveTransfer(BaseOperator):
     ui_color = '#a0e08c'
 
     @apply_defaults
-    def __init__(
+    def __init__(  # pylint:disable=too-many-arguments
             self,
             s3_key: str,
             field_dict: Dict,
@@ -148,20 +152,20 @@ class S3ToHiveTransfer(BaseOperator):
 
     def execute(self, context):
         # Downloading file from S3
-        self.s3 = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
-        self.hive = HiveCliHook(hive_cli_conn_id=self.hive_cli_conn_id)
+        hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
+        hive_hook = HiveCliHook(hive_cli_conn_id=self.hive_cli_conn_id)
         self.log.info("Downloading S3 file")
 
         if self.wildcard_match:
-            if not self.s3.check_for_wildcard_key(self.s3_key):
+            if not hook.check_for_wildcard_key(self.s3_key):
                 raise AirflowException("No key matches {0}"
                                        .format(self.s3_key))
-            s3_key_object = self.s3.get_wildcard_key(self.s3_key)
+            s3_key_object = hook.get_wildcard_key(self.s3_key)
         else:
-            if not self.s3.check_for_key(self.s3_key):
+            if not hook.check_for_key(self.s3_key):
                 raise AirflowException(
                     "The key {0} does not exists".format(self.s3_key))
-            s3_key_object = self.s3.get_key(self.s3_key)
+            s3_key_object = hook.get_key(self.s3_key)
 
         _, file_ext = os.path.splitext(s3_key_object.key)
         if (self.select_expression and self.input_compressed and
@@ -187,7 +191,7 @@ class S3ToHiveTransfer(BaseOperator):
                 if self.input_compressed:
                     input_serialization['CompressionType'] = 'GZIP'
 
-                content = self.s3.select_key(
+                content = hook.select_key(
                     bucket_name=s3_key_object.bucket_name,
                     key=s3_key_object.key,
                     expression=self.select_expression,
@@ -200,7 +204,7 @@ class S3ToHiveTransfer(BaseOperator):
 
             if self.select_expression or not self.headers:
                 self.log.info("Loading file %s into Hive", f.name)
-                self.hive.load_file(
+                hive_hook.load_file(
                     f.name,
                     self.hive_table,
                     field_dict=self.field_dict,
@@ -238,7 +242,7 @@ class S3ToHiveTransfer(BaseOperator):
                                                       tmp_dir))
                 self.log.info("Headless file %s", headless_file)
                 self.log.info("Loading file %s into Hive", headless_file)
-                self.hive.load_file(headless_file,
+                hive_hook.load_file(headless_file,
                                     self.hive_table,
                                     field_dict=self.field_dict,
                                     create=self.create,

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -44,7 +44,6 @@
 ./airflow/contrib/operators/emr_terminate_job_flow_operator.py
 ./airflow/contrib/operators/file_to_wasb.py
 ./airflow/contrib/operators/grpc_operator.py
-./airflow/contrib/operators/hive_to_dynamodb.py
 ./airflow/contrib/operators/jenkins_job_trigger_operator.py
 ./airflow/contrib/operators/jira_operator.py
 ./airflow/contrib/operators/mongo_to_s3.py
@@ -76,7 +75,6 @@
 ./airflow/contrib/operators/sqoop_operator.py
 ./airflow/contrib/operators/ssh_operator.py
 ./airflow/contrib/operators/vertica_operator.py
-./airflow/contrib/operators/vertica_to_hive.py
 ./airflow/contrib/operators/vertica_to_mysql.py
 ./airflow/contrib/operators/wasb_delete_blob_operator.py
 ./airflow/contrib/operators/winrm_operator.py
@@ -160,16 +158,11 @@
 ./airflow/operators/generic_transfer.py
 ./airflow/operators/hive_operator.py
 ./airflow/operators/hive_stats_operator.py
-./airflow/operators/hive_to_druid.py
-./airflow/operators/hive_to_mysql.py
-./airflow/operators/hive_to_samba_operator.py
 ./airflow/operators/http_operator.py
 ./airflow/operators/jdbc_operator.py
 ./airflow/operators/latest_only_operator.py
 ./airflow/operators/mssql_operator.py
-./airflow/operators/mssql_to_hive.py
 ./airflow/operators/mysql_operator.py
-./airflow/operators/mysql_to_hive.py
 ./airflow/operators/oracle_operator.py
 ./airflow/operators/papermill_operator.py
 ./airflow/operators/pig_operator.py
@@ -178,7 +171,6 @@
 ./airflow/operators/presto_to_mysql.py
 ./airflow/operators/python_operator.py
 ./airflow/operators/s3_file_transform_operator.py
-./airflow/operators/s3_to_hive_operator.py
 ./airflow/operators/s3_to_redshift_operator.py
 ./airflow/operators/slack_operator.py
 ./airflow/operators/sqlite_operator.py
@@ -317,12 +309,10 @@
 ./tests/operators/test_cassandra_to_gcs.py
 ./tests/operators/test_gcs_to_s3.py
 ./tests/operators/test_hive_operator.py
-./tests/operators/test_mssql_to_hive.py
 ./tests/operators/test_operators.py
 ./tests/operators/test_papermill_operator.py
 ./tests/operators/test_python_operator.py
 ./tests/operators/test_s3_file_transform_operator.py
-./tests/operators/test_s3_to_hive_operator.py
 ./tests/operators/test_s3_to_redshift_operator.py
 ./tests/operators/test_virtualenv_operator.py
 ./tests/plugins/test_plugin.py

--- a/tests/operators/test_s3_to_hive_operator.py
+++ b/tests/operators/test_s3_to_hive_operator.py
@@ -42,7 +42,7 @@ except ImportError:
 class TestS3ToHiveTransfer(unittest.TestCase):
 
     def setUp(self):
-        self.fn = {}
+        self.file_names = {}
         self.task_id = 'S3ToHiveTransferTest'
         self.s3_key = 'S32hive_test_file'
         self.field_dict = OrderedDict([('Sno', 'BIGINT'), ('Some,Text', 'STRING')])
@@ -124,13 +124,13 @@ class TestS3ToHiveTransfer(unittest.TestCase):
     # file types (file extension and header)
     def _set_fn(self, fn, ext, header):
         key = self._get_key(ext, header)
-        self.fn[key] = fn
+        self.file_names[key] = fn
 
     # Helper method to fetch a file of a
     # certain format (file extension and header)
     def _get_fn(self, ext, header):
         key = self._get_key(ext, header)
-        return self.fn[key]
+        return self.file_names[key]
 
     @staticmethod
     def _get_key(ext, header):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6133

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
