### PR TITLE
[AIRFLOW-6504] Allow specifying configmap for Airflow Local Setting

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1561,20 +1561,19 @@
 
         ``airflow-configmap.yaml``:
 
-          .. code-block:: yaml
+        .. code-block:: yaml
 
-            ---
-            apiVersion: v1
-            kind: ConfigMap
-            metadata:
-              name: airflow-configmap
-            data:
-              airflow_local_settings.py: |
-                  def pod_mutation_hook(pod):
-                      pod.labels.update({"organization": "abc"})
-
-              airflow.cfg: |
-                  ...
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: airflow-configmap
+          data:
+            airflow_local_settings.py: |
+                def pod_mutation_hook(pod):
+                    ...
+            airflow.cfg: |
+                ...
       version_added: ~
       type: string
       example: "airflow-configmap"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1546,10 +1546,38 @@
       default: "default"
     - name: airflow_configmap
       description: |
-        The name of the Kubernetes ConfigMap Containing the Airflow Configuration (this file)
+        The name of the Kubernetes ConfigMap containing the Airflow Configuration (this file)
       version_added: ~
       type: string
-      example: ~
+      example: "airflow-configmap"
+      default: ""
+    - name: airflow_local_settings_configmap
+      description: |
+        The name of the Kubernetes ConfigMap containing ``airflow_local_settings.py`` file.
+
+        For example:
+
+        ``airflow_local_settings_configmap = "airflow-configmap"`` if you have the following ConfigMap.
+
+        ``airflow-configmap.yaml``:
+
+          .. code-block:: yaml
+
+            ---
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: airflow-configmap
+            data:
+              airflow_local_settings.py: |
+                  def pod_mutation_hook(pod):
+                      pod.labels.update({"organization": "abc"})
+
+              airflow.cfg: |
+                  ...
+      version_added: ~
+      type: string
+      example: "airflow-configmap"
       default: ""
     - name: dags_in_image
       description: |

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -694,8 +694,34 @@ worker_pods_creation_batch_size = 1
 # The Kubernetes namespace where airflow workers should be created. Defaults to ``default``
 namespace = default
 
-# The name of the Kubernetes ConfigMap Containing the Airflow Configuration (this file)
+# The name of the Kubernetes ConfigMap containing the Airflow Configuration (this file)
+# Example: airflow_configmap = airflow-configmap
 airflow_configmap =
+
+# The name of the Kubernetes ConfigMap containing ``airflow_local_settings.py`` file.
+#
+# For example:
+#
+# ``airflow_local_settings_configmap = "airflow-configmap"`` if you have the following ConfigMap.
+#
+# ``airflow-configmap.yaml``:
+#
+#   .. code-block:: yaml
+#
+#     ---
+#     apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: airflow-configmap
+#     data:
+#       airflow_local_settings.py: |
+#           def pod_mutation_hook(pod):
+#               pod.labels.update({"organization": "abc"})
+#
+#       airflow.cfg: |
+#           ...
+# Example: airflow_local_settings_configmap = airflow-configmap
+airflow_local_settings_configmap =
 
 # For docker image already contains DAGs, this is set to ``True``, and the worker will
 # search for dags in dags_folder,

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -706,20 +706,19 @@ airflow_configmap =
 #
 # ``airflow-configmap.yaml``:
 #
-#   .. code-block:: yaml
+# .. code-block:: yaml
 #
-#     ---
-#     apiVersion: v1
-#     kind: ConfigMap
-#     metadata:
-#       name: airflow-configmap
-#     data:
-#       airflow_local_settings.py: |
-#           def pod_mutation_hook(pod):
-#               pod.labels.update({"organization": "abc"})
-#
-#       airflow.cfg: |
-#           ...
+#   ---
+#   apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: airflow-configmap
+#   data:
+#     airflow_local_settings.py: |
+#         def pod_mutation_hook(pod):
+#             ...
+#     airflow.cfg: |
+#         ...
 # Example: airflow_local_settings_configmap = airflow-configmap
 airflow_local_settings_configmap =
 

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -194,6 +194,11 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
         # configmap
         self.airflow_configmap = conf.get(self.kubernetes_section, 'airflow_configmap')
 
+        # The worker pod may optionally have a valid Airflow local settings loaded via a
+        # configmap
+        self.airflow_local_settings_configmap = conf.get(
+            self.kubernetes_section, 'airflow_local_settings_configmap')
+
         affinity_json = conf.get(self.kubernetes_section, 'affinity')
         if affinity_json:
             self.kube_affinity = json.loads(affinity_json)

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -280,6 +280,17 @@ class WorkerConfiguration(LoggingMixin):
                 read_only=True
             )
 
+        # Mount the airflow_local_settings.py file via a configmap the user has specified
+        if self.kube_config.airflow_local_settings_configmap:
+            config_volume_name = 'airflow-config'
+            config_path = '{}/config/airflow_local_settings.py'.format(self.worker_airflow_home)
+            volume_mounts[config_volume_name] = k8s.V1VolumeMount(
+                name=config_volume_name,
+                mount_path=config_path,
+                sub_path='airflow_local_settings.py',
+                read_only=True
+            )
+
         return list(volume_mounts.values())
 
     def _get_volumes(self) -> List[k8s.V1Volume]:
@@ -346,6 +357,16 @@ class WorkerConfiguration(LoggingMixin):
                 name=config_volume_name,
                 config_map=k8s.V1ConfigMapVolumeSource(
                     name=self.kube_config.airflow_configmap
+                )
+            )
+
+        # Mount the airflow_local_settings.py file via a configmap the user has specified
+        if self.kube_config.airflow_local_settings_configmap:
+            config_volume_name = 'airflow-config'
+            volumes[config_volume_name] = k8s.V1Volume(
+                name=config_volume_name,
+                config_map=k8s.V1ConfigMapVolumeSource(
+                    name=self.kube_config.airflow_local_settings_configmap
                 )
             )
 


### PR DESCRIPTION
Currently `airflow.cfg` file can be passed via ConfigMap using `airflow_configmap` under `[kubernetes]` section setting.

We want to be able to specify `airflow_local_settings.py` via configmap too so that the Kubernetes Worker has this file. We need `airflow_local_settings.py` to specify pod_mutation_hook. 

Without that currently, if we are using `KubernetesExecutor` and have a task with `KubernetesPodOperator`, it will inherit and change Pod using `pod_mutation_hook`

---
Issue link: [AIRFLOW-6504](https://issues.apache.org/jira/browse/AIRFLOW-6504/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
