### PR TITLE
[AIRFLOW-6392] Remove cyclic dependency baseoperator <-> helpers

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -67,6 +67,34 @@ Now users instead of `import from airflow.utils.files import TemporaryDirectory`
 do `from tempfile import TemporaryDirectory`. Both context managers provide the same
 interface, thus no additional changes should be required.
 
+### Chain and cross_downstream moved from helpers to BaseOperator
+
+The `chain` and `cross_downstream` methods are now moved to airflow.models.baseoperator module from
+`airflow.utils.helpers` module.
+
+The baseoperator module seems to be a better choice to keep
+closely coupled methods together. Helpers module is supposed to contain standalone helper methods
+that can be imported by all classes.
+
+The `chain` method and `cross_downstream` method both use BaseOperator. If any other package imports
+any classes or functions from helpers module, then it automatically has an
+implicit dependency to BaseOperator. That can often lead to cyclic dependencies.
+
+More information in [AIFLOW-6392](https://issues.apache.org/jira/browse/AIRFLOW-6392)
+
+In Airflow <2.0 you imported those two methods like this:
+
+```python
+from airflow.utils.helpers import chain
+from airflow.utils.helpers import cross_downstream
+```
+
+In Airflow 2.0 it should be changed to:
+```python
+from airflow.models.baseoperator import chain
+from airflow.models.baseoperator import cross_downstream
+```
+
 ### Change python3 as Dataflow Hooks/Operators default interpreter
 
 Now the `py_interpreter` argument for DataFlow Hooks/Operators has been changed from python2 to python3.

--- a/airflow/example_dags/example_short_circuit_operator.py
+++ b/airflow/example_dags/example_short_circuit_operator.py
@@ -18,15 +18,15 @@
 # under the License.
 
 """Example DAG demonstrating the usage of the ShortCircuitOperator."""
-
-import airflow.utils.helpers
 from airflow.models import DAG
+from airflow.models.baseoperator import chain
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import ShortCircuitOperator
+from airflow.utils import dates
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': dates.days_ago(2),
 }
 
 dag = DAG(dag_id='example_short_circuit_operator', default_args=args)
@@ -46,5 +46,5 @@ cond_false = ShortCircuitOperator(
 ds_true = [DummyOperator(task_id='true_' + str(i), dag=dag) for i in [1, 2]]
 ds_false = [DummyOperator(task_id='false_' + str(i), dag=dag) for i in [1, 2]]
 
-airflow.utils.helpers.chain(cond_true, *ds_true)
-airflow.utils.helpers.chain(cond_false, *ds_false)
+chain(cond_true, *ds_true)
+chain(cond_false, *ds_false)

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -26,7 +26,9 @@ import sys
 import warnings
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta
-from typing import Any, Callable, ClassVar, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple, Type, Union
+from typing import (
+    Any, Callable, ClassVar, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple, Type, Union, cast,
+)
 
 import attr
 import jinja2
@@ -670,6 +672,7 @@ class BaseOperator(Operator, LoggingMixin):
 
         for k, v in self.__dict__.items():
             if k not in shallow_copy:
+                # noinspection PyArgumentList
                 setattr(result, k, copy.deepcopy(v, memo))
             else:
                 setattr(result, k, copy.copy(v))
@@ -1115,6 +1118,96 @@ class BaseOperator(Operator, LoggingMixin):
                 } | {'_task_type', 'subdag', 'ui_color', 'ui_fgcolor', 'template_fields'})
 
         return cls.__serialized_fields
+
+
+def chain(*tasks: Union[BaseOperator, List[BaseOperator]]):
+    r"""
+    Given a number of tasks, builds a dependency chain.
+    Support mix airflow.models.BaseOperator and List[airflow.models.BaseOperator].
+    If you want to chain between two List[airflow.models.BaseOperator], have to
+    make sure they have same length.
+
+    .. code-block:: python
+
+         chain(t1, [t2, t3], [t4, t5], t6)
+
+    is equivalent to::
+
+         / -> t2 -> t4 \
+       t1               -> t6
+         \ -> t3 -> t5 /
+
+    .. code-block:: python
+
+        t1.set_downstream(t2)
+        t1.set_downstream(t3)
+        t2.set_downstream(t4)
+        t3.set_downstream(t5)
+        t4.set_downstream(t6)
+        t5.set_downstream(t6)
+
+    :param tasks: List of tasks or List[airflow.models.BaseOperator] to set dependencies
+    :type tasks: List[airflow.models.BaseOperator] or airflow.models.BaseOperator
+    """
+    for index, up_task in enumerate(tasks[:-1]):
+        down_task = tasks[index + 1]
+        if isinstance(up_task, BaseOperator):
+            up_task.set_downstream(down_task)
+            continue
+        if isinstance(down_task, BaseOperator):
+            down_task.set_upstream(up_task)
+            continue
+        if not isinstance(up_task, List) or not isinstance(down_task, List):
+            raise TypeError(
+                'Chain not supported between instances of {up_type} and {down_type}'.format(
+                    up_type=type(up_task), down_type=type(down_task)))
+        up_task_list = cast(List[BaseOperator], up_task)
+        down_task_list = cast(List[BaseOperator], down_task)
+        if len(up_task_list) != len(down_task_list):
+            raise AirflowException(
+                f'Chain not supported different length Iterable '
+                f'but get {len(up_task_list)} and {len(down_task_list)}')
+        for up_t, down_t in zip(up_task_list, down_task_list):
+            up_t.set_downstream(down_t)
+
+
+def cross_downstream(from_tasks: List[BaseOperator],
+                     to_tasks: Union[BaseOperator, List[BaseOperator]]):
+    r"""
+    Set downstream dependencies for all tasks in from_tasks to all tasks in to_tasks.
+
+    .. code-block:: python
+
+        cross_downstream(from_tasks=[t1, t2, t3], to_tasks=[t4, t5, t6])
+
+    is equivalent to::
+
+        t1 ---> t4
+           \ /
+        t2 -X -> t5
+           / \
+        t3 ---> t6
+
+
+    .. code-block:: python
+
+        t1.set_downstream(t4)
+        t1.set_downstream(t5)
+        t1.set_downstream(t6)
+        t2.set_downstream(t4)
+        t2.set_downstream(t5)
+        t2.set_downstream(t6)
+        t3.set_downstream(t4)
+        t3.set_downstream(t5)
+        t3.set_downstream(t6)
+
+    :param from_tasks: List of tasks to start from.
+    :type from_tasks: List[airflow.models.BaseOperator]
+    :param to_tasks: List of tasks to set as downstream dependencies.
+    :type to_tasks: List[airflow.models.BaseOperator]
+    """
+    for task in from_tasks:
+        task.set_downstream(to_tasks)
 
 
 @attr.s(auto_attribs=True)

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -31,13 +31,6 @@ from jinja2 import Template
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 
-try:
-    # Fix Python > 3.7 deprecation
-    from collections.abc import Iterable
-except ImportError:
-    # Preserve Python < 3.3 compatibility
-    from collections import Iterable
-
 # When killing processes, time to wait after issuing a SIGTERM before issuing a
 # SIGKILL.
 DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM = conf.getint(
@@ -140,83 +133,6 @@ def as_flattened_list(iterable):
     ['blue', 'red', 'green', 'yellow', 'pink']
     """
     return [e for i in iterable for e in i]
-
-
-def chain(*tasks):
-    r"""
-    Given a number of tasks, builds a dependency chain.
-    Support mix airflow.models.BaseOperator and List[airflow.models.BaseOperator].
-    If you want to chain between two List[airflow.models.BaseOperator], have to
-    make sure they have same length.
-
-    chain(t1, [t2, t3], [t4, t5], t6)
-
-    is equivalent to
-
-      / -> t2 -> t4 \
-    t1               -> t6
-      \ -> t3 -> t5 /
-
-    t1.set_downstream(t2)
-    t1.set_downstream(t3)
-    t2.set_downstream(t4)
-    t3.set_downstream(t5)
-    t4.set_downstream(t6)
-    t5.set_downstream(t6)
-
-    :param tasks: List of tasks or List[airflow.models.BaseOperator] to set dependencies
-    :type tasks: List[airflow.models.BaseOperator] or airflow.models.BaseOperator
-    """
-    from airflow.models.baseoperator import BaseOperator
-    for index, up_task in enumerate(tasks[:-1]):
-        down_task = tasks[index + 1]
-        if isinstance(up_task, BaseOperator):
-            up_task.set_downstream(down_task)
-        elif isinstance(down_task, BaseOperator):
-            down_task.set_upstream(up_task)
-        else:
-            if not isinstance(up_task, Iterable) or not isinstance(down_task, Iterable):
-                raise TypeError(
-                    'Chain not supported between instances of {up_type} and {down_type}'.format(
-                        up_type=type(up_task), down_type=type(down_task)))
-            elif len(up_task) != len(down_task):
-                raise AirflowException(
-                    'Chain not supported different length Iterable but get {up_len} and {down_len}'.format(
-                        up_len=len(up_task), down_len=len(down_task)))
-            else:
-                for up, down in zip(up_task, down_task):
-                    up.set_downstream(down)
-
-
-def cross_downstream(from_tasks, to_tasks):
-    r"""
-    Set downstream dependencies for all tasks in from_tasks to all tasks in to_tasks.
-    E.g.: cross_downstream(from_tasks=[t1, t2, t3], to_tasks=[t4, t5, t6])
-    Is equivalent to:
-
-    t1 --> t4
-       \ /
-    t2 -X> t5
-       / \
-    t3 --> t6
-
-    t1.set_downstream(t4)
-    t1.set_downstream(t5)
-    t1.set_downstream(t6)
-    t2.set_downstream(t4)
-    t2.set_downstream(t5)
-    t2.set_downstream(t6)
-    t3.set_downstream(t4)
-    t3.set_downstream(t5)
-    t3.set_downstream(t6)
-
-    :param from_tasks: List of tasks to start from.
-    :type from_tasks: List[airflow.models.BaseOperator]
-    :param to_tasks: List of tasks to set as downstream dependencies.
-    :type to_tasks: List[airflow.models.BaseOperator]
-    """
-    for task in from_tasks:
-        task.set_downstream(to_tasks)
 
 
 def pprinttable(rows):

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -271,8 +271,12 @@ and equivalent to:
     op1.set_downstream([op2, op3])
 
 
-Relationship Helper
---------------------
+Relationship Builders
+---------------------
+
+*Moved in Airflow 2.0*
+
+In Airflow 2.0 those two methods moved from ``airflow.utils.helpers`` to ``airflow.models.baseoperator``.
 
 ``chain`` and ``cross_downstream`` function provide easier ways to set relationships
 between operators in specific situation.


### PR DESCRIPTION
There is a hidden cyclic dependency between baseoperator and helpers module.
It's hidden by local import but it is detected when baseoperator/helpers are
removed from pylint_todo.txt (and it's really there).

The dependency comes from BaseOperator using helpers and two helpers methods
(chain and cross_downstream) using BaseOperator. This can be solved by
converting the chain and cross_downstream methods to be static methods in
BaseOperator class.

- [x] Description above provides context of the change
- [x] Commit message contains  [\[AIRFLOW-6392\]](https://issues.apache.org/jira/browse/AIRFLOW-6392) or `[AIRFLOW-XXXX]` for document-only changes
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow  "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).


In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.