### PR TITLE
[AIRFLOW-5834] Option to skip serve_logs process with workers

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -577,6 +577,11 @@ class CLIFactory:
         'autoscale': Arg(
             ('-a', '--autoscale'),
             help="Minimum and Maximum number of worker to autoscale"),
+        'skip_serve_logs': Arg(
+            ("-s", "--skip_serve_logs"),
+            default=False,
+            help="Don't start the serve logs process along with the workers.",
+            action="store_true"),
     }
     subparsers = (
         {
@@ -871,7 +876,7 @@ class CLIFactory:
             'func': lazy_load_command('airflow.cli.commands.worker_command.worker'),
             'help': "Start a Celery worker node",
             'args': ('do_pickle', 'queues', 'concurrency', 'celery_hostname',
-                     'pid', 'daemon', 'stdout', 'stderr', 'log_file', 'autoscale'),
+                     'pid', 'daemon', 'stdout', 'stderr', 'log_file', 'autoscale', 'skip_serve_logs'),
         }, {
             'name': 'flower',
             'func': lazy_load_command('airflow.cli.commands.flower_command.flower'),

--- a/airflow/cli/commands/worker_command.py
+++ b/airflow/cli/commands/worker_command.py
@@ -28,6 +28,14 @@ from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging, sigint_handler
 
 
+def _serve_logs(env, skip_serve_logs=False):
+    """Starts serve_logs sub-process"""
+    if skip_serve_logs is False:
+        sub_proc = subprocess.Popen(['airflow', 'serve_logs'], env=env, close_fds=True)
+        return sub_proc
+    return None
+
+
 @cli_utils.action_logging
 def worker(args):
     """Starts Airflow Celery worker"""
@@ -43,8 +51,11 @@ def worker(args):
     from celery.bin import worker  # pylint: disable=redefined-outer-name
 
     autoscale = args.autoscale
+    skip_serve_logs = args.skip_serve_logs
+
     if autoscale is None and conf.has_option("celery", "worker_autoscale"):
         autoscale = conf.get("celery", "worker_autoscale")
+
     worker = worker.worker(app=celery_app)   # pylint: disable=redefined-outer-name
     options = {
         'optimization': 'fair',
@@ -76,9 +87,8 @@ def worker(args):
             stderr=stderr,
         )
         with ctx:
-            sub_proc = subprocess.Popen(['airflow', 'serve_logs'], env=env, close_fds=True)
+            sub_proc = _serve_logs(env, skip_serve_logs)
             worker.run(**options)
-            sub_proc.kill()
 
         stdout.close()
         stderr.close()
@@ -86,7 +96,8 @@ def worker(args):
         signal.signal(signal.SIGINT, sigint_handler)
         signal.signal(signal.SIGTERM, sigint_handler)
 
-        sub_proc = subprocess.Popen(['airflow', 'serve_logs'], env=env, close_fds=True)
-
+        sub_proc = _serve_logs(env, skip_serve_logs)
         worker.run(**options)
+
+    if sub_proc:
         sub_proc.kill()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) i
  - https://issues.apache.org/jira/browse/AIRFLOW-5834

### Description

- [ ] Adding an option to skip serve logs process starting with workers. With the advent of K8s, serving logs from workers isn't useful anymore. Also, fundamentally it feels wrong to serve two entirely diff processes from one command. 

### Tests

- [ ] Added unit tests

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
