### PR TITLE
[AIRFLOW-6208] Implement fileno in StreamLogWriter

### DIFF
--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -116,6 +116,13 @@ class StreamLogWriter:
         """
         return False
 
+    def fileno(self):
+        """
+        Returns the stdout file descriptor 1.
+        For compatibility reasons e.g python subprocess module stdout redirection.
+        """
+        return 1
+
 
 class RedirectStdHandler(StreamHandler):
     """

--- a/tests/utils/test_logging_mixin.py
+++ b/tests/utils/test_logging_mixin.py
@@ -91,6 +91,13 @@ class TestStreamLogWriter(unittest.TestCase):
         log = StreamLogWriter(logger, 1)
         self.assertFalse(log.isatty())
 
+    def test_fileno(self):
+        logger = mock.MagicMock()
+        logger.log = mock.MagicMock()
+
+        log = StreamLogWriter(logger, 1)
+        self.assertEqual(log.fileno(), 1)
+
     def test_encoding(self):
         logger = mock.MagicMock()
         logger.log = mock.MagicMock()


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-6208) issues and references them in the PR title. 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Tasks running with the python operator using subprocess.run fail when stdout is redirected to sys.stdout as the StreamLogWriter class does not implement the file descriptor return function fileno()

```
import sys
import subprocess
subprocess.run("echo 1", shell=True, check=True, stdout=sys.stdout, stderr=sys.stderr)
```

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 930, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/usr/lib/python3.8/site-packages/airflow/operators/python_operator.py", line 113, in execute
    return_value = self.execute_callable()
  File "/usr/lib/python3.8/site-packages/airflow/operators/python_operator.py", line 118, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/home/user/airflow/dags/subprocess.py", line 39, in sp
    subprocess.run("echo 1", shell=True, check=True, stdout=sys.stdout, stderr=sys.stderr)
  File "/usr/lib/python3.8/subprocess.py", line 489, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.8/subprocess.py", line 804, in __init__
    errread, errwrite) = self._get_handles(stdin, stdout, stderr)
  File "/usr/lib/python3.8/subprocess.py", line 1487, in _get_handles
    c2pwrite = stdout.fileno()
AttributeError: 'StreamLogWriter' object has no attribute 'fileno'
```

Implementing fileno in StreamLogWriter and returning 1 (file descriptor number for stdout) resolves this.

### Tests

- [X] My PR adds the following unit tests:

Added:
test_fileno in file tests/utils/test_logging_mixin.py

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
