### PR TITLE
[AIRFLOW-6361] Run LocalTaskJob directly in Celery task

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -23,11 +23,11 @@ import argparse
 import os
 import textwrap
 from argparse import RawTextHelpFormatter
-from typing import Callable
+from typing import Callable, List
 
 from tabulate import tabulate_formats
 
-from airflow import api, settings
+from airflow import AirflowException, api, settings
 from airflow.configuration import conf
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.utils.cli import alternative_conn_specs
@@ -1063,3 +1063,26 @@ class CLIFactory:
 def get_parser():
     """Calls static method inside factory which creates argument parser"""
     return CLIFactory.get_parser()
+
+
+def exec_airflow_command(command_to_exec: List[str]):
+    """
+    Execute command using CLI.
+
+    The command is run in the current process and thread.
+
+    :param command_to_exec: list of program arguments. The first element should contain the "airflow" element.
+    :type command_to_exec List[str]
+    """
+    parser = CLIFactory.get_parser()
+
+    if not command_to_exec:
+        raise AirflowException("You should specify the program argument using `command_to_exec` parameter.")
+
+    if command_to_exec[0] != "airflow":
+        raise AirflowException('The first element must be equal to "airflow".')
+
+    # drop "airflow"
+    command_to_exec = command_to_exec[1:]
+    args = parser.parse_args(command_to_exec)
+    args.func(args)

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1076,9 +1076,6 @@ def exec_airflow_command(command_to_exec: List[str]):
     """
     parser = CLIFactory.get_parser()
 
-    if not command_to_exec:
-        raise AirflowException("You should specify the program argument using `command_to_exec` parameter.")
-
     if command_to_exec[0] != "airflow":
         raise AirflowException('The first element must be equal to "airflow".')
 

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -25,7 +25,7 @@ import textwrap
 from argparse import RawTextHelpFormatter
 from typing import Callable, List, Optional
 
-from setproctitle import setproctitle
+from setproctitle import setproctitle  # pylint: disable=no-name-in-module
 from tabulate import tabulate_formats
 
 from airflow import AirflowException, api, settings

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -17,8 +17,6 @@
 # under the License.
 """Celery executor."""
 import math
-import os
-import subprocess
 import time
 import traceback
 from multiprocessing import Pool, cpu_count
@@ -27,6 +25,7 @@ from typing import Any, List, Optional, Tuple, Union
 from celery import Celery, Task, states as celery_states
 from celery.result import AsyncResult
 
+from airflow.bin.cli import CLIFactory
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
@@ -63,13 +62,13 @@ def execute_command(command_to_exec: CommandType) -> None:
     """Executes command."""
     log = LoggingMixin().log
     log.info("Executing command in Celery: %s", command_to_exec)
-    env = os.environ.copy()
     try:
-        subprocess.check_call(command_to_exec, stderr=subprocess.STDOUT,
-                              close_fds=True, env=env)
-    except subprocess.CalledProcessError as e:
-        log.exception('execute_command encountered a CalledProcessError')
-        log.error(e.output)
+        parser = CLIFactory.get_parser()
+        # drop "airflow"
+        command_to_exec = command_to_exec[1:]
+        args = parser.parse_args(command_to_exec)
+        args.func(args)
+    except:  # pylint: disable=bare-except # noqa: E722
         raise AirflowException('Celery command failed')
 
 

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -25,7 +25,7 @@ from typing import Any, List, Optional, Tuple, Union
 from celery import Celery, Task, states as celery_states
 from celery.result import AsyncResult
 
-from airflow.bin.cli import CLIFactory
+from airflow.bin.cli import exec_airflow_command
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
@@ -63,11 +63,7 @@ def execute_command(command_to_exec: CommandType) -> None:
     log = LoggingMixin().log
     log.info("Executing command in Celery: %s", command_to_exec)
     try:
-        parser = CLIFactory.get_parser()
-        # drop "airflow"
-        command_to_exec = command_to_exec[1:]
-        args = parser.parse_args(command_to_exec)
-        args.func(args)
+        exec_airflow_command(command_to_exec)
     except:  # pylint: disable=bare-except # noqa: E722
         raise AirflowException('Celery command failed')
 

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -22,7 +22,6 @@ import os
 
 import psutil
 
-from airflow.bin.cli import exec_airflow_command
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.helpers import reap_process_group
 
@@ -53,7 +52,7 @@ class StandardTaskRunner(BaseTaskRunner):
             self.log.info("Started process %d to run task", pid)
             return psutil.Process(pid)
         else:
-            from airflow.bin.cli import get_parser
+            from airflow.bin.cli import exec_airflow_command
             import signal
             import airflow.settings as settings
 

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -21,8 +21,8 @@
 import os
 
 import psutil
-from setproctitle import setproctitle
 
+from airflow.bin.cli import exec_airflow_command
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.helpers import reap_process_group
 
@@ -68,17 +68,9 @@ class StandardTaskRunner(BaseTaskRunner):
             settings.engine.pool.dispose()
             settings.engine.dispose()
 
-            parser = get_parser()
-            # [1:] - remove "airflow" from the start of the command
-            args = parser.parse_args(self._command[1:])
-
-            proc_title = "airflow task runner: {0.dag_id} {0.task_id} {0.execution_date}"
-            if hasattr(args, "job_id"):
-                proc_title += " {0.job_id}"
-            setproctitle(proc_title.format(args))
-
             try:
-                args.func(args)
+                exec_airflow_command(self._command)
+
                 os._exit(0)
             except Exception:
                 os._exit(1)

--- a/docs/executor/celery.rst
+++ b/docs/executor/celery.rst
@@ -43,7 +43,7 @@ Here are a few imperative requirements for your workers:
   Chef, Puppet, Ansible, or whatever you use to configure machines in your
   environment. If all your boxes have a common mount point, having your
   pipelines files shared there should work as well
-
+- Plugins are only loaded at startup, so after making changes to plugins you must restart workers.
 
 To kick off a worker, you need to setup Airflow and kick off the worker
 subcommand

--- a/tests/bin/test_cli.py
+++ b/tests/bin/test_cli.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from airflow import AirflowException
+from airflow.bin.cli import exec_airflow_command
+
+
+class ExecAirflowCommandTestCase(unittest.TestCase):
+    def test_should_execute_cli(self):
+        with redirect_stdout(io.StringIO()) as stdout:
+            exec_airflow_command(["airflow", "config"])
+        stdout = stdout.getvalue()
+        self.assertIn("[core]", stdout)
+
+    def test_should_accept_only_airflow(self):
+        with self.assertRaisesRegex(AirflowException, 'The first element must be equal to "airflow".'):
+            exec_airflow_command(["cat", "config"])
+
+    def test_should_raise_exception_on_invalid_command(self):
+        with self.assertRaises(SystemExit):
+            exec_airflow_command(["airflow", "invalid-command"])

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -79,8 +79,8 @@ class TestCeleryExecutor(unittest.TestCase):
             executor.start()
 
             with start_worker(app=app, logfile=sys.stdout, loglevel='info'):
-                success_command = ['true', 'some_parameter']
-                fail_command = ['false', 'some_parameter']
+                success_command = ["airflow", "version"]
+                fail_command = ["airflow", "invalid-command"]
                 execute_date = datetime.datetime.now()
 
                 cached_celery_backend = celery_executor.execute_command.backend


### PR DESCRIPTION
Hello,

The executor runs multiple processes to perform one task. Many processes have a very short life cycle, so the process of starting it is a significant overhead.

Firstly, the Celery executor trigger Celery tasks - app.task. This task runs the CLI  command (first process), which contains LocalTaskJob. LocalTaskJob runs the separate command (second process) that executes user-code. This level of isolation is redundant because LocalTaskJob doesn't execute unsafe code. The first command is run by a new process creation, not by a fork, so this is an expensive operation. I suggest running code from the first process as part of the celery task to reduce the need to create new processes.

The code currently uses CLIFactory to run the LocalTaskJob It is better to do this without unnecessary dependence on CLI, but it is a big change and I plan to do it in a separate PR.
WIP PR: https://github.com/mik-laj/incubator-airflow/pull/10 (Travis green :-D )

Performance benchmark: 
===================
Example DAG from Airflow with unneeded sleep instructions deleted.
```python
"""Example DAG demonstrating the usage of the BashOperator."""

from datetime import timedelta

import airflow
from airflow.models import DAG
from airflow.operators.bash_operator import BashOperator
from airflow.operators.dummy_operator import DummyOperator

args = {
    'owner': 'airflow',
    'start_date': airflow.utils.dates.days_ago(2),
}

dag = DAG(
    dag_id='example_bash_operator',
    default_args=args,
    schedule_interval='0 0 * * *',
    dagrun_timeout=timedelta(minutes=60),
)

run_this_last = DummyOperator(
    task_id='run_this_last',
    dag=dag,
)

# [START howto_operator_bash]
run_this = BashOperator(
    task_id='run_after_loop',
    bash_command='echo 1',
    dag=dag,
)
# [END howto_operator_bash]

run_this >> run_this_last

for i in range(3):
    task = BashOperator(
        task_id='runme_' + str(i),
        bash_command='echo "{{ task_instance_key_str }}",
        dag=dag,
    )
    task >> run_this

# [START howto_operator_bash_template]
also_run_this = BashOperator(
    task_id='also_run_this',
    bash_command='echo "run_id={{ run_id }} | dag_run={{ dag_run }}"',
    dag=dag,
)
# [END howto_operator_bash_template]
also_run_this >> run_this_last

if __name__ == "__main__":
    dag.cli()

```
```python
import airflow
from airflow import DAG
from airflow.models import DagBag

dagbag = airflow.models.DagBag()
dag: DAG = dagbag.get_dag("example_bash_operator")

dag.clear()
dag.run()
```
Environment: Brreze
```
unset AIRFLOW__CORE__DAGS_FOLDER
unset AIRFLOW__CORE__UNIT_TEST_MODE
chmod -R 777 /root
sudo -E su airflow
export AIRFLOW__CORE__EXECUTOR="CeleryExecutor"
export AIRFLOW__CELERY__BROKER_URL="redis://redis:6379/0"
export AIRFLOW__CELERY__WORKER_CONCURRENCY=8
seq 1 10 | xargs -n 1 -I {} bash -c "time python /files/benchmark_speed.py > /dev/null 2>&1" | grep '^(real\|user\|sys)';
```

Result: 

|Fn.     | After | Before | Change|
|--------|-------|--------|-------|
|AVERAGE | 56.48 | 38.32  | -32%  |
|VAR     | 23.60 | 0.04   | -98%  |
|MAX     | 68.29 | 38.68  | -43%  |
|MIN     | 53.26 | 38.08  | -28%  |
|STDEV   | 4.86  | 0.19   | -96%. |

Raw data
After:
```
real 0m38.394s
user 0m4.340s
sys 0m1.600s

real 0m38.355s
user 0m4.700s
sys 0m1.340s

real 0m38.675s
user 0m4.760s
sys 0m1.530s

real 0m38.488s
user 0m4.770s
sys 0m1.280s

real 0m38.434s
user 0m4.600s
sys 0m1.390s

real 0m38.378s
user 0m4.500s
sys 0m1.270s

real 0m38.106s
user 0m4.200s
sys 0m1.100s

real 0m38.082s
user 0m4.170s
sys 0m1.030s

real 0m38.173s
user 0m4.290s
sys 0m1.340s

real 0m38.161s
user 0m4.460s
sys 0m1.370s
```

Before:
```
real 0m53.488s
user 0m5.140s
sys 0m1.700s

real 1m8.288s
user 0m6.430s
sys 0m2.200s

real 0m53.371s
user 0m5.330s
sys 0m1.630s

real 0m58.939s
user 0m6.470s
sys 0m1.730s

real 0m53.255s
user 0m4.950s
sys 0m1.640s

real 0m58.802s
user 0m5.970s
sys 0m1.790s

real 0m58.449s
user 0m5.380s
sys 0m1.580s

real 0m53.308s
user 0m5.120s
sys 0m1.430s

real 0m53.485s
user 0m5.220s
sys 0m1.290s

real 0m53.387s
user 0m5.020s
sys 0m1.590s
```

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6361

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
