### PR TITLE
Adjust the MASTER_URL of spark-submit in SparkSubmitHook

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -185,6 +185,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 conn_data['master'] = "{}:{}".format(conn.host, conn.port)
             else:
                 conn_data['master'] = conn.host
+            if conn.uri_without_query:
+                conn_data['master'] = conn.uri_without_query
 
             # Determine optional yarn queue from the extra field
             extra = conn.extra_dejson

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -115,6 +115,7 @@ class Connection(Base, LoggingMixin):
             schema=None, port=None, extra=None,
             uri=None):
         self.conn_id = conn_id
+        self.uri_without_query = None
         if uri:
             self.parse_from_uri(uri)
         else:
@@ -144,6 +145,10 @@ class Connection(Base, LoggingMixin):
         self.port = uri_parts.port
         if uri_parts.query:
             self.extra = json.dumps(dict(parse_qsl(uri_parts.query, keep_blank_values=True)))
+        if conn_type:
+            self.uri_without_query = uri_parts.scheme + "://" + uri_parts.netloc + uri_parts.path
+        else:
+            self.uri_without_query = uri_parts.netloc + uri_parts.path
 
     def get_password(self):
         if self._password and self.is_encrypted:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6212
  - https://issues.apache.org/jira/browse/AIRFLOW-6214

### Description

- As the Jira issue described, if users set the connection URL by system environemnt, for example: `AIRFLOW_CONN_SPARK_DEFAULT=spark://localhost:7077`,   conn_data['master'] does not contain `'spark://'` this scheme prefix.

Due to the source code, 
```
           if conn.port:
                conn_data['master'] = "{}:{}".format(conn.host, conn.port)
            else:
                conn_data['master'] = conn.host
```
if there is `uri` instance variable in `Connection` (the value of AIRFLOW_CONN_SPARK_DEFAULT will be passing as uri),  "spark://" will be not in `conn.host`. This is related to this snippet in `Connection` class, as the output of `parse_netloc_to_hostname` return only hostname without scheme(`"spark://"`):
```   
   def parse_from_uri(self, uri):
        uri_parts = urlparse(uri)
        conn_type = uri_parts.scheme
        if conn_type == 'postgresql':
            conn_type = 'postgres'
        elif '-' in conn_type:
            conn_type = conn_type.replace('-', '_')
        self.conn_type = conn_type
        self.host = parse_netloc_to_hostname(uri_parts)
        quoted_schema = uri_parts.path[1:]
        self.schema = unquote(quoted_schema) if quoted_schema else quoted_schema
```


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
not need test.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
