### PR TITLE
[AIRFLOW-4488] fix typo for non-RBAC UI in max_active_runs_per_dag

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1014,7 +1014,7 @@ class Airflow(AirflowViewMixin, BaseView):
             of queueable processes:
               <code>parallelism</code>,
               <code>dag_concurrency</code>,
-              <code>max_active_dag_runs_per_dag</code>,
+              <code>max_active_runs_per_dag</code>,
               <code>non_pooled_task_slot_count</code><br/>
             {}
             <br/>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-4488

### Description
https://github.com/apache/airflow/commit/86fdd145329bb0a474c6dab1a7557f11415f76ee  introduced the `max_active_runs_per_dag` setting
https://github.com/apache/airflow/pull/3286 introduced the message using that setting but it had typo: `max_active_dag_runs_per_dag` when it should have been `max_active_runs_per_dag`

The message exist only in non-RBAC UI in `v1-10` so this PR targets ` v1-10 test` branch

### Tests

- Not needed

### Documentation

- Not needed
