### PR TITLE
[AIRFLOW-6113] [AIP-21] Rename GCP transfer operator

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -441,7 +441,7 @@ The following table shows changes in import paths.
 |airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook                                                                   |airflow.gcp.hooks.cloud_sql.CloudSQLHook                                                                   |
 |airflow.contrib.hooks.gcp_tasks_hook.CloudTasksHook                                                               |airflow.gcp.hooks.tasks.CloudTasksHook                                                                     |
 |airflow.contrib.hooks.gcp_text_to_speech_hook.GCPTextToSpeechHook                                                 |airflow.gcp.hooks.text_to_speech.CloudTextToSpeechHook                                                     |
-|airflow.contrib.hooks.gcp_transfer_hook.GCPTransferServiceHook                                                    |airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook                                    |
+|airflow.contrib.hooks.gcp_transfer_hook.GCPTransferServiceHook                                                    |airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook                                    |
 |airflow.contrib.hooks.gcp_translate_hook.CloudTranslateHook                                                       |airflow.gcp.hooks.translate.CloudTranslateHook                                                             |
 |airflow.contrib.hooks.gcp_video_intelligence_hook.CloudVideoIntelligenceHook                                      |airflow.gcp.hooks.video_intelligence.CloudVideoIntelligenceHook                                            |
 |airflow.contrib.hooks.gcp_vision_hook.CloudVisionHook                                                             |airflow.providers.google.cloud.hooks.vision.CloudVisionHook                                                                   |
@@ -539,15 +539,15 @@ The following table shows changes in import paths.
 |airflow.contrib.operators.gcp_spanner_operator.CloudSpannerInstanceDeployOperator                                 |airflow.gcp.operators.spanner.CloudSpannerInstanceDeployOperator                                           |
 |airflow.contrib.operators.gcp_speech_to_text_operator.GcpSpeechToTextRecognizeSpeechOperator                      |airflow.gcp.operators.speech_to_text.CloudSpeechToTextRecognizeSpeechOperator
 |airflow.contrib.operators.gcp_text_to_speech_operator.GcpTextToSpeechSynthesizeOperator                           |airflow.gcp.operators.text_to_speech.CloudTextToSpeechSynthesizeOperator                                     |
-|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobCreateOperator                               |airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobCreateOperator                   |
-|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobDeleteOperator                               |airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobDeleteOperator                   |
-|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobUpdateOperator                               |airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobUpdateOperator                   |
-|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationCancelOperator                         |airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationCancelOperator             |
-|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationGetOperator                            |airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationGetOperator                |
-|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationPauseOperator                          |airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationPauseOperator              |
-|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationResumeOperator                         |airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationResumeOperator             |
-|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationsListOperator                          |airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationsListOperator              |
-|airflow.contrib.operators.gcp_transfer_operator.GoogleCloudStorageToGoogleCloudStorageTransferOperator            |airflow.gcp.operators.cloud_storage_transfer_service.GoogleCloudStorageToGoogleCloudStorageTransferOperator|
+|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobCreateOperator                               |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceCreateJobOperator                   |
+|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobDeleteOperator                               |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceDeleteJobOperator                   |
+|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobUpdateOperator                               |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceUpdateJobOperator                   |
+|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationCancelOperator                         |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceCancelOperationOperator             |
+|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationGetOperator                            |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceGetOperationOperator                |
+|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationPauseOperator                          |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServicePauseOperationOperator              |
+|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationResumeOperator                         |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceResumeOperationOperator             |
+|airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationsListOperator                          |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceListOperationsOperator              |
+|airflow.contrib.operators.gcp_transfer_operator.GoogleCloudStorageToGoogleCloudStorageTransferOperator            |airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceGCSToGCSOperator|
 |airflow.contrib.operators.gcp_translate_operator.CloudTranslateTextOperator                                       |airflow.gcp.operators.translate.CloudTranslateTextOperator                                                 |
 |airflow.contrib.operators.gcp_translate_speech_operator.GcpTranslateSpeechOperator                                |airflow.gcp.operators.translate_speech.GcpTranslateSpeechOperator                                          |
 |airflow.contrib.operators.gcp_video_intelligence_operator.CloudVideoIntelligenceDetectVideoExplicitContentOperator|airflow.gcp.operators.video_intelligence.CloudVideoIntelligenceDetectVideoExplicitContentOperator          |
@@ -592,7 +592,7 @@ The following table shows changes in import paths.
 |airflow.contrib.operators.pubsub_operator.PubSubTopicDeleteOperator                                               |airflow.providers.google.cloud.operators.pubsub.PubSubTopicDeleteOperator                                                     |
 |airflow.contrib.operators.sql_to_gcs.BaseSQLToGoogleCloudStorageOperator                                          |airflow.operators.sql_to_gcs.BaseSQLToGoogleCloudStorageOperator                                           |
 |airflow.contrib.sensors.bigquery_sensor.BigQueryTableSensor                                                       |airflow.gcp.sensors.bigquery.BigQueryTableExistenceSensor                                                  |
-|airflow.contrib.sensors.gcp_transfer_sensor.GCPTransferServiceWaitForJobStatusSensor                              |airflow.gcp.sensors.cloud_storage_transfer_service.GCPTransferServiceWaitForJobStatusSensor                |
+|airflow.contrib.sensors.gcp_transfer_sensor.GCPTransferServiceWaitForJobStatusSensor                              |airflow.gcp.sensors.cloud_storage_transfer_service.DataTransferServiceJobStatusSensor                |
 |airflow.contrib.sensors.gcs_sensor.GoogleCloudStorageObjectSensor                                                 |airflow.gcp.sensors.gcs.GoogleCloudStorageObjectSensor                                                     |
 |airflow.contrib.sensors.gcs_sensor.GoogleCloudStorageObjectUpdatedSensor                                          |airflow.gcp.sensors.gcs.GoogleCloudStorageObjectUpdatedSensor                                              |
 |airflow.contrib.sensors.gcs_sensor.GoogleCloudStoragePrefixSensor                                                 |airflow.gcp.sensors.gcs.GoogleCloudStoragePrefixSensor                                                     |
@@ -1149,7 +1149,7 @@ The default value of `expected_statuses` is SUCCESS so that change is backwards 
 The class `GoogleCloudStorageToGoogleCloudStorageTransferOperator` has been moved from
 `airflow.contrib.operators.gcs_to_gcs_transfer_operator` to `airflow.contrib.operators.gcp_transfer_operator`
 
-the class `S3ToGoogleCloudStorageTransferOperator` has been moved from
+the class `CloudDataTransferServiceS3ToGCSOperator` has been moved from
 `airflow.contrib.operators.s3_to_gcs_transfer_operator` to `airflow.contrib.operators.gcp_transfer_operator`
 
 The change was made to keep all the operators related to GCS Transfer Services in one file.

--- a/airflow/contrib/hooks/gcp_transfer_hook.py
+++ b/airflow/contrib/hooks/gcp_transfer_hook.py
@@ -22,12 +22,23 @@ This module is deprecated. Please use `airflow.gcp.hooks.cloud_storage_transfer_
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.hooks.cloud_storage_transfer_service import (  # noqa
-    GcpTransferJobsStatus, GcpTransferOperationStatus, GCPTransferServiceHook,
-)
+from airflow.gcp.hooks.cloud_storage_transfer_service import CloudDataTransferServiceHook
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.hooks.cloud_storage_transfer_service`",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GCPTransferServiceHook(CloudDataTransferServiceHook):
+    """
+    This class is deprecated. Please use `airflow.gcp.hooks.data_transfer.CloudDataTransferServiceHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.hooks.data_transfer.CloudDataTransferServiceHook`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_transfer_operator.py
+++ b/airflow/contrib/operators/gcp_transfer_operator.py
@@ -22,16 +22,171 @@ This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_trans
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.operators.cloud_storage_transfer_service import (  # noqa
-    GcpTransferServiceJobCreateOperator, GcpTransferServiceJobDeleteOperator,
-    GcpTransferServiceJobUpdateOperator, GcpTransferServiceOperationCancelOperator,
-    GcpTransferServiceOperationGetOperator, GcpTransferServiceOperationPauseOperator,
-    GcpTransferServiceOperationResumeOperator, GcpTransferServiceOperationsListOperator,
-    GoogleCloudStorageToGoogleCloudStorageTransferOperator, TransferJobPreprocessor, TransferJobValidator,
+from airflow.gcp.operators.cloud_storage_transfer_service import (
+    CloudDataTransferServiceCancelOperationOperator, CloudDataTransferServiceCreateJobOperator,
+    CloudDataTransferServiceDeleteJobOperator, CloudDataTransferServiceGCSToGCSOperator,
+    CloudDataTransferServiceGetOperationOperator, CloudDataTransferServiceListOperationsOperator,
+    CloudDataTransferServicePauseOperationOperator, CloudDataTransferServiceResumeOperationOperator,
+    CloudDataTransferServiceS3ToGCSOperator, CloudDataTransferServiceUpdateJobOperator,
 )
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_transfer_service`",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GcpTransferServiceJobCreateOperator(CloudDataTransferServiceCreateJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceCreateJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceCreateJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcpTransferServiceJobDeleteOperator(CloudDataTransferServiceDeleteJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceDeleteJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceDeleteJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcpTransferServiceJobUpdateOperator(CloudDataTransferServiceUpdateJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceUpdateJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceUpdateJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcpTransferServiceOperationCancelOperator(CloudDataTransferServiceCancelOperationOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceCancelOperationOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceCancelOperationOperator`.
+            """,
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcpTransferServiceOperationGetOperator(CloudDataTransferServiceGetOperationOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceGetOperationOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceGetOperationOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcpTransferServiceOperationPauseOperator(CloudDataTransferServicePauseOperationOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServicePauseOperationOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServicePauseOperationOperator`.
+            """,
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcpTransferServiceOperationResumeOperator(CloudDataTransferServiceResumeOperationOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceResumeOperationOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceResumeOperationOperator`.
+            """,
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GcpTransferServiceOperationsListOperator(CloudDataTransferServiceListOperationsOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceListOperationsOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceListOperationsOperator`.
+            """,
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class GoogleCloudStorageToGoogleCloudStorageTransferOperator(CloudDataTransferServiceGCSToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceGCSToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceGCSToGCSOperator`.
+            """,
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class S3ToGoogleCloudStorageTransferOperator(CloudDataTransferServiceS3ToGCSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceS3ToGCSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """"This class is deprecated.
+            Please use `airflow.gcp.operators.data_transfer.CloudDataTransferServiceS3ToGCSOperator`.
+            """,
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_to_gcs_transfer_operator.py
+++ b/airflow/contrib/operators/gcs_to_gcs_transfer_operator.py
@@ -23,9 +23,6 @@ This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_trans
 import warnings
 
 # pylint: disable=unused-import
-from airflow.gcp.operators.cloud_storage_transfer_service import (  # # noqa
-    GoogleCloudStorageToGoogleCloudStorageTransferOperator,
-)
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_transfer_service`.",

--- a/airflow/contrib/operators/s3_to_gcs_transfer_operator.py
+++ b/airflow/contrib/operators/s3_to_gcs_transfer_operator.py
@@ -22,7 +22,7 @@ This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_trans
 import warnings
 
 # pylint: disable=unused-import,line-too-long
-from airflow.gcp.operators.cloud_storage_transfer_service import S3ToGoogleCloudStorageTransferOperator  # noqa isort:skip
+from airflow.gcp.operators.cloud_storage_transfer_service import CloudDataTransferServiceS3ToGCSOperator  # noqa isort:skip
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.operators.cloud_storage_transfer_service`.",

--- a/airflow/contrib/sensors/gcp_transfer_sensor.py
+++ b/airflow/contrib/sensors/gcp_transfer_sensor.py
@@ -20,12 +20,23 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.gcp.sensors.cloud_storage_transfer_service import (  # noqa
-    GCPTransferServiceWaitForJobStatusSensor,
-)
+from airflow.gcp.sensors.cloud_storage_transfer_service import CloudDataTransferServiceJobStatusSensor
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.gcp.sensors.cloud_storage_transfer_service`.",
     DeprecationWarning, stacklevel=2
 )
+
+
+class GCPTransferServiceWaitForJobStatusSensor(CloudDataTransferServiceJobStatusSensor):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.sensors.transfer.CloudDataTransferServiceJobStatusSensor`.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.sensors.transfer.CloudDataTransferServiceJobStatusSensor`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/gcp/hooks/cloud_storage_transfer_service.py
+++ b/airflow/gcp/hooks/cloud_storage_transfer_service.py
@@ -100,7 +100,7 @@ NEGATIVE_STATUSES = {GcpTransferOperationStatus.FAILED, GcpTransferOperationStat
 
 
 # noinspection PyAbstractClass
-class GCPTransferServiceHook(CloudBaseHook):
+class CloudDataTransferServiceHook(CloudBaseHook):
     """
     Hook for Google Storage Transfer Service.
 
@@ -406,7 +406,8 @@ class GCPTransferServiceHook(CloudBaseHook):
                 request_filter={FILTER_PROJECT_ID: job[PROJECT_ID], FILTER_JOB_NAMES: [job[NAME]]}
             )
 
-            if GCPTransferServiceHook.operations_contain_expected_statuses(operations, expected_statuses):
+            if CloudDataTransferServiceHook.\
+                    operations_contain_expected_statuses(operations, expected_statuses):
                 return
             time.sleep(TIME_TO_SLEEP_IN_SECONDS)
         raise AirflowException("Timeout. The operation could not be completed within the allotted time.")

--- a/airflow/gcp/operators/cloud_storage_transfer_service.py
+++ b/airflow/gcp/operators/cloud_storage_transfer_service.py
@@ -30,7 +30,7 @@ from airflow.gcp.hooks.cloud_storage_transfer_service import (
     ACCESS_KEY_ID, AWS_ACCESS_KEY, AWS_S3_DATA_SOURCE, BUCKET_NAME, DAY, DESCRIPTION, GCS_DATA_SINK,
     GCS_DATA_SOURCE, HOURS, HTTP_DATA_SOURCE, MINUTES, MONTH, OBJECT_CONDITIONS, PROJECT_ID, SCHEDULE,
     SCHEDULE_END_DATE, SCHEDULE_START_DATE, SECONDS, SECRET_ACCESS_KEY, START_TIME_OF_DAY, STATUS,
-    TRANSFER_OPTIONS, TRANSFER_SPEC, YEAR, GcpTransferJobsStatus, GCPTransferServiceHook,
+    TRANSFER_OPTIONS, TRANSFER_SPEC, YEAR, CloudDataTransferServiceHook, GcpTransferJobsStatus,
 )
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
@@ -160,7 +160,7 @@ class TransferJobValidator:
             self._verify_data_source()
 
 
-class GcpTransferServiceJobCreateOperator(BaseOperator):
+class CloudDataTransferServiceCreateJobOperator(BaseOperator):
     """
     Creates a transfer job that runs periodically.
 
@@ -171,7 +171,7 @@ class GcpTransferServiceJobCreateOperator(BaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcpTransferServiceJobCreateOperator`
+        :ref:`howto/operator:CloudDataTransferServiceCreateJobOperator`
 
     :param body: (Required) The request body, as described in
         https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/create#request-body
@@ -218,17 +218,17 @@ class GcpTransferServiceJobCreateOperator(BaseOperator):
 
     def execute(self, context):
         TransferJobPreprocessor(body=self.body, aws_conn_id=self.aws_conn_id).process_body()
-        hook = GCPTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
         return hook.create_transfer_job(body=self.body)
 
 
-class GcpTransferServiceJobUpdateOperator(BaseOperator):
+class CloudDataTransferServiceUpdateJobOperator(BaseOperator):
     """
     Updates a transfer job that runs periodically.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcpTransferServiceJobUpdateOperator`
+        :ref:`howto/operator:CloudDataTransferServiceUpdateJobOperator`
 
     :param job_name: (Required) Name of the job to be updated
     :type job_name: str
@@ -281,11 +281,11 @@ class GcpTransferServiceJobUpdateOperator(BaseOperator):
 
     def execute(self, context):
         TransferJobPreprocessor(body=self.body, aws_conn_id=self.aws_conn_id).process_body()
-        hook = GCPTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
         return hook.update_transfer_job(job_name=self.job_name, body=self.body)
 
 
-class GcpTransferServiceJobDeleteOperator(BaseOperator):
+class CloudDataTransferServiceDeleteJobOperator(BaseOperator):
     """
     Delete a transfer job. This is a soft delete. After a transfer job is
     deleted, the job and all the transfer executions are subject to garbage
@@ -294,7 +294,7 @@ class GcpTransferServiceJobDeleteOperator(BaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcpTransferServiceJobDeleteOperator`
+        :ref:`howto/operator:CloudDataTransferServiceDeleteJobOperator`
 
     :param job_name: (Required) Name of the TRANSFER operation
     :type job_name: str
@@ -335,18 +335,18 @@ class GcpTransferServiceJobDeleteOperator(BaseOperator):
 
     def execute(self, context):
         self._validate_inputs()
-        hook = GCPTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
         hook.delete_transfer_job(job_name=self.job_name, project_id=self.project_id)
 
 
-class GcpTransferServiceOperationGetOperator(BaseOperator):
+class CloudDataTransferServiceGetOperationOperator(BaseOperator):
     """
     Gets the latest state of a long-running operation in Google Storage Transfer
     Service.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcpTransferServiceOperationGetOperator`
+        :ref:`howto/operator:CloudDataTransferServiceGetOperationOperator`
 
     :param operation_name: (Required) Name of the transfer operation.
     :type operation_name: str
@@ -380,19 +380,19 @@ class GcpTransferServiceOperationGetOperator(BaseOperator):
             raise AirflowException("The required parameter 'operation_name' is empty or None")
 
     def execute(self, context):
-        hook = GCPTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
         operation = hook.get_transfer_operation(operation_name=self.operation_name)
         return operation
 
 
-class GcpTransferServiceOperationsListOperator(BaseOperator):
+class CloudDataTransferServiceListOperationsOperator(BaseOperator):
     """
     Lists long-running operations in Google Storage Transfer
     Service that match the specified filter.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcpTransferServiceOperationsListOperator`
+        :ref:`howto/operator:CloudDataTransferServiceListOperationsOperator`
 
     :param request_filter: (Required) A request filter, as described in
             https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/list#body.QUERY_PARAMETERS.filter
@@ -433,19 +433,19 @@ class GcpTransferServiceOperationsListOperator(BaseOperator):
             raise AirflowException("The required parameter 'filter' is empty or None")
 
     def execute(self, context):
-        hook = GCPTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
         operations_list = hook.list_transfer_operations(request_filter=self.filter)
         self.log.info(operations_list)
         return operations_list
 
 
-class GcpTransferServiceOperationPauseOperator(BaseOperator):
+class CloudDataTransferServicePauseOperationOperator(BaseOperator):
     """
     Pauses a transfer operation in Google Storage Transfer Service.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcpTransferServiceOperationPauseOperator`
+        :ref:`howto/operator:CloudDataTransferServicePauseOperationOperator`
 
     :param operation_name: (Required) Name of the transfer operation.
     :type operation_name: str
@@ -478,17 +478,17 @@ class GcpTransferServiceOperationPauseOperator(BaseOperator):
             raise AirflowException("The required parameter 'operation_name' is empty or None")
 
     def execute(self, context):
-        hook = GCPTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
         hook.pause_transfer_operation(operation_name=self.operation_name)
 
 
-class GcpTransferServiceOperationResumeOperator(BaseOperator):
+class CloudDataTransferServiceResumeOperationOperator(BaseOperator):
     """
     Resumes a transfer operation in Google Storage Transfer Service.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcpTransferServiceOperationResumeOperator`
+        :ref:`howto/operator:CloudDataTransferServiceResumeOperationOperator`
 
     :param operation_name: (Required) Name of the transfer operation.
     :type operation_name: str
@@ -521,17 +521,17 @@ class GcpTransferServiceOperationResumeOperator(BaseOperator):
             raise AirflowException("The required parameter 'operation_name' is empty or None")
 
     def execute(self, context):
-        hook = GCPTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
         hook.resume_transfer_operation(operation_name=self.operation_name)
 
 
-class GcpTransferServiceOperationCancelOperator(BaseOperator):
+class CloudDataTransferServiceCancelOperationOperator(BaseOperator):
     """
     Cancels a transfer operation in Google Storage Transfer Service.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GcpTransferServiceOperationCancelOperator`
+        :ref:`howto/operator:CloudDataTransferServiceCancelOperationOperator`
 
     :param operation_name: (Required) Name of the transfer operation.
     :type operation_name: str
@@ -565,11 +565,11 @@ class GcpTransferServiceOperationCancelOperator(BaseOperator):
             raise AirflowException("The required parameter 'operation_name' is empty or None")
 
     def execute(self, context):
-        hook = GCPTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
         hook.cancel_transfer_operation(operation_name=self.operation_name)
 
 
-class S3ToGoogleCloudStorageTransferOperator(BaseOperator):
+class CloudDataTransferServiceS3ToGCSOperator(BaseOperator):
     """
     Synchronizes an S3 bucket with a Google Cloud Storage bucket using the
     GCP Storage Transfer Service.
@@ -668,7 +668,7 @@ class S3ToGoogleCloudStorageTransferOperator(BaseOperator):
         self.timeout = timeout
 
     def execute(self, context):
-        hook = GCPTransferServiceHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        hook = CloudDataTransferServiceHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
         body = self._create_body()
 
         TransferJobPreprocessor(body=body, aws_conn_id=self.aws_conn_id, default_schedule=True).process_body()
@@ -703,7 +703,7 @@ class S3ToGoogleCloudStorageTransferOperator(BaseOperator):
         return body
 
 
-class GoogleCloudStorageToGoogleCloudStorageTransferOperator(BaseOperator):
+class CloudDataTransferServiceGCSToGCSOperator(BaseOperator):
     """
     Copies objects from a bucket to another using the GCP Storage Transfer
     Service.
@@ -809,7 +809,7 @@ class GoogleCloudStorageToGoogleCloudStorageTransferOperator(BaseOperator):
         self.timeout = timeout
 
     def execute(self, context):
-        hook = GCPTransferServiceHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        hook = CloudDataTransferServiceHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
 
         body = self._create_body()
 

--- a/airflow/gcp/sensors/cloud_storage_transfer_service.py
+++ b/airflow/gcp/sensors/cloud_storage_transfer_service.py
@@ -21,19 +21,19 @@ This module contains a Google Cloud Transfer sensor.
 """
 from typing import Optional, Set, Union
 
-from airflow.gcp.hooks.cloud_storage_transfer_service import GCPTransferServiceHook
+from airflow.gcp.hooks.cloud_storage_transfer_service import CloudDataTransferServiceHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class GCPTransferServiceWaitForJobStatusSensor(BaseSensorOperator):
+class CloudDataTransferServiceJobStatusSensor(BaseSensorOperator):
     """
     Waits for at least one operation belonging to the job to have the
     expected status.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:GCPTransferServiceWaitForJobStatusSensor`
+        :ref:`howto/operator:CloudDataTransferServiceJobStatusSensor`
 
     :param job_name: The name of the transfer job
     :type job_name: str
@@ -73,12 +73,12 @@ class GCPTransferServiceWaitForJobStatusSensor(BaseSensorOperator):
         self.gcp_cloud_conn_id = gcp_conn_id
 
     def poke(self, context):
-        hook = GCPTransferServiceHook(gcp_conn_id=self.gcp_cloud_conn_id)
+        hook = CloudDataTransferServiceHook(gcp_conn_id=self.gcp_cloud_conn_id)
         operations = hook.list_transfer_operations(
             request_filter={'project_id': self.project_id, 'job_names': [self.job_name]}
         )
 
-        check = GCPTransferServiceHook.operations_contain_expected_statuses(
+        check = CloudDataTransferServiceHook.operations_contain_expected_statuses(
             operations=operations, expected_statuses=self.expected_statuses
         )
         if check:

--- a/docs/howto/operator/gcp/cloud_storage_transfer_service.rst
+++ b/docs/howto/operator/gcp/cloud_storage_transfer_service.rst
@@ -29,10 +29,10 @@ Prerequisite Tasks
 
 .. include:: _partials/prerequisite_tasks.rst
 
-.. _howto/operator:GcpTransferServiceJobCreateOperator:
+.. _howto/operator:CloudDataTransferServiceCreateJobOperator:
 
-GcpTransferServiceJobCreateOperator
------------------------------------
+CloudDataTransferServiceCreateJobOperator
+-----------------------------------------
 
 Create a transfer job.
 
@@ -56,7 +56,7 @@ If you want to create a job transfer that copies data from AWS S3 then you must 
 The selected connection for AWS can be indicated by the parameter ``aws_conn_id``.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobCreateOperator`.
+:class:`~airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceCreateJobOperator`.
 
 Arguments
 """""""""
@@ -102,15 +102,15 @@ More information
 See `Google Cloud Transfer Service - Method: transferJobs.create
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/create>`_.
 
-.. _howto/operator:GcpTransferServiceJobDeleteOperator:
+.. _howto/operator:CloudDataTransferServiceDeleteJobOperator:
 
-GcpTransferServiceJobDeleteOperator
------------------------------------
+CloudDataTransferServiceDeleteJobOperator
+-----------------------------------------
 
 Deletes a transfer job.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobDeleteOperator`.
+:class:`~airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceDeleteJobOperator`.
 
 Arguments
 """""""""
@@ -146,15 +146,15 @@ More information
 See `Google Cloud Transfer Service - REST Resource: transferJobs - Status
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs#Status>`_
 
-.. _howto/operator:GcpTransferServiceJobUpdateOperator:
+.. _howto/operator:CloudDataTransferServiceUpdateJobOperator:
 
-GcpTransferServiceJobUpdateOperator
------------------------------------
+CloudDataTransferServiceUpdateJobOperator
+-----------------------------------------
 
 Updates a transfer job.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobUpdateOperator`.
+:class:`~airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceUpdateJobOperator`.
 
 Arguments
 """""""""
@@ -195,15 +195,15 @@ More information
 See `Google Cloud Transfer Service - Method: transferJobs.patch
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/patch>`_
 
-.. _howto/operator:GcpTransferServiceOperationCancelOperator:
+.. _howto/operator:CloudDataTransferServiceCancelOperationOperator:
 
-GcpTransferServiceOperationCancelOperator
------------------------------------------
+CloudDataTransferServiceCancelOperationOperator
+-----------------------------------------------
 
 Gets a transfer operation. The result is returned to XCOM.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationCancelOperator`.
+:class:`~airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceCancelOperationOperator`.
 
 Arguments
 """""""""
@@ -240,15 +240,15 @@ See `Google Cloud Transfer Service - Method: transferOperations.cancel
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferOperations/cancel>`_
 
 
-.. _howto/operator:GcpTransferServiceOperationGetOperator:
+.. _howto/operator:CloudDataTransferServiceGetOperationOperator:
 
-GcpTransferServiceOperationGetOperator
---------------------------------------
+CloudDataTransferServiceGetOperationOperator
+--------------------------------------------
 
 Gets a transfer operation. The result is returned to XCOM.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationGetOperator`.
+:class:`~airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceGetOperationOperator`.
 
 Arguments
 """""""""
@@ -284,15 +284,15 @@ More information
 See `Google Cloud Transfer Service - Method: transferOperations.get
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferOperations/get>`_
 
-.. _howto/operator:GcpTransferServiceOperationsListOperator:
+.. _howto/operator:CloudDataTransferServiceListOperationsOperator:
 
-GcpTransferServiceOperationsListOperator
-----------------------------------------
+CloudDataTransferServiceListOperationsOperator
+----------------------------------------------
 
 List a transfer operations. The result is returned to XCOM.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationsListOperator`.
+:class:`~airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceListOperationsOperator`.
 
 Arguments
 """""""""
@@ -328,15 +328,15 @@ More information
 See `Google Cloud Transfer Service - Method: transferOperations.list
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferOperations/list>`_
 
-.. _howto/operator:GcpTransferServiceOperationPauseOperator:
+.. _howto/operator:CloudDataTransferServicePauseOperationOperator:
 
-GcpTransferServiceOperationPauseOperator
-----------------------------------------
+CloudDataTransferServicePauseOperationOperator
+----------------------------------------------
 
 Pauses a transfer operations.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationPauseOperator`.
+:class:`~airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServicePauseOperationOperator`.
 
 Arguments
 """""""""
@@ -372,15 +372,15 @@ More information
 See `Google Cloud Transfer Service - Method: transferOperations.pause
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferOperations/pause>`_
 
-.. _howto/operator:GcpTransferServiceOperationResumeOperator:
+.. _howto/operator:CloudDataTransferServiceResumeOperationOperator:
 
-GcpTransferServiceOperationResumeOperator
------------------------------------------
+CloudDataTransferServiceResumeOperationOperator
+-----------------------------------------------
 
 Resumes a transfer operations.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceOperationResumeOperator`.
+:class:`~airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceResumeOperationOperator`.
 
 Arguments
 """""""""
@@ -416,15 +416,15 @@ More information
 See `Google Cloud Transfer Service - Method: transferOperations.resume
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferOperations/resume>`_
 
-.. _howto/operator:GCPTransferServiceWaitForJobStatusSensor:
+.. _howto/operator:CloudDataTransferServiceJobStatusSensor:
 
-GCPTransferServiceWaitForJobStatusSensor
-----------------------------------------
+CloudDataTransferServiceJobStatusSensor
+---------------------------------------
 
 Waits for at least one operation belonging to the job to have the expected status.
 
 For parameter definition, take a look at
-:class:`~airflow.gcp.sensors.cloud_storage_transfer_service.GCPTransferServiceWaitForJobStatusSensor`.
+:class:`~airflow.gcp.sensors.cloud_storage_transfer_service.CloudDataTransferServiceJobStatusSensor`.
 
 Arguments
 """""""""

--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -28,8 +28,8 @@ from parameterized import parameterized
 from airflow import AirflowException
 from airflow.gcp.hooks.cloud_storage_transfer_service import (
     DESCRIPTION, FILTER_JOB_NAMES, FILTER_PROJECT_ID, METADATA, OPERATIONS, PROJECT_ID, STATUS,
-    TIME_TO_SLEEP_IN_SECONDS, TRANSFER_JOB, TRANSFER_JOB_FIELD_MASK, TRANSFER_JOBS, GcpTransferJobsStatus,
-    GcpTransferOperationStatus, GCPTransferServiceHook,
+    TIME_TO_SLEEP_IN_SECONDS, TRANSFER_JOB, TRANSFER_JOB_FIELD_MASK, TRANSFER_JOBS,
+    CloudDataTransferServiceHook, GcpTransferJobsStatus, GcpTransferOperationStatus,
 )
 from tests.gcp.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,
@@ -71,9 +71,9 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
             'airflow.gcp.hooks.base.CloudBaseHook.__init__',
             new=mock_base_gcp_hook_no_default_project_id,
         ):
-            self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
+            self.gct_hook = CloudDataTransferServiceHook(gcp_conn_id='test')
 
-    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook._authorize")
     @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.build")
     def test_gct_client_creation(self, mock_build, mock_authorize):
         result = self.gct_hook.get_conn()
@@ -88,7 +88,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_create_transfer_job(self, get_conn, mock_project_id):
         create_method = get_conn.return_value.transferJobs.return_value.create
         execute_method = create_method.return_value.execute
@@ -98,7 +98,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         create_method.assert_called_once_with(body=TEST_BODY)
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_get_transfer_job(self, get_conn):
         get_method = get_conn.return_value.transferJobs.return_value.get
         execute_method = get_method.return_value.execute
@@ -114,7 +114,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_list_transfer_job(self, get_conn, mock_project_id):
         list_method = get_conn.return_value.transferJobs.return_value.list
         list_execute_method = list_method.return_value.execute
@@ -139,7 +139,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_update_transfer_job(self, get_conn, mock_project_id):
         update_method = get_conn.return_value.transferJobs.return_value.patch
         execute_method = update_method.return_value.execute
@@ -153,7 +153,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         )
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_delete_transfer_job(self, get_conn):
         update_method = get_conn.return_value.transferJobs.return_value.patch
         execute_method = update_method.return_value.execute
@@ -170,7 +170,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         )
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_cancel_transfer_operation(self, get_conn):
         cancel_method = get_conn.return_value.transferOperations.return_value.cancel
         execute_method = cancel_method.return_value.execute
@@ -179,7 +179,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         cancel_method.assert_called_once_with(name=TEST_TRANSFER_OPERATION_NAME)
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_get_transfer_operation(self, get_conn):
         get_method = get_conn.return_value.transferOperations.return_value.get
         execute_method = get_method.return_value.execute
@@ -194,7 +194,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_list_transfer_operation(self, get_conn, mock_project_id):
         list_method = get_conn.return_value.transferOperations.return_value.list
         list_execute_method = list_method.return_value.execute
@@ -214,7 +214,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         )
         list_execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_pause_transfer_operation(self, get_conn):
         pause_method = get_conn.return_value.transferOperations.return_value.pause
         execute_method = pause_method.return_value.execute
@@ -223,7 +223,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         pause_method.assert_called_once_with(name=TEST_TRANSFER_OPERATION_NAME)
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_resume_transfer_operation(self, get_conn):
         resume_method = get_conn.return_value.transferOperations.return_value.resume
         execute_method = resume_method.return_value.execute
@@ -239,7 +239,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
     )
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.time.sleep')
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.'
-                'GCPTransferServiceHook.list_transfer_operations')
+                'CloudDataTransferServiceHook.list_transfer_operations')
     def test_wait_for_transfer_job(self, mock_list, mock_sleep, mock_project_id):
         mock_list.side_effect = [
             [{METADATA: {STATUS: GcpTransferOperationStatus.IN_PROGRESS}}],
@@ -263,7 +263,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         return_value=None
     )
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.time.sleep')
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_wait_for_transfer_job_failed(
         self, mock_get_conn, mock_sleep, mock_project_id
     ):
@@ -287,7 +287,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         return_value=None
     )
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.time.sleep')
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_wait_for_transfer_job_expect_failed(
         self, get_conn, mock_sleep, mock_project_id
     ):  # pylint: disable=unused-argument
@@ -339,7 +339,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
                 ", ".join(expected_statuses)
             ),
         ):
-            GCPTransferServiceHook.operations_contain_expected_statuses(
+            CloudDataTransferServiceHook.operations_contain_expected_statuses(
                 operations, GcpTransferOperationStatus.IN_PROGRESS
             )
 
@@ -368,7 +368,8 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
     def test_operations_contain_expected_statuses_green_path(self, statuses, expected_statuses):
         operations = [{NAME: TEST_TRANSFER_OPERATION_NAME, METADATA: {STATUS: status}} for status in statuses]
 
-        result = GCPTransferServiceHook.operations_contain_expected_statuses(operations, expected_statuses)
+        result = \
+            CloudDataTransferServiceHook.operations_contain_expected_statuses(operations, expected_statuses)
 
         self.assertTrue(result)
 
@@ -379,9 +380,9 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
             'airflow.gcp.hooks.base.CloudBaseHook.__init__',
             new=mock_base_gcp_hook_default_project_id,
         ):
-            self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
+            self.gct_hook = CloudDataTransferServiceHook(gcp_conn_id='test')
 
-    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook._authorize")
     @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.build")
     def test_gct_client_creation(self, mock_build, mock_authorize):
         result = self.gct_hook.get_conn()
@@ -396,7 +397,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_create_transfer_job(self, get_conn, mock_project_id):
         create_method = get_conn.return_value.transferJobs.return_value.create
         execute_method = create_method.return_value.execute
@@ -411,7 +412,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_get_transfer_job(self, get_conn, mock_project_id):
         get_method = get_conn.return_value.transferJobs.return_value.get
         execute_method = get_method.return_value.execute
@@ -427,7 +428,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_list_transfer_job(self, get_conn, mock_project_id):
         list_method = get_conn.return_value.transferJobs.return_value.list
         list_execute_method = list_method.return_value.execute
@@ -455,7 +456,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_update_transfer_job(self, get_conn, mock_project_id):
         update_method = get_conn.return_value.transferJobs.return_value.patch
         execute_method = update_method.return_value.execute
@@ -470,7 +471,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         )
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_delete_transfer_job(self, get_conn):
         update_method = get_conn.return_value.transferJobs.return_value.patch
         execute_method = update_method.return_value.execute
@@ -487,7 +488,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         )
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_cancel_transfer_operation(self, get_conn):
         cancel_method = get_conn.return_value.transferOperations.return_value.cancel
         execute_method = cancel_method.return_value.execute
@@ -496,7 +497,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         cancel_method.assert_called_once_with(name=TEST_TRANSFER_OPERATION_NAME)
         execute_method.assert_called_once_with(num_retries=5)
 
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_get_transfer_operation(self, get_conn):
         get_method = get_conn.return_value.transferOperations.return_value.get
         execute_method = get_method.return_value.execute
@@ -511,7 +512,7 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID_HOOK_UNIT_TEST
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_list_transfer_operation(self, get_conn, mock_project_id):
         list_method = get_conn.return_value.transferOperations.return_value.list
         list_execute_method = list_method.return_value.execute
@@ -553,9 +554,9 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
             'airflow.gcp.hooks.base.CloudBaseHook.__init__',
             new=mock_base_gcp_hook_no_default_project_id,
         ):
-            self.gct_hook = GCPTransferServiceHook(gcp_conn_id='test')
+            self.gct_hook = CloudDataTransferServiceHook(gcp_conn_id='test')
 
-    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook._authorize")
+    @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook._authorize")
     @mock.patch("airflow.gcp.hooks.cloud_storage_transfer_service.build")
     def test_gct_client_creation(self, mock_build, mock_authorize):
         result = self.gct_hook.get_conn()
@@ -570,7 +571,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_create_transfer_job(self, get_conn, mock_project_id):
         create_method = get_conn.return_value.transferJobs.return_value.create
         execute_method = create_method.return_value.execute
@@ -589,7 +590,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_get_transfer_job(self, get_conn, mock_project_id):
         get_method = get_conn.return_value.transferJobs.return_value.get
         execute_method = get_method.return_value.execute
@@ -608,7 +609,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_list_transfer_job(self, get_conn, mock_project_id):
         list_method = get_conn.return_value.transferJobs.return_value.list
         list_execute_method = list_method.return_value.execute
@@ -632,7 +633,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_list_transfer_operation_multiple_page(self, get_conn, mock_project_id):
         pages_requests = [
             mock.Mock(**{'execute.return_value': {"operations": [TEST_TRANSFER_OPERATION]}}) for _ in range(4)
@@ -651,7 +652,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_update_transfer_job(self, get_conn, mock_project_id):
         update_method = get_conn.return_value.transferJobs.return_value.patch
         execute_method = update_method.return_value.execute
@@ -672,7 +673,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_delete_transfer_job(self, get_conn, mock_project_id):  # pylint: disable=unused-argument
         with self.assertRaises(AirflowException) as e:
             self.gct_hook.delete_transfer_job(  # pylint: disable=no-value-for-parameter
@@ -689,7 +690,7 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
         new_callable=PropertyMock,
         return_value=None
     )
-    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')
+    @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook.get_conn')
     def test_list_transfer_operation(self, get_conn, mock_project_id):
         list_method = get_conn.return_value.transferOperations.return_value.list
         list_execute_method = list_method.return_value.execute

--- a/tests/gcp/operators/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/operators/test_cloud_storage_transfer_service.py
@@ -34,11 +34,11 @@ from airflow.gcp.hooks.cloud_storage_transfer_service import (
     SECRET_ACCESS_KEY, START_TIME_OF_DAY, STATUS, TRANSFER_SPEC,
 )
 from airflow.gcp.operators.cloud_storage_transfer_service import (
-    GcpTransferServiceJobCreateOperator, GcpTransferServiceJobDeleteOperator,
-    GcpTransferServiceJobUpdateOperator, GcpTransferServiceOperationCancelOperator,
-    GcpTransferServiceOperationGetOperator, GcpTransferServiceOperationPauseOperator,
-    GcpTransferServiceOperationResumeOperator, GcpTransferServiceOperationsListOperator,
-    GoogleCloudStorageToGoogleCloudStorageTransferOperator, S3ToGoogleCloudStorageTransferOperator,
+    CloudDataTransferServiceCancelOperationOperator, CloudDataTransferServiceCreateJobOperator,
+    CloudDataTransferServiceDeleteJobOperator, CloudDataTransferServiceGCSToGCSOperator,
+    CloudDataTransferServiceGetOperationOperator, CloudDataTransferServiceListOperationsOperator,
+    CloudDataTransferServicePauseOperationOperator, CloudDataTransferServiceResumeOperationOperator,
+    CloudDataTransferServiceS3ToGCSOperator, CloudDataTransferServiceUpdateJobOperator,
     TransferJobPreprocessor, TransferJobValidator,
 )
 from airflow.models import DAG, TaskInstance
@@ -228,12 +228,12 @@ class TestTransferJobValidator(unittest.TestCase):
 
 
 class TestGcpStorageTransferJobCreateOperator(unittest.TestCase):
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_job_create_gcs(self, mock_hook):
         mock_hook.return_value.create_transfer_job.return_value = VALID_TRANSFER_JOB_GCS_RAW
         body = deepcopy(VALID_TRANSFER_JOB_GCS)
         del body['name']
-        op = GcpTransferServiceJobCreateOperator(body=body, task_id=TASK_ID)
+        op = CloudDataTransferServiceCreateJobOperator(body=body, task_id=TASK_ID)
         result = op.execute(None)
 
         mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
@@ -242,7 +242,7 @@ class TestGcpStorageTransferJobCreateOperator(unittest.TestCase):
 
         self.assertEqual(result, VALID_TRANSFER_JOB_GCS_RAW)
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.AwsHook')
     def test_job_create_aws(self, aws_hook, mock_hook):
         mock_hook.return_value.create_transfer_job.return_value = VALID_TRANSFER_JOB_AWS_RAW
@@ -251,7 +251,7 @@ class TestGcpStorageTransferJobCreateOperator(unittest.TestCase):
         )
         body = deepcopy(VALID_TRANSFER_JOB_AWS)
         del body['name']
-        op = GcpTransferServiceJobCreateOperator(body=body, task_id=TASK_ID)
+        op = CloudDataTransferServiceCreateJobOperator(body=body, task_id=TASK_ID)
 
         result = op.execute(None)
 
@@ -261,7 +261,7 @@ class TestGcpStorageTransferJobCreateOperator(unittest.TestCase):
 
         self.assertEqual(result, VALID_TRANSFER_JOB_AWS_RAW)
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.AwsHook')
     def test_job_create_multiple(self, aws_hook, gcp_hook):
         aws_hook.return_value.get_credentials.return_value = Credentials(
@@ -270,23 +270,23 @@ class TestGcpStorageTransferJobCreateOperator(unittest.TestCase):
         gcp_hook.return_value.create_transfer_job.return_value = VALID_TRANSFER_JOB_AWS_RAW
         body = deepcopy(VALID_TRANSFER_JOB_AWS)
 
-        op = GcpTransferServiceJobCreateOperator(body=body, task_id=TASK_ID)
+        op = CloudDataTransferServiceCreateJobOperator(body=body, task_id=TASK_ID)
         result = op.execute(None)
         self.assertEqual(result, VALID_TRANSFER_JOB_AWS_RAW)
 
-        op = GcpTransferServiceJobCreateOperator(body=body, task_id=TASK_ID)
+        op = CloudDataTransferServiceCreateJobOperator(body=body, task_id=TASK_ID)
         result = op.execute(None)
         self.assertEqual(result, VALID_TRANSFER_JOB_AWS_RAW)
 
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
         # pylint: disable=attribute-defined-outside-init
         self.dag = DAG(dag_id, default_args={'start_date': DEFAULT_DATE})
-        op = GcpTransferServiceJobCreateOperator(
+        op = CloudDataTransferServiceCreateJobOperator(
             body={"description": "{{ dag.dag_id }}"},
             gcp_conn_id='{{ dag.dag_id }}',
             aws_conn_id='{{ dag.dag_id }}',
@@ -301,12 +301,12 @@ class TestGcpStorageTransferJobCreateOperator(unittest.TestCase):
 
 
 class TestGcpStorageTransferJobUpdateOperator(unittest.TestCase):
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_job_update(self, mock_hook):
         mock_hook.return_value.update_transfer_job.return_value = VALID_TRANSFER_JOB_GCS
         body = {'transferJob': {'description': 'example-name'}, 'updateTransferJobFieldMask': DESCRIPTION}
 
-        op = GcpTransferServiceJobUpdateOperator(job_name=JOB_NAME, body=body, task_id=TASK_ID)
+        op = CloudDataTransferServiceUpdateJobOperator(job_name=JOB_NAME, body=body, task_id=TASK_ID)
         result = op.execute(None)
 
         mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
@@ -316,12 +316,12 @@ class TestGcpStorageTransferJobUpdateOperator(unittest.TestCase):
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GcpTransferServiceJobUpdateOperator(
+        op = CloudDataTransferServiceUpdateJobOperator(
             job_name='{{ dag.dag_id }}',
             body={'transferJob': {"name": "{{ dag.dag_id }}"}},
             task_id='task-id',
@@ -334,9 +334,9 @@ class TestGcpStorageTransferJobUpdateOperator(unittest.TestCase):
 
 
 class TestGcpStorageTransferJobDeleteOperator(unittest.TestCase):
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_job_delete(self, mock_hook):
-        op = GcpTransferServiceJobDeleteOperator(
+        op = CloudDataTransferServiceDeleteJobOperator(
             job_name=JOB_NAME, project_id=GCP_PROJECT_ID, task_id='task-id'
         )
         op.execute(None)
@@ -348,12 +348,12 @@ class TestGcpStorageTransferJobDeleteOperator(unittest.TestCase):
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_job_delete_with_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GcpTransferServiceJobDeleteOperator(
+        op = CloudDataTransferServiceDeleteJobOperator(
             job_name='{{ dag.dag_id }}',
             gcp_conn_id='{{ dag.dag_id }}',
             api_version='{{ dag.dag_id }}',
@@ -366,10 +366,10 @@ class TestGcpStorageTransferJobDeleteOperator(unittest.TestCase):
         self.assertEqual(dag_id, getattr(op, 'gcp_conn_id'))
         self.assertEqual(dag_id, getattr(op, 'api_version'))
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_job_delete_should_throw_ex_when_name_none(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GcpTransferServiceJobDeleteOperator(job_name="", task_id='task-id')
+            op = CloudDataTransferServiceDeleteJobOperator(job_name="", task_id='task-id')
             op.execute(None)
         err = cm.exception
         self.assertIn("The required parameter 'job_name' is empty or None", str(err))
@@ -377,10 +377,10 @@ class TestGcpStorageTransferJobDeleteOperator(unittest.TestCase):
 
 
 class TestGpcStorageTransferOperationsGetOperator(unittest.TestCase):
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_get(self, mock_hook):
         mock_hook.return_value.get_transfer_operation.return_value = VALID_OPERATION
-        op = GcpTransferServiceOperationGetOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
+        op = CloudDataTransferServiceGetOperationOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
         mock_hook.return_value.get_transfer_operation.assert_called_once_with(operation_name=OPERATION_NAME)
@@ -389,22 +389,22 @@ class TestGpcStorageTransferOperationsGetOperator(unittest.TestCase):
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_get_with_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GcpTransferServiceOperationGetOperator(
+        op = CloudDataTransferServiceGetOperationOperator(
             operation_name='{{ dag.dag_id }}', task_id='task-id', dag=self.dag
         )
         ti = TaskInstance(op, DEFAULT_DATE)
         ti.render_templates()
         self.assertEqual(dag_id, getattr(op, 'operation_name'))
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_get_should_throw_ex_when_operation_name_none(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GcpTransferServiceOperationGetOperator(operation_name="", task_id=TASK_ID)
+            op = CloudDataTransferServiceGetOperationOperator(operation_name="", task_id=TASK_ID)
             op.execute(None)
         err = cm.exception
         self.assertIn("The required parameter 'operation_name' is empty or None", str(err))
@@ -412,10 +412,10 @@ class TestGpcStorageTransferOperationsGetOperator(unittest.TestCase):
 
 
 class TestGcpStorageTransferOperationListOperator(unittest.TestCase):
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_list(self, mock_hook):
         mock_hook.return_value.list_transfer_operations.return_value = [VALID_TRANSFER_JOB_GCS]
-        op = GcpTransferServiceOperationsListOperator(request_filter=TEST_FILTER, task_id=TASK_ID)
+        op = CloudDataTransferServiceListOperationsOperator(request_filter=TEST_FILTER, task_id=TASK_ID)
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
         mock_hook.return_value.list_transfer_operations.assert_called_once_with(request_filter=TEST_FILTER)
@@ -424,12 +424,12 @@ class TestGcpStorageTransferOperationListOperator(unittest.TestCase):
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GcpTransferServiceOperationsListOperator(
+        op = CloudDataTransferServiceListOperationsOperator(
             request_filter={"job_names": ['{{ dag.dag_id }}']},
             gcp_conn_id='{{ dag.dag_id }}',
             task_id='task-id',
@@ -446,9 +446,9 @@ class TestGcpStorageTransferOperationListOperator(unittest.TestCase):
 
 
 class TestGcpStorageTransferOperationsPauseOperator(unittest.TestCase):
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_pause(self, mock_hook):
-        op = GcpTransferServiceOperationPauseOperator(operation_name=OPERATION_NAME, task_id='task-id')
+        op = CloudDataTransferServicePauseOperationOperator(operation_name=OPERATION_NAME, task_id='task-id')
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
         mock_hook.return_value.pause_transfer_operation.assert_called_once_with(operation_name=OPERATION_NAME)
@@ -456,12 +456,12 @@ class TestGcpStorageTransferOperationsPauseOperator(unittest.TestCase):
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_pause_with_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GcpTransferServiceOperationPauseOperator(
+        op = CloudDataTransferServicePauseOperationOperator(
             operation_name='{{ dag.dag_id }}',
             gcp_conn_id='{{ dag.dag_id }}',
             api_version='{{ dag.dag_id }}',
@@ -474,10 +474,10 @@ class TestGcpStorageTransferOperationsPauseOperator(unittest.TestCase):
         self.assertEqual(dag_id, getattr(op, 'gcp_conn_id'))
         self.assertEqual(dag_id, getattr(op, 'api_version'))
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_pause_should_throw_ex_when_name_none(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GcpTransferServiceOperationPauseOperator(operation_name="", task_id='task-id')
+            op = CloudDataTransferServicePauseOperationOperator(operation_name="", task_id='task-id')
             op.execute(None)
         err = cm.exception
         self.assertIn("The required parameter 'operation_name' is empty or None", str(err))
@@ -485,9 +485,9 @@ class TestGcpStorageTransferOperationsPauseOperator(unittest.TestCase):
 
 
 class TestGcpStorageTransferOperationsResumeOperator(unittest.TestCase):
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_resume(self, mock_hook):
-        op = GcpTransferServiceOperationResumeOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
+        op = CloudDataTransferServiceResumeOperationOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
         mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
         mock_hook.return_value.resume_transfer_operation.assert_called_once_with(
@@ -498,12 +498,12 @@ class TestGcpStorageTransferOperationsResumeOperator(unittest.TestCase):
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_resume_with_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GcpTransferServiceOperationResumeOperator(
+        op = CloudDataTransferServiceResumeOperationOperator(
             operation_name='{{ dag.dag_id }}',
             gcp_conn_id='{{ dag.dag_id }}',
             api_version='{{ dag.dag_id }}',
@@ -516,10 +516,10 @@ class TestGcpStorageTransferOperationsResumeOperator(unittest.TestCase):
         self.assertEqual(dag_id, getattr(op, 'gcp_conn_id'))
         self.assertEqual(dag_id, getattr(op, 'api_version'))
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_resume_should_throw_ex_when_name_none(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GcpTransferServiceOperationResumeOperator(operation_name="", task_id=TASK_ID)
+            op = CloudDataTransferServiceResumeOperationOperator(operation_name="", task_id=TASK_ID)
             op.execute(None)
         err = cm.exception
         self.assertIn("The required parameter 'operation_name' is empty or None", str(err))
@@ -527,9 +527,9 @@ class TestGcpStorageTransferOperationsResumeOperator(unittest.TestCase):
 
 
 class TestGcpStorageTransferOperationsCancelOperator(unittest.TestCase):
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_cancel(self, mock_hook):
-        op = GcpTransferServiceOperationCancelOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
+        op = CloudDataTransferServiceCancelOperationOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
         mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
         mock_hook.return_value.cancel_transfer_operation.assert_called_once_with(
@@ -540,12 +540,12 @@ class TestGcpStorageTransferOperationsCancelOperator(unittest.TestCase):
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_cancel_with_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GcpTransferServiceOperationCancelOperator(
+        op = CloudDataTransferServiceCancelOperationOperator(
             operation_name='{{ dag.dag_id }}',
             gcp_conn_id='{{ dag.dag_id }}',
             api_version='{{ dag.dag_id }}',
@@ -558,10 +558,10 @@ class TestGcpStorageTransferOperationsCancelOperator(unittest.TestCase):
         self.assertEqual(dag_id, getattr(op, 'gcp_conn_id'))
         self.assertEqual(dag_id, getattr(op, 'api_version'))
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_operation_cancel_should_throw_ex_when_name_none(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
-            op = GcpTransferServiceOperationCancelOperator(operation_name="", task_id=TASK_ID)
+            op = CloudDataTransferServiceCancelOperationOperator(operation_name="", task_id=TASK_ID)
             op.execute(None)
         err = cm.exception
         self.assertIn("The required parameter 'operation_name' is empty or None", str(err))
@@ -570,7 +570,7 @@ class TestGcpStorageTransferOperationsCancelOperator(unittest.TestCase):
 
 class TestS3ToGoogleCloudStorageTransferOperator(unittest.TestCase):
     def test_constructor(self):
-        operator = S3ToGoogleCloudStorageTransferOperator(
+        operator = CloudDataTransferServiceS3ToGCSOperator(
             task_id=TASK_ID,
             s3_bucket=AWS_BUCKET_NAME,
             gcs_bucket=GCS_BUCKET_NAME,
@@ -589,12 +589,12 @@ class TestS3ToGoogleCloudStorageTransferOperator(unittest.TestCase):
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = S3ToGoogleCloudStorageTransferOperator(
+        op = CloudDataTransferServiceS3ToGCSOperator(
             s3_bucket='{{ dag.dag_id }}',
             gcs_bucket='{{ dag.dag_id }}',
             description='{{ dag.dag_id }}',
@@ -615,14 +615,14 @@ class TestS3ToGoogleCloudStorageTransferOperator(unittest.TestCase):
 
         self.assertEqual(dag_id, getattr(op, 'gcp_conn_id'))
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.AwsHook')
     def test_execute(self, mock_aws_hook, mock_transfer_hook):
         mock_aws_hook.return_value.get_credentials.return_value = Credentials(
             TEST_AWS_ACCESS_KEY_ID, TEST_AWS_ACCESS_SECRET, None
         )
 
-        operator = S3ToGoogleCloudStorageTransferOperator(
+        operator = CloudDataTransferServiceS3ToGCSOperator(
             task_id=TASK_ID,
             s3_bucket=AWS_BUCKET_NAME,
             gcs_bucket=GCS_BUCKET_NAME,
@@ -638,14 +638,14 @@ class TestS3ToGoogleCloudStorageTransferOperator(unittest.TestCase):
 
         self.assertTrue(mock_transfer_hook.return_value.wait_for_transfer_job.called)
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.AwsHook')
     def test_execute_skip_wait(self, mock_aws_hook, mock_transfer_hook):
         mock_aws_hook.return_value.get_credentials.return_value = Credentials(
             TEST_AWS_ACCESS_KEY_ID, TEST_AWS_ACCESS_SECRET, None
         )
 
-        operator = S3ToGoogleCloudStorageTransferOperator(
+        operator = CloudDataTransferServiceS3ToGCSOperator(
             task_id=TASK_ID,
             s3_bucket=AWS_BUCKET_NAME,
             gcs_bucket=GCS_BUCKET_NAME,
@@ -665,7 +665,7 @@ class TestS3ToGoogleCloudStorageTransferOperator(unittest.TestCase):
 
 class TestGoogleCloudStorageToGoogleCloudStorageTransferOperator(unittest.TestCase):
     def test_constructor(self):
-        operator = GoogleCloudStorageToGoogleCloudStorageTransferOperator(
+        operator = CloudDataTransferServiceGCSToGCSOperator(
             task_id=TASK_ID,
             source_bucket=GCS_BUCKET_NAME,
             destination_bucket=GCS_BUCKET_NAME,
@@ -684,12 +684,12 @@ class TestGoogleCloudStorageToGoogleCloudStorageTransferOperator(unittest.TestCa
     # Setting all of the operator's input parameters as templated dag_ids
     # (could be anything else) just to test if the templating works for all
     # fields
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)  # pylint: disable=attribute-defined-outside-init
-        op = GoogleCloudStorageToGoogleCloudStorageTransferOperator(
+        op = CloudDataTransferServiceGCSToGCSOperator(
             source_bucket='{{ dag.dag_id }}',
             destination_bucket='{{ dag.dag_id }}',
             description='{{ dag.dag_id }}',
@@ -710,9 +710,9 @@ class TestGoogleCloudStorageToGoogleCloudStorageTransferOperator(unittest.TestCa
 
         self.assertEqual(dag_id, getattr(op, 'gcp_conn_id'))
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_execute(self, mock_transfer_hook):
-        operator = GoogleCloudStorageToGoogleCloudStorageTransferOperator(
+        operator = CloudDataTransferServiceGCSToGCSOperator(
             task_id=TASK_ID,
             source_bucket=GCS_BUCKET_NAME,
             destination_bucket=GCS_BUCKET_NAME,
@@ -727,9 +727,9 @@ class TestGoogleCloudStorageToGoogleCloudStorageTransferOperator(unittest.TestCa
         )
         self.assertTrue(mock_transfer_hook.return_value.wait_for_transfer_job.called)
 
-    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_execute_skip_wait(self, mock_transfer_hook):
-        operator = GoogleCloudStorageToGoogleCloudStorageTransferOperator(
+        operator = CloudDataTransferServiceGCSToGCSOperator(
             task_id=TASK_ID,
             source_bucket=GCS_BUCKET_NAME,
             destination_bucket=GCS_BUCKET_NAME,

--- a/tests/gcp/sensors/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/sensors/test_cloud_storage_transfer_service.py
@@ -22,17 +22,17 @@ import mock
 from parameterized import parameterized
 
 from airflow.gcp.hooks.cloud_storage_transfer_service import GcpTransferOperationStatus
-from airflow.gcp.sensors.cloud_storage_transfer_service import GCPTransferServiceWaitForJobStatusSensor
+from airflow.gcp.sensors.cloud_storage_transfer_service import CloudDataTransferServiceJobStatusSensor
 
 
 class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
-    @mock.patch('airflow.gcp.sensors.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.sensors.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_wait_for_status_success(self, mock_tool):
         operations = [{'metadata': {'status': GcpTransferOperationStatus.SUCCESS}}]
         mock_tool.return_value.list_transfer_operations.return_value = operations
         mock_tool.operations_contain_expected_statuses.return_value = True
 
-        op = GCPTransferServiceWaitForJobStatusSensor(
+        op = CloudDataTransferServiceJobStatusSensor(
             task_id='task-id',
             job_name='job-name',
             project_id='project-id',
@@ -50,10 +50,10 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @mock.patch('airflow.gcp.sensors.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.sensors.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_wait_for_status_success_default_expected_status(self, mock_tool):
 
-        op = GCPTransferServiceWaitForJobStatusSensor(
+        op = CloudDataTransferServiceJobStatusSensor(
             task_id='task-id',
             job_name='job-name',
             project_id='project-id',
@@ -69,7 +69,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @mock.patch('airflow.gcp.sensors.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.sensors.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_wait_for_status_after_retry(self, mock_tool):
         operations_set = [
             [{'metadata': {'status': GcpTransferOperationStatus.SUCCESS}}],
@@ -79,7 +79,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
         mock_tool.return_value.list_transfer_operations.side_effect = operations_set
         mock_tool.operations_contain_expected_statuses.side_effect = [False, True]
 
-        op = GCPTransferServiceWaitForJobStatusSensor(
+        op = CloudDataTransferServiceJobStatusSensor(
             task_id='task-id',
             job_name='job-name',
             project_id='project-id',
@@ -113,14 +113,14 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
             ),
         ]
     )
-    @mock.patch('airflow.gcp.sensors.cloud_storage_transfer_service.GCPTransferServiceHook')
+    @mock.patch('airflow.gcp.sensors.cloud_storage_transfer_service.CloudDataTransferServiceHook')
     def test_wait_for_status_normalize_status(self, expected_status, received_status, mock_tool):
         operations = [{'metadata': {'status': GcpTransferOperationStatus.SUCCESS}}]
 
         mock_tool.return_value.list_transfer_operations.return_value = operations
         mock_tool.operations_contain_expected_statuses.side_effect = [False, True]
 
-        op = GCPTransferServiceWaitForJobStatusSensor(
+        op = CloudDataTransferServiceJobStatusSensor(
             task_id='task-id',
             job_name='job-name',
             project_id='project-id',

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -109,7 +109,7 @@ HOOK = [
         "airflow.contrib.hooks.gcp_tasks_hook.CloudTasksHook",
     ),
     (
-        "airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook",
+        "airflow.gcp.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook",
         "airflow.contrib.hooks.gcp_transfer_hook.GCPTransferServiceHook",
     ),
     (
@@ -427,50 +427,50 @@ OPERATOR = [
         "airflow.contrib.operators.gcp_text_to_speech_operator.GcpTextToSpeechSynthesizeOperator",
     ),
     (
-        "airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobCreateOperator",
+        "airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceCreateJobOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobCreateOperator",
     ),
     (
-        "airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobDeleteOperator",
+        "airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceDeleteJobOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobDeleteOperator",
     ),
     (
-        "airflow.gcp.operators.cloud_storage_transfer_service.GcpTransferServiceJobUpdateOperator",
+        "airflow.gcp.operators.cloud_storage_transfer_service.CloudDataTransferServiceUpdateJobOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobUpdateOperator",
     ),
     (
         "airflow.gcp.operators.cloud_storage_transfer_service."
-        "GcpTransferServiceOperationCancelOperator",
+        "CloudDataTransferServiceCancelOperationOperator",
         "airflow.contrib.operators.gcp_transfer_operator."
         "GcpTransferServiceOperationCancelOperator",
     ),
     (
         "airflow.gcp.operators.cloud_storage_transfer_service."
-        "GcpTransferServiceOperationGetOperator",
+        "CloudDataTransferServiceGetOperationOperator",
         "airflow.contrib.operators.gcp_transfer_operator."
         "GcpTransferServiceOperationGetOperator",
     ),
     (
         "airflow.gcp.operators.cloud_storage_transfer_service."
-        "GcpTransferServiceOperationPauseOperator",
+        "CloudDataTransferServicePauseOperationOperator",
         "airflow.contrib.operators.gcp_transfer_operator."
         "GcpTransferServiceOperationPauseOperator",
     ),
     (
         "airflow.gcp.operators.cloud_storage_transfer_service."
-        "GcpTransferServiceOperationResumeOperator",
+        "CloudDataTransferServiceResumeOperationOperator",
         "airflow.contrib.operators.gcp_transfer_operator."
         "GcpTransferServiceOperationResumeOperator",
     ),
     (
         "airflow.gcp.operators.cloud_storage_transfer_service."
-        "GcpTransferServiceOperationsListOperator",
+        "CloudDataTransferServiceListOperationsOperator",
         "airflow.contrib.operators.gcp_transfer_operator."
         "GcpTransferServiceOperationsListOperator",
     ),
     (
         "airflow.gcp.operators.cloud_storage_transfer_service."
-        "GoogleCloudStorageToGoogleCloudStorageTransferOperator",
+        "CloudDataTransferServiceGCSToGCSOperator",
         "airflow.contrib.operators.gcp_transfer_operator."
         "GoogleCloudStorageToGoogleCloudStorageTransferOperator",
     ),
@@ -777,7 +777,7 @@ SENSOR = [
     ),
     (
         "airflow.gcp.sensors.cloud_storage_transfer_service."
-        "GCPTransferServiceWaitForJobStatusSensor",
+        "CloudDataTransferServiceJobStatusSensor",
         "airflow.contrib.sensors.gcp_transfer_sensor."
         "GCPTransferServiceWaitForJobStatusSensor",
     ),


### PR DESCRIPTION
PR contains changes regarding AIP-21 (renaming GCP operators and hooks):
- renamed GCP modules
- adde deprecation warnings to the contrib modules
- fixed tests
- updated UPDATING.md

---
- [x] Description above provides context of the change
- [x] Commit message contains [\[AIRFLOW-6113\]](https://issues.apache.org/jira/browse/AIRFLOW-XXXX) or `[AIRFLOW-XXXX]` for document-only changes
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
