### PR TITLE
[AIRFLOW-6185] SQLAlchemy Connection model schema not aligned with Alembic schema

### DIFF
--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -68,8 +68,11 @@ def run_migrations_offline():
 
     """
     context.configure(
-        url=settings.SQL_ALCHEMY_CONN, target_metadata=target_metadata,
-        literal_binds=True, compare_type=COMPARE_TYPE)
+        url=settings.SQL_ALCHEMY_CONN,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=COMPARE_TYPE,
+        render_as_batch=True)
 
     with context.begin_transaction():
         context.run_migrations()
@@ -91,6 +94,7 @@ def run_migrations_online():
             target_metadata=target_metadata,
             compare_type=COMPARE_TYPE,
             include_object=include_object,
+            render_as_batch=True
         )
 
         with context.begin_transaction():

--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -22,6 +22,7 @@ from logging.config import fileConfig
 from alembic import context
 
 from airflow import models, settings
+from airflow.models.serialized_dag import SerializedDagModel  # noqa
 
 
 def include_object(_, name, type_, *args):

--- a/airflow/migrations/versions/fe461863935f_increase_length_for_connection_password.py
+++ b/airflow/migrations/versions/fe461863935f_increase_length_for_connection_password.py
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""increase_length_for_connection_password
+
+Revision ID: fe461863935f
+Revises: 08364691d074
+Create Date: 2019-12-08 09:47:09.033009
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'fe461863935f'
+down_revision = '08364691d074'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply increase_length_for_connection_password"""
+    with op.batch_alter_table('connection', schema=None) as batch_op:
+        batch_op.alter_column('password',
+                              existing_type=sa.VARCHAR(length=500),
+                              type_=sa.String(length=5000),
+                              existing_nullable=True)
+
+
+def downgrade():
+    """Unapply increase_length_for_connection_password"""
+    with op.batch_alter_table('connection', schema=None) as batch_op:
+        batch_op.alter_column('password',
+                              existing_type=sa.String(length=5000),
+                              type_=sa.VARCHAR(length=500),
+                              existing_nullable=True)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-6185

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
   - Create a new alembic revision to increase `Connection.password` to 5000, syncing with the SQLAlchemy model, and set `render_as_batch=True` for both online & offline migrations to work with `SQLite` backend.
   - Import `SerializedDagModel` to `migrations/env.py`. As `SerializedDagModel` was removed from `models` (#6601 ), alembic thinks that the object was removed, and will try to remove the table in autogenerated schema migration. This can avoid the behavior

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
