### PR TITLE
[AIRFLOW-6418] Remove SystemTest.skip decorator

### DIFF
--- a/tests/test_example_dags_system.py
+++ b/tests/test_example_dags_system.py
@@ -21,7 +21,6 @@ from parameterized import parameterized
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@SystemTest.skip()
 class TestExampleDagsSystem(SystemTest):
     @parameterized.expand([
         "example_bash_operator",

--- a/tests/test_utils/system_tests_class.py
+++ b/tests/test_utils/system_tests_class.py
@@ -20,7 +20,7 @@ import os
 from contextlib import ContextDecorator
 from shutil import move
 from tempfile import mkdtemp
-from unittest import TestCase, skip
+from unittest import SkipTest, TestCase
 
 from airflow import AirflowException, models
 from airflow.configuration import AIRFLOW_HOME, AirflowConfigParser, get_airflow_config
@@ -94,11 +94,10 @@ class empty_dags_directory(  # pylint: disable=invalid-name
 
 
 class SystemTest(TestCase, LoggingMixin):
-    @staticmethod
-    def skip():
+    def run(self, result=None):
         if os.environ.get('ENABLE_SYSTEM_TESTS') != 'true':
-            return skip(SKIP_SYSTEM_TEST_WARNING)
-        return lambda cls: cls
+            raise SkipTest(SKIP_SYSTEM_TEST_WARNING)
+        return super().run(result)
 
     def setUp(self) -> None:
         """


### PR DESCRIPTION
Instead of forcing the user to use a decorator, we can override the "run" method in the class.


- [X] Description above provides context of the change
- [X] Commit message contains [\[AIRFLOW-6418\]](https://issues.apache.org/jira/browse/AIRFLOW-6418) or `[AIRFLOW-6418]` for document-only changes
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
