### PR TITLE
[AIRFLOW-6322] Add pytest.mark.slow marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -31,3 +31,6 @@ norecursedirs =
 faulthandler_timeout = 480
 log_print = True
 log_level = INFO
+
+markers =
+    slow: slow test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6322

### Description

- [x] This adds a pytest marker for slow tests
  - related to https://github.com/apache/airflow/pull/6811#discussion_r360658365

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - this PR needs to be accepted before the marker can be used in tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - none required for this PR
