### PR TITLE
[AIRFLOW-6490] Improve time delta comparison in local task job tests

### DIFF
--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -159,7 +159,10 @@ class TestLocalTaskJob(unittest.TestCase):
             for i in range(1, len(heartbeat_records)):
                 time1 = heartbeat_records[i - 1]
                 time2 = heartbeat_records[i]
-                self.assertGreaterEqual((time2 - time1).total_seconds(), job.heartrate)
+                # Assert that difference small enough to avoid:
+                # AssertionError: 1.996401 not greater than or equal to 2
+                delta = (time2 - time1).total_seconds()
+                self.assertAlmostEqual(delta, job.heartrate, delta=0.006)
 
     @unittest.skipIf('mysql' in conf.get('core', 'sql_alchemy_conn'),
                      "flaky when run on mysql")


### PR DESCRIPTION
This PR eliminates small flakiness from local task job test that occurs when something happens faster"
```
AssertionError: 1.996401 not greater than or equal to 2
```

---
Issue link: [AIRFLOW-6490](https://issues.apache.org/jira/browse/AIRFLOW-6490/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
