### PR TITLE
[AIRFLOW-5944] Display rendered template_fields without accessing DAG files

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -316,6 +316,18 @@
       type: string
       example: ~
       default: "30"
+    - name: max_num_rendered_ti_fields_per_task
+      description: |
+        Maximum number of Rendered Task Instance Fields (Template Fields) per task to store
+        in the Database.
+        When Dag Serialization is enabled (``store_serialized_dags=True``), all the template_fields
+        for each of Task Instance are stored in the Database.
+        Keeping this number small may cause an error when you try to view ``Rendered`` tab in
+        TaskInstance view for older tasks.
+      version_added: 2.0.0
+      type: integer
+      example: ~
+      default: "30"
     - name: check_slas
       description: |
         On each dagrun check against defined SLAs

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -181,6 +181,14 @@ store_serialized_dags = False
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.
 min_serialized_dag_update_interval = 30
 
+# Maximum number of Rendered Task Instance Fields (Template Fields) per task to store
+# in the Database.
+# When Dag Serialization is enabled (``store_serialized_dags=True``), all the template_fields
+# for each of Task Instance are stored in the Database.
+# Keeping this number small may cause an error when you try to view ``Rendered`` tab in
+# TaskInstance view for older tasks.
+max_num_rendered_ti_fields_per_task = 30
+
 # On each dagrun check against defined SLAs
 check_slas = True
 

--- a/airflow/migrations/versions/852ae6c715af_add_rendered_task_instance_fields_table.py
+++ b/airflow/migrations/versions/852ae6c715af_add_rendered_task_instance_fields_table.py
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add RenderedTaskInstanceFields table
+
+Revision ID: 852ae6c715af
+Revises: b25a55525161
+Create Date: 2020-03-10 22:19:18.034961
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '852ae6c715af'
+down_revision = 'b25a55525161'
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = 'rendered_task_instance_fields'
+
+
+def upgrade():
+    """Apply Add RenderedTaskInstanceFields table"""
+    json_type = sa.JSON
+    conn = op.get_bind()  # pylint: disable=no-member
+
+    if conn.dialect.name != "postgresql":
+        # Mysql 5.7+/MariaDB 10.2.3 has JSON support. Rather than checking for
+        # versions, check for the function existing.
+        try:
+            conn.execute("SELECT JSON_VALID(1)").fetchone()
+        except sa.exc.OperationalError:
+            json_type = sa.Text
+
+    op.create_table(
+        TABLE_NAME,  # pylint: disable=no-member
+        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.Column('task_id', sa.String(length=250), nullable=False),
+        sa.Column('execution_date', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('rendered_fields', json_type(), nullable=False),
+        sa.PrimaryKeyConstraint('dag_id', 'task_id', 'execution_date')
+    )
+
+
+def downgrade():
+    """Drop RenderedTaskInstanceFields table"""
+    op.drop_table(TABLE_NAME)   # pylint: disable=no-member

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -26,6 +26,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.errors import ImportError  # pylint: disable=redefined-builtin
 from airflow.models.log import Log
 from airflow.models.pool import Pool
+from airflow.models.renderedtifields import RenderedTaskInstanceFields
 from airflow.models.skipmixin import SkipMixin
 from airflow.models.slamiss import SlaMiss
 from airflow.models.taskfail import TaskFail

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -116,25 +116,18 @@ class DagBag(BaseDagBag, LoggingMixin):
     def dag_ids(self) -> List[str]:
         return self.dags.keys()
 
-    def get_dag(self, dag_id: str, from_file_only: bool = False):
+    def get_dag(self, dag_id):
         """
         Gets the DAG out of the dictionary, and refreshes it if expired
 
         :param dag_id: DAG Id
         :type dag_id: str
-        :param from_file_only: returns a DAG loaded from file.
-        :type from_file_only: bool
         """
         # Avoid circular import
         from airflow.models.dag import DagModel
 
         # Only read DAGs from DB if this dagbag is store_serialized_dags.
-        # from_file_only is an exception, currently it is for renderring templates
-        # in UI only. Because functions are gone in serialized DAGs, DAGs must be
-        # imported from files.
-        # FIXME: this exception should be removed in future, then webserver can be
-        # decoupled from DAG files.
-        if self.store_serialized_dags and not from_file_only:
+        if self.store_serialized_dags:
             # Import here so that serialized dag is only imported when serialization is enabled
             from airflow.models.serialized_dag import SerializedDagModel
             if dag_id not in self.dags:

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -1,0 +1,137 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Save Rendered Template Fields """
+from typing import Optional
+
+import sqlalchemy_jsonfield
+from sqlalchemy import Column, String, and_, tuple_
+from sqlalchemy.orm import Session
+
+from airflow.configuration import conf
+from airflow.models.base import ID_LEN, Base
+from airflow.models.taskinstance import TaskInstance
+from airflow.serialization.helpers import serialize_template_field
+from airflow.settings import json
+from airflow.utils.session import provide_session
+from airflow.utils.sqlalchemy import UtcDateTime
+
+
+class RenderedTaskInstanceFields(Base):
+    """
+    Save Rendered Template Fields
+    """
+
+    __tablename__ = "rendered_task_instance_fields"
+
+    dag_id = Column(String(ID_LEN), primary_key=True)
+    task_id = Column(String(ID_LEN), primary_key=True)
+    execution_date = Column(UtcDateTime, primary_key=True)
+    rendered_fields = Column(sqlalchemy_jsonfield.JSONField(json=json), nullable=False)
+
+    def __init__(self, ti: TaskInstance, render_templates=True):
+        self.dag_id = ti.dag_id
+        self.task_id = ti.task_id
+        self.task = ti.task
+        self.execution_date = ti.execution_date
+        self.ti = ti
+        if render_templates:
+            ti.render_templates()
+        self.rendered_fields = {
+            field: serialize_template_field(
+                getattr(self.task, field)
+            ) for field in self.task.template_fields
+        }
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: {self.dag_id}.{self.task_id} {self.execution_date}"
+
+    @classmethod
+    @provide_session
+    def get_templated_fields(cls, ti: TaskInstance, session: Session = None) -> Optional[dict]:
+        """
+        Get templated field for a TaskInstance from the RenderedTaskInstanceFields
+        table.
+
+        :param ti: Task Instance
+        :param session: SqlAlchemy Session
+        :return: Rendered Templated TI field
+        """
+        result = session.query(cls.rendered_fields).filter(
+            cls.dag_id == ti.dag_id,
+            cls.task_id == ti.task_id,
+            cls.execution_date == ti.execution_date
+        ).one_or_none()
+
+        if result:
+            rendered_fields = result.rendered_fields
+            return rendered_fields
+        else:
+            return None
+
+    @provide_session
+    def write(self, session: Session = None):
+        """Write instance to database
+
+        :param session: SqlAlchemy Session
+        """
+        session.merge(self)
+
+    @classmethod
+    @provide_session
+    def delete_old_records(
+        cls, task_id: str, dag_id: str,
+        num_to_keep=conf.getint("core", "max_num_rendered_ti_fields_per_task", fallback=0),
+        session: Session = None
+    ):
+        """
+        Keep only Last X (num_to_keep) number of records for a task by deleting others
+
+        :param task_id: Task ID
+        :param dag_id: Dag ID
+        :param num_to_keep: Number of Records to keep
+        :param session: SqlAlchemy Session
+        """
+        if num_to_keep <= 0:
+            return
+
+        # Fetch Top X records given dag_id & task_id ordered by Execution Date
+        subq1 = (
+            session
+            .query(cls.dag_id, cls.task_id, cls.execution_date)
+            .filter(cls.dag_id == dag_id, cls.task_id == task_id)
+            .order_by(cls.execution_date.desc())
+            .limit(num_to_keep)
+            .subquery('subq1')
+        )
+
+        # Second Subquery
+        # Workaround for MySQL Limitation (https://stackoverflow.com/a/19344141/5691525)
+        # Limitation: This version of MySQL does not yet support
+        # LIMIT & IN/ALL/ANY/SOME subquery
+        subq2 = (
+            session
+            .query(subq1.c.dag_id, subq1.c.task_id, subq1.c.execution_date)
+            .subquery('subq2')
+        )
+
+        session.query(cls) \
+            .filter(and_(
+                cls.dag_id == dag_id,
+                cls.task_id == task_id,
+                tuple_(cls.dag_id, cls.task_id, cls.execution_date).notin_(subq2))) \
+            .delete(synchronize_session=False)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -48,6 +48,7 @@ from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.variable import Variable
 from airflow.models.xcom import XCOM_RETURN_KEY, XCom
 from airflow.sentry import Sentry
+from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies import REQUEUEABLE_DEPS, RUNNING_DEPS
@@ -889,6 +890,7 @@ class TaskInstance(Base, LoggingMixin):
         :type pool: str
         """
         from airflow.sensors.base_sensor_operator import BaseSensorOperator
+        from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 
         task = self.task
         self.test_mode = test_mode
@@ -927,6 +929,10 @@ class TaskInstance(Base, LoggingMixin):
                 start_time = time.time()
 
                 self.render_templates(context=context)
+                if STORE_SERIALIZED_DAGS:
+                    RTIF.write(RTIF(ti=self, render_templates=False), session=session)
+                    RTIF.delete_old_records(self.task_id, self.dag_id, session=session)
+
                 # Export context to make it available for operators to use.
                 airflow_context_vars = context_to_airflow_vars(context, in_env_var_format=True)
                 self.log.info("Exporting the following env vars:\n%s",
@@ -1356,6 +1362,23 @@ class TaskInstance(Base, LoggingMixin):
             'yesterday_ds': yesterday_ds,
             'yesterday_ds_nodash': yesterday_ds_nodash,
         }
+
+    def get_rendered_template_fields(self):
+        """
+        Fetch rendered template fields from DB if Serialization is enabled.
+        Else just render the templates
+        """
+        from airflow.models.renderedtifields import RenderedTaskInstanceFields
+        if STORE_SERIALIZED_DAGS:
+            rtif = RenderedTaskInstanceFields.get_templated_fields(self)
+            if rtif:
+                for field_name, rendered_value in rtif.items():
+                    setattr(self.task, field_name, rendered_value)
+            else:
+                # TODO: Fetch Unrendered strings
+                ...
+        else:
+            self.render_templates()
 
     def overwrite_params_with_dag_run_conf(self, params, dag_run):
         if dag_run and dag_run.conf:

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Serialized DAG and BaseOperator"""
+from typing import Union
+
+from airflow.settings import json
+
+
+def serialize_template_field(template_field: dict) -> Union[str, dict]:
+    """
+    Return a serializable representation of the templated_field.
+    If a templated_field contains a Class or Instance for recursive templating, store them
+    as strings. If the templated_field is not recursive return the field
+
+    :param template_field: Task's Templated Field
+    """
+
+    def is_jsonable(x):
+        try:
+            json.dumps(x)
+            return True
+        except (TypeError, OverflowError):
+            return False
+
+    if not is_jsonable(template_field):
+        return str(template_field)
+    else:
+        return template_field

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -1,0 +1,213 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for RenderedTaskInstanceFields."""
+
+import unittest
+from datetime import date, timedelta
+
+from parameterized import parameterized
+
+from airflow import settings
+from airflow.models import Variable
+from airflow.models.dag import DAG
+from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
+from airflow.models.taskinstance import TaskInstance as TI
+from airflow.operators.bash import BashOperator
+from airflow.utils.session import create_session
+from airflow.utils.timezone import datetime
+from tests.test_utils.db import clear_rendered_ti_fields
+
+TEST_DAG = DAG("example_rendered_ti_field", schedule_interval=None)
+START_DATE = datetime(2018, 1, 1)
+EXECUTION_DATE = datetime(2019, 1, 1)
+
+
+class ClassWithCustomAttributes:
+    """Class for testing purpose: allows to create objects with custom attributes in one single statement."""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __str__(self):
+        return "{}({})".format(ClassWithCustomAttributes.__name__, str(self.__dict__))
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class TestRenderedTaskInstanceFields(unittest.TestCase):
+    """Unit tests for RenderedTaskInstanceFields."""
+
+    def setUp(self):
+        clear_rendered_ti_fields()
+
+    def tearDown(self):
+        clear_rendered_ti_fields()
+
+    @parameterized.expand([
+        (None, None),
+        ([], []),
+        ({}, {}),
+        ("test-string", "test-string"),
+        ({"foo": "bar"}, {"foo": "bar"}),
+        ("{{ task.task_id }}", "test"),
+        (date(2018, 12, 6), "2018-12-06"),
+        (datetime(2018, 12, 6, 10, 55), "2018-12-06 10:55:00+00:00"),
+        (
+            ClassWithCustomAttributes(
+                att1="{{ task.task_id }}", att2="{{ task.task_id }}", template_fields=["att1"]),
+            "ClassWithCustomAttributes({'att1': 'test', 'att2': '{{ task.task_id }}', "
+            "'template_fields': ['att1']})",
+        ),
+        (
+            ClassWithCustomAttributes(nested1=ClassWithCustomAttributes(att1="{{ task.task_id }}",
+                                                                        att2="{{ task.task_id }}",
+                                                                        template_fields=["att1"]),
+                                      nested2=ClassWithCustomAttributes(att3="{{ task.task_id }}",
+                                                                        att4="{{ task.task_id }}",
+                                                                        template_fields=["att3"]),
+                                      template_fields=["nested1"]),
+            "ClassWithCustomAttributes({'nested1': ClassWithCustomAttributes("
+            "{'att1': 'test', 'att2': '{{ task.task_id }}', 'template_fields': ['att1']}), "
+            "'nested2': ClassWithCustomAttributes("
+            "{'att3': '{{ task.task_id }}', 'att4': '{{ task.task_id }}', 'template_fields': ['att3']}), "
+            "'template_fields': ['nested1']})",
+        ),
+    ])
+    def test_get_templated_fields(self, templated_field, expected_rendered_field):
+        """
+        Test that template_fields are rendered correctly, stored in the Database,
+        and are correctly fetched using RTIF.get_templated_fields
+        """
+        dag = DAG("test_serialized_rendered_fields", start_date=START_DATE)
+        with dag:
+            task = BashOperator(task_id="test", bash_command=templated_field)
+
+        ti = TI(task=task, execution_date=EXECUTION_DATE)
+        rtif = RTIF(ti=ti)
+        self.assertEqual(ti.dag_id, rtif.dag_id)
+        self.assertEqual(ti.task_id, rtif.task_id)
+        self.assertEqual(ti.execution_date, rtif.execution_date)
+        self.assertEqual(expected_rendered_field, rtif.rendered_fields.get("bash_command"))
+
+        with create_session() as session:
+            session.add(rtif)
+
+        self.assertEqual(
+            {"bash_command": expected_rendered_field, "env": None},
+            RTIF.get_templated_fields(ti=ti))
+
+        # Test the else part of get_templated_fields
+        # i.e. for the TIs that are not stored in RTIF table
+        # Fetching them will return None
+        with dag:
+            task_2 = BashOperator(task_id="test2", bash_command=templated_field)
+
+        ti2 = TI(task_2, EXECUTION_DATE)
+        self.assertIsNone(RTIF.get_templated_fields(ti=ti2))
+
+    def test_delete_old_records(self):
+        """
+        Test that old records are deleted from rendered_task_instance_fields table
+        for a given task_id and dag_id.
+        """
+        session = settings.Session()
+        dag = DAG("test_delete_old_records", start_date=START_DATE)
+        with dag:
+            task = BashOperator(task_id="test", bash_command="echo {{ ds }}")
+
+        rtif_1 = RTIF(TI(task=task, execution_date=EXECUTION_DATE))
+        rtif_2 = RTIF(TI(task=task, execution_date=EXECUTION_DATE + timedelta(days=1)))
+        rtif_3 = RTIF(TI(task=task, execution_date=EXECUTION_DATE + timedelta(days=2)))
+
+        session.add(rtif_1)
+        session.add(rtif_2)
+        session.add(rtif_3)
+        session.commit()
+
+        result = session.query(RTIF)\
+            .filter(RTIF.dag_id == dag.dag_id, RTIF.task_id == task.task_id).all()
+
+        self.assertIn(rtif_1, result)
+        self.assertIn(rtif_2, result)
+        self.assertIn(rtif_3, result)
+        self.assertEqual(3, len(result))
+
+        # Verify old records are deleted and only 1 record is kept
+        RTIF.delete_old_records(task_id=task.task_id, dag_id=task.dag_id, num_to_keep=1)
+        result = session.query(RTIF) \
+            .filter(RTIF.dag_id == dag.dag_id, RTIF.task_id == task.task_id).all()
+        self.assertEqual(1, len(result))
+        self.assertEqual(rtif_3.execution_date, result[0].execution_date)
+
+    def test_write(self):
+        """
+        Test records can be written and overwritten
+        """
+        Variable.set(key="test_key", value="test_val")
+
+        session = settings.Session()
+        result = session.query(RTIF).all()
+        self.assertEqual([], result)
+
+        with DAG("test_write", start_date=START_DATE):
+            task = BashOperator(task_id="test", bash_command="echo {{ var.value.test_key }}")
+
+        rtif = RTIF(TI(task=task, execution_date=EXECUTION_DATE))
+        rtif.write()
+        result = session.query(RTIF.dag_id, RTIF.task_id, RTIF.rendered_fields).filter(
+            RTIF.dag_id == rtif.dag_id,
+            RTIF.task_id == rtif.task_id,
+            RTIF.execution_date == rtif.execution_date
+        ).first()
+        self.assertEqual(
+            (
+                'test_write', 'test', {
+                    'bash_command': 'echo test_val', 'env': None
+                }
+            ), result)
+
+        # Test that overwrite saves new values to the DB
+        Variable.delete("test_key")
+        Variable.set(key="test_key", value="test_val_updated")
+
+        with DAG("test_write", start_date=START_DATE):
+            updated_task = BashOperator(task_id="test", bash_command="echo {{ var.value.test_key }}")
+
+        rtif_updated = RTIF(TI(task=updated_task, execution_date=EXECUTION_DATE))
+        rtif_updated.write()
+
+        result_updated = session.query(RTIF.dag_id, RTIF.task_id, RTIF.rendered_fields).filter(
+            RTIF.dag_id == rtif_updated.dag_id,
+            RTIF.task_id == rtif_updated.task_id,
+            RTIF.execution_date == rtif_updated.execution_date
+        ).first()
+        self.assertEqual(
+            (
+                'test_write', 'test', {
+                    'bash_command': 'echo test_val_updated', 'env': None
+                }
+            ), result_updated)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -33,7 +33,9 @@ from sqlalchemy.orm.session import Session
 from airflow import models, settings
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowSkipException
-from airflow.models import DAG, DagRun, Pool, TaskFail, TaskInstance as TI, TaskReschedule, Variable
+from airflow.models import (
+    DAG, DagRun, Pool, RenderedTaskInstanceFields, TaskFail, TaskInstance as TI, TaskReschedule, Variable,
+)
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import PythonOperator
@@ -1541,6 +1543,36 @@ class TestTaskInstance(unittest.TestCase):
         generate_command = TI.generate_command(dag_id=dag_id, task_id=task_id,
                                                execution_date=DEFAULT_DATE, mark_success=True)
         assert assert_command == generate_command
+
+    @parameterized.expand([
+        (True, ),
+        (False, )
+    ])
+    def test_get_rendered_template_fields(self, store_serialized_dag):
+        # SetUp
+        settings.STORE_SERIALIZED_DAGS = store_serialized_dag
+
+        with DAG('test-dag', start_date=DEFAULT_DATE):
+            task = BashOperator(task_id='op1', bash_command="{{ task.task_id }}")
+
+        ti = TI(task=task, execution_date=DEFAULT_DATE)
+
+        with create_session() as session:
+            session.add(RenderedTaskInstanceFields(ti))
+
+        # Create new TI for the same Task
+        with DAG('test-dag', start_date=DEFAULT_DATE):
+            new_task = BashOperator(task_id='op1', bash_command="{{ task.task_id }}")
+
+        new_ti = TI(task=new_task, execution_date=DEFAULT_DATE)
+        new_ti.get_rendered_template_fields()
+
+        self.assertEqual(settings.STORE_SERIALIZED_DAGS, store_serialized_dag)
+        self.assertEqual("op1", ti.task.bash_command)
+
+        # CleanUp
+        with create_session() as session:
+            session.query(RenderedTaskInstanceFields).delete()
 
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -15,7 +15,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from airflow.models import Connection, DagModel, DagRun, DagTag, Pool, SlaMiss, TaskInstance, errors
+from airflow.models import (
+    Connection, DagModel, DagRun, DagTag, Pool, RenderedTaskInstanceFields, SlaMiss, TaskInstance, errors,
+)
 from airflow.utils.db import add_default_pool_if_not_exists, create_default_connections
 from airflow.utils.session import create_session
 
@@ -58,3 +60,8 @@ def set_default_pool_slots(slots):
     with create_session() as session:
         default_pool = Pool.get_default_pool(session)
         default_pool.slots = slots
+
+
+def clear_rendered_ti_fields():
+    with create_session() as session:
+        session.query(RenderedTaskInstanceFields).delete()

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -45,6 +45,9 @@ from airflow.executors.celery_executor import CeleryExecutor
 from airflow.jobs.base_job import BaseJob
 from airflow.models import DAG, Connection, DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
+from airflow.models.serialized_dag import SerializedDagModel
+from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.settings import Session
 from airflow.ti_deps.dependencies import QUEUEABLE_STATES, RUNNABLE_STATES
@@ -1876,6 +1879,48 @@ class TestTaskInstanceView(TestBase):
         # in to FAB) but simply that our UTC conversion was run - i.e. it
         # doesn't blow up!
         self.check_content_in_response('List Task Instance', resp)
+
+
+class TestRenderedView(TestBase):
+
+    def setUp(self):
+        super().setUp()
+        self.default_date = datetime(2020, 3, 1)
+        self.dag = DAG("testdag", start_date=self.default_date)
+        self.task = BashOperator(
+            task_id='testtask',
+            bash_command='{{ task_instance_key_str }}',
+            dag=self.dag
+        )
+        SerializedDagModel.write_dag(self.dag)
+        with create_session() as session:
+            session.query(RTIF).delete()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        with create_session() as session:
+            session.query(RTIF).delete()
+
+    @mock.patch('airflow.www.views.STORE_SERIALIZED_DAGS', True)
+    @mock.patch('airflow.models.taskinstance.STORE_SERIALIZED_DAGS', True)
+    @mock.patch('airflow.www.views.dagbag.get_dag')
+    def test_rendered_view(self, get_dag_function):
+        """
+        Test that the Rendered View contains the values from RenderedTaskInstanceFields
+        """
+        get_dag_function.return_value = SerializedDagModel.get(self.dag.dag_id).dag
+
+        self.assertEqual(self.task.bash_command, '{{ task_instance_key_str }}')
+        ti = TaskInstance(self.task, self.default_date)
+
+        with create_session() as session:
+            session.add(RTIF(ti))
+
+        url = ('rendered?task_id=testtask&dag_id=testdag&execution_date={}'
+               .format(self.percent_encode(self.default_date)))
+
+        resp = self.client.get(url, follow_redirects=True)
+        self.check_content_in_response("testdag__testtask__20200301", resp)
 
 
 class TestTriggerDag(TestBase):


### PR DESCRIPTION

One of the limitations with the current implementation of DAG serialization is that Templated fields still need access to DAG Files.

Potential solution 1: Store rendered version in the DB somewhere.
Limitation: Tasks that are not yet run won't be able to render the templated fields (this is a useful debugging aid, especially for those without CLI access to run `airflow tasks render`) .

Potential solution 2: Store both rendered & unrendered version in the DB somewhere. This will allow getting past the Limitation in Solution (1). We should store only the current unrendered version and store the last X number of rendered versions. This will also have an advantage that old task would have the rendered version that was correct at that time (which is not possible currently).
Limitation/Issue: Maintaining two separate tables without much benefit

Potential solution 3: Store rendered version in TI table and unrendered version in a separate column in DAG serialization table. This means that each TI would have an associated rendered field without creating an extra table and duplicating dag_id, task_id & execution_date. Once we start storing different version of serialized DAGs we can have each DAG row have it's unrendered version.

---
Issue link: [AIRFLOW-5944](https://issues.apache.org/jira/browse/AIRFLOW-5944)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.