### PR TITLE
[AIRFLOW-6315] Create .airflow_db_initialised always in tests dir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,9 @@ def breeze_test_helper(request):
     # Setup test environment for breeze
     home = os.environ.get("HOME")
     airflow_home = os.environ.get("AIRFLOW_HOME") or os.path.join(home, "airflow")
-    os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.path.join(home, "tests", "dags")
+    tests_directory = os.path.dirname(os.path.realpath(__file__))
+
+    os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.path.join(tests_directory, "dags")
     os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
     os.environ["AWS_DEFAULT_REGION"] = (
         os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,19 +75,18 @@ def breeze_test_helper(request):
     print(" AIRFLOW ".center(60, "="))
 
     # Setup test environment for breeze
-    home = os.getcwd()
-    airflow_home = os.environ.get("AIRFLOW_HOME") or home
-    os.environ["AIRFLOW_SOURCES"] = home
+    home = os.environ.get("HOME")
+    airflow_home = os.environ.get("AIRFLOW_HOME") or os.path.join(home, "airflow")
     os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.path.join(home, "tests", "dags")
     os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
     os.environ["AWS_DEFAULT_REGION"] = (
         os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
     )
 
-    print(f"Airflow home {airflow_home}\nHome of the user: {home}")
+    print(f"Home of the user: {home}\nAirflow home {airflow_home}")
 
     # Initialize Airflow db if required
-    pid_file = os.path.join(home, ".airflow_db_initialised")
+    lock_file = os.path.join(airflow_home, ".airflow_db_initialised")
     if request.config.option.db_init:
         print("Initializing the DB - forced with --with-db-init switch.")
         try:
@@ -95,7 +94,7 @@ def breeze_test_helper(request):
         except:  # pylint: disable=bare-except # noqa
             print("Skipping db initialization because database already exists.")
         db.resetdb()
-    elif not os.path.exists(pid_file):
+    elif not os.path.exists(lock_file):
         print(
             "Initializing the DB - first time after entering the container.\n"
             "You can force re-initialization the database by adding --with-db-init switch to run-tests."
@@ -106,7 +105,7 @@ def breeze_test_helper(request):
             print("Skipping db initialization because database already exists.")
         db.resetdb()
         # Create pid file
-        with open(pid_file, "w+"):
+        with open(lock_file, "w+"):
             pass
     else:
         print(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6315

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

I observed that directory where `. airflow_db_initialised` file is created depends on where is the test we run. The file is used by `breeze_test_helper` to keep information that db has been initialised. 
This change will keep the file always in root directory fo tests. 

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
