### PR TITLE
[AIRFLOW-6308] Unpin Kombu for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ cassandra = [
 celery = [
     'celery~=4.3',
     'flower>=0.7.3, <1.0',
-    'kombu==4.6.3',
+    'kombu==4.6.3;python_version<"3.0"',
     'tornado>=4.2.0, <6.0',  # Dep of flower. Pin to a version that works on Py3.5.2
 ]
 cgroups = [


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-6308


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

I get the following message when installing Airflow with celery. `pip install apache-airflow[celery]==1.10.7rc1`

```
/Users/kaxilnaik/Library/Caches/pip/wheels/41/25/09/b031a72c5a49481397652b172f561c44aa87a12e679922158f
Successfully built alembic unicodecsv sqlalchemy psutil flask-admin pyrsistent sqlalchemy-utils
ERROR: celery 4.4.0 has requirement kombu<4.7,>=4.6.7, but you'll have kombu 4.6.3 which is incompatible.
Installing collected packages: attrs, six, more-itertools, zipp, importlib-metadata, pyrsistent, jsonschema, docutils, lockfile, python-daemon, typing-extensions, MarkupSafe, jinja2, Werkzeug, itsdangerous, click, flask, certifi, urllib3, idna, chardet, requests, sqlalchemy, Mako, python-editor, python-dateutil, alembic, unicodecsv, cached-property, tabulate, text-unidecode, pytz, tzlocal, pytzdata, pendulum, WTForms, flask-wtf, psutil, configparser, croniter, sqlalchemy-jsonfield, flask-caching, cattrs, future, iso8601, colorlog, thrift, setproctitle, gunicorn, funcsigs, lazy-object-proxy, PyJWT, Flask-JWT-Extended, Flask-SQLAlchemy, prison, marshmallow, sqlalchemy-utils, marshmallow-enum, babel, Flask-Babel, defusedxml, python3-openid, Flask-OpenID, PyYAML, apispec, colorama, marshmallow-sqlalchemy, flask-login, flask-appbuilder, graphviz, termcolor, zope.deprecation, argcomplete, markdown, tenacity, dill, numpy, pandas, flask-admin, pygments, json-merge-patch, flask-swagger, tornado, billiard, vine, amqp, kombu, celery, flower, apache-airflow
Successfully installed Flask-Babel-0.12.2 Flask-JWT-Extended-3.24.1 Flask-OpenID-1.2.5 Flask-SQLAlchemy-2.4.1 Mako-1.1.0 MarkupSafe-1.1.1 PyJWT-1.7.1 PyYAML-5.2 WTForms-2.2.1 Werkzeug-0.16.0 alembic-1.3.2 amqp-2.5.2 apache-airflow-1.10.7rc1 apispec-1.3.3 argcomplete-1.10.3 attrs-19.3.0 babel-2.7.0 billiard-3.6.1.0 cached-property-1.5.1 cattrs-0.9.0 celery-4.4.0 certifi-2019.11.28 chardet-3.0.4 click-7.0 colorama-0.4.3 colorlog-4.0.2 configparser-3.5.3 croniter-0.3.30 defusedxml-0.6.0 dill-0.3.1.1 docutils-0.15.2 flask-1.1.1 flask-admin-1.5.4 flask-appbuilder-2.2.1 flask-caching-1.3.3 flask-login-0.4.1 flask-swagger-0.2.13 flask-wtf-0.14.2 flower-0.9.3 funcsigs-1.0.2 future-0.16.0 graphviz-0.13.2 gunicorn-19.10.0 idna-2.8 importlib-metadata-1.3.0 iso8601-0.1.12 itsdangerous-1.1.0 jinja2-2.10.3 json-merge-patch-0.2 jsonschema-3.2.0 kombu-4.6.3 lazy-object-proxy-1.4.3 lockfile-0.12.2 markdown-2.6.11 marshmallow-2.19.5 marshmallow-enum-1.5.1 marshmallow-sqlalchemy-0.18.0 more-itertools-8.0.2 numpy-1.17.4 pandas-0.25.3 pendulum-1.4.4 prison-0.1.2 psutil-5.6.7 pygments-2.5.2 pyrsistent-0.15.6 python-daemon-2.1.2 python-dateutil-2.8.1 python-editor-1.0.4 python3-openid-3.1.0 pytz-2019.3 pytzdata-2019.3 requests-2.22.0 setproctitle-1.1.10 six-1.13.0 sqlalchemy-1.3.12 sqlalchemy-jsonfield-0.9.0 sqlalchemy-utils-0.36.0 tabulate-0.8.6 tenacity-4.12.0 termcolor-1.1.0 text-unidecode-1.2 thrift-0.13.0 tornado-5.1.1 typing-extensions-3.7.4.1 tzlocal-1.5.1 unicodecsv-0.14.1 urllib3-1.25.7 vine-1.3.0 zipp-0.6.0 zope.deprecation-4.4.0
```

**Note**: This is not blocking issue for 1.10.7

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
