### PR TITLE
[AIRFLOW-6153] Allow adding Custom Fields to Serialized Operators

### DIFF
--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -42,7 +42,8 @@ class QDSLink(BaseOperatorLink):
         :return: url link
         """
         ti = TaskInstance(task=operator, execution_date=dttm)
-        conn = BaseHook.get_connection(operator.kwargs['qubole_conn_id'])
+        conn = BaseHook.get_connection(
+            getattr(operator, "qubole_conn_id", None) or operator.kwargs['qubole_conn_id'])
         if conn and conn.host:
             host = re.sub(r'api$', 'v2/analyze?command_id=', conn.host)
         else:
@@ -240,3 +241,9 @@ class QuboleOperator(BaseOperator):
             self.kwargs[name] = value
         else:
             object.__setattr__(self, name, value)
+
+    @classmethod
+    def get_serialized_fields(cls):
+        """Serialized QuboleOperator contain exactly these fields."""
+        cls._serialized_fields = frozenset(super().get_serialized_fields() | {"qubole_conn_id"})
+        return cls._serialized_fields

--- a/airflow/gcp/operators/bigquery.py
+++ b/airflow/gcp/operators/bigquery.py
@@ -594,6 +594,12 @@ class BigQueryOperator(BaseOperator):
             self.log.info('Cancelling running query')
             self.bq_cursor.cancel_query()
 
+    @classmethod
+    def get_serialized_fields(cls):
+        """Serialized BigQueryOperator contain exactly these fields."""
+        cls._serialized_fields = frozenset(super().get_serialized_fields() | {"sql"})
+        return cls._serialized_fields
+
 
 class BigQueryCreateEmptyTableOperator(BaseOperator):
     """

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1080,8 +1080,8 @@ class BaseOperator(Operator, LoggingMixin):
             cls._serialized_fields = frozenset(
                 vars(BaseOperator(task_id='test')).keys() - {
                     'inlets', 'outlets', '_upstream_task_ids', 'default_args', 'dag', '_dag'
-                } | {'_task_type', 'subdag', 'ui_color', 'ui_fgcolor', 'template_fields'}
-            )
+                } | {'_task_type', 'subdag', 'ui_color', 'ui_fgcolor', 'template_fields'})
+
         return cls._serialized_fields
 
 

--- a/airflow/utils/tests.py
+++ b/airflow/utils/tests.py
@@ -75,11 +75,18 @@ class CustomBaseOperator(BaseOperator):
     operator_extra_links = ()
 
     @apply_defaults
-    def __init__(self, *args, **kwargs):
+    def __init__(self, bash_command=None, *args, **kwargs):
         super(CustomBaseOperator, self).__init__(*args, **kwargs)
+        self.bash_command = bash_command
 
     def execute(self, context):
         self.log.info("Hello World!")
+
+    @classmethod
+    def get_serialized_fields(cls):
+        """Stringified CustomBaseOperator contain exactly these fields."""
+        cls._serialized_fields = frozenset(super().get_serialized_fields() | {"bash_command"})
+        return cls._serialized_fields
 
 
 class GoogleLink(BaseOperatorLink):

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -288,8 +288,7 @@ class TestStringifiedDAGs(unittest.TestCase):
         extra link.
         """
         self.assertEqual(
-            task.operator_extra_link_dict[GoogleLink.name].get_link(
-                task, datetime(2019, 8, 1)),
+            task.get_extra_links(datetime(2019, 8, 1), GoogleLink.name),
             "https://www.google.com"
         )
 
@@ -381,6 +380,17 @@ class TestStringifiedDAGs(unittest.TestCase):
 
         round_tripped = SerializedDAG._deserialize(serialized)
         self.assertEqual(val, round_tripped)
+
+    def test_extra_serialized_field(self):
+        dag = DAG(dag_id='simple_dag', start_date=datetime(2019, 8, 1))
+        CustomBaseOperator(task_id='simple_task', dag=dag, bash_command="true")
+
+        serialized_dag = SerializedDAG.to_dict(dag)
+        self.assertIn("bash_command", serialized_dag["dag"]["tasks"][0])
+
+        dag = SerializedDAG.from_dict(serialized_dag)
+        simple_task = dag.task_dict["simple_task"]
+        self.assertEqual(getattr(simple_task, "bash_command"), "true")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-6153


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
We would want to allow fields like `sql` (in BigQueryOperator) and `qubole_conn_id` (in QuboleOperator) to be serialized and saved in DB. This is needed for OperatorLinks to work for both the respective operators as they rely on this field.



### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
