### PR TITLE
[AIRFLOW-6519] Make TI logs constants in Webserver configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -778,6 +778,27 @@
       type: string
       example: ~
       default: "5"
+    - name: log_fetch_delay_sec
+      description: |
+        Time interval (in secs) to wait before next log fetching.
+      version_added: ~
+      type: int
+      example: ~
+      default: "2"
+    - name: log_auto_tailing_offset
+      description: |
+        Distance away from page bottom to enable auto tailing.
+      version_added: ~
+      type: int
+      example: ~
+      default: "30"
+    - name: log_animation_speed
+      description: |
+        Animation speed for auto tailing log display.
+      version_added: ~
+      type: int
+      example: ~
+      default: "1000"
     - name: hide_paused_dags_by_default
       description: |
         By default, the webserver shows paused DAGs. Flip this to hide paused

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -379,6 +379,15 @@ demo_mode = False
 # while fetching logs from other worker machine
 log_fetch_timeout_sec = 5
 
+# Time interval (in secs) to wait before next log fetching.
+log_fetch_delay_sec = 2
+
+# Distance away from page bottom to enable auto tailing.
+log_auto_tailing_offset = 30
+
+# Animation speed for auto tailing log display.
+log_animation_speed = 1000
+
 # By default, the webserver shows paused DAGs. Flip this to hide paused
 # DAGs by default
 hide_paused_dags_by_default = False

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -221,12 +221,15 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
 
             globals = {
                 'hostname': socket.getfqdn() if conf.getboolean(
-                    'webserver',
-                    'EXPOSE_HOSTNAME',
-                    fallback=True) else 'redact',
+                    'webserver', 'EXPOSE_HOSTNAME', fallback=True) else 'redact',
                 'navbar_color': conf.get(
-                    'webserver',
-                    'NAVBAR_COLOR'),
+                    'webserver', 'NAVBAR_COLOR'),
+                'log_fetch_delay_sec': conf.getint(
+                    'webserver', 'log_fetch_delay_sec', fallback=2),
+                'log_auto_tailing_offset': conf.getint(
+                    'webserver', 'log_auto_tailing_offset', fallback=30),
+                'log_animation_speed': conf.getint(
+                    'webserver', 'log_animation_speed', fallback=1000)
             }
 
             if 'analytics_tool' in conf.getsection('webserver'):

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -54,11 +54,11 @@
 <script>
     // TODO: make those constants configurable.
     // Time interval to wait before next log fetching. Default 2s.
-    const DELAY = 2e3;
+    const DELAY = "{{ (log_fetch_delay_sec | int ) * 1000 }}";
     // Distance away from page bottom to enable auto tailing.
-    const AUTO_TAILING_OFFSET = 30;
+    const AUTO_TAILING_OFFSET = "{{ log_auto_tailing_offset | int }}";
     // Animation speed for auto tailing log display.
-    const ANIMATION_SPEED = 1000;
+    const ANIMATION_SPEED = "{{ log_animation_speed | int }}";
     // Total number of tabs to show.
     const TOTAL_ATTEMPTS = "{{ logs|length }}";
 

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -52,7 +52,6 @@
 {% block tail %}
 {{ super() }}
 <script>
-    // TODO: make those constants configurable.
     // Time interval to wait before next log fetching. Default 2s.
     const DELAY = "{{ (log_fetch_delay_sec | int ) * 1000 }}";
     // Distance away from page bottom to enable auto tailing.


### PR DESCRIPTION
Some of the TaskInstance logs constants in the webserver (in ti_log.html) can be made configurable.

---
Issue link: [AIRFLOW-6519](https://issues.apache.org/jira/browse/AIRFLOW-6519/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
