### PR TITLE
[AIRFLOW-6540] Using DockerContainer - Display all containers logs

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -234,13 +234,16 @@ class DockerOperator(BaseOperator):
                 working_dir=self.working_dir,
                 tty=self.tty,
             )
+
+            lines = self.cli.attach(container=self.container['Id'],
+                                    stdout=True,
+                                    stderr=True,
+                                    stream=True)
+
             self.cli.start(self.container['Id'])
 
             line = ''
-            for line in self.cli.attach(container=self.container['Id'],
-                                        stdout=True,
-                                        stderr=True,
-                                        stream=True):
+            for line in lines:
                 line = line.strip()
                 if hasattr(line, 'decode'):
                     line = line.decode('utf-8')


### PR DESCRIPTION
### **_Before:_**
If the container emits logs very early (after the start but before the attach),
then those logs are lost.

### **_Now:_**
Because attach is done before start, no logs are lost any more.

---
Issue link: [AIRFLOW-6540](https://issues.apache.org/jira/browse/AIRFLOW-6540/)

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
