### PR TITLE
[AIRFLOW-XXXX] Boring cyborg automatically inserts issue link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,14 @@
 ---
-Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX
+Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)
 
 - [ ] Description above provides context of the change
-- [ ] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
+- [ ] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
 - [ ] Unit tests coverage for changes (not needed for documentation changes)
 - [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
 - [ ] Relevant documentation is updated including usage instructions.
 - [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
 
-(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.
+<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.
 
 ---
 In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -159,3 +159,13 @@ firstPRWelcomeComment: |
 # Comment to be posted to congratulate user on their first merged PR
 firstPRMergeComment: >
   Awesome work, congrats on your first merged pull request!
+
+insertIssueLinkInPrDescription:
+  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"
+  matchers:
+    jiraIssueMatch:
+      titleIssueIdRegexp: \[(AIRFLOW-[0-9]{4})\]
+      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1}/)"
+    docOnlyIssueMatch:
+      titleIssueIdRegexp: \[(AIRFLOW-X{4})\]
+      descriptionIssueLink: "`Document only change, no JIRA issue`"


### PR DESCRIPTION
Issue link in PR will be now automatically inserted by the boring
cyborg probot integration. It also handles the case of document-only
changes and it will keep the link updated if the title of the PR
is updated.

---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-XXXX

- [x] Description above provides context of the change
- [x] Commit message starts with `[AIRFLOW-NNNN]`, where AIRFLOW-NNNN = JIRA ID*
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

(*) For document-only changes, no JIRA issue is needed. Commit message starts `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
