### PR TITLE
[AIRFLOW-6536] Make job_id parameter optional

### DIFF
--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -433,7 +433,7 @@ class DatabricksRunNowOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            job_id,
+            job_id=None,
             json=None,
             notebook_params=None,
             python_params=None,

--- a/tests/contrib/operators/test_databricks_operator.py
+++ b/tests/contrib/operators/test_databricks_operator.py
@@ -283,9 +283,10 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
             'notebook_params': NOTEBOOK_PARAMS,
             'jar_params': JAR_PARAMS,
             'python_params': PYTHON_PARAMS,
-            'spark_submit_params': SPARK_SUBMIT_PARAMS
+            'spark_submit_params': SPARK_SUBMIT_PARAMS,
+            'job_id': JOB_ID
         }
-        op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=json)
+        op = DatabricksRunNowOperator(task_id=TASK_ID, json=json)
 
         expected = databricks_operator._deep_string_coerce({
             'notebook_params': NOTEBOOK_PARAMS,


### PR DESCRIPTION
job_id parameter should be optional because it can be passed in json(dict) parameter.

---
Issue link: [AIRFLOW-6536](https://issues.apache.org/jira/browse/AIRFLOW-6536/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
