### PR TITLE
[AIRFLOW-6106] [AIP-21] Rename GCP compute operators

### DIFF
--- a/airflow/contrib/hooks/gcp_compute_hook.py
+++ b/airflow/contrib/hooks/gcp_compute_hook.py
@@ -20,8 +20,7 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.hooks.compute import ComputeEngineHook  # noqa
+from airflow.gcp.hooks.compute import ComputeEngineHook
 
 warnings.warn(
     "This module is deprecated. Please use airflow.gcp.hooks.compute`",

--- a/airflow/contrib/operators/gcp_compute_operator.py
+++ b/airflow/contrib/operators/gcp_compute_operator.py
@@ -20,14 +20,97 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.operators.compute import (  # noqa
-    GceBaseOperator, GceInstanceGroupManagerUpdateTemplateOperator, GceInstanceStartOperator,
-    GceInstanceStopOperator, GceInstanceTemplateCopyOperator, GceSetMachineTypeOperator,
-    GcpBodyFieldSanitizer, GcpBodyFieldValidator,
+from airflow.gcp.operators.compute import (
+    ComputeEngineBaseOperator, ComputeEngineCopyInstanceTemplateOperator,
+    ComputeEngineInstanceGroupUpdateManagerTemplateOperator, ComputeEngineSetMachineTypeOperator,
+    ComputeEngineStartInstanceOperator, ComputeEngineStopInstanceOperator,
 )
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.compute`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GceBaseOperator(ComputeEngineBaseOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.compute.ComputeEngineBaseOperator`.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.compute.ComputeEngineBaseOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GceInstanceGroupManagerUpdateTemplateOperator(ComputeEngineInstanceGroupUpdateManagerTemplateOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.compute.ComputeEngineInstanceGroupUpdateManagerTemplateOperator`.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated. Please use
+            `airflow.gcp.operators.compute.ComputeEngineInstanceGroupUpdateManagerTemplateOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GceInstanceStartOperator(ComputeEngineStartInstanceOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.compute.ComputeEngineStartInstanceOperator`.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.compute.ComputeEngineStartInstanceOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GceInstanceStopOperator(ComputeEngineStopInstanceOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.compute.ComputeEngineStopInstanceOperator`.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.compute.ComputeEngineStopInstanceOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GceInstanceTemplateCopyOperator(ComputeEngineCopyInstanceTemplateOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.compute.ComputeEngineCopyInstanceTemplateOperator`.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """"This class is deprecated.
+            Please use `airflow.gcp.operators.compute.ComputeEngineCopyInstanceTemplateOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GceSetMachineTypeOperator(ComputeEngineSetMachineTypeOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.compute.ComputeEngineSetMachineTypeOperator`.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.compute.ComputeEngineSetMachineTypeOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/gcp/example_dags/example_compute.py
+++ b/airflow/gcp/example_dags/example_compute.py
@@ -35,7 +35,8 @@ import os
 import airflow
 from airflow import models
 from airflow.gcp.operators.compute import (
-    GceInstanceStartOperator, GceInstanceStopOperator, GceSetMachineTypeOperator,
+    ComputeEngineSetMachineTypeOperator, ComputeEngineStartInstanceOperator,
+    ComputeEngineStopInstanceOperator,
 )
 
 # [START howto_operator_gce_args_common]
@@ -62,7 +63,7 @@ with models.DAG(
     schedule_interval=None  # Override to match your needs
 ) as dag:
     # [START howto_operator_gce_start]
-    gce_instance_start = GceInstanceStartOperator(
+    gce_instance_start = ComputeEngineStartInstanceOperator(
         project_id=GCP_PROJECT_ID,
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
@@ -71,14 +72,14 @@ with models.DAG(
     # [END howto_operator_gce_start]
     # Duplicate start for idempotence testing
     # [START howto_operator_gce_start_no_project_id]
-    gce_instance_start2 = GceInstanceStartOperator(
+    gce_instance_start2 = ComputeEngineStartInstanceOperator(
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
         task_id='gcp_compute_start_task2'
     )
     # [END howto_operator_gce_start_no_project_id]
     # [START howto_operator_gce_stop]
-    gce_instance_stop = GceInstanceStopOperator(
+    gce_instance_stop = ComputeEngineStopInstanceOperator(
         project_id=GCP_PROJECT_ID,
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
@@ -87,14 +88,14 @@ with models.DAG(
     # [END howto_operator_gce_stop]
     # Duplicate stop for idempotence testing
     # [START howto_operator_gce_stop_no_project_id]
-    gce_instance_stop2 = GceInstanceStopOperator(
+    gce_instance_stop2 = ComputeEngineStopInstanceOperator(
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
         task_id='gcp_compute_stop_task2'
     )
     # [END howto_operator_gce_stop_no_project_id]
     # [START howto_operator_gce_set_machine_type]
-    gce_set_machine_type = GceSetMachineTypeOperator(
+    gce_set_machine_type = ComputeEngineSetMachineTypeOperator(
         project_id=GCP_PROJECT_ID,
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
@@ -104,7 +105,7 @@ with models.DAG(
     # [END howto_operator_gce_set_machine_type]
     # Duplicate set machine type for idempotence testing
     # [START howto_operator_gce_set_machine_type_no_project_id]
-    gce_set_machine_type2 = GceSetMachineTypeOperator(
+    gce_set_machine_type2 = ComputeEngineSetMachineTypeOperator(
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
         body=SET_MACHINE_TYPE_BODY,

--- a/airflow/gcp/example_dags/example_compute_igm.py
+++ b/airflow/gcp/example_dags/example_compute_igm.py
@@ -44,7 +44,7 @@ import os
 import airflow
 from airflow import models
 from airflow.gcp.operators.compute import (
-    GceInstanceGroupManagerUpdateTemplateOperator, GceInstanceTemplateCopyOperator,
+    ComputeEngineCopyInstanceTemplateOperator, ComputeEngineInstanceGroupUpdateManagerTemplateOperator,
 )
 
 # [START howto_operator_compute_igm_common_args]
@@ -102,7 +102,7 @@ with models.DAG(
     schedule_interval=None  # Override to match your needs
 ) as dag:
     # [START howto_operator_gce_igm_copy_template]
-    gce_instance_template_copy = GceInstanceTemplateCopyOperator(
+    gce_instance_template_copy = ComputeEngineCopyInstanceTemplateOperator(
         project_id=GCP_PROJECT_ID,
         resource_id=GCE_TEMPLATE_NAME,
         body_patch=GCE_INSTANCE_TEMPLATE_BODY_UPDATE,
@@ -111,7 +111,7 @@ with models.DAG(
     # [END howto_operator_gce_igm_copy_template]
     # Added to check for idempotence
     # [START howto_operator_gce_igm_copy_template_no_project_id]
-    gce_instance_template_copy2 = GceInstanceTemplateCopyOperator(
+    gce_instance_template_copy2 = ComputeEngineCopyInstanceTemplateOperator(
         resource_id=GCE_TEMPLATE_NAME,
         body_patch=GCE_INSTANCE_TEMPLATE_BODY_UPDATE,
         task_id='gcp_compute_igm_copy_template_task_2'
@@ -119,7 +119,7 @@ with models.DAG(
     # [END howto_operator_gce_igm_copy_template_no_project_id]
     # [START howto_operator_gce_igm_update_template]
     gce_instance_group_manager_update_template = \
-        GceInstanceGroupManagerUpdateTemplateOperator(
+        ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
             zone=GCE_ZONE,
@@ -132,7 +132,7 @@ with models.DAG(
     # Added to check for idempotence (and without UPDATE_POLICY)
     # [START howto_operator_gce_igm_update_template_no_project_id]
     gce_instance_group_manager_update_template2 = \
-        GceInstanceGroupManagerUpdateTemplateOperator(
+        ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
             zone=GCE_ZONE,
             source_template=SOURCE_TEMPLATE_URL,

--- a/airflow/gcp/operators/compute.py
+++ b/airflow/gcp/operators/compute.py
@@ -34,7 +34,7 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class GceBaseOperator(BaseOperator):
+class ComputeEngineBaseOperator(BaseOperator):
     """
     Abstract base operator for Google Compute Engine operators to inherit from.
     """
@@ -67,13 +67,13 @@ class GceBaseOperator(BaseOperator):
         pass
 
 
-class GceInstanceStartOperator(GceBaseOperator):
+class ComputeEngineStartInstanceOperator(ComputeEngineBaseOperator):
     """
     Starts an instance in Google Compute Engine.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GceInstanceStartOperator`
+        :ref:`howto/operator:ComputeEngineStartInstanceOperator`
 
     :param zone: Google Cloud Platform zone where the instance exists.
     :type zone: str
@@ -115,13 +115,13 @@ class GceInstanceStartOperator(GceBaseOperator):
                                    project_id=self.project_id)
 
 
-class GceInstanceStopOperator(GceBaseOperator):
+class ComputeEngineStopInstanceOperator(ComputeEngineBaseOperator):
     """
     Stops an instance in Google Compute Engine.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GceInstanceStopOperator`
+        :ref:`howto/operator:ComputeEngineStopInstanceOperator`
 
     :param zone: Google Cloud Platform zone where the instance exists.
     :type zone: str
@@ -168,14 +168,14 @@ SET_MACHINE_TYPE_VALIDATION_SPECIFICATION = [
 ]
 
 
-class GceSetMachineTypeOperator(GceBaseOperator):
+class ComputeEngineSetMachineTypeOperator(ComputeEngineBaseOperator):
     """
     Changes the machine type for a stopped instance to the machine type specified in
         the request.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GceSetMachineTypeOperator`
+        :ref:`howto/operator:ComputeEngineSetMachineTypeOperator`
 
     :param zone: Google Cloud Platform zone where the instance exists.
     :type zone: str
@@ -282,13 +282,13 @@ GCE_INSTANCE_TEMPLATE_FIELDS_TO_SANITIZE = [
 ]
 
 
-class GceInstanceTemplateCopyOperator(GceBaseOperator):
+class ComputeEngineCopyInstanceTemplateOperator(ComputeEngineBaseOperator):
     """
     Copies the instance template, applying specified changes.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GceInstanceTemplateCopyOperator`
+        :ref:`howto/operator:ComputeEngineCopyInstanceTemplateOperator`
 
     :param resource_id: Name of the Instance Template
     :type resource_id: str
@@ -391,7 +391,7 @@ class GceInstanceTemplateCopyOperator(GceBaseOperator):
                                           project_id=self.project_id)
 
 
-class GceInstanceGroupManagerUpdateTemplateOperator(GceBaseOperator):
+class ComputeEngineInstanceGroupUpdateManagerTemplateOperator(ComputeEngineBaseOperator):
     """
     Patches the Instance Group Manager, replacing source template URL with the
     destination one. API V1 does not have update/patch operations for Instance
@@ -399,7 +399,7 @@ class GceInstanceGroupManagerUpdateTemplateOperator(GceBaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GceInstanceGroupManagerUpdateTemplateOperator`
+        :ref:`howto/operator:ComputeEngineInstanceGroupUpdateManagerTemplateOperator`
 
     :param resource_id: Name of the Instance Group Manager
     :type resource_id: str

--- a/docs/howto/operator/gcp/compute.rst
+++ b/docs/howto/operator/gcp/compute.rst
@@ -29,13 +29,13 @@ Prerequisite Tasks
 
 .. include:: _partials/prerequisite_tasks.rst
 
-.. _howto/operator:GceInstanceStartOperator:
+.. _howto/operator:ComputeEngineStartInstanceOperator:
 
-GceInstanceStartOperator
-------------------------
+ComputeEngineStartInstanceOperator
+----------------------------------
 
 Use the
-:class:`~airflow.gcp.operators.compute.GceInstanceStartOperator`
+:class:`~airflow.gcp.operators.compute.ComputeEngineStartInstanceOperator`
 to start an existing Google Compute Engine instance.
 
 
@@ -85,15 +85,15 @@ More information
 See Google Compute Engine API documentation to `start an instance
 <https://cloud.google.com/compute/docs/reference/rest/v1/instances/start>`_.
 
-.. _howto/operator:GceInstanceStopOperator:
+.. _howto/operator:ComputeEngineStopInstanceOperator:
 
-GceInstanceStopOperator
------------------------
+ComputeEngineStopInstanceOperator
+---------------------------------
 
 Use the operator to stop Google Compute Engine instance.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.compute.GceInstanceStopOperator`
+:class:`~airflow.gcp.operators.compute.ComputeEngineStopInstanceOperator`
 
 Arguments
 """""""""
@@ -140,15 +140,15 @@ More information
 See Google Compute Engine API documentation to `stop an instance
 <https://cloud.google.com/compute/docs/reference/rest/v1/instances/stop>`_.
 
-.. _howto/operator:GceSetMachineTypeOperator:
+.. _howto/operator:ComputeEngineSetMachineTypeOperator:
 
-GceSetMachineTypeOperator
--------------------------
+ComputeEngineSetMachineTypeOperator
+-----------------------------------
 
 Use the operator to change machine type of a Google Compute Engine instance.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.compute.GceSetMachineTypeOperator`.
+:class:`~airflow.gcp.operators.compute.ComputeEngineSetMachineTypeOperator`.
 
 Arguments
 """""""""
@@ -201,16 +201,16 @@ More information
 See Google Compute Engine API documentation to `set the machine type
 <https://cloud.google.com/compute/docs/reference/rest/v1/instances/setMachineType>`_.
 
-.. _howto/operator:GceInstanceTemplateCopyOperator:
+.. _howto/operator:ComputeEngineCopyInstanceTemplateOperator:
 
-GceInstanceTemplateCopyOperator
--------------------------------
+ComputeEngineCopyInstanceTemplateOperator
+-----------------------------------------
 
 Use the operator to copy an existing Google Compute Engine instance template
 applying a patch to it.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.compute.GceInstanceTemplateCopyOperator`.
+:class:`~airflow.gcp.operators.compute.ComputeEngineCopyInstanceTemplateOperator`.
 
 Arguments
 """""""""
@@ -262,15 +262,15 @@ More information
 See Google Compute Engine API documentation to `create a new instance with an existing template
 <https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates>`_.
 
-.. _howto/operator:GceInstanceGroupManagerUpdateTemplateOperator:
+.. _howto/operator:ComputeEngineInstanceGroupUpdateManagerTemplateOperator:
 
-GceInstanceGroupManagerUpdateTemplateOperator
----------------------------------------------
+ComputeEngineInstanceGroupUpdateManagerTemplateOperator
+-------------------------------------------------------
 
 Use the operator to update a template in Google Compute Engine Instance Group Manager.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.compute.GceInstanceGroupManagerUpdateTemplateOperator`.
+:class:`~airflow.gcp.operators.compute.ComputeEngineInstanceGroupUpdateManagerTemplateOperator`.
 
 Arguments
 """""""""
@@ -320,7 +320,7 @@ Templating
 Troubleshooting
 """""""""""""""
 
-You might find that your GceInstanceGroupManagerUpdateTemplateOperator fails with
+You might find that your ComputeEngineInstanceGroupUpdateManagerTemplateOperator fails with
 missing permissions. To execute the operation, the service account requires
 the permissions that theService Account User role provides
 (assigned via Google Cloud IAM).

--- a/tests/gcp/operators/test_compute.py
+++ b/tests/gcp/operators/test_compute.py
@@ -28,8 +28,9 @@ from googleapiclient.errors import HttpError
 
 from airflow import AirflowException
 from airflow.gcp.operators.compute import (
-    GceInstanceGroupManagerUpdateTemplateOperator, GceInstanceStartOperator, GceInstanceStopOperator,
-    GceInstanceTemplateCopyOperator, GceSetMachineTypeOperator,
+    ComputeEngineCopyInstanceTemplateOperator, ComputeEngineInstanceGroupUpdateManagerTemplateOperator,
+    ComputeEngineSetMachineTypeOperator, ComputeEngineStartInstanceOperator,
+    ComputeEngineStopInstanceOperator,
 )
 from airflow.models import DAG, TaskInstance
 from airflow.utils import timezone
@@ -52,7 +53,7 @@ class TestGceInstanceStart(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_instance_start(self, mock_hook):
         mock_hook.return_value.start_instance.return_value = True
-        op = GceInstanceStartOperator(
+        op = ComputeEngineStartInstanceOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=RESOURCE_ID,
@@ -75,7 +76,7 @@ class TestGceInstanceStart(unittest.TestCase):
             'start_date': DEFAULT_DATE
         }
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GceInstanceStartOperator(
+        op = ComputeEngineStartInstanceOperator(
             project_id='{{ dag.dag_id }}',
             zone='{{ dag.dag_id }}',
             resource_id='{{ dag.dag_id }}',
@@ -95,7 +96,7 @@ class TestGceInstanceStart(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_start_should_throw_ex_when_missing_project_id(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceInstanceStartOperator(
+            op = ComputeEngineStartInstanceOperator(
                 project_id="",
                 zone=GCE_ZONE,
                 resource_id=RESOURCE_ID,
@@ -108,7 +109,7 @@ class TestGceInstanceStart(unittest.TestCase):
 
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_start_should_not_throw_ex_when_project_id_none(self, _):
-        op = GceInstanceStartOperator(
+        op = ComputeEngineStartInstanceOperator(
             zone=GCE_ZONE,
             resource_id=RESOURCE_ID,
             task_id='id'
@@ -118,7 +119,7 @@ class TestGceInstanceStart(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_start_should_throw_ex_when_missing_zone(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceInstanceStartOperator(
+            op = ComputeEngineStartInstanceOperator(
                 project_id=GCP_PROJECT_ID,
                 zone="",
                 resource_id=RESOURCE_ID,
@@ -132,7 +133,7 @@ class TestGceInstanceStart(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_start_should_throw_ex_when_missing_resource_id(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceInstanceStartOperator(
+            op = ComputeEngineStartInstanceOperator(
                 project_id=GCP_PROJECT_ID,
                 zone=GCE_ZONE,
                 resource_id="",
@@ -147,7 +148,7 @@ class TestGceInstanceStart(unittest.TestCase):
 class TestGceInstanceStop(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_instance_stop(self, mock_hook):
-        op = GceInstanceStopOperator(
+        op = ComputeEngineStopInstanceOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=RESOURCE_ID,
@@ -169,7 +170,7 @@ class TestGceInstanceStop(unittest.TestCase):
             'start_date': DEFAULT_DATE
         }
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GceInstanceStopOperator(
+        op = ComputeEngineStopInstanceOperator(
             project_id='{{ dag.dag_id }}',
             zone='{{ dag.dag_id }}',
             resource_id='{{ dag.dag_id }}',
@@ -189,7 +190,7 @@ class TestGceInstanceStop(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_stop_should_throw_ex_when_missing_project_id(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceInstanceStopOperator(
+            op = ComputeEngineStopInstanceOperator(
                 project_id="",
                 zone=GCE_ZONE,
                 resource_id=RESOURCE_ID,
@@ -202,7 +203,7 @@ class TestGceInstanceStop(unittest.TestCase):
 
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_stop_should_not_throw_ex_when_project_id_none(self, mock_hook):
-        op = GceInstanceStopOperator(
+        op = ComputeEngineStopInstanceOperator(
             zone=GCE_ZONE,
             resource_id=RESOURCE_ID,
             task_id='id'
@@ -217,7 +218,7 @@ class TestGceInstanceStop(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_stop_should_throw_ex_when_missing_zone(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceInstanceStopOperator(
+            op = ComputeEngineStopInstanceOperator(
                 project_id=GCP_PROJECT_ID,
                 zone="",
                 resource_id=RESOURCE_ID,
@@ -231,7 +232,7 @@ class TestGceInstanceStop(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_stop_should_throw_ex_when_missing_resource_id(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceInstanceStopOperator(
+            op = ComputeEngineStopInstanceOperator(
                 project_id=GCP_PROJECT_ID,
                 zone=GCE_ZONE,
                 resource_id="",
@@ -247,7 +248,7 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_set_machine_type(self, mock_hook):
         mock_hook.return_value.set_machine_type.return_value = True
-        op = GceSetMachineTypeOperator(
+        op = ComputeEngineSetMachineTypeOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=RESOURCE_ID,
@@ -273,7 +274,7 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
             'start_date': DEFAULT_DATE
         }
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GceSetMachineTypeOperator(
+        op = ComputeEngineSetMachineTypeOperator(
             project_id='{{ dag.dag_id }}',
             zone='{{ dag.dag_id }}',
             resource_id='{{ dag.dag_id }}',
@@ -294,7 +295,7 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_set_machine_type_should_throw_ex_when_missing_project_id(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceSetMachineTypeOperator(
+            op = ComputeEngineSetMachineTypeOperator(
                 project_id="",
                 zone=GCE_ZONE,
                 resource_id=RESOURCE_ID,
@@ -308,7 +309,7 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
 
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_set_machine_type_should_not_throw_ex_when_project_id_none(self, mock_hook):
-        op = GceSetMachineTypeOperator(
+        op = ComputeEngineSetMachineTypeOperator(
             zone=GCE_ZONE,
             resource_id=RESOURCE_ID,
             body=SET_MACHINE_TYPE_BODY,
@@ -327,7 +328,7 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_set_machine_type_should_throw_ex_when_missing_zone(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceSetMachineTypeOperator(
+            op = ComputeEngineSetMachineTypeOperator(
                 project_id=GCP_PROJECT_ID,
                 zone="",
                 resource_id=RESOURCE_ID,
@@ -342,7 +343,7 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_set_machine_type_should_throw_ex_when_missing_resource_id(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceSetMachineTypeOperator(
+            op = ComputeEngineSetMachineTypeOperator(
                 project_id=GCP_PROJECT_ID,
                 zone=GCE_ZONE,
                 resource_id="",
@@ -357,7 +358,7 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_set_machine_type_should_throw_ex_when_missing_machine_type(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GceSetMachineTypeOperator(
+            op = ComputeEngineSetMachineTypeOperator(
                 project_id=GCP_PROJECT_ID,
                 zone=GCE_ZONE,
                 resource_id=RESOURCE_ID,
@@ -404,7 +405,7 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
         _check_zone_operation_status.return_value = ast.literal_eval(
             self.MOCK_OP_RESPONSE)
         with self.assertRaises(AirflowException) as cm:
-            op = GceSetMachineTypeOperator(
+            op = ComputeEngineSetMachineTypeOperator(
                 project_id=GCP_PROJECT_ID,
                 zone=GCE_ZONE,
                 resource_id=RESOURCE_ID,
@@ -524,7 +525,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET,
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             task_id='id',
@@ -547,7 +548,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET,
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             task_id='id',
             body_patch={"name": GCE_INSTANCE_TEMPLATE_NEW_NAME}
@@ -567,7 +568,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         mock_hook.return_value.get_instance_template.side_effect = [
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             task_id='id',
@@ -586,7 +587,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET,
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             request_id=GCE_INSTANCE_TEMPLATE_REQUEST_ID,
@@ -610,7 +611,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET,
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             request_id=GCE_INSTANCE_TEMPLATE_REQUEST_ID,
@@ -638,7 +639,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET,
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             task_id='id',
@@ -668,7 +669,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET,
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             task_id='id',
@@ -698,7 +699,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET,
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             task_id='id',
@@ -751,7 +752,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET,
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
-        op = GceInstanceTemplateCopyOperator(
+        op = ComputeEngineCopyInstanceTemplateOperator(
             project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_TEMPLATE_NAME,
             task_id='id',
@@ -813,7 +814,7 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
             GCE_INSTANCE_TEMPLATE_BODY_GET_NEW
         ]
         with self.assertRaises(AirflowException) as cm:
-            op = GceInstanceTemplateCopyOperator(
+            op = ComputeEngineCopyInstanceTemplateOperator(
                 project_id=GCP_PROJECT_ID,
                 resource_id=GCE_INSTANCE_TEMPLATE_NAME,
                 request_id=GCE_INSTANCE_TEMPLATE_REQUEST_ID,
@@ -932,7 +933,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
     def test_successful_instance_group_update(self, mock_hook):
         mock_hook.return_value.get_instance_group_manager.return_value = \
             deepcopy(GCE_INSTANCE_GROUP_MANAGER_GET)
-        op = GceInstanceGroupManagerUpdateTemplateOperator(
+        op = ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
@@ -956,7 +957,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
     def test_successful_instance_group_update_missing_project_id(self, mock_hook):
         mock_hook.return_value.get_instance_group_manager.return_value = \
             deepcopy(GCE_INSTANCE_GROUP_MANAGER_GET)
-        op = GceInstanceGroupManagerUpdateTemplateOperator(
+        op = ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             zone=GCE_ZONE,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
             task_id='id',
@@ -981,7 +982,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
         del instance_group_manager_no_template['instanceTemplate']
         mock_hook.return_value.get_instance_group_manager.return_value = \
             instance_group_manager_no_template
-        op = GceInstanceGroupManagerUpdateTemplateOperator(
+        op = ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
@@ -1010,7 +1011,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
         del instance_group_manager_no_versions['versions']
         mock_hook.return_value.get_instance_group_manager.return_value = \
             instance_group_manager_no_versions
-        op = GceInstanceGroupManagerUpdateTemplateOperator(
+        op = ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
@@ -1037,7 +1038,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
     def test_successful_instance_group_update_with_update_policy(self, mock_hook):
         mock_hook.return_value.get_instance_group_manager.return_value = \
             deepcopy(GCE_INSTANCE_GROUP_MANAGER_GET)
-        op = GceInstanceGroupManagerUpdateTemplateOperator(
+        op = ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
@@ -1065,7 +1066,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
     def test_successful_instance_group_update_with_request_id(self, mock_hook):
         mock_hook.return_value.get_instance_group_manager.return_value = \
             deepcopy(GCE_INSTANCE_GROUP_MANAGER_GET)
-        op = GceInstanceGroupManagerUpdateTemplateOperator(
+        op = ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
@@ -1089,7 +1090,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
     @mock.patch('airflow.gcp.operators.compute.ComputeEngineHook')
     def test_try_to_use_api_v1(self, _):
         with self.assertRaises(AirflowException) as cm:
-            GceInstanceGroupManagerUpdateTemplateOperator(
+            ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
                 project_id=GCP_PROJECT_ID,
                 zone=GCE_ZONE,
                 resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
@@ -1105,7 +1106,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
     def test_try_to_use_non_existing_template(self, mock_hook):
         mock_hook.return_value.get_instance_group_manager.return_value = \
             deepcopy(GCE_INSTANCE_GROUP_MANAGER_GET)
-        op = GceInstanceGroupManagerUpdateTemplateOperator(
+        op = ComputeEngineInstanceGroupUpdateManagerTemplateOperator(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -207,28 +207,28 @@ OPERATOR = [
         "airflow.contrib.operators.gcp_cloud_build_operator.CloudBuildCreateBuildOperator",
     ),
     (
-        "airflow.gcp.operators.compute.GceBaseOperator",
+        "airflow.gcp.operators.compute.ComputeEngineBaseOperator",
         "airflow.contrib.operators.gcp_compute_operator.GceBaseOperator",
     ),
     (
-        "airflow.gcp.operators.compute.GceInstanceGroupManagerUpdateTemplateOperator",
+        "airflow.gcp.operators.compute.ComputeEngineInstanceGroupUpdateManagerTemplateOperator",
         "airflow.contrib.operators.gcp_compute_operator."
         "GceInstanceGroupManagerUpdateTemplateOperator",
     ),
     (
-        "airflow.gcp.operators.compute.GceInstanceStartOperator",
+        "airflow.gcp.operators.compute.ComputeEngineStartInstanceOperator",
         "airflow.contrib.operators.gcp_compute_operator.GceInstanceStartOperator",
     ),
     (
-        "airflow.gcp.operators.compute.GceInstanceStopOperator",
+        "airflow.gcp.operators.compute.ComputeEngineStopInstanceOperator",
         "airflow.contrib.operators.gcp_compute_operator.GceInstanceStopOperator",
     ),
     (
-        "airflow.gcp.operators.compute.GceInstanceTemplateCopyOperator",
+        "airflow.gcp.operators.compute.ComputeEngineCopyInstanceTemplateOperator",
         "airflow.contrib.operators.gcp_compute_operator.GceInstanceTemplateCopyOperator",
     ),
     (
-        "airflow.gcp.operators.compute.GceSetMachineTypeOperator",
+        "airflow.gcp.operators.compute.ComputeEngineSetMachineTypeOperator",
         "airflow.contrib.operators.gcp_compute_operator.GceSetMachineTypeOperator",
     ),
     (


### PR DESCRIPTION
Rename GCP compute operators.
### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6106
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
