### PR TITLE
[AIRFLOW-4428] error if exec_date before default_args.start_date in t…

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -60,6 +60,14 @@ def _trigger_dag(
     if replace_microseconds:
         execution_date = execution_date.replace(microsecond=0)
 
+    if dag.default_args and 'start_date' in dag.default_args:
+        min_dag_start_date = dag.default_args["start_date"]
+        if min_dag_start_date and execution_date < min_dag_start_date:
+            raise ValueError(
+                "The execution_date [{0}] should be >= start_date [{1}] from DAG's default_args".format(
+                    execution_date.isoformat(),
+                    min_dag_start_date.isoformat()))
+
     if not run_id:
         run_id = "manual__{0}".format(execution_date.isoformat())
 

--- a/tests/api/common/experimental/test_trigger_dag.py
+++ b/tests/api/common/experimental/test_trigger_dag.py
@@ -24,6 +24,7 @@ from unittest import mock
 from airflow.api.common.experimental.trigger_dag import _trigger_dag
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun
+from airflow.utils import timezone
 
 
 class TestTriggerDag(unittest.TestCase):
@@ -107,6 +108,46 @@ class TestTriggerDag(unittest.TestCase):
             replace_microseconds=True)
 
         self.assertEqual(triggers[0].conf, json.loads(conf))
+
+    @mock.patch('airflow.models.DagBag')
+    def test_trigger_dag_with_too_early_start_date(self, dag_bag_mock):
+        dag_id = "trigger_dag_with_too_early_start_date"
+        dag = DAG(dag_id, default_args={'start_date': timezone.datetime(2016, 9, 5, 10, 10, 0)})
+        dag_bag_mock.dags = [dag_id]
+        dag_bag_mock.get_dag.return_value = dag
+        dag_run = DagRun()
+
+        self.assertRaises(
+            ValueError,
+            _trigger_dag,
+            dag_id,
+            dag_bag_mock,
+            dag_run,
+            run_id=None,
+            conf=None,
+            execution_date=timezone.datetime(2015, 7, 5, 10, 10, 0),
+            replace_microseconds=True,
+        )
+
+    @mock.patch('airflow.models.DagBag')
+    def test_trigger_dag_with_valid_start_date(self, dag_bag_mock):
+        dag_id = "trigger_dag_with_valid_start_date"
+        dag = DAG(dag_id, default_args={'start_date': timezone.datetime(2016, 9, 5, 10, 10, 0)})
+        dag_bag_mock.dags = [dag_id]
+        dag_bag_mock.get_dag.return_value = dag
+        dag_run = DagRun()
+
+        triggers = _trigger_dag(
+            dag_id,
+            dag_bag_mock,
+            dag_run,
+            run_id=None,
+            conf=None,
+            execution_date=timezone.datetime(2018, 7, 5, 10, 10, 0),
+            replace_microseconds=True,
+        )
+
+        assert len(triggers) == 1
 
     @mock.patch('airflow.models.DagBag')
     def test_trigger_dag_with_dict_conf(self, dag_bag_mock):


### PR DESCRIPTION
…rigger_dag

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-4428](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-4428\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4428
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-4428\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
