### PR TITLE
[AIRFLOW-6459] Increase verbosity of pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,7 +18,7 @@
 [pytest]
 addopts =
     -rasl
-    --verbosity=1
+    --verbosity=2
 ;    This will treat all tests as flaky
 ;    --force-flaky
 norecursedirs =


### PR DESCRIPTION
I have the impression that more flaky tests have appeared recently. Unfortunately, these tests stop the test process unexpectedly.  We are unable to determine what test it causes because we only have information about the last file. I think that logs should be more useful and provide more information, so I increase the verbosity level.  I also love short logs, but I love logs more that provide usefully information.

Sample output
```
Starting the tests with those pytest arguments: --junitxml=/root/airflow/logs/all_tests.xml --verbosity=0 --durations=100 --cov=airflow/ --cov-config=.coveragerc --cov-report=html:airflow/www/static/coverage/ --pythonwarnings=ignore::DeprecationWarning --pythonwarnings=ignore::PendingDeprecationWarning tests/

============================= test session starts ==============================
platform linux -- Python 3.7.6, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /opt/airflow, inifile: pytest.ini
plugins: cov-2.8.1, flaky-3.6.1, requests-mock-1.7.0, celery-4.4.0
collected 4360 items / 3 skipped / 4357 selected

tests/test_config_templates.py ....                                      [  0%]
tests/test_configuration.py .................................            [  0%]
tests/test_core.py ........................                              [  1%]
tests/test_core_to_contrib.py .......................................... [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
.........................                                                [ 11%]
tests/test_example_dags_system.py ss                                     [ 11%]
tests/test_impersonation.py ..Timeout (0:08:00)!
Thread 0x00007fdf84c4d700 (most recent call first):
  File "/usr/local/lib/python3.7/threading.py", line 296 in wait
  File "/usr/local/lib/python3.7/queue.py", line 170 in get
  File "/usr/local/lib/python3.7/site-packages/cassandra/cluster.py", line 3609 in run
  File "/usr/local/lib/python3.7/site-packages/sentry_sdk/integrations/threading.py", line 67 in run
  File "/usr/local/lib/python3.7/threading.py", line 926 in _bootstrap_inner
  File "/usr/local/lib/python3.7/threading.py", line 890 in _bootstrap

Thread 0x00007fdf95296700 (most recent call first):
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 122 in __init__
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 196 in frame
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 223 in getfirstlinesource
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 239 in getsource
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 679 in _getentrysource
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 768 in repr_traceback_entry
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 820 in repr_traceback
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 876 in repr_excinfo
  File "/usr/local/lib/python3.7/site-packages/_pytest/_code/code.py", line 630 in getrepr
  File "/usr/local/lib/python3.7/site-packages/_pytest/nodes.py", line 325 in _repr_failure_py
  File "/usr/local/lib/python3.7/site-packages/_pytest/python.py", line 809 in repr_failure
  File "/usr/local/lib/python3.7/site-packages/_pytest/reports.py", line 286 in from_item_and_call
  File "/usr/local/lib/python3.7/site-packages/_pytest/runner.py", line 250 in pytest_runtest_makereport
  File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/usr/local/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/usr/local/lib/python3.7/site-packages/flaky/flaky_pytest_plugin.py", line 132 in call_and_report
  File "/usr/local/lib/python3.7/site-packages/_pytest/runner.py", line 96 in runtestprotocol
  File "/usr/local/lib/python3.7/site-packages/_pytest/runner.py", line 81 in pytest_runtest_protocol
  File "/usr/local/lib/python3.7/site-packages/flaky/flaky_pytest_plugin.py", line 92 in pytest_runtest_protocol
  File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/usr/local/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/usr/local/lib/python3.7/site-packages/_pytest/main.py", line 270 in pytest_runtestloop
  File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/usr/local/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/usr/local/lib/python3.7/site-packages/_pytest/main.py", line 246 in _main
  File "/usr/local/lib/python3.7/site-packages/_pytest/main.py", line 196 in wrap_session
  File "/usr/local/lib/python3.7/site-packages/_pytest/main.py", line 239 in pytest_cmdline_main
  File "/usr/local/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/usr/local/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/usr/local/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/usr/local/lib/python3.7/site-packages/_pytest/config/__init__.py", line 92 in main
  File "/usr/local/bin/pytest", line 10 in <module>


No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

The build has been terminated
```
---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6459

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
