### PR TITLE
[AIRFLOW-6216] Allow pytests to be run without "tests"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,6 +40,7 @@
 !.rat-excludes
 !.flake8
 !pylintrc
+!pytest.ini
 !LICENSE
 !MANIFEST.in
 !NOTICE

--- a/Dockerfile
+++ b/Dockerfile
@@ -340,7 +340,7 @@ COPY docs/ ${AIRFLOW_SOURCES}/docs/
 COPY tests/ ${AIRFLOW_SOURCES}/tests/
 COPY airflow/ ${AIRFLOW_SOURCES}/airflow/
 COPY .coveragerc .rat-excludes .flake8 pylintrc LICENSE MANIFEST.in NOTICE CHANGELOG.txt \
-     .github \
+     .github pytest.ini \
      setup.cfg setup.py \
      ${AIRFLOW_SOURCES}/
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,6 +26,8 @@ addopts =
     --ignore=tests/dags/test_impersonation_subdag.py
     --ignore=tests/dags/test_subdag.py
 norecursedirs =
+    .eggs
+    airflow
     tests/dags_with_system_exit
     tests/test_utils
     tests/dags_corrupted

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -105,6 +105,7 @@ elif [[ ${AIRFLOW_MOUNT_HOST_VOLUMES_FOR_STATIC_CHECKS} == "true" ]]; then
       "-v" "${AIRFLOW_SOURCES}/tests:/opt/airflow/tests:cached" \
       "-v" "${AIRFLOW_SOURCES}/.flake8:/opt/airflow/.flake8:cached" \
       "-v" "${AIRFLOW_SOURCES}/pylintrc:/opt/airflow/pylintrc:cached" \
+      "-v" "${AIRFLOW_SOURCES}/pytest.ini:/opt/airflow/pytest.ini:cached" \
       "-v" "${AIRFLOW_SOURCES}/setup.cfg:/opt/airflow/setup.cfg:cached" \
       "-v" "${AIRFLOW_SOURCES}/setup.py:/opt/airflow/setup.py:cached" \
       "-v" "${AIRFLOW_SOURCES}/.rat-excludes:/opt/airflow/.rat-excludes:cached" \

--- a/scripts/ci/docker-compose-local.yml
+++ b/scripts/ci/docker-compose-local.yml
@@ -50,6 +50,7 @@ services:
       - ../../.inputrc:/root/.inputrc:cached
       - ../../.flake8:/opt/airflow/.flake8:cached
       - ../../pylintrc:/opt/airflow/pylintrc:cached
+      - ../../pytest.ini:/opt/airflow/pytest.ini:cached
       - ../../.rat-excludes:/opt/airflow/.rat-excludes:cached
       - ../../logs:/root/airflow/logs:cached
       - ../../tmp:/opt/airflow/tmp:cached

--- a/tests/integration/kubernetes/test_kubernetes_executor.py
+++ b/tests/integration/kubernetes/test_kubernetes_executor.py
@@ -30,7 +30,7 @@ from urllib3.util.retry import Retry
 try:
     check_call(["/usr/local/bin/kubectl", "get", "pods"])
 except Exception as e:  # pylint: disable=broad-except
-    if os.environ.get('KUBERNETES_VERSION'):
+    if os.environ.get('KUBERNETES_VERSION') and os.environ.get('ENV', 'kubernetes') == 'kubernetes':
         raise e
     else:
         raise unittest.SkipTest(

--- a/tests/integration/kubernetes/test_kubernetes_pod_operator.py
+++ b/tests/integration/kubernetes/test_kubernetes_pod_operator.py
@@ -40,7 +40,7 @@ from airflow.version import version as airflow_version
 try:
     check_call(["/usr/local/bin/kubectl", "get", "pods"])
 except Exception as e:  # pylint: disable=broad-except
-    if os.environ.get('KUBERNETES_VERSION'):
+    if os.environ.get('KUBERNETES_VERSION') and os.environ.get('ENV', 'kubernetes') == 'kubernetes':
         raise e
     else:
         raise unittest.SkipTest(


### PR DESCRIPTION
With this change you should be able to simply run `pytest` to run all the tests in the main airflow directory.

This consist of two changes:

* moving pytest.ini to the main airflow directory
* skipping collecting kubernetes tests when ENV != kubernetes

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6216

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
