### PR TITLE
[AIRFLOW-6460] "Reduce timeout in pytest (#7051)"

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,6 @@ norecursedirs =
     tests/test_utils
     tests/dags_corrupted
     tests/dags
-faulthandler_timeout = 90
+faulthandler_timeout = 480
 log_print = True
 log_level = INFO


### PR DESCRIPTION
This reverts commit bf3fa1fda2f45946e2bf4b2d3377a5c0bc23664d.

test_impersonation.py runs almost always for much longer on python 3.7 on master and this fails the whole build and a number of subsequent tests.

We need to fix test_impersonation.py but for now let's revert this change

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6460

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
