### PR TITLE
[AIRFLOW-6537] Fix backticks in rst files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -151,7 +151,7 @@ repos:
       - id: check-xml
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.2
+    rev: v1.4.4
     hooks:
       - id: rst-backticks
       - id: python-no-log-warn

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -439,7 +439,7 @@ Basic authentication for Celery Flower is supported.
 
 You can specify the details either as an optional argument in the Flower process launching
 command, or as a configuration item in your ``airflow.cfg``. For both cases, please provide
-`user:password` pairs separated by a comma.
+``user:password`` pairs separated by a comma.
 
 .. code-block:: bash
 
@@ -542,7 +542,7 @@ The first time Airflow is started, the ``airflow.cfg`` file is generated with th
 key. The key is saved to option ``fernet_key`` of section ``[core]``.
 
 You can also configure a fernet key using environment variables. This will overwrite the value from the
-`airflow.cfg` file
+``airflow.cfg`` file
 
     .. code-block:: bash
 

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -147,7 +147,7 @@ The following file formats are supported:
  * ``x11``.
 
 By default, the application search for DAGs in the directory specified in ``dags_folder`` option in
-`[core]` section specified in the file ``airflow.cfg``. You can change it with the ``--subdir`` switch.
+``[core]`` section specified in the file ``airflow.cfg``. You can change it with the ``--subdir`` switch.
 
 Display DAGs structure
 ----------------------


### PR DESCRIPTION
I fixed small bugs in the hook:
https://github.com/pre-commit/pygrep-hooks/pull/24
Detect single backticks at the start of the line


---
Issue link: [AIRFLOW-6537](https://issues.apache.org/jira/browse/AIRFLOW-6537/)

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
