### PR TITLE
[AIRFLOW-6382] Extract provide/create session to session module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -224,6 +224,12 @@ repos:
           ^airflow/sensors/.*$|
           ^airflow/providers/.*$|
           ^airflow/contrib/.*$
+      - id: provide-create-sessions
+        language: pygrep
+        name: Make sure provide_session and create_session are imported from airflow.utils.session
+        entry: "from airflow\\.utils\\.db import.* (provide_session|create_session)"
+        files: \.py$
+        pass_filenames: true
       - id: base-operator
         language: pygrep
         name: Make sure BaseOperator is imported from airflow.models outside of core

--- a/airflow/api/common/experimental/delete_dag.py
+++ b/airflow/api/common/experimental/delete_dag.py
@@ -25,8 +25,8 @@ from airflow.exceptions import DagNotFound
 from airflow.models import DagModel, TaskFail
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.settings import STORE_SERIALIZED_DAGS
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 
 @provide_session

--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -28,7 +28,7 @@ from airflow.models import DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/api/common/experimental/pool.py
+++ b/airflow/api/common/experimental/pool.py
@@ -19,7 +19,7 @@
 """Pool APIs."""
 from airflow.exceptions import AirflowBadRequest, PoolNotFound
 from airflow.models import Pool
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 @provide_session

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -22,13 +22,14 @@ from sqlalchemy.orm import exc
 from tabulate import tabulate
 
 from airflow.models import Connection
-from airflow.utils import cli as cli_utils, db
+from airflow.utils import cli as cli_utils
 from airflow.utils.cli import alternative_conn_specs
+from airflow.utils.session import create_session
 
 
 def connections_list(args):
     """Lists all connections at the command line"""
-    with db.create_session() as session:
+    with create_session() as session:
         conns = session.query(Connection.conn_id, Connection.conn_type,
                               Connection.host, Connection.port,
                               Connection.is_encrypted,
@@ -76,7 +77,7 @@ def connections_add(args):
     if args.conn_extra is not None:
         new_conn.set_extra(args.conn_extra)
 
-    with db.create_session() as session:
+    with create_session() as session:
         if not (session.query(Connection)
                 .filter(Connection.conn_id == new_conn.conn_id).first()):
             session.add(new_conn)
@@ -100,7 +101,7 @@ def connections_add(args):
 @cli_utils.action_logging
 def connections_delete(args):
     """Deletes connection from DB"""
-    with db.create_session() as session:
+    with create_session() as session:
         try:
             to_delete = (session
                          .query(Connection)

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -29,9 +29,10 @@ from tabulate import tabulate
 from airflow import DAG, AirflowException, conf, jobs, settings
 from airflow.api.client import get_current_api_client
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
-from airflow.utils import cli as cli_utils, db
+from airflow.utils import cli as cli_utils
 from airflow.utils.cli import get_dag, process_subdir, sigint_handler
 from airflow.utils.dot_renderer import render_dag
+from airflow.utils.session import create_session
 
 
 def _tabulate_dag_runs(dag_runs: List[DagRun], tablefmt="fancy_grid"):
@@ -266,7 +267,7 @@ def dag_list_jobs(args, dag=None):
     if args.state:
         queries.append(jobs.BaseJob.state == args.state)
 
-    with db.create_session() as session:
+    with create_session() as session:
         all_jobs = (session
                     .query(jobs.BaseJob)
                     .filter(*queries)

--- a/airflow/cli/commands/rotate_fernet_key_command.py
+++ b/airflow/cli/commands/rotate_fernet_key_command.py
@@ -16,13 +16,14 @@
 # under the License.
 """Rotate Fernet key command"""
 from airflow.models import Connection, Variable
-from airflow.utils import cli as cli_utils, db
+from airflow.utils import cli as cli_utils
+from airflow.utils.session import create_session
 
 
 @cli_utils.action_logging
 def rotate_fernet_key(args):
     """Rotates all encrypted connection credentials and variables"""
-    with db.create_session() as session:
+    with create_session() as session:
         for conn in session.query(Connection).filter(
                 Connection.is_encrypted | Connection.is_extra_encrypted):
             conn.rotate_fernet_key()

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -28,10 +28,11 @@ from airflow import DAG, AirflowException, conf, jobs, settings
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.models import DagPickle, TaskInstance
 from airflow.ti_deps.dep_context import SCHEDULER_QUEUED_DEPS, DepContext
-from airflow.utils import cli as cli_utils, db
+from airflow.utils import cli as cli_utils
 from airflow.utils.cli import get_dag, get_dag_by_pickle, get_dags
 from airflow.utils.log.logging_mixin import StreamLogWriter
 from airflow.utils.net import get_hostname
+from airflow.utils.session import create_session
 
 
 def _run_task_by_selected_method(args, dag, ti):
@@ -59,7 +60,7 @@ def _run_task_by_executor(args, dag, ti):
     if args.ship_dag:
         try:
             # Running remotely, so pickling the DAG
-            with db.create_session() as session:
+            with create_session() as session:
                 pickle = DagPickle(dag)
                 session.add(pickle)
                 pickle_id = pickle.id

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -21,12 +21,13 @@ import json
 import os
 
 from airflow.models import Variable
-from airflow.utils import cli as cli_utils, db
+from airflow.utils import cli as cli_utils
+from airflow.utils.session import create_session
 
 
 def variables_list(args):
     """Displays all of the variables"""
-    with db.create_session() as session:
+    with create_session() as session:
         variables = session.query(Variable)
     print("\n".join(var.key for var in variables))
 
@@ -95,7 +96,7 @@ def _import_helper(filepath):
 def _variable_export_helper(filepath):
     """Helps export all of the variables to the file"""
     var_dict = {}
-    with db.create_session() as session:
+    with create_session() as session:
         qry = session.query(Variable).all()
 
         data = json.JSONDecoder()

--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -25,8 +25,8 @@ from flask_oauthlib.client import OAuth
 
 from airflow import models
 from airflow.configuration import AirflowConfigException, conf
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 log = LoggingMixin().log
 

--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -25,8 +25,8 @@ from flask_oauthlib.client import OAuth
 
 from airflow import models
 from airflow.configuration import conf
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 log = LoggingMixin().log
 

--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -32,8 +32,8 @@ from airflow import models
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
 from airflow.security import utils
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 # pylint: disable=c-extension-no-member
 LOGIN_MANAGER = flask_login.LoginManager()

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -30,8 +30,8 @@ from wtforms.validators import InputRequired
 
 from airflow import models
 from airflow.configuration import AirflowConfigException, conf
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 login_manager = flask_login.LoginManager()
 login_manager.login_view = 'airflow.login'  # Calls login() below

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -32,8 +32,8 @@ from wtforms import Form, PasswordField, StringField
 from wtforms.validators import InputRequired
 
 from airflow import models
-from airflow.utils.db import create_session, provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import create_session, provide_session
 
 LOGIN_MANAGER = flask_login.LoginManager()
 LOGIN_MANAGER.login_view = 'airflow.login'  # Calls login() below

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -41,8 +41,8 @@ from airflow.kubernetes.pod_launcher import PodLauncher
 from airflow.kubernetes.worker_configuration import WorkerConfiguration
 from airflow.models import KubeResourceVersion, KubeWorkerIdentifier, TaskInstance
 from airflow.models.taskinstance import TaskInstanceKeyType
-from airflow.utils.db import create_session, provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 
 MAX_POD_ID_LEN = 253

--- a/airflow/gcp/hooks/cloud_sql.py
+++ b/airflow/gcp/hooks/cloud_sql.py
@@ -51,7 +51,7 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.hooks.mysql_hook import MySqlHook
 from airflow.hooks.postgres_hook import PostgresHook
 from airflow.models import Connection
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 UNIX_PATH_MAX = 108
 

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -23,8 +23,8 @@ from typing import Iterable
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 CONN_ENV_PREFIX = 'AIRFLOW_CONN_'
 

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -39,7 +39,7 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceKeyType
 from airflow.ti_deps.dep_context import BACKFILL_QUEUED_DEPS, DepContext
 from airflow.utils import timezone
 from airflow.utils.configuration import tmp_configuration_copy
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -33,10 +33,10 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.models.base import ID_LEN, Base
 from airflow.stats import Stats
 from airflow.utils import helpers, timezone
-from airflow.utils.db import create_session, provide_session
 from airflow.utils.helpers import convert_camel_to_snake
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 from airflow.utils.state import State
 

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -27,8 +27,8 @@ from airflow.jobs.base_job import BaseJob
 from airflow.stats import Stats
 from airflow.task.task_runner import get_task_runner
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
 from airflow.utils.net import get_hostname
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -50,10 +50,10 @@ from airflow.utils import asciiart, helpers, timezone
 from airflow.utils.dag_processing import (
     AbstractDagFileProcessorProcess, DagFileProcessorAgent, SimpleDag, SimpleDagBag,
 )
-from airflow.utils.db import provide_session
 from airflow.utils.email import get_email_address_list, send_email
 from airflow.utils.file import list_py_file_paths
 from airflow.utils.log.logging_mixin import LoggingMixin, StreamLogWriter, set_context
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
+++ b/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
@@ -30,7 +30,7 @@ from alembic import op
 from sqlalchemy import Column, Float, Integer, PickleType, String
 from sqlalchemy.ext.declarative import declarative_base
 
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
 # revision identifiers, used by Alembic.

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -47,11 +47,11 @@ from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.helpers import validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.operator_resources import Resources
+from airflow.utils.session import provide_session
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -47,10 +47,10 @@ from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.settings import MIN_SERIALIZED_DAG_UPDATE_INTERVAL, STORE_SERIALIZED_DAGS
 from airflow.utils import timezone
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
-from airflow.utils.db import provide_session
 from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.helpers import validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import Interval, UtcDateTime
 from airflow.utils.state import State
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -35,10 +35,10 @@ from airflow.dag.base_dag import BaseDagBag
 from airflow.exceptions import AirflowDagCycleException
 from airflow.stats import Stats
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
 from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.helpers import pprinttable
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.utils.timeout import timeout
 
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -30,8 +30,8 @@ from airflow.models.base import ID_LEN, Base
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 from airflow.utils.state import State
 

--- a/airflow/models/kubernetes.py
+++ b/airflow/models/kubernetes.py
@@ -23,7 +23,7 @@ from sqlalchemy import Boolean, Column, String, true as sqltrue
 from sqlalchemy.orm import Session
 
 from airflow.models.base import Base
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class KubeResourceVersion(Base):

--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -21,7 +21,7 @@ from sqlalchemy import Column, Integer, String, Text, func
 
 from airflow.models.base import Base
 from airflow.ti_deps.deps.pool_slots_available_dep import STATES_TO_COUNT_AS_RUNNING
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -31,8 +31,9 @@ from airflow import DAG
 from airflow.models.base import ID_LEN, Base
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.settings import json
-from airflow.utils import db, timezone
+from airflow.utils import timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
 log = LoggingMixin().log
@@ -90,7 +91,7 @@ class SerializedDagModel(Base):
             hashlib.sha1(full_filepath.encode('utf-8')).digest()[-2:], byteorder='big', signed=False)
 
     @classmethod
-    @db.provide_session
+    @provide_session
     def write_dag(cls, dag: DAG, min_update_interval: Optional[int] = None, session=None):
         """Serializes a DAG and writes it into database.
 
@@ -112,7 +113,7 @@ class SerializedDagModel(Base):
         log.debug("DAG: %s written to the DB", dag.dag_id)
 
     @classmethod
-    @db.provide_session
+    @provide_session
     def read_all_dags(cls, session=None) -> Dict[str, 'SerializedDAG']:
         """Reads all DAGs in serialized_dag table.
 
@@ -146,7 +147,7 @@ class SerializedDagModel(Base):
         return dag
 
     @classmethod
-    @db.provide_session
+    @provide_session
     def remove_dag(cls, dag_id: str, session=None):
         """Deletes a DAG with given dag_id.
 
@@ -156,7 +157,7 @@ class SerializedDagModel(Base):
         session.execute(cls.__table__.delete().where(cls.dag_id == dag_id))
 
     @classmethod
-    @db.provide_session
+    @provide_session
     def remove_deleted_dags(cls, alive_dag_filelocs: List[str], session=None):
         """Deletes DAGs not included in alive_dag_filelocs.
 
@@ -175,7 +176,7 @@ class SerializedDagModel(Base):
                      cls.fileloc.notin_(alive_dag_filelocs))))
 
     @classmethod
-    @db.provide_session
+    @provide_session
     def has_dag(cls, dag_id: str, session=None) -> bool:
         """Checks a DAG exist in serialized_dag table.
 
@@ -185,7 +186,7 @@ class SerializedDagModel(Base):
         return session.query(exists().where(cls.dag_id == dag_id)).scalar()
 
     @classmethod
-    @db.provide_session
+    @provide_session
     def get(cls, dag_id: str, session=None) -> Optional['SerializedDagModel']:
         """
         Get the SerializedDAG for the given dag ID.

--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -21,8 +21,8 @@ from typing import Iterable, Set, Union
 
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -51,11 +51,11 @@ from airflow.sentry import Sentry
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import REQUEUEABLE_DEPS, RUNNING_DEPS, DepContext
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
 from airflow.utils.email import send_email
 from airflow.utils.helpers import is_container
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
+from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout

--- a/airflow/models/taskreschedule.py
+++ b/airflow/models/taskreschedule.py
@@ -20,7 +20,7 @@
 from sqlalchemy import Column, ForeignKeyConstraint, Index, Integer, String, asc
 
 from airflow.models.base import ID_LEN, Base
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
 

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -27,8 +27,8 @@ from sqlalchemy.orm import synonym
 
 from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 
 class Variable(Base, LoggingMixin):

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -28,9 +28,9 @@ from sqlalchemy.orm import Query, Session, reconstructor
 from airflow.configuration import conf
 from airflow.models.base import ID_LEN, Base
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
 from airflow.utils.helpers import is_container
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
 # MAX XCOM Size is 48KB

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -31,8 +31,8 @@ from airflow.models.dag import DAG, DagContext
 from airflow.models.pool import Pool
 from airflow.models.taskinstance import TaskInstance
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
-from airflow.utils.db import create_session, provide_session
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -24,8 +24,8 @@ from sqlalchemy import func
 from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
-from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -23,8 +23,8 @@
 from functools import wraps
 
 from airflow.configuration import conf
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 log = LoggingMixin().log

--- a/airflow/ti_deps/deps/base_ti_dep.py
+++ b/airflow/ti_deps/deps/base_ti_dep.py
@@ -19,7 +19,7 @@
 
 from typing import NamedTuple
 
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class BaseTIDep:

--- a/airflow/ti_deps/deps/dag_ti_slots_available_dep.py
+++ b/airflow/ti_deps/deps/dag_ti_slots_available_dep.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class DagTISlotsAvailableDep(BaseTIDep):

--- a/airflow/ti_deps/deps/dag_unpaused_dep.py
+++ b/airflow/ti_deps/deps/dag_unpaused_dep.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class DagUnpausedDep(BaseTIDep):

--- a/airflow/ti_deps/deps/dagrun_exists_dep.py
+++ b/airflow/ti_deps/deps/dagrun_exists_dep.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/ti_deps/deps/dagrun_id_dep.py
+++ b/airflow/ti_deps/deps/dagrun_id_dep.py
@@ -22,7 +22,7 @@
 from re import match
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class DagrunIdDep(BaseTIDep):

--- a/airflow/ti_deps/deps/exec_date_after_start_date_dep.py
+++ b/airflow/ti_deps/deps/exec_date_after_start_date_dep.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class ExecDateAfterStartDateDep(BaseTIDep):

--- a/airflow/ti_deps/deps/not_in_retry_period_dep.py
+++ b/airflow/ti_deps/deps/not_in_retry_period_dep.py
@@ -19,7 +19,7 @@
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/ti_deps/deps/pool_slots_available_dep.py
+++ b/airflow/ti_deps/deps/pool_slots_available_dep.py
@@ -20,7 +20,7 @@
 """This module defines dep for pool slots availability"""
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 STATES_TO_COUNT_AS_RUNNING = [State.RUNNING, State.QUEUED]

--- a/airflow/ti_deps/deps/prev_dagrun_dep.py
+++ b/airflow/ti_deps/deps/prev_dagrun_dep.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/ti_deps/deps/ready_to_reschedule.py
+++ b/airflow/ti_deps/deps/ready_to_reschedule.py
@@ -20,7 +20,7 @@
 from airflow.models import TaskReschedule
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/ti_deps/deps/runnable_exec_date_dep.py
+++ b/airflow/ti_deps/deps/runnable_exec_date_dep.py
@@ -19,7 +19,7 @@
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class RunnableExecDateDep(BaseTIDep):

--- a/airflow/ti_deps/deps/task_concurrency_dep.py
+++ b/airflow/ti_deps/deps/task_concurrency_dep.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class TaskConcurrencyDep(BaseTIDep):

--- a/airflow/ti_deps/deps/task_not_running_dep.py
+++ b/airflow/ti_deps/deps/task_not_running_dep.py
@@ -19,7 +19,7 @@
 """Contains the TaskNotRunningDep."""
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -21,7 +21,7 @@ from sqlalchemy import case, func
 
 import airflow
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/ti_deps/deps/valid_state_dep.py
+++ b/airflow/ti_deps/deps/valid_state_dep.py
@@ -19,7 +19,7 @@
 
 from airflow.exceptions import AirflowException
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 class ValidStateDep(BaseTIDep):

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -38,7 +38,7 @@ from typing import Optional
 from airflow import AirflowException, settings
 from airflow.models import DagBag, DagPickle, Log
 from airflow.utils import cli_action_loggers
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 
 def action_logging(f):

--- a/airflow/utils/cli_action_loggers.py
+++ b/airflow/utils/cli_action_loggers.py
@@ -25,7 +25,7 @@ so that registered callbacks can be used all through the same python process.
 import logging
 from typing import Callable, List
 
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 
 
 def register_pre_exec_callback(action_logger):

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -43,10 +43,10 @@ from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.stats import Stats
 from airflow.utils import timezone
-from airflow.utils.db import provide_session
 from airflow.utils.file import list_py_file_paths
 from airflow.utils.helpers import reap_process_group
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 

--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+from functools import wraps
+
+from airflow import settings
+
+
+@contextlib.contextmanager
+def create_session():
+    """
+    Contextmanager that will create and teardown a session.
+    """
+    session = settings.Session()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def provide_session(func):
+    """
+    Function decorator that provides a session if it isn't provided.
+    If you want to reuse a session or run the function as part of a
+    database transaction, you pass it to the function, if not this wrapper
+    will create one and close it for you.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        arg_session = 'session'
+
+        func_params = func.__code__.co_varnames
+        session_in_args = arg_session in func_params and \
+            func_params.index(arg_session) < len(args)
+        session_in_kwargs = arg_session in kwargs
+
+        if session_in_kwargs or session_in_args:
+            return func(*args, **kwargs)
+        else:
+            with create_session() as session:
+                kwargs[arg_session] = session
+                return func(*args, **kwargs)
+
+    return wrapper

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -25,7 +25,7 @@ import pendulum
 from flask import after_this_request, flash, g, redirect, request, url_for
 
 from airflow.models import Log
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 
 
 def action_logging(f):

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -25,8 +25,8 @@ from sqlalchemy import and_, or_
 
 from airflow import models
 from airflow.exceptions import AirflowException
-from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 from airflow.www.app import appbuilder
 
 EXISTING_ROLES = {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -58,8 +58,8 @@ from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.ti_deps.dep_context import RUNNING_DEPS, SCHEDULER_QUEUED_DEPS, DepContext
 from airflow.utils import timezone
 from airflow.utils.dates import infer_time_unit, scale_time_units
-from airflow.utils.db import create_session, provide_session
 from airflow.utils.helpers import alchemy_to_dict, render_log_filename
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.www import utils as wwwutils
 from airflow.www.app import app, appbuilder

--- a/tests/api/client/test_local_client.py
+++ b/tests/api/client/test_local_client.py
@@ -28,7 +28,7 @@ from airflow.api.client.local_client import Client
 from airflow.example_dags import example_bash_operator
 from airflow.models import DagBag, DagModel
 from airflow.utils import timezone
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.test_utils.db import clear_db_pools
 

--- a/tests/api/common/experimental/test_delete_dag.py
+++ b/tests/api/common/experimental/test_delete_dag.py
@@ -24,7 +24,7 @@ from airflow.api.common.experimental.delete_dag import delete_dag
 from airflow.exceptions import DagNotFound
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 
 DM = models.DagModel

--- a/tests/api/common/experimental/test_mark_tasks.py
+++ b/tests/api/common/experimental/test_mark_tasks.py
@@ -30,7 +30,7 @@ from airflow.configuration import conf
 from airflow.models import DagRun
 from airflow.utils import timezone
 from airflow.utils.dates import days_ago
-from airflow.utils.db import create_session, provide_session
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from tests.test_utils.db import clear_db_runs
 

--- a/tests/api/common/experimental/test_pool.py
+++ b/tests/api/common/experimental/test_pool.py
@@ -23,7 +23,7 @@ from airflow import models
 from airflow.api.common.experimental import pool as pool_api
 from airflow.exceptions import AirflowBadRequest, PoolNotFound
 from airflow.models.pool import Pool
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from tests.test_utils.db import clear_db_pools
 
 

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -24,7 +24,8 @@ from parameterized import parameterized
 from airflow.bin import cli
 from airflow.cli.commands import connection_command
 from airflow.models import Connection
-from airflow.utils.db import create_session, merge_conn, provide_session
+from airflow.utils.db import merge_conn
+from airflow.utils.session import create_session, provide_session
 from tests.test_utils.db import clear_db_connections
 
 TEST_CONN_IDS = [f"new{index}" for index in range(1, 7)]

--- a/tests/contrib/hooks/test_databricks_hook.py
+++ b/tests/contrib/hooks/test_databricks_hook.py
@@ -29,7 +29,7 @@ from airflow import __version__
 from airflow.contrib.hooks.databricks_hook import SUBMIT_RUN_ENDPOINT, DatabricksHook, RunState
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
-from airflow.utils import db
+from airflow.utils.session import provide_session
 
 TASK_ID = 'databricks-operator'
 DEFAULT_CONN_ID = 'databricks_default'
@@ -154,7 +154,7 @@ class TestDatabricksHook(unittest.TestCase):
     Tests for DatabricksHook.
     """
 
-    @db.provide_session
+    @provide_session
     def setUp(self, session=None):
         conn = session.query(Connection) \
             .filter(Connection.conn_id == DEFAULT_CONN_ID) \
@@ -395,7 +395,7 @@ class TestDatabricksHookToken(unittest.TestCase):
     Tests for DatabricksHook when auth is done with token.
     """
 
-    @db.provide_session
+    @provide_session
     def setUp(self, session=None):
         conn = session.query(Connection) \
             .filter(Connection.conn_id == DEFAULT_CONN_ID) \

--- a/tests/contrib/hooks/test_pagerduty_hook.py
+++ b/tests/contrib/hooks/test_pagerduty_hook.py
@@ -23,13 +23,13 @@ from unittest import mock
 
 from airflow.contrib.hooks.pagerduty_hook import PagerdutyHook
 from airflow.models import Connection
-from airflow.utils import db
+from airflow.utils.session import provide_session
 
 DEFAULT_CONN_ID = "pagerduty_default"
 
 
 class TestPagerdutyHook(unittest.TestCase):
-    @db.provide_session
+    @provide_session
     def setUp(self, session=None):
         session.add(Connection(
             conn_id=DEFAULT_CONN_ID,
@@ -38,7 +38,7 @@ class TestPagerdutyHook(unittest.TestCase):
         ))
         session.commit()
 
-    @db.provide_session
+    @provide_session
     def test_without_routing_key_extra(self, session):
         session.add(Connection(
             conn_id="pagerduty_no_extra",

--- a/tests/contrib/hooks/test_ssh_hook.py
+++ b/tests/contrib/hooks/test_ssh_hook.py
@@ -27,7 +27,7 @@ import paramiko
 from airflow.contrib.hooks.ssh_hook import SSHHook
 from airflow.models import Connection
 from airflow.utils import db
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 
 HELLO_SERVER_CMD = """
 import socket, sys

--- a/tests/gcp/operators/test_bigquery.py
+++ b/tests/gcp/operators/test_bigquery.py
@@ -35,7 +35,7 @@ from airflow.gcp.operators.bigquery import (
 from airflow.models import DAG, TaskFail, TaskInstance, XCom
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.settings import Session
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 TASK_ID = 'test-bq-generic-operator'
 TEST_DATASET = 'test-dataset'

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -39,7 +39,7 @@ from airflow.jobs.scheduler_job import DagFileProcessor
 from airflow.models import DAG, DagBag, DagRun, Pool, TaskInstance as TI
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from tests.test_utils.db import clear_db_pools, clear_db_runs, set_default_pool_slots

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -26,7 +26,7 @@ from sqlalchemy.exc import OperationalError
 
 from airflow.jobs import BaseJob
 from airflow.utils import timezone
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 
 

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -31,8 +31,8 @@ from airflow.jobs import LocalTaskJob
 from airflow.models import DAG, TaskInstance as TI
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
-from airflow.utils.db import create_session
 from airflow.utils.net import get_hostname
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.test_utils.db import clear_db_runs
 from tests.test_utils.mock_executor import MockExecutor

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -43,8 +43,8 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
 from airflow.utils.dag_processing import SimpleDag, SimpleDagBag
 from airflow.utils.dates import days_ago
-from airflow.utils.db import create_session, provide_session
 from airflow.utils.file import list_py_file_paths
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from tests.test_utils.db import (
     clear_db_dags, clear_db_errors, clear_db_pools, clear_db_runs, clear_db_sla_miss, set_default_pool_slots,

--- a/tests/models/test_cleartasks.py
+++ b/tests/models/test_cleartasks.py
@@ -26,7 +26,7 @@ from airflow.configuration import conf
 from airflow.models import DAG, TaskInstance as TI, XCom, clear_task_instances
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.models import DEFAULT_DATE
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -43,8 +43,8 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils import timezone
-from airflow.utils.db import create_session
 from airflow.utils.file import list_py_file_paths
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime as datetime_tz
 from airflow.utils.weight_rule import WeightRule

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -31,7 +31,7 @@ from airflow import models
 from airflow.configuration import conf
 from airflow.models import DagBag, DagModel, TaskInstance as TI
 from airflow.models.taskinstance import SimpleTaskInstance
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.models import DEFAULT_DATE, TEST_DAGS_FOLDER
 from tests.test_utils.config import conf_vars

--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -25,7 +25,7 @@ from airflow import example_dags as example_dags_module
 from airflow.models import DagBag
 from airflow.models.serialized_dag import SerializedDagModel as SDM
 from airflow.serialization.serialized_objects import SerializedDAG
-from airflow.utils import db
+from airflow.utils.session import create_session
 
 
 # To move it to a shared module.
@@ -36,7 +36,7 @@ def make_example_dags(module):
 
 
 def clear_db_serialized_dags():
-    with db.create_session() as session:
+    with create_session() as session:
         session.query(SDM).delete()
 
 
@@ -63,7 +63,7 @@ class SerializedDagModelTest(unittest.TestCase):
         """DAGs can be written into database."""
         example_dags = self._write_example_dags()
 
-        with db.create_session() as session:
+        with create_session() as session:
             for dag in example_dags.values():
                 self.assertTrue(SDM.has_dag(dag.dag_id))
                 result = session.query(

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -42,7 +42,7 @@ from airflow.ti_deps.dep_context import REQUEUEABLE_DEPS, RUNNABLE_STATES, RUNNI
 from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils import timezone
-from airflow.utils.db import create_session, provide_session
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from tests.models import DEFAULT_DATE
 from tests.test_utils import db

--- a/tests/operators/test_branch_operator.py
+++ b/tests/operators/test_branch_operator.py
@@ -24,7 +24,7 @@ from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.operators.branch_operator import BaseBranchOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)

--- a/tests/operators/test_dagrun_operator.py
+++ b/tests/operators/test_dagrun_operator.py
@@ -25,7 +25,7 @@ from unittest import TestCase
 from airflow.models import DAG, DagModel, DagRun, Log, TaskInstance
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from airflow.utils import timezone
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 
 DEFAULT_DATE = datetime(2019, 1, 1, tzinfo=timezone.utc)
 TEST_DAG_ID = "testdag"

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -30,7 +30,7 @@ from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator, PythonOperator, ShortCircuitOperator
 from airflow.utils import timezone
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -28,7 +28,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.subdag_operator import SkippedStatePropagationOptions, SubDagOperator
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from tests.test_utils.db import clear_db_runs

--- a/tests/providers/sftp/hooks/test_sftp_hook.py
+++ b/tests/providers/sftp/hooks/test_sftp_hook.py
@@ -27,7 +27,7 @@ from parameterized import parameterized
 
 from airflow.models import Connection
 from airflow.providers.sftp.hooks.sftp_hook import SFTPHook
-from airflow.utils.db import provide_session
+from airflow.utils.session import provide_session
 
 TMP_PATH = '/tmp'
 TMP_DIR_FOR_TESTS = 'tests_sftp_hook_dir'

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -17,7 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 from airflow.models import Connection, DagModel, DagRun, Pool, SlaMiss, TaskInstance, errors
-from airflow.utils.db import add_default_pool_if_not_exists, create_default_connections, create_session
+from airflow.utils.db import add_default_pool_if_not_exists, create_default_connections
+from airflow.utils.session import create_session
 
 
 def clear_db_runs():

--- a/tests/test_utils/mock_executor.py
+++ b/tests/test_utils/mock_executor.py
@@ -19,7 +19,7 @@
 from collections import defaultdict
 
 from airflow.executors.base_executor import BaseExecutor
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 
 

--- a/tests/ti_deps/deps/test_pool_slots_available_dep.py
+++ b/tests/ti_deps/deps/test_pool_slots_available_dep.py
@@ -22,7 +22,7 @@ from mock import Mock, patch
 
 from airflow.models import Pool
 from airflow.ti_deps.deps.pool_slots_available_dep import STATES_TO_COUNT_AS_RUNNING, PoolSlotsAvailableDep
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from tests.test_utils import db
 
 

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from airflow.models import TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule
 

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -33,8 +33,8 @@ from airflow.models import DagBag, TaskInstance as TI
 from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.utils import timezone
 from airflow.utils.dag_processing import DagFileProcessorAgent, DagFileProcessorManager, DagFileStat
-from airflow.utils.db import create_session
 from airflow.utils.file import correct_maybe_zipped
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_runs

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -26,9 +26,9 @@ from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONF
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.utils.db import create_session
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import set_context
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -49,7 +49,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.settings import Session
 from airflow.ti_deps.dep_context import QUEUEABLE_STATES, RUNNABLE_STATES
 from airflow.utils import dates, timezone
-from airflow.utils.db import create_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.www import app as application


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6382

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Extracting `provide_session` and `create_session` to separate module
reduces number of cyclic imports and make a disctinction between
session and database.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
