### PR TITLE
[AIRFLOW-6313] Unify example or doc dag owner

### DIFF
--- a/airflow/contrib/example_dags/example_azure_container_instances_operator.py
+++ b/airflow/contrib/example_dags/example_azure_container_instances_operator.py
@@ -25,7 +25,7 @@ from airflow import DAG
 from airflow.contrib.operators.azure_container_instances_operator import AzureContainerInstancesOperator
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': datetime(2018, 11, 1),
     'email': ['airflow@example.com'],

--- a/airflow/contrib/example_dags/example_azure_cosmosdb_sensor.py
+++ b/airflow/contrib/example_dags/example_azure_cosmosdb_sensor.py
@@ -33,7 +33,7 @@ from airflow.contrib.sensors.azure_cosmos_sensor import AzureCosmosDocumentSenso
 from airflow.utils import dates
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': dates.days_ago(2),
     'email': ['airflow@example.com'],

--- a/airflow/contrib/example_dags/example_databricks_operator.py
+++ b/airflow/contrib/example_dags/example_databricks_operator.py
@@ -37,7 +37,7 @@ from airflow import DAG
 from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'email': ['airflow@example.com'],
     'depends_on_past': False,
     'start_date': airflow.utils.dates.days_ago(2)

--- a/airflow/contrib/example_dags/example_dingding_operator.py
+++ b/airflow/contrib/example_dags/example_dingding_operator.py
@@ -26,7 +26,7 @@ from airflow import DAG
 from airflow.contrib.operators.dingding_operator import DingdingOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'retries': 3,
     'start_date': airflow.utils.dates.days_ago(2)
 }

--- a/airflow/contrib/example_dags/example_emr_job_flow_automatic_steps.py
+++ b/airflow/contrib/example_dags/example_emr_job_flow_automatic_steps.py
@@ -27,7 +27,7 @@ from airflow.contrib.operators.emr_create_job_flow_operator import EmrCreateJobF
 from airflow.contrib.sensors.emr_job_flow_sensor import EmrJobFlowSensor
 
 DEFAULT_ARGS = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': airflow.utils.dates.days_ago(2),
     'email': ['airflow@example.com'],

--- a/airflow/contrib/example_dags/example_emr_job_flow_manual_steps.py
+++ b/airflow/contrib/example_dags/example_emr_job_flow_manual_steps.py
@@ -32,7 +32,7 @@ from airflow.contrib.operators.emr_terminate_job_flow_operator import EmrTermina
 from airflow.contrib.sensors.emr_step_sensor import EmrStepSensor
 
 DEFAULT_ARGS = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': airflow.utils.dates.days_ago(2),
     'email': ['airflow@example.com'],

--- a/airflow/contrib/example_dags/example_kubernetes_executor.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor.py
@@ -26,7 +26,7 @@ from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2)
 }
 

--- a/airflow/contrib/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor_config.py
@@ -27,7 +27,7 @@ from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2)
 }
 

--- a/airflow/contrib/example_dags/example_kubernetes_operator.py
+++ b/airflow/contrib/example_dags/example_kubernetes_operator.py
@@ -31,7 +31,7 @@ try:
     from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
     default_args = {
-        'owner': 'Airflow',
+        'owner': 'airflow',
         'start_date': days_ago(2)
     }
 

--- a/airflow/contrib/example_dags/example_papermill_operator.py
+++ b/airflow/contrib/example_dags/example_papermill_operator.py
@@ -29,7 +29,7 @@ from airflow.models import DAG
 from airflow.operators.papermill_operator import PapermillOperator
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2)
 }
 

--- a/airflow/contrib/example_dags/example_qubole_operator.py
+++ b/airflow/contrib/example_dags/example_qubole_operator.py
@@ -38,7 +38,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator, PythonOperator
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': airflow.utils.dates.days_ago(2),
     'email': ['airflow@example.com'],

--- a/airflow/contrib/example_dags/example_qubole_sensor.py
+++ b/airflow/contrib/example_dags/example_qubole_sensor.py
@@ -33,7 +33,7 @@ from airflow.contrib.sensors.qubole_sensor import QuboleFileSensor, QubolePartit
 from airflow.utils import dates
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': dates.days_ago(2),
     'email': ['airflow@example.com'],

--- a/airflow/contrib/example_dags/example_winrm_operator.py
+++ b/airflow/contrib/example_dags/example_winrm_operator.py
@@ -38,7 +38,7 @@ from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2)
 }
 

--- a/airflow/example_dags/docker_copy_data.py
+++ b/airflow/example_dags/docker_copy_data.py
@@ -35,7 +35,7 @@ TODO: Review the workflow, change it accordingly to
 # from airflow.operators.docker_operator import DockerOperator
 #
 # default_args = {
-#     'owner': 'Airflow',
+#     'owner': 'airflow',
 #     'depends_on_past': False,
 #     'start_date': airflow.utils.dates.days_ago(2),
 #     'email': ['airflow@example.com'],

--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -27,7 +27,7 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
 }
 

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -27,7 +27,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
 }
 

--- a/airflow/example_dags/example_branch_python_dop_operator_3.py
+++ b/airflow/example_dags/example_branch_python_dop_operator_3.py
@@ -28,7 +28,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
     'depends_on_past': True,
 }

--- a/airflow/example_dags/example_docker_operator.py
+++ b/airflow/example_dags/example_docker_operator.py
@@ -24,7 +24,7 @@ from datetime import timedelta
 from airflow.operators.docker_operator import DockerOperator
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': airflow.utils.dates.days_ago(2),
     'email': ['airflow@example.com'],

--- a/airflow/example_dags/example_gcs_to_bq.py
+++ b/airflow/example_dags/example_gcs_to_bq.py
@@ -25,7 +25,7 @@ from airflow.operators import bash_operator
 from airflow.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2)
 }
 

--- a/airflow/example_dags/example_http_operator.py
+++ b/airflow/example_dags/example_http_operator.py
@@ -28,7 +28,7 @@ from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.sensors.http_sensor import HttpSensor
 
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': airflow.utils.dates.days_ago(2),
     'email': ['airflow@example.com'],

--- a/airflow/example_dags/example_pig_operator.py
+++ b/airflow/example_dags/example_pig_operator.py
@@ -24,7 +24,7 @@ from airflow.models import DAG
 from airflow.operators.pig_operator import PigOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
 }
 

--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -27,7 +27,7 @@ from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator, PythonVirtualenvOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
 }
 

--- a/airflow/example_dags/example_short_circuit_operator.py
+++ b/airflow/example_dags/example_short_circuit_operator.py
@@ -25,7 +25,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import ShortCircuitOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
 }
 

--- a/airflow/example_dags/example_skip_dag.py
+++ b/airflow/example_dags/example_skip_dag.py
@@ -25,7 +25,7 @@ from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
 }
 

--- a/airflow/example_dags/example_subdag_operator.py
+++ b/airflow/example_dags/example_subdag_operator.py
@@ -28,7 +28,7 @@ from airflow.operators.subdag_operator import SubDagOperator
 DAG_NAME = 'example_subdag_operator'
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
 }
 

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -30,7 +30,7 @@ from airflow.operators.python_operator import PythonOperator
 
 dag = DAG(
     dag_id="example_trigger_target_dag",
-    default_args={"start_date": airflow.utils.dates.days_ago(2), "owner": "Airflow"},
+    default_args={"start_date": airflow.utils.dates.days_ago(2), "owner": "airflow"},
     schedule_interval=None,
 )
 

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -24,7 +24,7 @@ from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2),
 }
 

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -31,7 +31,7 @@ from airflow.operators.bash_operator import BashOperator
 # These args will get passed on to each operator
 # You can override them on a per-task basis during operator initialization
 default_args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'depends_on_past': False,
     'start_date': airflow.utils.dates.days_ago(2),
     'email': ['airflow@example.com'],

--- a/airflow/gcp/operators/dataflow.py
+++ b/airflow/gcp/operators/dataflow.py
@@ -55,7 +55,7 @@ class DataFlowJavaOperator(BaseOperator):
     **Example**: ::
 
         default_args = {
-            'owner': 'Airflow',
+            'owner': 'airflow',
             'depends_on_past': False,
             'start_date':
                 (2016, 8, 1),

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -92,7 +92,7 @@ any of its operators. This makes it easy to apply a common parameter to many ope
 
     default_args = {
         'start_date': datetime(2016, 1, 1),
-        'owner': 'Airflow'
+        'owner': 'airflow'
     }
 
     dag = DAG('my_dag', default_args=default_args)

--- a/docs/dag-run.rst
+++ b/docs/dag-run.rst
@@ -94,7 +94,7 @@ in the configuration file. When turned off, the scheduler creates a DAG run only
 
 
     default_args = {
-        'owner': 'Airflow',
+        'owner': 'airflow',
         'depends_on_past': False,
         'email': ['airflow@example.com'],
         'email_on_failure': False,

--- a/docs/lineage.rst
+++ b/docs/lineage.rst
@@ -40,7 +40,7 @@ works.
     FILE_CATEGORIES = ["CAT1", "CAT2", "CAT3"]
 
     args = {
-        'owner': 'Airflow',
+        'owner': 'airflow',
         'start_date': airflow.utils.dates.days_ago(2)
     }
 

--- a/docs/timezone.rst
+++ b/docs/timezone.rst
@@ -77,7 +77,7 @@ words if you have a default time zone setting of ``Europe/Amsterdam`` and create
 
     default_args=dict(
         start_date=datetime(2016, 1, 1),
-        owner='Airflow'
+        owner='airflow'
     )
 
     dag = DAG('my_dag', default_args=default_args)
@@ -122,7 +122,7 @@ using ``pendulum``.
 
     default_args=dict(
         start_date=datetime(2016, 1, 1, tzinfo=local_tz),
-        owner='Airflow'
+        owner='airflow'
     )
 
     dag = DAG('my_tz_dag', default_args=default_args)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -42,7 +42,7 @@ complicated, a line by line explanation follows below.
 
 
     default_args = {
-        'owner': 'Airflow',
+        'owner': 'airflow',
         'depends_on_past': False,
         'start_date': datetime(2015, 6, 1),
         'email': ['airflow@example.com'],
@@ -133,7 +133,7 @@ of default parameters that we can use when creating tasks.
     from datetime import datetime, timedelta
 
     default_args = {
-        'owner': 'Airflow',
+        'owner': 'airflow',
         'depends_on_past': False,
         'start_date': datetime(2015, 6, 1),
         'email': ['airflow@example.com'],
@@ -318,7 +318,7 @@ something like this:
 
 
     default_args = {
-        'owner': 'Airflow',
+        'owner': 'airflow',
         'depends_on_past': False,
         'start_date': datetime(2015, 6, 1),
         'email': ['airflow@example.com'],

--- a/scripts/perf/dags/perf_dag_1.py
+++ b/scripts/perf/dags/perf_dag_1.py
@@ -26,7 +26,7 @@ from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(3),
 }
 

--- a/scripts/perf/dags/perf_dag_2.py
+++ b/scripts/perf/dags/perf_dag_2.py
@@ -26,7 +26,7 @@ from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
 
 args = {
-    'owner': 'Airflow',
+    'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(3),
 }
 


### PR DESCRIPTION
We already change Airflow DAG default owner to 'airflow'
in https://github.com/apache/airflow/pull/4151 but some
of our example DAGs and docs are still using
owner = 'Airflow', This patch to unify them

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6313
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We already change Airflow DAG default owner to 'airflow'
in https://github.com/apache/airflow/pull/4151 but some
of our example DAGs and docs are still using
owner = 'Airflow', This patch to unify them

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Non need

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
