### PR TITLE
[AIRFLOW-XXX] Fix DebugExecutor docs

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -300,15 +300,15 @@ for debugging purposes. Using this executor you can run and debug DAGs from your
 
 **IDE setup steps:**
 
-1. Add ``main`` block at the end of your DAG file to make it runnable:
+1. Add ``main`` block at the end of your DAG file to make it runnable.
+It will run a backfill job:
 
-  .. code-block:: python
+.. code-block:: python
 
-    if __name__ == '__main__':
-      dag.clear(reset_dag_runs=True)
-      dag.run()
+  if __name__ == '__main__':
+    dag.clear(reset_dag_runs=True)
+    dag.run()
 
-   When you add those lines, running a DAG file will run a backfill job.
 
 2. Setup ``AIRFLOW__CORE__EXECUTOR=DebugExecutor`` in run configuration of your IDE. In
    this step you should also setup all environment variables required by your DAG.

--- a/docs/executor/debug.rst
+++ b/docs/executor/debug.rst
@@ -33,15 +33,15 @@ all other running or scheduled tasks fail immediately. To enable this option set
 
 **IDE setup steps:**
 
-1. Add ``main`` block at the end of your DAG file to make it runnable:
+1. Add ``main`` block at the end of your DAG file to make it runnable.
+It will run a backfill job:
 
-  .. code-block:: python
+.. code-block:: python
 
-    if __name__ == '__main__':
-      dag.clear(reset_dag_runs=True)
-      dag.run()
+  if __name__ == '__main__':
+    dag.clear(reset_dag_runs=True)
+    dag.run()
 
-   When you add those lines, running a DAG file will run a backfill job.
 
 2. Setup ``AIRFLOW__CORE__EXECUTOR=DebugExecutor`` in run configuration of your IDE. In
    this step you should also setup all environment variables required by your DAG.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
