### PR TITLE
[AIRFLOW-6319] Add support for AWS Athena workgroups

### DIFF
--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -54,7 +54,7 @@ class AWSAthenaHook(AwsHook):
             self.conn = self.get_client_type('athena')
         return self.conn
 
-    def run_query(self, query, query_context, result_configuration, client_request_token=None):
+    def run_query(self, query, query_context, result_configuration, client_request_token=None, workgroup='default'):
         """
         Run Presto query on athena with provided config and return submitted query_execution_id
 
@@ -66,12 +66,15 @@ class AWSAthenaHook(AwsHook):
         :type result_configuration: dict
         :param client_request_token: Unique token created by user to avoid multiple executions of same query
         :type client_request_token: str
+        :param workgroup: Athena workgroup name, when not specified, will be 'default'
+        :type workgroup: str
         :return: str
         """
         response = self.get_conn().start_query_execution(QueryString=query,
                                                          ClientRequestToken=client_request_token,
                                                          QueryExecutionContext=query_context,
-                                                         ResultConfiguration=result_configuration)
+                                                         ResultConfiguration=result_configuration,
+                                                         Workgroup=workgroup)
         query_execution_id = response['QueryExecutionId']
         return query_execution_id
 

--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -54,7 +54,8 @@ class AWSAthenaHook(AwsHook):
             self.conn = self.get_client_type('athena')
         return self.conn
 
-    def run_query(self, query, query_context, result_configuration, client_request_token=None, workgroup='default'):
+    def run_query(self, query, query_context, result_configuration, client_request_token=None,
+                  workgroup='default'):
         """
         Run Presto query on athena with provided config and return submitted query_execution_id
 

--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -52,6 +52,7 @@ class AWSAthenaOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self, query, database, output_location, aws_conn_id='aws_default', client_request_token=None,
+                 workgroup='default',
                  query_execution_context=None, result_configuration=None, sleep_time=30, max_tries=None,
                  *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -60,6 +61,7 @@ class AWSAthenaOperator(BaseOperator):
         self.output_location = output_location
         self.aws_conn_id = aws_conn_id
         self.client_request_token = client_request_token or str(uuid4())
+        self.workgroup = workgroup
         self.query_execution_context = query_execution_context or {}
         self.result_configuration = result_configuration or {}
         self.sleep_time = sleep_time
@@ -79,7 +81,8 @@ class AWSAthenaOperator(BaseOperator):
         self.query_execution_context['Database'] = self.database
         self.result_configuration['OutputLocation'] = self.output_location
         self.query_execution_id = self.hook.run_query(self.query, self.query_execution_context,
-                                                      self.result_configuration, self.client_request_token)
+                                                      self.result_configuration, self.client_request_token,
+                                                      self.workgroup)
         query_status = self.hook.poll_query_status(self.query_execution_id, self.max_tries)
 
         if query_status in AWSAthenaHook.FAILURE_STATES:

--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -34,7 +34,8 @@ MOCK_DATA = {
     'query': 'SELECT * FROM TEST_TABLE',
     'database': 'TEST_DATABASE',
     'outputLocation': 's3://test_s3_bucket/',
-    'client_request_token': 'eac427d0-1c6d-4dfb-96aa-2835d3ac6595'
+    'client_request_token': 'eac427d0-1c6d-4dfb-96aa-2835d3ac6595',
+    'workgroup': 'default'
 }
 
 query_context = {
@@ -77,7 +78,7 @@ class TestAWSAthenaOperator(unittest.TestCase):
     def test_hook_run_small_success_query(self, mock_conn, mock_run_query, mock_check_query_status):
         self.athena.execute(None)
         mock_run_query.assert_called_once_with(MOCK_DATA['query'], query_context, result_configuration,
-                                               MOCK_DATA['client_request_token'])
+                                               MOCK_DATA['client_request_token'], MOCK_DATA['workgroup'])
         self.assertEqual(mock_check_query_status.call_count, 1)
 
     @mock.patch.object(AWSAthenaHook, 'check_query_status', side_effect=("RUNNING", "RUNNING", "SUCCESS",))
@@ -86,7 +87,7 @@ class TestAWSAthenaOperator(unittest.TestCase):
     def test_hook_run_big_success_query(self, mock_conn, mock_run_query, mock_check_query_status):
         self.athena.execute(None)
         mock_run_query.assert_called_once_with(MOCK_DATA['query'], query_context, result_configuration,
-                                               MOCK_DATA['client_request_token'])
+                                               MOCK_DATA['client_request_token'], MOCK_DATA['workgroup'])
         self.assertEqual(mock_check_query_status.call_count, 3)
 
     @mock.patch.object(AWSAthenaHook, 'check_query_status', side_effect=(None, None,))
@@ -96,7 +97,7 @@ class TestAWSAthenaOperator(unittest.TestCase):
         with self.assertRaises(Exception):
             self.athena.execute(None)
         mock_run_query.assert_called_once_with(MOCK_DATA['query'], query_context, result_configuration,
-                                               MOCK_DATA['client_request_token'])
+                                               MOCK_DATA['client_request_token'], MOCK_DATA['workgroup'])
         self.assertEqual(mock_check_query_status.call_count, 3)
 
     @mock.patch.object(AWSAthenaHook, 'get_state_change_reason')
@@ -108,7 +109,7 @@ class TestAWSAthenaOperator(unittest.TestCase):
         with self.assertRaises(Exception):
             self.athena.execute(None)
         mock_run_query.assert_called_once_with(MOCK_DATA['query'], query_context, result_configuration,
-                                               MOCK_DATA['client_request_token'])
+                                               MOCK_DATA['client_request_token'], MOCK_DATA['workgroup'])
         self.assertEqual(mock_check_query_status.call_count, 2)
         self.assertEqual(mock_get_state_change_reason.call_count, 1)
 
@@ -119,7 +120,7 @@ class TestAWSAthenaOperator(unittest.TestCase):
         with self.assertRaises(Exception):
             self.athena.execute(None)
         mock_run_query.assert_called_once_with(MOCK_DATA['query'], query_context, result_configuration,
-                                               MOCK_DATA['client_request_token'])
+                                               MOCK_DATA['client_request_token'], MOCK_DATA['workgroup'])
         self.assertEqual(mock_check_query_status.call_count, 3)
 
     @mock.patch.object(AWSAthenaHook, 'check_query_status', side_effect=("RUNNING", "RUNNING", "RUNNING",))
@@ -129,7 +130,7 @@ class TestAWSAthenaOperator(unittest.TestCase):
         with self.assertRaises(Exception):
             self.athena.execute(None)
         mock_run_query.assert_called_once_with(MOCK_DATA['query'], query_context, result_configuration,
-                                               MOCK_DATA['client_request_token'])
+                                               MOCK_DATA['client_request_token'], MOCK_DATA['workgroup'])
         self.assertEqual(mock_check_query_status.call_count, 3)
 
     @mock.patch.object(AWSAthenaHook, 'check_query_status', side_effect=("SUCCESS",))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://jira.apache.org/jira/browse/AIRFLOW-6319

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The AWS Athena hooks ans operators currently do not provide the ability to use workgroups for running queries. More on the feature here - https://docs.aws.amazon.com/athena/latest/ug/workgroups.html & https://docs.aws.amazon.com/athena/latest/ug/user-created-workgroups.html

I propose we add the ability to pass in workgroup names while creating the Athena connection. The default workgroup name in Athena is `default` - so we can make that the parameter default when a workgroup is not passed in by the user. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I have not added more tests but modified existing tests to use a `default` workgroup. I would like suggestions on how to add tests that use a non-default workgroup. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
