### PR TITLE
 [AIRFLOW-XXX] add notice for Mesos Executor deprecation in docs

### DIFF
--- a/docs/howto/executor/use-mesos.rst
+++ b/docs/howto/executor/use-mesos.rst
@@ -18,6 +18,12 @@
 Scaling Out with Mesos (community contributed)
 ==============================================
 
+.. note::
+    Mesos Executor is deprecated (Jira_)
+
+.. _Jira: https://issues.apache.org/jira/browse/AIRFLOW-4313
+
+
 There are two ways you can run airflow as a mesos framework:
 
 1. Running airflow tasks directly on mesos slaves, requiring each mesos slave to have airflow installed and configured.


### PR DESCRIPTION
### Description

MesosExecutor is deprecated from Master https://github.com/apache/airflow/pull/5115 but there is no notice in docs of v1.10.X for that deprecation. Fresh users normally find information in docs (there is no need for them to read change log as they don't perform any upgrade).