### PR TITLE
[AIRFLOW-XXXX] Fix downgrade function of db migration 0e2a74e0fc9f

### DIFF
--- a/airflow/migrations/versions/0e2a74e0fc9f_add_time_zone_awareness.py
+++ b/airflow/migrations/versions/0e2a74e0fc9f_add_time_zone_awareness.py
@@ -345,7 +345,7 @@ def downgrade():
 
         op.alter_column(
             table_name="import_error",
-            column_name="DATETIME",
+            column_name="timestamp",
             type_=mysql.DATETIME(fsp=6),
         )
 
@@ -375,7 +375,7 @@ def downgrade():
             nullable=False,
         )
         op.alter_column(
-            table_name="sla_miss", column_name="DATETIME", type_=mysql.DATETIME(fsp=6)
+            table_name="sla_miss", column_name="timestamp", type_=mysql.DATETIME(fsp=6)
         )
 
         op.alter_column(
@@ -415,7 +415,7 @@ def downgrade():
         )
 
         op.alter_column(
-            table_name="xcom", column_name="DATETIME", type_=mysql.DATETIME(fsp=6)
+            table_name="xcom", column_name="timestamp", type_=mysql.DATETIME(fsp=6)
         )
         op.alter_column(
             table_name="xcom", column_name="execution_date", type_=mysql.DATETIME(fsp=6)


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The db migration rev 0e2a74e0fc9f has a few invalid column names in its downgrade steps. Obviously there's no 'DATETIME' column in the tables and they should be 'timestamp' (as you can see in the upgrade steps). 
I think when the file was coded the author did a replace all and didn't check what was replaced.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just fixing typos 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


