### PR TITLE
[AIRFLOW-6346] Enhance dag default_view and orientation

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -56,7 +56,7 @@
     {% endif %}
     <ul class="nav nav-pills">
       {% if dag.parent_dag is defined and dag.parent_dag %}
-          <li class="never_active"><a href="{{ url_for('Airflow.' + dag.get_default_view(), dag_id=dag.parent_dag.dag_id, base_date=base_date_arg, execution_date=execution_date_arg) }}">
+          <li class="never_active"><a href="{{ url_for('Airflow.' + dag.default_view, dag_id=dag.parent_dag.dag_id, base_date=base_date_arg, execution_date=execution_date_arg) }}">
               <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
               Back to {{ dag.parent_dag.dag_id }}</a>
           </li>
@@ -141,7 +141,7 @@
         </div>
         <div class="modal-body">
           <div id="div_btn_subdag">
-            <a id="btn_subdag" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.' + dag.get_default_view()) }}">
+            <a id="btn_subdag" type="button" class="btn btn-primary" data-base-url="{{ url_for('Airflow.' + dag.default_view) }}">
                 Zoom into Sub DAG
               </a>
               <hr/>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -99,7 +99,7 @@
                 <!-- Column 3: Name -->
                 <td>
                     <span>
-                      <a href="{{ url_for('Airflow.'+ dag.get_default_view(), dag_id=dag.dag_id) }}" title="{{ dag.description }}">
+                      <a href="{{ url_for('Airflow.'+ dag.default_view, dag_id=dag.dag_id) }}" title="{{ dag.description }}">
                           {{ dag.dag_id }}
                       </a>
                     </span>

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -109,6 +109,48 @@ class TestDag(unittest.TestCase):
         params_combined.update(params2)
         self.assertEqual(params_combined, dag.params)
 
+    def test_dag_invalid_default_view(self):
+        """
+        Test invalid `default_view` of DAG initialization
+        """
+        with self.assertRaisesRegex(AirflowException,
+                                    'Invalid values of dag.default_view: only support'):
+            models.DAG(
+                dag_id='test-invalid-default_view',
+                default_view='airflow'
+            )
+
+    def test_dag_default_view_default_value(self):
+        """
+        Test `default_view` default value of DAG initialization
+        """
+        dag = models.DAG(
+            dag_id='test-default_default_view'
+        )
+        self.assertEqual(conf.get('webserver', 'dag_default_view').lower(),
+                         dag._default_view)
+
+    def test_dag_invalid_orientation(self):
+        """
+        Test invalid `orientation` of DAG initialization
+        """
+        with self.assertRaisesRegex(AirflowException,
+                                    'Invalid values of dag.orientation: only support'):
+            models.DAG(
+                dag_id='test-invalid-orientation',
+                orientation='airflow'
+            )
+
+    def test_dag_orientation_default_value(self):
+        """
+        Test `orientation` default value of DAG initialization
+        """
+        dag = models.DAG(
+            dag_id='test-default_orientation'
+        )
+        self.assertEqual(conf.get('webserver', 'dag_orientation'),
+                         dag.orientation)
+
     def test_dag_as_context_manager(self):
         """
         Test DAG as a context manager.
@@ -756,8 +798,8 @@ class TestDag(unittest.TestCase):
         self.assertEqual(set(orm_dag.owners.split(', ')), {'owner1', 'owner2'})
         self.assertEqual(orm_dag.last_scheduler_run, now)
         self.assertTrue(orm_dag.is_active)
-        self.assertIsNone(orm_dag.default_view)
-        self.assertEqual(orm_dag.get_default_view(),
+        self.assertIsNotNone(orm_dag.default_view)
+        self.assertEqual(orm_dag.default_view,
                          conf.get('webserver', 'dag_default_view').lower())
         self.assertEqual(orm_dag.safe_dag_id, 'dag')
 
@@ -794,7 +836,7 @@ class TestDag(unittest.TestCase):
 
         orm_dag = session.query(DagModel).filter(DagModel.dag_id == 'dag').one()
         self.assertIsNotNone(orm_dag.default_view)
-        self.assertEqual(orm_dag.get_default_view(), "graph")
+        self.assertEqual(orm_dag.default_view, "graph")
         session.close()
 
     @patch('airflow.models.dag.DagBag')


### PR DESCRIPTION
* Only DEFAULT_VIEW_PRESETS are acceptable
* Only ORIENTATION_PRESETS are acceptable
* Use webserver.dag_default_view in airflow.cfg as default value
* Remove DAG and DagModel function get_default_view
* Rename _default_value to default_value

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6346

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

* Only DEFAULT_VIEW_PRESETS are acceptable
* Only ORIENTATION_PRESETS are acceptable
* Use webserver.dag_default_view in airflow.cfg as default value
* Remove DAG and DagModel function get_default_view
* Rename _default_value to default_value

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
