### PR TITLE
[AIRFLOW-6427] Fix error in example_qubole_operator dag

### DIFF
--- a/airflow/contrib/example_dags/example_qubole_operator.py
+++ b/airflow/contrib/example_dags/example_qubole_operator.py
@@ -188,7 +188,7 @@ with DAG(
         hive_table='default_qubole_airline_origin_destination',
         db_table='exported_airline_origin_destination',
         where_clause='id < 10',
-        db_parallelism=2,
+        parallelism=2,
         dbtap_id=2064,
         trigger_rule="all_done"
     )


### PR DESCRIPTION
With the current example (https://github.com/apache/airflow/blob/aa90753cf5f64bf435044cf2e6b81a02fdcf6b33/airflow/contrib/example_dags/example_qubole_operator.py#L191), I get the following error:

```
airflow.exceptions.AirflowException: Invalid arguments were passed to QuboleOperator (task_id: db_import). Invalid arguments were:
*args: ()
**kwargs: {'db_parallelism': 2}
```

The `qds_sdk` contains the following:

```python
optparser.add_option("--parallelism", dest="db_parallelism",
                         help="Mode 1 and 2: Number of parallel threads to use for extracting data")
```

and hence it should be `parallelism` and not `db_parallelism`

---
- [x] Description above provides context of the change
- [x] Commit message contains [\[AIRFLOW-6427\]](https://issues.apache.org/jira/browse/AIRFLOW-6427)
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
