### PR TITLE
[AIRFLOW-6270] Remove "good" errors from docs building

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -545,8 +545,8 @@ class CLIFactory:
         'user_import': Arg(
             ("import",),
             metavar="FILEPATH",
-            help="Import users from JSON file. Example format:" +
-                    textwrap.dedent('''
+            help="Import users from JSON file. Example format::\n" +
+                    textwrap.indent(textwrap.dedent('''
                     [
                         {
                             "email": "foo@bar.org",
@@ -555,7 +555,7 @@ class CLIFactory:
                             "roles": ["Public"],
                             "username": "jondoe"
                         }
-                    ]'''),
+                    ]'''), " " * 4),
         ),
         'user_export': Arg(
             ("export",),


### PR DESCRIPTION
When docs are build, errrors/warnigs are printed which might be confusing to
the user. The three lines:

None:3: (ERROR/3) Unexpected indentation.
None:9: (WARNING/2) Definition list ends without a blank line; unexpected unindent.
None:10: (WARNING/2) Block quote ends without a blank line; unexpected unindent.

They are always printed but they are always ignored because they does not affect CI.

---

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
