### PR TITLE
[AIRFLOW-6471] Add pytest-instafail plugin

### DIFF
--- a/scripts/ci/in_container/entrypoint_ci.sh
+++ b/scripts/ci/in_container/entrypoint_ci.sh
@@ -204,6 +204,7 @@ if [[ "${TRAVIS}" == "true" ]]; then
     TRAVIS_ARGS=(
         "--junitxml=${XUNIT_FILE}"
         "--verbosity=0"
+        "--instafail"
         "--durations=100"
         "--cov=airflow/"
         "--cov-config=.coveragerc"

--- a/setup.py
+++ b/setup.py
@@ -389,6 +389,7 @@ devel = [
     'pysftp',
     'pytest',
     'pytest-cov',
+    'pytest-instafail',
     'pywinrm',
     'qds-sdk>=1.9.6',
     'requests_mock',


### PR DESCRIPTION
We have a problem currently that if a test fails in CI we do not see the
failures immediately - only when it finishes, but when tests hang, sometimes
the details about failed tests are not shown immediately. We tried to increase
verbosity but it's not very helpful.

The pytest-instafail plugin solves the problem without increasing verbosity.

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6471

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
