### PR TITLE
[AIRFLOW-6480] Hide kerberos command if kerberos is disabled

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -933,12 +933,6 @@ class CLIFactory:
             'name': 'db',
             'subcommands': DB_COMMANDS,
         }, {
-            'name': 'kerberos',
-            'func': lazy_load_command('airflow.cli.commands.kerberos_command.kerberos'),
-            'help': "Start a kerberos ticket renewer",
-            'args': ('principal', 'keytab', 'pid',
-                     'daemon', 'stdout', 'stderr', 'log_file'),
-        }, {
             'name': 'webserver',
             'func': lazy_load_command('airflow.cli.commands.webserver_command.webserver'),
             'help': "Start a Airflow webserver instance",
@@ -1010,6 +1004,14 @@ class CLIFactory:
                         'flower_basic_auth', 'broker_api', 'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
                 },
             )
+        })
+    if conf.get("core", "security") == 'kerberos' or BUILD_DOCS:
+        subparsers.append({
+            'name': 'kerberos',
+            'func': lazy_load_command('airflow.cli.commands.kerberos_command.kerberos'),
+            'help': "Start a kerberos ticket renewer",
+            'args': ('principal', 'keytab', 'pid',
+                     'daemon', 'stdout', 'stderr', 'log_file'),
         })
     subparsers_dict = {sp.get('name') or sp['func'].__name__: sp for sp in subparsers}  # type: ignore
     dag_subparsers = (


### PR DESCRIPTION
Similar to: https://github.com/apache/airflow/pull/6877

Most users do not use Kerberos, so this command will not work.

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6480

- [X] Description above provides context of the change
- [X] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
