### PR TITLE
[AIRFLOW-XXXX] Update operation chaining documentation

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -162,7 +162,7 @@ DAG Assignment
 
 *Added in Airflow 1.8*
 
-Operators do not  sa be assigned to DAGs immediately (previously ``dag`` was
+Operators do not have to be assigned to DAGs immediately (previously ``dag`` was
 a required argument). However, once an operator is assigned to a DAG, it can not
 be transferred or unassigned. DAG assignment can be done explicitly when the
 operator is created, through deferred assignment, or even inferred from other

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -162,7 +162,7 @@ DAG Assignment
 
 *Added in Airflow 1.8*
 
-Operators do not have to be assigned to DAGs immediately (previously ``dag`` was
+Operators do not  sa be assigned to DAGs immediately (previously ``dag`` was
 a required argument). However, once an operator is assigned to a DAG, it can not
 be transferred or unassigned. DAG assignment can be done explicitly when the
 operator is created, through deferred assignment, or even inferred from other
@@ -304,7 +304,7 @@ concat them with bitshift composition.
 
     op1 >> op2 >> op3 >> op4 >> op5
 
-use ``chain`` could do that
+This can be accomplished using ``chain``
 
 .. code:: python
 
@@ -316,7 +316,7 @@ even without operator's name
 
     chain([DummyOperator(task_id='op' + i, dag=dag) for i in range(1, 6)])
 
-``chain`` could handle list of operators
+``chain`` can handle a list of operators
 
 .. code:: python
 
@@ -328,8 +328,7 @@ is equivalent to:
 
     op1 >> [op2, op3] >> op4
 
-Have to same size when ``chain`` set relationships between two list
-of operators.
+When ``chain`` sets relationships between two lists of operators, they must have the same size.
 
 .. code:: python
 


### PR DESCRIPTION
##### Correct grammatical errors in the section dealing with the use of `chain` to set operator ordering; specifically when discussing the use of multiple lists in the same function call.
---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
