### PR TITLE
[AIRFLOW-6347] BugFix: Can't get task logs when serialization is enabled

### DIFF
--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -98,7 +98,6 @@
         "is_paused_upon_creation":  { "type": "boolean" }
       },
       "required": [
-        "params",
         "_dag_id",
         "fileloc",
         "tasks"

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -266,7 +266,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
     Class specific attributes used by UI are move to object attributes.
     """
 
-    _decorated_fields = {'executor_config', 'params'}
+    _decorated_fields = {'executor_config'}
 
     _CONSTRUCTOR_PARAMS = dict(signature(BaseOperator).parameters)
 
@@ -453,7 +453,7 @@ class SerializedDAG(DAG, BaseSerialization):
     not pickle-able. SerializedDAG works for all DAGs.
     """
 
-    _decorated_fields = {'schedule_interval', 'default_args', 'params'}
+    _decorated_fields = {'schedule_interval', 'default_args'}
 
     @staticmethod
     def __get_constructor_defaults():  # pylint: disable=no-method-argument

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -268,7 +268,10 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
     _decorated_fields = {'executor_config'}
 
-    _CONSTRUCTOR_PARAMS = dict(signature(BaseOperator).parameters)
+    _CONSTRUCTOR_PARAMS = {
+        k: v for k, v in signature(BaseOperator).parameters.items()
+        if v.default is not v.empty
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -465,6 +468,7 @@ class SerializedDAG(DAG, BaseSerialization):
         }
         return {
             param_to_attr.get(k, k): v for k, v in signature(DAG).parameters.items()
+            if v.default is not v.empty
         }
     _CONSTRUCTOR_PARAMS = __get_constructor_defaults.__func__()  # type: ignore
     del __get_constructor_defaults

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -253,7 +253,9 @@ class BaseSerialization:
         default. (This is because ``"default" is "default"`` will be False as
         they are different strings with the same characters.)
 
-        Also returns True if the value is an empty list or empty dict.
+        Also returns True if the value is an empty list or empty dict. This is done
+        to account for the case where the default value of the field is None but has the
+        ``field = field or {}`` set.
         """
         if attrname in cls._CONSTRUCTOR_PARAMS and \
                 (cls._CONSTRUCTOR_PARAMS[attrname].default is value or (value in [{}, []])):

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -252,6 +252,8 @@ class BaseSerialization:
         user explicitly specifies an attribute with the same "value" as the
         default. (This is because ``"default" is "default"`` will be False as
         they are different strings with the same characters.)
+
+        Also returns True if the value is an empty list or empty dict.
         """
         if attrname in cls._CONSTRUCTOR_PARAMS and \
                 (cls._CONSTRUCTOR_PARAMS[attrname].default is value or (value in [{}, []])):

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -64,7 +64,7 @@ def apply_defaults(func):
             dag_args = copy(dag.default_args) or {}
             dag_params = copy(dag.params) or {}
 
-        params = kwargs.get('params', {})
+        params = kwargs.get('params', {}) or {}
         dag_params.update(params)
 
         default_args = {}

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -391,7 +391,7 @@ class TestStringifiedDAGs(unittest.TestCase):
         (None, {}),
         ({"param_1": "value_1"}, {"param_1": "value_1"}),
     ])
-    def test_params_roundtrip(self, val, expected_val):
+    def test_dag_params_roundtrip(self, val, expected_val):
         """
         Test that params work both on Serialized DAGs & Tasks
         """
@@ -407,6 +407,28 @@ class TestStringifiedDAGs(unittest.TestCase):
         deserialized_dag = SerializedDAG.from_dict(serialized_dag)
         deserialized_simple_task = deserialized_dag.task_dict["simple_task"]
         self.assertEqual(expected_val, deserialized_dag.params)
+        self.assertEqual(expected_val, deserialized_simple_task.params)
+
+    @parameterized.expand([
+        (None, {}),
+        ({"param_1": "value_1"}, {"param_1": "value_1"}),
+    ])
+    def test_task_params_roundtrip(self, val, expected_val):
+        """
+        Test that params work both on Serialized DAGs & Tasks
+        """
+        dag = DAG(dag_id='simple_dag')
+        BaseOperator(task_id='simple_task', dag=dag, params=val,
+                     start_date=datetime(2019, 8, 1))
+
+        serialized_dag = SerializedDAG.to_dict(dag)
+        if val:
+            self.assertIn("params", serialized_dag["dag"]["tasks"][0])
+        else:
+            self.assertNotIn("params", serialized_dag["dag"]["tasks"][0])
+
+        deserialized_dag = SerializedDAG.from_dict(serialized_dag)
+        deserialized_simple_task = deserialized_dag.task_dict["simple_task"]
         self.assertEqual(expected_val, deserialized_simple_task.params)
 
     def test_extra_serialized_field_and_operator_links(self):

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -390,10 +390,6 @@ class TestStringifiedDAGs(unittest.TestCase):
     @parameterized.expand([
         (None, {}),
         ({"param_1": "value_1"}, {"param_1": "value_1"}),
-        (
-            {"param_1": {"nested_param_1": "value_1"}},
-            {"param_1": {"nested_param_1": "value_1"}},
-        ),
     ])
     def test_params_roundtrip(self, val, expected_val):
         """

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -55,7 +55,6 @@ serialized_simple_dag_ground_truth = {
         },
         "start_date": 1564617600.0,
         "is_paused_upon_creation": False,
-        "params": {},
         "_dag_id": "simple_dag",
         "fileloc": None,
         "tasks": [
@@ -159,6 +158,9 @@ def collect_dags():
     dags.update(make_example_dags(example_dags))
     dags.update(make_example_dags(contrib_example_dags))
     dags.update(make_example_dags(gcp_example_dags))
+
+    # Filter subdags as they are stored in same row in Serialized Dag table
+    dags = {dag_id: dag for dag_id, dag in dags.items() if not dag.is_subdag}
     return dags
 
 
@@ -241,6 +243,9 @@ class TestStringifiedDAGs(unittest.TestCase):
         self.assertTrue(set(stringified_dags.keys()) == set(dags.keys()))
 
         # Verify deserialized DAGs.
+        for dag_id in stringified_dags:
+            self.validate_deserialized_dag(stringified_dags[dag_id], dags[dag_id])
+
         example_skip_dag = stringified_dags['example_skip_dag']
         skip_operator_1_task = example_skip_dag.task_dict['skip_operator_1']
         self.validate_deserialized_task(
@@ -260,6 +265,22 @@ class TestStringifiedDAGs(unittest.TestCase):
             SubDagOperator.ui_fgcolor
         )
 
+    def validate_deserialized_dag(self, serialized_dag, dag):
+        """
+        Verify that all example DAGs work with DAG Serialization by
+        checking fields between Serialized Dags & non-Serialized Dags
+        """
+        fields_to_check = [
+            "task_ids", "params", "fileloc", "max_active_runs", "concurrency",
+            "is_paused_upon_creation", "doc_md", "safe_dag_id", "is_subdag",
+            "catchup", "description", "start_date", "end_date", "parent_dag",
+            "template_searchpath"
+        ]
+
+        # fields_to_check = dag.get_serialized_fields()
+        for field in fields_to_check:
+            self.assertEqual(getattr(serialized_dag, field), getattr(dag, field))
+
     def validate_deserialized_task(self, task, task_type, ui_color, ui_fgcolor):
         """Verify non-airflow operators are casted to BaseOperator."""
         self.assertTrue(isinstance(task, SerializedBaseOperator))
@@ -275,6 +296,8 @@ class TestStringifiedDAGs(unittest.TestCase):
             self.assertTrue(isinstance(task.subdag, DAG))
         else:
             self.assertIsNone(task.subdag)
+        self.assertEqual({}, task.params)
+        self.assertEqual({}, task.executor_config)
 
     @parameterized.expand([
         (datetime(2019, 8, 1), None, datetime(2019, 8, 1)),
@@ -335,7 +358,6 @@ class TestStringifiedDAGs(unittest.TestCase):
             "__version": 1,
             "dag": {
                 "default_args": {"__type": "dict", "__var": {}},
-                "params": {},
                 "_dag_id": "simple_dag",
                 "fileloc": __file__,
                 "tasks": [],
@@ -364,6 +386,32 @@ class TestStringifiedDAGs(unittest.TestCase):
 
         round_tripped = SerializedDAG._deserialize(serialized)
         self.assertEqual(val, round_tripped)
+
+    @parameterized.expand([
+        (None, {}),
+        ({"param_1": "value_1"}, {"param_1": "value_1"}),
+        (
+            {"param_1": {"nested_param_1": "value_1"}},
+            {"param_1": {"nested_param_1": "value_1"}},
+        ),
+    ])
+    def test_params_roundtrip(self, val, expected_val):
+        """
+        Test that params work both on Serialized DAGs & Tasks
+        """
+        dag = DAG(dag_id='simple_dag', params=val)
+        BaseOperator(task_id='simple_task', dag=dag, start_date=datetime(2019, 8, 1))
+
+        serialized_dag = SerializedDAG.to_dict(dag)
+        if val:
+            self.assertIn("params", serialized_dag["dag"])
+        else:
+            self.assertNotIn("params", serialized_dag["dag"])
+
+        deserialized_dag = SerializedDAG.from_dict(serialized_dag)
+        deserialized_simple_task = deserialized_dag.task_dict["simple_task"]
+        self.assertEqual(expected_val, deserialized_dag.params)
+        self.assertEqual(expected_val, deserialized_simple_task.params)
 
     def test_extra_serialized_field_and_operator_links(self):
         """


### PR DESCRIPTION
Quoting from Jira:

**Problem**:
When I set next config options in `airflow.cfg`:

```ini
[core]
store_serialized_dags = True
min_serialized_dag_update_interval = 3
 ```

View with task logs shows infinity Js spinner, while in webserver log I see next error:
```
[2019-12-25 14:48:57,640] {{app.py:1891}} ERROR - Exception on /get_logs_with_metadata [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/www_rbac/decorators.py", line 121, in wrapper
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/flask_appbuilder/security/decorators.py", line 101, in wraps
    return f(self, *args, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/www_rbac/decorators.py", line 56, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/utils/db.py", line 74, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/www_rbac/views.py", line 637, in get_logs_with_metadata
    logs, metadata = _get_logs_with_metadata(try_number, metadata)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/www_rbac/views.py", line 628, in _get_logs_with_metadata
    logs, metadatas = handler.read(ti, try_number, metadata=metadata)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/utils/log/file_task_handler.py", line 169, in read
    log, metadata = self._read(task_instance, try_number_element, metadata)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/utils/log/file_task_handler.py", line 98, in _read
    log_relative_path = self._render_filename(ti, try_number)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/utils/log/file_task_handler.py", line 75, in _render_filename
    jinja_context = ti.get_template_context()
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/utils/db.py", line 74, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 1149, in get_template_context
    if 'tables' in task.params:
TypeError: argument of type 'NoneType' is not iterable
```

**Solution:**
This is because we use `self.params = params or {}` and where default value of `params` is `None` in DAG and Operators and Dag S10n ignore all the None field. 

While de-serializing `params` was being set to None because of the following line:

```python
keys_to_set_none = dag.get_serialized_fields() - encoded_dag.keys() - cls._CONSTRUCTOR_PARAMS.keys()
        for k in keys_to_set_none:
            setattr(dag, k, None)
```


---
Issue link: [AIRFLOW-6347](https://issues.apache.org/jira/browse/AIRFLOW-6347/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
