### PR TITLE
[AIRFLOW-6104] [AIP-21] Rename Datastore opertors

### DIFF
--- a/airflow/contrib/operators/datastore_export_operator.py
+++ b/airflow/contrib/operators/datastore_export_operator.py
@@ -20,10 +20,24 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.operators.datastore import DatastoreExportOperator  # noqa
+from airflow.gcp.operators.datastore import CloudDatastoreExportEntitiesOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.datastore`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class DatastoreExportOperator(CloudDatastoreExportEntitiesOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.datastore.CloudDatastoreExportEntitiesOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.l
+            Please use `airflow.gcp.operators.datastore.CloudDatastoreExportEntitiesOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/datastore_import_operator.py
+++ b/airflow/contrib/operators/datastore_import_operator.py
@@ -20,10 +20,24 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.operators.datastore import DatastoreImportOperator  # noqa
+from airflow.gcp.operators.datastore import CloudDatastoreImportEntitiesOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.datastore`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class DatastoreImportOperator(CloudDatastoreImportEntitiesOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.datastore.CloudDatastoreImportEntitiesOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.datastore.CloudDatastoreImportEntitiesOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/gcp/example_dags/example_datastore.py
+++ b/airflow/gcp/example_dags/example_datastore.py
@@ -26,7 +26,9 @@ This example requires that your project contains Datastore instance.
 import os
 
 from airflow import models
-from airflow.gcp.operators.datastore import DatastoreExportOperator, DatastoreImportOperator
+from airflow.gcp.operators.datastore import (
+    CloudDatastoreExportEntitiesOperator, CloudDatastoreImportEntitiesOperator,
+)
 from airflow.utils import dates
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
@@ -39,7 +41,7 @@ with models.DAG(
     default_args=default_args,
     schedule_interval=None,  # Override to match your needs
 ) as dag:
-    export_task = DatastoreExportOperator(
+    export_task = CloudDatastoreExportEntitiesOperator(
         task_id="export_task",
         bucket=BUCKET,
         project_id=GCP_PROJECT_ID,
@@ -49,7 +51,7 @@ with models.DAG(
     bucket = "{{ task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[2] }}"
     file = "{{ '/'.join(task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[3:]) }}"
 
-    import_task = DatastoreImportOperator(
+    import_task = CloudDatastoreImportEntitiesOperator(
         task_id="import_task", bucket=bucket, file=file, project_id=GCP_PROJECT_ID
     )
 

--- a/airflow/gcp/operators/datastore.py
+++ b/airflow/gcp/operators/datastore.py
@@ -29,7 +29,7 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class DatastoreExportOperator(BaseOperator):
+class CloudDatastoreExportEntitiesOperator(BaseOperator):
     """
     Export entities from Google Cloud Datastore to Cloud Storage
 
@@ -116,7 +116,7 @@ class DatastoreExportOperator(BaseOperator):
         return result
 
 
-class DatastoreImportOperator(BaseOperator):
+class CloudDatastoreImportEntitiesOperator(BaseOperator):
     """
     Import entities from Cloud Storage to Google Cloud Datastore
 

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -171,11 +171,11 @@ OPERATOR = [
         "airflow.contrib.operators.dataflow_operator.DataflowTemplateOperator",
     ),
     (
-        "airflow.gcp.operators.datastore.DatastoreExportOperator",
+        "airflow.gcp.operators.datastore.CloudDatastoreExportEntitiesOperator",
         "airflow.contrib.operators.datastore_export_operator.DatastoreExportOperator",
     ),
     (
-        "airflow.gcp.operators.datastore.DatastoreImportOperator",
+        "airflow.gcp.operators.datastore.CloudDatastoreImportEntitiesOperator",
         "airflow.contrib.operators.datastore_import_operator.DatastoreImportOperator",
     ),
     (


### PR DESCRIPTION
Rename Datastore operators

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6104
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
