### PR TITLE
[AIRFLOW-XXXX] Decrease frequency of PR labelling Github Action

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -31,7 +31,7 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: paulfantom/periodic-labeler@master
+      - uses: docker://potiuk/periodic-labeler:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -25,7 +25,7 @@
 name: Pull Request labeler
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '5 0 * * *'
 
 jobs:
   labeler:


### PR DESCRIPTION
With the current frequency we are going to exhaust our 2000 free
minutes in about 10 days. We should decrease the frequency quickly.

It depends on the previous commit where I switched the source of auto-labeler to my repo.

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
