### PR TITLE
[AIRFLOW-6222] http hook should log response text

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -141,8 +141,7 @@ class HttpHook(BaseHook):
             response.raise_for_status()
         except requests.exceptions.HTTPError:
             self.log.error("HTTP error: %s", response.reason)
-            if self.method not in ['GET', 'HEAD']:
-                self.log.error(response.text)
+            self.log.error(response.text)
             raise AirflowException(str(response.status_code) + ":" + response.reason)
 
     def run_and_check(self, session, prepped_request, extra_options):

--- a/tests/sensors/test_http_sensor.py
+++ b/tests/sensors/test_http_sensor.py
@@ -129,6 +129,7 @@ class TestHttpSensor(unittest.TestCase):
         response = requests.Response()
         response.status_code = 404
         response.reason = 'Not Found'
+        response._content = b'This endpoint doesnt exist'
         mock_session_send.return_value = response
 
         task = HttpSensor(
@@ -150,11 +151,17 @@ class TestHttpSensor(unittest.TestCase):
             self.assertTrue(mock_errors.called)
             calls = [
                 mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('This endpoint doesnt exist'),
                 mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('This endpoint doesnt exist'),
                 mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('This endpoint doesnt exist'),
                 mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('This endpoint doesnt exist'),
                 mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('This endpoint doesnt exist'),
                 mock.call('HTTP error: %s', 'Not Found'),
+                mock.call('This endpoint doesnt exist'),
             ]
             mock_errors.assert_has_calls(calls)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6222

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
currently it doesn't log response text in the case of a GET or HEAD request
it should, because response.text is a property on the Response object and is helpful for debugging!

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
