### PR TITLE
[AIRFLOW-5912] Expose lineage API

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -80,3 +80,6 @@ pylint_todo.txt
 .bash_history
 .bash_aliases
 .inputrc
+
+# the example notebook is ASF 2 licensed but RAT cannot read this
+input_notebook.ipynb

--- a/airflow/api/client/api_client.py
+++ b/airflow/api/client/api_client.py
@@ -70,3 +70,12 @@ class Client:
         :param name: pool name
         """
         raise NotImplementedError()
+
+    def get_lineage(self, dag_id: str, execution_date: str):
+        """
+        Return the lineage information for the dag on this execution date
+        :param dag_id:
+        :param execution_date:
+        :return:
+        """
+        raise NotImplementedError()

--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -93,3 +93,9 @@ class Client(api_client.Client):
         url = urljoin(self._api_base_url, endpoint)
         pool = self._request(url, method='DELETE')
         return pool['pool'], pool['slots'], pool['description']
+
+    def get_lineage(self, dag_id: str, execution_date: str):
+        endpoint = f"/api/experimental/lineage/{dag_id}/{execution_date}"
+        url = urljoin(self._api_base_url, endpoint)
+        data = self._request(url, method='GET')
+        return data['message']

--- a/airflow/api/client/local_client.py
+++ b/airflow/api/client/local_client.py
@@ -20,6 +20,7 @@
 
 from airflow.api.client import api_client
 from airflow.api.common.experimental import delete_dag, pool, trigger_dag
+from airflow.api.common.experimental.get_lineage import get_lineage as get_lineage_api
 
 
 class Client(api_client.Client):
@@ -50,3 +51,7 @@ class Client(api_client.Client):
     def delete_pool(self, name):
         the_pool = pool.delete_pool(name=name)
         return the_pool.pool, the_pool.slots, the_pool.description
+
+    def get_lineage(self, dag_id, execution_date):
+        lineage = get_lineage_api(dag_id=dag_id, execution_date=execution_date)
+        return lineage

--- a/airflow/api/common/experimental/get_lineage.py
+++ b/airflow/api/common/experimental/get_lineage.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Lineage apis
+"""
+import datetime
+from typing import Any, Dict, List
+
+from airflow.api.common.experimental import check_and_get_dag, check_and_get_dagrun
+from airflow.lineage import PIPELINE_INLETS, PIPELINE_OUTLETS
+from airflow.models.xcom import XCom
+from airflow.utils.session import provide_session
+
+
+@provide_session
+def get_lineage(dag_id: str, execution_date: datetime.datetime, session=None) -> Dict[str, Dict[str, Any]]:
+    """
+    Gets the lineage information for dag specified
+    """
+    dag = check_and_get_dag(dag_id)
+    check_and_get_dagrun(dag, execution_date)
+
+    inlets: List[XCom] = XCom.get_many(dag_ids=dag_id, execution_date=execution_date,
+                                       key=PIPELINE_INLETS, session=session).all()
+    outlets: List[XCom] = XCom.get_many(dag_ids=dag_id, execution_date=execution_date,
+                                        key=PIPELINE_OUTLETS, session=session).all()
+
+    lineage: Dict[str, Dict[str, Any]] = {}
+    for meta in inlets:
+        lineage[meta.task_id] = {'inlets': meta.value}
+
+    for meta in outlets:
+        lineage[meta.task_id]['outlets'] = meta.value
+
+    return {'task_ids': lineage}

--- a/airflow/example_dags/example_papermill_operator.py
+++ b/airflow/example_dags/example_papermill_operator.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+from datetime import timedelta
+
+import scrapbook as sb
+
+import airflow
+from airflow.lineage import AUTO
+from airflow.models import DAG
+from airflow.operators.papermill_operator import PapermillOperator
+from airflow.operators.python_operator import PythonOperator
+
+
+def check_notebook(inlets, execution_date):
+    """
+    Verify the message in the notebook
+    """
+    notebook = sb.read_notebook(inlets[0].url)
+    message = notebook.scraps['message']
+    print(f"Message in notebook {message} for {execution_date}")
+
+    if message.data != f"Ran from Airflow at {execution_date}!":
+        return False
+
+    return True
+
+
+args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2)
+}
+
+dag = DAG(
+    dag_id='example_papermill_operator', default_args=args,
+    schedule_interval='0 0 * * *',
+    dagrun_timeout=timedelta(minutes=60))
+
+run_this = PapermillOperator(
+    task_id="run_example_notebook",
+    dag=dag,
+    input_nb=os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                          "input_notebook.ipynb"),
+    output_nb="/tmp/out-{{ execution_date }}.ipynb",
+    parameters={"msgs": "Ran from Airflow at {{ execution_date }}!"}
+)
+
+check_output = PythonOperator(
+    task_id='check_out',
+    python_callable=check_notebook,
+    dag=dag,
+    inlets=AUTO)
+
+check_output.set_upstream(run_this)
+
+if __name__ == "__main__":
+    dag.cli()

--- a/airflow/example_dags/input_notebook.ipynb
+++ b/airflow/example_dags/input_notebook.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " Licensed to the Apache Software Foundation (ASF) under one\n",
+    " or more contributor license agreements.  See the NOTICE file\n",
+    " distributed with this work for additional information\n",
+    " regarding copyright ownership.  The ASF licenses this file\n",
+    " to you under the Apache License, Version 2.0 (the\n",
+    " \"License\"); you may not use this file except in compliance\n",
+    " with the License.  You may obtain a copy of the License at\n",
+    "\n",
+    "   http://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    " Unless required by applicable law or agreed to in writing,\n",
+    " software distributed under the License is distributed on an\n",
+    " \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n",
+    " KIND, either express or implied.  See the License for the\n",
+    " specific language governing permissions and limitations\n",
+    " under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is an example jupyter notebook for Apache Airflow that shows how to use\n",
+    "papermill in combination with scrapbook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scrapbook as sb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parameter tag for cells is used to tell papermill where it can find variables it needs to set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "msgs = \"Hello!\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Inside the notebook you can save data by calling the glue function. Then later you can read the results of that notebook by “scrap” name (see the Airflow Papermill example DAG)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/scrapbook.scrap.text+json": {
+       "data": "Hello!",
+       "encoder": "text",
+       "name": "message",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "message"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sb.glue('message', msgs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -154,8 +154,6 @@ def prepare_lineage(func):
 
             self.inlets.extend(_inlets)
             self.inlets.extend(self._inlets)
-            self.inlets = [_render_object(i, context)
-                           for i in self.inlets if attr.has(i)]
 
         elif self._inlets:
             raise AttributeError("inlets is not a list, operator, string or attr annotated object")
@@ -165,8 +163,12 @@ def prepare_lineage(func):
 
         self.outlets.extend(self._outlets)
 
-        self.outlets = list(map(lambda i: _render_object(i, context),
-                            filter(attr.has, self.outlets)))
+        # render inlets and outlets
+        self.inlets = [_render_object(i, context)
+                       for i in self.inlets if attr.has(i)]
+
+        self.outlets = [_render_object(i, context)
+                        for i in self.outlets if attr.has(i)]
 
         self.log.debug("inlets: %s, outlets: %s", self.inlets, self.outlets)
         return func(self, context, *args, **kwargs)

--- a/docs/rest-api-ref.rst
+++ b/docs/rest-api-ref.rst
@@ -98,3 +98,7 @@ Endpoints
 .. http:delete:: /api/experimental/pools/<string:name>
 
   Delete pool.
+
+.. http:get:: /api/experimental/lineage/<DAG_ID>/<string:execution_date>/
+
+  Returns the lineage information for the dag.

--- a/setup.py
+++ b/setup.py
@@ -287,8 +287,8 @@ pagerduty = [
     'pypd>=1.1.0',
 ]
 papermill = [
-    'papermill[all]>=1.0.0',
-    'nteract-scrapbook[all]>=0.2.1',
+    'papermill[all]>=1.2.1',
+    'nteract-scrapbook[all]>=0.3.1',
 ]
 password = [
     'bcrypt>=2.0.0',
@@ -434,7 +434,7 @@ def do_setup():
         version=version,
         packages=find_packages(exclude=['tests*']),
         package_data={
-            '': ['airflow/alembic.ini', "airflow/git_version"],
+            '': ['airflow/alembic.ini', "airflow/git_version", "*.ipynb"],
             'airflow.serialization': ["*.json"],
         },
         include_package_data=True,


### PR DESCRIPTION
Only lineage items obtained from XCom were rendered rather than
all. Additionally source tasks are recorded.

---
Issue link: [AIRFLOW-5912](https://issues.apache.org/jira/browse/AIRFLOW-5912)

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
