### PR TITLE
[AIRFLOW-6428] Fix import path for airflow.utils.dates.days_ago in Example DAGs

### DIFF
--- a/airflow/contrib/example_dags/example_databricks_operator.py
+++ b/airflow/contrib/example_dags/example_databricks_operator.py
@@ -32,15 +32,15 @@ For more information about the state of a run refer to
 https://docs.databricks.com/api/latest/jobs.html#runstate
 """
 
-import airflow
 from airflow import DAG
 from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
+from airflow.utils.dates import days_ago
 
 default_args = {
     'owner': 'airflow',
     'email': ['airflow@example.com'],
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 
 with DAG(
@@ -48,7 +48,6 @@ with DAG(
     default_args=default_args,
     schedule_interval='@daily'
 ) as dag:
-
     new_cluster = {
         'spark_version': '2.1.0-db3-scala2.11',
         'node_type_id': 'r3.xlarge',

--- a/airflow/contrib/example_dags/example_dingding_operator.py
+++ b/airflow/contrib/example_dags/example_dingding_operator.py
@@ -21,14 +21,14 @@ This is an example dag for using the DingdingOperator.
 """
 from datetime import timedelta
 
-import airflow
 from airflow import DAG
 from airflow.contrib.operators.dingding_operator import DingdingOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
     'retries': 3,
-    'start_date': airflow.utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 
 

--- a/airflow/contrib/example_dags/example_emr_job_flow_automatic_steps.py
+++ b/airflow/contrib/example_dags/example_emr_job_flow_automatic_steps.py
@@ -21,15 +21,15 @@ This is an example dag for a AWS EMR Pipeline with auto steps.
 """
 from datetime import timedelta
 
-import airflow
 from airflow import DAG
 from airflow.contrib.operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator
 from airflow.contrib.sensors.emr_job_flow_sensor import EmrJobFlowSensor
+from airflow.utils.dates import days_ago
 
 DEFAULT_ARGS = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False

--- a/airflow/contrib/example_dags/example_emr_job_flow_manual_steps.py
+++ b/airflow/contrib/example_dags/example_emr_job_flow_manual_steps.py
@@ -24,17 +24,17 @@ terminating the cluster.
 """
 from datetime import timedelta
 
-import airflow
 from airflow import DAG
 from airflow.contrib.operators.emr_add_steps_operator import EmrAddStepsOperator
 from airflow.contrib.operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator
 from airflow.contrib.operators.emr_terminate_job_flow_operator import EmrTerminateJobFlowOperator
 from airflow.contrib.sensors.emr_step_sensor import EmrStepSensor
+from airflow.utils.dates import days_ago
 
 DEFAULT_ARGS = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False

--- a/airflow/contrib/example_dags/example_gcs_to_gdrive.py
+++ b/airflow/contrib/example_dags/example_gcs_to_gdrive.py
@@ -21,13 +21,13 @@ Example DAG using GoogleCloudStorageToGoogleDriveOperator.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.contrib.operators.gcs_to_gdrive_operator import GcsToGDriveOperator
+from airflow.utils.dates import days_ago
 
 GCS_TO_GDRIVE_BUCKET = os.environ.get("GCS_TO_DRIVE_BUCKET", "example-object")
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 with models.DAG(
     "example_gcs_to_gdrive", default_args=default_args, schedule_interval=None  # Override to match your needs

--- a/airflow/contrib/example_dags/example_kubernetes_executor.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor.py
@@ -21,13 +21,13 @@ This is an example dag for using the Kubernetes Executor.
 """
 import os
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 
 with DAG(

--- a/airflow/contrib/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor_config.py
@@ -21,14 +21,14 @@ This is an example dag for using a Kubernetes Executor Configuration.
 """
 import os
 
-import airflow
 from airflow.contrib.example_dags.libs.helper import print_stuff
 from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
 
 default_args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 
 with DAG(

--- a/airflow/contrib/example_dags/example_papermill_operator.py
+++ b/airflow/contrib/example_dags/example_papermill_operator.py
@@ -24,13 +24,13 @@ templated.
 
 from datetime import timedelta
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.papermill_operator import PapermillOperator
+from airflow.utils.dates import days_ago
 
 default_args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 
 with DAG(

--- a/airflow/contrib/example_dags/example_qubole_operator.py
+++ b/airflow/contrib/example_dags/example_qubole_operator.py
@@ -31,16 +31,16 @@ example. Also be aware that it might spin up clusters to run these examples.*
 import filecmp
 import random
 
-import airflow
 from airflow import DAG
 from airflow.contrib.operators.qubole_operator import QuboleOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator, PythonOperator
+from airflow.utils.dates import days_ago
 
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False

--- a/airflow/contrib/example_dags/example_twitter_dag.py
+++ b/airflow/contrib/example_dags/example_twitter_dag.py
@@ -31,11 +31,11 @@ This is an example dag for managing twitter data.
 """
 from datetime import date, timedelta
 
-import airflow
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.hive_operator import HiveOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
 
 # --------------------------------------------------------------------------------
 # Create a few placeholder scripts. In practice these would be different python
@@ -74,7 +74,7 @@ def transfertodb():
 default_args = {
     'owner': 'Ekhtiar',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(5),
+    'start_date': days_ago(5),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False,

--- a/airflow/contrib/example_dags/example_winrm_operator.py
+++ b/airflow/contrib/example_dags/example_winrm_operator.py
@@ -31,15 +31,15 @@ This is an example dag for using the WinRMOperator.
 """
 from datetime import timedelta
 
-import airflow
 from airflow.contrib.hooks.winrm_hook import WinRMHook
 from airflow.contrib.operators.winrm_operator import WinRMOperator
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils.dates import days_ago
 
 default_args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 
 with DAG(

--- a/airflow/example_dags/docker_copy_data.py
+++ b/airflow/example_dags/docker_copy_data.py
@@ -28,16 +28,16 @@ TODO: Review the workflow, change it accordingly to
 
 #
 # from airflow import DAG
-# import airflow
 # from datetime import timedelta
 # from airflow.operators import BashOperator
 # from airflow.operators import ShortCircuitOperator
 # from airflow.operators.docker_operator import DockerOperator
+# from airflow.utils.dates import days_ago
 #
 # default_args = {
 #     'owner': 'airflow',
 #     'depends_on_past': False,
-#     'start_date': airflow.utils.dates.days_ago(2),
+#     'start_date': days_ago(2),
 #     'email': ['airflow@example.com'],
 #     'email_on_failure': False,
 #     'email_on_retry': False,

--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -21,14 +21,14 @@
 
 from datetime import timedelta
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
 }
 
 dag = DAG(

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -21,14 +21,14 @@
 
 import random
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
 }
 
 dag = DAG(

--- a/airflow/example_dags/example_branch_python_dop_operator_3.py
+++ b/airflow/example_dags/example_branch_python_dop_operator_3.py
@@ -22,14 +22,14 @@ Example DAG demonstrating the usage of BranchPythonOperator with depends_on_past
 or skipped on alternating runs.
 """
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
     'depends_on_past': True,
 }
 

--- a/airflow/example_dags/example_docker_operator.py
+++ b/airflow/example_dags/example_docker_operator.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-import airflow
+from airflow.utils.dates import days_ago
 from airflow import DAG
 from airflow.operators import BashOperator
 from datetime import timedelta
@@ -26,7 +26,7 @@ from airflow.operators.docker_operator import DockerOperator
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False,

--- a/airflow/example_dags/example_docker_swarm_operator.py
+++ b/airflow/example_dags/example_docker_swarm_operator.py
@@ -19,14 +19,14 @@
 
 """
 from datetime import timedelta
-import airflow
+from airflow.utils.dates import days_ago
 from airflow import DAG
 from airflow.contrib.operators.docker_swarm_operator import DockerSwarmOperator
 
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(1),
+    'start_date': days_ago(1),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False

--- a/airflow/example_dags/example_gcs_to_bq.py
+++ b/airflow/example_dags/example_gcs_to_bq.py
@@ -19,14 +19,14 @@
 """
 Example DAG using GoogleCloudStorageToBigQueryOperator.
 """
-import airflow
 from airflow import models
 from airflow.operators import bash_operator
 from airflow.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 
 dag = models.DAG(

--- a/airflow/example_dags/example_gcs_to_gcs.py
+++ b/airflow/example_dags/example_gcs_to_gcs.py
@@ -22,11 +22,11 @@ Example Airflow DAG for Google Cloud Storage to Google Cloud Storage transfer op
 
 import os
 
-import airflow
 from airflow import models
 from airflow.operators.gcs_to_gcs import GoogleCloudStorageSynchronizeBuckets
+from airflow.utils.dates import days_ago
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 BUCKET_1_SRC = os.environ.get("GCP_GCS_BUCKET_1_SRC", "test-gcs-sync-1-src")
 BUCKET_1_DST = os.environ.get("GCP_GCS_BUCKET_1_DST", "test-gcs-sync-1-dst")

--- a/airflow/example_dags/example_gcs_to_sftp.py
+++ b/airflow/example_dags/example_gcs_to_sftp.py
@@ -22,11 +22,11 @@ Example Airflow DAG for Google Cloud Storage to SFTP transfer operators.
 
 import os
 
-import airflow
 from airflow import models
 from airflow.operators.gcs_to_sftp import GoogleCloudStorageToSFTPOperator
+from airflow.utils.dates import days_ago
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 BUCKET_SRC = os.environ.get("GCP_GCS_BUCKET_1_SRC", "test-gcs-sftp")
 OBJECT_SRC_1 = "parent-1.bin"

--- a/airflow/example_dags/example_http_operator.py
+++ b/airflow/example_dags/example_http_operator.py
@@ -22,15 +22,15 @@
 import json
 from datetime import timedelta
 
-import airflow
 from airflow import DAG
 from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.sensors.http_sensor import HttpSensor
+from airflow.utils.dates import days_ago
 
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False,

--- a/airflow/example_dags/example_latest_only.py
+++ b/airflow/example_dags/example_latest_only.py
@@ -21,15 +21,15 @@
 
 import datetime as dt
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.utils.dates import days_ago
 
 dag = DAG(
     dag_id='latest_only',
     schedule_interval=dt.timedelta(hours=4),
-    start_date=airflow.utils.dates.days_ago(2),
+    start_date=days_ago(2),
 )
 
 latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)

--- a/airflow/example_dags/example_latest_only_with_trigger.py
+++ b/airflow/example_dags/example_latest_only_with_trigger.py
@@ -21,16 +21,16 @@ Example LatestOnlyOperator and TriggerRule interactions
 """
 import datetime as dt
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.utils.dates import days_ago
 from airflow.utils.trigger_rule import TriggerRule
 
 dag = DAG(
     dag_id='latest_only_with_trigger',
     schedule_interval=dt.timedelta(hours=4),
-    start_date=airflow.utils.dates.days_ago(2),
+    start_date=days_ago(2),
 )
 
 latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -21,16 +21,16 @@
 
 from datetime import timedelta
 
-import airflow
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
 
 dag = DAG(
     "example_passing_params_via_test_command",
     default_args={
         "owner": "airflow",
-        "start_date": airflow.utils.dates.days_ago(1),
+        "start_date": days_ago(1),
     },
     schedule_interval='*/1 * * * *',
     dagrun_timeout=timedelta(minutes=4),

--- a/airflow/example_dags/example_pig_operator.py
+++ b/airflow/example_dags/example_pig_operator.py
@@ -19,13 +19,13 @@
 
 """Example DAG demonstrating the usage of the PigOperator."""
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.pig_operator import PigOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
 }
 
 dag = DAG(

--- a/airflow/example_dags/example_postgres_to_gcs.py
+++ b/airflow/example_dags/example_postgres_to_gcs.py
@@ -19,15 +19,15 @@
 """
 Example DAG using PostgresToGoogleCloudStorageOperator.
 """
-import airflow
 from airflow import models
 from airflow.operators.postgres_to_gcs import PostgresToGoogleCloudStorageOperator
+from airflow.utils.dates import days_ago
 
 GCS_BUCKET = "postgres_to_gcs_example"
 FILENAME = "test_file"
 SQL_QUERY = "select * from test_table;"
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 with models.DAG(
     dag_id='example_postgres_to_gcs',

--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -22,13 +22,13 @@
 import time
 from pprint import pprint
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator, PythonVirtualenvOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
 }
 
 dag = DAG(

--- a/airflow/example_dags/example_skip_dag.py
+++ b/airflow/example_dags/example_skip_dag.py
@@ -19,14 +19,14 @@
 
 """Example DAG demonstrating the DummyOperator and a custom DummySkipOperator which skips by default."""
 
-import airflow
 from airflow.exceptions import AirflowSkipException
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
 }
 
 

--- a/airflow/example_dags/example_subdag_operator.py
+++ b/airflow/example_dags/example_subdag_operator.py
@@ -19,17 +19,17 @@
 
 """Example DAG demonstrating the usage of the SubDagOperator."""
 
-import airflow
 from airflow.example_dags.subdags.subdag import subdag
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.subdag_operator import SubDagOperator
+from airflow.utils.dates import days_ago
 
 DAG_NAME = 'example_subdag_operator'
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
 }
 
 dag = DAG(

--- a/airflow/example_dags/example_trigger_controller_dag.py
+++ b/airflow/example_dags/example_trigger_controller_dag.py
@@ -23,13 +23,13 @@ Example usage of the TriggerDagRunOperator. This example holds 2 DAGs:
 2. 2nd DAG (example_trigger_target_dag) which will be triggered by the TriggerDagRunOperator in the 1st DAG
 """
 
-import airflow.utils.dates
 from airflow import DAG
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
+from airflow.utils.dates import days_ago
 
 dag = DAG(
     dag_id="example_trigger_controller_dag",
-    default_args={"owner": "airflow", "start_date": airflow.utils.dates.days_ago(2)},
+    default_args={"owner": "airflow", "start_date": days_ago(2)},
     schedule_interval="@once",
 )
 

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -23,14 +23,14 @@ Example usage of the TriggerDagRunOperator. This example holds 2 DAGs:
 2. 2nd DAG (example_trigger_target_dag) which will be triggered by the TriggerDagRunOperator in the 1st DAG
 """
 
-import airflow.utils.dates
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
 
 dag = DAG(
     dag_id="example_trigger_target_dag",
-    default_args={"start_date": airflow.utils.dates.days_ago(2), "owner": "airflow"},
+    default_args={"start_date": days_ago(2), "owner": "airflow"},
     schedule_interval=None,
 )
 

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -19,13 +19,13 @@
 
 """Example DAG demonstrating the usage of XComs."""
 
-import airflow
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
 }
 
 dag = DAG('example_xcom', schedule_interval="@once", default_args=args)

--- a/airflow/example_dags/test_utils.py
+++ b/airflow/example_dags/test_utils.py
@@ -17,9 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 """Used for unit tests"""
-import airflow
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
 
 dag = DAG(dag_id='test_utils', schedule_interval=None)
 
@@ -27,6 +27,6 @@ task = BashOperator(
     task_id='sleeps_forever',
     dag=dag,
     bash_command="sleep 10000000000",
-    start_date=airflow.utils.dates.days_ago(2),
+    start_date=days_ago(2),
     owner='airflow',
 )

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -25,12 +25,12 @@ Documentation that goes along with the Airflow tutorial located
 # [START tutorial]
 from datetime import timedelta
 
-import airflow
 # [START import_module]
 # The DAG object; we'll need this to instantiate a DAG
 from airflow import DAG
 # Operators; we need this to operate!
 from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
 
 # [END import_module]
 
@@ -40,7 +40,7 @@ from airflow.operators.bash_operator import BashOperator
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': airflow.utils.dates.days_ago(2),
+    'start_date': days_ago(2),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False,

--- a/airflow/gcp/example_dags/example_automl_nl_text_classification.py
+++ b/airflow/gcp/example_dags/example_automl_nl_text_classification.py
@@ -22,13 +22,13 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
     AutoMLCreateDatasetOperator, AutoMLDeleteDatasetOperator, AutoMLDeleteModelOperator,
     AutoMLImportDataOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -54,7 +54,7 @@ DATASET = {
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_TEXT_CLS_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 # Example DAG for AutoML Natural Language Text Classification

--- a/airflow/gcp/example_dags/example_automl_nl_text_extraction.py
+++ b/airflow/gcp/example_dags/example_automl_nl_text_extraction.py
@@ -22,13 +22,13 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
     AutoMLCreateDatasetOperator, AutoMLDeleteDatasetOperator, AutoMLDeleteModelOperator,
     AutoMLImportDataOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -51,7 +51,7 @@ DATASET = {"display_name": "test_text_dataset", "text_extraction_dataset_metadat
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_TEXT_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 # Example DAG for AutoML Natural Language Entities Extraction

--- a/airflow/gcp/example_dags/example_automl_nl_text_sentiment.py
+++ b/airflow/gcp/example_dags/example_automl_nl_text_sentiment.py
@@ -22,13 +22,13 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
     AutoMLCreateDatasetOperator, AutoMLDeleteDatasetOperator, AutoMLDeleteModelOperator,
     AutoMLImportDataOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -54,7 +54,7 @@ DATASET = {
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_SENTIMENT_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 # Example DAG for AutoML Natural Language Text Sentiment

--- a/airflow/gcp/example_dags/example_automl_tables.py
+++ b/airflow/gcp/example_dags/example_automl_tables.py
@@ -24,7 +24,6 @@ import os
 from copy import deepcopy
 from typing import Dict, List
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
@@ -33,6 +32,7 @@ from airflow.gcp.operators.automl import (
     AutoMLListDatasetOperator, AutoMLPredictOperator, AutoMLTablesListColumnSpecsOperator,
     AutoMLTablesListTableSpecsOperator, AutoMLTablesUpdateDatasetOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -60,7 +60,7 @@ DATASET = {
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_DATASET_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 

--- a/airflow/gcp/example_dags/example_automl_translation.py
+++ b/airflow/gcp/example_dags/example_automl_translation.py
@@ -22,13 +22,13 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
     AutoMLCreateDatasetOperator, AutoMLDeleteDatasetOperator, AutoMLDeleteModelOperator,
     AutoMLImportDataOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -57,7 +57,7 @@ DATASET = {
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_TRANSLATION_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 

--- a/airflow/gcp/example_dags/example_automl_video_intelligence_classification.py
+++ b/airflow/gcp/example_dags/example_automl_video_intelligence_classification.py
@@ -22,13 +22,13 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
     AutoMLCreateDatasetOperator, AutoMLDeleteDatasetOperator, AutoMLDeleteModelOperator,
     AutoMLImportDataOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -54,7 +54,7 @@ DATASET = {
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_VIDEO_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 

--- a/airflow/gcp/example_dags/example_automl_video_intelligence_tracking.py
+++ b/airflow/gcp/example_dags/example_automl_video_intelligence_tracking.py
@@ -22,13 +22,13 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
     AutoMLCreateDatasetOperator, AutoMLDeleteDatasetOperator, AutoMLDeleteModelOperator,
     AutoMLImportDataOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -55,7 +55,7 @@ DATASET = {
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_TRACKING_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 

--- a/airflow/gcp/example_dags/example_automl_vision_classification.py
+++ b/airflow/gcp/example_dags/example_automl_vision_classification.py
@@ -22,13 +22,13 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
     AutoMLCreateDatasetOperator, AutoMLDeleteDatasetOperator, AutoMLDeleteModelOperator,
     AutoMLImportDataOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -54,7 +54,7 @@ DATASET = {
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_VISION_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 

--- a/airflow/gcp/example_dags/example_automl_vision_object_detection.py
+++ b/airflow/gcp/example_dags/example_automl_vision_object_detection.py
@@ -22,13 +22,13 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.hooks.automl import CloudAutoMLHook
 from airflow.gcp.operators.automl import (
     AutoMLCreateDatasetOperator, AutoMLDeleteDatasetOperator, AutoMLDeleteModelOperator,
     AutoMLImportDataOperator, AutoMLTrainModelOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 GCP_AUTOML_LOCATION = os.environ.get("GCP_AUTOML_LOCATION", "us-central1")
@@ -54,7 +54,7 @@ DATASET = {
 
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [GCP_AUTOML_DETECTION_BUCKET]}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 extract_object_id = CloudAutoMLHook.extract_object_id
 
 

--- a/airflow/gcp/example_dags/example_bigquery.py
+++ b/airflow/gcp/example_dags/example_bigquery.py
@@ -23,7 +23,6 @@ Example Airflow DAG for Google BigQuery service.
 import os
 from urllib.parse import urlparse
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.bigquery import (
     BigQueryCreateEmptyDatasetOperator, BigQueryCreateEmptyTableOperator, BigQueryCreateExternalTableOperator,
@@ -34,11 +33,12 @@ from airflow.gcp.operators.bigquery import (
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.bigquery_to_bigquery import BigQueryToBigQueryOperator
 from airflow.operators.bigquery_to_gcs import BigQueryToCloudStorageOperator
+from airflow.utils.dates import days_ago
 
 # 0x06012c8cf97BEaD5deAe237070F9587f8E7A266d = CryptoKitties contract address
 WALLET_ADDRESS = os.environ.get("GCP_ETH_WALLET_ADDRESS", "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d")
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 MOST_VALUABLE_INCOMING_TRANSACTIONS = """
 SELECT

--- a/airflow/gcp/example_dags/example_bigquery_dts.py
+++ b/airflow/gcp/example_dags/example_bigquery_dts.py
@@ -26,12 +26,12 @@ import time
 from google.cloud.bigquery_datatransfer_v1.types import TransferConfig
 from google.protobuf.json_format import ParseDict
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.bigquery_dts import (
     BigQueryCreateDataTransferOperator, BigQueryDataTransferServiceStartTransferRunsOperator,
 )
 from airflow.gcp.sensors.bigquery_dts import BigQueryDataTransferServiceTransferRunSensor
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
 BUCKET_URI = os.environ.get(
@@ -69,7 +69,7 @@ TRANSFER_CONFIG = ParseDict(
 
 # [END howto_bigquery_dts_create_args]
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 with models.DAG(
     "example_gcp_bigquery_dts",

--- a/airflow/gcp/example_dags/example_bigtable.py
+++ b/airflow/gcp/example_dags/example_bigtable.py
@@ -50,13 +50,13 @@ This DAG relies on the following environment variables:
 import json
 from os import getenv
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.bigtable import (
     BigtableCreateInstanceOperator, BigtableCreateTableOperator, BigtableDeleteInstanceOperator,
     BigtableDeleteTableOperator, BigtableUpdateClusterOperator,
 )
 from airflow.gcp.sensors.bigtable import BigtableTableReplicationCompletedSensor
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_gcp_bigtable_args]
 GCP_PROJECT_ID = getenv('GCP_PROJECT_ID', 'example-project')
@@ -74,7 +74,7 @@ CBT_POKE_INTERVAL = getenv('CBT_POKE_INTERVAL', '60')
 # [END howto_operator_gcp_bigtable_args]
 
 default_args = {
-    'start_date': airflow.utils.dates.days_ago(1)
+    'start_date': days_ago(1)
 }
 
 with models.DAG(

--- a/airflow/gcp/example_dags/example_cloud_sql.py
+++ b/airflow/gcp/example_dags/example_cloud_sql.py
@@ -31,7 +31,6 @@ https://airflow.apache.org/concepts.html#variables
 import os
 from urllib.parse import urlsplit
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.cloud_sql import (
     CloudSQLCreateInstanceDatabaseOperator, CloudSQLCreateInstanceOperator,
@@ -41,6 +40,7 @@ from airflow.gcp.operators.cloud_sql import (
 from airflow.gcp.operators.gcs import (
     GoogleCloudStorageBucketCreateAclEntryOperator, GoogleCloudStorageObjectCreateAclEntryOperator,
 )
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_cloudsql_arguments]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
@@ -176,7 +176,7 @@ db_patch_body = {
 # [END howto_operator_cloudsql_db_patch_body]
 
 default_args = {
-    'start_date': airflow.utils.dates.days_ago(1)
+    'start_date': days_ago(1)
 }
 
 with models.DAG(

--- a/airflow/gcp/example_dags/example_cloud_sql_query.py
+++ b/airflow/gcp/example_dags/example_cloud_sql_query.py
@@ -42,9 +42,9 @@ import subprocess
 from os.path import expanduser
 from urllib.parse import quote_plus
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.cloud_sql import CloudSQLExecuteQueryOperator
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_cloudsql_query_arguments]
 
@@ -92,7 +92,7 @@ SQL = [
 
 # [END howto_operator_cloudsql_query_arguments]
 default_args = {
-    'start_date': airflow.utils.dates.days_ago(1)
+    'start_date': days_ago(1)
 }
 
 

--- a/airflow/gcp/example_dags/example_compute.py
+++ b/airflow/gcp/example_dags/example_compute.py
@@ -32,12 +32,12 @@ This DAG relies on the following OS environment variables
 
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.compute import (
     ComputeEngineSetMachineTypeOperator, ComputeEngineStartInstanceOperator,
     ComputeEngineStopInstanceOperator,
 )
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_gce_args_common]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
@@ -46,7 +46,7 @@ GCE_INSTANCE = os.environ.get('GCE_INSTANCE', 'testinstance')
 # [END howto_operator_gce_args_common]
 
 default_args = {
-    'start_date': airflow.utils.dates.days_ago(1),
+    'start_date': days_ago(1),
 }
 
 # [START howto_operator_gce_args_set_machine_type]

--- a/airflow/gcp/example_dags/example_compute_igm.py
+++ b/airflow/gcp/example_dags/example_compute_igm.py
@@ -41,11 +41,11 @@ Variables for update template in Group Manager:
 
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.compute import (
     ComputeEngineCopyInstanceTemplateOperator, ComputeEngineInstanceGroupUpdateManagerTemplateOperator,
 )
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_compute_igm_common_args]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
@@ -53,7 +53,7 @@ GCE_ZONE = os.environ.get('GCE_ZONE', 'europe-west1-b')
 # [END howto_operator_compute_igm_common_args]
 
 default_args = {
-    'start_date': airflow.utils.dates.days_ago(1)
+    'start_date': days_ago(1)
 }
 
 # [START howto_operator_compute_template_copy_args]

--- a/airflow/gcp/example_dags/example_dataflow.py
+++ b/airflow/gcp/example_dags/example_dataflow.py
@@ -22,12 +22,12 @@ Example Airflow DAG for Google Cloud Dataflow service
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.dataflow import (
     CheckJobRunning, DataflowCreateJavaJobOperator, DataflowCreatePythonJobOperator,
     DataflowTemplatedJobStartOperator,
 )
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 GCS_TMP = os.environ.get('GCP_DATAFLOW_GCS_TMP', 'gs://test-dataflow-example/temp/')
@@ -36,7 +36,7 @@ GCS_OUTPUT = os.environ.get('GCP_DATAFLOW_GCS_OUTPUT', 'gs://test-dataflow-examp
 GCS_JAR = os.environ.get('GCP_DATAFLOW_JAR', 'gs://test-dataflow-example/word-count-beam-bundled-0.1.jar')
 
 default_args = {
-    "start_date": airflow.utils.dates.days_ago(1),
+    "start_date": days_ago(1),
     'dataflow_default_options': {
         'project': GCP_PROJECT_ID,
         'tempLocation': GCS_TMP,

--- a/airflow/gcp/example_dags/example_dlp_operator.py
+++ b/airflow/gcp/example_dags/example_dlp_operator.py
@@ -29,14 +29,14 @@ import os
 
 from google.cloud.dlp_v2.types import ContentItem, InspectConfig, InspectTemplate
 
-import airflow
 from airflow.gcp.operators.dlp import (
     CloudDLPCreateInspectTemplateOperator, CloudDLPDeleteInspectTemplateOperator,
     CloudDLPInspectContentOperator,
 )
 from airflow.models import DAG
+from airflow.utils.dates import days_ago
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 
 GCP_PROJECT = os.environ.get("GCP_PROJECT_ID", "example-project")

--- a/airflow/gcp/example_dags/example_gcs.py
+++ b/airflow/gcp/example_dags/example_gcs.py
@@ -22,7 +22,6 @@ Example Airflow DAG for Google Cloud Storage operators.
 
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.gcs import (
     GcsFileTransformOperator, GoogleCloudStorageBucketCreateAclEntryOperator,
@@ -33,8 +32,9 @@ from airflow.gcp.operators.gcs import (
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.gcs_to_gcs import GoogleCloudStorageToGoogleCloudStorageOperator
 from airflow.operators.local_to_gcs import FileToGoogleCloudStorageOperator
+from airflow.utils.dates import days_ago
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 # [START howto_operator_gcs_acl_args_common]
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-id")

--- a/airflow/gcp/example_dags/example_kubernetes_engine.py
+++ b/airflow/gcp/example_dags/example_kubernetes_engine.py
@@ -22,12 +22,12 @@ Example Airflow DAG for Google Kubernetes Engine.
 
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.kubernetes_engine import (
     GKEClusterCreateOperator, GKEClusterDeleteOperator, GKEPodOperator,
 )
 from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
 GCP_LOCATION = os.environ.get("GCP_GKE_LOCATION", "europe-north1-a")
@@ -35,7 +35,7 @@ CLUSTER_NAME = os.environ.get("GCP_GKE_CLUSTER_NAME", "cluster-name")
 
 CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 with models.DAG(
     "example_gcp_gke",

--- a/airflow/gcp/example_dags/example_mlengine.py
+++ b/airflow/gcp/example_dags/example_mlengine.py
@@ -23,7 +23,6 @@ Example Airflow DAG for Google ML Engine service.
 import os
 from typing import Dict
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.mlengine import (
     MLEngineBatchPredictionOperator, MLEngineCreateVersionOperator, MLEngineDeleteModelOperator,
@@ -32,6 +31,7 @@ from airflow.gcp.operators.mlengine import (
 )
 from airflow.gcp.utils import mlengine_operator_utils
 from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
 
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
 
@@ -50,7 +50,7 @@ SUMMARY_TMP = os.environ.get("GCP_MLENGINE_DATAFLOW_TMP", "gs://test-airflow-mle
 SUMMARY_STAGING = os.environ.get("GCP_MLENGINE_DATAFLOW_STAGING", "gs://test-airflow-mlengine/staging/")
 
 default_args = {
-    "start_date": airflow.utils.dates.days_ago(1),
+    "start_date": days_ago(1),
     "params": {
         "model_name": MODEL_NAME
     }

--- a/airflow/gcp/example_dags/example_spanner.py
+++ b/airflow/gcp/example_dags/example_spanner.py
@@ -35,13 +35,13 @@ This DAG relies on the following environment variables
 
 import os
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.spanner import (
     CloudSpannerInstanceDatabaseDeleteOperator, CloudSpannerInstanceDatabaseDeployOperator,
     CloudSpannerInstanceDatabaseQueryOperator, CloudSpannerInstanceDatabaseUpdateOperator,
     CloudSpannerInstanceDeleteOperator, CloudSpannerInstanceDeployOperator,
 )
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_spanner_arguments]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
@@ -56,7 +56,7 @@ OPERATION_ID = 'unique_operation_id'
 # [END howto_operator_spanner_arguments]
 
 default_args = {
-    'start_date': airflow.utils.dates.days_ago(1)
+    'start_date': days_ago(1)
 }
 
 with models.DAG(

--- a/airflow/gcp/example_dags/example_tasks.py
+++ b/airflow/gcp/example_dags/example_tasks.py
@@ -30,13 +30,13 @@ from google.api_core.retry import Retry
 from google.cloud.tasks_v2.types import Queue
 from google.protobuf import timestamp_pb2
 
-import airflow
 from airflow.gcp.operators.tasks import (
     CloudTasksQueueCreateOperator, CloudTasksTaskCreateOperator, CloudTasksTaskRunOperator,
 )
 from airflow.models import DAG
+from airflow.utils.dates import days_ago
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 timestamp = timestamp_pb2.Timestamp()
 timestamp.FromDatetime(datetime.now() + timedelta(hours=12))  # pylint: disable=no-member
 

--- a/airflow/gcp/example_dags/example_translate.py
+++ b/airflow/gcp/example_dags/example_translate.py
@@ -23,12 +23,12 @@ service in the Google Cloud Platform.
 
 """
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.translate import CloudTranslateTextOperator
 from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
 
-default_args = {'start_date': airflow.utils.dates.days_ago(1)}
+default_args = {'start_date': days_ago(1)}
 
 with models.DAG(
     'example_gcp_translate', default_args=default_args, schedule_interval=None  # Override to match your needs

--- a/airflow/gcp/example_dags/example_video_intelligence.py
+++ b/airflow/gcp/example_dags/example_video_intelligence.py
@@ -30,18 +30,18 @@ import os
 # [START howto_operator_vision_retry_import]
 from google.api_core.retry import Retry
 
-import airflow
 from airflow import models
 from airflow.gcp.operators.video_intelligence import (
     CloudVideoIntelligenceDetectVideoExplicitContentOperator, CloudVideoIntelligenceDetectVideoLabelsOperator,
     CloudVideoIntelligenceDetectVideoShotsOperator,
 )
 from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
 
 # [END howto_operator_vision_retry_import]
 
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 # [START howto_operator_video_intelligence_os_args]
 GCP_BUCKET_NAME = os.environ.get(

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -23,12 +23,12 @@ operators to manage a cluster and submit jobs.
 
 import os
 
-import airflow
 from airflow import models
 from airflow.providers.google.cloud.operators.dataproc import (
     DataprocClusterCreateOperator, DataprocClusterDeleteOperator, DataprocSubmitJobOperator,
     DataprocUpdateClusterOperator,
 )
+from airflow.utils.dates import days_ago
 
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "an-id")
 CLUSTER_NAME = os.environ.get("GCP_DATAPROC_CLUSTER_NAME", "example-project")
@@ -122,7 +122,7 @@ HADOOP_JOB = {
 
 with models.DAG(
     "example_gcp_dataproc",
-    default_args={"start_date": airflow.utils.dates.days_ago(1)},
+    default_args={"start_date": days_ago(1)},
     schedule_interval=None,
 ) as dag:
     create_cluster = DataprocClusterCreateOperator(

--- a/airflow/providers/google/cloud/example_dags/example_natural_language.py
+++ b/airflow/providers/google/cloud/example_dags/example_natural_language.py
@@ -23,13 +23,13 @@ Example Airflow DAG for Google Cloud Natural Language service
 
 from google.cloud.language_v1.proto.language_service_pb2 import Document
 
-import airflow
 from airflow import models
 from airflow.operators.bash_operator import BashOperator
 from airflow.providers.google.cloud.operators.natural_language import (
     CloudNaturalLanguageAnalyzeEntitiesOperator, CloudNaturalLanguageAnalyzeEntitySentimentOperator,
     CloudNaturalLanguageAnalyzeSentimentOperator, CloudNaturalLanguageClassifyTextOperator,
 )
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_gcp_natural_language_document_text]
 TEXT = """Airflow is a platform to programmatically author, schedule and monitor workflows.
@@ -48,7 +48,7 @@ document_gcs = Document(gcs_content_uri=GCS_CONTENT_URI, type="PLAIN_TEXT")
 # [END howto_operator_gcp_natural_language_document_gcs]
 
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 with models.DAG(
     "example_gcp_natural_language",

--- a/airflow/providers/google/cloud/example_dags/example_pubsub.py
+++ b/airflow/providers/google/cloud/example_dags/example_pubsub.py
@@ -22,7 +22,6 @@ Example Airflow DAG that uses Google PubSub services.
 """
 import os
 
-import airflow
 from airflow import models
 from airflow.operators.bash_operator import BashOperator
 from airflow.providers.google.cloud.operators.pubsub import (
@@ -30,12 +29,13 @@ from airflow.providers.google.cloud.operators.pubsub import (
     PubSubTopicCreateOperator, PubSubTopicDeleteOperator,
 )
 from airflow.providers.google.cloud.sensors.pubsub import PubSubPullSensor
+from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
 TOPIC = "PubSubTestTopic"
 MESSAGE = {"data": b"Tool", "attributes": {"name": "wrench", "mass": "1.3kg", "count": "3"}}
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 # [START howto_operator_gcp_pubsub_pull_messages_result_cmd]
 echo_cmd = """

--- a/airflow/providers/google/cloud/example_dags/example_sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_sftp_to_gcs.py
@@ -22,11 +22,11 @@ Example Airflow DAG for Google Cloud Storage to SFTP transfer operators.
 
 import os
 
-import airflow
 from airflow import models
 from airflow.providers.google.cloud.operators.sftp_to_gcs import SFTPToGoogleCloudStorageOperator
+from airflow.utils.dates import days_ago
 
-default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 BUCKET_SRC = os.environ.get("GCP_GCS_BUCKET_1_SRC", "test-sftp-gcs")
 

--- a/airflow/providers/google/cloud/example_dags/example_vision.py
+++ b/airflow/providers/google/cloud/example_dags/example_vision.py
@@ -34,7 +34,6 @@ This DAG relies on the following OS environment variables
 
 import os
 
-import airflow
 from airflow import models
 from airflow.operators.bash_operator import BashOperator
 from airflow.providers.google.cloud.operators.vision import (
@@ -46,6 +45,7 @@ from airflow.providers.google.cloud.operators.vision import (
     CloudVisionProductSetUpdateOperator, CloudVisionProductUpdateOperator,
     CloudVisionReferenceImageCreateOperator, CloudVisionRemoveProductFromProductSetOperator,
 )
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_vision_retry_import]
 from google.api_core.retry import Retry  # isort:skip pylint: disable=wrong-import-order
@@ -64,7 +64,7 @@ from google.cloud.vision import enums  # isort:skip pylint: disable=wrong-import
 # [END howto_operator_vision_enums_import]
 
 
-default_args = {'start_date': airflow.utils.dates.days_ago(1)}
+default_args = {'start_date': days_ago(1)}
 
 # [START howto_operator_vision_args_common]
 GCP_VISION_LOCATION = os.environ.get('GCP_VISION_LOCATION', 'europe-west1')

--- a/docs/lineage.rst
+++ b/docs/lineage.rst
@@ -35,13 +35,14 @@ works.
     from airflow.lineage import AUTO
     from airflow.lineage.entities import File
     from airflow.models import DAG
+    from airflow.utils.dates import days_ago
     from datetime import timedelta
 
     FILE_CATEGORIES = ["CAT1", "CAT2", "CAT3"]
 
     args = {
         'owner': 'airflow',
-        'start_date': airflow.utils.dates.days_ago(2)
+        'start_date': days_ago(2)
     }
 
     dag = DAG(

--- a/scripts/perf/dags/perf_dag_1.py
+++ b/scripts/perf/dags/perf_dag_1.py
@@ -21,13 +21,13 @@ This dag tests performance of simple bash commands executed with Airflow.
 """
 from datetime import timedelta
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(3),
+    'start_date': days_ago(3),
 }
 
 dag = DAG(

--- a/scripts/perf/dags/perf_dag_2.py
+++ b/scripts/perf/dags/perf_dag_2.py
@@ -21,13 +21,13 @@ This dag tests performance of simple bash commands executed with Airflow.
 """
 from datetime import timedelta
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
-    'start_date': airflow.utils.dates.days_ago(3),
+    'start_date': days_ago(3),
 }
 
 dag = DAG(

--- a/tests/dags/test_example_bash_operator.py
+++ b/tests/dags/test_example_bash_operator.py
@@ -18,15 +18,15 @@
 # under the License.
 from datetime import timedelta
 
-import airflow
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
     'retries': 3,
-    'start_date': airflow.utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 
 dag = DAG(


### PR DESCRIPTION
Import the `days_ago` function directly from `airflow.utils.dates` in all our Example DAGs.


~Currently, without the entry in __init__.py, IDEs show that it could not find the reference to dates in most of our example_dags as they contain `airflow.utils.dates.days_ago(1)` and hence if you try to find the reference for days_ago function or dates modules it can't find it.~

![image](https://user-images.githubusercontent.com/8811558/71675633-1b8f7a00-2d76-11ea-97d4-3ddeff029d13.png)
![image](https://user-images.githubusercontent.com/8811558/71675654-277b3c00-2d76-11ea-8123-c47d1ef7ef1d.png)





---
- [x] Description above provides context of the change
- [x] Commit message contains [\[AIRFLOW-6428\]](https://issues.apache.org/jira/browse/AIRFLOW-6428)
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
