### PR TITLE
[AIRFLOW-6192] Stop creating Hook from SFTPSensor.__init__

### DIFF
--- a/airflow/contrib/sensors/sftp_sensor.py
+++ b/airflow/contrib/sensors/sftp_sensor.py
@@ -39,9 +39,11 @@ class SFTPSensor(BaseSensorOperator):
     def __init__(self, path, sftp_conn_id='sftp_default', *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.path = path
-        self.hook = SFTPHook(sftp_conn_id)
+        self.hook = None
+        self.sftp_conn_id = sftp_conn_id
 
     def poke(self, context):
+        self.hook = SFTPHook(self.sftp_conn_id)
         self.log.info('Poking for %s', self.path)
         try:
             self.hook.get_mod_time(self.path)

--- a/tests/contrib/sensors/test_sftp_sensor.py
+++ b/tests/contrib/sensors/test_sftp_sensor.py
@@ -69,3 +69,9 @@ class TestSFTPSensor(unittest.TestCase):
             sftp_sensor.poke(context)
             sftp_hook_mock.return_value.get_mod_time.assert_called_once_with(
                 '/path/to/file/1970-01-01.txt')
+
+    def test_hook_not_created_during_init(self):
+        sftp_sensor = SFTPSensor(
+            task_id='unit_test',
+            path='/path/to/file/1970-01-01.txt')
+        self.assertIsNone(sftp_sensor.hook)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6192


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
From Slack (https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1575647500146200):

When I create a task based upon the SFTPSensor and then parse the Python file, do I see two log entries coming from base_hook.py referencing the default sftp connection id? I also see the same log messages whenever the DAGs are refreshed.

```
airflow@0030a4ae49df:~$ python dags/sftp_sensor.py
[2019-12-06 15:45:16,440] settings.py:252 INFO - settings.configure_orm(): Using pool settings. pool_size=5, max_overflow=10, pool_recycle=1800, pid=9685
/usr/local/lib/python3.7/site-packages/psycopg2/_init_.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
""")
[2019-12-06 15:45:17,535] base_hook.py:84 INFO - Using connection to: id: sftp_default. Host: localhost, Port: 22, Schema: None, Login: airflow, Password: None, extra:

{'key_file': '~/.ssh/id_rsa', 'no_host_key_check': True}
[2019-12-06 15:45:17,539] base_hook.py:84 INFO - Using connection to: id: sftp_default. Host: localhost, Port: 22, Schema: None, Login: airflow, Password: None, extra:

{'key_file': '~/.ssh/id_rsa', 'no_host_key_check': True}
airflow@0030a4ae49df:~$ airflow list_dags
[2019-12-06 15:47:43,529] settings.py:252 INFO - settings.configure_orm(): Using pool settings. pool_size=5, max_overflow=10, pool_recycle=1800, pid=11223
/usr/local/lib/python3.7/site-packages/psycopg2/_init_.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
""")
[2019-12-06 15:47:44,631] _init_.py:51 INFO - Using executor LocalExecutor
[2019-12-06 15:47:44,631] dagbag.py:92 INFO - Filling up the DagBag from /usr/local/airflow/dags
[2019-12-06 15:47:48,998] base_hook.py:84 INFO - Using connection to: id: sftp_default. Host: localhost, Port: 22, Schema: None, Login: airflow, Password: None, extra:

{'key_file': '~/.ssh/id_rsa', 'no_host_key_check': True}
[2019-12-06 15:47:49,005] base_hook.py:84 INFO - Using connection to: id: sftp_default. Host: localhost, Port: 22, Schema: None, Login: airflow, Password: None, extra:

{'key_file': '~/.ssh/id_rsa', 'no_host_key_check': True}

```
This is on v1.10.6

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
