### PR TITLE
[AIRFLOW-6533] Add cli commands to manage config

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -130,6 +130,21 @@ class CLIFactory:
             choices=tabulate_formats,
             default="fancy_grid"),
 
+        # config
+        'section': Arg(
+            ("section",),
+            nargs="?",
+            type=str,
+            help="Section of the config"),
+        'option': Arg(
+            ("option",),
+            type=str,
+            help="Option in the given section"),
+        'value': Arg(
+            ("value",),
+            type=str,
+            help="Value for the option"),
+
         # list_dag_runs
         'no_backfill': Arg(
             ("--no_backfill",),
@@ -923,11 +938,36 @@ class CLIFactory:
             'args': ('roles',),
         },
     )
+    CONFIG_COMMANDS = (
+        {
+            'name': 'show',
+            'func': lazy_load_command('airflow.cli.commands.config_command.show_config'),
+            'help': 'Show current application configuration',
+            'args': ('section',),
+        },
+        {
+            'name': 'set',
+            'func': lazy_load_command('airflow.cli.commands.config_command.set_config_option'),
+            'help': 'Set an option in config: '
+                    'airflow config set --section=core.executor --value=LocalExecutor',
+            'args': ('section', 'option', 'value', 'cfg_path'),
+        },
+        {
+            'name': 'path',
+            'func': lazy_load_command('airflow.cli.commands.config_command.get_config_location'),
+            'help': 'Show path to airflow.cfg',
+            'args': (),
+        },
+    )
     subparsers = [
         {
             'help': 'List and manage DAGs',
             'name': 'dags',
             'subcommands': DAGS_SUBCOMMANDS,
+        }, {
+            'help': 'Config operations',
+            'name': 'config',
+            'subcommands': CONFIG_COMMANDS,
         }, {
             'help': 'List and manage tasks',
             'name': 'tasks',
@@ -995,12 +1035,6 @@ class CLIFactory:
             'help': 'Rotate all encrypted connection credentials and variables; see '
                     'https://airflow.readthedocs.io/en/stable/howto/secure-connections.html'
                     '#rotating-encryption-keys',
-            'args': (),
-        },
-        {
-            'name': 'config',
-            'func': lazy_load_command('airflow.cli.commands.config_command.show_config'),
-            'help': 'Show current application configuration',
             'args': (),
         },
     ]

--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -17,11 +17,65 @@
 """Config sub-commands"""
 import io
 
-from airflow.configuration import conf
+from configupdater import ConfigUpdater, NoSectionError
+
+from airflow.configuration import AirflowConfigException, conf, resolve_actual_config
+from airflow.utils.helpers import ask_yesno
 
 
 def show_config(args):
     """Show current application configuration"""
     with io.StringIO() as output:
-        conf.write(output)
+        if args.section:
+            section = args.section
+            if conf.has_section(section):
+                conf._write_section(  # pylint: disable=protected-access
+                    fp=output,
+                    section_name=section,
+                    section_items=conf.getsection(section).items(),
+                    delimiter=" = ",
+                )
+            else:
+                raise AirflowConfigException(f"No section '{section}'")
+        else:
+            conf.write(output)
         print(output.getvalue())
+
+
+def set_config_option(args):
+    """Set option in config"""
+    config_path = args.cfg_path or resolve_actual_config()
+    section, option, value = args.section, args.option, args.value
+
+    do_the_change = ask_yesno(f"Update section {section}, option {option} with {value}? [Y/n]", assume="Y")
+    if not do_the_change:
+        print("Update skipped")
+        return
+
+    updater = ConfigUpdater()
+    updater.read(config_path)
+    try:
+        updater.set(section, option, value)
+    except NoSectionError:
+        # Add section if not exists
+        updater.add_section(section)
+        updater.set(section, option, value)
+    updater.update_file()
+    print(f"Config changed: {section}.{option}={value} in {config_path}")
+
+    # Check if environment variable set
+    env_value = conf._get_env_var_option(  # pylint: disable=protected-access
+        section=section,
+        key=option
+    )
+    if env_value:
+        print(
+            f"WARNING: Environment variable `AIRFLOW__{section.upper()}__{option.upper()}` "
+            f"set to {env_value}. This will overwrite your config for `{option}`."
+        )
+
+
+def get_config_location(args):
+    """Show location of current airflow.cfg"""
+    config_path = resolve_actual_config()
+    print(config_path)

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -72,7 +72,7 @@ def alchemy_to_dict(obj):
     return output
 
 
-def ask_yesno(question):
+def ask_yesno(question, assume=None):
     """
     Helper to get yes / no answer from user.
     """
@@ -87,6 +87,8 @@ def ask_yesno(question):
             return True
         elif choice in no:
             return False
+        elif not choice and assume:
+            return assume.lower() in yes
         else:
             print("Please respond by yes or no.")
 

--- a/docs/howto/set-config.rst
+++ b/docs/howto/set-config.rst
@@ -76,4 +76,9 @@ The universal order of precedence for all configuration options is as follows:
 #. Airflow's built in defaults
 
 .. note::
+    Airflow command line tool has a convenient methods to work with configuration.
+    For more information on configuration options, see :doc:`../usage-cli`
+
+
+.. note::
     For more information on configuration options, see :doc:`../configurations-ref`

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -174,3 +174,38 @@ You will see a similar result as in the screenshot below.
 .. figure:: img/usage_cli_imgcat.png
 
     Preview of DAG in iTerm2
+
+
+Display Airflow config
+----------------------
+
+Airflow command line tool has a convenient methods to work with configuration.
+To display current configuration use:
+
+.. code-block:: bash
+
+    airflow config show
+
+To shorten the output to a single section:
+
+.. code-block:: bash
+
+    airflow config show core
+
+There is also a simple method to check where is the current config file:
+
+.. code-block:: bash
+
+    airflow config path
+
+Update Airflow config
+----------------------
+
+To update ``airflow.cfg`` from command line level use:
+
+.. code-block:: bash
+
+    airflow config set SECTION OPTION VALUE
+
+Beware that this will override the config file but if environment variable
+``AIRFLOW__SECTION__OPTION`` is set the changes will have no result.

--- a/setup.py
+++ b/setup.py
@@ -449,6 +449,7 @@ def do_setup():
         # DEPENDENCIES_EPOCH_NUMBER in the Dockerfile
         #####################################################################################################
         install_requires=[
+            'ConfigUpdater>=1.0.1',
             'alembic>=1.2, <2.0',
             'argcomplete~=1.10',
             'attrs~=19.3',

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -17,11 +17,26 @@
 import contextlib
 import io
 import unittest
+from configparser import ConfigParser
+from contextlib import contextmanager
+from shutil import copy
+from tempfile import NamedTemporaryFile
 from unittest import mock
 
 from airflow.bin import cli
 from airflow.cli.commands import config_command
+from airflow.configuration import TEST_CONFIG_FILE, conf
 from tests.test_utils.config import conf_vars
+
+
+@contextmanager
+def temporary_config():
+    with NamedTemporaryFile() as f:
+        copy(TEST_CONFIG_FILE, f.name)
+        try:
+            yield f.name
+        finally:
+            copy(f.name, TEST_CONFIG_FILE)
 
 
 class TestCliConfig(unittest.TestCase):
@@ -32,7 +47,7 @@ class TestCliConfig(unittest.TestCase):
     @mock.patch("airflow.cli.commands.config_command.io.StringIO")
     @mock.patch("airflow.cli.commands.config_command.conf")
     def test_cli_show_config_should_write_data(self, mock_conf, mock_stringio):
-        config_command.show_config(self.parser.parse_args(['config']))
+        config_command.show_config(self.parser.parse_args(['config', 'show']))
         mock_conf.write.assert_called_once_with(mock_stringio.return_value.__enter__.return_value)
 
     @conf_vars({
@@ -40,6 +55,66 @@ class TestCliConfig(unittest.TestCase):
     })
     def test_cli_show_config_should_display_key(self):
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
-            config_command.show_config(self.parser.parse_args(['config']))
+            config_command.show_config(self.parser.parse_args(['config', 'show']))
         self.assertIn('[core]', temp_stdout.getvalue())
         self.assertIn('testkey = test_value', temp_stdout.getvalue())
+
+    @conf_vars({
+        ('core', 'testkey'): 'test_value',
+        ('logging', 'testkey'): 'test_value'
+    })
+    def test_cli_show_config_should_display_only_selected_section(self):
+        with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+            config_command.show_config(self.parser.parse_args(['config', 'show', 'logging']))
+        self.assertIn('[logging]', temp_stdout.getvalue())
+        self.assertIn('testkey = test_value', temp_stdout.getvalue())
+
+    @mock.patch("airflow.configuration.resolve_actual_config")
+    @mock.patch("airflow.cli.commands.config_command.ask_yesno")
+    def test_cli_set_config_should_override(self, mock_ask_yes_no, mock_resolve_config):
+        with temporary_config() as tmp_cfg:
+            mock_resolve_config.return_value = tmp_cfg
+
+            config_command.set_config_option(
+                self.parser.parse_args(['config', 'set', 'core', 'testkey', 'other_test_value'])
+            )
+            # Reload config from file
+            conf.read(TEST_CONFIG_FILE)
+
+            mock_ask_yes_no.assert_called_once_with(mock.ANY, assume="Y")
+            value = conf.get("core", "testkey")
+            self.assertEqual("other_test_value", value)
+
+    @mock.patch("airflow.configuration.resolve_actual_config")
+    @mock.patch("airflow.cli.commands.config_command.ask_yesno")
+    def test_cli_set_config_should_create_new_section(self, mock_ask_yes_no, mock_resolve_config):
+        with temporary_config() as tmp_cfg:
+            mock_resolve_config.return_value = tmp_cfg
+
+            config_command.set_config_option(
+                self.parser.parse_args(['config', 'set', 'new', 'testkey', 'other_test_value'])
+            )
+            # Reload config from file
+            conf.read(TEST_CONFIG_FILE)
+
+            value = conf.get("new", "testkey")
+            self.assertEqual("other_test_value", value)
+
+    @mock.patch("airflow.configuration.resolve_actual_config")
+    @mock.patch("airflow.cli.commands.config_command.ask_yesno")
+    def test_cli_set_config_should_skip_on_no(self, mock_ask_yes_no, mock_resolve_config):
+        mock_ask_yes_no.return_value = False
+
+        with temporary_config() as tmp_cfg:
+            mock_resolve_config.return_value = tmp_cfg
+            with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+                config_command.set_config_option(
+                    self.parser.parse_args(['config', 'set', 'new', 'testkey', 'other_value'])
+                )
+            self.assertIn("Update skipped", temp_stdout.getvalue())
+
+            current_conf = ConfigParser()
+            current_conf.read(TEST_CONFIG_FILE)
+
+            # Nothing should change
+            self.assertFalse(current_conf.has_section("new"))


### PR DESCRIPTION
This PR improves show command by adding `--section` option. I also added `set` that allow user to override record in airflow.cfg from cli level and `location` that prints location of airflow.cfg.

---
Issue link: [AIRFLOW-6533](https://issues.apache.org/jira/browse/AIRFLOW-6533)

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
