### PR TITLE
[AIRFLOW-6247] Fix sort order in Alembic Migration template

### DIFF
--- a/airflow/alembic.ini
+++ b/airflow/alembic.ini
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -83,3 +83,9 @@ formatter = generic
 [formatter_generic]
 format = %(levelname)-5.5s [%(name)s] %(message)s
 datefmt = %H:%M:%S
+
+[post_write_hooks]
+hooks=isort
+
+isort.type=console_scripts
+isort.entrypoint=isort

--- a/airflow/migrations/script.py.mako
+++ b/airflow/migrations/script.py.mako
@@ -24,8 +24,8 @@ Create Date: ${create_date}
 
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.

--- a/setup.py
+++ b/setup.py
@@ -441,7 +441,7 @@ def do_setup():
         # DEPENDENCIES_EPOCH_NUMBER in the Dockerfile
         #####################################################################################################
         install_requires=[
-            'alembic>=1.0, <2.0',
+            'alembic>=1.2, <2.0',
             'argcomplete~=1.10',
             'attrs~=19.3',
             'cached_property~=1.5',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-6247

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The current template (`script.py.mako`) for the migration script would fail the isort check. This PR fixes it.



### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Current static check (isort) checks the generated file.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
