### PR TITLE
[AIRFLOW-6405] Add GCP BigQuery Table Upsert Operator

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_bigquery.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery.py
@@ -28,7 +28,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryCreateEmptyDatasetOperator, BigQueryCreateEmptyTableOperator, BigQueryCreateExternalTableOperator,
     BigQueryDeleteDatasetOperator, BigQueryDeleteTableOperator, BigQueryExecuteQueryOperator,
     BigQueryGetDataOperator, BigQueryGetDatasetOperator, BigQueryGetDatasetTablesOperator,
-    BigQueryPatchDatasetOperator, BigQueryUpdateDatasetOperator,
+    BigQueryPatchDatasetOperator, BigQueryUpdateDatasetOperator, BigQueryUpsertTableOperator,
 )
 from airflow.providers.google.cloud.operators.bigquery_to_bigquery import BigQueryToBigQueryOperator
 from airflow.providers.google.cloud.operators.bigquery_to_gcs import BigQueryToGCSOperator
@@ -253,6 +253,15 @@ with models.DAG(
         delete_contents=True
     )
 
+    update_table = BigQueryUpsertTableOperator(
+        task_id="update_table", dataset_id=DATASET_NAME, table_resource={
+            "tableReference": {
+                "tableId": "test-table-id"
+            },
+            "expirationTime": 12345678
+        }
+    )
+
     create_dataset >> execute_query_save >> delete_dataset
     create_dataset >> get_empty_dataset_tables >> create_table >> get_dataset_tables >> delete_dataset
     create_dataset >> get_dataset >> delete_dataset
@@ -264,3 +273,4 @@ with models.DAG(
     execute_query_external_table >> bigquery_to_gcs >> delete_dataset
     create_table >> create_view >> delete_view >> delete_table >> delete_dataset
     create_dataset_with_location >> create_table_with_location >> delete_dataset_with_location
+    create_dataset >> create_table >> update_table >> delete_table >> delete_dataset

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -36,7 +36,6 @@ from pandas_gbq.gbq import (
 )
 
 from airflow import AirflowException
-from airflow.exceptions import AirflowBadRequest
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -1111,16 +1110,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
         """
         service = self.get_service()
         # check to see if the table exists
-        if 'tableReference' not in table_resource:
-            raise AirflowBadRequest(
-                '"tableReference" is required within table_resource parameter. '
-                'See https://cloud.google.com/bigquery/docs/reference/v2/tables#resource'
-            )
-        if 'tableId' not in table_resource["tableReference"]:
-            raise AirflowBadRequest(
-                '"tableId" is required within table_resource["tableReference"]. '
-                'See https://cloud.google.com/bigquery/docs/reference/v2/tables#resource'
-            )
         table_id = table_resource['tableReference']['tableId']
         project_id = project_id if project_id is not None else self.project_id
         tables_list_resp = service.tables().list(  # pylint: disable=no-member

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -36,6 +36,7 @@ from pandas_gbq.gbq import (
 )
 
 from airflow import AirflowException
+from airflow.exceptions import AirflowBadRequest
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -1110,6 +1111,16 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
         """
         service = self.get_service()
         # check to see if the table exists
+        if 'tableReference' not in table_resource:
+            raise AirflowBadRequest(
+                '"tableReference" is required within table_resource parameter. '
+                'See https://cloud.google.com/bigquery/docs/reference/v2/tables#resource'
+            )
+        if 'tableId' not in table_resource["tableReference"]:
+            raise AirflowBadRequest(
+                '"tableId" is required within table_resource["tableReference"]. '
+                'See https://cloud.google.com/bigquery/docs/reference/v2/tables#resource'
+            )
         table_id = table_resource['tableReference']['tableId']
         project_id = project_id if project_id is not None else self.project_id
         tables_list_resp = service.tables().list(  # pylint: disable=no-member

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -23,7 +23,6 @@ from googleapiclient.errors import HttpError
 from parameterized import parameterized
 
 from airflow import AirflowException
-from airflow.exceptions import AirflowBadRequest
 from airflow.providers.google.cloud.hooks import bigquery as hook
 from airflow.providers.google.cloud.hooks.bigquery import (
     _api_resource_configs_duplication_check, _cleanse_time_partitioning, _validate_src_fmt_configs,
@@ -1415,51 +1414,6 @@ class TestTableOperations(unittest.TestCase):
             tableId=table1
         )
 
-    @mock.patch(
-        'airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID),
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_table_upsert_on_exception1(self, mock_get_service, mock_get_creds_and_proj_id):
-        table_resource = {
-            "expirationTime": 123456
-        }
-        bq_hook = hook.BigQueryHook()
-        with self.assertRaisesRegex(
-            AirflowBadRequest,
-            r"\"tableReference\" is required within table_resource parameter. "
-            r"See https://cloud.google.com/bigquery/docs/reference/v2/tables#resource"
-        ):
-            bq_hook.run_table_upsert(
-                dataset_id=DATASET_ID,
-                table_resource=table_resource,
-                project_id=PROJECT_ID
-            )
-
-    @mock.patch(
-        'airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID),
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_table_upsert_on_exception2(self, mock_get_service, mock_get_creds_and_proj_id):
-        table_resource = {
-            "expiration": 123456,
-            "tableReference": {
-                "table": TABLE_ID
-            }
-        }
-        bq_hook = hook.BigQueryHook()
-        with self.assertRaisesRegex(
-            AirflowBadRequest,
-            r"\"tableId\" is required within table_resource\[\"tableReference\"\]. "
-            "See https://cloud.google.com/bigquery/docs/reference/v2/tables#resource"
-        ):
-            bq_hook.run_table_upsert(
-                dataset_id=DATASET_ID,
-                table_resource=table_resource,
-                project_id=PROJECT_ID
-            )
-
 
 class TestBigQueryCursor(unittest.TestCase):
 
@@ -1745,11 +1699,11 @@ class TestLabelsInRunJob(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_query_with_arg(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
-
         def run_with_config(config):
             self.assertEqual(
                 config['labels'], {'label1': 'test1', 'label2': 'test2'}
             )
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()
@@ -2026,6 +1980,7 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
     def test_run_load_default(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
         def run_with_config(config):
             self.assertIsNone(config['load'].get('timePartitioning'))
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()
@@ -2067,6 +2022,7 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
                     'expirationMs': 1000
                 }
             )
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()
@@ -2088,6 +2044,7 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
     def test_run_query_default(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
         def run_with_config(config):
             self.assertIsNone(config['query'].get('timePartitioning'))
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()
@@ -2111,6 +2068,7 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
                     'expirationMs': 1000
                 }
             )
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()
@@ -2153,9 +2111,9 @@ class TestClusteringInRunJob(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_load_default(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
-
         def run_with_config(config):
             self.assertIsNone(config['load'].get('clustering'))
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()
@@ -2174,7 +2132,6 @@ class TestClusteringInRunJob(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_load_with_arg(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
-
         def run_with_config(config):
             self.assertEqual(
                 config['load']['clustering'],
@@ -2182,6 +2139,7 @@ class TestClusteringInRunJob(unittest.TestCase):
                     'fields': ['field1', 'field2']
                 }
             )
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()
@@ -2202,9 +2160,9 @@ class TestClusteringInRunJob(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_query_default(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
-
         def run_with_config(config):
             self.assertIsNone(config['query'].get('clustering'))
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()
@@ -2219,7 +2177,6 @@ class TestClusteringInRunJob(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_query_with_arg(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
-
         def run_with_config(config):
             self.assertEqual(
                 config['query']['clustering'],
@@ -2227,6 +2184,7 @@ class TestClusteringInRunJob(unittest.TestCase):
                     'fields': ['field1', 'field2']
                 }
             )
+
         mocked_rwc.side_effect = run_with_config
 
         bq_hook = hook.BigQueryHook()


### PR DESCRIPTION
### JIRA Issue
Link to JIRA issue: https://issues.apache.org/jira/browse/AIRFLOW-6405

### Description

1. Currently there is a BigQuery Hook named `run_table_upsert` but there is no BigQuery Table Upsert Operator utilizing this hook. This PR includes a new GCP BigQuery Operator to include this.

2. This new operator allows updating the given table with given parameters or else creates a new table if it is not already present.

3. It also adds a few test cases for the existing hook.

---
Issue link: [AIRFLOW-6405](https://issues.apache.org/jira/browse/AIRFLOW-6405)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
