### PR TITLE
[AIRFLOW-6238] Filter dags returned by dag_stats

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -328,7 +328,7 @@
         }
         d3.selectAll(".loading-last-run").remove();
       });
-      d3.json("{{ url_for('Airflow.dag_stats') }}", function(error, json) {
+      d3.json("{{ url_for('Airflow.dag_stats') }}?dag_ids=" + (encoded_dag_ids.join(',')), function(error, json) {
         for(var dag_id in json) {
             states = json[dag_id];
             g = d3.select('svg#dag-run-' + dag_id.replace(/\./g, '__dot__'))

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1395,6 +1395,22 @@ class TestDagACLView(TestBase):
         self.check_content_in_response('example_subdag_operator', resp)
         self.check_content_in_response('example_bash_operator', resp)
 
+    def test_dag_stats_success_when_selecting_dags(self):
+        resp = self.client.get('dag_stats?dag_ids=example_subdag_operator', follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        stats = json.loads(resp.data.decode('utf-8'))
+        self.assertNotIn('example_bash_operator', stats)
+        self.assertIn('example_subdag_operator', stats)
+
+        # Multiple
+        resp = self.client.get('dag_stats?dag_ids=example_subdag_operator,example_bash_operator',
+                               follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        stats = json.loads(resp.data.decode('utf-8'))
+        self.assertIn('example_bash_operator', stats)
+        self.assertIn('example_subdag_operator', stats)
+        self.check_content_not_in_response('example_xcom', resp)
+
     def test_task_stats_success(self):
         self.logout()
         self.login()


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-6238

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The dag_stats endpoint returns all dags by default. This can result in an extremely large payload ~ 3mb and slow response time when you have a lot of dags (In our case 1500+).

The accompanying pull request adds a dag_ids get parameter to the dag_stats end point which is populated by the dags present on the page.

Please see related and merged issue for task_stats: https://issues.apache.org/jira/browse/AIRFLOW-6095

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

 NA.