### PR TITLE
[AIRFLOW-6444] Fix invalid argument error in example_dataflow dag

### DIFF
--- a/airflow/gcp/example_dags/example_dataflow.py
+++ b/airflow/gcp/example_dags/example_dataflow.py
@@ -73,7 +73,6 @@ with models.DAG(
         options={
             'output': GCS_OUTPUT,
         },
-        check_if_running=CheckJobRunning.WaitForRun,
     )
     # [END howto_operator_start_python_job]
 


### PR DESCRIPTION
Currently, I get the following error when I run https://github.com/apache/airflow/blob/master/airflow/gcp/example_dags/example_dataflow.py

```
airflow.exceptions.AirflowException: Invalid arguments were passed to DataflowCreatePythonJobOperator (task_id: start-python-job). Invalid arguments were:
*args: ()
**kwargs: {'check_if_running': <CheckJobRunning.WaitForRun: 3>}
```

The error is because there is no such argument in `DataflowCreatePythonJobOperator`

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6444

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
