### PR TITLE
[AIRFLOW-6311] Remove python2 from codebase

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -183,11 +183,8 @@ def configure_orm(disable_connection_pool=False):
         engine_args['max_overflow'] = max_overflow
 
     # Allow the user to specify an encoding for their DB otherwise default
-    # to utf-8 so jobs & users with non-latin1 characters can still use
-    # us.
+    # to utf-8 so jobs & users with non-latin1 characters can still use us.
     engine_args['encoding'] = conf.get('core', 'SQL_ENGINE_ENCODING', fallback='utf-8')
-    # For Python2 we get back a newstr and need a str
-    engine_args['encoding'] = engine_args['encoding'].__str__()
 
     if conf.has_option('core', 'sql_alchemy_connect_args'):
         connect_args = import_string(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-6311


### Description

-  Remove workaround for python2 `newstr` from settings.py
- Change default python interpreter for dataflow to python3, given that support is mostly finished. and they are also about to sunset python2 in 2020, ( thought the timeline has not been set yet)
    - Dataflow python3 support roadmap: https://issues.apache.org/jira/browse/BEAM-1251#comment-16979381]
    - Python2 sunset schedule: https://issues.apache.org/jira/browse/BEAM-8371
    - Apache-beam sign (without detailed timeline) on https://python3statement.org/
- It depends on when will this be merged in. We may also drop the `py_interpreter` all together

