### PR TITLE
[AIRFLOW-6183] Fix flaky GCS hook gzip test

### DIFF
--- a/tests/gcp/hooks/test_gcs.py
+++ b/tests/gcp/hooks/test_gcs.py
@@ -18,7 +18,6 @@
 # under the License.
 # pylint: disable=too-many-lines
 import copy
-import gzip as gz
 import io
 import os
 import tempfile
@@ -648,12 +647,16 @@ class TestGoogleCloudStorageHookUpload(unittest.TestCase):
             content_type='text/plain'
         )
 
+    @mock.patch(GCS_STRING.format('BytesIO'))
+    @mock.patch(GCS_STRING.format('gz.GzipFile'))
     @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
-    def test_upload_data_str_gzip(self, mock_service):
+    def test_upload_data_str_gzip(self, mock_service, mock_gzip, mock_bytes_io):
         test_bucket = 'test_bucket'
         test_object = 'test_object'
         encoding = 'utf-8'
 
+        gzip_ctx = mock_gzip.return_value.__enter__.return_value
+        data = mock_bytes_io.return_value.getvalue.return_value
         upload_method = mock_service.return_value.bucket.return_value\
             .blob.return_value.upload_from_string
 
@@ -662,16 +665,10 @@ class TestGoogleCloudStorageHookUpload(unittest.TestCase):
                              data=self.testdata_str,
                              gzip=True)
 
-        data = bytes(self.testdata_str, encoding)
-        out = io.BytesIO()
-        with gz.GzipFile(fileobj=out, mode="w") as f:
-            f.write(data)
-        data = out.getvalue()
-
-        upload_method.assert_called_once_with(
-            data,
-            content_type='text/plain'
-        )
+        byte_str = bytes(self.testdata_str, encoding)
+        mock_gzip.assert_called_once_with(fileobj=mock_bytes_io.return_value, mode="w")
+        gzip_ctx.write.assert_called_once_with(byte_str)
+        upload_method.assert_called_once_with(data, content_type='text/plain')
 
     @mock.patch(GCS_STRING.format('BytesIO'))
     @mock.patch(GCS_STRING.format('gz.GzipFile'))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6183

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This PR fixes flaky comparison of two gzipped byte strings. When the difference in time creation of two files was big enough then 5th byte of the later file was different 👀

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
