### PR TITLE
[AIRFLOW-6394] Simplify github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,10 @@
-Make sure you have checked _all_ steps below.
-
-### Jira
-
-- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
-  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
-  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
-  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
-  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
-
-### Description
-
-- [ ] Here are some details about my PR, including screenshots of any UI changes:
-
-### Tests
-
-- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
-
-### Commits
-
-- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
-  1. Subject is separated from body by a blank line
-  1. Subject is limited to 50 characters (not including Jira issue reference)
-  1. Subject does not end with a period
-  1. Subject uses the imperative mood ("add", not "adding")
-  1. Body wraps at 72 characters
-  1. Body explains "what" and "why", not "how"
-
-### Documentation
-
-- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
-  - All the public functions and the classes in the PR contain docstrings that explain what it does
-  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
+- [ ] Description above provides context of the change
+- [ ] Commit message contains [\[AIRFLOW-XXXX\]](https://issues.apache.org/jira/browse/AIRFLOW-XXXX) or `[AIRFLOW-XXXX]` for document-only changes
+- [ ] Unit tests coverage for changes (not needed for documentation changes)
+- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
+- [ ] Relevant documentation is updated including usage instructions.
+- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
+In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
+In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
+In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
+Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.


### PR DESCRIPTION
Our Github template is not really useful for most people. Almost no-one is
marking the tick-marks when submitting the PR and not many people update the
link to the AIRFLOW ticket. I don't think it serves the purpose of teaching
people as it is too long to be actually read and acted upon

We should simplify it.

And later we should add probot checks to automate most of the stuff that we
wanted to enforce with the template

- [x] Description above provides context of the change
- [x] Commit message contains  [\[AIRFLOW-6394\]](https://issues.apache.org/jira/browse/AIRFLOW-6394) or `[AIRFLOW-XXXX]` for document-only changes
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow  "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).


In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.