### PR TITLE
[AIRFLOW-6476] Fix directories created by docker

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -77,4 +77,5 @@ pylint_todo.txt
 # Locally mounted files
 .*egg-info/*
 .bash_history
+.bash_aliases
 .inputrc

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -78,6 +78,19 @@ function print_info() {
     fi
 }
 
+function sanitize_file() {
+    if [[ -d "${1}" ]]; then
+        rm -rf "${1}"
+    fi
+    touch "${1}"
+
+}
+function sanitize_mounted_files() {
+    sanitize_file "${AIRFLOW_SOURCES}/.bash_history"
+    sanitize_file "${AIRFLOW_SOURCES}/.bash_aliases"
+    sanitize_file "${AIRFLOW_SOURCES}/.inputrc"
+}
+
 declare -a AIRFLOW_CONTAINER_EXTRA_DOCKER_FLAGS
 if [[ ${AIRFLOW_MOUNT_SOURCE_DIR_FOR_STATIC_CHECKS} == "true" ]]; then
     print_info
@@ -125,6 +138,7 @@ else
 fi
 
 export AIRFLOW_CONTAINER_EXTRA_DOCKER_FLAGS
+
 
 #
 # Creates cache directory where we will keep temporary files needed for the build
@@ -578,6 +592,7 @@ function basic_sanity_checks() {
     check_if_coreutils_installed
     create_cache_directory
     forget_last_answer
+    sanitize_mounted_files
 }
 
 


### PR DESCRIPTION
Some of the files that are mounted to breeze might not be created when first
time run and then docker will turn them into directories.

We should delete dirs/touch files in both breeze script and static check
scripts to get it fixed

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
