### PR TITLE
[AIRFLOW-6426] Fix error in example_gcs dag

### DIFF
--- a/airflow/gcp/example_dags/example_gcs.py
+++ b/airflow/gcp/example_dags/example_gcs.py
@@ -127,7 +127,7 @@ with models.DAG(
     )
 
     delete_files = GoogleCloudStorageDeleteOperator(
-        task_id="delete_files", bucket_name=BUCKET_1, prefix=""
+        task_id="delete_files", bucket_name=BUCKET_1, objects=[BUCKET_FILE_LOCATION]
     )
 
     [create_bucket1, create_bucket2] >> list_buckets >> list_buckets_result


### PR DESCRIPTION
I get the following error with the current example_gcs DAG: https://github.com/apache/airflow/blob/aa90753cf5f64bf435044cf2e6b81a02fdcf6b33/airflow/gcp/example_dags/example_gcs.py#L130

```
  File "/opt/airflow/airflow/gcp/operators/gcs.py", line 372, in __init__
    raise ValueError("Either object or prefix should be set. Both are None")
ValueError: Either object or prefix should be set. Both are None
```

---
- [x] Description above provides context of the change
- [x] Commit message contains [\[AIRFLOW-6426\]](https://issues.apache.org/jira/browse/AIRFLOW-6426) 
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
