### PR TITLE
[AIRFLOW-6467] Use self.dag i/o creating a new one

### DIFF
--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -95,14 +95,11 @@ class TestExternalTaskSensor(unittest.TestCase):
         )
 
     def test_templated_sensor(self):
-        dag = DAG(TEST_DAG_ID, self.args)
-
-        with dag:
+        with self.dag:
             sensor = ExternalTaskSensor(
                 task_id='templated_task',
                 external_dag_id='dag_{{ ds }}',
-                external_task_id='task_{{ ds }}',
-                start_date=DEFAULT_DATE
+                external_task_id='task_{{ ds }}'
             )
 
         instance = TaskInstance(sensor, DEFAULT_DATE)


### PR DESCRIPTION
In this unit test method, self.dag can be used instead of creating a local variable named "dag".
---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6467

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
