### PR TITLE
[AIRFLOW-6447] Add GitHub Action to add Labels on Pull Requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+
+provider:GCP:
+  - airflow/**/gcp/*
+  - airflow/providers/google/cloud/*
+  - airflow/**/gcp_*.py
+  - airflow/**/gcs_*.py
+  - airflow/**/bigquery_*.py
+
+provider:AWS:
+  - airflow/**/aws/*
+  - airflow/providers/amazon/aws/*
+  - airflow/**/aws_*.py
+  - airflow/**/ecs_*.py
+  - airflow/**/emr_*.py
+  - airflow/**/sagemaker_*.py
+
+provider:Azure:
+  - airflow/**/azure/*
+  - airflow/**/azure_*.py
+  - airflow/**/adls_*.py
+  - airflow/**/wasb_*.py
+
+provider:Apache:
+  - airflow/providers/apache/*
+
+k8s:
+  - airflow/**/kubernetes_*.py
+  - airflow/kubernetes/*
+
+area:dev:
+  - scripts/*
+  - dev/*
+
+area:docs:
+  - docs/*
+
+area:webserver:
+  - airflow/www/*
+  - airflow/www_rbac/*
+
+area:cli:
+  - airflow/bin/cli.py
+  - airflow/cli/**/*.py

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# The workflow relies on .github/labeler.yml file which contains configuration.
+# For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Add GitHub Action to add Labels on Pull Requests. I have tested this on my local fork

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6447

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
