### PR TITLE
[AIRFLOW-XXXX] improve clarity of confirm message

### DIFF
--- a/confirm
+++ b/confirm
@@ -20,7 +20,7 @@ set -euo pipefail
 if [[ "${FORCE_ANSWER_TO_QUESTIONS:=""}" != "" ]]; then
     RESPONSE=${FORCE_ANSWER_TO_QUESTIONS}
     echo
-    echo "Forcing response '${FORCE_ANSWER_TO_QUESTIONS}' to ${1}."
+    echo "Forcing response '${FORCE_ANSWER_TO_QUESTIONS}' to '${1}?'"
     case "${RESPONSE}" in
         [yY][eE][sS]|[yY])
             exit 0 ;;


### PR DESCRIPTION
Clarifies confirm messaging

Before:
```
Forcing response 'no' to rebuild CI.
```

After
```
Forcing response 'no' to 'rebuild CI?'
```

Why?

The sentence `Forcing response 'no' to rebuild CI` can mean "forcing response "no" _in order to_ rebuild CI -- i.e. we must rebuild CI, and to do so, we must force the answer no.

Adding quotes _and_ question mark makes it clear that we are forcing "no" to _the question_ "should we rebuild ci?".


---
Issue link: `Document only change, no JIRA issue`

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
