### PR TITLE
[AIRFLOW-6517] make merge_dicts function recursive

### DIFF
--- a/airflow/utils/log/json_formatter.py
+++ b/airflow/utils/log/json_formatter.py
@@ -27,10 +27,16 @@ import logging
 
 def merge_dicts(dict1, dict2):
     """
-    Merge two dicts
+    Merge two dicts recursively, returning new dict (input dict is not mutated).
+
+    Lists are not concatenated. Items in dict2 overwrite those also found in dict1.
     """
     merged = dict1.copy()
-    merged.update(dict2)
+    for k, v in dict2.items():
+        if k in merged and isinstance(v, dict):
+            merged[k] = merge_dicts(merged.get(k, {}), v)
+        else:
+            merged[k] = v
     return merged
 
 

--- a/tests/utils/log/test_json_formatter.py
+++ b/tests/utils/log/test_json_formatter.py
@@ -47,6 +47,34 @@ class TestJSONFormatter(unittest.TestCase):
         merged = merge_dicts(dict1, dict2)
         self.assertDictEqual(merged, {'a': 1, 'b': 3, 'c': 3, 'd': 42})
 
+    def test_merge_dicts_recursive_overlap_l1(self):
+        """
+        Test merge_dicts with recursive dict; one level of nesting
+        """
+        dict1 = {'a': 1, 'r': {'a': 1, 'b': 2}}
+        dict2 = {'a': 1, 'r': {'c': 3, 'b': 0}}
+        merged = merge_dicts(dict1, dict2)
+        self.assertDictEqual(merged, {'a': 1, 'r': {'a': 1, 'b': 0, 'c': 3}})
+
+    def test_merge_dicts_recursive_overlap_l2(self):
+        """
+        Test merge_dicts with recursive dict; two levels of nesting
+        """
+
+        dict1 = {'a': 1, 'r': {'a': 1, 'b': {'a': 1}}}
+        dict2 = {'a': 1, 'r': {'c': 3, 'b': {'b': 1}}}
+        merged = merge_dicts(dict1, dict2)
+        self.assertDictEqual(merged, {'a': 1, 'r': {'a': 1, 'b': {'a': 1, 'b': 1}, 'c': 3}})
+
+    def test_merge_dicts_recursive_right_only(self):
+        """
+        Test merge_dicts with recursive when dict1 doesn't have any nested dict
+        """
+        dict1 = {'a': 1}
+        dict2 = {'a': 1, 'r': {'c': 3, 'b': 0}}
+        merged = merge_dicts(dict1, dict2)
+        self.assertDictEqual(merged, {'a': 1, 'r': {'b': 0, 'c': 3}})
+
     def test_format(self):
         """
         Test format method from JSONFormatter


### PR DESCRIPTION
to support nested dictionaries

it is a utility used in jsonformatter but useful for merging kwargs between conn extra and hook params

---
Issue link: [AIRFLOW-6517](https://issues.apache.org/jira/browse/AIRFLOW-6517/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
