### PR TITLE
[AIRFLOW-6297] Add Airflow website link to UI docs

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -150,6 +150,10 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
             else:
                 airflow_doc_site = 'https://airflow.apache.org/docs/{}'.format(version.version)
 
+            appbuilder.add_link("Website",
+                                href='https://airflow.apache.org',
+                                category="Docs",
+                                category_icon="fa-globe")
             appbuilder.add_link("Documentation",
                                 href=airflow_doc_site,
                                 category="Docs",


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6297
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add Airflow website link to UI docs, screenshots below:

![](https://tva1.sinaimg.cn/large/006tNbRwgy1ga22vzjz3qj31na09iwgb.jpg)