### PR TITLE
[AIRFLOW-6345] Ensure arguments to ProxyFix are integers

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -49,11 +49,11 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
         app.wsgi_app = ProxyFix(
             app.wsgi_app,
             num_proxies=conf.get("webserver", "PROXY_FIX_NUM_PROXIES", fallback=None),
-            x_for=conf.get("webserver", "PROXY_FIX_X_FOR", fallback=1),
-            x_proto=conf.get("webserver", "PROXY_FIX_X_PROTO", fallback=1),
-            x_host=conf.get("webserver", "PROXY_FIX_X_HOST", fallback=1),
-            x_port=conf.get("webserver", "PROXY_FIX_X_PORT", fallback=1),
-            x_prefix=conf.get("webserver", "PROXY_FIX_X_PREFIX", fallback=1)
+            x_for=conf.getint("webserver", "PROXY_FIX_X_FOR", fallback=1),
+            x_proto=conf.getint("webserver", "PROXY_FIX_X_PROTO", fallback=1),
+            x_host=conf.getint("webserver", "PROXY_FIX_X_HOST", fallback=1),
+            x_port=conf.getint("webserver", "PROXY_FIX_X_PORT", fallback=1),
+            x_prefix=conf.getint("webserver", "PROXY_FIX_X_PREFIX", fallback=1)
         )
     app.secret_key = conf.get('webserver', 'SECRET_KEY')
 

--- a/tests/www/test_app.py
+++ b/tests/www/test_app.py
@@ -36,11 +36,11 @@ class TestApp(unittest.TestCase):
     def test_constructor_proxyfix(self):
         app, _ = application.create_app(session=Session, testing=True)
         self.assertTrue(isinstance(app.wsgi_app, ProxyFix))
-        self.assertEqual(app.wsgi_app.x_for, '1')
-        self.assertEqual(app.wsgi_app.x_proto, '1')
-        self.assertEqual(app.wsgi_app.x_host, '1')
-        self.assertEqual(app.wsgi_app.x_port, '1')
-        self.assertEqual(app.wsgi_app.x_prefix, '1')
+        self.assertEqual(app.wsgi_app.x_for, 1)
+        self.assertEqual(app.wsgi_app.x_proto, 1)
+        self.assertEqual(app.wsgi_app.x_host, 1)
+        self.assertEqual(app.wsgi_app.x_port, 1)
+        self.assertEqual(app.wsgi_app.x_prefix, 1)
 
     @conf_vars({('webserver', 'enable_proxy_fix'): 'True',
                 ('webserver', 'proxy_fix_x_for'): '3',
@@ -51,8 +51,8 @@ class TestApp(unittest.TestCase):
     def test_constructor_proxyfix_args(self):
         app, _ = application.create_app(session=Session, testing=True)
         self.assertTrue(isinstance(app.wsgi_app, ProxyFix))
-        self.assertEqual(app.wsgi_app.x_for, '3')
-        self.assertEqual(app.wsgi_app.x_proto, '4')
-        self.assertEqual(app.wsgi_app.x_host, '5')
-        self.assertEqual(app.wsgi_app.x_port, '6')
-        self.assertEqual(app.wsgi_app.x_prefix, '7')
+        self.assertEqual(app.wsgi_app.x_for, 3)
+        self.assertEqual(app.wsgi_app.x_proto, 4)
+        self.assertEqual(app.wsgi_app.x_host, 5)
+        self.assertEqual(app.wsgi_app.x_port, 6)
+        self.assertEqual(app.wsgi_app.x_prefix, 7)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6345

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This fixes a type mismatch between the string value returned by the Airflow configuration module, and the integer expected by Werkzeug.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests updated to reflect requirement for integers

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
