### PR TITLE
[AIRFLOW-6417] Disable approval requirements from mergeable

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -45,9 +45,6 @@ mergeable:
           - must_include:
               regex: (\https\:\/\/issues\.apache\.org\/jira\/browse\/AIRFLOW\-\d{1,4})
               message: Link to the Jira Issue
-      - do: approvals
-        min:
-          count: 1
       # If package.json is updated, so should yarn.lock
       - do: dependent
         changed:


### PR DESCRIPTION
I review PR that are in good condition in the first place - they have a green label next to the title. Unfortunately, now all PRs are always red before they are accepted. When accepted, they are often merged immediately, so all open PRs are always red. This useful indicator now makes no sense.

<img width="976" alt="Screenshot 2020-01-01 at 12 32 07" src="https://user-images.githubusercontent.com/12058428/71640926-bfecc000-2c93-11ea-8d2f-84520c273c33.png">

In my opinion, we do not have a problem with merging PRs that are not accepted, so this option does not solve any of our problems. 


- [X] Description above provides context of the change
- [X] Commit message contains [\[AIRFLOW-6417\]](https://issues.apache.org/jira/browse/AIRFLOW-6417) or `[AIRFLOW-6417]` for document-only changes
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
