### PR TITLE
[AIRFLOW-6368][Depends on 6367] Move conf tests from test_core to test_configuration

### DIFF
--- a/tests/models/test_variable.py
+++ b/tests/models/test_variable.py
@@ -80,3 +80,69 @@ class TestVariable(unittest.TestCase):
             self.assertTrue(test_var.is_encrypted)
             self.assertEqual(test_var.val, 'value')
             self.assertEqual(Fernet(key2).decrypt(test_var._val.encode()), b'value')
+
+    def test_variable_set_get_round_trip(self):
+        Variable.set("tested_var_set_id", "Monday morning breakfast")
+        self.assertEqual("Monday morning breakfast", Variable.get("tested_var_set_id"))
+
+    def test_variable_set_get_round_trip_json(self):
+        value = {"a": 17, "b": 47}
+        Variable.set("tested_var_set_id", value, serialize_json=True)
+        self.assertEqual(value, Variable.get("tested_var_set_id", deserialize_json=True))
+
+    def test_get_non_existing_var_should_return_default(self):
+        default_value = "some default val"
+        self.assertEqual(default_value, Variable.get("thisIdDoesNotExist",
+                                                     default_var=default_value))
+
+    def test_get_non_existing_var_should_raise_key_error(self):
+        with self.assertRaises(KeyError):
+            Variable.get("thisIdDoesNotExist")
+
+    def test_get_non_existing_var_with_none_default_should_return_none(self):
+        self.assertIsNone(Variable.get("thisIdDoesNotExist", default_var=None))
+
+    def test_get_non_existing_var_should_not_deserialize_json_default(self):
+        default_value = "}{ this is a non JSON default }{"
+        self.assertEqual(default_value, Variable.get("thisIdDoesNotExist",
+                                                     default_var=default_value,
+                                                     deserialize_json=True))
+
+    def test_variable_setdefault_round_trip(self):
+        key = "tested_var_setdefault_1_id"
+        value = "Monday morning breakfast in Paris"
+        Variable.setdefault(key, value)
+        self.assertEqual(value, Variable.get(key))
+
+    def test_variable_setdefault_round_trip_json(self):
+        key = "tested_var_setdefault_2_id"
+        value = {"city": 'Paris', "Happiness": True}
+        Variable.setdefault(key, value, deserialize_json=True)
+        self.assertEqual(value, Variable.get(key, deserialize_json=True))
+
+    def test_variable_setdefault_existing_json(self):
+        key = "tested_var_setdefault_2_id"
+        value = {"city": 'Paris', "Happiness": True}
+        Variable.set(key, value, serialize_json=True)
+        val = Variable.setdefault(key, value, deserialize_json=True)
+        # Check the returned value, and the stored value are handled correctly.
+        self.assertEqual(value, val)
+        self.assertEqual(value, Variable.get(key, deserialize_json=True))
+
+    def test_variable_delete(self):
+        key = "tested_var_delete"
+        value = "to be deleted"
+
+        # No-op if the variable doesn't exist
+        Variable.delete(key)
+        with self.assertRaises(KeyError):
+            Variable.get(key)
+
+        # Set the variable
+        Variable.set(key, value)
+        self.assertEqual(value, Variable.get(key))
+
+        # Delete the variable
+        Variable.delete(key)
+        with self.assertRaises(KeyError):
+            Variable.get(key)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,7 +38,7 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.jobs.scheduler_job import DagFileProcessor
-from airflow.models import DagBag, DagRun, TaskFail, TaskInstance, Variable
+from airflow.models import DagBag, DagRun, TaskFail, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
@@ -626,72 +626,6 @@ class TestCore(unittest.TestCase):
             task=self.runme_0, execution_date=DEFAULT_DATE)
         ti.dag = self.dag_bash
         ti.run(ignore_ti_state=True)
-
-    def test_variable_set_get_round_trip(self):
-        Variable.set("tested_var_set_id", "Monday morning breakfast")
-        self.assertEqual("Monday morning breakfast", Variable.get("tested_var_set_id"))
-
-    def test_variable_set_get_round_trip_json(self):
-        value = {"a": 17, "b": 47}
-        Variable.set("tested_var_set_id", value, serialize_json=True)
-        self.assertEqual(value, Variable.get("tested_var_set_id", deserialize_json=True))
-
-    def test_get_non_existing_var_should_return_default(self):
-        default_value = "some default val"
-        self.assertEqual(default_value, Variable.get("thisIdDoesNotExist",
-                                                     default_var=default_value))
-
-    def test_get_non_existing_var_should_raise_key_error(self):
-        with self.assertRaises(KeyError):
-            Variable.get("thisIdDoesNotExist")
-
-    def test_get_non_existing_var_with_none_default_should_return_none(self):
-        self.assertIsNone(Variable.get("thisIdDoesNotExist", default_var=None))
-
-    def test_get_non_existing_var_should_not_deserialize_json_default(self):
-        default_value = "}{ this is a non JSON default }{"
-        self.assertEqual(default_value, Variable.get("thisIdDoesNotExist",
-                                                     default_var=default_value,
-                                                     deserialize_json=True))
-
-    def test_variable_setdefault_round_trip(self):
-        key = "tested_var_setdefault_1_id"
-        value = "Monday morning breakfast in Paris"
-        Variable.setdefault(key, value)
-        self.assertEqual(value, Variable.get(key))
-
-    def test_variable_setdefault_round_trip_json(self):
-        key = "tested_var_setdefault_2_id"
-        value = {"city": 'Paris', "Happiness": True}
-        Variable.setdefault(key, value, deserialize_json=True)
-        self.assertEqual(value, Variable.get(key, deserialize_json=True))
-
-    def test_variable_setdefault_existing_json(self):
-        key = "tested_var_setdefault_2_id"
-        value = {"city": 'Paris', "Happiness": True}
-        Variable.set(key, value, serialize_json=True)
-        val = Variable.setdefault(key, value, deserialize_json=True)
-        # Check the returned value, and the stored value are handled correctly.
-        self.assertEqual(value, val)
-        self.assertEqual(value, Variable.get(key, deserialize_json=True))
-
-    def test_variable_delete(self):
-        key = "tested_var_delete"
-        value = "to be deleted"
-
-        # No-op if the variable doesn't exist
-        Variable.delete(key)
-        with self.assertRaises(KeyError):
-            Variable.get(key)
-
-        # Set the variable
-        Variable.set(key, value)
-        self.assertEqual(value, Variable.get(key))
-
-        # Delete the variable
-        Variable.delete(key)
-        with self.assertRaises(KeyError):
-            Variable.get(key)
 
     def test_parameterized_config_gen(self):
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6368

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
