### PR TITLE
[AIRFLOW-6205] The 'airflow db shell' works on mysql without port/passwd

### DIFF
--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -61,8 +61,8 @@ def shell(args):
                 [client]
                 host     = {url.host}
                 user     = {url.username}
-                password = {url.password}
-                port     = {url.port}
+                password = {url.password or ""}
+                port     = {url.port or ""}
                 database = {url.database}
                 """).strip()
             f.write(content.encode())

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -61,7 +61,7 @@ class TestCliDb(unittest.TestCase):
             ['mysql', '--defaults-extra-file=/tmp/name']
         )
         mock_tmp_file.return_value.__enter__.return_value.write.assert_called_once_with(
-            b'[client]\nhost     = mysql\nuser     = root\npassword = None\nport     = None'
+            b'[client]\nhost     = mysql\nuser     = root\npassword = \nport     = '
             b'\ndatabase = airflow'
         )
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6205

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The `airflow db shell' command now works also for mysql with no port/password

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
