### PR TITLE
[AIRFLOW-6209] Drop gcp_service_account_keys option

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -41,6 +41,12 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Remove gcp_service_account_keys option in airflow.cfg file
+
+This option has been removed because it is no longer supported by the Google Cloud Platform. The new
+recommended service account keys management method for the GCP platform is
+[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
+
 ### Removal of airflow.AirflowMacroPlugin class
 
 The class was there in airflow package but it has not been used (apparently since 2015).

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -43,8 +43,8 @@ assists users migrating to a new version.
 
 ### Remove gcp_service_account_keys option in airflow.cfg file
 
-This option has been removed because it is no longer supported by the Google Cloud Platform. The new
-recommended service account keys management method for the GCP platform is
+This option has been removed because it is no longer supported by the Google Kubernetes Engine. The new
+recommended service account keys for the Google Cloud Platform management method is
 [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
 
 ### Removal of airflow.AirflowMacroPlugin class

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -754,10 +754,6 @@ worker_service_account_name =
 # required, provide a comma separated list: secret_a,secret_b
 image_pull_secrets =
 
-# GCP Service Account Keys to be provided to tasks run on Kubernetes Executors
-# Should be supplied in the format: key-name-1:key-path-1,key-name-2:key-path-2
-gcp_service_account_keys =
-
 # Use the service account kubernetes gives to pods to connect to kubernetes cluster.
 # It's intended for clients that expect to be running inside a pod running on kubernetes.
 # It will raise an exception if called from a process not running in a kubernetes environment.

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -171,9 +171,6 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
         # cluster has RBAC enabled, your workers may need service account permissions to
         # interact with cluster components.
         self.executor_namespace = conf.get(self.kubernetes_section, 'namespace')
-        # Task secrets managed by KubernetesExecutor.
-        self.gcp_service_account_keys = conf.get(self.kubernetes_section,
-                                                 'gcp_service_account_keys')
 
         # If the user is using the git-sync container to clone their repository via git,
         # allow them to specify repository, tag, and pod name for the init container.
@@ -723,17 +720,6 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                     secret_name, e
                 )
                 raise
-
-        # For each GCP service account key, inject it as a secret in executor
-        # namespace with the specific secret name configured in the airflow.cfg.
-        # We let exceptions to pass through to users.
-        if self.kube_config.gcp_service_account_keys:
-            name_path_pair_list = [
-                {'name': account_spec.strip().split('=')[0],
-                 'path': account_spec.strip().split('=')[1]}
-                for account_spec in self.kube_config.gcp_service_account_keys.split(',')]
-            for service_account in name_path_pair_list:
-                _create_or_update_secret(service_account['name'], service_account['path'])
 
     def start(self) -> None:
         """Starts the executor"""

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -249,14 +249,6 @@ class PodGenerator:
                     limits=limits
                 )
 
-        annotations = namespaced.get('annotations', {})
-        gcp_service_account_key = namespaced.get('gcp_service_account_key', None)
-
-        if annotations is not None and gcp_service_account_key is not None:
-            annotations.update({
-                'iam.cloud.google.com/service-account': gcp_service_account_key
-            })
-
         pod_spec_generator = PodGenerator(
             image=namespaced.get('image'),
             envs=namespaced.get('env'),

--- a/scripts/ci/kubernetes/app/templates/configmaps.template.yaml
+++ b/scripts/ci/kubernetes/app/templates/configmaps.template.yaml
@@ -177,7 +177,6 @@ data:
     logs_volume_host =
     in_cluster = True
     namespace = default
-    gcp_service_account_keys =
 
     # Example affinity and toleration definitions.
     affinity = {"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"NotIn","values":["4e5e6a99-e28a-450b-bba9-e0124853de9b"]}]}]}}}


### PR DESCRIPTION
I wanna remove this option, because it is no longer supported by the Google Cloud Platform. The new
recommended service account keys management method for the GCP platform is
[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).

After merge, we should also add note in https://cwiki.apache.org/confluence/display/AIRFLOW/Managing+Per-task+Credentials+in+KubernetesExecutor

---

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6209
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
