### PR TITLE
[AIRFLOW-6506] do_xcom_push defaulting to True

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -170,6 +170,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  schedulername: Optional[str] = None,
                  full_pod_spec: Optional[k8s.V1Pod] = None,
                  init_containers: Optional[List[k8s.V1Container]] = None,
+                 do_xcom_push: bool = False,
                  *args,
                  **kwargs):
         if kwargs.get('xcom_push') is not None:
@@ -177,7 +178,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         super().__init__(*args, resources=None, **kwargs)
 
         self.pod = None
-
+        self.do_xcom_push = do_xcom_push
         self.image = image
         self.namespace = namespace
         self.cmds = cmds or []

--- a/tests/integration/kubernetes/test_kubernetes_pod_operator.py
+++ b/tests/integration/kubernetes/test_kubernetes_pod_operator.py
@@ -92,6 +92,25 @@ class TestKubernetesPodOperator(unittest.TestCase):
             }
         }
 
+    def test_do_xcom_push_defaults_false(self):
+        new_config_path = '/tmp/kube_config'
+        old_config_path = os.path.expanduser('~/.kube/config')
+        shutil.copy(old_config_path, new_config_path)
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            config_file=new_config_path,
+        )
+        self.assertFalse(k.do_xcom_push)
+
     def test_config_path_move(self):
         new_config_path = '/tmp/kube_config'
         old_config_path = os.path.expanduser('~/.kube/config')


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6506](https://issues.apache.org/jira/browse/AIRFLOW-6506/)

As of airflow 1.10.7, `do_xcom_push` defaults to true on the BaseOperator. The KubePodOperator was not setting the `do_xcom_push` variables so it was stuck as True.

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
