### PR TITLE
[AIRFLOW-6544] add log_id to end_of_log mark log record

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -203,6 +203,7 @@ if REMOTE_LOGGING:
         ELASTICSEARCH_WRITE_STDOUT: str = conf.get('elasticsearch', 'WRITE_STDOUT')
         ELASTICSEARCH_JSON_FORMAT: str = conf.get('elasticsearch', 'JSON_FORMAT')
         ELASTICSEARCH_JSON_FIELDS: str = conf.get('elasticsearch', 'JSON_FIELDS')
+        ELASTICSEARCH_INDEX: str = conf.get('elasticsearch', 'INDEX')
 
         ELASTIC_REMOTE_HANDLERS: Dict[str, Dict[str, str]] = {
             'task': {
@@ -215,7 +216,8 @@ if REMOTE_LOGGING:
                 'host': ELASTICSEARCH_HOST,
                 'write_stdout': ELASTICSEARCH_WRITE_STDOUT,
                 'json_format': ELASTICSEARCH_JSON_FORMAT,
-                'json_fields': ELASTICSEARCH_JSON_FIELDS
+                'json_fields': ELASTICSEARCH_JSON_FIELDS,
+                'index': ELASTICSEARCH_INDEX
             },
         }
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1521,6 +1521,13 @@
       type: string
       example: ~
       default: "asctime, filename, lineno, levelname, message"
+    - name: index
+      description: |
+        Index used to store airflow logs
+      version_added: ~
+      type: string
+      example: ~
+      default: "filebeat-*"
 - name: elasticsearch_configs
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1523,7 +1523,7 @@
       default: "asctime, filename, lineno, levelname, message"
     - name: index
       description: |
-        Index used to store airflow logs
+        Index used to store airflow logs, optional
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1483,7 +1483,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "{{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}"
+      default: "{dag_id}-{task_id}-{execution_date}-{try_number}"
     - name: end_of_log_mark
       description: |
         Used to mark the end of a log stream for a task

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1527,7 +1527,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "filebeat-*"
+      default: "*"
 - name: elasticsearch_configs
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1523,7 +1523,7 @@
       default: "asctime, filename, lineno, levelname, message"
     - name: index
       description: |
-        Index used to store airflow logs, optional
+        Index used to store airflow logs
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1483,7 +1483,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "{dag_id}-{task_id}-{execution_date}-{try_number}"
+      default: "{{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}"
     - name: end_of_log_mark
       description: |
         Used to mark the end of a log stream for a task

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -699,7 +699,7 @@ json_format = False
 json_fields = asctime, filename, lineno, levelname, message
 
 # Index used to store airflow logs
-index = filebeat-*
+index = *
 
 [elasticsearch_configs]
 use_ssl = False

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -698,6 +698,9 @@ json_format = False
 # Log fields to also attach to the json output, if enabled
 json_fields = asctime, filename, lineno, levelname, message
 
+# Index used to store airflow logs
+index = filebeat-*
+
 [elasticsearch_configs]
 use_ssl = False
 verify_certs = True

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -679,7 +679,7 @@ hide_sensitive_variable_fields = True
 host =
 
 # Format of the log_id, which is used to query for a given tasks logs
-log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+log_id_template = {dag_id}-{task_id}-{execution_date}-{try_number}
 
 # Used to mark the end of a log stream for a task
 end_of_log_mark = end_of_log

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -679,7 +679,7 @@ hide_sensitive_variable_fields = True
 host =
 
 # Format of the log_id, which is used to query for a given tasks logs
-log_id_template = {dag_id}-{task_id}-{execution_date}-{try_number}
+log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
 
 # Used to mark the end of a log stream for a task
 end_of_log_mark = end_of_log

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -53,7 +53,6 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
     PAGE = 0
     MAX_LINE_PER_PAGE = 1000
 
-    # pylint: disable=too-many-instance-attributes
     # 16 is reasonable in this case
     # pylint: disable-msg=too-many-arguments
     def __init__(self, base_log_folder, filename_template,

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -210,7 +210,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         if self.json_format:
             self.formatter = JSONFormatter(
-                self.formatter._fmt,  # pylint: disable=protected-access
+                self.formatter._fmt if self.formatter else None,  # pylint: disable=protected-access
                 json_fields=self.json_fields,
                 extras={
                     'dag_id': str(ti.dag_id),

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -58,7 +58,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
     def __init__(self, base_log_folder, filename_template,
                  log_id_template, end_of_log_mark,
                  write_stdout, json_format, json_fields,
-                 index = '*',
+                 index='*',
                  host='localhost:9200',
                  es_kwargs=conf.getsection("elasticsearch_configs")):
         """

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -55,6 +55,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
     # pylint: disable=too-many-instance-attributes
     # 16 is reasonable in this case
+    # pylint: disable-msg=too-many-arguments
     def __init__(self, base_log_folder, filename_template,
                  log_id_template, end_of_log_mark,
                  write_stdout, json_format, json_fields, index,

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -253,7 +253,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
             self.handler.stream = self.handler._open()  # pylint: disable=protected-access
 
         # Mark the end of file using end of log mark,
-        # so we know where to stop while auto-tailing.\
+        # so we know where to stop while auto-tailing.
         if self.write_stdout:
             print()
         self.handler.emit(logging.LogRecord(None, logging.INFO, None, 0, self.end_of_log_mark, None, None))

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -257,6 +257,10 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         # Mark the end of file using end of log mark,
         # so we know where to stop while auto-tailing.
+        # end-of-log mark has to be in its separate line in the console, so
+        # add an obnoxious print() for reliably separate the mark into a
+        # separate line so that elasticsearch can search for this log mark
+        # record
         if self.write_stdout:
             print()
         self.handler.emit(logging.makeLogRecord({'msg': self.end_of_log_mark}))

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -53,6 +53,8 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
     PAGE = 0
     MAX_LINE_PER_PAGE = 1000
 
+    # pylint: disable=too-many-instance-attributes
+    # 16 is reasonable in this case
     def __init__(self, base_log_folder, filename_template,
                  log_id_template, end_of_log_mark,
                  write_stdout, json_format, json_fields, index,

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -256,7 +256,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         # so we know where to stop while auto-tailing.
         if self.write_stdout:
             print()
-        self.handler.emit(logging.LogRecord(None, logging.INFO, None, 0, self.end_of_log_mark, None, None))
+        self.handler.emit(logging.makeLogRecord({'msg': self.end_of_log_mark}))
 
         if self.write_stdout:
             self.handler.close()

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -57,7 +57,8 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
     # pylint: disable-msg=too-many-arguments
     def __init__(self, base_log_folder, filename_template,
                  log_id_template, end_of_log_mark,
-                 write_stdout, json_format, json_fields, index,
+                 write_stdout, json_format, json_fields,
+                 index = '*',
                  host='localhost:9200',
                  es_kwargs=conf.getsection("elasticsearch_configs")):
         """

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -257,6 +257,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         # Mark the end of file using end of log mark,
         # so we know where to stop while auto-tailing.
+        #
         # end-of-log mark has to be in its separate line in the console, so
         # add an obnoxious print() for reliably separate the mark into a
         # separate line so that elasticsearch can search for this log mark

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -55,7 +55,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
     def __init__(self, base_log_folder, filename_template,
                  log_id_template, end_of_log_mark,
-                 write_stdout, json_format, json_fields,
+                 write_stdout, json_format, json_fields, index,
                  host='localhost:9200',
                  es_kwargs=conf.getsection("elasticsearch_configs")):
         """
@@ -70,7 +70,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         self.log_id_template, self.log_id_jinja_template = \
             parse_template_string(log_id_template)
-        self.index = conf.get('elasticsearch', 'INDEX')
+        self.index = index
         self.client = elasticsearch.Elasticsearch([host], **es_kwargs)
 
         self.mark_end_on_close = True

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -343,7 +343,8 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.end_of_log_mark,
             self.write_stdout,
             self.json_format,
-            self.json_fields
+            self.json_fields,
+            self.index
         )
         log_id = self.es_task_handler._render_log_id(self.ti, 1)
         self.assertEqual(expected_log_id, log_id)

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -35,6 +35,7 @@ from airflow.utils.timezone import datetime
 
 from .elasticmock import elasticmock
 
+
 # pylint: disable=too-many-instance-attributes
 # 11 is reasonable in this case
 class TestElasticsearchTaskHandler(unittest.TestCase):

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -54,7 +54,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.write_stdout = False
         self.json_format = False
         self.json_fields = 'asctime,filename,lineno,levelname,message'
-        self.index = "test-index"
+        self.index = "test_index"
         self.es_task_handler = ElasticsearchTaskHandler(
             self.local_log_location,
             self.filename_template,

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -53,6 +53,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.write_stdout = False
         self.json_format = False
         self.json_fields = 'asctime,filename,lineno,levelname,message'
+        self.index = "test-index"
         self.es_task_handler = ElasticsearchTaskHandler(
             self.local_log_location,
             self.filename_template,
@@ -60,7 +61,8 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.end_of_log_mark,
             self.write_stdout,
             self.json_format,
-            self.json_fields
+            self.json_fields,
+            self.index
         )
 
         self.es = elasticsearch.Elasticsearch(  # pylint: disable=invalid-name
@@ -104,6 +106,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.write_stdout,
             self.json_format,
             self.json_fields,
+            self.index,
             es_conf
         )
 

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
 import os
 import shutil
 import unittest

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -306,6 +306,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
                   'r') as log_file:
             msg = json.loads(log_file.read())
             self.assertEqual(self.end_of_log_mark, msg['message'])
+
             # create log_id based on log_id_template
             msg['log_id'] = self.log_id_template.format(
                 dag_id=msg['dag_id'],
@@ -314,6 +315,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
                 try_number=msg['try_number'])
             msg['message'] = msg['message'].strip()
             msg['offset'] = 100
+
             self.es.index(index=self.index_name2, doc_type=self.doc_type,
                           body=msg, id=2)
         self.assertTrue(es_task_handler.closed)

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -266,19 +266,12 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.es_task_handler.set_context(self.ti)
 
     def test_close(self):
-        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-        self.es_task_handler.formatter = formatter
-
         self.es_task_handler.set_context(self.ti)
         self.es_task_handler.close()
         with open(os.path.join(self.local_log_location,
                                self.filename_template.format(try_number=1)),
                   'r') as log_file:
-            # end_of_log_mark may contain characters like '\n' which is needed to
-            # have the log uploaded but will not be stored in elasticsearch.
-            # so apply the strip() to log_file.read()
-            log_line = log_file.read().strip()
-            self.assertEqual(self.end_of_log_mark.strip(), log_line.split(" - ")[-1])
+            self.assertIn(self.end_of_log_mark, log_file.read())
         self.assertTrue(self.es_task_handler.closed)
 
     def test_close_no_mark_end(self):

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -306,6 +306,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
                   'r') as log_file:
             msg = json.loads(log_file.read())
             self.assertEqual(self.end_of_log_mark, msg['message'])
+            # create log_id based on log_id_template
             msg['log_id'] = self.log_id_template.format(
                 dag_id=msg['dag_id'],
                 task_id=msg['task_id'],

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -275,7 +275,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             # have the log uploaded but will not be stored in elasticsearch.
             # so apply the strip() to log_file.read()
             log_line = log_file.read().strip()
-            self.assertEqual(self.end_of_log_mark.strip(), log_line)
+            self.assertEqual(self.end_of_log_mark.strip(), log_line.split(" - ")[-1])
         self.assertTrue(self.es_task_handler.closed)
 
     def test_close_no_mark_end(self):

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -92,10 +92,11 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.log_id_template,
             self.end_of_log_mark,
             self.write_stdout,
-            True, # json_format
+            True,  # json_format
             self.json_fields,
             self.index_name2
             )
+
     def tearDown(self):
         shutil.rmtree(self.local_log_location.split(os.path.sep)[0], ignore_errors=True)
 
@@ -119,8 +120,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.json_format,
             self.json_fields,
             self.index,
-            es_conf
-        )
+            es_conf)
 
     def test_read(self):
         ts = pendulum.now()
@@ -284,7 +284,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.log_id_template,
             self.end_of_log_mark,
             self.write_stdout,
-            True, # json_format
+            True,  # json_format
             self.json_fields,
             self.index
         )
@@ -318,10 +318,10 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertTrue(es_task_handler.closed)
 
         logs, metadatas = self.es_task_handler2.read(self.ti,
-                                                self.ti.try_number,
-                                                {'offset': 0,
-                                                 'last_log_timestamp': str(pendulum.now()),
-                                                 'end_of_log': False})
+                                                     self.ti.try_number,
+                                                     {'offset': 0,
+                                                      'last_log_timestamp': str(pendulum.now()),
+                                                      'end_of_log': False})
 
         self.assertEqual(1, len(logs))
         self.assertEqual(log_id_test_message, logs[0])

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -95,7 +95,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             True,  # json_format
             self.json_fields,
             self.index_name2
-            )
+        )
 
     def tearDown(self):
         shutil.rmtree(self.local_log_location.split(os.path.sep)[0], ignore_errors=True)

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -35,7 +35,8 @@ from airflow.utils.timezone import datetime
 
 from .elasticmock import elasticmock
 
-
+# pylint: disable=too-many-instance-attributes
+# 11 is reasonable in this case
 class TestElasticsearchTaskHandler(unittest.TestCase):
     DAG_ID = 'dag_for_testing_file_task_handler'
     TASK_ID = 'task_for_testing_file_log_handler'


### PR DESCRIPTION
The “end of log” marker does not include the primary key of the logs: log_id. The issue is then airflow-web does not know when to stop tailing the logs. 
We print the end of log marker using handler emit() method that adds the dag_id, task_id, execution_date and try_number into the log records. Previously we do not have tests to validate the log_id look up logic from elasticsearch and such a test is added here.

---
Issue link: [AIRFLOW-6544](https://issues.apache.org/jira/browse/AIRFLOW-6544)

- [x] Description above provides context of the change

- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
