### PR TITLE
[AIRFLOW-6177] Log DAG processors timeout event at error level, not info

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -1111,7 +1111,7 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         for file_path, processor in self._processors.items():
             duration = now - processor.start_time
             if duration > self._processor_timeout:
-                self.log.info(
+                self.log.error(
                     "Processor for %s with PID %s started at %s has timed out, "
                     "killing it.",
                     file_path, processor.pid, processor.start_time.isoformat())


### PR DESCRIPTION
This case prevents a DAG from being scheduled by the scheduler so should be an error to make troubleshooting easier.

https://issues.apache.org/jira/browse/AIRFLOW-6177