### PR TITLE
[AIRFLOW-1076] Add get method for template variable accessor

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1178,33 +1178,55 @@ class TaskInstance(Base, LoggingMixin):
 
         class VariableAccessor:
             """
-            Wrapper around Variable. This way you can get variables in templates by using
-            {var.value.your_variable_name}.
+            Wrapper around Variable. This way you can get variables in
+            templates by using ``{{ var.value.variable_name }}`` or
+            ``{{ var.value.get('variable_name', 'fallback') }}``.
             """
             def __init__(self):
                 self.var = None
 
-            def __getattr__(self, item):
+            def __getattr__(
+                self,
+                item: str,
+            ):
                 self.var = Variable.get(item)
                 return self.var
 
             def __repr__(self):
                 return str(self.var)
 
+            @staticmethod
+            def get(
+                item: str,
+                default_var: Any = Variable._Variable__NO_DEFAULT_SENTINEL,
+            ):
+                return Variable.get(item, default_var=default_var)
+
         class VariableJsonAccessor:
             """
-            Wrapper around deserialized Variables. This way you can get variables
-            in templates by using {var.json.your_variable_name}.
+            Wrapper around Variable. This way you can get variables in
+            templates by using ``{{ var.json.variable_name }}`` or
+            ``{{ var.json.get('variable_name', {'fall': 'back'}) }}``.
             """
             def __init__(self):
                 self.var = None
 
-            def __getattr__(self, item):
+            def __getattr__(
+                self,
+                item: str,
+            ):
                 self.var = Variable.get(item, deserialize_json=True)
                 return self.var
 
             def __repr__(self):
                 return str(self.var)
+
+            @staticmethod
+            def get(
+                item: str,
+                default_var: Any = Variable._Variable__NO_DEFAULT_SENTINEL,
+            ):
+                return Variable.get(item, default_var=default_var, deserialize_json=True)
 
         return {
             'conf': conf,

--- a/docs/macros-ref.rst
+++ b/docs/macros-ref.rst
@@ -88,7 +88,12 @@ attributes and methods.
 The ``var`` template variable allows you to access variables defined in Airflow's
 UI. You can access them as either plain-text or JSON. If you use JSON, you are
 also able to walk nested structures, such as dictionaries like:
-``{{ var.json.my_dict_var.key1 }}``
+``{{ var.json.my_dict_var.key1 }}``.
+
+It is also possible to fetch a variable by string if needed with
+``{{ var.value.get('my.var', 'fallback') }}`` or
+``{{ var.json.get('my.dict.var', {'key1': 'val1'}) }}``. Defaults can be
+supplied in case the variable does not exist.
 
 Macros
 ------

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -568,67 +568,6 @@ class TestCore(unittest.TestCase):
         t.execute = verify_templated_field
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
-    def test_template_with_variable(self):
-        """
-        Test the availability of variables in templates
-        """
-        val = {
-            'test_value': 'a test value'
-        }
-        Variable.set("a_variable", val['test_value'])
-
-        def verify_templated_field(context):
-            self.assertEqual(context['ti'].task.some_templated_field,
-                             val['test_value'])
-
-        t = OperatorSubclass(
-            task_id='test_complex_template',
-            some_templated_field='{{ var.value.a_variable }}',
-            dag=self.dag)
-        t.execute = verify_templated_field
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-    def test_template_with_json_variable(self):
-        """
-        Test the availability of variables (serialized as JSON) in templates
-        """
-        val = {
-            'test_value': {'foo': 'bar', 'obj': {'v1': 'yes', 'v2': 'no'}}
-        }
-        Variable.set("a_variable", val['test_value'], serialize_json=True)
-
-        def verify_templated_field(context):
-            self.assertEqual(context['ti'].task.some_templated_field,
-                             val['test_value']['obj']['v2'])
-
-        t = OperatorSubclass(
-            task_id='test_complex_template',
-            some_templated_field='{{ var.json.a_variable.obj.v2 }}',
-            dag=self.dag)
-        t.execute = verify_templated_field
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-    def test_template_with_json_variable_as_value(self):
-        """
-        Test the availability of variables (serialized as JSON) in templates, but
-        accessed as a value
-        """
-        val = {
-            'test_value': {'foo': 'bar'}
-        }
-        Variable.set("a_variable", val['test_value'], serialize_json=True)
-
-        def verify_templated_field(context):
-            self.assertEqual(context['ti'].task.some_templated_field,
-                             '{\n  "foo": "bar"\n}')
-
-        t = OperatorSubclass(
-            task_id='test_complex_template',
-            some_templated_field='{{ var.value.a_variable }}',
-            dag=self.dag)
-        t.execute = verify_templated_field
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
     def test_template_non_bool(self):
         """
         Test templates can handle objects with no sense of truthiness


### PR DESCRIPTION
Support getting variables in templates by string. This is necessary when
fetching variables with characters not allowed in a class attribute
name. We can then also support returning default values when a variable does
not exist.

Original PR went stale, https://github.com/apache/airflow/pull/2223.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1076

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - See above.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Added unit tests for calling `var.value.get()` and `var.json.get()`, with or without default

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
