### PR TITLE
[AIRFLOW-6374] Automate sending emails for Release management

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -2,3 +2,4 @@ click>=6.6,<7
 jira>=2.0.0
 keyring==10.1
 gitpython
+jinja2~=2.10

--- a/dev/send_email.py
+++ b/dev/send_email.py
@@ -1,0 +1,333 @@
+#!/usr/bin/python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This tool is based on the Superset send_email script:
+# https://github.com/apache/incubator-superset/blob/master/RELEASING/send_email.py
+import os
+import smtplib
+import ssl
+import sys
+from typing import List, Union
+
+try:
+    import jinja2
+except ModuleNotFoundError:
+    sys.exit("Jinja2 is a required dependency for this script")
+try:
+    import click
+except ModuleNotFoundError:
+    sys.exit("Click is a required dependency for this script")
+
+
+SMTP_PORT = 587
+SMTP_SERVER = "mail-relay.apache.org"
+PROJECT_NAME = "Airflow"
+PROJECT_MODULE = "airflow"
+PROJECT_DESCRIPTION = "Apache Airflow - A platform to programmatically author, " \
+                      "schedule, and monitor workflows"
+TWITTER_HANDLE = "@ApacheAirflow"
+MAILING_LIST = {
+    "dev": f"dev@{PROJECT_MODULE}.apache.org",
+    "users": f"users@{PROJECT_MODULE}.apache.org"
+}
+
+
+def string_comma_to_list(message: str) -> List[str]:
+    """
+    Split string to list
+    """
+    return message.split(",") if message else []
+
+
+def send_email(
+    smtp_server: str, smpt_port: int,
+    username: str, password: str,
+    sender_email: str, receiver_email: Union[str, List], message: str,
+):
+    """
+    Send a simple text email (SMTP)
+    """
+    context = ssl.create_default_context()
+    with smtplib.SMTP(smtp_server, smpt_port) as server:
+        server.starttls(context=context)
+        server.login(username, password)
+        server.sendmail(sender_email, receiver_email, message)
+
+
+def render_template(template_file: str, **kwargs) -> str:
+    """
+    Simple render template based on named parameters
+
+    :param template_file: The template file location
+    :kwargs: Named parameters to use when rendering the template
+    :return: Rendered template
+    """
+    template = jinja2.Template(open(template_file).read())
+    return template.render(kwargs)
+
+
+def show_message(entity: str, message: str):
+    """
+    Show message on the Command Line
+    """
+    width, _ = click.get_terminal_size()
+
+    click.secho("-" * width, fg="blue")
+    click.secho(f"{entity} Message:", fg="bright_red", bold=True)
+    click.secho("-" * width, fg="blue")
+    click.echo(message)
+    click.secho("-" * width, fg="blue")
+
+
+def inter_send_email(
+    username: str, password: str, sender_email: str, receiver_email: Union[str, List],
+    message: str
+):
+    """
+    Send email using SMTP
+    """
+    show_message("SMTP", message)
+
+    click.confirm("Is the Email message ok?", abort=True)
+
+    try:
+        send_email(
+            SMTP_SERVER, SMTP_PORT, username, password, sender_email, receiver_email, message,
+        )
+        click.secho("✅ Email sent successfully", fg="green")
+    except smtplib.SMTPAuthenticationError:
+        sys.exit("SMTP User authentication error, Email not sent!")
+    except Exception as e:  # pylint: disable=broad-except
+        sys.exit(f"SMTP exception {e}")
+
+
+class BaseParameters:
+    """
+    Base Class to send emails using Apache Creds and for Jinja templating
+    """
+    def __init__(
+        self, name=None, email=None, username=None, password=None,
+        version=None, version_rc=None
+    ):
+        self.name = name
+        self.email = email
+        self.username = username
+        self.password = password
+        self.version = version
+        self.version_rc = version_rc
+        self.template_arguments = dict()
+
+    def __repr__(self):
+        return f"Apache Credentials: {self.email}/{self.username}/{self.version}/{self.version_rc}"
+
+
+@click.group(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.pass_context
+@click.option(
+    "-e", "--apache_email",
+    prompt="Apache Email",
+    envvar="APACHE_EMAIL", show_envvar=True,
+    help="Your Apache email will be used for SMTP From",
+    required=True
+)
+@click.option(
+    "-u", "--apache_username",
+    prompt="Apache Username",
+    envvar="APACHE_USERNAME", show_envvar=True,
+    help="Your LDAP Apache username",
+    required=True,
+)
+@click.password_option(  # type: ignore
+    "-p", "--apache_password",
+    prompt="Apache Password",
+    envvar="APACHE_PASSWORD", show_envvar=True,
+    help="Your LDAP Apache password",
+    required=True,
+)
+@click.option(
+    "-v", "--version",
+    prompt="Version",
+    envvar="AIRFLOW_VERSION", show_envvar=True,
+    help="Release Version",
+    required=True,
+)
+@click.option(
+    "-rc", "--version_rc",
+    prompt="Version (with RC)",
+    envvar="AIRFLOW_VERSION_RC", show_envvar=True,
+    help="Release Candidate Version",
+    required=True,
+)
+@click.option(  # type: ignore
+    "-n", "--name",
+    prompt="Your Name",
+    default=lambda: os.environ.get('USER', ''),
+    show_default="Current User",
+    help="Name of the Release Manager",
+    type=click.STRING,
+    required=True,
+)
+def cli(
+    ctx, apache_email: str,
+    apache_username: str, apache_password: str, version: str, version_rc: str,
+    name: str
+):
+    """
+    🚀 CLI to send emails for the following:
+
+    \b
+    * Voting thread for the rc
+    * Result of the voting for the rc
+    * Announcing that the new version has been released
+    """
+    base_parameters = BaseParameters(
+        name, apache_email, apache_username, apache_password, version, version_rc
+    )
+    base_parameters.template_arguments["project_name"] = PROJECT_NAME
+    base_parameters.template_arguments["project_module"] = PROJECT_MODULE
+    base_parameters.template_arguments["project_description"] = PROJECT_DESCRIPTION
+    base_parameters.template_arguments["version"] = base_parameters.version
+    base_parameters.template_arguments["version_rc"] = base_parameters.version_rc
+    base_parameters.template_arguments["sender_email"] = base_parameters.email
+    base_parameters.template_arguments["twitter_handle"] = TWITTER_HANDLE
+    base_parameters.template_arguments["release_manager"] = base_parameters.name
+    ctx.obj = base_parameters
+
+
+@cli.command("vote")
+@click.option(
+    "--receiver_email",
+    default=MAILING_LIST.get("dev"),
+    type=click.STRING,
+    prompt="The receiver email (To:)",
+)
+@click.pass_obj
+def vote(base_parameters, receiver_email: str):
+    """
+    Send email calling for Votes on RC
+    """
+    template_file = "templates/vote_email.j2"
+    base_parameters.template_arguments["receiver_email"] = receiver_email
+    message = render_template(template_file, **base_parameters.template_arguments)
+    inter_send_email(
+        base_parameters.username,
+        base_parameters.password,
+        base_parameters.template_arguments["sender_email"],
+        base_parameters.template_arguments["receiver_email"],
+        message,
+    )
+    if click.confirm("Show Slack message for announcement?", default=True):
+        base_parameters.template_arguments["slack_rc"] = False
+        slack_msg = render_template("templates/slack.j2", **base_parameters.template_arguments)
+        show_message("Slack", slack_msg)
+
+
+@cli.command("result")
+@click.option(
+    "-re", "--receiver_email",
+    default=MAILING_LIST.get("dev"),
+    type=click.STRING,
+    prompt="The receiver email (To:)",
+)
+@click.option(
+    "--vote_bindings",
+    default="",
+    type=click.STRING,
+    prompt="A List of people with +1 binding vote (ex: Max,Grace,Krist)",
+)
+@click.option(
+    "--vote_nonbindings",
+    default="",
+    type=click.STRING,
+    prompt="A List of people with +1 non binding vote (ex: Ville)",
+)
+@click.option(
+    "--vote_negatives",
+    default="",
+    type=click.STRING,
+    prompt="A List of people with -1 vote (ex: John)",
+)
+@click.pass_obj
+def result(
+    base_parameters,
+    receiver_email: str, vote_bindings: str, vote_nonbindings: str, vote_negatives: str,
+):
+    """
+    Send email with results of voting on RC
+    """
+    template_file = "templates/result_email.j2"
+    base_parameters.template_arguments["receiver_email"] = receiver_email
+    base_parameters.template_arguments["vote_bindings"] = string_comma_to_list(
+        vote_bindings
+    )
+    base_parameters.template_arguments["vote_nonbindings"] = string_comma_to_list(
+        vote_nonbindings
+    )
+    base_parameters.template_arguments["vote_negatives"] = string_comma_to_list(
+        vote_negatives
+    )
+    message = render_template(template_file, **base_parameters.template_arguments)
+    inter_send_email(
+        base_parameters.username, base_parameters.password,
+        base_parameters.template_arguments["sender_email"],
+        base_parameters.template_arguments["receiver_email"],
+        message,
+    )
+
+
+@cli.command("announce")
+@click.option(
+    "--receiver_email",
+    default=",".join(list(MAILING_LIST.values())),
+    prompt="The receiver email (To:)",
+    help="Receiver's email address. If more than 1, separate them by comma"
+)
+@click.pass_obj
+def announce(
+    base_parameters, receiver_email: str
+):
+    """
+    Send email to announce release of the new version
+    """
+    receiver_emails: List[str] = string_comma_to_list(receiver_email)
+
+    template_file = "templates/announce_email.j2"
+    base_parameters.template_arguments["receiver_email"] = receiver_emails
+    message = render_template(template_file, **base_parameters.template_arguments)
+
+    inter_send_email(
+        base_parameters.username, base_parameters.password,
+        base_parameters.template_arguments["sender_email"],
+        base_parameters.template_arguments["receiver_email"],
+        message,
+    )
+
+    if click.confirm("Show Slack message for announcement?", default=True):
+        base_parameters.template_arguments["slack_rc"] = False
+        slack_msg = render_template(
+            "templates/slack.j2", **base_parameters.template_arguments)
+        show_message("Slack", slack_msg)
+    if click.confirm("Show Twitter message for announcement?", default=True):
+        twitter_msg = render_template(
+            "templates/twitter.j2", **base_parameters.template_arguments)
+        show_message("Twitter", twitter_msg)
+
+
+if __name__ == '__main__':
+    cli()   # pylint: disable=no-value-for-parameter

--- a/dev/templates/announce_email.j2
+++ b/dev/templates/announce_email.j2
@@ -1,0 +1,47 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-#}
+To: {{ receiver_email | list | join(', ') }}
+From: {{ sender_email }}
+Subject: [ANNOUNCE] Apache {{ project_name }} version {{ version }} Released
+
+Dear {{ project_name }} community,
+
+I am pleased to announce that {{ project_name }} {{ version }} has just been released.
+
+{{ project_description }}
+
+The official source release:
+https://dist.apache.org/repos/dist/release/{{ project_module }}/{{ version }}
+
+The Pypi package:
+https://pypi.org/project/apache-{{ project_module }}/{{ version }}/
+
+The documentation is available on:
+https://{{ project_module }}.apache.org/docs/{{ version }}/
+
+Find the CHANGELOG here for more details:
+https://{{ project_module }}.apache.org/docs/{{ version }}/changelog.html
+
+If you have any usage questions, or have problems when upgrading or
+find any problems about enhancements included in this release, please
+don't hesitate to let us know by sending feedback to this mailing
+list.
+
+Cheers,
+{{ release_manager }}

--- a/dev/templates/result_email.j2
+++ b/dev/templates/result_email.j2
@@ -1,0 +1,57 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-#}
+To: {{ receiver_email }}
+From: {{ sender_email }}
+Subject: [RESULT][VOTE] Release Apache {{ project_name }} {{ version }} based on {{ version_rc }}
+
+The vote to release Apache {{ project_name }} version {{ version }} based on {{ version_rc }} is now closed.
+
+{% if vote_negatives|length > vote_bindings|length -%}
+The vote did NOT PASS with {{vote_bindings|length}} binding "+1", {{ vote_nonbindings|length}} non-binding "+1" and {{vote_negatives|length}} "-1" votes:
+{% elif vote_bindings|length > 2 -%}
+The vote PASSED with {{vote_bindings|length}} binding "+1", {{ vote_nonbindings|length}} non-binding "+1" and {{vote_negatives|length}} "-1" votes:
+{% else -%}
+The vote is non conclusive with {{vote_bindings|length}} binding "+1", {{ vote_nonbindings|length}} non-binding "+1" and {{vote_negatives|length}} "-1" votes:
+{%- endif %}
+
+{% if vote_bindings|length > 0 -%}
+"+1" Binding votes:
+{% for voter in vote_bindings -%}
+- {{ voter }}
+{% endfor -%}
+{%- endif %}
+
+{% if vote_nonbindings|length > 0 -%}
+"+1" Non-binding votes:
+{% for voter in vote_nonbindings -%}
+- {{ voter }}
+{% endfor -%}
+{%- endif %}
+
+{% if vote_negatives|length > 0 -%}
+"-1" Binding votes:
+{% for voter in vote_negatives -%}
+- {{ voter }}
+{% endfor -%}
+{%- endif %}
+
+I'll continue with the release process and the release announcement will follow shortly.
+
+Thanks,
+{{ release_manager }}

--- a/dev/templates/slack.j2
+++ b/dev/templates/slack.j2
@@ -1,0 +1,31 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-#}
+{% if slack_rc -%}
+@here We've just released {{ project_name }} {{ version }} :tada:
+:package: https://pypi.org/project/{{ project_module }}/{{ version }}/
+:books: https://{{ project_module }}.apache.org/docs/{{ version }}/
+:hammer_and_wrench: https://{{ project_module }}.apache.org/docs/{{ version }}/changelog.html
+{% else -%}
+@here  Hot off the press :hotsprings: :fire: {{ project_name }} {{ version_rc }} available for testing.
+
+Snapshots have been uploaded on PyPI too: `pip install {{ project_module }}=={{ version_rc }}`
+**ChangeLog:** https://github.com/apache/{{ project_module }}/blob/{{ version_rc }}/CHANGELOG.txt
+
+Please let us know if you have any issues on {{ receiver_email }}
+{%- endif %}

--- a/dev/templates/twitter.j2
+++ b/dev/templates/twitter.j2
@@ -1,0 +1,23 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-#}
+We've just released {{ twitter_handle }} {{ version }} 🎉
+
+📦 https://pypi.org/project/{{ project_module }}/{{ version }}/
+📚 https://{{ project_module }}.apache.org/docs/{{ version }}/
+🛠 https://{{ project_module }}.apache.org/docs/{{ version }}/changelog.html

--- a/dev/templates/vote_email.j2
+++ b/dev/templates/vote_email.j2
@@ -1,0 +1,56 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-#}
+To: {{ receiver_email }}
+From: {{ sender_email }}
+Subject: [VOTE] Release Apache {{ project_name }} {{ version }} based on {{ version_rc }}
+
+Hello {{ project_name }} Community,
+
+This is a call for the vote to release Apache {{ project_name }} version {{ version }}.
+
+The release candidate:
+https://dist.apache.org/repos/dist/dev/{{ project_module }}/{{ version_rc }}/
+
+*apache-airflow-{{ version_rc }}-source.tar.gz* is a source release that comes
+with INSTALL instructions.
+*apache-airflow-{{ version_rc }}-bin.tar.gz* is the binary Python "sdist" release.
+
+Public keys are available at: https://www.apache.org/dist/{{ project_module }}/KEYS
+
+The Change Log for the release:
+https://github.com/apache/{{ project_module }}/blob/{{ version_rc }}/CHANGELOG.md
+
+The vote will be open for at least 72 hours or until the necessary number
+of votes are reached.
+
+Please vote accordingly:
+
+[ ] +1 approve
+[ ] +0 no opinion
+[ ] -1 disapprove with the reason
+
+Only votes from PMC members are binding, but members of the community are
+encouraged to test the release and vote with "(non-binding)".
+
+Please note that the version number excludes the `rcX` string, so it's now
+simply {{ version }}. This will allow us to rename the artifact without modifying
+the artifact checksums when we actually release.
+
+Thanks,
+{{ release_manager }}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6374


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Currently, the release process involves sending some emails to Dev List, User List etc.

It would be ideal to have a script that automates the email part and gives us the text that we can copy-paste for Slack

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
n/a

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
