### PR TITLE
[AIRFLOW-6462] Limit exported variables in Dockerfile/Breeze

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,44 +146,49 @@ RUN mkdir -pv /usr/share/man/man1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENV HADOOP_DISTRO="cdh" HADOOP_MAJOR="5" HADOOP_DISTRO_VERSION="5.11.0" HADOOP_VERSION="2.6.0" \
-    HADOOP_HOME="/opt/hadoop-cdh"
-ENV HIVE_VERSION="1.1.0" HIVE_HOME="/opt/hive"
-ENV HADOOP_URL="https://archive.cloudera.com/${HADOOP_DISTRO}${HADOOP_MAJOR}/${HADOOP_DISTRO}/${HADOOP_MAJOR}/"
-ENV MINICLUSTER_BASE="https://github.com/bolkedebruin/minicluster/releases/download/" \
-    MINICLUSTER_HOME="/opt/minicluster" \
-    MINICLUSTER_VER="1.1"
+ENV HADOOP_HOME="/opt/hadoop-cdh" HIVE_HOME="/opt/hive"
 
-RUN mkdir -pv "${HADOOP_HOME}" \
+# Install Hadoop and Hive
+# It is done in one step to share variables.
+RUN HADOOP_DISTRO="cdh" \
+    && HADOOP_MAJOR="5" \
+    && HADOOP_DISTRO_VERSION="5.11.0" \
+    && HADOOP_VERSION="2.6.0" \
+    && HADOOP_URL="https://archive.cloudera.com/${HADOOP_DISTRO}${HADOOP_MAJOR}/${HADOOP_DISTRO}/${HADOOP_MAJOR}/"\
+    && HADOOP_DOWNLOAD_URL="${HADOOP_URL}hadoop-${HADOOP_VERSION}-${HADOOP_DISTRO}${HADOOP_DISTRO_VERSION}.tar.gz" \
+    && HADOOP_TMP_FILE="/tmp/hadoop.tar.gz" \
+    && mkdir -pv "${HADOOP_HOME}" \
+    && curl -L "${HADOOP_DOWNLOAD_URL}" > "${HADOOP_TMP_FILE}" \
+    && tar xzf "${HADOOP_TMP_FILE}" --absolute-names --strip-components 1 -C "${HADOOP_HOME}" \
+    && rm "${HADOOP_TMP_FILE}" \
+    && echo "Installing Hive" \
+    && HIVE_VERSION="1.1.0" \
+    && HIVE_URL="${HADOOP_URL}hive-${HIVE_VERSION}-${HADOOP_DISTRO}${HADOOP_DISTRO_VERSION}.tar.gz" \
+    && HIVE_VERSION="1.1.0" \
+    && HIVE_TMP_FILE="/tmp/hive.tar.gz" \
     && mkdir -pv "${HIVE_HOME}" \
-    && mkdir -pv "${MINICLUSTER_HOME}" \
     && mkdir -pv "/user/hive/warehouse" \
     && chmod -R 777 "${HIVE_HOME}" \
-    && chmod -R 777 "/user/"
-
-ENV HADOOP_DOWNLOAD_URL="${HADOOP_URL}hadoop-${HADOOP_VERSION}-${HADOOP_DISTRO}${HADOOP_DISTRO_VERSION}.tar.gz" \
-    HADOOP_TMP_FILE="/tmp/hadoop.tar.gz"
-
-RUN curl -L "${HADOOP_DOWNLOAD_URL}" > "${HADOOP_TMP_FILE}" \
-    && tar xzf "${HADOOP_TMP_FILE}" --absolute-names --strip-components 1 -C "${HADOOP_HOME}" \
-    && rm "${HADOOP_TMP_FILE}"
-
-ENV HIVE_URL="${HADOOP_URL}hive-${HIVE_VERSION}-${HADOOP_DISTRO}${HADOOP_DISTRO_VERSION}.tar.gz" \
-    HIVE_TMP_FILE="/tmp/hive.tar.gz"
-
-RUN curl -L "${HIVE_URL}" >"${HIVE_TMP_FILE}" \
+    && chmod -R 777 "/user/" \
+    && curl -L "${HIVE_URL}" > "${HIVE_TMP_FILE}" \
     && tar xzf "${HIVE_TMP_FILE}" --strip-components 1 -C "${HIVE_HOME}" \
     && rm "${HIVE_TMP_FILE}"
 
-ENV MINICLUSTER_URL="${MINICLUSTER_BASE}${MINICLUSTER_VER}/minicluster-${MINICLUSTER_VER}-SNAPSHOT-bin.zip" \
-    MINICLUSTER_TMP_FILE="/tmp/minicluster.zip"
+ENV PATH "${PATH}:/opt/hive/bin"
 
-RUN curl -L "${MINICLUSTER_URL}" > "${MINICLUSTER_TMP_FILE}" \
+# Install Minicluster
+ENV MINICLUSTER_HOME="/opt/minicluster"
+
+RUN MINICLUSTER_BASE="https://github.com/bolkedebruin/minicluster/releases/download/" \
+    && MINICLUSTER_VER="1.1" \
+    && MINICLUSTER_URL="${MINICLUSTER_BASE}${MINICLUSTER_VER}/minicluster-${MINICLUSTER_VER}-SNAPSHOT-bin.zip" \
+    && MINICLUSTER_TMP_FILE="/tmp/minicluster.zip" \
+    && mkdir -pv "${MINICLUSTER_HOME}" \
+    && curl -L "${MINICLUSTER_URL}" > "${MINICLUSTER_TMP_FILE}" \
     && unzip "${MINICLUSTER_TMP_FILE}" -d "/opt" \
     && rm "${MINICLUSTER_TMP_FILE}"
 
-ENV PATH "${PATH}:/opt/hive/bin"
-
+# Install Docker
 RUN curl -L https://download.docker.com/linux/debian/gpg | apt-key add - \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" \
     && apt-get update \
@@ -191,30 +196,30 @@ RUN curl -L https://download.docker.com/linux/debian/gpg | apt-key add - \
     && apt-get autoremove -yqq --purge \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install kubectl
 ARG KUBECTL_VERSION="v1.15.0"
-ENV KUBECTL_VERSION=${KUBECTL_VERSION}
-ARG KIND_VERSION="v0.5.0"
-ENV KIND_VERSION=${KIND_VERSION}
 
 RUN curl -Lo kubectl \
   "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
   && chmod +x kubectl \
   && mv kubectl /usr/local/bin/kubectl
 
+# Install Kind
+ARG KIND_VERSION="v0.5.0"
+
 RUN curl -Lo kind \
    "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" \
    && chmod +x kind \
    && mv kind /usr/local/bin/kind
 
+# Install Apache RAT
 ARG RAT_VERSION="0.13"
+ENV RAT_JAR="/opt/apache-rat-${RAT_VERSION}.jar"
 
-ENV RAT_VERSION="${RAT_VERSION}" \
-    RAT_JAR="/opt/apache-rat-${RAT_VERSION}.jar" \
-    RAT_URL="https://repo1.maven.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
-ENV RAT_JAR_MD5="${RAT_JAR}.md5" \
-    RAT_URL_MD5="${RAT_URL}.md5"
-
-RUN echo "Downloading RAT from ${RAT_URL} to ${RAT_JAR}" \
+RUN  RAT_URL="https://repo1.maven.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar" \
+    && RAT_JAR_MD5="${RAT_JAR}.md5" \
+    && RAT_URL_MD5="${RAT_URL}.md5" \
+    && echo "Downloading RAT from ${RAT_URL} to ${RAT_JAR}" \
     && curl -L "${RAT_URL}" > "${RAT_JAR}" \
     && curl -L "${RAT_URL_MD5}" > "${RAT_JAR_MD5}" \
     && jar -tf "${RAT_JAR}" >/dev/null \
@@ -295,8 +300,6 @@ ENV AIRFLOW_REPO=${AIRFLOW_REPO}
 
 ARG AIRFLOW_BRANCH=master
 ENV AIRFLOW_BRANCH=${AIRFLOW_BRANCH}
-
-ENV AIRFLOW_GITHUB_DOWNLOAD=https://raw.githubusercontent.com/${AIRFLOW_REPO}/${AIRFLOW_BRANCH}
 
 # Airflow Extras installed
 ARG AIRFLOW_EXTRAS="all"

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,10 +146,11 @@ RUN mkdir -pv /usr/share/man/man1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENV HADOOP_HOME="/opt/hadoop-cdh" HIVE_HOME="/opt/hive"
 
 # Install Hadoop and Hive
 # It is done in one step to share variables.
+ENV HADOOP_HOME="/opt/hadoop-cdh" HIVE_HOME="/opt/hive"
+
 RUN HADOOP_DISTRO="cdh" \
     && HADOOP_MAJOR="5" \
     && HADOOP_DISTRO_VERSION="5.11.0" \
@@ -214,9 +215,9 @@ RUN curl -Lo kind \
 
 # Install Apache RAT
 ARG RAT_VERSION="0.13"
-ENV RAT_JAR="/opt/apache-rat-${RAT_VERSION}.jar"
 
 RUN  RAT_URL="https://repo1.maven.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar" \
+    && RAT_JAR="/opt/apache-rat.jar" \
     && RAT_JAR_MD5="${RAT_JAR}.md5" \
     && RAT_URL_MD5="${RAT_URL}.md5" \
     && echo "Downloading RAT from ${RAT_URL} to ${RAT_JAR}" \

--- a/scripts/ci/in_container/run_check_licence.sh
+++ b/scripts/ci/in_container/run_check_licence.sh
@@ -38,7 +38,7 @@ sudo mkdir -p docs/_build/html/
 
 echo "Running license checks. This can take a while."
 
-if ! java -jar "${RAT_JAR}" -E "${AIRFLOW_SOURCES}"/.rat-excludes \
+if ! java -jar "/opt/apache-rat.jar" -E "${AIRFLOW_SOURCES}"/.rat-excludes \
     -d "${AIRFLOW_SOURCES}" | tee "${AIRFLOW_SOURCES}/logs/rat-results.txt" ; then
    echo >&2 "RAT exited abnormally"
    exit 1


### PR DESCRIPTION

We have a lot of variables after typing the command `export` in a clean environment. I would like to limit their number. to make the result of the export command more readable.


After:
```bash
declare -x ADDITIONAL_PATH="~/.local/bin"
declare -x AIRFLOW_BRANCH="master"
declare -x AIRFLOW_CI_BUILD_EPOCH="1"
declare -x AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD="true"
declare -x AIRFLOW_CONTAINER_DOCKER_IMAGE="apache/airflow:master-python3.6-ci"
declare -x AIRFLOW_EXTRAS="devel_ci"
declare -x AIRFLOW_HOME="/root/airflow"
declare -x AIRFLOW_REPO="apache/airflow"
declare -x AIRFLOW_SOURCES="/opt/airflow"
declare -x AIRFLOW_VERSION="2.0.0.dev0"
declare -x AIRFLOW__CORE__DAGS_FOLDER="/opt/airflow/tests/dags"
declare -x AIRFLOW__CORE__EXECUTOR="SequentialExecutor"
declare -x AIRFLOW__CORE__SQL_ALCHEMY_CONN="sqlite:////root/airflow/airflow.db"
declare -x AIRFLOW__CORE__UNIT_TEST_MODE="True"
declare -x AWS_DEFAULT_REGION="us-east-1"
declare -x BACKEND="sqlite"
declare -x BREEZE="true"
declare -x CASS_DRIVER_BUILD_CONCURRENCY="8"
declare -x CASS_DRIVER_NO_CYTHON="1"
declare -x CELERY_BROKER_URLS="amqp://guest:guest@rabbitmq:5672,redis://redis:6379/0"
declare -x DEBIAN_FRONTEND="noninteractive"
declare -x DEPENDENCIES_EPOCH_NUMBER="2"
declare -x DISABLE_CHECKS_FOR_TESTS="missing-docstring,no-self-use,too-many-public-methods,protected-access,do-not-use-asserts"
declare -x DOCKER_HOST="tcp://docker:2375"
declare -x ENV="docker"
declare -x GPG_KEY="0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D"
declare -x HADOOP_DISTRO="cdh"
declare -x HADOOP_HOME="/opt/hadoop-cdh"
declare -x HADOOP_OPTS="-D/opt/krb5.conf"
declare -x HIVE_HOME="/opt/hive"
declare -x HOME="/root"
declare -x HOSTNAME="e484de340f32"
declare -x JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/"
declare -x KRB5_CONFIG="/etc/krb5.conf"
declare -x KRB5_KTNAME="/etc/airflow.keytab"
declare -x KUBERNETES_MODE="git_mode"
declare -x KUBERNETES_VERSION="v1.13.0"
declare -x LANG="C.UTF-8"
declare -x LANGUAGE="C.UTF-8"
declare -x LC_ALL="C.UTF-8"
declare -x LC_CTYPE="C.UTF-8"
declare -x LC_MESSAGES="C.UTF-8"
declare -x MINICLUSTER_HOME="/opt/minicluster"
declare -x OLDPWD="/opt/airflow"
declare -x PATH="/root:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hive/bin:/opt/airflow"
declare -x PIP_DEPENDENCIES_EPOCH_NUMBER="2"
declare -x PIP_NO_CACHE_DIR="true"
declare -x PIP_VERSION="19.0.2"
declare -x PWD="/opt/airflow"
declare -x PYTHONDONTWRITEBYTECODE="true"
declare -x PYTHON_BASE_IMAGE="python:3.6-slim-stretch"
declare -x PYTHON_GET_PIP_SHA256="b86f36cc4345ae87bfd4f10ef6b2dbfa7a872fbff70608a1e43944d283fd0eee"
declare -x PYTHON_GET_PIP_URL="https://github.com/pypa/get-pip/raw/ffe826207a010164265d9cc807978e3604d18ca0/get-pip.py"
declare -x PYTHON_PIP_VERSION="19.3.1"
declare -x PYTHON_VERSION="3.6.10"
declare -x RUN_TESTS="false"
declare -x SHLVL="2"
declare -x SOURCE_BRANCH="master"
declare -x TERM="xterm"
declare -x USER="root"
declare -x XUNIT_FILE="/root/airflow/logs/all_tests.xml"
```
Before:
```bash
declare -x ADDITIONAL_PATH="~/.local/bin"
declare -x AIRFLOW_BRANCH="master"
declare -x AIRFLOW_CI_BUILD_EPOCH="1"
declare -x AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD="true"
declare -x AIRFLOW_CONTAINER_DOCKER_IMAGE="apache/airflow:master-python3.6-ci"
declare -x AIRFLOW_EXTRAS="devel_ci"
declare -x AIRFLOW_GITHUB_DOWNLOAD="https://raw.githubusercontent.com/apache/airflow/master"
declare -x AIRFLOW_HOME="/root/airflow"
declare -x AIRFLOW_REPO="apache/airflow"
declare -x AIRFLOW_SOURCES="/opt/airflow"
declare -x AIRFLOW_VERSION="2.0.0.dev0"
declare -x AIRFLOW__CORE__DAGS_FOLDER="/opt/airflow/tests/dags"
declare -x AIRFLOW__CORE__EXECUTOR="SequentialExecutor"
declare -x AIRFLOW__CORE__SQL_ALCHEMY_CONN="sqlite:////root/airflow/airflow.db"
declare -x AIRFLOW__CORE__UNIT_TEST_MODE="True"
declare -x AWS_DEFAULT_REGION="us-east-1"
declare -x BACKEND="sqlite"
declare -x BREEZE="true"
declare -x CASS_DRIVER_BUILD_CONCURRENCY="8"
declare -x CASS_DRIVER_NO_CYTHON="1"
declare -x CELERY_BROKER_URLS="amqp://guest:guest@rabbitmq:5672,redis://redis:6379/0"
declare -x DEBIAN_FRONTEND="noninteractive"
declare -x DEPENDENCIES_EPOCH_NUMBER="2"
declare -x DISABLE_CHECKS_FOR_TESTS="missing-docstring,no-self-use,too-many-public-methods,protected-access,do-not-use-asserts"
declare -x DOCKER_HOST="tcp://docker:2375"
declare -x ENV="docker"
declare -x GPG_KEY="0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D"
declare -x HADOOP_DISTRO="cdh"
declare -x HADOOP_DISTRO_VERSION="5.11.0"
declare -x HADOOP_DOWNLOAD_URL="https://archive.cloudera.com/cdh5/cdh/5/hadoop-2.6.0-cdh5.11.0.tar.gz"
declare -x HADOOP_HOME="/opt/hadoop-cdh"
declare -x HADOOP_MAJOR="5"
declare -x HADOOP_OPTS="-D/opt/krb5.conf"
declare -x HADOOP_TMP_FILE="/tmp/hadoop.tar.gz"
declare -x HADOOP_URL="https://archive.cloudera.com/cdh5/cdh/5/"
declare -x HADOOP_VERSION="2.6.0"
declare -x HIVE_HOME="/opt/hive"
declare -x HIVE_TMP_FILE="/tmp/hive.tar.gz"
declare -x HIVE_URL="https://archive.cloudera.com/cdh5/cdh/5/hive-1.1.0-cdh5.11.0.tar.gz"
declare -x HIVE_VERSION="1.1.0"
declare -x HOME="/root"
declare -x HOSTNAME="10d460be0a01"
declare -x JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/"
declare -x KIND_VERSION="v0.5.0"
declare -x KRB5_CONFIG="/etc/krb5.conf"
declare -x KRB5_KTNAME="/etc/airflow.keytab"
declare -x KUBECTL_VERSION="v1.15.0"
declare -x KUBERNETES_MODE="git_mode"
declare -x KUBERNETES_VERSION="v1.13.0"
declare -x LANG="C.UTF-8"
declare -x LANGUAGE="C.UTF-8"
declare -x LC_ALL="C.UTF-8"
declare -x LC_CTYPE="C.UTF-8"
declare -x LC_MESSAGES="C.UTF-8"
declare -x MINICLUSTER_BASE="https://github.com/bolkedebruin/minicluster/releases/download/"
declare -x MINICLUSTER_HOME="/opt/minicluster"
declare -x MINICLUSTER_TMP_FILE="/tmp/minicluster.zip"
declare -x MINICLUSTER_URL="https://github.com/bolkedebruin/minicluster/releases/download/1.1/minicluster-1.1-SNAPSHOT-bin.zip"
declare -x MINICLUSTER_VER="1.1"
declare -x OLDPWD="/opt/airflow"
declare -x PATH="/root:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hive/bin:/opt/airflow"
declare -x PIP_DEPENDENCIES_EPOCH_NUMBER="2"
declare -x PIP_NO_CACHE_DIR="true"
declare -x PIP_VERSION="19.0.2"
declare -x PWD="/opt/airflow"
declare -x PYTHONDONTWRITEBYTECODE="true"
declare -x PYTHON_BASE_IMAGE="python:3.6-slim-stretch"
declare -x PYTHON_GET_PIP_SHA256="b86f36cc4345ae87bfd4f10ef6b2dbfa7a872fbff70608a1e43944d283fd0eee"
declare -x PYTHON_GET_PIP_URL="https://github.com/pypa/get-pip/raw/ffe826207a010164265d9cc807978e3604d18ca0/get-pip.py"
declare -x PYTHON_PIP_VERSION="19.3.1"
declare -x PYTHON_VERSION="3.6.10"
declare -x RAT_JAR="/opt/apache-rat-0.13.jar"
declare -x RAT_JAR_MD5="/opt/apache-rat-0.13.jar.md5"
declare -x RAT_URL="https://repo1.maven.org/maven2/org/apache/rat/apache-rat/0.13/apache-rat-0.13.jar"
declare -x RAT_URL_MD5="https://repo1.maven.org/maven2/org/apache/rat/apache-rat/0.13/apache-rat-0.13.jar.md5"
declare -x RAT_VERSION="0.13"
declare -x RUN_TESTS="false"
declare -x SHLVL="2"
declare -x SOURCE_BRANCH="master"
declare -x TERM="xterm"
declare -x USER="root"
declare -x XUNIT_FILE="/root/airflow/logs/all_tests.xml"
```
---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6462

- [X] Description above provides context of the change
- [X] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
