### PR TITLE
[AIRFLOW-6385] BugFix: SlackAPIPostOperator fails when blocks not set

### DIFF
--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -127,8 +127,8 @@ class SlackAPIPostOperator(SlackAPIOperator):
         self.username = username
         self.text = text
         self.icon_url = icon_url
-        self.attachments = attachments
-        self.blocks = blocks
+        self.attachments = attachments or []
+        self.blocks = blocks or []
         super().__init__(method=self.method,
                          *args, **kwargs)
 

--- a/tests/operators/test_slack_operator.py
+++ b/tests/operators/test_slack_operator.py
@@ -171,6 +171,31 @@ class TestSlackAPIPostOperator(unittest.TestCase):
         self.assertEqual(slack_api_post_operator.token, None)
         self.assertEqual(slack_api_post_operator.slack_conn_id, test_slack_conn_id)
 
+    @mock.patch('airflow.operators.slack_operator.SlackHook')
+    def test_api_call_params_with_default_args(self, mock_hook):
+        test_slack_conn_id = 'test_slack_conn_id'
+
+        slack_api_post_operator = SlackAPIPostOperator(
+            task_id='slack',
+            username=self.test_username,
+            slack_conn_id=test_slack_conn_id,
+        )
+
+        slack_api_post_operator.execute()
+
+        expected_api_params = {
+            'channel': "#general",
+            'username': self.test_username,
+            'text': 'No message has been set.\n'
+                    'Here is a cat video instead\n'
+                    'https://www.youtube.com/watch?v=J---aiyznGQ',
+            'icon_url': "https://raw.githubusercontent.com/apache/"
+                        "airflow/master/airflow/www/static/pin_100.png",
+            'attachments': '[]',
+            'blocks': '[]',
+        }
+        self.assertEqual(expected_api_params, slack_api_post_operator.api_params)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Issue**:
After upgrade to 1.10.7 all slack notifications became faulty
SlackAPIPostOperator fails when blocks not set

```python
    t_slack_ok = SlackAPIPostOperator(
        task_id = 'notify_ok',
        token = Variable.get('slack.token'),
        channel = Variable.get('slack.channel'),
        text = ':rocket: {{ dag.dag_id }} for {{ ds }} has succeeded',
        dag = dag)
```

Causing an operator error:
```
[2019-12-28 21:55:14,668] {taskinstance.py:1088} ERROR - Slack API call failed (invalid_blocks_format)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/airflow/models/taskinstance.py", line 955, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/usr/local/lib/python3.6/dist-packages/airflow/operators/slack_operator.py", line 85, in execute
    slack.call(self.method, self.api_params)
  File "/usr/local/lib/python3.6/dist-packages/airflow/hooks/slack_hook.py", line 62, in call
    raise AirflowException(msg)
```
**Fix**: 
It is because the default value is None and `json.dumps(None)` is `null`  which is not valid for Slack message layout: https://api.slack.com/messaging/composing/layouts

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6385

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
