### PR TITLE
[AIRFLOW-6167] Escape column name in create table in hive

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -433,7 +433,7 @@ class HiveCliHook(BaseHook):
             if field_dict is None:
                 raise ValueError("Must provide a field dict when creating a table")
             fields = ",\n    ".join(
-                [k + ' ' + v for k, v in field_dict.items()])
+                ['`{k}` {v}'.format(k=k.strip('`'), v=v) for k, v in field_dict.items()])
             hql += "CREATE TABLE IF NOT EXISTS {table} (\n{fields})\n".format(
                 table=table, fields=fields)
             if partition:

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -144,7 +144,7 @@ class TestHiveCliHook(unittest.TestCase):
         filepath = "/path/to/input/file"
         table = "output_table"
         field_dict = OrderedDict([("name", "string"), ("gender", "string")])
-        fields = ",\n    ".join([k + ' ' + v for k, v in field_dict.items()])
+        fields = ",\n    ".join(['`{k}` {v}'.format(k=k.strip('`'), v=v) for k, v in field_dict.items()])
 
         hook = HiveCliHook()
         hook.load_file(filepath=filepath, table=table, field_dict=field_dict, create=True, recreate=True)
@@ -232,16 +232,16 @@ class TestHiveCliHook(unittest.TestCase):
 
         query = """
             CREATE TABLE IF NOT EXISTS t (
-                b BOOLEAN,
-                i BIGINT,
-                t BIGINT,
-                f DOUBLE,
-                c STRING,
-                M TIMESTAMP,
-                O STRING,
-                S STRING,
-                U STRING,
-                V STRING)
+                `b` BOOLEAN,
+                `i` BIGINT,
+                `t` BIGINT,
+                `f` DOUBLE,
+                `c` STRING,
+                `M` TIMESTAMP,
+                `O` STRING,
+                `S` STRING,
+                `U` STRING,
+                `V` STRING)
             ROW FORMAT DELIMITED
             FIELDS TERMINATED BY ','
             STORED AS textfile


### PR DESCRIPTION
Hive query will fail if column name contains keyword, unless escaped.
Fix is always escaping column name when creating table.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6167
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Hive query will fail if column name contains keyword, unless escaped.
Fix is always escaping column name when creating table.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

@KevinYang21 