### PR TITLE
[AIRFLOW-6239] Filter dags return by last_dagruns

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -313,7 +313,7 @@
           }
         });
       });
-      d3.json("{{ url_for('Airflow.last_dagruns') }}", function(error, json) {
+      d3.json("{{ url_for('Airflow.last_dagruns') }}?dag_ids=" + (encoded_dag_ids.join(',')), function(error, json) {
         for(var safe_dag_id in json) {
           dag_id = json[safe_dag_id].dag_id;
           last_run = json[safe_dag_id].last_run;

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -426,18 +426,29 @@ class Airflow(AirflowBaseView):
     def last_dagruns(self, session=None):
         DagRun = models.DagRun
 
-        filter_dag_ids = appbuilder.sm.get_accessible_dag_ids()
+        allowed_dag_ids = appbuilder.sm.get_accessible_dag_ids()
+
+        if 'all_dags' in allowed_dag_ids:
+            allowed_dag_ids = [dag_id for dag_id, in session.query(models.DagModel.dag_id)]
+
+        selected_dag_ids = {
+            unquote(dag_id) for dag_id in request.args.get('dag_ids', '').split(',') if dag_id
+        }
+
+        if selected_dag_ids:
+            filter_dag_ids = selected_dag_ids.intersection(allowed_dag_ids)
+        else:
+            filter_dag_ids = allowed_dag_ids
 
         if not filter_dag_ids:
-            return
+            return wwwutils.json_response({})
 
         query = session.query(
             DagRun.dag_id, sqla.func.max(DagRun.execution_date).label('last_run')
         ).group_by(DagRun.dag_id)
 
-        if 'all_dags' not in filter_dag_ids:
-            # Filter to only ask for accesible dags
-            query = query.filter(DagRun.dag_id.in_(filter_dag_ids.keys()))
+        # Filter to only ask for accessible and selected dags
+        query = query.filter(DagRun.dag_id.in_(filter_dag_ids))
 
         resp = {
             r.dag_id.replace('.', '__dot__'): {

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -496,6 +496,22 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.get('last_dagruns', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
 
+    def test_last_dagruns_success_when_selecting_dags(self):
+        resp = self.client.get('last_dagruns?dag_ids=example_subdag_operator', follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        stats = json.loads(resp.data.decode('utf-8'))
+        self.assertNotIn('example_bash_operator', stats)
+        self.assertIn('example_subdag_operator', stats)
+
+        # Multiple
+        resp = self.client.get('last_dagruns?dag_ids=example_subdag_operator,example_bash_operator',
+                               follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        stats = json.loads(resp.data.decode('utf-8'))
+        self.assertIn('example_bash_operator', stats)
+        self.assertIn('example_subdag_operator', stats)
+        self.check_content_not_in_response('example_xcom', resp)
+
     def test_tree(self):
         url = 'tree?dag_id=example_bash_operator'
         resp = self.client.get(url, follow_redirects=True)


### PR DESCRIPTION
Add dag_ids get parameter to last_dagruns endpoint so can filter by the
set of dag_ids present on the dags view. This is intended to speed up
the response time on systems running a large number of dags.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-6239
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The last_dagruns endpoint returns all dags by default. This can result in an extremely slow response time when you have a lot of dags (In our case 1500+ takes 8 seconds).

The accompanying pull request adds a dag_ids get parameter to the last_dagruns end point which is populated by the dags present on the page.

Please see related and merged issue for task_stats: https://issues.apache.org/jira/browse/AIRFLOW-6095
### Tests

- [x] My PR adds the following unit tests

(see test_views)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

NA