### PR TITLE
[AIRFLOW-6491] improve parameter handling in breeze

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,8 +168,7 @@ repos:
         name: Check Shell scripts syntax correctness
         language: docker_image
         entry: koalaman/shellcheck:stable -x -a
-        types: [shell]
-        files: ^breeze$|^breeze-complete$|\.sh$|^hooks/build$|^hooks/push$
+        files: ^breeze$|^breeze-complete$|\.sh$|^hooks/build$|^hooks/push$|\.bash$|\.bats$
         exclude: ^airflow/_vendor/.*$
       - id: lint-dockerfile
         name: Lint dockerfile

--- a/breeze
+++ b/breeze
@@ -37,19 +37,10 @@ mkdir -pv "${BUILD_CACHE_DIR}"
 mkdir -pv "${TMP_DIR}"
 mkdir -pv "${FILES_DIR}"
 
-function save_to_file {
-    # shellcheck disable=SC2005
-    echo "$(eval echo "\$$1")" > "${BUILD_CACHE_DIR}/.$1"
-}
-
-function read_from_file {
-    cat "${BUILD_CACHE_DIR}/.$1" 2>/dev/null || true
-}
-
-export PYTHON_VERSION="${PYTHON_VERSION:=$(read_from_file PYTHON_VERSION)}"
-
 # shellcheck source=scripts/ci/_utils.sh
 . "${SCRIPTS_CI_DIR}/_utils.sh"
+
+export PYTHON_VERSION="${PYTHON_VERSION:=$(read_from_file PYTHON_VERSION)}"
 
 basic_sanity_checks
 
@@ -711,50 +702,14 @@ export KUBERNETES_VERSION=${KUBERNETES_VERSION:=${_BREEZE_DEFAULT_KUBERNETES_VER
 # Default mode of Kubernetes to use
 export KUBERNETES_MODE=${KUBERNETES_MODE:=${_BREEZE_DEFAULT_KUBERNETES_MODE}}
 
-#################### Check python version ##########################################
-if [[ ${_BREEZE_ALLOWED_PYTHON_VERSIONS:=} != *" ${PYTHON_VERSION} "* ]]; then
-    echo >&2
-    echo >&2 "ERROR:  Allowed Python versions: [${_BREEZE_ALLOWED_PYTHON_VERSIONS}]. Is: '${PYTHON_VERSION}'."
-    echo >&2
-    echo >&2 "Switch to virtualenv with the supported python version or specify python with --python flag."
-    echo >&2
-    exit 1
-fi
+check_for_allowed_params "PYTHON_VERSION"  "Python version" "--python"
+check_for_allowed_params "BACKEND"  "backend" "--backend"
+check_for_allowed_params "KUBERNETES_MODE"  "Kubernetes mode" "--kubernetes-mode"
+check_for_allowed_params "ENV"  "environment" "--env"
+check_for_allowed_params "KUBERNETES_VERSION"  "Kubernetes version" "--kubernetes-version"
 
-#################### Check environments ##########################################
-if [[ ${_BREEZE_ALLOWED_ENVS:=} != *" ${ENV} "* ]]; then
-    echo >&2
-    echo >&2 "ERROR:  Allowed environments are [${_BREEZE_ALLOWED_ENVS}]. Used: '${ENV}'"
-    echo >&2
-    exit 1
-fi
-
-#################### Check backends ##########################################
-if [[ ${_BREEZE_ALLOWED_BACKENDS:=} != *" ${BACKEND} "* ]]; then
-    echo >&2
-    echo >&2 "ERROR:  Allowed backends are [${_BREEZE_ALLOWED_BACKENDS}]. Used: '${BACKEND}'"
-    echo >&2
-    exit 1
-fi
-
-#################### Check environments ##########################################
-if [[ ${_BREEZE_ALLOWED_KUBERNETES_VERSIONS} != *" ${KUBERNETES_VERSION} "* ]]; then
-    echo >&2
-    echo >&2 "ERROR:  Allowed kubernetes versions" \
-         "are [${_BREEZE_ALLOWED_KUBERNETES_VERSIONS}]. Used: '${KUBERNETES_VERSION}'"
-    echo >&2
-    exit 1
-fi
-
-#################### Check environments ##########################################
-if [[ ${_BREEZE_ALLOWED_KUBERNETES_MODES} != *" ${KUBERNETES_MODE} "* ]]; then
-    echo >&2
-    echo >&2 "ERROR:  Allowed kubernetes modes" \
-         "are [${_BREEZE_ALLOWED_KUBERNETES_MODES}]. Used: '${KUBERNETES_MODE}'"
-    echo >&2
-    exit 1
-fi
-
+save_to_file DOCKERHUB_USER
+save_to_file DOCKERHUB_REPO
 
 # Those files are mounted into container when run locally
 # .bash_history is preserved and you can modify .bash_aliases and .inputrc
@@ -762,14 +717,6 @@ fi
 touch "${MY_DIR}/.bash_history"
 touch "${MY_DIR}/.bash_aliases"
 touch "${MY_DIR}/.inputrc"
-
-save_to_file BACKEND
-save_to_file ENV
-save_to_file KUBERNETES_VERSION
-save_to_file KUBERNETES_MODE
-save_to_file PYTHON_VERSION
-save_to_file DOCKERHUB_USER
-save_to_file DOCKERHUB_REPO
 
 #################### Cleanup image if requested ########################################
 if [[ "${CLEANUP_IMAGES}" == "true" ]]; then

--- a/tests/bats/bats_utils.bash
+++ b/tests/bats/bats_utils.bash
@@ -15,5 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-export AIRFLOW_SOURCES=$(pwd)
+AIRFLOW_SOURCES=$(pwd)
+export AIRFLOW_SOURCES
 source scripts/ci/_utils.sh

--- a/tests/bats/test_breeze_params.bats
+++ b/tests/bats/test_breeze_params.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2030
+# shellcheck disable=SC2031
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+setup() {
+  load bats_utils
+  rm -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
+}
+
+teardown() {
+  load bats_utils
+  rm -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
+}
+
+@test "Test missing value for a parameter" {
+  load bats_utils
+  export _BREEZE_ALLOWED_TEST_PARAMS=" a b c "
+  run check_for_allowed_params "TEST_PARAM"  "Test Param" "--message"
+  diff <(echo "${output}") - <<EOF
+
+ERROR:  Allowed Test Param: [ a b c ]. Is: ''.
+
+Switch to supported value with --message flag.
+EOF
+  [ "${status}" == "1" ]
+}
+
+@test "Test wrong value for a parameter but proper stored in the .build/PARAM" {
+  load bats_utils
+
+  export _BREEZE_ALLOWED_TEST_PARAMS=" a b c "
+  export TEST_PARAM=x
+  echo "a" > "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
+  run check_for_allowed_params "TEST_PARAM"  "Test Param" "--message"
+  diff <(echo "${output}") - <<EOF
+
+ERROR:  Allowed Test Param: [ a b c ]. Is: 'x'.
+
+Switch to supported value with --message flag.
+EOF
+  [ -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
+  diff <(cat "${AIRFLOW_SOURCES}/.build/.TEST_PARAM") <(echo "a")
+  [ "${status}" == "1" ]
+}
+
+@test "Test wrong value for a parameter stored in the .build/PARAM" {
+  load bats_utils
+
+  export _BREEZE_ALLOWED_TEST_PARAMS=" a b c "
+  export TEST_PARAM=x
+  echo "x" > "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
+  run check_for_allowed_params "TEST_PARAM"  "Test Param" "--message"
+  diff <(echo "${output}") - <<EOF
+
+ERROR:  Allowed Test Param: [ a b c ]. Is: 'x'.
+
+Switch to supported value with --message flag.
+
+Removing ${AIRFLOW_SOURCES}/.build/.TEST_PARAM. Next time you run it, it should be OK.
+EOF
+  [ ! -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
+  [ "${status}" == "1" ]
+}
+
+
+@test "Test correct value for a parameter" {
+  load bats_utils
+  export _BREEZE_ALLOWED_TEST_PARAMS=" a b c "
+  export TEST_PARAM=a
+  run check_for_allowed_params "TEST_PARAM"  "Test Param" "--message"
+  diff <(echo "${output}") <(echo "")
+  [ -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
+  diff <(echo "a") <(cat "${AIRFLOW_SOURCES}/.build/.TEST_PARAM")
+  [ "${status}" == "0" ]
+}
+
+@test "Test read_parameter from missing file" {
+  load bats_utils
+  run read_from_file TEST_PARAM
+  [ -z "${TEST_FILE}" ]
+  diff <(echo "${output}") <(echo "")
+  [ ! -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
+  [ "${status}" == "0" ]
+}
+
+@test "Test read_parameter from file" {
+  load bats_utils
+  echo "a" > "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
+  run read_from_file TEST_PARAM
+  diff <(echo "${output}") <(echo "a")
+  [ -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
+  [ "${status}" == "0" ]
+}


### PR DESCRIPTION
While working on improving the way we run Kubernetes tests, we found out that I
need to fix handling of parameters - we change Kubernetes version used via Kind
and the old versions are no longer valid, however it was not properly
removed/saved.

We use the opportunity to add automated tests for that feature.

This commit depends on #7081 so please check only last commit.

---
Issue link: [AIRFLOW-6491](https://issues.apache.org/jira/browse/AIRFLOW-6491/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
