### PR TITLE
Revert "[AIRFLOW-6451] self._print_stat() in dag_processing.py should be skippable"

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -316,13 +316,6 @@
       type: string
       example: ~
       default: "30"
-    - name: print_dag_processing_stats
-      description: |
-        Print stats about DAG processing progress
-      version_added: ~
-      type: string
-      example: ~
-      default: "True"
     - name: check_slas
       description: |
         On each dagrun check against defined SLAs

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -182,9 +182,6 @@ store_serialized_dags = False
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.
 min_serialized_dag_update_interval = 30
 
-# Print stats about DAG processing progress
-print_dag_processing_stats = True
-
 # On each dagrun check against defined SLAs
 check_slas = True
 


### PR DESCRIPTION
Reverts apache/airflow#7096 to do in a slightly different way (without a new config option), and reverting this so that the new change is easier to backport to 1.10 releases.