### PR TITLE
[AIRFLOW-6511] Remove BATS docker containers

### DIFF
--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -663,10 +663,10 @@ function run_flake8() {
 function run_bats_tests() {
     FILES=("$@")
     if [[ "${#FILES[@]}" == "0" ]]; then
-        docker run --workdir /airflow -v "$(pwd):/airflow"  \
+        docker run --workdir /airflow -v "$(pwd):/airflow" --rm \
             bats/bats:latest --tap -r /airflow/tests/bats | tee -a "${OUTPUT_LOG}"
     else
-        docker run --workdir /airflow -v "$(pwd):/airflow" \
+        docker run --workdir /airflow -v "$(pwd):/airflow" --rm \
             bats/bats:latest --tap -r "${FILES[@]}" | tee -a "${OUTPUT_LOG}"
     fi
 }


### PR DESCRIPTION
The containers were not removed and you have to remove them
with `dockery system prune`. The --rm flag is added.

---
Issue link: [AIRFLOW-6511](https://issues.apache.org/jira/browse/AIRFLOW-6511/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
