### PR TITLE
[AIRFLOW-6508] Update the version of cattrs from 0.9 to 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -450,7 +450,7 @@ def do_setup():
             'argcomplete~=1.10',
             'attrs~=19.3',
             'cached_property~=1.5',
-            'cattrs~=0.9',
+            'cattrs~=1.0',
             'colorlog==4.0.2',
             'croniter>=0.3.17, <0.4',
             'cryptography>=0.9.3',


### PR DESCRIPTION
cattrs 0.9 with Python 3.8 causes following error.
```
$ airflow
Traceback (most recent call last):
  File "/Users/sarutak/airflow-env/bin/airflow", line 27, in <module>
    from airflow.bin.cli import CLIFactory
  File "/Users/sarutak/airflow-env/lib/python3.8/site-packages/airflow/__init__.py", line 40, in <module>
    from airflow.models.dag import DAG
  File "/Users/sarutak/airflow-env/lib/python3.8/site-packages/airflow/models/__init__.py", line 21, in <module>
    from airflow.models.baseoperator import BaseOperator, BaseOperatorLink  # noqa: F401
  File "/Users/sarutak/airflow-env/lib/python3.8/site-packages/airflow/models/baseoperator.py", line 41, in <module>
    from airflow.lineage import apply_lineage, prepare_lineage
  File "/Users/sarutak/airflow-env/lib/python3.8/site-packages/airflow/lineage/__init__.py", line 28, in <module>
    from cattr import structure, unstructure
  File "/Users/sarutak/airflow-env/lib/python3.8/site-packages/cattr/__init__.py", line 2, in <module>
    from .converters import Converter, UnstructureStrategy
  File "/Users/sarutak/airflow-env/lib/python3.8/site-packages/cattr/converters.py", line 3, in <module>
    from ._compat import (
  File "/Users/sarutak/airflow-env/lib/python3.8/site-packages/cattr/_compat.py", line 86, in <module>
    from typing import _Union
ImportError: cannot import name '_Union' from 'typing' (/opt/python/3.8.0/lib/python3.8/typing.py) 
```
This issue is resolved in cattrs 1.0.
https://github.com/Tinche/cattrs/pull/73

So let's update it.

---
Issue link: [AIRFLOW-6508](https://issues.apache.org/jira/browse/AIRFLOW-6508/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
