### PR TITLE
[AIRFLOW-XXXX] Move airflow-config-yaml pre-commit before pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -256,6 +256,14 @@ repos:
         files: ^.*LICENSE.*$|^.*LICENCE.*$
         pass_filenames: false
         require_serial: true
+      - id: airflow-config-yaml
+        name: Checks for consistency between config.yml and default_config.cfg
+        language: python
+        files: "^airflow/config_templates/config.yml$|^airflow/config_templates/default_airflow.cfg$"
+        pass_filenames: false
+        require_serial: false
+        entry: scripts/ci/pre_commit_yaml_to_cfg.py
+        additional_dependencies: ['pyyaml']
       - id: mypy
         name: Run mypy
         language: system
@@ -290,11 +298,3 @@ repos:
         entry: "./scripts/ci/pre_commit_bat_tests.sh"
         files: ^tests/bats/.*\.bats$
         pass_filenames: true
-      - id: airflow-config-yaml
-        name: Checks for consistency between config.yml and default_config.cfg
-        language: python
-        files: "^airflow/config_templates/config.yml$|^airflow/config_templates/default_airflow.cfg$"
-        pass_filenames: false
-        require_serial: false
-        entry: scripts/ci/pre_commit_yaml_to_cfg.py
-        additional_dependencies: ['pyyaml']


### PR DESCRIPTION
Move airflow-config-yaml pre-commit before pylint so we fail fast before the expensive pylint and mypy checks

---
Issue link: `Document only change, no JIRA issue`

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
