### PR TITLE
[AIRFLOW-6520] Simplify `airflow config` command

### DIFF
--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -15,15 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 """Config sub-commands"""
+import io
+
 from airflow.configuration import conf
 
 
 def show_config(args):
     """Show current application configuration"""
-    config = conf.as_dict(display_sensitive=True, raw=True)
-
-    for section_key, parameters in sorted(config.items()):
-        print(f"[{section_key}]")
-        for parameter_key, value in sorted(parameters.items()):
-            print(f"{parameter_key}={value}")
-        print()
+    with io.StringIO() as output:
+        conf.write(output)
+        print(output.getvalue())


### PR DESCRIPTION
It is better to convert to INI using the standard library. It is more tested and more stable.  I am afraid that our implementation works for edge cases.

---
Issue link: [AIRFLOW-6520](https://issues.apache.org/jira/browse/AIRFLOW-6520/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
