### PR TITLE
[AIRFLOW-6509] Description for how to create an user is incorrect in some docs.

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -31,7 +31,7 @@ following CLI commands to create an account:
 .. code-block:: bash
 
     # create an admin user
-    airflow users -c --username admin --firstname Peter --lastname Parker --role Admin --email spiderman@superhero.org
+    airflow users create --username admin --firstname Peter --lastname Parker --role Admin --email spiderman@superhero.org
 
 It is however possible to switch on authentication by either using one of the supplied
 backends or creating your own.
@@ -50,7 +50,7 @@ Password
 
 One of the simplest mechanisms for authentication is requiring users to specify a password before logging in.
 
-Please use command line interface ``airflow users --create`` to create accounts, or do that in the UI.
+Please use command line interface ``airflow users create`` to create accounts, or do that in the UI.
 
 
 LDAP

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -36,7 +36,7 @@ The installation is quick and straightforward.
     airflow db init
 
     # if you build with master
-    airflow users -c --username admin --firstname Peter --lastname Parker --role Admin --email spiderman@superhero.org
+    airflow users create --username admin --firstname Peter --lastname Parker --role Admin --email spiderman@superhero.org
 
     # start the web server, default port is 8080
     airflow webserver -p 8080


### PR DESCRIPTION
In `start.rst` and `security.rst`, description for how to create user is wrong.
We can't do like
```
airflow users -c ...
```

Instead, we should do like
``
airflow users create ...
```

---
Issue link: [AIRFLOW-6509](https://issues.apache.org/jira/browse/AIRFLOW-6509/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
