### PR TITLE
[AIRFLOW-6436] Add x_frame_enabled config in config.yml

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -818,9 +818,16 @@
       description: |
         Default setting for wrap toggle on DAG code and TI log views.
       version_added: ~
-      type: string
+      type: boolean
       example: ~
       default: "False"
+    - name: x_frame_enabled
+      description: |
+        Allow the UI to be rendered in a frame
+      version_added: ~
+      type: boolean
+      example: ~
+      default: "True"
     - name: analytics_tool
       description: |
         Send anonymous user activity to your analytics tool


### PR DESCRIPTION
https://github.com/apache/airflow/commit/e36ecb4c99f9e983d9b9554f03324b5dc108b9c6 was merged today, the config for which was added in default_airflow.cfg 

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6436

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
