### PR TITLE
[AIRFLOW-6398] improve flakey test test_mark_success_no_kill

### DIFF
--- a/tests/dags/test_mark_success.py
+++ b/tests/dags/test_mark_success.py
@@ -17,9 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
+from time import sleep
 
 from airflow.models import DAG
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.python_operator import PythonOperator
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 
@@ -28,8 +29,10 @@ args = {
     'start_date': DEFAULT_DATE,
 }
 
+
 dag = DAG(dag_id='test_mark_success', default_args=args)
-task = BashOperator(
+task = PythonOperator(
     task_id='task1',
-    bash_command='sleep 600',
+    python_callable=lambda x: sleep(x),  # pylint: disable=W0108
+    op_args=[600],
     dag=dag)


### PR DESCRIPTION
test `test_mark_success_no_kill` fails regularly

part of the problem is that it depends on timing of a subprocess and database operations.  currently it uses bash operator to call sleep 600.  this introduces an unnecessary layer of multiprocessing. there is also a bug in bash operator which was exacerbating the problem.  (see [AIRFLOW-6397](https://issues.apache.org/jira/browse/AIRFLOW-6397) / #6958 )

we can reduce complexity by using python operator instead of bash operator.


Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6398
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
