### PR TITLE
[AIRFLOW-3189] Remove schema from get_uri response if None

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -74,8 +74,11 @@ class DbApiHook(BaseHook):
         host = conn.host
         if conn.port is not None:
             host += ':{port}'.format(port=conn.port)
-        return '{conn.conn_type}://{login}{host}/{conn.schema}'.format(
+        uri = '{conn.conn_type}://{login}{host}/'.format(
             conn=conn, login=login, host=host)
+        if conn.schema:
+            uri += conn.schema
+        return uri
 
     def get_sqlalchemy_engine(self, engine_kwargs=None):
         if engine_kwargs is None:

--- a/tests/hooks/test_dbapi_hook.py
+++ b/tests/hooks/test_dbapi_hook.py
@@ -22,6 +22,7 @@ import unittest
 from unittest import mock
 
 from airflow.hooks.dbapi_hook import DbApiHook
+from airflow.models import Connection
 
 
 class TestDbApiHook(unittest.TestCase):
@@ -149,3 +150,25 @@ class TestDbApiHook(unittest.TestCase):
         sql = "INSERT INTO {}  VALUES (%s)".format(table)
         for row in rows:
             self.cur.execute.assert_any_call(sql, row)
+
+    def test_get_uri_schema_not_none(self):
+        self.db_hook.get_connection = mock.MagicMock(return_value=Connection(
+            conn_type="conn_type",
+            host="host",
+            login="login",
+            password="password",
+            schema="schema",
+            port=1
+        ))
+        self.assertEqual("conn_type://login:password@host:1/schema", self.db_hook.get_uri())
+
+    def test_get_uri_schema_none(self):
+        self.db_hook.get_connection = mock.MagicMock(return_value=Connection(
+            conn_type="conn_type",
+            host="host",
+            login="login",
+            password="password",
+            schema=None,
+            port=1
+        ))
+        self.assertEqual("conn_type://login:password@host:1/", self.db_hook.get_uri())


### PR DESCRIPTION
"None" was appended to URI if schema=None. A check was added if
schema is None.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3189
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description
In DbApiHook method get_uri "None" was appended to uri when schema was not set. This PR adds check if schema is None.
- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_get_uri_schema_not_none and test_get_uri_schema_none in TestDbApiHook

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
