### PR TITLE
[AIRFLOW-6487]  Romove unnecessary for-loop

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -1020,6 +1020,8 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
             now = timezone.utcnow()
             file_paths_recently_processed = []
             for file_path in self._file_paths:
+                if self._file_process_interval == 0:
+                    break
                 last_finish_time = self.get_last_finish_time(file_path)
                 if (last_finish_time is not None and
                     (now - last_finish_time).total_seconds() <


### PR DESCRIPTION
---
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6487
Romove unnecessary for loop:

In DagFileProcessorManager, dag files are processed periodically. Processor manager will put dag into queue except file_paths_in_progress, file_paths_recently_processed and files_paths_at_run_limit. While min_file_process_interval = 0 in config by default, there is unnecessary for-loop when get file_paths_recently_processed.

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
