### PR TITLE
[AIRFLOW-6510] - Fix Druid operator rendering from file

### DIFF
--- a/tests/contrib/operators/test_druid_operator.py
+++ b/tests/contrib/operators/test_druid_operator.py
@@ -61,7 +61,6 @@ class TestDruidOperator(unittest.TestCase):
         )
         ti = TaskInstance(operator, DEFAULT_DATE)
         ti.render_templates()
-
         expected = '''
             {
                 "type": "index_hadoop",

--- a/tests/contrib/operators/test_druid_operator.py
+++ b/tests/contrib/operators/test_druid_operator.py
@@ -62,19 +62,19 @@ class TestDruidOperator(unittest.TestCase):
         ti = TaskInstance(operator, DEFAULT_DATE)
         ti.render_templates()
 
-        expected = '''{
-    "datasource": "datasource_prd",
-    "spec": {
-        "dataSchema": {
-            "granularitySpec": {
-                "intervals": [
-                    "2017-01-01/2017-01-02"
-                ]
+        expected = '''
+            {
+                "type": "index_hadoop",
+                "datasource": "datasource_prd",
+                "spec": {
+                    "dataSchema": {
+                        "granularitySpec": {
+                            "intervals": ["2017-01-01/2017-01-02"]
+                        }
+                    }
+                }
             }
-        }
-    },
-    "type": "index_hadoop"
-}'''
+        '''
         self.assertEqual(expected, getattr(operator, 'json_index_file'))
 
 

--- a/tests/contrib/operators/test_druid_operator.py
+++ b/tests/contrib/operators/test_druid_operator.py
@@ -47,7 +47,7 @@ class TestDruidOperator(unittest.TestCase):
             )
 
             open_mock.assert_called_once_with('index_spec.json')
-            self.assertEqual(druid.index_spec_str, '{\n    "some": "json"\n}')
+            self.assertEqual(druid.json_index_file, '{\n    "some": "json"\n}')
 
     def test_render_template(self):
         json_str = '''

--- a/tests/contrib/operators/test_druid_operator.py
+++ b/tests/contrib/operators/test_druid_operator.py
@@ -19,7 +19,6 @@
 #
 
 import unittest
-from unittest import mock
 
 from airflow import DAG
 from airflow.contrib.operators.druid_operator import DruidOperator
@@ -37,18 +36,6 @@ class TestDruidOperator(unittest.TestCase):
         }
         self.dag = DAG('test_dag_id', default_args=args)
 
-    def test_read_spec_from_file(self):
-        open_mock = mock.mock_open(read_data='{"some": "json"}')
-        with mock.patch('airflow.contrib.operators.druid_operator.open', open_mock, create=True) as open_mock:
-            druid = DruidOperator(
-                task_id='druid_indexing_job',
-                json_index_file='index_spec.json',
-                dag=self.dag
-            )
-
-            open_mock.assert_called_once_with('index_spec.json')
-            self.assertEqual(druid.json_index_file, '{\n    "some": "json"\n}')
-
     def test_render_template(self):
         json_str = '''
             {
@@ -63,22 +50,19 @@ class TestDruidOperator(unittest.TestCase):
                 }
             }
         '''
-        open_mock = mock.mock_open(read_data=json_str)
-        with mock.patch('airflow.contrib.operators.druid_operator.open', open_mock, create=True) as open_mock:
-            operator = DruidOperator(
-                task_id='spark_submit_job',
-                json_index_file='index_spec.json',
-                params={
-                    'index_type': 'index_hadoop',
-                    'datasource': 'datasource_prd'
-                },
-                dag=self.dag
-            )
-            ti = TaskInstance(operator, DEFAULT_DATE)
-            ti.render_templates()
+        operator = DruidOperator(
+            task_id='spark_submit_job',
+            json_index_file=json_str,
+            params={
+                'index_type': 'index_hadoop',
+                'datasource': 'datasource_prd'
+            },
+            dag=self.dag
+        )
+        ti = TaskInstance(operator, DEFAULT_DATE)
+        ti.render_templates()
 
-            open_mock.assert_called_once_with('index_spec.json')
-            expected = '''{
+        expected = '''{
     "datasource": "datasource_prd",
     "spec": {
         "dataSchema": {
@@ -91,7 +75,7 @@ class TestDruidOperator(unittest.TestCase):
     },
     "type": "index_hadoop"
 }'''
-            self.assertEqual(expected, getattr(operator, 'index_spec_str'))
+        self.assertEqual(expected, getattr(operator, 'json_index_file'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dear maintainers,

Please accept my PR which fixes the way druid specification json is loaded by leveraging template fields as in most other operators, rather that manually parsing the file in the operator.

Fixed existing tests and deleted one unneeded test case, as the operator is no longer opening a file.

---
Issue link: [AIRFLOW-6510](https://issues.apache.org/jira/browse/AIRFLOW-6510/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
