### PR TITLE
[AIRFLOW-6234] KubernetesPodOperator secret volume - allow defaultMode override

### DIFF
--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -143,7 +143,8 @@ class KubernetesRequestFactory:
             req['spec']['volumes'].append({
                 'name': vol_id,
                 'secret': {
-                    'secretName': vol.secret
+                    'secretName': vol.secret,
+                    'defaultMode': vol.volume_mode
                 }
             })
 

--- a/airflow/contrib/kubernetes/secret.py
+++ b/airflow/contrib/kubernetes/secret.py
@@ -20,7 +20,7 @@ from airflow.exceptions import AirflowConfigException
 class Secret(object):
     """Defines Kubernetes Secret Volume"""
 
-    def __init__(self, deploy_type, deploy_target, secret, key=None):
+    def __init__(self, deploy_type, deploy_target, secret, key=None, volume_mode=None):
         """Initialize a Kubernetes Secret Object. Used to track requested secrets from
         the user.
         :param deploy_type: The type of secret deploy in Kubernetes, either `env` or
@@ -34,6 +34,9 @@ class Secret(object):
         :type secret: str
         :param key: (Optional) Key of the secret within the Kubernetes Secret
             if not provided in `deploy_type` `env` it will mount all secrets in object
+        :param volume_mode (Optional) defaultMode for volume in case where
+            secret is mounted as a volume. Eg: 256 to set defaultMode of 0400 (octal)
+            for SSH key.
         :type key: str or None
         """
         self.deploy_type = deploy_type
@@ -50,19 +53,22 @@ class Secret(object):
 
         self.secret = secret
         self.key = key
+        self.volume_mode = volume_mode
 
     def __eq__(self, other):
         return (
             self.deploy_type == other.deploy_type and
             self.deploy_target == other.deploy_target and
             self.secret == other.secret and
-            self.key == other.key
+            self.key == other.key and
+            self.volume_mode == other.volume_mode
         )
 
     def __repr__(self):
-        return 'Secret({}, {}, {}, {})'.format(
+        return 'Secret({}, {}, {}, {}, {})'.format(
             self.deploy_type,
             self.deploy_target,
             self.secret,
-            self.key
+            self.key,
+            self.volume_mode
         )

--- a/tests/contrib/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py
+++ b/tests/contrib/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py
@@ -154,7 +154,8 @@ class TestKubernetesRequestFactory(unittest.TestCase):
         secrets = [
             Secret('volume', 'KEY1', 's1', 'key-1'),
             Secret('env', 'KEY2', 's2'),
-            Secret('volume', 'KEY3', 's3', 'key-2')
+            Secret('volume', 'KEY3', 's3', 'key-2'),
+            Secret('volume', 'KEY4', 's4', volume_mode=256)
         ]
         pod = Pod('v3.14', {}, [], secrets=secrets)
         self.expected['spec']['containers'][0]['volumeMounts'] = [{
@@ -164,6 +165,10 @@ class TestKubernetesRequestFactory(unittest.TestCase):
         }, {
             'mountPath': 'KEY3',
             'name': 'secretvol1',
+            'readOnly': True
+        }, {
+            'mountPath': 'KEY4',
+            'name': 'secretVol2',
             'readOnly': True
         }]
         self.expected['spec']['volumes'] = [{
@@ -175,6 +180,12 @@ class TestKubernetesRequestFactory(unittest.TestCase):
             'name': 'secretvol1',
             'secret': {
                 'secretName': 's3'
+            }
+        }, {
+            'name': 'secretVol2',
+            'secret': {
+                'secretName': 's4',
+                'defaultMode': 256
             }
         }]
         KubernetesRequestFactory.extract_volume_secrets(pod, self.input_req)


### PR DESCRIPTION

### Description

- This PR adds optional parameter to Kubernetes secret to allow override of defaultMode on mounted volume. This is necessary for certain types of secrets, eg: SSH keys to have correct filesystem permissions.

### Tests

- tests/contrib/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py  / test_extract_volume_secrets



