### PR TITLE
[WIP][AIRFLOW-6494] SSH host_proxy has to be fresh

### DIFF
--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -171,6 +171,13 @@ class SSHHook(BaseHook):
                              'against Man-In-The-Middle attacks')
             # Default is RejectPolicy
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        # restart host_proxy to avoid "Broken Pipe" error
+        if getattr(self, 'host_proxy') is not None:
+            if not self.host_proxy.closed:
+                self.host_proxy.close()
+            self.host_proxy = paramiko.ProxyCommand(' '.join(self.host_proxy.cmd))
+
         connect_kwargs = dict(
             hostname=self.remote_host,
             username=self.username,


### PR DESCRIPTION
AIRFLOW-1762 moved host_proxy in contrib/hooks/ssh_hook.py to init, which makes the ssh client to reuse the proxy socket whenever `get_conn()` is called.

The inconsistency between when SSH Client and ProxyCommand is initialized and closed sometimes results in "Broken Pipe" error when `get_conn()` is called multiple times.

This commit also clean up some parameter parsing logic that rendered
extraneous by AIRFLOW-1762.

---
Issue link: [AIRFLOW-6494](https://issues.apache.org/jira/browse/AIRFLOW-6494)

- [x] Description above provides context of the change
- [ ] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
