### PR TITLE
[AIRFLOW-6475] Remove duplication of volume mount specs in Breeze.

### DIFF
--- a/scripts/ci/docker-compose-local.yml
+++ b/scripts/ci/docker-compose-local.yml
@@ -30,31 +30,32 @@ services:
     # or those that might be useful to see in the host as output of the
     # tests (such as logs)
     volumes:
-      - ../../airflow:/opt/airflow/airflow:cached
-      - ../../setup.cfg:/opt/airflow/setup.cfg:cached
-      - ../../setup.py:/opt/airflow/setup.py:cached
-      - ../../dags:/opt/airflow/dags:cached
-      - ../../dev:/opt/airflow/dev:cached
-      - ../../docs:/opt/airflow/docs:cached
-      - ../../hooks:/opt/airflow/hooks:cached
-      - ../../scripts:/opt/airflow/scripts:cached
-      - ../../tests:/opt/airflow/tests:cached
+      - ../../.bash_aliases:/root/.bash_aliases:cached
+      - ../../.bash_history:/root/.bash_history:cached
       - ../../.coveragerc:/opt/airflow/.coveragerc:cached
+      - ../../.flake8:/opt/airflow/.flake8:cached
+      - ../../.github:/opt/airflow/.github:cached
+      - ../../.inputrc:/root/.inputrc:cached
+      - ../../.rat-excludes:/opt/airflow/.rat-excludes:cached
+      - ../../CHANGELOG.txt:/opt/airflow/CHANGELOG:cached
       - ../../LICENSE:/opt/airflow/LICENSE:cached
       - ../../MANIFEST.in:/opt/airflow/MANIFEST.in:cached
       - ../../NOTICE:/opt/airflow/NOTICE:cached
-      - ../../CHANGELOG.txt:/opt/airflow/CHANGELOG:cached
-      - ../../.github:/opt/airflow/.github:cached
-      - ../../.bash_history:/root/.bash_history:cached
-      - ../../.bash_aliases:/root/.bash_aliases:cached
-      - ../../.inputrc:/root/.inputrc:cached
-      - ../../.flake8:/opt/airflow/.flake8:cached
+      - ../../airflow:/opt/airflow/airflow:cached
+      - ../../common:/opt/airflow/common:cached
+      - ../../dags:/opt/airflow/dags:cached
+      - ../../dev:/opt/airflow/dev:cached
+      - ../../docs:/opt/airflow/docs:cached
+      - ../../files:/files:cached
+      - ../../hooks:/opt/airflow/hooks:cached
+      - ../../logs:/root/airflow/logs:cached
       - ../../pylintrc:/opt/airflow/pylintrc:cached
       - ../../pytest.ini:/opt/airflow/pytest.ini:cached
-      - ../../.rat-excludes:/opt/airflow/.rat-excludes:cached
-      - ../../logs:/root/airflow/logs:cached
+      - ../../scripts:/opt/airflow/scripts:cached
+      - ../../setup.cfg:/opt/airflow/setup.cfg:cached
+      - ../../setup.py:/opt/airflow/setup.py:cached
+      - ../../tests:/opt/airflow/tests:cached
       - ../../tmp:/opt/airflow/tmp:cached
-      - ../../files:/files:cached
     environment:
       - HOST_USER_ID
       - HOST_GROUP_ID

--- a/tests/bats/test_yaml_parser.bats
+++ b/tests/bats/test_yaml_parser.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+@test "yaml parsing missing file" {
+  load bats_utils
+  run parse_yaml
+  [ "${status}" == 1 ]
+  [ "${output}" == "Please provide yaml filename as first parameter." ]
+}
+
+@test "yaml parsing existing file" {
+  load bats_utils
+  run parse_yaml "scripts/ci/docker-compose-local.yml"
+  diff <(echo "${output}") - << 'EOF'
+1="--"
+version="2.2"
+services_mysql_ports_1="${MYSQL_HOST_PORT}:3306"
+services_postgres_ports_1="${POSTGRES_HOST_PORT}:5432"
+services_airflow-testing_volumes_1="../../.bash_aliases:/root/.bash_aliases:cached"
+services_airflow-testing_volumes_2="../../.bash_history:/root/.bash_history:cached"
+services_airflow-testing_volumes_3="../../.coveragerc:/opt/airflow/.coveragerc:cached"
+services_airflow-testing_volumes_4="../../.flake8:/opt/airflow/.flake8:cached"
+services_airflow-testing_volumes_5="../../.github:/opt/airflow/.github:cached"
+services_airflow-testing_volumes_6="../../.inputrc:/root/.inputrc:cached"
+services_airflow-testing_volumes_7="../../.rat-excludes:/opt/airflow/.rat-excludes:cached"
+services_airflow-testing_volumes_8="../../CHANGELOG.txt:/opt/airflow/CHANGELOG:cached"
+services_airflow-testing_volumes_9="../../LICENSE:/opt/airflow/LICENSE:cached"
+services_airflow-testing_volumes_10="../../MANIFEST.in:/opt/airflow/MANIFEST.in:cached"
+services_airflow-testing_volumes_11="../../NOTICE:/opt/airflow/NOTICE:cached"
+services_airflow-testing_volumes_12="../../airflow:/opt/airflow/airflow:cached"
+services_airflow-testing_volumes_13="../../common:/opt/airflow/common:cached"
+services_airflow-testing_volumes_14="../../dags:/opt/airflow/dags:cached"
+services_airflow-testing_volumes_15="../../dev:/opt/airflow/dev:cached"
+services_airflow-testing_volumes_16="../../docs:/opt/airflow/docs:cached"
+services_airflow-testing_volumes_17="../../files:/files:cached"
+services_airflow-testing_volumes_18="../../hooks:/opt/airflow/hooks:cached"
+services_airflow-testing_volumes_19="../../logs:/root/airflow/logs:cached"
+services_airflow-testing_volumes_20="../../pylintrc:/opt/airflow/pylintrc:cached"
+services_airflow-testing_volumes_21="../../pytest.ini:/opt/airflow/pytest.ini:cached"
+services_airflow-testing_volumes_22="../../scripts:/opt/airflow/scripts:cached"
+services_airflow-testing_volumes_23="../../setup.cfg:/opt/airflow/setup.cfg:cached"
+services_airflow-testing_volumes_24="../../setup.py:/opt/airflow/setup.py:cached"
+services_airflow-testing_volumes_25="../../tests:/opt/airflow/tests:cached"
+services_airflow-testing_volumes_26="../../tmp:/opt/airflow/tmp:cached"
+services_airflow-testing_environment_1="HOST_USER_ID"
+services_airflow-testing_environment_2="HOST_GROUP_ID"
+services_airflow-testing_environment_3="PYTHONDONTWRITEBYTECODE"
+services_airflow-testing_ports_1="${WEBSERVER_HOST_PORT}:8080"
+EOF
+
+}
+
+
+@test "convert yaml docker file to docker params" {
+  load bats_utils
+  run convert_docker_mounts_to_docker_params
+  diff <(echo "${output}") - << EOF
+-v
+${AIRFLOW_SOURCES}/.bash_aliases:/root/.bash_aliases:cached
+-v
+${AIRFLOW_SOURCES}/.bash_history:/root/.bash_history:cached
+-v
+${AIRFLOW_SOURCES}/.coveragerc:/opt/airflow/.coveragerc:cached
+-v
+${AIRFLOW_SOURCES}/.flake8:/opt/airflow/.flake8:cached
+-v
+${AIRFLOW_SOURCES}/.github:/opt/airflow/.github:cached
+-v
+${AIRFLOW_SOURCES}/.inputrc:/root/.inputrc:cached
+-v
+${AIRFLOW_SOURCES}/.rat-excludes:/opt/airflow/.rat-excludes:cached
+-v
+${AIRFLOW_SOURCES}/CHANGELOG.txt:/opt/airflow/CHANGELOG:cached
+-v
+${AIRFLOW_SOURCES}/LICENSE:/opt/airflow/LICENSE:cached
+-v
+${AIRFLOW_SOURCES}/MANIFEST.in:/opt/airflow/MANIFEST.in:cached
+-v
+${AIRFLOW_SOURCES}/NOTICE:/opt/airflow/NOTICE:cached
+-v
+${AIRFLOW_SOURCES}/airflow:/opt/airflow/airflow:cached
+-v
+${AIRFLOW_SOURCES}/common:/opt/airflow/common:cached
+-v
+${AIRFLOW_SOURCES}/dags:/opt/airflow/dags:cached
+-v
+${AIRFLOW_SOURCES}/dev:/opt/airflow/dev:cached
+-v
+${AIRFLOW_SOURCES}/docs:/opt/airflow/docs:cached
+-v
+${AIRFLOW_SOURCES}/files:/files:cached
+-v
+${AIRFLOW_SOURCES}/hooks:/opt/airflow/hooks:cached
+-v
+${AIRFLOW_SOURCES}/logs:/root/airflow/logs:cached
+-v
+${AIRFLOW_SOURCES}/pylintrc:/opt/airflow/pylintrc:cached
+-v
+${AIRFLOW_SOURCES}/pytest.ini:/opt/airflow/pytest.ini:cached
+-v
+${AIRFLOW_SOURCES}/scripts:/opt/airflow/scripts:cached
+-v
+${AIRFLOW_SOURCES}/setup.cfg:/opt/airflow/setup.cfg:cached
+-v
+${AIRFLOW_SOURCES}/setup.py:/opt/airflow/setup.py:cached
+-v
+${AIRFLOW_SOURCES}/tests:/opt/airflow/tests:cached
+-v
+${AIRFLOW_SOURCES}/tmp:/opt/airflow/tmp:cached
+EOF
+}


### PR DESCRIPTION
We had two sets of duplicated local volume mounts - one for ./breeze
interactive runs (with docker_compose) and the other with scripts that are used
to run static checks.

The volumes from the .yaml for docker compose are now the "source of truth"
and the bash script parses the yaml and useis volume mounts from there.

Note. This one depends on #7081. 

---
Issue link: [AIRFLOW-6475](https://issues.apache.org/jira/browse/AIRFLOW-6475/)

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
