### PR TITLE
[AIRFLOW-5463] Use same session to delete and add variable in set

### DIFF
--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -132,7 +132,7 @@ class Variable(Base, LoggingMixin):
         else:
             stored_value = str(value)
 
-        Variable.delete(key)
+        Variable.delete(key, session=session)
         session.add(Variable(key=key, val=stored_value))  # type: ignore
         session.flush()
 


### PR DESCRIPTION
Why:
* In our system we had a postgres connection error during Variable.set
resulting in the variable being deleted. The intention of this change is
that an error should leave the variable unchanged.

https://issues.apache.org/jira/browse/AIRFLOW-5463

### Tests

I was unable to see a good way to test this, is there a way to make delete succeed and add error? You could consider it a refactoring since the variable tests continue to pass.
