### PR TITLE
[AIRFLOW-5840] Add operator extra link to external task sensor

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -133,6 +133,12 @@ def register_inbuilt_operator_links() -> None:
     except ImportError:
         pass
 
+    try:
+        from airflow.sensors.external_task_sensor import ExternalTaskLink   # pylint: disable=R0401
+        inbuilt_operator_links.update([ExternalTaskLink])
+    except ImportError:
+        pass
+
     registered_operator_link_classes.update({
         "{}.{}".format(link.__module__, link.__name__): link
         for link in inbuilt_operator_links

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -340,7 +340,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 v = set(v)
             elif k == "subdag":
                 v = SerializedDAG.deserialize_dag(v)
-            elif k in {"retry_delay", "execution_timeout"}:
+            elif k in {"retry_delay", "execution_timeout", "execution_delta"}:
                 v = cls._deserialize_timedelta(v)
             elif k.endswith("_date"):
                 v = cls._deserialize_datetime(v)


### PR DESCRIPTION
This adds an "operator extra link" by default to external task sensors, linking to the graph of the DAG run they're waiting for. If multiple execution dates are being waited for, the link instead is not provided.

---
Issue link: [AIRFLOW-5840](https://issues.apache.org/jira/browse/AIRFLOW-5840)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
