### PR TITLE
Fargate Executor

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -32,6 +32,7 @@ class ExecutorLoader:
     DASK_EXECUTOR = "DaskExecutor"
     KUBERNETES_EXECUTOR = "KubernetesExecutor"
     DEBUG_EXECUTOR = "DebugExecutor"
+    FARGATE_EXECUTOR = "FargateExecutor"
 
     _default_executor: Optional[BaseExecutor] = None
     executors = {
@@ -40,7 +41,8 @@ class ExecutorLoader:
         CELERY_EXECUTOR: 'airflow.executors.celery_executor',
         DASK_EXECUTOR: 'airflow.executors.dask_executor',
         KUBERNETES_EXECUTOR: 'airflow.executors.kubernetes_executor',
-        DEBUG_EXECUTOR: 'airflow.executors.debug_executor'
+        DEBUG_EXECUTOR: 'airflow.executors.debug_executor',
+        FARGATE_EXECUTOR: 'airflow.executors.fargate_executor'
     }
 
     @classmethod

--- a/airflow/executors/fargate_executor.py
+++ b/airflow/executors/fargate_executor.py
@@ -140,7 +140,7 @@ class FargateExecutor(BaseExecutor):
         """
         while True:
             self.sync()
-            if not self.active_workers:
+            if not len(self.active_workers):
                 break
             time.sleep(heartbeat_interval)
 
@@ -148,11 +148,10 @@ class FargateExecutor(BaseExecutor):
         """
         This method is called when the daemon receives a SIGTERM
         """
-        self.sync()
-        for worker in self.active_workers:
+        for arn in self.active_workers.get_all_arns():
             self.ecs.stop_task(
                 cluster=self.cluster,
-                task=worker.task_arn,
+                task=arn,
                 reason='Airflow Executor received a sig-term'
             )
         self.end()

--- a/airflow/executors/fargate_executor.py
+++ b/airflow/executors/fargate_executor.py
@@ -1,0 +1,401 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""AWS Fargate Executor."""
+
+import time
+from typing import Dict, List, Optional
+
+from .base_executor import BaseExecutor, TaskInstanceKeyType
+from airflow.utils.module_loading import import_string
+from airflow.utils.state import State
+
+from airflow import configuration
+import boto3  # Additional Requirement from base-airflow
+
+
+class FargateExecutor(BaseExecutor):
+    """
+    The Airflow Scheduler create a shell command, and passes it to the executor. This Fargate Executor simply runs
+    said airflow command on a remote AWS Fargate Cluster with an task-definition configured with the same containers as
+    the Scheduler. It then periodically checks in with the launched tasks (via task-arns) to determine the status.
+
+    Prerequisite: proper configuration of boto3 library
+    See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html for credential management
+    """
+
+    # Number of retries in the scenario where the API cannot find a task key. We do this because sometimes AWS falsely
+    # returns an error on a newly instantiated task that exists.
+    MAX_FAILURE_CHECKS = 3
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # This is the function used to generate boto3's execute-task api calls.
+        if configuration.conf.has_option('fargate', 'execution_config_function'):
+            self.executor_config_function = import_string(
+                configuration.conf.get('fargate', 'execution_config_function')
+            )()
+        else:
+            self.executor_config_function = default_task_id_to_fargate_options_function()
+        self.region = configuration.conf.get('fargate', 'region')
+        self.cluster = configuration.conf.get('fargate', 'cluster')
+        self.active_workers: Optional[FargateTaskCollection] = None
+        self.ecs = None
+
+    def start(self):
+        self.active_workers = FargateTaskCollection()
+        # NOTE: See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html for authentication
+        # and access-key management. You can store an environmental variable, setup aws config from console, or use IAM
+        # roles.
+        self.ecs = boto3.client('ecs', region_name=self.region)
+
+    def sync(self):
+        # Check on all active workers
+        all_task_arns = self.active_workers.get_all_arns()
+        if not all_task_arns:
+            self.log.debug("No active tasks, skipping sync")
+            return
+        self.log.debug("Active Workers: {}".format(all_task_arns))
+        describe_dict = self.ecs.describe_tasks(tasks=all_task_arns, cluster=self.cluster)
+        self.log.debug(f'ECS Response: {describe_dict}')
+        # check & handle the failures first in the JSON response.
+        if describe_dict['failures']:
+            self._sync_api_failures(describe_dict['failures'])
+        # check & handle airflow sucesses & failures next
+        updated_tasks = describe_dict['tasks']
+        for task_json in updated_tasks:
+            task = FargateTask(task_json)
+            # Update the active workers with new statuses. Consequtive task failure counter resets back to 0.
+            self.active_workers.update_task(task)
+            # get state of current task
+            task_state = task.get_task_state()
+            task_key = self.active_workers.arn_to_key[task.task_arn]
+            # mark finished tasks as either a success/failure
+            if task_state == State.FAILED:
+                self.fail(task_key)
+            elif task_state == State.SUCCESS:
+                self.success(task_key)
+            # if task is no longer running then remove from active workers and place in finished
+            if task_state != State.RUNNING:
+                self.log.debug(f'Task {task_key} marked as {task_state} after running on {task.task_arn}')
+                self.active_workers.pop_by_key(task_key)
+
+    def _sync_api_failures(self, arn_failures):
+        for failure in arn_failures:
+            arn = failure["arn"]
+            task = self.active_workers.task_by_arn(arn)
+            task.api_failure_count += 1
+            # Sometimes ECS doesn't update the ARN key right away, and will show up as missing. Check later.
+            if task.api_failure_count >= self.__class__.MAX_FAILURE_CHECKS:
+                task_key = self.active_workers.arn_to_key[arn]
+                self.active_workers.pop_by_key(task_key)
+                self.log.error(f'ECS Executor could not find task {arn} because {failure["reason"]}; '
+                               f'marking key {task_key} as failed')
+                self.fail(task_key)
+            else:
+                self.log.debug(f'ECS Executor could not find task {arn} because {failure["reason"]}; '
+                               f'skipping for now on strike #{task.api_failure_count}')
+
+    def execute_async(self, key: TaskInstanceKeyType, command: str, queue=None, executor_config=None):
+        """
+        This method will execute the command asynchronously.
+        """
+        # run a task
+        task_execution_api = self.executor_config_function(command)
+        try:
+            task_response = self.ecs.run_task(**task_execution_api)
+            self.log.debug(f'Executor responded with "{task_response}"')
+            if task_response['failures'] or not task_response['tasks']:
+                raise FargateError(', '.join([str(f) for f in task_response['failures']]))
+            task = FargateTask(task_response['tasks'][0])
+            self.log.info(f'Executor running task "{key}" on "{task.task_arn}"')
+            self.active_workers.add_task(task, key)
+        except Exception as e:
+            self.log.error(f'Executor failed to run task {key} with the following exception: {str(e)}')
+            self.fail(key)
+
+    def end(self, heartbeat_interval=10):
+        """
+        This method is called when the caller is done submitting job and is
+        wants to wait synchronously for the job submitted previously to be
+        all done.
+        """
+        while True:
+            self.sync()
+            if not self.active_workers:
+                break
+            time.sleep(heartbeat_interval)
+
+    def terminate(self):
+        """
+        This method is called when the daemon receives a SIGTERM
+        """
+        self.sync()
+        for worker in self.active_workers:
+            self.ecs.stop_task(
+                cluster=self.cluster,
+                task=worker.task_arn,
+                reason='Airflow Executor received a sig-term'
+            )
+        self.end(heartbeat_interval=5)
+
+
+def default_task_id_to_fargate_options_function():
+    """
+    This is a function which returns a function. The outer function takes no arguments, and returns the inner function.
+    The inner function takes in an airflow CLI command an outputs a json compatible with the boto3 run_task API
+    linked above. In other words, if you don't like the way I call the boto3 Fargate API then call it yourself by
+    overriding the airflow config file.
+
+    i.e: execution_config_function = pipeline_plugin.default_task_id_to_fargate_options_function
+    """
+    # Absolutely mandatory configurations
+    region = configuration.conf.get('fargate', 'region')
+    cluster = configuration.conf.get('fargate', 'cluster')
+
+    # grab a few variables
+    task_definition = configuration.conf.get('fargate', 'task_definition')
+    container_name = configuration.conf.get('fargate', 'container_name')
+    security_groups = configuration.conf.get('fargate', 'security_groups').split(',')
+
+    launch_type = 'FARGATE'
+    if configuration.conf.has_option('fargate', 'launch_type'):
+        launch_type = configuration.conf.get('fargate', 'launch_type')
+
+    platform_version = 'LATEST'
+    if configuration.conf.has_option('fargate', 'platform_version'):
+        platform_version = configuration.conf.get('fargate', 'platform_version')
+
+    assign_public_ip = 'ENABLED'
+    if configuration.conf.has_option('fargate', 'assign_public_ip'):
+        assign_public_ip = configuration.conf.get('fargate', 'assign_public_ip')
+
+    subnets = None
+    if configuration.conf.has_option('fargate', 'subnets'):
+        subnets = configuration.conf.get('fargate', 'subnets').split(',')
+
+    # build the function based on the provided configurations
+    return get_default_execute_config_function(region, cluster, task_definition, container_name, platform_version,
+                                               launch_type, assign_public_ip, security_groups, subnets)
+
+
+def get_default_execute_config_function(region: str, cluster: str, task_definition: str, container_name: str,
+                                        platform_version: str, launch_type: str, assign_public_ip: str,
+                                        security_groups: List[str], subnets: List[str]):
+    # If no subnet list provided, get all subnets from default region
+    if not subnets:
+        ec2 = boto3.client('ec2', region_name=region)
+        subnets = [x['SubnetId'] for x in ec2.describe_subnets()['Subnets']]
+
+    network_configuration = {
+        'awsvpcConfiguration': {
+            'subnets': subnets,
+            'securityGroups': security_groups,
+            'assignPublicIp': assign_public_ip
+        }
+    }
+
+    def with_default(airflow_task_command):
+        if isinstance(airflow_task_command, str):
+            # This is done for backwards compatibility with older versions of airflow (Airflow < 1.10.2)
+            # split airflow bash command into an array to feed into the entrypoint of the docker container.
+            airflow_task_command = airflow_task_command.split(',')
+        execution_config = dict(
+            cluster=cluster,
+            taskDefinition=task_definition,
+            overrides={
+                'containerOverrides': [
+                    {
+                        'name': container_name,
+                        # The docker file will receive an array of commands & run them with exec "$@"
+                        'command': airflow_task_command
+                    }
+                ]
+            },
+            count=1,
+            launchType=launch_type,
+            platformVersion=platform_version,
+            networkConfiguration=network_configuration
+        )
+        return execution_config
+
+    return with_default
+
+
+class FargateTask:
+    """This class wraps around the boto3 JSON response of the start_task v1 API call. Mildly useful"""
+    def __init__(self, json_response):
+        self.json = json_response
+        self.api_failure_count = 0
+
+    @property
+    def cluster_arn(self):
+        return self.json['clusterArn']
+
+    @property
+    def connectivity(self):
+        return self.json['connectivity']
+
+    @property
+    def connectivity_at(self):
+        return self.json['connectivityAt']
+
+    @property
+    def containers(self):
+        return self.json['containers']
+
+    @property
+    def cpu(self):
+        return self.json['cpu']
+
+    @property
+    def created_at(self):
+        return self.json['createdAt']
+
+    @property
+    def desired_status(self):
+        return self.json['desiredStatus']
+
+    @property
+    def group(self):
+        return self.json['group']
+
+    @property
+    def health_status(self):
+        return self.json['healthStatus']
+
+    @property
+    def last_status(self):
+        return self.json['lastStatus']
+
+    @property
+    def launch_type(self):
+        return self.json['launchType']
+
+    @property
+    def memory(self):
+        return self.json['memory']
+
+    @property
+    def overrides(self):
+        return self.json['overrides']
+
+    @property
+    def platform_version(self):
+        return self.json['platformVersion']
+
+    @property
+    def pull_started_at(self):
+        return self.json['pullStartedAt']
+
+    @property
+    def pull_stopped_at(self):
+        return self.json['pullStoppedAt']
+
+    @property
+    def started_at(self):
+        return self.json['startedAt']
+
+    @property
+    def tags(self):
+        return self.json['tags']
+
+    @property
+    def task_arn(self):
+        return self.json['taskArn']
+
+    @property
+    def task_definition_arn(self):
+        return self.json['taskDefinitionArn']
+
+    @property
+    def version(self):
+        return self.json['version']
+
+    def get_task_state(self) -> State:
+        """Checks all containers in a given task to check task status. Each container has a last-known status,
+        a health-status, and an exit-code. This method only checks exit codes and statuses.
+        """
+        # lastStatus can be RUNNING'|'PENDING'|'STOPPED'
+        # healthStatus can be 'HEALTHY'|'UNHEALTHY'|'UNKNOWN'
+        containers = self.containers
+        is_finished = all([x['lastStatus'] == "STOPPED" for x in containers])
+        has_exit_codes = all(['exitCode' in x for x in containers])
+        if not is_finished or not has_exit_codes:
+            return State.RUNNING
+        is_error = any([x['exitCode'] != 0 for x in containers])
+        return State.FAILED if is_error else State.SUCCESS
+
+    def __repr__(self):
+        return f'({self.task_arn}, {self.get_task_state()})'
+
+
+class FargateTaskCollection:
+    """
+    A three-way dictionary between Airflow task ids, Fargate ARNs, and Fargate task objects
+    """
+    def __init__(self):
+        self.key_to_arn: Dict[TaskInstanceKeyType, str] = {}
+        self.arn_to_key: Dict[str, TaskInstanceKeyType] = {}
+        self.tasks: Dict[str, FargateTask] = {}
+
+    def add_task(self, task: FargateTask, airflow_task_key: TaskInstanceKeyType):
+        arn = task.task_arn
+        self.tasks[arn] = task
+        self.key_to_arn[airflow_task_key] = arn
+        self.arn_to_key[arn] = airflow_task_key
+
+    def update_task(self, task: FargateTask):
+        self.tasks[task.task_arn] = task
+
+    def task_by_key(self, task_key: TaskInstanceKeyType) -> FargateTask:
+        arn = self.key_to_arn[task_key]
+        return self.task_by_arn(arn)
+
+    def task_by_arn(self, arn) -> FargateTask:
+        return self.tasks[arn]
+
+    def pop_by_key(self, task_key: TaskInstanceKeyType) -> FargateTask:
+        arn = self.key_to_arn[task_key]
+        task = self.tasks[arn]
+        del self.key_to_arn[task_key]
+        del self.arn_to_key[arn]
+        del self.tasks[arn]
+        return task
+
+    def pop_by_arn(self, arn: str) -> FargateTask:
+        task = self.tasks[arn]
+        task_key = self.arn_to_key[arn]
+        del self.key_to_arn[task_key]
+        del self.arn_to_key[arn]
+        del self.tasks[arn]
+        return task
+
+    def get_all_arns(self) -> List[str]:
+        return list(self.key_to_arn.values())
+
+    def get_all_task_keys(self) -> List[TaskInstanceKeyType]:
+        return list(self.key_to_arn.keys())
+
+    def __getitem__(self, value):
+        return self.task_by_arn(value)
+
+    def __len__(self):
+        return len(self.tasks)
+
+
+class FargateError(Exception):
+    pass

--- a/tests/executors/test_fargate_executor.py
+++ b/tests/executors/test_fargate_executor.py
@@ -1,47 +1,81 @@
-import unittest
-from unittest.mock import Mock
-
+import datetime as dt
+from unittest import mock, TestCase
+from botocore import loaders as botoloader
+from airflow.configuration import conf
 from airflow.executors.fargate_executor import *
 
 
-class TestFargateTaskCollection(unittest.TestCase):
-    def test_fargate_collection(self):
-        collection = FargateTaskCollection()
-        # Add first task
-        first_task = FargateTask({'arn': '001'})
-        first_airflow_key = Mock(spec=TaskInstanceKeyType)
-        collection.add_task(first_task, first_airflow_key)
-        # Add second task
-        second_task = FargateTask({'arn': '002'})
-        second_airflow_key = Mock(spec=TaskInstanceKeyType)
-        collection.add_task(second_task, second_airflow_key)
+class TestFargateTaskCollection(TestCase):
+    def test_add(self):
+        self.assertEqual(len(self.collection), 2)
 
         # Check basic get for first task
-        self.assertEqual(len(collection), 2)
-        self.assertEqual(collection.task_by_arn('001'), first_task)
-        self.assertEqual(collection['001'], first_task)
-        self.assertEqual(collection.task_by_key(first_airflow_key), first_task)
+        self.assertEqual(self.collection.task_by_arn('001'), self.first_task)
+        self.assertEqual(self.collection['001'], self.first_task)
+        self.assertEqual(self.collection.task_by_key(self.first_airflow_key), self.first_task)
 
         # Check basic get for second task
-        self.assertEqual(collection.task_by_arn('002'), second_task)
-        self.assertEqual(collection['002'], second_task)
-        self.assertEqual(collection.task_by_key(second_airflow_key), second_task)
+        self.assertEqual(self.collection.task_by_arn('002'), self.second_task)
+        self.assertEqual(self.collection['002'], self.second_task)
+        self.assertEqual(self.collection.task_by_key(self.second_airflow_key), self.second_task)
 
+    def test_list(self):
         # Check basic list by ARNs & airflow-task-keys
-        self.assertListEqual(collection.get_all_arns(), ['001', '002'])
-        self.assertListEqual(collection.get_all_task_keys(), [first_airflow_key, second_airflow_key])
+        self.assertListEqual(self.collection.get_all_arns(), ['001', '002'])
+        self.assertListEqual(self.collection.get_all_task_keys(), [self.first_airflow_key, self.second_airflow_key])
 
+    def test_pop(self):
         # pop first task & ensure that it's removed
-        self.assertEqual(collection.pop_by_arn('001'), first_task)
-        self.assertNotIn('001', collection.get_all_arns())
-        collection.add_task(first_task, first_airflow_key)
-        self.assertEqual(collection.pop_by_key(first_airflow_key), first_task)
-        self.assertNotIn('001', collection.get_all_arns())
+        self.assertEqual(self.collection.pop_by_arn('001'), self.first_task)
+        self.assertNotIn('001', self.collection.get_all_arns())
+        self.collection.add_task(self.first_task, self.first_airflow_key)
+        self.assertEqual(self.collection.pop_by_key(self.first_airflow_key), self.first_task)
+        self.assertNotIn('001', self.collection.get_all_arns())
 
+    def test_update(self):
         # update arn with new task object
-        collection.add_task(first_task, first_airflow_key)
-        self.assertEqual(collection['001'], first_task)
-        updated_task = FargateTask({'arn': '001'})
-        collection.update_task(updated_task)
-        self.assertEqual(collection['001'], updated_task)
+        self.collection.add_task(self.first_task, self.first_airflow_key)
+        self.assertEqual(self.collection['001'], self.first_task)
+        updated_task = FargateTask({'taskArn': '001'})
+        self.collection.update_task(updated_task)
+        self.assertEqual(self.collection['001'], updated_task)
+
+    def test_task_state(self):
+        running_fargate_task = FargateTask({
+            'taskArn': 'ABC',
+            'containers': [{
+                'lastStatus': 'PENDING',
+                'exitCode': 0
+            }]
+        })
+
+        success_fargate_task = FargateTask({
+            'taskArn': 'ABC',
+            'containers': [{
+                'lastStatus': 'STOPPED',
+                'exitCode': 0
+            }]
+        })
+
+        failed_fargate_task = FargateTask({
+            'taskArn': 'ABC',
+            'containers': [{
+                'lastStatus': 'STOPPED',
+                'exitCode': 100
+            }]
+        })
+        self.assertEqual(running_fargate_task.get_task_state(), State.RUNNING)
+        self.assertEqual(success_fargate_task.get_task_state(), State.SUCCESS)
+        self.assertEqual(failed_fargate_task.get_task_state(), State.FAILED)
+
+    def setUp(self):
+        self.collection = FargateTaskCollection()
+        # Add first task
+        self.first_task = FargateTask({'taskArn': '001'})
+        self.first_airflow_key = mock.Mock(spec=TaskInstanceKeyType)
+        self.collection.add_task(self.first_task, self.first_airflow_key)
+        # Add second task
+        self.second_task = FargateTask({'taskArn': '002'})
+        self.second_airflow_key = mock.Mock(spec=TaskInstanceKeyType)
+        self.collection.add_task(self.second_task, self.second_airflow_key)
 

--- a/tests/executors/test_fargate_executor.py
+++ b/tests/executors/test_fargate_executor.py
@@ -79,3 +79,274 @@ class TestFargateTaskCollection(TestCase):
         self.second_airflow_key = mock.Mock(spec=TaskInstanceKeyType)
         self.collection.add_task(self.second_task, self.second_airflow_key)
 
+
+class TestFargateExecutor(TestCase):
+    def test_configs(self):
+        # region & cluster must be specified
+        self.assertTrue(conf.has_option('fargate', 'region'))
+        self.assertIsNotNone(conf.get('fargate', 'region'))
+
+        self.assertTrue(conf.has_option('fargate', 'cluster'))
+        self.assertIsNotNone(conf.get('fargate', 'cluster'))
+
+        self.assertTrue(conf.has_option('fargate', 'execution_config_function'))
+        self.assertIsNotNone(conf.get('fargate', 'execution_config_function'))
+
+        default_func = 'airflow.executor.default_task_id_to_fargate_options_function'
+        if conf.get('fargate', 'execution_config_function') == default_func:
+            self.assertTrue(conf.has_option('fargate', 'task_definition'))
+            self.assertIsNotNone(conf.get('fargate', 'task_definition'))
+
+            self.assertTrue(conf.has_option('fargate', 'container_name'))
+            self.assertIsNotNone(conf.get('fargate', 'container_name'))
+
+            self.assertIsNotNone(conf.get('fargate', 'security_groups'))
+            self.assertIsNotNone(conf.get('fargate', 'security_groups'))
+
+            self.assertIsNotNone(conf.get('fargate', 'security_groups'))
+            self.assertIsNotNone(conf.get('fargate', 'security_groups'))
+
+            self.assertIsNotNone(conf.get('fargate', 'subnets'))
+            self.assertIsNotNone(conf.get('fargate', 'subnets'))
+
+            self.assertIsNotNone(conf.get('fargate', 'platform_version'))
+            self.assertIsNotNone(conf.get('fargate', 'platform_version'))
+
+            self.assertIsNotNone(conf.get('fargate', 'launch_type'))
+            self.assertIsNotNone(conf.get('fargate', 'launch_type'))
+
+            self.assertIsNotNone(conf.get('fargate', 'assign_public_ip'))
+            self.assertIsNotNone(conf.get('fargate', 'assign_public_ip'))
+
+    def test_execute(self):
+        airflow_key = mock.Mock(spec=TaskInstanceKeyType)
+        airflow_cmd = mock.Mock(spec=CommandType)
+        self.executor.execute_async(airflow_key, airflow_cmd)
+
+        ecs_mock = self.executor.ecs
+
+        # ensure that run_task is called correctly as defined by Botocore docs
+        ecs_mock.run_task.assert_called_once()
+        self.assert_botocore_call('RunTask', *ecs_mock.run_task.call_args)
+
+        # ensure that run_task is called correctly as defined by Botocore docs
+        self.executor.ecs.run_task.assert_called_once()
+        self.assert_botocore_call('RunTask', *self.executor.ecs.run_task.call_args)
+
+        # task is stored in active worker
+        self.assertEqual(len(self.executor.active_workers), 1)
+        self.assertIn(self.executor.active_workers.task_by_key(airflow_key).task_arn, '001')
+
+    @mock.patch('airflow.executors.base_executor.BaseExecutor.fail')
+    def test_failed_execute_api(self, fail_mock):
+        self.executor.ecs.run_task.return_value = {
+            'tasks': [],
+            'failures': [{
+                'arn': '001',
+                'reason': 'Sample Failure',
+                'detail': 'UnitTest Failure - Please ignore'
+            }]
+        }
+
+        airflow_key = mock.Mock(spec=TaskInstanceKeyType)
+        airflow_cmd = mock.Mock(spec=CommandType)
+        self.executor.execute_async(airflow_key, airflow_cmd)
+
+        # task is not stored in active workers
+        self.assertEqual(len(self.executor.active_workers), 0)
+        # Task is immediately failed
+        fail_mock.assert_called_once()
+
+    @mock.patch('airflow.executors.base_executor.BaseExecutor.fail')
+    @mock.patch('airflow.executors.base_executor.BaseExecutor.success')
+    def test_sync(self, success_mock, fail_mock):
+        after_fargate_task = self.__mock_sync()
+        self.assertEqual(after_fargate_task.get_task_state(), State.SUCCESS)
+
+        self.executor.sync()
+
+        # ensure that run_task is called correctly as defined by Botocore docs
+        self.executor.ecs.describe_tasks.assert_called_once()
+        self.assert_botocore_call('DescribeTasks',
+                                  *self.executor.ecs.describe_tasks.call_args)
+
+        # task is not stored in active workers
+        self.assertEqual(len(self.executor.active_workers), 0)
+        # Task is immediately succeeded
+        success_mock.assert_called_once()
+        self.assertFalse(fail_mock.called)
+
+    @mock.patch('airflow.executors.base_executor.BaseExecutor.fail')
+    @mock.patch('airflow.executors.base_executor.BaseExecutor.success')
+    def test_failed_sync(self, success_mock, fail_mock):
+        after_fargate_task = self.__mock_sync()
+
+        # set container's exit code to failure
+        after_fargate_task.json['containers'][0]['exitCode'] = 100
+        self.assertEqual(after_fargate_task.get_task_state(), State.FAILED)
+
+        self.executor.sync()
+
+        # ensure that run_task is called correctly as defined by Botocore docs
+        self.executor.ecs.describe_tasks.assert_called_once()
+        self.assert_botocore_call('DescribeTasks',
+                                  *self.executor.ecs.describe_tasks.call_args)
+
+        # task is not stored in active workers
+        self.assertEqual(len(self.executor.active_workers), 0)
+        # Task is immediately succeeded
+        fail_mock.assert_called_once()
+        self.assertFalse(success_mock.called)
+
+    @mock.patch('airflow.executors.base_executor.BaseExecutor.fail')
+    @mock.patch('airflow.executors.base_executor.BaseExecutor.success')
+    def test_failed_sync_api(self, success_mock, fail_mock):
+        self.__mock_sync()
+        self.executor.ecs.describe_tasks.return_value = {
+            'tasks': [],
+            'failures': [{
+                'arn': 'ABC',
+                'reason': 'Sample Failure',
+                'detail': 'UnitTest Failure - Please ignore'
+            }]
+        }
+
+        # Call Sync 3 times with failures
+        for check_count in range(FargateExecutor.MAX_FAILURE_CHECKS - 1):
+            self.executor.sync()
+            # ensure that run_task is called correctly as defined by Botocore docs
+            self.assertEqual(self.executor.ecs.describe_tasks.call_count,
+                             check_count + 1)
+            self.assert_botocore_call('DescribeTasks',
+                                      *self.executor.ecs.describe_tasks.call_args)
+
+            # Ensure task arn is not removed from active
+            self.assertIn('ABC', self.executor.active_workers.get_all_arns())
+
+            # Task is not failed or succeeded
+            self.assertFalse(fail_mock.called)
+            self.assertFalse(success_mock.called)
+
+        # Last call should fail the task
+        self.executor.sync()
+        self.assertNotIn('ABC', self.executor.active_workers.get_all_arns())
+        self.assertTrue(fail_mock.called)
+        self.assertFalse(success_mock.called)
+
+    def assert_botocore_call(self, method_name, args, kwargs):
+        """Asserts that a given method-call adheres to Botocore's API docs"""
+        # Boto3 doesn't like args
+        self.assertEqual(len(args), 0)
+        # Now check kwargs, recursively
+        input_shape_name = self.ecs_model['operations'][method_name]['input']['shape']
+        input_shape = self.ecs_model['shapes'][input_shape_name]
+        self.__assert_botocore_shape(input_shape, kwargs)
+
+    def __assert_botocore_shape(self, input_shape, input_value):
+        """Asserts that a given value adheres to Botocore's API docs"""
+        if 'required' in input_shape:
+            for required_key in input_shape['required']:
+                self.assertIn(required_key, input_value.keys())
+
+        if 'type' in input_shape:
+            if input_shape['type'] == 'boolean':
+                self.assertIsInstance(input_value, bool)
+            elif input_shape['type'] == 'double':
+                self.assertIsInstance(input_value, float)
+            elif input_shape['type'] == 'integer':
+                self.assertIsInstance(input_value, int)
+            elif input_shape['type'] == 'list':
+                self.assertIsInstance(input_value, list)
+            elif input_shape['type'] == 'long':
+                self.assertIsInstance(input_value, int)
+            elif input_shape['type'] == 'map':
+                self.assertIsInstance(input_value, dict)
+            elif input_shape['type'] == 'string':
+                self.assertIsInstance(input_value, str)
+            elif input_shape['type'] == 'timestamp':
+                self.assertIsInstance(input_value, (dt.datetime, dt.date))
+            elif input_shape['type'] == 'structure':
+                if 'member' in input_shape:
+                    member_name = input_shape['member']['shape']
+                    member_shape = self.ecs_model['shapes'][member_name]
+                    if member_name in input_value:
+                        member_value = input_value[member_name]
+                        self.__assert_botocore_shape(member_shape, member_value)
+                elif 'members' in input_shape:
+                    for member_name in input_shape['members']:
+                        shape_name = input_shape['members'][member_name]['shape']
+                        member_shape = self.ecs_model['shapes'][shape_name]
+                        if member_name in input_value:
+                            member_value = input_value[member_name]
+                            self.__assert_botocore_shape(member_shape, member_value)
+
+        if 'enum' in input_shape:
+            self.assertIn(input_value, input_shape['enum'])
+        if 'min' in input_shape:
+            self.assertGreaterEqual(input_value, input_shape['min'])
+        if 'max' in input_shape:
+            self.assertLessEqual(input_value, input_shape['max'])
+        if 'pattern' in input_shape:
+            self.assertRegex(input_value, input_shape['pattern'])
+
+    def setUp(self) -> None:
+        loader = botoloader.Loader()
+        self.ecs_model = loader.load_service_model('ecs', 'service-2')
+        self.__set_mocked_executor()
+
+    def __set_mocked_executor(self):
+        """Mock ECS such that there's nothing wrong with anything"""
+        executor = FargateExecutor()
+        executor.start()
+
+        # replace boto3 ecs client with mock
+        ecs_mock = mock.Mock()
+        run_task_ret_val = {
+            'tasks': [{'taskArn': '001'}],
+            'failures': []
+        }
+        ecs_mock.run_task.return_value = run_task_ret_val
+        executor.ecs = ecs_mock
+
+        self.executor = executor
+
+    def __mock_sync(self):
+        """Mock ECS such that there's nothing wrong with anything"""
+
+        # create running fargate instance
+        before_fargate_task = mock.Mock(spec=FargateTask)
+        before_fargate_task.task_arn = 'ABC'
+        before_fargate_task.api_failure_count = 0
+        before_fargate_task.get_task_state.return_value = State.RUNNING
+
+        after_fargate_task = FargateTask({
+            'taskArn': 'ABC',
+            'containers': [{
+                'lastStatus': 'STOPPED',
+                'exitCode': 0
+            }]
+        })
+
+        airflow_key = mock.Mock(spec=TaskInstanceKeyType)
+        self.executor.active_workers.add_task(before_fargate_task, airflow_key)
+
+        self.executor.ecs.describe_tasks.return_value = {
+            'tasks': [after_fargate_task.json],
+            'failures': []
+        }
+        return after_fargate_task
+
+
+
+    @mock.patch('airflow.executors.fargate_executor.FargateExecutor.sync')
+    @mock.patch('airflow.executors.base_executor.BaseExecutor.trigger_tasks')
+    @mock.patch('airflow.stats.Stats.gauge')
+    def test_gauge_executor_metrics(self, mock_stats_gauge, mock_trigger_tasks, mock_sync):
+        executor = FargateExecutor()
+        executor.heartbeat()
+        calls = [
+            mock.call('executor.open_slots', mock.ANY),
+            mock.call('executor.queued_tasks', mock.ANY),
+            mock.call('executor.running_tasks', mock.ANY)
+        ]
+        mock_stats_gauge.assert_has_calls(calls)

--- a/tests/executors/test_fargate_executor.py
+++ b/tests/executors/test_fargate_executor.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import Mock
+
+from airflow.executors.fargate_executor import *
+
+
+class TestFargateTaskCollection(unittest.TestCase):
+    def test_fargate_collection(self):
+        collection = FargateTaskCollection()
+        # Add first task
+        first_task = FargateTask({'arn': '001'})
+        first_airflow_key = Mock(spec=TaskInstanceKeyType)
+        collection.add_task(first_task, first_airflow_key)
+        # Add second task
+        second_task = FargateTask({'arn': '002'})
+        second_airflow_key = Mock(spec=TaskInstanceKeyType)
+        collection.add_task(second_task, second_airflow_key)
+
+        # Check basic get for first task
+        self.assertEqual(len(collection), 2)
+        self.assertEqual(collection.task_by_arn('001'), first_task)
+        self.assertEqual(collection['001'], first_task)
+        self.assertEqual(collection.task_by_key(first_airflow_key), first_task)
+
+        # Check basic get for second task
+        self.assertEqual(collection.task_by_arn('002'), second_task)
+        self.assertEqual(collection['002'], second_task)
+        self.assertEqual(collection.task_by_key(second_airflow_key), second_task)
+
+        # Check basic list by ARNs & airflow-task-keys
+        self.assertListEqual(collection.get_all_arns(), ['001', '002'])
+        self.assertListEqual(collection.get_all_task_keys(), [first_airflow_key, second_airflow_key])
+
+        # pop first task & ensure that it's removed
+        self.assertEqual(collection.pop_by_arn('001'), first_task)
+        self.assertNotIn('001', collection.get_all_arns())
+        collection.add_task(first_task, first_airflow_key)
+        self.assertEqual(collection.pop_by_key(first_airflow_key), first_task)
+        self.assertNotIn('001', collection.get_all_arns())
+
+        # update arn with new task object
+        collection.add_task(first_task, first_airflow_key)
+        self.assertEqual(collection['001'], first_task)
+        updated_task = FargateTask({'arn': '001'})
+        collection.update_task(updated_task)
+        self.assertEqual(collection['001'], updated_task)
+


### PR DESCRIPTION
An AWS Fargate Executor that runs every task on a new Fargate Instance. The instance launches an Airflow Docker Container (i.e: Puckel's Airflow Docker), executes the task generated by the scheduler, then reaches the container reaches a timely demise.
If the exit code of the 

- container is anything other than 0 the task fails.
- If the boto3 API calls to Fargate fails 3 times _consecutively_, then the task fails.
- If the executor is unable to call out to the Fargate task (due to internet connectivity issues or incorrect IAM roles) then the task fails.

Otherwise the task succeeds.