### PR TITLE
[AIRFLOW-6413] Add config file for Mergeable Github integration

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+version: 2
+mergeable:
+  - when: pull_request.*, pull_request_review.*
+    validate:
+      - do: title
+        # Do not merge when it is marked work in progress (WIP)
+        must_exclude:
+          regex: ^\[WIP\]
+          message: This is work in progress. Do not merge yet.
+        begins_with:
+          match: '[AIRFLOW-'
+        must_include:
+          regex: ^(\[AIRFLOW-XXXX\]|\[AIRFLOW\-\d{1,4}\])
+          message: Must include Jira issue in title.
+      - do: label
+        must_exclude:
+          regex: 'wip'
+      # All todo check boxes must be checked.
+      - do: description
+        must_exclude:
+          regex: \[ \]
+          message: There are incomplete TODO task(s) unchecked.
+        no_empty:
+          enabled: true
+        or:
+          - must_include:
+              regex: (\[AIRFLOW-XXXX\])
+          - must_include:
+              regex: (\https\:\/\/issues\.apache\.org\/jira\/browse\/AIRFLOW\-\d{1,4})
+              message: Link to the Jira Issue
+      - do: approvals
+        min:
+          count: 1
+      # If package.json is updated, so should yarn.lock
+      - do: dependent
+        changed:
+          file: 'package.json'
+          files: ['yarn.lock']


### PR DESCRIPTION
Add config for  https://github.com/apps/mergeable

Jira: https://issues.apache.org/jira/browse/AIRFLOW-6413

- [x] Description above provides context of the change
- [x] Commit message contains [\[AIRFLOW-XXXX\]](https://issues.apache.org/jira/browse/AIRFLOW-XXXX) or `[AIRFLOW-XXXX]` for document-only changes
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
