### PR TITLE
[AIRFLOW-4824] Add charset handling for SqlAlchemy engine for MySqlHook

### DIFF
--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -117,6 +117,14 @@ class MySqlHook(DbApiHook):
         conn = MySQLdb.connect(**conn_config)
         return conn
 
+    def get_uri(self):
+        conn = self.get_connection(getattr(self, self.conn_name_attr))
+        uri = super(MySqlHook, self).get_uri()
+        if conn.extra_dejson.get('charset', False):
+            charset = conn.extra_dejson["charset"]
+            return "{uri}?charset={charset}".format(uri=uri, charset=charset)
+        return uri
+
     def bulk_load(self, table, tmp_file):
         """
         Loads a tab-delimited file into a database table

--- a/tests/hooks/test_mysql_hook.py
+++ b/tests/hooks/test_mysql_hook.py
@@ -40,6 +40,7 @@ class TestMySqlHookConn(unittest.TestCase):
         super().setUp()
 
         self.connection = Connection(
+            conn_type='mysql',
             login='login',
             password='password',
             host='host',
@@ -60,6 +61,14 @@ class TestMySqlHookConn(unittest.TestCase):
         self.assertEqual(kwargs['passwd'], 'password')
         self.assertEqual(kwargs['host'], 'host')
         self.assertEqual(kwargs['db'], 'schema')
+
+    @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
+    def test_get_uri(self, mock_connect):
+        self.connection.extra = json.dumps({'charset': 'utf-8'})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        args, kwargs = mock_connect.call_args
+        self.assertEqual(self.db_hook.get_uri(), "mysql://login:password@host/schema?charset=utf-8")
 
     @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
     def test_get_conn_from_connection(self, mock_connect):


### PR DESCRIPTION
Airflow should handle various charsets for connections with MySQL dbs.
This change allows to set charset in extra field of a connection when
using SqlAlchemy engine.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4824
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Airflow should handle various charsets for connections with MySQL dbs.
This change allows to set charset in extra field of a connection when
using SqlAlchemy engine.
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_get_uri in TestMySqlHookConn
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
