### PR TITLE
[AIRFLOW-6507] Replace the use of imp.load_source with another solution.

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -248,7 +248,7 @@ class DagBag(BaseDagBag, LoggingMixin):
 
             with timeout(self.DAGBAG_IMPORT_TIMEOUT):
                 try:
-                    m = imp.load_source(mod_name, filepath)
+                    m = importlib.machinery.SourceFileLoader(mod_name, filepath).load_module()
                     mods.append(m)
                 except Exception as e:
                     self.log.exception("Failed to import: %s", filepath)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -247,7 +247,9 @@ class DagBag(BaseDagBag, LoggingMixin):
 
             with timeout(self.DAGBAG_IMPORT_TIMEOUT):
                 try:
-                    m = importlib.machinery.SourceFileLoader(mod_name, filepath).load_module()
+                    spec = importlib.util.spec_from_file_location(mod_name, filepath)
+                    m = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(m)
                     mods.append(m)
                 except Exception as e:
                     self.log.exception("Failed to import: %s", filepath)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -250,6 +250,7 @@ class DagBag(BaseDagBag, LoggingMixin):
                     loader = importlib.machinery.SourceFileLoader(mod_name, filepath)
                     spec = importlib.util.spec_from_loader(mod_name, loader)
                     m = importlib.util.module_from_spec(spec)
+                    sys.modules[spec.name] = m
                     loader.exec_module(m)
                     mods.append(m)
                 except Exception as e:

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -247,9 +247,10 @@ class DagBag(BaseDagBag, LoggingMixin):
 
             with timeout(self.DAGBAG_IMPORT_TIMEOUT):
                 try:
-                    spec = importlib.util.spec_from_file_location(mod_name, filepath)
+                    loader = importlib.machinery.SourceFileLoader(mod_name, filepath)
+                    spec = importlib.util.spec_from_loader(mod_name, loader)
                     m = importlib.util.module_from_spec(spec)
-                    spec.loader.exec_module(m)
+                    loader.exec_module(m)
                     mods.append(m)
                 except Exception as e:
                     self.log.exception("Failed to import: %s", filepath)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -18,7 +18,6 @@
 # under the License.
 
 import hashlib
-import imp
 import importlib
 import os
 import sys


### PR DESCRIPTION
As of Python 3.4, imp module will be deprecated and recommended to use importlib.
https://docs.python.org/3/library/imp.html

Almost all the part of code in Airflow uses importlib except for imp.load_source in models/dagbag.py.
This change propose a solution that use `importlib.SourceFileLoader`.

I didn't add new test-case because existing test-cases in `TestDagBag` covers.

---
Issue link: [AIRFLOW-6507](https://issues.apache.org/jira/browse/AIRFLOW-6507/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
