### PR TITLE
[AIRFLOW-6436] Cleanup for Airflow Configs doc generator code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -291,5 +291,5 @@ repos:
         files: "^airflow/config_templates/config.yml$|^airflow/config_templates/default_airflow.cfg$"
         pass_filenames: false
         require_serial: false
-        entry: airflow/utils/config_yaml_to_cfg.py
+        entry: scripts/ci/pre_commit_yaml_to_cfg.py
         additional_dependencies: ['pyyaml']

--- a/docs/configurations-ref.rst
+++ b/docs/configurations-ref.rst
@@ -19,6 +19,13 @@
 Configuration Reference
 =======================
 
+This page contains the list of all the available Airflow configurations that you
+can set in ``airflow.cfg`` file or using environment variables.
+
+.. contents:: Sections:
+   :local:
+   :depth: 1
+
 .. jinja:: config_ctx
 
     {% for section in configs %}
@@ -45,6 +52,7 @@ Configuration Reference
 
     :Type: {{ option["type"] }}
     :Default: ``{{ "''" if option["default"] == "" else option["default"] }}``
+    :Environment Variable: ``AIRFLOW__{{ section["name"] | upper }}__{{ option["name"] | upper }}``
     {% if option["example"] %}
     :Example:
         ``{{ option["example"] }}``

--- a/scripts/ci/pre_commit_yaml_to_cfg.py
+++ b/scripts/ci/pre_commit_yaml_to_cfg.py
@@ -124,7 +124,8 @@ def write_config(yaml_config_file_path: str, default_cfg_file_path: str):
 
 
 if __name__ == '__main__':
-    airflow_config_dir = os.path.join(os.path.dirname(__file__), "..", "config_templates")
+    airflow_config_dir = os.path.join(
+        os.path.dirname(__file__), "../../airflow/config_templates")
     airflow_default_config_path = os.path.join(airflow_config_dir, "default_airflow.cfg")
     airflow_config_yaml_file_path = os.path.join(airflow_config_dir, "config.yml")
 


### PR DESCRIPTION
Follow Up of https://github.com/apache/airflow/pull/7015 to cleanup code

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6436

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
