### PR TITLE
[AIRFLOW-6268] Prevent ajax calls when no dags present

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -53,13 +53,13 @@
                 <th>Owner</th>
                 <th style="padding-left: 5px;">Recent Tasks
                   <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Status of tasks from all active DAG runs or, if not currently active, from most recent run."></span>
-                  <img id="loading" width="15" src="{{ url_for("static", filename="loading.gif") }}">
+                  <img class="loading-task-stats" width="15" src="{{ url_for("static", filename="loading.gif") }}">
                 </th>
                 <th style="padding-left: 5px;">Last Run <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Execution Date/Time of Highest Dag Run."></span>
                 </th>
                 <th style="padding-left: 5px;">DAG Runs
                   <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Status of all previous DAG runs."></span>
-                  <img id="loading" width="15" src="{{ url_for("static", filename="loading.gif") }}">
+                  <img class="loading-dag-stats"  width="15" src="{{ url_for("static", filename="loading.gif") }}">
                 </th>
                 <th class="text-center">Links</th>
             </tr>
@@ -302,7 +302,8 @@
       circle_margin = 4;
       stroke_width = 2;
       stroke_width_hover = 6;
-      d3.json("{{ url_for('Airflow.blocked') }}", function(error, json) {
+
+      function blockedHandler(error, json) {
         $.each(json, function() {
           $('.label.schedule.' + this.dag_id)
           .attr('title', this.active_dag_run + '/' + this.max_active_runs + ' active dag runs')
@@ -312,8 +313,9 @@
             .css('background-color', 'red');
           }
         });
-      });
-      d3.json("{{ url_for('Airflow.last_dagruns') }}?dag_ids=" + (encoded_dag_ids.join(',')), function(error, json) {
+      }
+
+      function lastDagRunsHandler(error, json) {
         for(var safe_dag_id in json) {
           dag_id = json[safe_dag_id].dag_id;
           last_run = json[safe_dag_id].last_run;
@@ -327,8 +329,9 @@
           g.selectAll(".loading-last-run").remove();
         }
         d3.selectAll(".loading-last-run").remove();
-      });
-      d3.json("{{ url_for('Airflow.dag_stats') }}?dag_ids=" + (encoded_dag_ids.join(',')), function(error, json) {
+      }
+
+      function dagStatsHandler(error, json) {
         for(var dag_id in json) {
             states = json[dag_id];
             g = d3.select('svg#dag-run-' + dag_id.replace(/\./g, '__dot__'))
@@ -397,7 +400,7 @@
               .duration(500)
               .delay(function(d, i){return i*50;})
               .style("opacity", 1);
-            d3.select("#loading").remove();
+            d3.select(".loading-dag-stats").remove();
         }
         $("#pause_header").tooltip();
         $("#statuses_info").tooltip();
@@ -406,8 +409,9 @@
           html: true,
           container: "body",
         });
-      });
-      d3.json("{{ url_for('Airflow.task_stats') }}?dag_ids=" + (encoded_dag_ids.join(',')), function(error, json) {
+      }
+
+      function taskStatsHandler(error, json) {
         for(var dag_id in json) {
             states = json[dag_id];
             g = d3.select('svg#task-run-' + dag_id.replace(/\./g, '__dot__'))
@@ -476,7 +480,7 @@
               .duration(500)
               .delay(function(d, i){return i*50;})
               .style("opacity", 1);
-            d3.select("#loading").remove();
+            d3.select(".loading-task-stats").remove();
         }
         $("#pause_header").tooltip();
         $("#statuses_info").tooltip();
@@ -485,6 +489,20 @@
           html: true,
           container: "body",
         });
-      });
+      }
+
+      if (encoded_dag_ids.length > 0) {
+        // dags on page fetch stats
+        d3.json("{{ url_for('Airflow.blocked') }}", blockedHandler);
+        d3.json("{{ url_for('Airflow.last_dagruns') }}?dag_ids=" + (encoded_dag_ids.join(',')), lastDagRunsHandler);
+        d3.json("{{ url_for('Airflow.dag_stats') }}?dag_ids=" + (encoded_dag_ids.join(',')), dagStatsHandler);
+        d3.json("{{ url_for('Airflow.task_stats') }}?dag_ids=" + (encoded_dag_ids.join(',')), taskStatsHandler);
+      }
+      else {
+        // no dags, hide the loading gifs
+        $(".loading-task-stats").remove();
+        $(".loading-dag-stats").remove();
+      }
+
   </script>
 {% endblock %}


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-6268

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When searching for DAGs in the UI and no results are returned four AJAX requests are still issued (dag_stats, task_stasks, blocked and last_dagruns) which return the state of the entire the system.

This small changes prevents the AJAX requests being issued when there are no DAGs on the page.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

N/A no unit tests for frontend code at present. Tested locally.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

N/A
