### PR TITLE
[AIRFLOW-6270] Remove "good" errors from docs building

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -133,7 +133,8 @@ else
 fi
 
 
-SUCCEED_LINE=$(make html |\
+SUCCEED_LINE=$(make html 2>&1|\
+    grep -v "^None:.*indent.*" |\
     tee /dev/tty |\
     grep 'build succeeded' |\
     head -1)


### PR DESCRIPTION
When docs are build, errrors/warnigs are printed which might be confusing to
the user. The three lines:

None:3: (ERROR/3) Unexpected indentation.
None:9: (WARNING/2) Definition list ends without a blank line; unexpected unindent.
None:10: (WARNING/2) Block quote ends without a blank line; unexpected unindent.

Are always printed but they are not real errors - as an effect people think
that those are real errors that they have to fix (but they do not know how).

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6270

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
