### PR TITLE
[AIRFLOW-6425] Serialization: Add missing DAG parameters to Json Schema

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1513,7 +1513,9 @@ class DAG(BaseDag, LoggingMixin):
                 'parent_dag', '_old_context_manager_dags', 'safe_dag_id', 'last_loaded',
                 '_full_filepath', 'user_defined_filters', 'user_defined_macros',
                 '_schedule_interval', 'partial', '_old_context_manager_dags',
-                '_pickle_id', '_log', 'is_subdag', 'task_dict'
+                '_pickle_id', '_log', 'is_subdag', 'task_dict', 'template_searchpath',
+                'sla_miss_callback', 'on_success_callback', 'on_failure_callback',
+                'template_undefined', 'jinja_environment_kwargs'
             }
         return cls.__serialized_fields
 

--- a/airflow/serialization/json_schema.py
+++ b/airflow/serialization/json_schema.py
@@ -50,9 +50,9 @@ class Validator(Protocol):
         ...
 
 
-def load_dag_schema() -> Validator:
+def load_schema() -> dict:
     """
-    Load Json Schema for DAG
+    Load & return Json Schema for DAG
     """
     schema_file_name = 'schema.json'
     schema_file = pkgutil.get_data(__name__, schema_file_name)
@@ -61,5 +61,13 @@ def load_dag_schema() -> Validator:
         raise AirflowException("Schema file {} does not exists".format(schema_file_name))
 
     schema = json.loads(schema_file.decode())
+    return schema
+
+
+def load_and_validate_dag_schema() -> Validator:
+    """
+    Load & Validate Json Schema for DAG
+    """
+    schema = load_schema()
     jsonschema.Draft7Validator.check_schema(schema)
     return jsonschema.Draft7Validator(schema)

--- a/airflow/serialization/json_schema.py
+++ b/airflow/serialization/json_schema.py
@@ -50,9 +50,9 @@ class Validator(Protocol):
         ...
 
 
-def load_schema() -> dict:
+def load_dag_schema_dict() -> dict:
     """
-    Load & return Json Schema for DAG
+    Load & return Json Schema for DAG as Python dict
     """
     schema_file_name = 'schema.json'
     schema_file = pkgutil.get_data(__name__, schema_file_name)
@@ -64,10 +64,10 @@ def load_schema() -> dict:
     return schema
 
 
-def load_and_validate_dag_schema() -> Validator:
+def load_dag_schema() -> Validator:
     """
     Load & Validate Json Schema for DAG
     """
-    schema = load_schema()
+    schema = load_dag_schema_dict()
     jsonschema.Draft7Validator.check_schema(schema)
     return jsonschema.Draft7Validator(schema)

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -92,7 +92,10 @@
         "start_date": { "$ref": "#/definitions/datetime" },
         "end_date": { "$ref": "#/definitions/datetime" },
         "dagrun_timeout": { "$ref": "#/definitions/timedelta" },
-        "doc_md": { "type" : "string"}
+        "doc_md": { "type" : "string"},
+        "_default_view": { "type" : "string"},
+        "_access_control": {"$ref": "#/definitions/dict" },
+        "is_paused_upon_creation":  { "type": "boolean" }
       },
       "required": [
         "params",

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -30,7 +30,7 @@ from airflow import DAG, AirflowException, LoggingMixin
 from airflow.models import Connection
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
-from airflow.serialization.json_schema import Validator, load_dag_schema
+from airflow.serialization.json_schema import Validator, load_and_validate_dag_schema
 from airflow.settings import json
 from airflow.www.utils import get_python_source
 
@@ -475,7 +475,7 @@ class SerializedDAG(DAG, BaseSerialization):
     _CONSTRUCTOR_PARAMS = __get_constructor_defaults.__func__()  # type: ignore
     del __get_constructor_defaults
 
-    _json_schema = load_dag_schema()
+    _json_schema = load_and_validate_dag_schema()
 
     @classmethod
     def serialize_dag(cls, dag: DAG) -> dict:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -30,7 +30,7 @@ from airflow import DAG, AirflowException, LoggingMixin
 from airflow.models import Connection
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
-from airflow.serialization.json_schema import Validator, load_and_validate_dag_schema
+from airflow.serialization.json_schema import Validator, load_dag_schema
 from airflow.settings import json
 from airflow.www.utils import get_python_source
 
@@ -475,7 +475,7 @@ class SerializedDAG(DAG, BaseSerialization):
     _CONSTRUCTOR_PARAMS = __get_constructor_defaults.__func__()  # type: ignore
     del __get_constructor_defaults
 
-    _json_schema = load_and_validate_dag_schema()
+    _json_schema = load_dag_schema()
 
     @classmethod
     def serialize_dag(cls, dag: DAG) -> dict:

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -35,7 +35,7 @@ from airflow.models import DAG, Connection, DagBag, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.subdag_operator import SubDagOperator
-from airflow.serialization.json_schema import load_schema
+from airflow.serialization.json_schema import load_dag_schema_dict
 from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
 from tests.test_utils.mock_operators import CustomOperator, CustomOpLink, GoogleLink
 
@@ -470,7 +470,7 @@ class TestStringifiedDAGs(unittest.TestCase):
         Additional Properties are disabled on DAGs. This test verifies that all the
         keys in DAG.get_serialized_fields are listed in Schema definition.
         """
-        dag_schema: dict = load_schema()["definitions"]["dag"]["properties"]
+        dag_schema: dict = load_dag_schema_dict()["definitions"]["dag"]["properties"]
 
         # The parameters we add manually in Serialization needs to be ignored
         ignored_keys: set = {"is_subdag", "tasks"}

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -35,6 +35,7 @@ from airflow.models import DAG, Connection, DagBag, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.subdag_operator import SubDagOperator
+from airflow.serialization.json_schema import load_schema
 from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
 from tests.test_utils.mock_operators import CustomOperator, CustomOpLink, GoogleLink
 
@@ -53,6 +54,7 @@ serialized_simple_dag_ground_truth = {
             }
         },
         "start_date": 1564617600.0,
+        "is_paused_upon_creation": False,
         "params": {},
         "_dag_id": "simple_dag",
         "fileloc": None,
@@ -107,6 +109,7 @@ def make_simple_dag():
             "depends_on_past": False,
         },
         start_date=datetime(2019, 8, 1),
+        is_paused_upon_creation=False,
     )
     BaseOperator(task_id='simple_task', dag=dag, owner='airflow')
     CustomOperator(task_id='custom_task', dag=dag)
@@ -461,6 +464,18 @@ class TestStringifiedDAGs(unittest.TestCase):
         # Test Deserialized link registered via Airflow Plugin
         google_link_from_plugin = simple_task.get_extra_links(test_date, GoogleLink.name)
         self.assertEqual("https://www.google.com", google_link_from_plugin)
+
+    def test_dag_serialized_fields_with_schema(self):
+        """
+        Additional Properties are disabled on DAGs. This test verifies that all the
+        keys in DAG.get_serialized_fields are listed in Schema definition.
+        """
+        dag_schema: dict = load_schema()["definitions"]["dag"]["properties"]
+
+        # The parameters we add manually in Serialization needs to be ignored
+        ignored_keys: set = {"is_subdag", "tasks"}
+        dag_params: set = set(dag_schema.keys()) - ignored_keys
+        self.assertEqual(set(DAG.get_serialized_fields()), dag_params)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The following DAG currently fails:

Schema Validation error when DAG.is_paused_upon_creation is set

```python
def make_simple_dag():
    """Make very simple DAG to verify serialization result."""
    dag = DAG(
        dag_id='simple_dag',
        default_args={
            "retries": 1,
            "retry_delay": timedelta(minutes=5),
            "depends_on_past": False,
        },
        start_date=datetime(2019, 8, 1),
        is_paused_upon_creation=True,
    )
    BaseOperator(task_id='simple_task', dag=dag, owner='airflow')
    CustomOperator(task_id='custom_task', dag=dag)
    return {'simple_dag': dag}
```

**Error**:
```
 jsonschema.exceptions.ValidationError: Additional properties are not allowed ('is_paused_upon_creation' was unexpected)
```

*Reason*:

`is_paused_upon_creation` is in `DAG.get_serialized_fields()` but not in the Schema definition.

---
- [x] Description above provides context of the change
- [x] Commit message contains [\[AIRFLOW-6425\]](https://issues.apache.org/jira/browse/AIRFLOW-6425) 
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
