### PR TITLE
[AIRFLOW-XXXX] Update types in docstrings

### DIFF
--- a/airflow/contrib/operators/azure_container_instances_operator.py
+++ b/airflow/contrib/operators/azure_container_instances_operator.py
@@ -56,7 +56,7 @@ class AzureContainerInstancesOperator(BaseOperator):
     :type ci_conn_id: str
     :param registry_conn_id: connection id of a user which can login to a
         private docker registry. If None, we assume a public registry
-    :type registry_conn_id: str
+    :type registry_conn_id: Optional[str]
     :param resource_group: name of the resource group wherein this container
         instance should be started
     :type resource_group: str

--- a/airflow/contrib/operators/emr_add_steps_operator.py
+++ b/airflow/contrib/operators/emr_add_steps_operator.py
@@ -27,11 +27,11 @@ class EmrAddStepsOperator(BaseOperator):
     An operator that adds steps to an existing EMR job_flow.
 
     :param job_flow_id: id of the JobFlow to add steps to. (templated)
-    :type job_flow_id: str
+    :type job_flow_id: Optional[str]
     :param job_flow_name: name of the JobFlow to add steps to. Use as an alternative to passing
         job_flow_id. will search for id of JobFlow with matching name in one of the states in
         param cluster_states. Exactly one cluster like this should exist or will fail. (templated)
-    :type job_flow_name: str
+    :type job_flow_name: Optional[str]
     :param cluster_states: Acceptable cluster states when searching for JobFlow id by job_flow_name.
         (templated)
     :type cluster_states: list

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -42,9 +42,9 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
     :type soft_fail: bool
     :param poke_interval: Time in seconds that the job should wait in
         between each tries
-    :type poke_interval: int
+    :type poke_interval: float
     :param timeout: Time, in seconds before the task times out and fails.
-    :type timeout: int
+    :type timeout: float
     :param mode: How the sensor operates.
         Options are: ``{ poke | reschedule }``, default is ``poke``.
         When set to ``poke`` the sensor is taking up a worker slot for its

--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -47,11 +47,11 @@ class ExternalTaskSensor(BaseSensorOperator):
         For yesterday, use [positive!] datetime.timedelta(days=1). Either
         execution_delta or execution_date_fn can be passed to
         ExternalTaskSensor, but not both.
-    :type execution_delta: datetime.timedelta
+    :type execution_delta: Optional[datetime.timedelta]
     :param execution_date_fn: function that receives the current execution date
         and returns the desired execution dates to query. Either execution_delta
         or execution_date_fn can be passed to ExternalTaskSensor, but not both.
-    :type execution_date_fn: callable
+    :type execution_date_fn: Optional[Callable]
     :param check_existence: Set to `True` to check if the external task exists (when
         external_task_id is not None) or check if the DAG to wait for exists (when
         external_task_id is None), and immediately cease waiting if the external task


### PR DESCRIPTION
All changes are docstring changes. The types in docstrings were updated to fix warnings like: "Expected type 'x', got 'y' instead".

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
