### PR TITLE
[AIRFLOW-6109] [AIP-21] Rename GCP function operators

### DIFF
--- a/airflow/contrib/hooks/gcp_function_hook.py
+++ b/airflow/contrib/hooks/gcp_function_hook.py
@@ -20,8 +20,7 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.hooks.functions import CloudFunctionsHook  # noqa
+from airflow.gcp.hooks.functions import CloudFunctionsHook
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.functions`.",

--- a/airflow/contrib/operators/gcp_function_operator.py
+++ b/airflow/contrib/operators/gcp_function_operator.py
@@ -20,12 +20,41 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.operators.functions import (  # # noqa
-    GcfFunctionDeleteOperator, GcfFunctionDeployOperator, ZipPathPreprocessor,
+from airflow.gcp.operators.functions import (
+    CloudFunctionDeleteFunctionOperator, CloudFunctionDeployFunctionOperator,
 )
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.functions`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GcfFunctionDeleteOperator(CloudFunctionDeleteFunctionOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.function.CloudFunctionDeleteFunctionOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.function.CloudFunctionDeleteFunctionOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcfFunctionDeployOperator(CloudFunctionDeployFunctionOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.function.CloudFunctionDeployFunctionOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.function.CloudFunctionDeployFunctionOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/gcp/example_dags/example_functions.py
+++ b/airflow/gcp/example_dags/example_functions.py
@@ -45,7 +45,8 @@ import os
 
 from airflow import models
 from airflow.gcp.operators.functions import (
-    GcfFunctionDeleteOperator, GcfFunctionDeployOperator, GcfFunctionInvokeOperator,
+    CloudFunctionDeleteFunctionOperator, CloudFunctionDeployFunctionOperator,
+    CloudFunctionInvokeFunctionOperator,
 )
 from airflow.utils import dates
 
@@ -109,7 +110,7 @@ with models.DAG(
     schedule_interval=None  # Override to match your needs
 ) as dag:
     # [START howto_operator_gcf_deploy]
-    deploy_task = GcfFunctionDeployOperator(
+    deploy_task = CloudFunctionDeployFunctionOperator(
         task_id="gcf_deploy_task",
         project_id=GCP_PROJECT_ID,
         location=GCP_LOCATION,
@@ -118,7 +119,7 @@ with models.DAG(
     )
     # [END howto_operator_gcf_deploy]
     # [START howto_operator_gcf_deploy_no_project_id]
-    deploy2_task = GcfFunctionDeployOperator(
+    deploy2_task = CloudFunctionDeployFunctionOperator(
         task_id="gcf_deploy2_task",
         location=GCP_LOCATION,
         body=body,
@@ -126,7 +127,7 @@ with models.DAG(
     )
     # [END howto_operator_gcf_deploy_no_project_id]
     # [START howto_operator_gcf_invoke_function]
-    invoke_task = GcfFunctionInvokeOperator(
+    invoke_task = CloudFunctionInvokeFunctionOperator(
         task_id="invoke_task",
         project_id=GCP_PROJECT_ID,
         location=GCP_LOCATION,
@@ -135,7 +136,7 @@ with models.DAG(
     )
     # [END howto_operator_gcf_invoke_function]
     # [START howto_operator_gcf_delete]
-    delete_task = GcfFunctionDeleteOperator(
+    delete_task = CloudFunctionDeleteFunctionOperator(
         task_id="gcf_delete_task",
         name=FUNCTION_NAME
     )

--- a/airflow/gcp/operators/functions.py
+++ b/airflow/gcp/operators/functions.py
@@ -82,14 +82,14 @@ CLOUD_FUNCTION_VALIDATION = [
 ]  # type: List[Dict[str, Any]]
 
 
-class GcfFunctionDeployOperator(BaseOperator):
+class CloudFunctionDeployFunctionOperator(BaseOperator):
     """
     Creates a function in Google Cloud Functions.
     If a function with this name already exists, it will be updated.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcfFunctionDeployOperator`
+        :ref:`howto/operator:CloudFunctionDeployFunctionOperator`
 
     :param location: Google Cloud Platform region where the function should be created.
     :type location: str
@@ -292,13 +292,13 @@ FUNCTION_NAME_PATTERN = '^projects/[^/]+/locations/[^/]+/functions/[^/]+$'
 FUNCTION_NAME_COMPILED_PATTERN = re.compile(FUNCTION_NAME_PATTERN)
 
 
-class GcfFunctionDeleteOperator(BaseOperator):
+class CloudFunctionDeleteFunctionOperator(BaseOperator):
     """
     Deletes the specified function from Google Cloud Functions.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcfFunctionDeleteOperator`
+        :ref:`howto/operator:CloudFunctionDeleteFunctionOperator`
 
     :param name: A fully-qualified function name, matching
         the pattern: `^projects/[^/]+/locations/[^/]+/functions/[^/]+$`
@@ -346,14 +346,14 @@ class GcfFunctionDeleteOperator(BaseOperator):
                 raise e
 
 
-class GcfFunctionInvokeOperator(BaseOperator):
+class CloudFunctionInvokeFunctionOperator(BaseOperator):
     """
     Invokes a deployed Cloud Function. To be used for testing
     purposes as very limited traffic is allowed.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcfFunctionDeployOperator`
+        :ref:`howto/operator:CloudFunctionDeployFunctionOperator`
 
     :param function_id: ID of the function to be called
     :type function_id: str

--- a/docs/howto/operator/gcp/functions.rst
+++ b/docs/howto/operator/gcp/functions.rst
@@ -29,15 +29,15 @@ Prerequisite Tasks
 
 .. include:: _partials/prerequisite_tasks.rst
 
-.. _howto/operator:GcfFunctionDeleteOperator:
+.. _howto/operator:CloudFunctionDeleteFunctionOperator:
 
-GcfFunctionDeleteOperator
--------------------------
+CloudFunctionDeleteFunctionOperator
+-----------------------------------
 
 Use the operator to delete a function from Google Cloud Functions.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.functions.GcfFunctionDeleteOperator`.
+:class:`~airflow.gcp.operators.functions.CloudFunctionDeleteFunctionOperator`.
 
 Arguments
 """""""""
@@ -74,16 +74,16 @@ More information
 See Google Cloud Functions API documentation to `delete a function
 <https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/delete>`_.
 
-.. _howto/operator:GcfFunctionDeployOperator:
+.. _howto/operator:CloudFunctionDeployFunctionOperator:
 
-GcfFunctionDeployOperator
--------------------------
+CloudFunctionDeployFunctionOperator
+-----------------------------------
 
 Use the operator to deploy a function to Google Cloud Functions.
 If a function with this name already exists, it will be updated.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.functions.GcfFunctionDeployOperator`.
+:class:`~airflow.gcp.operators.functions.CloudFunctionDeployFunctionOperator`.
 
 
 Arguments

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -364,11 +364,11 @@ OPERATOR = [
         "airflow.contrib.operators.gcp_dlp_operator.CloudDLPUpdateStoredInfoTypeOperator",
     ),
     (
-        "airflow.gcp.operators.functions.GcfFunctionDeleteOperator",
+        "airflow.gcp.operators.functions.CloudFunctionDeleteFunctionOperator",
         "airflow.contrib.operators.gcp_function_operator.GcfFunctionDeleteOperator",
     ),
     (
-        "airflow.gcp.operators.functions.GcfFunctionDeployOperator",
+        "airflow.gcp.operators.functions.CloudFunctionDeployFunctionOperator",
         "airflow.contrib.operators.gcp_function_operator.GcfFunctionDeployOperator",
     ),
     (


### PR DESCRIPTION
PR contains changes regarding AIP-21 (renaming GCP operators and hooks).

These modules have been renamed:
- GcfFunctionDeleteOperator
- GcfFunctionDeployOperator
- GcfHook
- GcfFunctionInvokeOperator 

Deprecation warnings have been added to these modules:
- airflow/contrib/hooks/gcp_function_hook.py
- airflow/contrib/operators/gcp_function_operator.py 

Tests have been changed:
- tests/test_core_to_contrib.py
- tests/gcp/operators/test_functions.py
_______________________________________________________

- [x] Description above provides context of the change
- [x] Commit message contains [\[AIRFLOW-6109\]](https://issues.apache.org/jira/browse/AIRFLOW-6109) or `[AIRFLOW-XXXX]` for document-only changes
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
