### PR TITLE
[AIRFLOW-6191] Adjust pytest verbosity in CI and local environment

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -100,6 +100,13 @@ To run whole test class:
 
     pytest tests/test_core.py::TestCore
 
+You can use all available pytest flags, for example to increase log level
+for debugging purposes:
+
+.. code-block:: bash
+
+    pytest --log-level=DEBUG tests/test_core.py::TestCore
+
 **Note:** We do not provide a clear distinction between tests
 (Unit/Integration/System tests), but we are working on it.
 

--- a/scripts/ci/in_container/entrypoint_ci.sh
+++ b/scripts/ci/in_container/entrypoint_ci.sh
@@ -226,6 +226,7 @@ KUBERNETES_VERSION=${KUBERNETES_VERSION:=""}
 if [[ "${TRAVIS}" == "true" ]]; then
     TRAVIS_ARGS=(
         "--junitxml=${XUNIT_FILE}"
+        "--verbosity=0"
         "--durations=100"
         "--cov=airflow/"
         "--cov-config=.coveragerc"

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -17,7 +17,8 @@
 
 [pytest]
 addopts =
-    -raslv
+    -rasl
+    --verbosity=1
 ;    This will treat all tests as flaky
 ;    --force-flaky
     # DAG files


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6191

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
