### PR TITLE
[AIRFLOW-6488] Add missing relation to op4

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -399,6 +399,7 @@ and equivalent to:
 .. code:: python
 
     op1.set_downstream([op2, op3])
+    op4.set_upstream([op2, op3])
 
 
 Relationship Builders


### PR DESCRIPTION
Context: https://airflow.apache.org/docs/stable/concepts.html#concepts-operators, near line 401
In last "and equivalent to", it seems op4 should still depend on both op2 and op3.

op1 >> op2 >> op4
op1 >> op3 >> op4

and equivalent to:

op1.set_downstream([op2, op3])
**op4.set_upstream([op2, op3])** #Expected this, but it's missing.

---
Issue link: [AIRFLOW-6488](https://issues.apache.org/jira/browse/AIRFLOW-6488/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
