### PR TITLE
[AIRFLOW-XXXX] Add config to welcome first time contributors

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -145,3 +145,17 @@ labelPRBasedOnFilePath:
     - airflow/serialization/*
     - tests/serialization/*
     - docs/dag-serialization.rst
+
+# Comment to be posted to welcome users when they open their first PR
+firstPRWelcomeComment: |
+  Congratulations on your first Pull Request and welcome to the Apache Airflow community!
+  If you have any issues or are unsure about any anything please check our
+  Contribution Guide (https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst)
+
+  In case of doubts contact the developers at:
+  Mailing List: dev@airflow.apache.org
+  Slack: https://apache-airflow-slack.herokuapp.com/
+
+# Comment to be posted to congratulate user on their first merged PR
+firstPRMergeComment: >
+  Awesome work, congrats on your first merged pull request!


### PR DESCRIPTION
I have added a feature to [boring-cyborg](https://github.com/kaxil/boring-cyborg) to greet new contributors when they open new PR and when their first PR gets merged.

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
