### PR TITLE
[AIRFLOW-6331] Pylint: Disable Missing Module Docstring

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -170,6 +170,7 @@ disable=print-statement,
         fixme,  # There should be a good reason for adding a TODO
         pointless-statement,  # Is raised on the bitshift operator. Could be disabled only on /example_dags after https://github.com/PyCQA/pylint/projects/1.
         ungrouped-imports,  # Disabled to avoid conflict with isort import order rules, which is enabled in the project.
+        missing-module-docstring,
         import-outside-toplevel,    # We import outside toplevel to avoid cyclic imports
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6331

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

With pylint 2.4 and above you can differentiate between the various missing-docstring by using the three following sub-messages:

```
C0114 (missing-module-docstring)
C0115 (missing-class-docstring)
C0116 (missing-function-docstring)
```

Docstrings that start "This is module foobar." It is already self-evident what this module is. Restating it is redundant and prone to going out of date if the module ever changes name.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
