### PR TITLE
AIRFLOW-XXXX Update docs on example files for k8s

### DIFF
--- a/docs/executor/kubernetes.rst
+++ b/docs/executor/kubernetes.rst
@@ -20,7 +20,7 @@ Kubernetes Executor
 
 The kubernetes executor is introduced in Apache Airflow 1.10.0. The Kubernetes executor will create a new pod for every task instance.
 
-Example helm charts are available at ``scripts/ci/kubernetes/app/{secrets,volumes,postgres}.yaml`` in the source distribution.
+Example kubernetes files are available at ``scripts/ci/kubernetes/app/{secrets,volumes,postgres}.yaml`` in the source distribution (please note that these examples are not ideal for production environments).
 The volumes are optional and depend on your configuration. There are two volumes available:
 
 - **Dags**:

--- a/docs/executor/kubernetes.rst
+++ b/docs/executor/kubernetes.rst
@@ -20,7 +20,7 @@ Kubernetes Executor
 
 The kubernetes executor is introduced in Apache Airflow 1.10.0. The Kubernetes executor will create a new pod for every task instance.
 
-Example helm charts are available at ``scripts/ci/kubernetes/app/{airflow,volumes,postgres}.yaml`` in the source distribution.
+Example helm charts are available at ``scripts/ci/kubernetes/app/{secrets,volumes,postgres}.yaml`` in the source distribution.
 The volumes are optional and depend on your configuration. There are two volumes available:
 
 - **Dags**:


### PR DESCRIPTION
 Update docs on example files for k8s as there is no longer an `airflow.yaml` file in `scripts/ci/kubernetes/app/`, but there is now a `secrets.yaml`

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
