### PR TITLE
[AIRFLOW-XXXX] Used fixed periodic auto-labeler from potiuk's repo

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -31,7 +31,7 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: paulfantom/periodic-labeler@master
+      - uses: docker://potiuk/periodic-labeler:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
The periodic labeler had a bug that it was not using pagination.
In effect the labeler was checking only 30 oldest request and
if they all contained proper labels, it was not checking any more
PRs.

Details are available in
https://github.com/paulfantom/periodic-labeler/pull/4

But until it is merged, we switch to our own fixed version.

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
