### PR TITLE
[AIRFLOW-6245] Add custom waiters for AWS batch jobs

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -253,10 +253,30 @@ Migrated are:
 | airflow.contrib.hooks.aws_sns_hook.AwsSnsHook                   | airflow.providers.amazon.aws.hooks.sns.AwsSnsHook        |
 | airflow.contrib.operators.aws_athena_operator.AWSAthenaOperator | airflow.providers.amazon.aws.operators.athena.AWSAthenaOperator |
 | airflow.contrib.operators.awsbatch.AWSBatchOperator | airflow.providers.amazon.aws.operators.batch.AwsBatchOperator |
+| airflow.contrib.operators.awsbatch.BatchProtocol | airflow.providers.amazon.aws.hooks.batch_client.AwsBatchProtocol |
+| private attrs and methods on AWSBatchOperator | airflow.providers.amazon.aws.hooks.batch_client.AwsBatchClient |
+| n/a | airflow.providers.amazon.aws.hooks.batch_waiters.AwsBatchWaiters |
 | airflow.contrib.operators.aws_sqs_publish_operator.SQSPublishOperator | airflow.providers.amazon.aws.operators.sqs.SQSPublishOperator |
 | airflow.contrib.operators.aws_sns_publish_operator.SnsPublishOperator | airflow.providers.amazon.aws.operators.sns.SnsPublishOperator |
 | airflow.contrib.sensors.aws_athena_sensor.AthenaSensor       | airflow.providers.amazon.aws.sensors.athena.AthenaSensor        |
 | airflow.contrib.sensors.aws_sqs_sensor.SQSSensor             | airflow.providers.amazon.aws.sensors.sqs.SQSSensor        |
+
+### AWS Batch Operator
+
+The `AwsBatchOperator` was refactored to extract an `AwsBatchClient` (and inherit from it).  The
+changes are mostly backwards compatible and clarify the public API for these classes; some
+private methods on `AwsBatchOperator` for polling a job status were relocated and renamed
+to surface new public methods on `AwsBatchClient` (and via inheritance on `AwsBatchOperator`).  A
+couple of job attributes are renamed on an instance of `AwsBatchOperator`; these were mostly
+used like private attributes but they were surfaced in the public API, so any use of them needs
+to be updated as follows:
+- `AwsBatchOperator().jobId` -> `AwsBatchOperator().job_id`
+- `AwsBatchOperator().jobName` -> `AwsBatchOperator().job_name`
+
+The `AwsBatchOperator` gets a new option to define a custom model for waiting on job status changes.
+The `AwsBatchOperator` can use a new `waiters` parameter, an instance of `AwsBatchWaiters`, to
+specify that custom job waiters will be used to monitor a batch job.  See the latest API
+documentation for details.
 
 ### Additional arguments passed to BaseOperator cause an exception
 

--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -18,14 +18,25 @@
 # under the License.
 #
 
-"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.batch`."""
+"""This module is deprecated. Please use:
+
+  - `airflow.providers.amazon.aws.operators.batch`
+  - `airflow.providers.amazon.aws.hooks.batch_client`
+  - `airflow.providers.amazon.aws.hooks.batch_waiters`
+"""
 
 import warnings
 
+from typing_extensions import Protocol, runtime_checkable
+
+from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchProtocol
 from airflow.providers.amazon.aws.operators.batch import AwsBatchOperator
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.batch`.",
+    "This module is deprecated. "
+    "Please use `airflow.providers.amazon.aws.operators.batch`, "
+    "`airflow.providers.amazon.aws.hooks.batch_client`, and "
+    "`airflow.providers.amazon.aws.hooks.batch_waiters`",
     DeprecationWarning,
     stacklevel=2,
 )
@@ -44,3 +55,20 @@ class AWSBatchOperator(AwsBatchOperator):
             stacklevel=2,
         )
         super().__init__(*args, **kwargs)
+
+
+@runtime_checkable
+class BatchProtocol(AwsBatchProtocol, Protocol):
+    """
+    This class is deprecated. Please use `airflow.providers.amazon.aws.hooks.batch_client.AwsBatchProtocol`.
+    """
+
+    # A Protocol cannot be instantiated
+
+    def __new__(cls, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.providers.amazon.aws.hooks.batch_client.AwsBatchProtocol`.""",
+            DeprecationWarning,
+            stacklevel=2,
+        )

--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -1,0 +1,565 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+A client for AWS batch services
+
+.. seealso::
+
+    - http://boto3.readthedocs.io/en/latest/guide/configuration.html
+    - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
+    - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
+"""
+
+from random import uniform
+from time import sleep
+from typing import Dict, List, Optional, Union
+
+import botocore.client
+import botocore.exceptions
+import botocore.waiter
+from typing_extensions import Protocol, runtime_checkable
+
+from airflow import AirflowException, LoggingMixin
+from airflow.contrib.hooks.aws_hook import AwsHook
+
+# Add exceptions to pylint for the boto3 protocol only; ideally the boto3 library could provide
+# protocols for all their dynamically generated classes (try to migrate this to a PR on botocore).
+# Note that the use of invalid-name parameters should be restricted to the boto3 mappings only;
+# all the Airflow wrappers of boto3 clients should not adopt invalid-names to match boto3.
+# pylint: disable=invalid-name, unused-argument
+
+
+@runtime_checkable
+class AwsBatchProtocol(Protocol):
+    """
+    A structured Protocol for ``boto3.client('batch') -> botocore.client.Batch``.
+    This is used for type hints on :py:meth:`.AwsBatchClient.client`; it covers
+    only the subset of client methods required.
+
+    .. seealso::
+
+        - https://mypy.readthedocs.io/en/latest/protocols.html
+        - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
+    """
+
+    def describe_jobs(self, jobs: List[str]) -> Dict:
+        """
+        Get job descriptions from AWS batch
+
+        :param jobs: a list of JobId to describe
+        :type jobs: List[str]
+
+        :return: an API response to describe jobs
+        :rtype: Dict
+        """
+        ...
+
+    def get_waiter(self, waiterName: str) -> botocore.waiter.Waiter:
+        """
+        Get an AWS Batch service waiter
+
+        :param waiterName: The name of the waiter.  The name should match
+            the name (including the casing) of the key name in the waiter
+            model file (typically this is CamelCasing).
+        :type waiterName: str
+
+        :return: a waiter object for the named AWS batch service
+        :rtype: botocore.waiter.Waiter
+
+        .. note::
+            AWS batch might not have any waiters (until botocore PR-1307 is released).
+
+            .. code-block:: python
+
+                import boto3
+                boto3.client('batch').waiter_names == []
+
+        .. seealso::
+
+            - https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html#waiters
+            - https://github.com/boto/botocore/pull/1307
+        """
+        ...
+
+    def submit_job(
+        self,
+        jobName: str,
+        jobQueue: str,
+        jobDefinition: str,
+        arrayProperties: Dict,
+        parameters: Dict,
+        containerOverrides: Dict,
+    ) -> Dict:
+        """
+        Submit a batch job
+
+        :param jobName: the name for the AWS batch job
+        :type jobName: str
+
+        :param jobQueue: the queue name on AWS Batch
+        :type jobQueue: str
+
+        :param jobDefinition: the job definition name on AWS Batch
+        :type jobDefinition: str
+
+        :param arrayProperties: the same parameter that boto3 will receive
+        :type arrayProperties: Dict
+
+        :param parameters: the same parameter that boto3 will receive
+        :type parameters: Dict
+
+        :param containerOverrides: the same parameter that boto3 will receive
+        :type containerOverrides: Dict
+
+        :return: an API response
+        :rtype: Dict
+        """
+        ...
+
+    def terminate_job(self, jobId: str, reason: str) -> Dict:
+        """
+        Terminate a batch job
+
+        :param jobId: a job ID to terminate
+        :type jobId: str
+
+        :param reason: a reason to terminate job ID
+        :type reason: str
+
+        :return: an API response
+        :rtype: Dict
+        """
+        ...
+
+
+# Note that the use of invalid-name parameters should be restricted to the boto3 mappings only;
+# all the Airflow wrappers of boto3 clients should not adopt invalid-names to match boto3.
+# pylint: enable=invalid-name, unused-argument
+
+
+class AwsBatchClient(LoggingMixin):
+    """
+    A client for AWS batch services.
+
+    :param max_retries: exponential back-off retries, 4200 = 48 hours;
+        polling is only used when waiters is None
+    :type max_retries: Optional[int]
+
+    :param status_retries: number of HTTP retries to get job status, 10;
+        polling is only used when waiters is None
+    :type status_retries: Optional[int]
+
+    :param aws_conn_id: connection id of AWS credentials / region name. If None,
+        credential boto3 strategy will be used
+        (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
+    :type aws_conn_id: Optional[str]
+
+    :param region_name: region name to use in AWS client.
+        Override the region_name in connection (if provided)
+    :type region_name: Optional[str]
+
+    .. note::
+        Several methods use a default random delay to check or poll for job status, i.e.
+        ``random.uniform(DEFAULT_DELAY_MIN, DEFAULT_DELAY_MAX)``
+        Using a random interval helps to avoid AWS API throttle limits
+        when many concurrent tasks request job-descriptions.
+
+        To modify the global defaults for the range of jitter allowed when a
+        random delay is used to check batch job status, modify these defaults, e.g.:
+        .. code-block::
+
+            AwsBatchClient.DEFAULT_DELAY_MIN = 0
+            AwsBatchClient.DEFAULT_DELAY_MAX = 5
+
+        When explict delay values are used, a 1 second random jitter is applied to the
+        delay (e.g. a delay of 0 sec will be a ``random.uniform(0, 1)`` delay.  It is
+        generally recommended that random jitter is added to API requests.  A
+        convenience method is provided for this, e.g. to get a random delay of
+        10 sec +/- 5 sec: ``delay = AwsBatchClient.add_jitter(10, width=5, minima=0)``
+
+    .. seealso::
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
+        - https://docs.aws.amazon.com/general/latest/gr/api-retries.html
+        - https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+    """
+
+    MAX_RETRIES = 4200
+    STATUS_RETRIES = 10
+
+    # delays are in seconds
+    DEFAULT_DELAY_MIN = 1
+    DEFAULT_DELAY_MAX = 10
+
+    def __init__(
+        self,
+        max_retries: Optional[int] = None,
+        status_retries: Optional[int] = None,
+        aws_conn_id: Optional[str] = None,
+        region_name: Optional[str] = None,
+    ):
+        super().__init__()
+        self.max_retries = max_retries or self.MAX_RETRIES
+        self.status_retries = status_retries or self.STATUS_RETRIES
+        self.aws_conn_id = aws_conn_id
+        self.region_name = region_name
+        self._hook = None  # type: Union[AwsHook, None]
+        self._client = None  # type: Union[AwsBatchProtocol, botocore.client.BaseClient, None]
+
+    @property
+    def hook(self) -> AwsHook:
+        """
+        An AWS API connection manager (wraps boto3)
+
+        :return: the connected hook to AWS
+        :rtype: AwsHook
+        """
+        if self._hook is None:
+            self._hook = AwsHook(aws_conn_id=self.aws_conn_id)
+        return self._hook
+
+    @property
+    def client(self) -> Union[AwsBatchProtocol, botocore.client.BaseClient]:
+        """
+        An AWS API client for batch services, like ``boto3.client('batch')``
+
+        :return: a boto3 'batch' client for the ``.region_name``
+        :rtype: Union[AwsBatchProtocol, botocore.client.BaseClient]
+        """
+        if self._client is None:
+            self._client = self.hook.get_client_type("batch", region_name=self.region_name)
+        return self._client
+
+    def terminate_job(self, job_id: str, reason: str) -> Dict:
+        """
+        Terminate a batch job
+
+        :param job_id: a job ID to terminate
+        :type job_id: str
+
+        :param reason: a reason to terminate job ID
+        :type reason: str
+
+        :return: an API response
+        :rtype: Dict
+        """
+        response = self.client.terminate_job(jobId=job_id, reason=reason)
+        self.log.info(response)
+        return response
+
+    def check_job_success(self, job_id: str) -> bool:
+        """
+        Check the final status of the batch job; return True if the job
+        'SUCCEEDED', else raise an AirflowException
+
+        :param job_id: a batch job ID
+        :type job_id: str
+
+        :rtype: bool
+
+        :raises: AirflowException
+        """
+        job = self.get_job_description(job_id)
+        job_status = job.get("status")
+
+        if job_status == "SUCCEEDED":
+            self.log.info("AWS batch job ({}) succeeded: {}".format(job_id, job))
+            return True
+
+        if job_status == "FAILED":
+            raise AirflowException("AWS Batch job ({}) failed: {}".format(job_id, job))
+
+        if job_status in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
+            raise AirflowException("AWS Batch job ({}) is not complete: {}".format(job_id, job))
+
+        raise AirflowException("AWS Batch job ({}) has unknown status: {}".format(job_id, job))
+
+    def wait_for_job(self, job_id: str, delay: Union[int, float, None] = None):
+        """
+        Wait for batch job to complete
+
+        :param job_id: a batch job ID
+        :type job_id: str
+
+        :param delay: a delay before polling for job status
+        :type delay: Optional[Union[int, float]]
+
+        :raises: AirflowException
+        """
+        self.delay(delay)
+        self.poll_for_job_running(job_id, delay)
+        self.poll_for_job_complete(job_id, delay)
+        self.log.info("AWS Batch job (%s) has completed", job_id)
+
+    def poll_for_job_running(self, job_id: str, delay: Union[int, float, None] = None):
+        """
+        Poll for job running. The status that indicates a job is running or
+        already complete are: 'RUNNING'|'SUCCEEDED'|'FAILED'.
+
+        So the status options that this will wait for are the transitions from:
+        'SUBMITTED'>'PENDING'>'RUNNABLE'>'STARTING'>'RUNNING'|'SUCCEEDED'|'FAILED'
+
+        The completed status options are included for cases where the status
+        changes too quickly for polling to detect a RUNNING status that moves
+        quickly from STARTING to RUNNING to completed (often a failure).
+
+        :param job_id: a batch job ID
+        :type job_id: str
+
+        :param delay: a delay before polling for job status
+        :type delay: Optional[Union[int, float]]
+
+        :raises: AirflowException
+        """
+        self.delay(delay)
+        running_status = ["RUNNING", "SUCCEEDED", "FAILED"]
+        self.poll_job_status(job_id, running_status)
+
+    def poll_for_job_complete(self, job_id: str, delay: Union[int, float, None] = None):
+        """
+        Poll for job completion. The status that indicates job completion
+        are: 'SUCCEEDED'|'FAILED'.
+
+        So the status options that this will wait for are the transitions from:
+        'SUBMITTED'>'PENDING'>'RUNNABLE'>'STARTING'>'RUNNING'>'SUCCEEDED'|'FAILED'
+
+        :param job_id: a batch job ID
+        :type job_id: str
+
+        :param delay: a delay before polling for job status
+        :type delay: Optional[Union[int, float]]
+
+        :raises: AirflowException
+        """
+        self.delay(delay)
+        complete_status = ["SUCCEEDED", "FAILED"]
+        self.poll_job_status(job_id, complete_status)
+
+    def poll_job_status(self, job_id: str, match_status: List[str]) -> bool:
+        """
+        Poll for job status using an exponential back-off strategy (with max_retries).
+
+        :param job_id: a batch job ID
+        :type job_id: str
+
+        :param match_status: a list of job status to match; the batch job status are:
+            'SUBMITTED'|'PENDING'|'RUNNABLE'|'STARTING'|'RUNNING'|'SUCCEEDED'|'FAILED'
+        :type match_status: List[str]
+
+        :rtype: bool
+
+        :raises: AirflowException
+        """
+        retries = 0
+        while True:
+
+            job = self.get_job_description(job_id)
+            job_status = job.get("status")
+            self.log.info(
+                "AWS Batch job (%s) check status (%s) in %s", job_id, job_status, match_status,
+            )
+
+            if job_status in match_status:
+                return True
+
+            if retries >= self.max_retries:
+                raise AirflowException(
+                    "AWS Batch job ({}) status checks exceed max_retries".format(job_id)
+                )
+
+            retries += 1
+            pause = self.exponential_delay(retries)
+            self.log.info(
+                "AWS Batch job (%s) status check (%d of %d) in the next %.2f seconds",
+                job_id,
+                retries,
+                self.max_retries,
+                pause,
+            )
+            self.delay(pause)
+
+    def get_job_description(self, job_id: str) -> Dict:
+        """
+        Get job description (using status_retries).
+
+        :param job_id: a batch job ID
+        :type job_id: str
+
+        :return: an API response for describe jobs
+        :rtype: Dict
+
+        :raises: AirflowException
+        """
+        retries = 0
+        while True:
+            try:
+                response = self.client.describe_jobs(jobs=[job_id])
+                return self.parse_job_description(job_id, response)
+
+            except botocore.exceptions.ClientError as err:
+                error = err.response.get("Error", {})
+                if error.get("Code") == "TooManyRequestsException":
+                    pass  # allow it to retry, if possible
+                else:
+                    raise AirflowException(
+                        "AWS Batch job ({}) description error: {}".format(job_id, err)
+                    )
+
+            retries += 1
+            if retries >= self.status_retries:
+                raise AirflowException(
+                    "AWS Batch job ({}) description error: exceeded "
+                    "status_retries ({})".format(job_id, self.status_retries)
+                )
+
+            pause = self.exponential_delay(retries)
+            self.log.info(
+                "AWS Batch job (%s) description retry (%d of %d) in the next %.2f seconds",
+                job_id,
+                retries,
+                self.status_retries,
+                pause,
+            )
+            self.delay(pause)
+
+    @staticmethod
+    def parse_job_description(job_id: str, response: Dict) -> Dict:
+        """
+        Parse job description to extract description for job_id
+
+        :param job_id: a batch job ID
+        :type job_id: str
+
+        :param response: an API response for describe jobs
+        :type response: Dict
+
+        :return: an API response to describe job_id
+        :rtype: Dict
+
+        :raises: AirflowException
+        """
+        jobs = response.get("jobs", [])
+        matching_jobs = [job for job in jobs if job.get("jobId") == job_id]
+        if len(matching_jobs) != 1:
+            raise AirflowException(
+                "AWS Batch job ({}) description error: response: {}".format(job_id, response)
+            )
+
+        return matching_jobs[0]
+
+    @staticmethod
+    def add_jitter(
+        delay: Union[int, float], width: Union[int, float] = 1, minima: Union[int, float] = 0
+    ) -> float:
+        """
+        Use delay +/- width for random jitter
+
+        Adding jitter to status polling can help to avoid
+        AWS batch API limits for monitoring batch jobs with
+        a high concurrency in Airflow tasks.
+
+        :param delay: number of seconds to pause;
+            delay is assumed to be a positive number
+        :type delay: Union[int, float]
+
+        :param width: delay +/- width for random jitter;
+            width is assumed to be a positive number
+        :type width: Union[int, float]
+
+        :param minima: minimum delay allowed;
+            minima is assumed to be a non-negative number
+        :type minima: Union[int, float]
+
+        :return: uniform(delay - width, delay + width) jitter
+            and it is a non-negative number
+        :rtype: float
+        """
+        delay = abs(delay)
+        width = abs(width)
+        minima = abs(minima)
+        lower = max(minima, delay - width)
+        upper = delay + width
+        return uniform(lower, upper)
+
+    @staticmethod
+    def delay(delay: Union[int, float, None] = None):
+        """
+        Pause execution for ``delay`` seconds.
+
+        :param delay: a delay to pause execution using ``time.sleep(delay)``;
+            a small 1 second jitter is applied to the delay.
+        :type delay: Optional[Union[int, float]]
+
+        .. note::
+            This method uses a default random delay, i.e.
+            ``random.uniform(DEFAULT_DELAY_MIN, DEFAULT_DELAY_MAX)``;
+            using a random interval helps to avoid AWS API throttle limits
+            when many concurrent tasks request job-descriptions.
+        """
+        if delay is None:
+            delay = uniform(AwsBatchClient.DEFAULT_DELAY_MIN, AwsBatchClient.DEFAULT_DELAY_MAX)
+        else:
+            delay = AwsBatchClient.add_jitter(delay)
+        sleep(delay)
+
+    @staticmethod
+    def exponential_delay(tries: int) -> float:
+        """
+        An exponential back-off delay, with random jitter.  There is a maximum
+        interval of 10 minutes (with random jitter between 3 and 10 minutes).
+        This is used in the :py:meth:`.poll_for_job_status` method.
+
+        :param tries: Number of tries
+        :type tries: int
+
+        :rtype: float
+
+        Examples of behavior:
+
+        .. code-block:: python
+
+            def exp(tries):
+                max_interval = 600.0  # 10 minutes in seconds
+                delay = 1 + pow(tries * 0.6, 2)
+                delay = min(max_interval, delay)
+                print(delay / 3, delay)
+
+            for tries in range(10):
+                exp(tries)
+
+            #  0.33  1.0
+            #  0.45  1.35
+            #  0.81  2.44
+            #  1.41  4.23
+            #  2.25  6.76
+            #  3.33 10.00
+            #  4.65 13.95
+            #  6.21 18.64
+            #  8.01 24.04
+            # 10.05 30.15
+
+        .. seealso::
+
+            - https://docs.aws.amazon.com/general/latest/gr/api-retries.html
+            - https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+        """
+        max_interval = 600.0  # results in 3 to 10 minute delay
+        delay = 1 + pow(tries * 0.6, 2)
+        delay = min(max_interval, delay)
+        return uniform(delay / 3, delay)

--- a/airflow/providers/amazon/aws/hooks/batch_waiters.json
+++ b/airflow/providers/amazon/aws/hooks/batch_waiters.json
@@ -1,0 +1,105 @@
+{
+  "version": 2,
+  "waiters": {
+    "JobExists": {
+      "delay": 2,
+      "operation": "DescribeJobs",
+      "maxAttempts": 100,
+      "acceptors": [
+        {
+          "argument": "jobs[].status",
+          "expected": "SUBMITTED",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "PENDING",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "RUNNABLE",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "STARTING",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "RUNNING",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "FAILED",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "SUCCEEDED",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "",
+          "matcher": "error",
+          "state": "failure"
+        }
+      ]
+    },
+    "JobRunning": {
+      "delay": 5,
+      "operation": "DescribeJobs",
+      "maxAttempts": 100,
+      "acceptors": [
+        {
+          "argument": "jobs[].status",
+          "expected": "RUNNING",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "FAILED",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "SUCCEEDED",
+          "matcher": "pathAll",
+          "state": "success"
+        }
+      ]
+    },
+    "JobComplete": {
+      "delay": 300,
+      "operation": "DescribeJobs",
+      "maxAttempts": 288,
+      "description": "Wait until job status is SUCCEEDED or FAILED",
+      "acceptors": [
+        {
+          "argument": "jobs[].status",
+          "expected": "SUCCEEDED",
+          "matcher": "pathAll",
+          "state": "success"
+        },
+        {
+          "argument": "jobs[].status",
+          "expected": "FAILED",
+          "matcher": "pathAny",
+          "state": "failure"
+        }
+      ]
+    }
+  }
+}

--- a/airflow/providers/amazon/aws/hooks/batch_waiters.py
+++ b/airflow/providers/amazon/aws/hooks/batch_waiters.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""
+AWS batch service waiters
+
+.. seealso::
+
+    - https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html#waiters
+    - https://github.com/boto/botocore/blob/develop/botocore/waiter.py
+"""
+
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import botocore.client
+import botocore.exceptions
+import botocore.waiter
+
+from airflow import AirflowException
+from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClient
+
+
+class AwsBatchWaiters(AwsBatchClient):
+    """
+    A utility to manage waiters for AWS batch services.
+
+    :param waiter_config:  a custom waiter configuration for AWS batch services
+    :type waiter_config: Optional[Dict]
+
+    :param aws_conn_id: connection id of AWS credentials / region name. If None,
+        credential boto3 strategy will be used
+        (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
+    :type aws_conn_id: Optional[str]
+
+    :param region_name: region name to use in AWS client.
+        Override the AWS region in connection (if provided)
+    :type region_name: Optional[str]
+
+    Examples:
+
+    .. code-block:: python
+
+        import random
+        from airflow.providers.amazon.aws.operators.batch_waiters import AwsBatchWaiters
+
+        # to inspect default waiters
+        waiters = AwsBatchWaiters()
+        config = waiters.default_config  # type: Dict
+        waiter_names = waiters.list_waiters()  # -> ["JobComplete", "JobExists", "JobRunning"]
+
+        # The default_config is a useful stepping stone to creating custom waiters, e.g.
+        custom_config = waiters.default_config  # this is a deepcopy
+        # modify custom_config['waiters'] as necessary and get a new instance:
+        waiters = AwsBatchWaiters(waiter_config=custom_config)
+        waiters.waiter_config  # check the custom configuration (this is a deepcopy)
+        waiters.list_waiters() # names of custom waiters
+
+        # During the init for AwsBatchWaiters, the waiter_config is used to build a waiter_model;
+        # and note that this only occurs during the class init, to avoid any accidental mutations
+        # of waiter_config leaking into the waiter_model.
+        waiters.waiter_model  # -> botocore.waiter.WaiterModel object
+
+        # The waiter_model is combined with the waiters.client to get a specific waiter
+        # and the details of the config on that waiter can be further modified without any
+        # accidental impact on the generation of new waiters from the defined waiter_model, e.g.
+        waiters.get_waiter("JobExists").config.delay  # -> 5
+        waiter = waiters.get_waiter("JobExists")  # -> botocore.waiter.Batch.Waiter.JobExists object
+        waiter.config.delay = 10
+        waiters.get_waiter("JobExists").config.delay  # -> 5 as defined by waiter_model
+
+        # To use a specific waiter, update the config and call the `wait()` method for jobId, e.g.
+        waiter = waiters.get_waiter("JobExists")  # -> botocore.waiter.Batch.Waiter.JobExists object
+        waiter.config.delay = random.uniform(1, 10)  # seconds
+        waiter.config.max_attempts = 10
+        waiter.wait(jobs=[jobId])
+
+    .. seealso::
+
+        - https://www.2ndwatch.com/blog/use-waiters-boto3-write/
+        - https://github.com/boto/botocore/blob/develop/botocore/waiter.py
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#waiters
+        - https://github.com/boto/botocore/tree/develop/botocore/data/ec2/2016-11-15
+        - https://github.com/boto/botocore/issues/1915
+    """
+
+    def __init__(
+        self,
+        waiter_config: Optional[Dict] = None,
+        aws_conn_id: Optional[str] = None,
+        region_name: Optional[str] = None,
+    ):
+
+        AwsBatchClient.__init__(self, aws_conn_id=aws_conn_id, region_name=region_name)
+
+        self._default_config = None  # type: Optional[Dict]
+        self._waiter_config = waiter_config or self.default_config
+        self._waiter_model = botocore.waiter.WaiterModel(self._waiter_config)
+
+    @property
+    def default_config(self) -> Dict:
+        """
+        An immutable default waiter configuration
+
+        :return: a waiter configuration for AWS batch services
+        :rtype: Dict
+        """
+        if self._default_config is None:
+            config_path = Path(__file__).with_name("batch_waiters.json").absolute()
+            with open(config_path) as config_file:
+                self._default_config = json.load(config_file)
+        return deepcopy(self._default_config)  # avoid accidental mutation
+
+    @property
+    def waiter_config(self) -> Dict:
+        """
+        An immutable waiter configuration for this instance; a ``deepcopy`` is returned by this
+        property. During the init for AwsBatchWaiters, the waiter_config is used to build a
+        waiter_model and this only occurs during the class init, to avoid any accidental
+        mutations of waiter_config leaking into the waiter_model.
+
+        :return: a waiter configuration for AWS batch services
+        :rtype: Dict
+        """
+        return deepcopy(self._waiter_config)  # avoid accidental mutation
+
+    @property
+    def waiter_model(self) -> botocore.waiter.WaiterModel:
+        """
+        A configured waiter model used to generate waiters on AWS batch services.
+
+        :return: a waiter model for AWS batch services
+        :rtype: botocore.waiter.WaiterModel
+        """
+        return self._waiter_model
+
+    def get_waiter(self, waiter_name: str) -> botocore.waiter.Waiter:
+        """
+        Get an AWS Batch service waiter, using the configured ``.waiter_model``.
+
+        The ``.waiter_model`` is combined with the ``.client`` to get a specific waiter and
+        the properties of that waiter can be modified without any accidental impact on the
+        generation of new waiters from the ``.waiter_model``, e.g.
+        .. code-block::
+
+            waiters.get_waiter("JobExists").config.delay  # -> 5
+            waiter = waiters.get_waiter("JobExists")  # a new waiter object
+            waiter.config.delay = 10
+            waiters.get_waiter("JobExists").config.delay  # -> 5 as defined by waiter_model
+
+        To use a specific waiter, update the config and call the `wait()` method for jobId, e.g.
+        .. code-block::
+
+            import random
+            waiter = waiters.get_waiter("JobExists")  # a new waiter object
+            waiter.config.delay = random.uniform(1, 10)  # seconds
+            waiter.config.max_attempts = 10
+            waiter.wait(jobs=[jobId])
+
+        :param waiter_name: The name of the waiter. The name should match
+            the name (including the casing) of the key name in the waiter
+            model file (typically this is CamelCasing); see ``.list_waiters``.
+        :type waiter_name: str
+
+        :return: a waiter object for the named AWS batch service
+        :rtype: botocore.waiter.Waiter
+        """
+        return botocore.waiter.create_waiter_with_client(
+            waiter_name, self.waiter_model, self.client
+        )
+
+    def list_waiters(self) -> List[str]:
+        """
+        List the waiters in a waiter configuration for AWS Batch services.
+
+        :return: waiter names for AWS batch services
+        :rtype: List[str]
+        """
+        return self.waiter_model.waiter_names
+
+    def wait_for_job(self, job_id: str, delay: Union[int, float, None] = None):
+        """
+        Wait for batch job to complete.  This assumes that the ``.waiter_model`` is configured
+        using some variation of the ``.default_config`` so that it can generate waiters with the
+        following names: "JobExists", "JobRunning" and "JobComplete".
+
+        :param job_id: a batch job ID
+        :type job_id: str
+
+        :param delay:  A delay before polling for job status
+        :type delay: Union[int, float, None]
+
+        :raises: AirflowException
+
+        .. note::
+            This method adds a small random jitter to the ``delay`` (+/- 2 sec, >= 1 sec).
+            Using a random interval helps to avoid AWS API throttle limits when many
+            concurrent tasks request job-descriptions.
+
+            It also modifies the ``max_attempts`` to use the ``sys.maxsize``,
+            which allows Airflow to manage the timeout on waiting.
+        """
+        self.delay(delay)
+        try:
+            waiter = self.get_waiter("JobExists")
+            waiter.config.delay = self.add_jitter(waiter.config.delay, width=2, minima=1)
+            waiter.config.max_attempts = sys.maxsize  # timeout is managed by Airflow
+            waiter.wait(jobs=[job_id])
+
+            waiter = self.get_waiter("JobRunning")
+            waiter.config.delay = self.add_jitter(waiter.config.delay, width=2, minima=1)
+            waiter.config.max_attempts = sys.maxsize  # timeout is managed by Airflow
+            waiter.wait(jobs=[job_id])
+
+            waiter = self.get_waiter("JobComplete")
+            waiter.config.delay = self.add_jitter(waiter.config.delay, width=2, minima=1)
+            waiter.config.max_attempts = sys.maxsize  # timeout is managed by Airflow
+            waiter.wait(jobs=[job_id])
+
+        except (botocore.exceptions.ClientError, botocore.exceptions.WaiterError) as err:
+            raise AirflowException(err)

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -19,115 +19,79 @@
 #
 
 """
-Airflow operator for AWS batch service
+An Airflow operator for AWS Batch services
 
-.. seealso:: http://boto3.readthedocs.io/en/latest/reference/services/batch.html
+.. seealso::
+
+    - http://boto3.readthedocs.io/en/latest/guide/configuration.html
+    - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
+    - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
 """
+from typing import Dict, Optional
 
-import sys
-from random import randint
-from time import sleep
-from typing import Optional
-
-import botocore.exceptions
-import botocore.waiter
-
-from airflow.contrib.hooks.aws_hook import AwsHook
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
-from airflow.typing_compat import Protocol
+from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClient
 from airflow.utils.decorators import apply_defaults
 
-# pylint: disable=invalid-name, unused-argument
 
-
-class BatchProtocol(Protocol):
+class AwsBatchOperator(BaseOperator, AwsBatchClient):
     """
-    .. seealso:: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
-    """
-
-    def describe_jobs(self, jobs) -> dict:
-        """Get job descriptions from AWS batch"""
-        ...
-
-    def get_waiter(self, x: str) -> botocore.waiter.Waiter:
-        """Get an AWS service waiter
-
-        Note that AWS batch might not have any waiters (until botocore PR1307 is merged and released).
-
-        .. code-block:: python
-
-            import boto3
-            boto3.client('batch').waiter_names == []
-
-        .. seealso:: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html#waiters
-        .. seealso:: https://github.com/boto/botocore/pull/1307
-        """
-        ...
-
-    def submit_job(
-        self, jobName, jobQueue, jobDefinition, arrayProperties, parameters, containerOverrides
-    ) -> dict:
-        """Submit a batch job
-        :type jobName: str
-        :type jobQueue: str
-        :type jobDefinition: str
-        :type arrayProperties: dict
-        :type parameters: dict
-        :type containerOverrides: dict
-        """
-        ...
-
-    def terminate_job(self, jobId: str, reason: str) -> dict:
-        """Terminate a batch job"""
-        ...
-
-
-class AwsBatchOperator(BaseOperator):
-    """
-    Execute a job on AWS Batch Service
-
-    .. warning: the queue parameter was renamed to job_queue to segregate the
-                internal CeleryExecutor queue from the AWS Batch internal queue.
+    Execute a job on AWS Batch
 
     :param job_name: the name for the job that will run on AWS Batch (templated)
     :type job_name: str
+
     :param job_definition: the job definition name on AWS Batch
     :type job_definition: str
+
     :param job_queue: the queue name on AWS Batch
     :type job_queue: str
-    :param overrides: the same parameter that boto3 will receive on
-        containerOverrides (templated)
-        http://boto3.readthedocs.io/en/latest/reference/services/batch.html#Batch.Client.submit_job
-    :type overrides: dict
-    :param array_properties: the same parameter that boto3 will receive on
-        arrayProperties
-        http://boto3.readthedocs.io/en/latest/reference/services/batch.html#Batch.Client.submit_job
-    :type array_properties: dict
-    :param parameters: the same parameter that boto3 will receive on
-        parameters (templated)
-        http://boto3.readthedocs.io/en/latest/reference/services/batch.html#Batch.Client.submit_job
-    :type parameters: dict
-    :param max_retries: exponential backoff retries while waiter is not
-        merged, 4200 = 48 hours
+
+    :param overrides: the `containerOverrides` parameter for boto3 (templated)
+    :type overrides: Dict
+
+    :param array_properties: the `arrayProperties` parameter for boto3
+    :type array_properties: Dict
+
+    :param parameters: the `parameters` for boto3 (templated)
+    :type parameters: Dict
+
+    :param job_id: the job ID, usually unknown (None) until the
+        submit_job operation gets the jobId defined by AWS Batch
+    :type job_id: Optional[str]
+
+    :param waiters: an :py:class:`.AwsBatchWaiters` object (see note below);
+        if None, polling is used with max_retries and status_retries.
+    :type waiters: Optional[AwsBatchWaiters]
+
+    :param max_retries: exponential back-off retries, 4200 = 48 hours;
+        polling is only used when waiters is None
     :type max_retries: int
-    :param status_retries: number of retries to get job description (status), 10
+
+    :param status_retries: number of HTTP retries to get job status, 10;
+        polling is only used when waiters is None
     :type status_retries: int
+
     :param aws_conn_id: connection id of AWS credentials / region name. If None,
-        credential boto3 strategy will be used
-        (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
+        credential boto3 strategy will be used.
     :type aws_conn_id: str
+
     :param region_name: region name to use in AWS Hook.
         Override the region_name in connection (if provided)
     :type region_name: str
+
+    .. note::
+        Any custom waiters must return a waiter for these calls:
+        .. code-block:: python
+
+            waiter = waiters.get_waiter("JobExists")
+            waiter = waiters.get_waiter("JobRunning")
+            waiter = waiters.get_waiter("JobComplete")
     """
 
-    MAX_RETRIES = 4200
-    STATUS_RETRIES = 10
-
     ui_color = "#c3dae0"
-    client = None  # type: BatchProtocol
-    arn = None  # type: str
+    arn = None  # type: Optional[str]
     template_fields = (
         "job_name",
         "overrides",
@@ -143,39 +107,60 @@ class AwsBatchOperator(BaseOperator):
         overrides,
         array_properties=None,
         parameters=None,
+        job_id=None,
+        waiters=None,
         max_retries=None,
         status_retries=None,
         aws_conn_id=None,
         region_name=None,
         **kwargs,
     ):  # pylint: disable=too-many-arguments
-        super().__init__(**kwargs)
 
+        BaseOperator.__init__(self, **kwargs)
+        AwsBatchClient.__init__(
+            self,
+            max_retries=max_retries,
+            status_retries=status_retries,
+            aws_conn_id=aws_conn_id,
+            region_name=region_name,
+        )
+
+        self.job_id = job_id
         self.job_name = job_name
-        self.aws_conn_id = aws_conn_id
-        self.region_name = region_name
         self.job_definition = job_definition
         self.job_queue = job_queue
         self.overrides = overrides
         self.array_properties = array_properties or {}
         self.parameters = parameters
-        self.max_retries = max_retries or self.MAX_RETRIES
-        self.status_retries = status_retries or self.STATUS_RETRIES
+        self.waiters = waiters
 
-        self.jobId = None  # pylint: disable=invalid-name
-        self.jobName = None  # pylint: disable=invalid-name
+    def execute(self, context: Dict):
+        """
+        Submit and monitor an AWS Batch job
 
-        self.hook = self.get_hook()
+        :raises: AirflowException
+        """
+        self.submit_job(context)
+        self.monitor_job(context)
 
-    def execute(self, context):
+    def on_kill(self):
+        response = self.client.terminate_job(
+            jobId=self.job_id, reason="Task killed by the user"
+        )
+        self.log.info("AWS Batch job (%s) terminated: %s", self.job_id, response)
+
+    def submit_job(self, context: Dict):  # pylint: disable=unused-argument
+        """
+        Submit an AWS Batch job
+
+        :raises: AirflowException
+        """
         self.log.info(
-            "Running AWS Batch Job - job definition: %s - on queue %s",
+            "Running AWS Batch job - job definition: %s - on queue %s",
             self.job_definition,
             self.job_queue,
         )
-        self.log.info("AWS Batch Job - container overrides: %s", self.overrides)
-
-        self.client = self.hook.get_client_type("batch", region_name=self.region_name)
+        self.log.info("AWS Batch job - container overrides: %s", self.overrides)
 
         try:
             response = self.client.submit_job(
@@ -186,137 +171,29 @@ class AwsBatchOperator(BaseOperator):
                 parameters=self.parameters,
                 containerOverrides=self.overrides,
             )
+            self.job_id = response["jobId"]
 
-            self.log.info("AWS Batch Job started: %s", response)
-
-            self.jobId = response["jobId"]
-            self.jobName = response["jobName"]
-
-            self._wait_for_task_ended()
-            self._check_success_task()
-
-            self.log.info("AWS Batch Job has been successfully executed: %s", response)
+            self.log.info("AWS Batch job (%s) started: %s", self.job_id, response)
 
         except Exception as e:
-            self.log.info("AWS Batch Job has failed")
+            self.log.info("AWS Batch job (%s) failed submission", self.job_id)
             raise AirflowException(e)
 
-    def _wait_for_task_ended(self):
+    def monitor_job(self, context: Dict):  # pylint: disable=unused-argument
         """
-        Try to use a waiter from the below pull request
+        Monitor an AWS Batch job
 
-            * https://github.com/boto/botocore/pull/1307
-
-        If the waiter is not available apply a exponential backoff
-
-            * docs.aws.amazon.com/general/latest/gr/api-retries.html
+        :raises: AirflowException
         """
         try:
-            waiter = self.client.get_waiter("job_execution_complete")
-            waiter.config.max_attempts = sys.maxsize  # timeout is managed by airflow
-            waiter.wait(jobs=[self.jobId])
-        except ValueError:
-            self._poll_for_task_ended()
+            if self.waiters:
+                self.waiters.wait_for_job(self.job_id)
+            else:
+                self.wait_for_job(self.job_id)
 
-    def _poll_for_task_ended(self):
-        """
-        Poll for job status
+            self.check_job_success(self.job_id)
+            self.log.info("AWS Batch job (%s) succeeded", self.job_id)
 
-            * docs.aws.amazon.com/general/latest/gr/api-retries.html
-        """
-        # Allow a batch job some time to spin up.  A random interval
-        # decreases the chances of exceeding an AWS API throttle
-        # limit when there are many concurrent tasks.
-        pause = randint(5, 30)
-
-        tries = 0
-        while tries < self.max_retries:
-            tries += 1
-            self.log.info(
-                "AWS Batch job (%s) status check (%d of %d) in the next %.2f seconds",
-                self.jobId,
-                tries,
-                self.max_retries,
-                pause,
-            )
-            sleep(pause)
-
-            response = self._get_job_description()
-            jobs = response.get("jobs")
-            status = jobs[-1]["status"]  # check last job status
-            self.log.info("AWS Batch job (%s) status: %s", self.jobId, status)
-
-            # status options: 'SUBMITTED'|'PENDING'|'RUNNABLE'|'STARTING'|'RUNNING'|'SUCCEEDED'|'FAILED'
-            if status in ["SUCCEEDED", "FAILED"]:
-                break
-
-            pause = 1 + pow(tries * 0.3, 2)
-
-    def _get_job_description(self) -> Optional[dict]:
-        """
-        Get job description
-
-            * https://docs.aws.amazon.com/batch/latest/APIReference/API_DescribeJobs.html
-            * https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
-        """
-        tries = 0
-        while tries < self.status_retries:
-            tries += 1
-            try:
-                response = self.client.describe_jobs(jobs=[self.jobId])
-                if response and response.get("jobs"):
-                    return response
-                else:
-                    self.log.error("Job description has no jobs (%s): %s", self.jobId, response)
-            except botocore.exceptions.ClientError as err:
-                response = err.response
-                self.log.error("Job description error (%s): %s", self.jobId, response)
-                if tries < self.status_retries:
-                    error = response.get("Error", {})
-                    if error.get("Code") == "TooManyRequestsException":
-                        pause = randint(1, 10)  # avoid excess requests with a random pause
-                        self.log.info(
-                            "AWS Batch job (%s) status retry (%d of %d) in the next %.2f seconds",
-                            self.jobId,
-                            tries,
-                            self.status_retries,
-                            pause,
-                        )
-                        sleep(pause)
-                        continue
-
-        msg = "Failed to get job description ({})".format(self.jobId)
-        raise AirflowException(msg)
-
-    def _check_success_task(self):
-        """
-        Check the final status of the batch job; the job status options are:
-        'SUBMITTED'|'PENDING'|'RUNNABLE'|'STARTING'|'RUNNING'|'SUCCEEDED'|'FAILED'
-        """
-        response = self._get_job_description()
-        jobs = response.get("jobs")
-
-        matching_jobs = [job for job in jobs if job["jobId"] == self.jobId]
-        if not matching_jobs:
-            raise AirflowException(
-                "Job ({}) has no job description {}".format(self.jobId, response)
-            )
-
-        job = matching_jobs[0]
-        self.log.info("AWS Batch stopped, check status: %s", job)
-        job_status = job["status"]
-        if job_status == "FAILED":
-            reason = job["statusReason"]
-            raise AirflowException("Job ({}) failed with status {}".format(self.jobId, reason))
-        elif job_status in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
-            raise AirflowException(
-                "Job ({}) is still pending {}".format(self.jobId, job_status)
-            )
-
-    def get_hook(self):
-        """Get an AWS API client (boto3)"""
-        return AwsHook(aws_conn_id=self.aws_conn_id)
-
-    def on_kill(self):
-        response = self.client.terminate_job(jobId=self.jobId, reason="Task killed by the user")
-        self.log.info(response)
+        except Exception as e:
+            self.log.info("AWS Batch job (%s) failed monitoring", self.job_id)
+            raise AirflowException(e)

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -303,7 +303,8 @@ These integrations allow you to perform various operations within the Amazon Web
 
    * - `AWS Batch <https://aws.amazon.com/batch/>`__
      -
-     -
+     - :mod:`airflow.providers.amazon.aws.hooks.batch_client`,
+       :mod:`airflow.providers.amazon.aws.hooks.batch_waiters`
      - :mod:`airflow.providers.amazon.aws.operators.batch`
      -
 

--- a/tests/providers/amazon/aws/hooks/test_batch_client.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_client.py
@@ -1,0 +1,329 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=missing-docstring
+
+import unittest
+
+import botocore.exceptions
+import mock
+from parameterized import parameterized
+
+from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClient
+
+# Use dummy AWS credentials
+AWS_REGION = "eu-west-1"
+AWS_ACCESS_KEY_ID = "airflow_dummy_key"
+AWS_SECRET_ACCESS_KEY = "airflow_dummy_secret"
+
+JOB_ID = "8ba9d676-4108-4474-9dca-8bbac1da9b19"
+
+
+class TestAwsBatchClient(unittest.TestCase):
+
+    MAX_RETRIES = 2
+    STATUS_RETRIES = 3
+
+    @mock.patch.dict("os.environ", AWS_DEFAULT_REGION=AWS_REGION)
+    @mock.patch.dict("os.environ", AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID)
+    @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.AwsHook")
+    def setUp(self, aws_hook_mock):
+        self.aws_hook_mock = aws_hook_mock
+        self.batch_client = AwsBatchClient(
+            max_retries=self.MAX_RETRIES,
+            status_retries=self.STATUS_RETRIES,
+            aws_conn_id=None,
+            region_name=AWS_REGION,
+        )
+        self.client_mock = self.aws_hook_mock.return_value.get_client_type.return_value
+        self.assertEqual(self.batch_client.client, self.client_mock)  # setup client property
+
+        # don't pause in these unit tests
+        self.mock_delay = mock.Mock(return_value=None)
+        self.batch_client.delay = self.mock_delay
+        self.mock_exponential_delay = mock.Mock(return_value=0)
+        self.batch_client.exponential_delay = self.mock_exponential_delay
+
+    def test_init(self):
+        self.assertEqual(self.batch_client.max_retries, self.MAX_RETRIES)
+        self.assertEqual(self.batch_client.status_retries, self.STATUS_RETRIES)
+        self.assertEqual(self.batch_client.region_name, AWS_REGION)
+        self.assertEqual(self.batch_client.aws_conn_id, None)
+        self.assertEqual(self.batch_client.hook, self.aws_hook_mock.return_value)
+        self.assertEqual(self.batch_client.client, self.client_mock)
+
+        self.aws_hook_mock.assert_called_once_with(aws_conn_id=None)
+        self.aws_hook_mock.return_value.get_client_type.assert_called_once_with(
+            "batch", region_name=AWS_REGION
+        )
+
+    def test_wait_for_job_with_success(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [{"jobId": JOB_ID, "status": "SUCCEEDED"}]
+        }
+
+        with mock.patch.object(
+            self.batch_client,
+            "poll_for_job_running",
+            wraps=self.batch_client.poll_for_job_running,
+        ) as job_running:
+            self.batch_client.wait_for_job(JOB_ID)
+            job_running.assert_called_once_with(JOB_ID, None)
+
+        with mock.patch.object(
+            self.batch_client,
+            "poll_for_job_complete",
+            wraps=self.batch_client.poll_for_job_complete,
+        ) as job_complete:
+            self.batch_client.wait_for_job(JOB_ID)
+            job_complete.assert_called_once_with(JOB_ID, None)
+
+        self.assertEqual(self.client_mock.describe_jobs.call_count, 4)
+
+    def test_wait_for_job_with_failure(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [{"jobId": JOB_ID, "status": "FAILED"}]
+        }
+
+        with mock.patch.object(
+            self.batch_client,
+            "poll_for_job_running",
+            wraps=self.batch_client.poll_for_job_running,
+        ) as job_running:
+            self.batch_client.wait_for_job(JOB_ID)
+            job_running.assert_called_once_with(JOB_ID, None)
+
+        with mock.patch.object(
+            self.batch_client,
+            "poll_for_job_complete",
+            wraps=self.batch_client.poll_for_job_complete,
+        ) as job_complete:
+            self.batch_client.wait_for_job(JOB_ID)
+            job_complete.assert_called_once_with(JOB_ID, None)
+
+        self.assertEqual(self.client_mock.describe_jobs.call_count, 4)
+
+    def test_poll_job_running_for_status_running(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [{"jobId": JOB_ID, "status": "RUNNING"}]
+        }
+        self.batch_client.poll_for_job_running(JOB_ID)
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+
+    def test_poll_job_complete_for_status_success(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [{"jobId": JOB_ID, "status": "SUCCEEDED"}]
+        }
+        self.batch_client.poll_for_job_complete(JOB_ID)
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+
+    def test_poll_job_complete_raises_for_max_retries(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [{"jobId": JOB_ID, "status": "RUNNING"}]
+        }
+        with self.assertRaises(AirflowException) as e:
+            self.batch_client.poll_for_job_complete(JOB_ID)
+        msg = "AWS Batch job ({}) status checks exceed max_retries".format(JOB_ID)
+        self.assertIn(msg, str(e.exception))
+        self.client_mock.describe_jobs.assert_called_with(jobs=[JOB_ID])
+        self.assertEqual(self.client_mock.describe_jobs.call_count, self.MAX_RETRIES + 1)
+
+    def test_poll_job_status_hit_api_throttle(self):
+        self.client_mock.describe_jobs.side_effect = botocore.exceptions.ClientError(
+            error_response={"Error": {"Code": "TooManyRequestsException"}},
+            operation_name="get job description",
+        )
+        with self.assertRaises(AirflowException) as e:
+            self.batch_client.poll_for_job_complete(JOB_ID)
+        msg = "AWS Batch job ({}) description error".format(JOB_ID)
+        self.assertIn(msg, str(e.exception))
+        # It should retry when this client error occurs
+        self.client_mock.describe_jobs.assert_called_with(jobs=[JOB_ID])
+        self.assertEqual(self.client_mock.describe_jobs.call_count, self.STATUS_RETRIES)
+
+    def test_poll_job_status_with_client_error(self):
+        self.client_mock.describe_jobs.side_effect = botocore.exceptions.ClientError(
+            error_response={"Error": {"Code": "InvalidClientTokenId"}},
+            operation_name="get job description",
+        )
+        with self.assertRaises(AirflowException) as e:
+            self.batch_client.poll_for_job_complete(JOB_ID)
+        msg = "AWS Batch job ({}) description error".format(JOB_ID)
+        self.assertIn(msg, str(e.exception))
+        # It will not retry when this client error occurs
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+
+    def test_check_job_success(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [{"jobId": JOB_ID, "status": "SUCCEEDED"}]
+        }
+        status = self.batch_client.check_job_success(JOB_ID)
+        self.assertTrue(status)
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+
+    def test_check_job_success_raises_failed(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [
+                {
+                    "jobId": JOB_ID,
+                    "status": "FAILED",
+                    "statusReason": "This is an error reason",
+                    "attempts": [{"exitCode": 1}],
+                }
+            ]
+        }
+        with self.assertRaises(AirflowException) as e:
+            self.batch_client.check_job_success(JOB_ID)
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+        msg = "AWS Batch job ({}) failed".format(JOB_ID)
+        self.assertIn(msg, str(e.exception))
+
+    def test_check_job_success_raises_failed_for_multiple_attempts(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [
+                {
+                    "jobId": JOB_ID,
+                    "status": "FAILED",
+                    "statusReason": "This is an error reason",
+                    "attempts": [{"exitCode": 1}, {"exitCode": 10}],
+                }
+            ]
+        }
+        with self.assertRaises(AirflowException) as e:
+            self.batch_client.check_job_success(JOB_ID)
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+        msg = "AWS Batch job ({}) failed".format(JOB_ID)
+        self.assertIn(msg, str(e.exception))
+
+    def test_check_job_success_raises_incomplete(self):
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [{"jobId": JOB_ID, "status": "RUNNABLE"}]
+        }
+        with self.assertRaises(AirflowException) as e:
+            self.batch_client.check_job_success(JOB_ID)
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+        msg = "AWS Batch job ({}) is not complete".format(JOB_ID)
+        self.assertIn(msg, str(e.exception))
+
+    def test_check_job_success_raises_unknown_status(self):
+        status = "STRANGE"
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [{"jobId": JOB_ID, "status": status}]
+        }
+        with self.assertRaises(AirflowException) as e:
+            self.batch_client.check_job_success(JOB_ID)
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+        msg = "AWS Batch job ({}) has unknown status".format(JOB_ID)
+        self.assertIn(msg, str(e.exception))
+        self.assertIn(status, str(e.exception))
+
+    def test_check_job_success_raises_without_jobs(self):
+        self.client_mock.describe_jobs.return_value = {"jobs": []}
+        with self.assertRaises(AirflowException) as e:
+            self.batch_client.check_job_success(JOB_ID)
+        self.client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
+        msg = "AWS Batch job ({}) description error".format(JOB_ID)
+        self.assertIn(msg, str(e.exception))
+
+    def test_terminate_job(self):
+        self.client_mock.terminate_job.return_value = {}
+        reason = "Task killed by the user"
+        response = self.batch_client.terminate_job(JOB_ID, reason)
+        self.client_mock.terminate_job.assert_called_once_with(jobId=JOB_ID, reason=reason)
+        self.assertEqual(response, {})
+
+
+class TestAwsBatchClientDelays(unittest.TestCase):
+    @mock.patch.dict("os.environ", AWS_DEFAULT_REGION=AWS_REGION)
+    @mock.patch.dict("os.environ", AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID)
+    @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
+    def setUp(self):
+        self.batch_client = AwsBatchClient(region_name=AWS_REGION)
+
+    def test_init(self):
+        self.assertEqual(self.batch_client.max_retries, self.batch_client.MAX_RETRIES)
+        self.assertEqual(self.batch_client.status_retries, self.batch_client.STATUS_RETRIES)
+        self.assertEqual(self.batch_client.region_name, AWS_REGION)
+        self.assertEqual(self.batch_client.aws_conn_id, None)
+
+    def test_add_jitter(self):
+        minima = 0
+        width = 5
+        result = self.batch_client.add_jitter(0, width=width, minima=minima)
+        self.assertGreaterEqual(result, minima)
+        self.assertLessEqual(result, width)
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.uniform")
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.sleep")
+    def test_delay_defaults(self, mock_sleep, mock_uniform):
+        self.assertEqual(AwsBatchClient.DEFAULT_DELAY_MIN, 1)
+        self.assertEqual(AwsBatchClient.DEFAULT_DELAY_MAX, 10)
+        mock_uniform.return_value = 0
+        self.batch_client.delay()
+        mock_uniform.assert_called_once_with(
+            AwsBatchClient.DEFAULT_DELAY_MIN, AwsBatchClient.DEFAULT_DELAY_MAX
+        )
+        mock_sleep.assert_called_once_with(0)
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.uniform")
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.sleep")
+    def test_delay_with_zero(self, mock_sleep, mock_uniform):
+        self.batch_client.delay(0)
+        mock_uniform.assert_called_once_with(0, 1)  # in add_jitter
+        mock_sleep.assert_called_once_with(mock_uniform.return_value)
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.uniform")
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.sleep")
+    def test_delay_with_int(self, mock_sleep, mock_uniform):
+        self.batch_client.delay(5)
+        mock_uniform.assert_called_once_with(4, 6)  # in add_jitter
+        mock_sleep.assert_called_once_with(mock_uniform.return_value)
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.uniform")
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.sleep")
+    def test_delay_with_float(self, mock_sleep, mock_uniform):
+        self.batch_client.delay(5.0)
+        mock_uniform.assert_called_once_with(4.0, 6.0)  # in add_jitter
+        mock_sleep.assert_called_once_with(mock_uniform.return_value)
+
+    @parameterized.expand(
+        [
+            (0, 0, 1),
+            (1, 0, 2),
+            (2, 0, 3),
+            (3, 1, 5),
+            (4, 2, 7),
+            (5, 3, 11),
+            (6, 4, 14),
+            (7, 6, 19),
+            (8, 8, 25),
+            (9, 10, 31),
+            (45, 200, 600),  # > 40 tries invokes maximum delay allowed
+        ]
+    )
+    def test_exponential_delay(self, tries, lower, upper):
+        result = self.batch_client.exponential_delay(tries)
+        self.assertGreaterEqual(result, lower)
+        self.assertLessEqual(result, upper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/providers/amazon/aws/hooks/test_batch_waiters.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_waiters.py
@@ -1,0 +1,471 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=do-not-use-asserts, missing-docstring, redefined-outer-name
+
+
+"""
+Test AwsBatchWaiters
+
+This test suite uses a large suite of moto mocks for the
+AWS batch infrastructure.  These infrastructure mocks are
+derived from the moto test suite for testing the batch client.
+
+.. seealso::
+
+    - https://github.com/spulec/moto/pull/1197/files
+    - https://github.com/spulec/moto/blob/master/tests/test_batch/test_batch.py
+"""
+
+import inspect
+import unittest
+from typing import NamedTuple, Optional
+
+import boto3
+import botocore.client
+import botocore.exceptions
+import botocore.waiter
+import mock
+import pytest
+from moto import mock_batch, mock_ec2, mock_ecs, mock_iam, mock_logs
+
+from airflow import AirflowException
+from airflow.providers.amazon.aws.hooks.batch_waiters import AwsBatchWaiters
+
+# Use dummy AWS credentials
+AWS_REGION = "eu-west-1"
+AWS_ACCESS_KEY_ID = "airflow_dummy_key"
+AWS_SECRET_ACCESS_KEY = "airflow_dummy_secret"
+
+
+@pytest.fixture(scope="module")
+def aws_region():
+    return AWS_REGION
+
+
+@pytest.fixture(scope="module")
+def job_queue_name():
+    return "moto_test_job_queue"
+
+
+@pytest.fixture(scope="module")
+def job_definition_name():
+    return "moto_test_job_definition"
+
+
+#
+# AWS Clients
+#
+
+
+class AwsClients(NamedTuple):
+    batch: "botocore.client.Batch"
+    ec2: "botocore.client.EC2"
+    ecs: "botocore.client.ECS"
+    iam: "botocore.client.IAM"
+    log: "botocore.client.CloudWatchLogs"
+
+
+@pytest.yield_fixture(scope="module")
+def batch_client(aws_region):
+    with mock_batch():
+        yield boto3.client("batch", region_name=aws_region)
+
+
+@pytest.yield_fixture(scope="module")
+def ec2_client(aws_region):
+    with mock_ec2():
+        yield boto3.client("ec2", region_name=aws_region)
+
+
+@pytest.yield_fixture(scope="module")
+def ecs_client(aws_region):
+    with mock_ecs():
+        yield boto3.client("ecs", region_name=aws_region)
+
+
+@pytest.yield_fixture(scope="module")
+def iam_client(aws_region):
+    with mock_iam():
+        yield boto3.client("iam", region_name=aws_region)
+
+
+@pytest.yield_fixture(scope="module")
+def logs_client(aws_region):
+    with mock_logs():
+        yield boto3.client("logs", region_name=aws_region)
+
+
+@pytest.fixture(scope="module")
+def aws_clients(batch_client, ec2_client, ecs_client, iam_client, logs_client):
+    return AwsClients(
+        batch=batch_client, ec2=ec2_client, ecs=ecs_client, iam=iam_client, log=logs_client
+    )
+
+
+#
+# Batch Infrastructure
+#
+
+
+class Infrastructure:
+    aws_region: str
+    aws_clients: AwsClients
+    vpc_id: Optional[str] = None
+    subnet_id: Optional[str] = None
+    security_group_id: Optional[str] = None
+    iam_arn: Optional[str] = None
+    compute_env_name: Optional[str] = None
+    compute_env_arn: Optional[str] = None
+    job_queue_name: Optional[str] = None
+    job_queue_arn: Optional[str] = None
+    job_definition_name: Optional[str] = None
+    job_definition_arn: Optional[str] = None
+
+
+def batch_infrastructure(
+    aws_clients: AwsClients, aws_region: str, job_queue_name: str, job_definition_name: str
+) -> Infrastructure:
+    """
+    This function is not a fixture so that tests can pass the AWS clients to it and then
+    continue to use the infrastructure created by it while the client fixtures are in-tact for
+    the duration of a test.
+    """
+
+    infrastructure = Infrastructure()
+    infrastructure.aws_region = aws_region
+    infrastructure.aws_clients = aws_clients
+
+    resp = aws_clients.ec2.create_vpc(CidrBlock="172.30.0.0/24")
+    vpc_id = resp["Vpc"]["VpcId"]
+
+    resp = aws_clients.ec2.create_subnet(
+        AvailabilityZone=f"{aws_region}a", CidrBlock="172.30.0.0/25", VpcId=vpc_id
+    )
+    subnet_id = resp["Subnet"]["SubnetId"]
+
+    resp = aws_clients.ec2.create_security_group(
+        Description="moto_test_sg_desc", GroupName="moto_test_sg", VpcId=vpc_id
+    )
+    sg_id = resp["GroupId"]
+
+    resp = aws_clients.iam.create_role(
+        RoleName="MotoTestRole", AssumeRolePolicyDocument="moto_test_policy"
+    )
+    iam_arn = resp["Role"]["Arn"]
+
+    compute_env_name = "moto_test_compute_env"
+    resp = aws_clients.batch.create_compute_environment(
+        computeEnvironmentName=compute_env_name,
+        type="UNMANAGED",
+        state="ENABLED",
+        serviceRole=iam_arn,
+    )
+    compute_env_arn = resp["computeEnvironmentArn"]
+
+    resp = aws_clients.batch.create_job_queue(
+        jobQueueName=job_queue_name,
+        state="ENABLED",
+        priority=123,
+        computeEnvironmentOrder=[{"order": 123, "computeEnvironment": compute_env_arn}],
+    )
+    assert resp["jobQueueName"] == job_queue_name
+    assert resp["jobQueueArn"]
+    job_queue_arn = resp["jobQueueArn"]
+
+    resp = aws_clients.batch.register_job_definition(
+        jobDefinitionName=job_definition_name,
+        type="container",
+        containerProperties={
+            "image": "busybox",
+            "vcpus": 1,
+            "memory": 64,
+            "command": ["sleep", "10"],
+        },
+    )
+    assert resp["jobDefinitionName"] == job_definition_name
+    assert resp["jobDefinitionArn"]
+    job_definition_arn = resp["jobDefinitionArn"]
+    assert resp["revision"]
+    assert resp["jobDefinitionArn"].endswith(
+        "{0}:{1}".format(resp["jobDefinitionName"], resp["revision"])
+    )
+
+    infrastructure.vpc_id = vpc_id
+    infrastructure.subnet_id = subnet_id
+    infrastructure.security_group_id = sg_id
+    infrastructure.iam_arn = iam_arn
+    infrastructure.compute_env_name = compute_env_name
+    infrastructure.compute_env_arn = compute_env_arn
+    infrastructure.job_queue_name = job_queue_name
+    infrastructure.job_queue_arn = job_queue_arn
+    infrastructure.job_definition_name = job_definition_name
+    infrastructure.job_definition_arn = job_definition_arn
+    return infrastructure
+
+
+#
+# pytest tests
+#
+
+
+def test_aws_batch_waiters(aws_region):
+    assert inspect.isclass(AwsBatchWaiters)
+    batch_waiters = AwsBatchWaiters(region_name=aws_region)
+    assert isinstance(batch_waiters, AwsBatchWaiters)
+
+
+@mock_batch
+@mock_ec2
+@mock_ecs
+@mock_iam
+@mock_logs
+def test_aws_batch_job_waiting(aws_clients, aws_region, job_queue_name, job_definition_name):
+    """
+    Submit batch jobs and wait for various job status indicators or errors.
+    These batch job waiter tests can be slow and might need to be marked
+    for conditional skips if they take too long, although it seems to
+    run in about 30 sec to a minute.
+
+    .. note::
+        These tests have no control over how moto transitions the batch job status.
+
+    .. seealso::
+        - https://github.com/boto/botocore/blob/develop/botocore/waiter.py
+        - https://github.com/spulec/moto/blob/master/moto/batch/models.py#L360
+        - https://github.com/spulec/moto/blob/master/tests/test_batch/test_batch.py
+    """
+
+    aws_resources = batch_infrastructure(
+        aws_clients, aws_region, job_queue_name, job_definition_name
+    )
+    batch_waiters = AwsBatchWaiters(region_name=aws_resources.aws_region)
+
+    job_exists_waiter = batch_waiters.get_waiter("JobExists")
+    assert job_exists_waiter
+    assert isinstance(job_exists_waiter, botocore.waiter.Waiter)
+    assert job_exists_waiter.__class__.__name__ == "Batch.Waiter.JobExists"
+
+    job_running_waiter = batch_waiters.get_waiter("JobRunning")
+    assert job_running_waiter
+    assert isinstance(job_running_waiter, botocore.waiter.Waiter)
+    assert job_running_waiter.__class__.__name__ == "Batch.Waiter.JobRunning"
+
+    job_complete_waiter = batch_waiters.get_waiter("JobComplete")
+    assert job_complete_waiter
+    assert isinstance(job_complete_waiter, botocore.waiter.Waiter)
+    assert job_complete_waiter.__class__.__name__ == "Batch.Waiter.JobComplete"
+
+    # test waiting on a jobId that does not exist (this throws immediately)
+    with pytest.raises(botocore.exceptions.WaiterError) as err:
+        job_exists_waiter.config.delay = 0.2
+        job_exists_waiter.config.max_attempts = 2
+        job_exists_waiter.wait(jobs=["missing-job"])
+    assert isinstance(err.value, botocore.exceptions.WaiterError)
+    assert "Waiter JobExists failed" in str(err.value)
+
+    # Submit a job and wait for various job status indicators;
+    # moto transitions the batch job status automatically.
+
+    job_name = "test-job"
+    job_cmd = ['/bin/sh -c "for a in `seq 1 2`; do echo Hello World; sleep 0.25; done"']
+
+    job_response = aws_clients.batch.submit_job(
+        jobName=job_name,
+        jobQueue=aws_resources.job_queue_arn,
+        jobDefinition=aws_resources.job_definition_arn,
+        containerOverrides={"command": job_cmd},
+    )
+    job_id = job_response["jobId"]
+
+    job_description = aws_clients.batch.describe_jobs(jobs=[job_id])
+    job_status = [job for job in job_description["jobs"] if job["jobId"] == job_id][0]["status"]
+    assert job_status == "PENDING"
+
+    # this should not raise a WaiterError and note there is no 'state' maintained in
+    # the waiter that can be checked after calling wait() and it has no return value;
+    # see https://github.com/boto/botocore/blob/develop/botocore/waiter.py#L287
+    job_exists_waiter.config.delay = 0.2
+    job_exists_waiter.config.max_attempts = 20
+    job_exists_waiter.wait(jobs=[job_id])
+
+    # test waiting for job completion with too few attempts (possibly before job is running)
+    job_complete_waiter.config.delay = 0.1
+    job_complete_waiter.config.max_attempts = 1
+    with pytest.raises(botocore.exceptions.WaiterError) as err:
+        job_complete_waiter.wait(jobs=[job_id])
+    assert isinstance(err.value, botocore.exceptions.WaiterError)
+    assert "Waiter JobComplete failed: Max attempts exceeded" in str(err.value)
+
+    # wait for job to be running (or complete)
+    job_running_waiter.config.delay = 0.25  # sec delays between status checks
+    job_running_waiter.config.max_attempts = 50
+    job_running_waiter.wait(jobs=[job_id])
+
+    # wait for job completion
+    job_complete_waiter.config.delay = 0.25
+    job_complete_waiter.config.max_attempts = 50
+    job_complete_waiter.wait(jobs=[job_id])
+
+    job_description = aws_clients.batch.describe_jobs(jobs=[job_id])
+    job_status = [job for job in job_description["jobs"] if job["jobId"] == job_id][0]["status"]
+    assert job_status == "SUCCEEDED"
+
+
+# pylint: enable=do-not-use-asserts
+
+
+class TestAwsBatchWaiters(unittest.TestCase):
+    @mock.patch.dict("os.environ", AWS_DEFAULT_REGION=AWS_REGION)
+    @mock.patch.dict("os.environ", AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID)
+    @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.AwsHook")
+    def setUp(self, aws_hook_mock):
+        self.job_id = "8ba9d676-4108-4474-9dca-8bbac1da9b19"
+        self.region_name = AWS_REGION
+        self.aws_hook_mock = aws_hook_mock
+
+        self.batch_waiters = AwsBatchWaiters(region_name=self.region_name)
+        self.assertEqual(self.batch_waiters.aws_conn_id, None)
+        self.assertEqual(self.batch_waiters.region_name, self.region_name)
+
+        # init the mock hook
+        self.assertEqual(self.batch_waiters.hook, self.aws_hook_mock.return_value)
+        self.aws_hook_mock.assert_called_once_with(aws_conn_id=None)
+
+        # init the mock client
+        self.client_mock = self.batch_waiters.client
+        self.aws_hook_mock.return_value.get_client_type.assert_called_once_with(
+            "batch", region_name=self.region_name
+        )
+
+        # don't pause in these unit tests
+        self.mock_delay = mock.Mock(return_value=None)
+        self.batch_waiters.delay = self.mock_delay
+        self.mock_exponential_delay = mock.Mock(return_value=0)
+        self.batch_waiters.exponential_delay = self.mock_exponential_delay
+
+    def test_default_config(self):
+        # the default config is used when no custom config is provided
+        config = self.batch_waiters.default_config
+        self.assertEqual(config, self.batch_waiters.waiter_config)
+
+        self.assertIsInstance(config, dict)
+        self.assertEqual(config["version"], 2)
+        self.assertIsInstance(config["waiters"], dict)
+
+        waiters = list(sorted(config["waiters"].keys()))
+        self.assertEqual(waiters, ["JobComplete", "JobExists", "JobRunning"])
+
+    def test_list_waiters(self):
+        # the default config is used when no custom config is provided
+        config = self.batch_waiters.waiter_config
+
+        self.assertIsInstance(config["waiters"], dict)
+        waiters = list(sorted(config["waiters"].keys()))
+        self.assertEqual(waiters, ["JobComplete", "JobExists", "JobRunning"])
+        self.assertEqual(waiters, self.batch_waiters.list_waiters())
+
+    def test_waiter_model(self):
+        model = self.batch_waiters.waiter_model
+        self.assertIsInstance(model, botocore.waiter.WaiterModel)
+
+        # test some of the default config
+        self.assertEqual(model.version, 2)
+        waiters = sorted(model.waiter_names)
+        self.assertEqual(waiters, ["JobComplete", "JobExists", "JobRunning"])
+
+        # test errors when requesting a waiter with the wrong name
+        with self.assertRaises(ValueError) as e:
+            model.get_waiter("JobExist")
+        self.assertIn("Waiter does not exist: JobExist", str(e.exception))
+
+        # test some default waiter properties
+        waiter = model.get_waiter("JobExists")
+        self.assertIsInstance(waiter, botocore.waiter.SingleWaiterConfig)
+        self.assertEqual(waiter.max_attempts, 100)
+        waiter.max_attempts = 200
+        self.assertEqual(waiter.max_attempts, 200)
+        self.assertEqual(waiter.delay, 2)
+        waiter.delay = 10
+        self.assertEqual(waiter.delay, 10)
+        self.assertEqual(waiter.operation, "DescribeJobs")
+
+    def test_wait_for_job(self):
+        import sys
+
+        # mock delay for speedy test
+        mock_jitter = mock.Mock(return_value=0)
+        self.batch_waiters.add_jitter = mock_jitter
+
+        with mock.patch.object(self.batch_waiters, "get_waiter") as get_waiter:
+
+            self.batch_waiters.wait_for_job(self.job_id)
+
+            self.assertEqual(
+                get_waiter.call_args_list,
+                [mock.call("JobExists"), mock.call("JobRunning"), mock.call("JobComplete")],
+            )
+
+            mock_waiter = get_waiter.return_value
+            mock_waiter.wait.assert_called_with(jobs=[self.job_id])
+            self.assertEqual(mock_waiter.wait.call_count, 3)
+
+            mock_config = mock_waiter.config
+            self.assertEqual(mock_config.delay, 0)
+            self.assertEqual(mock_config.max_attempts, sys.maxsize)
+
+    def test_wait_for_job_raises_for_client_error(self):
+        # mock delay for speedy test
+        mock_jitter = mock.Mock(return_value=0)
+        self.batch_waiters.add_jitter = mock_jitter
+
+        with mock.patch.object(self.batch_waiters, "get_waiter") as get_waiter:
+            mock_waiter = get_waiter.return_value
+            mock_waiter.wait.side_effect = botocore.exceptions.ClientError(
+                error_response={"Error": {"Code": "TooManyRequestsException"}},
+                operation_name="get job description",
+            )
+            with self.assertRaises(AirflowException):
+                self.batch_waiters.wait_for_job(self.job_id)
+
+            self.assertEqual(get_waiter.call_args_list, [mock.call("JobExists")])
+            mock_waiter.wait.assert_called_with(jobs=[self.job_id])
+            self.assertEqual(mock_waiter.wait.call_count, 1)
+
+    def test_wait_for_job_raises_for_waiter_error(self):
+        # mock delay for speedy test
+        mock_jitter = mock.Mock(return_value=0)
+        self.batch_waiters.add_jitter = mock_jitter
+
+        with mock.patch.object(self.batch_waiters, "get_waiter") as get_waiter:
+            mock_waiter = get_waiter.return_value
+            mock_waiter.wait.side_effect = botocore.exceptions.WaiterError(
+                name="JobExists", reason="unit test error", last_response={}
+            )
+            with self.assertRaises(AirflowException):
+                self.batch_waiters.wait_for_job(self.job_id)
+
+            self.assertEqual(get_waiter.call_args_list, [mock.call("JobExists")])
+            mock_waiter.wait.assert_called_with(jobs=[self.job_id])
+            self.assertEqual(mock_waiter.wait.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -18,14 +18,19 @@
 # under the License.
 #
 
-import sys
+# pylint: disable=missing-docstring
+
 import unittest
 
-import botocore.exceptions
 import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.operators.batch import AwsBatchOperator
+
+# Use dummy AWS credentials
+AWS_REGION = "eu-west-1"
+AWS_ACCESS_KEY_ID = "airflow_dummy_key"
+AWS_SECRET_ACCESS_KEY = "airflow_dummy_secret"
 
 JOB_NAME = "51455483-c62c-48ac-9b88-53a6a725baa3"
 JOB_ID = "8ba9d676-4108-4474-9dca-8bbac1da9b19"
@@ -41,7 +46,10 @@ class TestAwsBatchOperator(unittest.TestCase):
     MAX_RETRIES = 2
     STATUS_RETRIES = 3
 
-    @mock.patch("airflow.providers.amazon.aws.operators.batch.AwsHook")
+    @mock.patch.dict("os.environ", AWS_DEFAULT_REGION=AWS_REGION)
+    @mock.patch.dict("os.environ", AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID)
+    @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
+    @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.AwsHook")
     def setUp(self, aws_hook_mock):
         self.aws_hook_mock = aws_hook_mock
         self.batch = AwsBatchOperator(
@@ -57,11 +65,25 @@ class TestAwsBatchOperator(unittest.TestCase):
             aws_conn_id=None,
             region_name="eu-west-1",
         )
+        self.client_mock = self.aws_hook_mock.return_value.get_client_type.return_value
+        self.assertEqual(self.batch.client, self.client_mock)  # setup client property
+
+        # don't pause in unit tests
+        self.mock_delay = mock.Mock(return_value=None)
+        self.batch.delay = self.mock_delay
+        self.mock_exponential_delay = mock.Mock(return_value=0)
+        self.batch.exponential_delay = self.mock_exponential_delay
+
+        # Assign a job ID for most tests, so they don't depend on a job submission.
+        self.assertIsNone(self.batch.job_id)
+        self.batch.job_id = JOB_ID
 
     def test_init(self):
+        self.assertEqual(self.batch.job_id, JOB_ID)
         self.assertEqual(self.batch.job_name, JOB_NAME)
         self.assertEqual(self.batch.job_queue, "queue")
         self.assertEqual(self.batch.job_definition, "hello-world")
+        self.assertEqual(self.batch.waiters, None)
         self.assertEqual(self.batch.max_retries, self.MAX_RETRIES)
         self.assertEqual(self.batch.status_retries, self.STATUS_RETRIES)
         self.assertEqual(self.batch.parameters, None)
@@ -70,24 +92,27 @@ class TestAwsBatchOperator(unittest.TestCase):
         self.assertEqual(self.batch.region_name, "eu-west-1")
         self.assertEqual(self.batch.aws_conn_id, None)
         self.assertEqual(self.batch.hook, self.aws_hook_mock.return_value)
+        self.assertEqual(self.batch.client, self.client_mock)
 
         self.aws_hook_mock.assert_called_once_with(aws_conn_id=None)
+        self.aws_hook_mock.return_value.get_client_type.assert_called_once_with(
+            "batch", region_name="eu-west-1"
+        )
 
     def test_template_fields_overrides(self):
         self.assertEqual(self.batch.template_fields, ("job_name", "overrides", "parameters",))
 
-    @mock.patch.object(AwsBatchOperator, "_wait_for_task_ended")
-    @mock.patch.object(AwsBatchOperator, "_check_success_task")
+    @mock.patch.object(AwsBatchOperator, "wait_for_job")
+    @mock.patch.object(AwsBatchOperator, "check_job_success")
     def test_execute_without_failures(self, check_mock, wait_mock):
-        client_mock = self.aws_hook_mock.return_value.get_client_type.return_value
-        client_mock.submit_job.return_value = RESPONSE_WITHOUT_FAILURES
+        # JOB_ID is in RESPONSE_WITHOUT_FAILURES
+        self.client_mock.submit_job.return_value = RESPONSE_WITHOUT_FAILURES
+        self.batch.job_id = None
+        self.batch.waiters = None  # use default wait
 
         self.batch.execute(None)
 
-        self.aws_hook_mock.return_value.get_client_type.assert_called_once_with(
-            "batch", region_name="eu-west-1"
-        )
-        client_mock.submit_job.assert_called_once_with(
+        self.client_mock.submit_job.assert_called_once_with(
             jobQueue="queue",
             jobName=JOB_NAME,
             containerOverrides={},
@@ -96,21 +121,17 @@ class TestAwsBatchOperator(unittest.TestCase):
             parameters=None,
         )
 
-        wait_mock.assert_called_once_with()
-        check_mock.assert_called_once_with()
-        self.assertEqual(self.batch.jobId, JOB_ID)
+        self.assertEqual(self.batch.job_id, JOB_ID)
+        wait_mock.assert_called_once_with(JOB_ID)
+        check_mock.assert_called_once_with(JOB_ID)
 
     def test_execute_with_failures(self):
-        client_mock = self.aws_hook_mock.return_value.get_client_type.return_value
-        client_mock.submit_job.return_value = ""
+        self.client_mock.submit_job.return_value = ""
 
         with self.assertRaises(AirflowException):
             self.batch.execute(None)
 
-        self.aws_hook_mock.return_value.get_client_type.assert_called_once_with(
-            "batch", region_name="eu-west-1"
-        )
-        client_mock.submit_job.assert_called_once_with(
+        self.client_mock.submit_job.assert_called_once_with(
             jobQueue="queue",
             jobName=JOB_NAME,
             containerOverrides={},
@@ -119,180 +140,24 @@ class TestAwsBatchOperator(unittest.TestCase):
             parameters=None,
         )
 
-    def test_wait_end_tasks(self):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
+    @mock.patch.object(AwsBatchOperator, "check_job_success")
+    def test_wait_job_complete_using_waiters(self, check_mock):
+        mock_waiters = mock.Mock()
+        self.batch.waiters = mock_waiters
 
-        self.batch._wait_for_task_ended()
-
-        client_mock.get_waiter.assert_called_once_with("job_execution_complete")
-        client_mock.get_waiter.return_value.wait.assert_called_once_with(jobs=[JOB_ID])
-        self.assertEqual(sys.maxsize, client_mock.get_waiter.return_value.config.max_attempts)
-
-    @mock.patch("airflow.providers.amazon.aws.operators.batch.randint")
-    def test_poll_job_status_success(self, mock_randint):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        mock_randint.return_value = 0  # don't pause in unit tests
-        client_mock.get_waiter.return_value.wait.side_effect = ValueError()
-        client_mock.describe_jobs.return_value = {
+        self.client_mock.submit_job.return_value = RESPONSE_WITHOUT_FAILURES
+        self.client_mock.describe_jobs.return_value = {
             "jobs": [{"jobId": JOB_ID, "status": "SUCCEEDED"}]
         }
+        self.batch.execute(None)
 
-        self.batch._wait_for_task_ended()
-
-        client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
-
-    @mock.patch("airflow.providers.amazon.aws.operators.batch.randint")
-    def test_poll_job_status_running(self, mock_randint):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        mock_randint.return_value = 0  # don't pause in unit tests
-        client_mock.get_waiter.return_value.wait.side_effect = ValueError()
-        client_mock.describe_jobs.return_value = {
-            "jobs": [{"jobId": JOB_ID, "status": "RUNNING"}]
-        }
-
-        self.batch._wait_for_task_ended()
-
-        # self.assertEqual(client_mock.describe_jobs.call_count, self.STATUS_RETRIES)
-        client_mock.describe_jobs.assert_called_with(jobs=[JOB_ID])
-        self.assertEqual(client_mock.describe_jobs.call_count, self.MAX_RETRIES)
-
-    @mock.patch("airflow.providers.amazon.aws.operators.batch.randint")
-    def test_poll_job_status_hit_api_throttle(self, mock_randint):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        mock_randint.return_value = 0  # don't pause in unit tests
-        client_mock.describe_jobs.side_effect = botocore.exceptions.ClientError(
-            error_response={"Error": {"Code": "TooManyRequestsException"}},
-            operation_name="get job description",
-        )
-
-        with self.assertRaises(Exception) as e:
-            self.batch._poll_for_task_ended()
-
-        self.assertIn("Failed to get job description", str(e.exception))
-        client_mock.describe_jobs.assert_called_with(jobs=[JOB_ID])
-        self.assertEqual(client_mock.describe_jobs.call_count, self.STATUS_RETRIES)
-
-    def test_check_success_tasks_raises(self):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        client_mock.describe_jobs.return_value = {"jobs": []}
-
-        with self.assertRaises(Exception) as e:
-            self.batch._check_success_task()
-
-        # Ordering of str(dict) is not guaranteed.
-        self.assertIn("Failed to get job description", str(e.exception))
-
-    def test_check_success_tasks_raises_failed(self):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        client_mock.describe_jobs.return_value = {
-            "jobs": [
-                {
-                    "jobId": JOB_ID,
-                    "status": "FAILED",
-                    "statusReason": "This is an error reason",
-                    "attempts": [{"exitCode": 1}],
-                }
-            ]
-        }
-
-        with self.assertRaises(Exception) as e:
-            self.batch._check_success_task()
-
-        # Ordering of str(dict) is not guaranteed.
-        self.assertIn("Job ({}) failed with status ".format(JOB_ID), str(e.exception))
-
-    def test_check_success_tasks_raises_pending(self):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        client_mock.describe_jobs.return_value = {
-            "jobs": [{"jobId": JOB_ID, "status": "RUNNABLE"}]
-        }
-
-        with self.assertRaises(Exception) as e:
-            self.batch._check_success_task()
-
-        # Ordering of str(dict) is not guaranteed.
-        self.assertIn("Job ({}) is still pending".format(JOB_ID), str(e.exception))
-
-    def test_check_success_tasks_raises_multiple(self):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        client_mock.describe_jobs.return_value = {
-            "jobs": [
-                {
-                    "jobId": JOB_ID,
-                    "status": "FAILED",
-                    "statusReason": "This is an error reason",
-                    "attempts": [{"exitCode": 1}, {"exitCode": 10}],
-                }
-            ]
-        }
-
-        with self.assertRaises(Exception) as e:
-            self.batch._check_success_task()
-
-        # Ordering of str(dict) is not guaranteed.
-        self.assertIn("Job ({}) failed with status ".format(JOB_ID), str(e.exception))
-
-    def test_check_success_task_not_raises(self):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        client_mock.describe_jobs.return_value = {
-            "jobs": [{"jobId": JOB_ID, "status": "SUCCEEDED"}]
-        }
-
-        self.batch._check_success_task()
-
-        # Ordering of str(dict) is not guaranteed.
-        client_mock.describe_jobs.assert_called_once_with(jobs=[JOB_ID])
-
-    def test_check_success_task_raises_without_jobs(self):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        client_mock.describe_jobs.return_value = {"jobs": []}
-
-        with self.assertRaises(Exception) as e:
-            self.batch._check_success_task()
-
-        client_mock.describe_jobs.assert_called_with(jobs=[JOB_ID])
-        self.assertEqual(client_mock.describe_jobs.call_count, self.STATUS_RETRIES)
-        self.assertIn("Failed to get job description", str(e.exception))
+        mock_waiters.wait_for_job.assert_called_once_with(JOB_ID)
+        check_mock.assert_called_once_with(JOB_ID)
 
     def test_kill_job(self):
-        client_mock = mock.Mock()
-        self.batch.jobId = JOB_ID
-        self.batch.client = client_mock
-
-        client_mock.terminate_job.return_value = {}
-
+        self.client_mock.terminate_job.return_value = {}
         self.batch.on_kill()
-
-        client_mock.terminate_job.assert_called_once_with(
+        self.client_mock.terminate_job.assert_called_once_with(
             jobId=JOB_ID, reason="Task killed by the user"
         )
 


### PR DESCRIPTION
### Design / PR notes and RFC

- open to commentary on the general design and approach applied in this PR
  - the intention is to preserve existing functionality, as is, with minor tweaks
- AFAICT, the public API is backwards compatible, unless noted in UPDATING.md
  - most changes are refactoring private methods
  - this adds new features to the public API
- for RFC, please ignore most details of the implementation, just add commentary to the conversation; if a slack discussion would help, ping me to setup a time (Pacific standard time)
- if it mostly looks OK, go ahead and give it a review
  - LMK if it would be easier to split this out into stacked PRs, but hopefully it's clear enough, although large
  - LMK if this requires additional integration testing (and how to do that easily)

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-6245

### Related issues

- https://github.com/boto/botocore/issues/1915
  - https://github.com/boto/botocore/pull/1921
  - While working on this PR, I also pushed up https://github.com/boto/botocore/pull/1921 and I'm not entirely sure how this PR and that one can change the landscape of waiting/polling on batch jobs, but this PR for Airflow will likely stand on its own for Airflow custom options

- While developing this PR, thoughts about custom options for async waiters lingered in the background.  This PR may not be the place to introduce that (it might follow on from this PR), but it's worth noting here that work on a base async operator is in https://github.com/apache/airflow/pull/6210

### Description

- [x] Here are some details about my PR:

This PR improves the batch job status polling by using exponential backoff with jitter, see
- https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

This PR creates a utility for generating and using custom waiters for the AWS batch service; see also:
- https://www.2ndwatch.com/blog/use-waiters-boto3-write/
- https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html#waiters
- This PR removes a dependency on a botocore change to the waiter for AWS batch jobs that has not been merged and released for several years, i.e.
  - https://github.com/boto/botocore/pull/1307

The utility for creating custom waiters can accept a waiter config to generate a custom waiter model.  This should allow users to specify any waiter model required for their use cases, which should satisfy https://issues.apache.org/jira/browse/AIRFLOW-6245 when the custom waiter can be plugged into the AWS batch operator.

### Tests

- [x] My PR adds unit tests for the generator of custom waiters for the AWS batch service

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
