### PR TITLE
[AIRFLOW-6261] flower_basic_auth eligible to _cmd

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -100,6 +100,7 @@ class AirflowConfigParser(ConfigParser):
         ('core', 'sql_alchemy_conn'),
         ('core', 'fernet_key'),
         ('celery', 'broker_url'),
+        ('celery', 'flower_basic_auth'),
         ('celery', 'result_backend'),
         ('atlas', 'password'),
         ('smtp', 'smtp_password'),

--- a/docs/howto/set-config.rst
+++ b/docs/howto/set-config.rst
@@ -52,6 +52,7 @@ The following config options support this ``_cmd`` version:
 * ``sql_alchemy_conn`` in ``[core]`` section
 * ``fernet_key`` in ``[core]`` section
 * ``broker_url`` in ``[celery]`` section
+* ``flower_basic_auth`` in ``[celery]`` section
 * ``result_backend`` in ``[celery]`` section
 * ``password`` in ``[atlas]`` section
 * ``smtp_password`` in ``[smtp]`` section


### PR DESCRIPTION
Make the configuration option flower_basic_auth from celery
available as the stdout of a command as it contains sensitive
information.