### PR TITLE
[AIRFLOW-6456] Remove create_mock_args in CLI tests

### DIFF
--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -22,9 +22,7 @@ import os
 import subprocess
 import tempfile
 import unittest
-from argparse import Namespace
 from datetime import datetime, time, timedelta
-from unittest.mock import MagicMock
 
 import mock
 import pytz
@@ -43,58 +41,6 @@ DEFAULT_DATE = timezone.make_aware(datetime(2015, 1, 1))
 TEST_DAG_FOLDER = os.path.join(
     os.path.dirname(dag_folder_path), 'dags')
 TEST_DAG_ID = 'unit_tests'
-
-
-def create_mock_args(  # pylint: disable=too-many-arguments
-    task_id,
-    dag_id,
-    subdir,
-    execution_date,
-    task_params=None,
-    dry_run=False,
-    queue=None,
-    pool=None,
-    priority_weight_total=None,
-    retries=0,
-    local=True,
-    mark_success=False,
-    ignore_all_dependencies=False,
-    ignore_depends_on_past=False,
-    ignore_dependencies=False,
-    force=False,
-    run_as_user=None,
-    executor_config=None,
-    cfg_path=None,
-    pickle=None,
-    raw=None,
-    interactive=None,
-):
-    if executor_config is None:
-        executor_config = {}
-    args = MagicMock(spec=Namespace)
-    args.task_id = task_id
-    args.dag_id = dag_id
-    args.subdir = subdir
-    args.task_params = task_params
-    args.execution_date = execution_date
-    args.dry_run = dry_run
-    args.queue = queue
-    args.pool = pool
-    args.priority_weight_total = priority_weight_total
-    args.retries = retries
-    args.local = local
-    args.run_as_user = run_as_user
-    args.executor_config = executor_config
-    args.cfg_path = cfg_path
-    args.pickle = pickle
-    args.raw = raw
-    args.mark_success = mark_success
-    args.ignore_all_dependencies = ignore_all_dependencies
-    args.ignore_depends_on_past = ignore_depends_on_past
-    args.ignore_dependencies = ignore_dependencies
-    args.force = force
-    args.interactive = interactive
-    return args
 
 
 EXAMPLE_DAGS_FOLDER = os.path.join(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -19,11 +19,9 @@
 #
 import io
 import unittest
-from argparse import Namespace
 from contextlib import redirect_stdout
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import MagicMock
 
 from parameterized import parameterized
 
@@ -48,58 +46,6 @@ def reset(dag_id):
     session.close()
 
 
-def create_mock_args(  # pylint: disable=too-many-arguments
-    task_id,
-    dag_id,
-    subdir,
-    execution_date,
-    task_params=None,
-    dry_run=False,
-    queue=None,
-    pool=None,
-    priority_weight_total=None,
-    retries=0,
-    local=True,
-    mark_success=False,
-    ignore_all_dependencies=False,
-    ignore_depends_on_past=False,
-    ignore_dependencies=False,
-    force=False,
-    run_as_user=None,
-    executor_config=None,
-    cfg_path=None,
-    pickle=None,
-    raw=None,
-    interactive=None,
-):
-    if executor_config is None:
-        executor_config = {}
-    args = MagicMock(spec=Namespace)
-    args.task_id = task_id
-    args.dag_id = dag_id
-    args.subdir = subdir
-    args.task_params = task_params
-    args.execution_date = execution_date
-    args.dry_run = dry_run
-    args.queue = queue
-    args.pool = pool
-    args.priority_weight_total = priority_weight_total
-    args.retries = retries
-    args.local = local
-    args.run_as_user = run_as_user
-    args.executor_config = executor_config
-    args.cfg_path = cfg_path
-    args.pickle = pickle
-    args.raw = raw
-    args.mark_success = mark_success
-    args.ignore_all_dependencies = ignore_all_dependencies
-    args.ignore_depends_on_past = ignore_depends_on_past
-    args.ignore_dependencies = ignore_dependencies
-    args.force = force
-    args.interactive = interactive
-    return args
-
-
 class TestCliTasks(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -117,12 +63,9 @@ class TestCliTasks(unittest.TestCase):
 
     def test_test(self):
         """Test the `airflow test` command"""
-        args = create_mock_args(
-            task_id='print_the_context',
-            dag_id='example_python_operator',
-            subdir=None,
-            execution_date=timezone.parse('2018-01-01')
-        )
+        args = self.parser.parse_args([
+            "tasks", "test", "example_python_operator", 'print_the_context', '2018-01-01'
+        ])
 
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_test(args)
@@ -232,13 +175,17 @@ class TestCliTasks(unittest.TestCase):
         task_command.task_clear(args)
 
     def test_local_run(self):
-        args = create_mock_args(
-            task_id='print_the_context',
-            dag_id='example_python_operator',
-            subdir='/root/dags/example_python_operator.py',
-            interactive=True,
-            execution_date=timezone.parse('2018-04-27T08:39:51.298439+00:00')
-        )
+        args = self.parser.parse_args([
+            'tasks',
+            'run',
+            'example_python_operator',
+            'print_the_context',
+            '2018-04-27T08:39:51.298439+00:00',
+            '--interactive',
+            '--subdir',
+            '/root/dags/example_python_operator.py'
+        ])
+
         dag = get_dag(args.subdir, args.dag_id)
         reset(dag.dag_id)
 


### PR DESCRIPTION
In all other tests we use a different convention for creating args object. 

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6456

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
