### PR TITLE
[AIRFLOW-XXX] Fix docstring minor issues in airflow/kubernetes/

### DIFF
--- a/airflow/kubernetes/kube_client.py
+++ b/airflow/kubernetes/kube_client.py
@@ -47,12 +47,12 @@ try:
             return cfg
 
     def _get_client_with_patched_configuration(cfg: Optional[Configuration]) -> client.CoreV1Api:
-        '''
+        """
         This is a workaround for supporting api token refresh in k8s client.
 
         The function can be replace with `return client.CoreV1Api()` once the
         upstream client supports token refresh.
-        '''
+        """
         if cfg:
             return client.CoreV1Api(api_client=ApiClient(configuration=cfg))
         else:

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -69,8 +69,6 @@ class PodGenerator:
     :type envs: Dict[str, str]
     :param cmds: The command to be run on the pod
     :type cmds: List[str]
-    :param secrets: Secrets to be launched to the pod
-    :type secrets: List[airflow.kubernetes.models.secret.Secret]
     :param image_pull_policy: Specify a policy to cache or always pull an image
     :type image_pull_policy: str
     :param image_pull_secrets: Any image pull secrets to be given to the pod.

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -228,7 +228,7 @@ class PodLauncher(LoggingMixin):
         return None
 
     def process_status(self, job_id, status):
-        """Process status infomration for the JOB"""
+        """Process status information for the JOB"""
         status = status.lower()
         if status == PodStatus.PENDING:
             return State.QUEUED


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

Pure docstring changes.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

1. Always use triple double quotes around docstrings (as pointed out in [PEP 257](https://www.python.org/dev/peps/pep-0257/))
2. Fix a typo in `pod_launcher.py`
3. Remove unused docstring for parameter `secrets` in class `PodGenerator`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

N.A.
