### PR TITLE
Remove {table} line 94

### DIFF
--- a/airflow/operators/s3_to_redshift_operator.py
+++ b/airflow/operators/s3_to_redshift_operator.py
@@ -91,7 +91,7 @@ class S3ToRedshiftTransfer(BaseOperator):
 
         copy_query = """
             COPY {schema}.{table}
-            FROM 's3://{s3_bucket}/{s3_key}/{table}'
+            FROM 's3://{s3_bucket}/{s3_key}'
             with credentials
             'aws_access_key_id={access_key};aws_secret_access_key={secret_key}'
             {copy_options};


### PR DESCRIPTION
When using the path FROM 's3://{s3_bucket}/{s3_key}/{table}' 
You get an error saying that there are no S3 prefix of {s3_key}/{table}
removing {table} fixed the issue

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX

- [ ] Description above provides context of the change
- [ ] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
