### PR TITLE
[AIRFLOW-6318] Change python3 as Dataflow default intrepreter

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -41,6 +41,10 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Change python3 as Dataflow Hooks/Operators default interpreter
+
+Now the `py_interpreter` argument for DataFlow Hooks/Operators has been changed from python2 to python3.
+
 ### Logging configuration has been moved to new section
 
 The following configurations have been moved from `[core]` to the new `[logging]` section.

--- a/airflow/gcp/hooks/dataflow.py
+++ b/airflow/gcp/hooks/dataflow.py
@@ -487,7 +487,7 @@ class DataflowHook(CloudBaseHook):
         py_options: List[str],
         project_id: Optional[str] = None,
         append_job_name: bool = True,
-        py_interpreter: str = "python2"
+        py_interpreter: str = "python3"
     ):
         """
         Starts Dataflow job.
@@ -505,7 +505,7 @@ class DataflowHook(CloudBaseHook):
         :param project_id: Optional, the GCP project ID in which to start a job.
             If set to None or missing, the default project_id from the GCP connection is used.
         :param py_interpreter: Python version of the beam pipeline.
-            If None, this defaults to the python2.
+            If None, this defaults to the python3.
             To track python versions supported by beam and related
             issues check: https://issues.apache.org/jira/browse/BEAM-1251
         :type py_interpreter: str

--- a/airflow/gcp/operators/dataflow.py
+++ b/airflow/gcp/operators/dataflow.py
@@ -367,7 +367,7 @@ class DataflowCreatePythonJobOperator(BaseOperator):
     :param options: Map of job specific options.
     :type options: dict
     :param py_interpreter: Python version of the beam pipeline.
-        If None, this defaults to the python2.
+        If None, this defaults to the python3.
         To track python versions supported by beam and related
         issues check: https://issues.apache.org/jira/browse/BEAM-1251
     :type py_interpreter: str
@@ -393,7 +393,7 @@ class DataflowCreatePythonJobOperator(BaseOperator):
             py_options: Optional[List[str]] = None,
             dataflow_default_options: Optional[dict] = None,
             options: Optional[dict] = None,
-            py_interpreter: str = "python2",
+            py_interpreter: str = "python3",
             gcp_conn_id: str = 'google_cloud_default',
             delegate_to: Optional[str] = None,
             poll_sleep: int = 10,

--- a/airflow/gcp/utils/mlengine_operator_utils.py
+++ b/airflow/gcp/utils/mlengine_operator_utils.py
@@ -49,7 +49,7 @@ def create_evaluate_ops(task_prefix,  # pylint: disable=too-many-arguments
                         model_name=None,
                         version_name=None,
                         dag=None,
-                        py_interpreter="python2"):
+                        py_interpreter="python3"):
     """
     Creates Operators needed for model evaluation and returns.
 
@@ -177,7 +177,7 @@ def create_evaluate_ops(task_prefix,  # pylint: disable=too-many-arguments
     :type dag: airflow.models.DAG
 
     :param py_interpreter: Python version of the beam pipeline.
-        If None, this defaults to the python2.
+        If None, this defaults to the python3.
         To track python versions supported by beam and related
         issues check: https://issues.apache.org/jira/browse/BEAM-1251
     :type py_interpreter: str

--- a/tests/gcp/hooks/test_dataflow.py
+++ b/tests/gcp/hooks/test_dataflow.py
@@ -80,7 +80,7 @@ TEST_PROJECT = 'test-project'
 TEST_JOB_NAME = 'test-job-name'
 TEST_JOB_ID = 'test-job-id'
 TEST_LOCATION = 'us-central1'
-DEFAULT_PY_INTERPRETER = 'python2'
+DEFAULT_PY_INTERPRETER = 'python3'
 
 
 class TestFallbackToVariables(unittest.TestCase):
@@ -175,7 +175,7 @@ class TestDataflowHook(unittest.TestCase):
         self.dataflow_hook.start_python_dataflow(
             job_name=JOB_NAME, variables=DATAFLOW_OPTIONS_PY,
             dataflow=PY_FILE, py_options=PY_OPTIONS)
-        expected_cmd = ["python2", '-m', PY_FILE,
+        expected_cmd = ["python3", '-m', PY_FILE,
                         '--region=us-central1',
                         '--runner=DataflowRunner', '--project=test',
                         '--labels=foo=bar',
@@ -185,7 +185,7 @@ class TestDataflowHook(unittest.TestCase):
                              sorted(expected_cmd))
 
     @parameterized.expand([
-        ('default_to_python2', "python2"),
+        ('default_to_python3', 'python3'),
         ('major_version_2', 'python2'),
         ('major_version_3', 'python3'),
         ('minor_version', 'python3.6')

--- a/tests/gcp/operators/test_dataflow.py
+++ b/tests/gcp/operators/test_dataflow.py
@@ -36,7 +36,7 @@ PARAMETERS = {
     'output': 'gs://test/output/my_output'
 }
 PY_FILE = 'gs://my-bucket/my-object.py'
-PY_INTERPRETER = 'python2'
+PY_INTERPRETER = 'python3'
 JAR_FILE = 'example/test.jar'
 JOB_CLASS = 'com.test.NotMain'
 PY_OPTIONS = ['-m']


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6318
  

### Description

- [x] Created from #6860 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
