### PR TITLE
[AIRFLOW-6141] Remove ReadyToRescheduleDep if sensor mode == poke

### DIFF
--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -174,4 +174,6 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         Adds one additional dependency for all sensor operators that
         checks if a sensor task instance can be rescheduled.
         """
-        return BaseOperator.deps.fget(self) | {ReadyToRescheduleDep()}
+        if self.reschedule:
+            return BaseOperator.deps.fget(self) | {ReadyToRescheduleDep()}
+        return BaseOperator.deps.fget(self)

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -363,10 +363,15 @@ class TestBaseSensor(unittest.TestCase):
             if ti.task_id == DUMMY_OP:
                 self.assertEqual(ti.state, State.NONE)
 
-    def test_should_include_ready_to_reschedule_dep(self):
+    def test_should_include_ready_to_reschedule_dep_in_reschedule_mode(self):
+        sensor = self._make_sensor(True, mode='reschedule')
+        deps = sensor.deps
+        self.assertIn(ReadyToRescheduleDep(), deps)
+
+    def test_should_not_include_ready_to_reschedule_dep_in_poke_mode(self):
         sensor = self._make_sensor(True)
         deps = sensor.deps
-        self.assertTrue(ReadyToRescheduleDep() in deps)
+        self.assertNotIn(ReadyToRescheduleDep(), deps)
 
     def test_invalid_mode(self):
         with self.assertRaises(AirflowException):


### PR DESCRIPTION
I am trying to fix [AIRFLOW-6141](https://issues.apache.org/jira/browse/AIRFLOW-6141)I saw that this rule is enabled when the sensor mode is not correct. It now works correctly in both modes.

---

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6141
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
