### PR TITLE
[AIRFLOW-6541] Use EmrJobFlowSensor for other states

### DIFF
--- a/airflow/providers/amazon/aws/sensors/emr_base.py
+++ b/airflow/providers/amazon/aws/sensors/emr_base.py
@@ -16,6 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from typing import Any, Dict, Optional
+
 from airflow.exceptions import AirflowException
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
@@ -24,8 +27,16 @@ from airflow.utils.decorators import apply_defaults
 class EmrBaseSensor(BaseSensorOperator):
     """
     Contains general sensor behavior for EMR.
-    Subclasses should implement get_emr_response() and state_from_response() methods.
-    Subclasses should also implement NON_TERMINAL_STATES and FAILED_STATE constants.
+
+    Subclasses should implement following methods:
+        - ``get_emr_response()``
+        - ``state_from_response()``
+        - ``failure_message_from_response()``
+
+    Subclasses should set ``target_states`` and ``failed_states`` fields.
+
+    :param aws_conn_id: aws connection to uses
+    :type aws_conn_id: str
     """
     ui_color = '#66c3ff'
 
@@ -36,6 +47,8 @@ class EmrBaseSensor(BaseSensorOperator):
             *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.aws_conn_id = aws_conn_id
+        self.target_states = None  # will be set in subclasses
+        self.failed_states = None  # will be set in subclasses
 
     def poke(self, context):
         response = self.get_emr_response()
@@ -47,14 +60,50 @@ class EmrBaseSensor(BaseSensorOperator):
         state = self.state_from_response(response)
         self.log.info('Job flow currently %s', state)
 
-        if state in self.NON_TERMINAL_STATES:
-            return False
+        if state in self.target_states:
+            return True
 
-        if state in self.FAILED_STATE:
+        if state in self.failed_states:
             final_message = 'EMR job failed'
             failure_message = self.failure_message_from_response(response)
             if failure_message:
                 final_message += ' ' + failure_message
             raise AirflowException(final_message)
 
-        return True
+        return False
+
+    def get_emr_response(self) -> Dict[str, Any]:
+        """
+        Make an API call with boto3 and get response.
+
+        :return: response
+        :rtype: dict[str, Any]
+        """
+        raise NotImplementedError(
+            'Please implement get_emr_response() in subclass')
+
+    @staticmethod
+    def state_from_response(response: Dict[str, Any]) -> str:
+        """
+        Get state from response dictionary.
+
+        :param response: response from AWS API
+        :type response: dict[str, Any]
+        :return: state
+        :rtype: str
+        """
+        raise NotImplementedError(
+            'Please implement state_from_response() in subclass')
+
+    @staticmethod
+    def failure_message_from_response(response: Dict[str, Any]) -> Optional[str]:
+        """
+        Get failure message from response dictionary.
+
+        :param response: response from AWS API
+        :type response: dict[str, Any]
+        :return: failure message
+        :rtype: Optional[str]
+        """
+        raise NotImplementedError(
+            'Please implement failure_message_from_response() in subclass')

--- a/airflow/providers/amazon/aws/sensors/emr_job_flow.py
+++ b/airflow/providers/amazon/aws/sensors/emr_job_flow.py
@@ -16,6 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from typing import Any, Dict, Iterable, Optional
+
 from airflow.providers.amazon.aws.hooks.emr import EmrHook
 from airflow.providers.amazon.aws.sensors.emr_base import EmrBaseSensor
 from airflow.utils.decorators import apply_defaults
@@ -23,41 +26,80 @@ from airflow.utils.decorators import apply_defaults
 
 class EmrJobFlowSensor(EmrBaseSensor):
     """
-    Asks for the state of the JobFlow until it reaches a terminal state.
+    Asks for the state of the EMR JobFlow (Cluster) until it reaches
+    any of the target states.
     If it fails the sensor errors, failing the task.
+
+    With the default target states, sensor waits cluster to be terminated.
+    When target_states is set to ['RUNNING', 'WAITING'] sensor waits
+    until job flow to be ready (after 'STARTING' and 'BOOTSTRAPPING' states)
 
     :param job_flow_id: job_flow_id to check the state of
     :type job_flow_id: str
+    :param target_states: the target states, sensor waits until
+        job flow reaches any of these states
+    :type target_states: list[str]
+    :param failed_states: the failure states, sensor fails when
+        job flow reaches any of these states
+    :type failed_states: list[str]
     """
 
-    NON_TERMINAL_STATES = ['STARTING', 'BOOTSTRAPPING', 'RUNNING',
-                           'WAITING', 'TERMINATING']
-    FAILED_STATE = ['TERMINATED_WITH_ERRORS']
-    template_fields = ['job_flow_id']
+    template_fields = ['job_flow_id', 'target_states', 'failed_states']
     template_ext = ()
 
     @apply_defaults
     def __init__(self,
-                 job_flow_id,
+                 job_flow_id: str,
+                 target_states: Optional[Iterable[str]] = None,
+                 failed_states: Optional[Iterable[str]] = None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
         self.job_flow_id = job_flow_id
+        self.target_states = target_states or ['TERMINATED']
+        self.failed_states = failed_states or ['TERMINATED_WITH_ERRORS']
 
-    def get_emr_response(self):
+    def get_emr_response(self) -> Dict[str, Any]:
+        """
+        Make an API call with boto3 and get cluster-level details.
+
+        .. seealso::
+            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.describe_cluster
+
+        :return: response
+        :rtype: dict[str, Any]
+        """
         emr = EmrHook(aws_conn_id=self.aws_conn_id).get_conn()
 
         self.log.info('Poking cluster %s', self.job_flow_id)
         return emr.describe_cluster(ClusterId=self.job_flow_id)
 
     @staticmethod
-    def state_from_response(response):
+    def state_from_response(response: Dict[str, Any]) -> str:
+        """
+        Get state from response dictionary.
+
+        :param response: response from AWS API
+        :type response: dict[str, Any]
+        :return: current state of the cluster
+        :rtype: str
+        """
         return response['Cluster']['Status']['State']
 
     @staticmethod
-    def failure_message_from_response(response):
-        state_change_reason = response['Cluster']['Status'].get('StateChangeReason')
+    def failure_message_from_response(response: Dict[str, Any]) -> Optional[str]:
+        """
+        Get failure message from response dictionary.
+
+        :param response: response from AWS API
+        :type response: dict[str, Any]
+        :return: failure message
+        :rtype: Optional[str]
+        """
+        cluster_status = response['Cluster']['Status']
+        state_change_reason = cluster_status.get('StateChangeReason')
         if state_change_reason:
-            return 'for code: {} with message {}'.format(state_change_reason.get('Code', 'No code'),
-                                                         state_change_reason.get('Message', 'Unknown'))
+            return 'for code: {} with message {}'.format(
+                state_change_reason.get('Code', 'No code'),
+                state_change_reason.get('Message', 'Unknown'))
         return None

--- a/airflow/providers/amazon/aws/sensors/emr_step.py
+++ b/airflow/providers/amazon/aws/sensors/emr_step.py
@@ -16,6 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from typing import Any, Dict, Iterable, Optional
+
 from airflow.providers.amazon.aws.hooks.emr import EmrHook
 from airflow.providers.amazon.aws.sensors.emr_base import EmrBaseSensor
 from airflow.utils.decorators import apply_defaults
@@ -23,45 +26,86 @@ from airflow.utils.decorators import apply_defaults
 
 class EmrStepSensor(EmrBaseSensor):
     """
-    Asks for the state of the step until it reaches a terminal state.
+    Asks for the state of the step until it reaches any of the target states.
     If it fails the sensor errors, failing the task.
+
+    With the default target states, sensor waits step to be completed.
 
     :param job_flow_id: job_flow_id which contains the step check the state of
     :type job_flow_id: str
     :param step_id: step to check the state of
     :type step_id: str
+    :param target_states: the target states, sensor waits until
+        step reaches any of these states
+    :type target_states: list[str]
+    :param failed_states: the failure states, sensor fails when
+        step reaches any of these states
+    :type failed_states: list[str]
     """
 
-    NON_TERMINAL_STATES = ['PENDING', 'RUNNING', 'CONTINUE', 'CANCEL_PENDING']
-    FAILED_STATE = ['CANCELLED', 'FAILED', 'INTERRUPTED']
-    template_fields = ['job_flow_id', 'step_id']
+    template_fields = ['job_flow_id', 'step_id',
+                       'target_states', 'failed_states']
     template_ext = ()
 
     @apply_defaults
     def __init__(self,
-                 job_flow_id,
-                 step_id,
+                 job_flow_id: str,
+                 step_id: str,
+                 target_states: Optional[Iterable[str]] = None,
+                 failed_states: Optional[Iterable[str]] = None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
         self.job_flow_id = job_flow_id
         self.step_id = step_id
+        self.target_states = target_states or ['COMPLETED']
+        self.failed_states = failed_states or ['CANCELLED', 'FAILED',
+                                               'INTERRUPTED']
 
-    def get_emr_response(self):
+    def get_emr_response(self) -> Dict[str, Any]:
+        """
+        Make an API call with boto3 and get details about the cluster step.
+
+        .. seealso::
+            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.describe_step
+
+        :return: response
+        :rtype: dict[str, Any]
+        """
         emr = EmrHook(aws_conn_id=self.aws_conn_id).get_conn()
 
-        self.log.info('Poking step %s on cluster %s', self.step_id, self.job_flow_id)
-        return emr.describe_step(ClusterId=self.job_flow_id, StepId=self.step_id)
+        self.log.info('Poking step %s on cluster %s',
+                      self.step_id,
+                      self.job_flow_id)
+        return emr.describe_step(ClusterId=self.job_flow_id,
+                                 StepId=self.step_id)
 
     @staticmethod
-    def state_from_response(response):
+    def state_from_response(response: Dict[str, Any]) -> str:
+        """
+        Get state from response dictionary.
+
+        :param response: response from AWS API
+        :type response: dict[str, Any]
+        :return: execution state of the cluster step
+        :rtype: str
+        """
         return response['Step']['Status']['State']
 
     @staticmethod
-    def failure_message_from_response(response):
+    def failure_message_from_response(response: Dict[str, Any]) -> Optional[str]:
+        """
+        Get failure message from response dictionary.
+
+        :param response: response from AWS API
+        :type response: dict[str, Any]
+        :return: failure message
+        :rtype: Optional[str]
+        """
         fail_details = response['Step']['Status'].get('FailureDetails')
         if fail_details:
-            return 'for reason {} with message {} and log file {}'.format(fail_details.get('Reason'),
-                                                                          fail_details.get('Message'),
-                                                                          fail_details.get('LogFile'))
+            return 'for reason {} with message {} and log file {}'.format(
+                fail_details.get('Reason'),
+                fail_details.get('Message'),
+                fail_details.get('LogFile'))
         return None


### PR DESCRIPTION
Currently, EmrJobFlowSensor waits cluster to be terminated (state: "TERMINATED"). It can be used for other purposes if cluster states to be checked (i.e., NON_TERMINAL_STATES) can be passed to the operator.

For example, this sensor could be used to wait cluster to be ready (state: "RUNNING" or "WAITING").

Remove class constants of EmrBaseSensor: NON_TERMINAL_STATES, FAILED_STATE. Add new parameters: target_states and failed_states. Eliminate pylint warnings. Do not change default behaviour of the updated sensors.

---
Issue link: [AIRFLOW-6541](https://issues.apache.org/jira/browse/AIRFLOW-6541)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
