### PR TITLE
[AIRFLOW-6410] Make Spark status_poll_interval explicit

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -86,7 +86,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :type name: str
     :param num_executors: Number of executors to launch
     :type num_executors: int
-    :param status_poll_interval: Seconds to wait between polls of driver status in cluster mode
+    :param status_poll_interval: Seconds to wait between polls of driver status in cluster
+        mode (Default: 1)
     :type status_poll_interval: int
     :param application_args: Arguments for the application being submitted
     :type application_args: list
@@ -120,7 +121,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                  proxy_user=None,
                  name='default-name',
                  num_executors=None,
-                 status_poll_interval=None,
+                 status_poll_interval=1,
                  application_args=None,
                  env_vars=None,
                  verbose=False,
@@ -145,7 +146,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._proxy_user = proxy_user
         self._name = name
         self._num_executors = num_executors
-        self._status_poll_interval = status_poll_interval or 1
+        self._status_poll_interval = status_poll_interval
         self._application_args = application_args
         self._env_vars = env_vars
         self._verbose = verbose

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -76,7 +76,8 @@ class SparkSubmitOperator(BaseOperator):
     :type name: str
     :param num_executors: Number of executors to launch
     :type num_executors: int
-    :param status_poll_interval: Seconds to wait between polls of driver status in cluster mode
+    :param status_poll_interval: Seconds to wait between polls of driver status in cluster
+        mode (Default: 1)
     :type status_poll_interval: int
     :param application_args: Arguments for the application being submitted (templated)
     :type application_args: list
@@ -116,7 +117,7 @@ class SparkSubmitOperator(BaseOperator):
                  proxy_user=None,
                  name='airflow-spark',
                  num_executors=None,
-                 status_poll_interval=None,
+                 status_poll_interval=1,
                  application_args=None,
                  env_vars=None,
                  verbose=False,


### PR DESCRIPTION
PR #6909 made this change. The default value should be explicit and documented. However, this was not the case in the PR. This PR fixes it.

- [x] Description above provides context of the change
- [x] Jira: https://issues.apache.org/jira/browse/AIRFLOW-6410
- [x] Unit tests coverage for changes (not needed for documentation changes). The current tests already cover it.
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
