### PR TITLE
[AIRFLOW-6527] Make send_task_to_executor timeout configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1159,6 +1159,14 @@
       type: string
       example: ~
       default: "prefork"
+    - name: operation_timeout
+      description: |
+        The number of seconds to wait before timing out ``send_task_to_executor`` or
+        ``fetch_celery_task_state`` operations.
+      version_added: ~
+      type: int
+      example: ~
+      default: "2"
 - name: celery_broker_transport_options
   description: |
     This section is for specifying options which can be passed to the

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -553,6 +553,10 @@ ssl_cacert =
 # https://docs.celeryproject.org/en/latest/userguide/concurrency/eventlet.html
 pool = prefork
 
+# The number of seconds to wait before timing out ``send_task_to_executor`` or
+# ``fetch_celery_task_state`` operations.
+operation_timeout = 2
+
 [celery_broker_transport_options]
 
 # This section is for specifying options which can be passed to the

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -41,6 +41,8 @@ CELERY_FETCH_ERR_MSG_HEADER = 'Error fetching Celery task state'
 
 CELERY_SEND_ERR_MSG_HEADER = 'Error sending Celery task'
 
+OPERATION_TIMEOUT = conf.getint('celery', 'operation_timeout', fallback=2)
+
 '''
 To start the celery worker, run the command:
 airflow celery worker
@@ -102,7 +104,7 @@ def fetch_celery_task_state(celery_task: Tuple[TaskInstanceKeyType, AsyncResult]
     """
 
     try:
-        with timeout(seconds=2):
+        with timeout(seconds=OPERATION_TIMEOUT):
             # Accessing state property of celery task will make actual network request
             # to get the current state of the task.
             return celery_task[0], celery_task[1].state
@@ -122,7 +124,7 @@ def send_task_to_executor(task_tuple: TaskInstanceInCelery) \
     """Sends task to executor."""
     key, _, command, queue, task_to_run = task_tuple
     try:
-        with timeout(seconds=2):
+        with timeout(seconds=OPERATION_TIMEOUT):
             result = task_to_run.apply_async(args=[command], queue=queue)
     except Exception as e:  # pylint: disable=broad-except
         exception_traceback = "Celery Task ID: {}\n{}".format(key, traceback.format_exc())

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -187,5 +187,9 @@ class TestCeleryExecutor(unittest.TestCase):
         mock_stats_gauge.assert_has_calls(calls)
 
 
+def test_operation_timeout_config():
+    assert celery_executor.OPERATION_TIMEOUT == 2
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change makes the timeout for sending tasks to Celery worker configurable. If people encounter the same Celery timeout error described in AIRFLOW-6527, they may increase `[celery]operation_timeout` to make the timeout less likely to happen.

---
Issue link: [AIRFLOW-6527](https://issues.apache.org/jira/browse/AIRFLOW-6527)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
