### PR TITLE
[AIRFLOW-6254] obscure conn extra in logs

### DIFF
--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -86,7 +86,7 @@ class BaseHook(LoggingMixin):
         conn = random.choice(list(cls.get_connections(conn_id)))
         if conn.host:
             log = LoggingMixin().log
-            log.info("Using connection to: %s", conn.debug_info())
+            log.info("Using connection to: %s", conn.log_info())
         return conn
 
     @classmethod

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -309,6 +309,17 @@ class Connection(Base, LoggingMixin):
     def __repr__(self):
         return self.conn_id
 
+    def log_info(self):
+        return ("id: {}. Host: {}, Port: {}, Schema: {}, "
+                "Login: {}, Password: {}, extra: {}".
+                format(self.conn_id,
+                       self.host,
+                       self.port,
+                       self.schema,
+                       self.login,
+                       "XXXXXXXX" if self.password else None,
+                       "XXXXXXXX" if self.extra_dejson else None))
+
     def debug_info(self):
         return ("id: {}. Host: {}, Port: {}, Schema: {}, "
                 "Login: {}, Password: {}, extra: {}".


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-6254)
  - https://issues.apache.org/jira/browse/AIRFLOW-6254

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When BaseHook.get_connection is called, it calls conn.log_info() on the returned conn object.

This is prints to log the full contents of conn.extra.

This is problematic because there can be sensitive information in conn.extra.

The present change resolves this by adding method conn.log_info which obscures extra, and calling that in get_connection instead of debug_info.

The debug_info method itself is left unchanged.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Insignificant change, no new functionality

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
