### PR TITLE
[AIRFLOW-6472] Correct short and long option in cli

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -241,12 +241,89 @@ The following configurations have been moved from `[core]` to the new `[logging]
 
 ### Simplification of CLI commands
 
+#### Grouped to improve UX of CLI
+
 Some commands have been grouped to improve UX of CLI. New commands are available according to the following table:
 
 | Old command               | New command                        |
 |---------------------------|------------------------------------|
 | ``airflow worker``        | ``airflow celery worker``          |
 | ``airflow flower``        | ``airflow celery flower``          |
+
+#### Cli use exactly single character for short option style change
+
+For Airflow short option, use exactly one single character, New commands are available according to the following table:
+
+| Old command                                        | New command                                       |
+| :------------------------------------------------- | :------------------------------------------------ |
+| ``airflow (dags|tasks|scheduler) [-sd, --subdir]`` | ``airflow (dags|tasks|scheduler) [-S, --subdir]`` |
+| ``airflow tasks test [-dr, --dry_run]``            | ``airflow tasks test [-n, --dry-run]``            |
+| ``airflow dags backfill [-dr, --dry_run]``         | ``airflow dags backfill [-n, --dry-run]``         |
+| ``airflow tasks clear [-dx, --dag_regex]``         | ``airflow tasks clear [-R, --dag-regex]``         |
+| ``airflow kerberos [-kt, --keytab]``               | ``airflow kerberos [-k, --keytab]``               |
+| ``airflow tasks run [-int, --interactive]``        | ``airflow tasks run [-N, --interactive]``         |
+| ``airflow webserver [-hn, --hostname]``            | ``airflow webserver [-H, --hostname]``            |
+| ``airflow celery worker [-cn, --celery_hostname]`` | ``airflow celery worker [-H, --celery-hostname]`` |
+| ``airflow celery flower [-hn, --hostname]``        | ``airflow celery flower [-H, --hostname]``        |
+| ``airflow celery flower [-fc, --flower_conf]``     | ``airflow celery flower [-c, --flower-conf]``     |
+| ``airflow celery flower [-ba, --basic_auth]``      | ``airflow celery flower [-A, --basic-auth]``      |
+| ``airflow celery flower [-tp, --task_params]``     | ``airflow celery flower [-t, --task-params]``     |
+| ``airflow celery flower [-pm, --post_mortem]``     | ``airflow celery flower [-m, --post-mortem]``     |
+
+For Airflow long option, use [kebab-case](https://en.wikipedia.org/wiki/Letter_case) instead of [snake_case](https://en.wikipedia.org/wiki/Snake_case)
+
+| Old option                         | New option                         |
+| :--------------------------------- | :--------------------------------- |
+| ``--task_regex``                   | ``--task-regex``                   |
+| ``--start_date``                   | ``--start-date``                   |
+| ``--end_date``                     | ``--end-date``                     |
+| ``--dry_run``                      | ``--dry-run``                      |
+| ``--no_backfill``                  | ``--no-backfill``                  |
+| ``--mark_success``                 | ``--mark-success``                 |
+| ``--donot_pickle``                 | ``--donot-pickle``                 |
+| ``--ignore_dependencies``          | ``--ignore-dependencies``          |
+| ``--ignore_first_depends_on_past`` | ``--ignore-first-depends-on-past`` |
+| ``--delay_on_limit``               | ``--delay-on-limit``               |
+| ``--reset_dagruns``                | ``--reset-dagruns``                |
+| ``--rerun_failed_tasks``           | ``--rerun-failed-tasks``           |
+| ``--run_backwards``                | ``--run-backwards``                |
+| ``--only_failed``                  | ``--only-failed``                  |
+| ``--only_running``                 | ``--only-running``                 |
+| ``--exclude_subdags``              | ``--exclude-subdags``              |
+| ``--exclude_parentdag``            | ``--exclude-parentdag``            |
+| ``--dag_regex``                    | ``--dag-regex``                    |
+| ``--run_id``                       | ``--run-id``                       |
+| ``--exec_date``                    | ``--exec-date``                    |
+| ``--ignore_all_dependencies``      | ``--ignore-all-dependencies``      |
+| ``--ignore_depends_on_past``       | ``--ignore-depends-on-past``       |
+| ``--ship_dag``                     | ``--ship-dag``                     |
+| ``--job_id``                       | ``--job-id``                       |
+| ``--cfg_path``                     | ``--cfg-path``                     |
+| ``--ssl_cert``                     | ``--ssl-cert``                     |
+| ``--ssl_key``                      | ``--ssl-key``                      |
+| ``--worker_timeout``               | ``--worker-timeout``               |
+| ``--access_logfile``               | ``--access-logfile``               |
+| ``--error_logfile``                | ``--error-logfile``                |
+| ``--dag_id``                       | ``--dag-id``                       |
+| ``--num_runs``                     | ``--num-runs``                     |
+| ``--do_pickle``                    | ``--do-pickle``                    |
+| ``--celery_hostname``              | ``--celery-hostname``              |
+| ``--broker_api``                   | ``--broker-api``                   |
+| ``--flower_conf``                  | ``--flower-conf``                  |
+| ``--url_prefix``                   | ``--url-prefix``                   |
+| ``--basic_auth``                   | ``--basic-auth``                   |
+| ``--task_params``                  | ``--task-params``                  |
+| ``--post_mortem``                  | ``--post-mortem``                  |
+| ``--conn_uri``                     | ``--conn-uri``                     |
+| ``--conn_type``                    | ``--conn-type``                    |
+| ``--conn_host``                    | ``--conn-host``                    |
+| ``--conn_login``                   | ``--conn-login``                   |
+| ``--conn_password``                | ``--conn-password``                |
+| ``--conn_schema``                  | ``--conn-schema``                  |
+| ``--conn_port``                    | ``--conn-port``                    |
+| ``--conn_extra``                   | ``--conn-extra``                   |
+| ``--use_random_password``          | ``--use-random-password``          |
+| ``--skip_serve_logs``              | ``--skip-serve-logs``              |
 
 ### Remove serve_logs command from CLI
 

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -86,22 +86,22 @@ class CLIFactory:
             ("execution_date",), help="The execution date of the DAG",
             type=parsedate),
         'task_regex': Arg(
-            ("-t", "--task_regex"),
+            ("-t", "--task-regex"),
             "The regex to filter specific task_ids to backfill (optional)"),
         'subdir': Arg(
-            ("-sd", "--subdir"),
+            ("-S", "--subdir"),
             "File location or directory from which to look for the dag. "
             "Defaults to '[AIRFLOW_HOME]/dags' where [AIRFLOW_HOME] is the "
             "value you set for 'AIRFLOW_HOME' config you set in 'airflow.cfg' ",
             default=DAGS_FOLDER),
         'start_date': Arg(
-            ("-s", "--start_date"), "Override start_date YYYY-MM-DD",
+            ("-s", "--start-date"), "Override start_date YYYY-MM-DD",
             type=parsedate),
         'end_date': Arg(
-            ("-e", "--end_date"), "Override end_date YYYY-MM-DD",
+            ("-e", "--end-date"), "Override end_date YYYY-MM-DD",
             type=parsedate),
         'dry_run': Arg(
-            ("-dr", "--dry_run"), "Perform a dry run", "store_true"),
+            ("-n", "--dry-run"), "Perform a dry run", "store_true"),
         'pid': Arg(
             ("--pid",), "PID file location",
             nargs='?'),
@@ -130,7 +130,7 @@ class CLIFactory:
 
         # list_dag_runs
         'no_backfill': Arg(
-            ("--no_backfill",),
+            ("--no-backfill",),
             "filter all the backfill dagruns given the dag id", "store_true"),
         'state': Arg(
             ("--state",),
@@ -145,7 +145,7 @@ class CLIFactory:
 
         # backfill
         'mark_success': Arg(
-            ("-m", "--mark_success"),
+            ("-m", "--mark-success"),
             "Mark jobs as succeeded without running them", "store_true"),
         'verbose': Arg(
             ("-v", "--verbose"),
@@ -154,20 +154,20 @@ class CLIFactory:
             ("-l", "--local"),
             "Run the task using the LocalExecutor", "store_true"),
         'donot_pickle': Arg(
-            ("-x", "--donot_pickle"), (
+            ("-x", "--donot-pickle"), (
                 "Do not attempt to pickle the DAG object to send over "
                 "to the workers, just tell the workers to run their version "
                 "of the code"),
             "store_true"),
         'bf_ignore_dependencies': Arg(
-            ("-i", "--ignore_dependencies"),
+            ("-i", "--ignore-dependencies"),
             (
                 "Skip upstream tasks, run only the tasks "
                 "matching the regexp. Only works in conjunction "
                 "with task_regex"),
             "store_true"),
         'bf_ignore_first_depends_on_past': Arg(
-            ("-I", "--ignore_first_depends_on_past"),
+            ("-I", "--ignore-first-depends-on-past"),
             (
                 "Ignores depends_on_past dependencies for the first "
                 "set of tasks only (subsequent executions in the backfill "
@@ -175,7 +175,7 @@ class CLIFactory:
             "store_true"),
         'pool': Arg(("--pool",), "Resource pool to use"),
         'delay_on_limit': Arg(
-            ("--delay_on_limit",),
+            ("--delay-on-limit",),
             help=("Amount of time in seconds to wait when the limit "
                   "on maximum active dag runs (max_active_runs) has "
                   "been reached before trying to execute a dag run "
@@ -183,21 +183,21 @@ class CLIFactory:
             type=float,
             default=1.0),
         'reset_dag_run': Arg(
-            ("--reset_dagruns",),
+            ("--reset-dagruns",),
             (
                 "if set, the backfill will delete existing "
                 "backfill-related DAG runs and start "
                 "anew with fresh, running DAG runs"),
             "store_true"),
         'rerun_failed_tasks': Arg(
-            ("--rerun_failed_tasks",),
+            ("--rerun-failed-tasks",),
             (
                 "if set, the backfill will auto-rerun "
                 "all the failed tasks for the backfill date range "
                 "instead of throwing exceptions"),
             "store_true"),
         'run_backwards': Arg(
-            ("-B", "--run_backwards",),
+            ("-B", "--run-backwards",),
             (
                 "if set, the backfill will run tasks from the most "
                 "recent day first.  if there are tasks that depend_on_past "
@@ -213,20 +213,20 @@ class CLIFactory:
         'upstream': Arg(
             ("-u", "--upstream"), "Include upstream tasks", "store_true"),
         'only_failed': Arg(
-            ("-f", "--only_failed"), "Only failed jobs", "store_true"),
+            ("-f", "--only-failed"), "Only failed jobs", "store_true"),
         'only_running': Arg(
-            ("-r", "--only_running"), "Only running jobs", "store_true"),
+            ("-r", "--only-running"), "Only running jobs", "store_true"),
         'downstream': Arg(
             ("-d", "--downstream"), "Include downstream tasks", "store_true"),
         'exclude_subdags': Arg(
-            ("-x", "--exclude_subdags"),
+            ("-x", "--exclude-subdags"),
             "Exclude subdags", "store_true"),
         'exclude_parentdag': Arg(
-            ("-xp", "--exclude_parentdag"),
+            ("-X", "--exclude-parentdag"),
             "Exclude ParentDAGS if the task cleared is a part of a SubDAG",
             "store_true"),
         'dag_regex': Arg(
-            ("-dx", "--dag_regex"),
+            ("-R", "--dag-regex"),
             "Search dag_id as regex instead of exact string", "store_true"),
         # show_dag
         'save': Arg(
@@ -249,12 +249,12 @@ class CLIFactory:
             "For more information, see: https://www.iterm2.com/documentation-images.html",
             action='store_true'),
         # trigger_dag
-        'run_id': Arg(("-r", "--run_id"), "Helps to identify this run"),
+        'run_id': Arg(("-r", "--run-id"), "Helps to identify this run"),
         'conf': Arg(
             ('-c', '--conf'),
             "JSON string that gets pickled into the DagRun's conf attribute"),
         'exec_date': Arg(
-            ("-e", "--exec_date"), help="The execution date of the DAG",
+            ("-e", "--exec-date"), help="The execution date of the DAG",
             type=parsedate),
         # pool
         'pool_name': Arg(
@@ -303,7 +303,7 @@ class CLIFactory:
         'principal': Arg(
             ("principal",), "kerberos principal", nargs='?'),
         'keytab': Arg(
-            ("-kt", "--keytab"), "keytab",
+            ("-k", "--keytab"), "keytab",
             nargs='?', default=conf.get('kerberos', 'keytab')),
         # run
         # TODO(aoen): "force" is a poor choice of name here since it implies it overrides
@@ -312,7 +312,7 @@ class CLIFactory:
         # the "ignore_all_dependencies" command should be called the"force" command
         # instead.
         'interactive': Arg(
-            ('-int', '--interactive'),
+            ('-N', '--interactive'),
             help='Do not capture standard output and error streams '
                  '(useful for interactive debugging)',
             action='store_true'),
@@ -323,7 +323,7 @@ class CLIFactory:
             "store_true"),
         'raw': Arg(("-r", "--raw"), argparse.SUPPRESS, "store_true"),
         'ignore_all_dependencies': Arg(
-            ("-A", "--ignore_all_dependencies"),
+            ("-A", "--ignore-all-dependencies"),
             "Ignores all non-critical dependencies, including ignore_ti_state and "
             "ignore_task_deps",
             "store_true"),
@@ -333,25 +333,25 @@ class CLIFactory:
         # slightly better (as it ignores all dependencies that are specific to the task),
         # so deprecate the old command name and use this instead.
         'ignore_dependencies': Arg(
-            ("-i", "--ignore_dependencies"),
+            ("-i", "--ignore-dependencies"),
             "Ignore task-specific dependencies, e.g. upstream, depends_on_past, and "
             "retry delay dependencies",
             "store_true"),
         'ignore_depends_on_past': Arg(
-            ("-I", "--ignore_depends_on_past"),
+            ("-I", "--ignore-depends-on-past"),
             "Ignore depends_on_past dependencies (but respect "
             "upstream dependencies)",
             "store_true"),
         'ship_dag': Arg(
-            ("--ship_dag",),
+            ("--ship-dag",),
             "Pickles (serializes) the DAG and ships it to the worker",
             "store_true"),
         'pickle': Arg(
             ("-p", "--pickle"),
             "Serialized pickle object of the entire dag (used internally)"),
-        'job_id': Arg(("-j", "--job_id"), argparse.SUPPRESS),
+        'job_id': Arg(("-j", "--job-id"), argparse.SUPPRESS),
         'cfg_path': Arg(
-            ("--cfg_path",), "Path to config file to use instead of airflow.cfg"),
+            ("--cfg-path",), "Path to config file to use instead of airflow.cfg"),
         # webserver
         'port': Arg(
             ("-p", "--port"),
@@ -359,11 +359,11 @@ class CLIFactory:
             type=int,
             help="The port on which to run the server"),
         'ssl_cert': Arg(
-            ("--ssl_cert",),
+            ("--ssl-cert",),
             default=conf.get('webserver', 'WEB_SERVER_SSL_CERT'),
             help="Path to the SSL certificate for the webserver"),
         'ssl_key': Arg(
-            ("--ssl_key",),
+            ("--ssl-key",),
             default=conf.get('webserver', 'WEB_SERVER_SSL_KEY'),
             help="Path to the key to use with the SSL certificate"),
         'workers': Arg(
@@ -377,12 +377,12 @@ class CLIFactory:
             choices=['sync', 'eventlet', 'gevent', 'tornado'],
             help="The worker class to use for Gunicorn"),
         'worker_timeout': Arg(
-            ("-t", "--worker_timeout"),
+            ("-t", "--worker-timeout"),
             default=conf.get('webserver', 'WEB_SERVER_WORKER_TIMEOUT'),
             type=int,
             help="The timeout for waiting on webserver workers"),
         'hostname': Arg(
-            ("-hn", "--hostname"),
+            ("-H", "--hostname"),
             default=conf.get('webserver', 'WEB_SERVER_HOST'),
             help="Set the hostname on which to run the web server"),
         'debug': Arg(
@@ -390,24 +390,24 @@ class CLIFactory:
             "Use the server that ships with Flask in debug mode",
             "store_true"),
         'access_logfile': Arg(
-            ("-A", "--access_logfile"),
+            ("-A", "--access-logfile"),
             default=conf.get('webserver', 'ACCESS_LOGFILE'),
             help="The logfile to store the webserver access log. Use '-' to print to "
                  "stderr"),
         'error_logfile': Arg(
-            ("-E", "--error_logfile"),
+            ("-E", "--error-logfile"),
             default=conf.get('webserver', 'ERROR_LOGFILE'),
             help="The logfile to store the webserver error log. Use '-' to print to "
                  "stderr"),
         # scheduler
-        'dag_id_opt': Arg(("-d", "--dag_id"), help="The id of the dag to run"),
+        'dag_id_opt': Arg(("-d", "--dag-id"), help="The id of the dag to run"),
         'num_runs': Arg(
-            ("-n", "--num_runs"),
+            ("-n", "--num-runs"),
             default=conf.getint('scheduler', 'num_runs'), type=int,
             help="Set the number of runs to execute before exiting"),
         # worker
         'do_pickle': Arg(
-            ("-p", "--do_pickle"),
+            ("-p", "--do-pickle"),
             default=False,
             help=(
                 "Attempt to pickle the DAG object to send over "
@@ -424,13 +424,13 @@ class CLIFactory:
             help="The number of worker processes",
             default=conf.get('celery', 'worker_concurrency')),
         'celery_hostname': Arg(
-            ("-cn", "--celery_hostname"),
+            ("-H", "--celery-hostname"),
             help=("Set the hostname of celery worker "
                   "if you have multiple workers on a single machine")),
         # flower
-        'broker_api': Arg(("-a", "--broker_api"), help="Broker api"),
+        'broker_api': Arg(("-a", "--broker-api"), help="Broker api"),
         'flower_hostname': Arg(
-            ("-hn", "--hostname"),
+            ("-H", "--hostname"),
             default=conf.get('celery', 'FLOWER_HOST'),
             help="Set the hostname on which to run the server"),
         'flower_port': Arg(
@@ -439,23 +439,23 @@ class CLIFactory:
             type=int,
             help="The port on which to run the server"),
         'flower_conf': Arg(
-            ("-fc", "--flower_conf"),
+            ("-c", "--flower-conf"),
             help="Configuration file for flower"),
         'flower_url_prefix': Arg(
-            ("-u", "--url_prefix"),
+            ("-u", "--url-prefix"),
             default=conf.get('celery', 'FLOWER_URL_PREFIX'),
             help="URL prefix for Flower"),
         'flower_basic_auth': Arg(
-            ("-ba", "--basic_auth"),
+            ("-A", "--basic-auth"),
             default=conf.get('celery', 'FLOWER_BASIC_AUTH'),
             help=("Securing Flower with Basic Authentication. "
                   "Accepts user:password pairs separated by a comma. "
                   "Example: flower_basic_auth = user1:password1,user2:password2")),
         'task_params': Arg(
-            ("-tp", "--task_params"),
+            ("-t", "--task-params"),
             help="Sends a JSON params dict to the task"),
         'post_mortem': Arg(
-            ("-pm", "--post_mortem"),
+            ("-m", "--post-mortem"),
             action="store_true",
             help="Open debugger on uncaught exception",
         ),
@@ -465,35 +465,35 @@ class CLIFactory:
             help='Connection id, required to add/delete a connection',
             type=str),
         'conn_uri': Arg(
-            ('--conn_uri',),
+            ('--conn-uri',),
             help='Connection URI, required to add a connection without conn_type',
             type=str),
         'conn_type': Arg(
-            ('--conn_type',),
+            ('--conn-type',),
             help='Connection type, required to add a connection without conn_uri',
             type=str),
         'conn_host': Arg(
-            ('--conn_host',),
+            ('--conn-host',),
             help='Connection host, optional when adding a connection',
             type=str),
         'conn_login': Arg(
-            ('--conn_login',),
+            ('--conn-login',),
             help='Connection login, optional when adding a connection',
             type=str),
         'conn_password': Arg(
-            ('--conn_password',),
+            ('--conn-password',),
             help='Connection password, optional when adding a connection',
             type=str),
         'conn_schema': Arg(
-            ('--conn_schema',),
+            ('--conn-schema',),
             help='Connection schema, optional when adding a connection',
             type=str),
         'conn_port': Arg(
-            ('--conn_port',),
+            ('--conn-port',),
             help='Connection port, optional when adding a connection',
             type=str),
         'conn_extra': Arg(
-            ('--conn_extra',),
+            ('--conn-extra',),
             help='Connection `Extra` field, optional when adding a connection',
             type=str),
         # users
@@ -535,10 +535,10 @@ class CLIFactory:
         'password': Arg(
             ('--password',),
             help='Password of the user, required to create a user '
-                 'without --use_random_password',
+                 'without --use-random-password',
             type=str),
         'use_random_password': Arg(
-            ('--use_random_password',),
+            ('--use-random-password',),
             help='Do not prompt for password. Use random string instead.'
                  ' Required to create a user without --password ',
             default=False,
@@ -579,7 +579,7 @@ class CLIFactory:
             ('-a', '--autoscale'),
             help="Minimum and Maximum number of worker to autoscale"),
         'skip_serve_logs': Arg(
-            ("-s", "--skip_serve_logs"),
+            ("-s", "--skip-serve-logs"),
             default=False,
             help="Don't start the serve logs process along with the workers",
             action="store_true"),
@@ -740,8 +740,7 @@ class CLIFactory:
             'func': lazy_load_command('airflow.cli.commands.task_command.task_states_for_dag_run'),
             'name': 'states_for_dag_run',
             'help': "Get the status of all task instances in a dag run",
-            'args': (
-                'dag_id', 'execution_date', 'output'),
+            'args': ('dag_id', 'execution_date', 'output'),
         },
     )
     POOLS_COMMANDS = (
@@ -837,19 +836,19 @@ class CLIFactory:
             'func': lazy_load_command('airflow.cli.commands.db_command.upgradedb'),
             'name': 'upgrade',
             'help': "Upgrade the metadata database to latest version",
-            'args': tuple(),
+            'args': (),
         },
         {
             'func': lazy_load_command('airflow.cli.commands.db_command.shell'),
             'name': 'shell',
             'help': "Runs a shell to access the database",
-            'args': tuple(),
+            'args': (),
         },
         {
             'func': lazy_load_command('airflow.cli.commands.db_command.check'),
             'name': 'check',
             'help': "Check if the database can be reached.",
-            'args': tuple(),
+            'args': (),
         },
     )
     CONNECTIONS_COMMANDS = (
@@ -872,7 +871,7 @@ class CLIFactory:
             'args': ('conn_id',),
         },
     )
-    USERS_COMMANDSS = (
+    USERS_COMMANDS = (
         {
             'func': lazy_load_command('airflow.cli.commands.user_command.users_list'),
             'name': 'list',
@@ -978,7 +977,7 @@ class CLIFactory:
             'name': 'version',
             'func': lazy_load_command('airflow.cli.commands.version_command.version'),
             'help': "Show the version",
-            'args': tuple(),
+            'args': (),
         }, {
             'help': "List/Add/Delete connections",
             'name': 'connections',
@@ -986,7 +985,7 @@ class CLIFactory:
         }, {
             'help': "CRUD operations on users",
             'name': 'users',
-            'subcommands': USERS_COMMANDSS,
+            'subcommands': USERS_COMMANDS,
         }, {
             'help': 'Create/List roles',
             'name': 'roles',
@@ -995,7 +994,7 @@ class CLIFactory:
             'name': 'sync_perm',
             'func': lazy_load_command('airflow.cli.commands.sync_perm_command.sync_perm'),
             'help': "Update permissions for existing roles and DAGs",
-            'args': tuple(),
+            'args': (),
         },
         {
             'name': 'rotate_fernet_key',

--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -47,13 +47,13 @@ def flower(args):
     ]
 
     if args.broker_api:
-        options.append(f"--broker_api={args.broker_api}")
+        options.append(f"--broker-api={args.broker_api}")
 
     if args.url_prefix:
         options.append(f"--url-prefix={args.url_prefix}")
 
     if args.basic_auth:
-        options.append(f"--basic_auth={args.basic_auth}")
+        options.append(f"--basic-auth={args.basic_auth}")
 
     if args.flower_conf:
         options.append(f"--conf={args.flower_conf}")

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -60,7 +60,7 @@ def connections_add(args):
         raise SystemExit(msg)
     if invalid_args:
         msg = ('The following args are not compatible with the ' +
-               '--add flag and --conn_uri flag: {invalid!r}')
+               '--add flag and --conn-uri flag: {invalid!r}')
         msg = msg.format(invalid=invalid_args)
         raise SystemExit(msg)
 

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -41,7 +41,7 @@ def my_py_command(test_mode, params):
     """
     Print out the "foo" param passed in via
     `airflow tasks test example_passing_params_via_test_command run_this <date>
-    -tp '{"foo":"bar"}'`
+    -t '{"foo":"bar"}'`
     """
     if test_mode:
         print(" 'foo' was passed in via test={} command : kwargs[params][foo] \

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -342,7 +342,7 @@ class TaskInstance(Base, LoggingMixin):
         :param raw: raw mode (needs more details)
         :type raw: Optional[bool]
         :param job_id: job ID (needs more details)
-        :type job_id: Optional[str]
+        :type job_id: Optional[int]
         :param pool: the Airflow pool that the task should run in
         :type pool: Optional[str]
         :param cfg_path: the Path to the configuration file
@@ -357,7 +357,7 @@ class TaskInstance(Base, LoggingMixin):
         if pickle_id:
             cmd.extend(["--pickle", pickle_id])
         if job_id:
-            cmd.extend(["--job-id", job_id])
+            cmd.extend(["--job-id", str(job_id)])
         if ignore_all_deps:
             cmd.extend(["--ignore-all-dependencies"])
         if ignore_task_deps:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -25,7 +25,7 @@ import os
 import signal
 import time
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from urllib.parse import quote
 
 import dill
@@ -294,72 +294,88 @@ class TaskInstance(Base, LoggingMixin):
             cfg_path=cfg_path)
 
     @staticmethod
-    def generate_command(dag_id,
-                         task_id,
-                         execution_date,
-                         mark_success=False,
-                         ignore_all_deps=False,
-                         ignore_depends_on_past=False,
-                         ignore_task_deps=False,
-                         ignore_ti_state=False,
-                         local=False,
-                         pickle_id=None,
-                         file_path=None,
-                         raw=False,
-                         job_id=None,
-                         pool=None,
-                         cfg_path=None
-                         ):
+    def generate_command(dag_id: str,
+                         task_id: str,
+                         execution_date: datetime,
+                         mark_success: Optional[bool] = False,
+                         ignore_all_deps: Optional[bool] = False,
+                         ignore_depends_on_past: Optional[bool] = False,
+                         ignore_task_deps: Optional[bool] = False,
+                         ignore_ti_state: Optional[bool] = False,
+                         local: Optional[bool] = False,
+                         pickle_id: Optional[str] = None,
+                         file_path: Optional[str] = None,
+                         raw: Optional[bool] = False,
+                         job_id: Optional[str] = None,
+                         pool: Optional[str] = None,
+                         cfg_path: Optional[str] = None
+                         ) -> List[str]:
         """
         Generates the shell command required to execute this task instance.
 
         :param dag_id: DAG ID
-        :type dag_id: unicode
+        :type dag_id: str
         :param task_id: Task ID
-        :type task_id: unicode
+        :type task_id: str
         :param execution_date: Execution date for the task
-        :type execution_date: datetime.datetime
+        :type execution_date: datetime
         :param mark_success: Whether to mark the task as successful
-        :type mark_success: bool
+        :type mark_success: Optional[bool]
         :param ignore_all_deps: Ignore all ignorable dependencies.
             Overrides the other ignore_* parameters.
-        :type ignore_all_deps: bool
+        :type ignore_all_deps: Optional[bool]
         :param ignore_depends_on_past: Ignore depends_on_past parameter of DAGs
             (e.g. for Backfills)
-        :type ignore_depends_on_past: bool
+        :type ignore_depends_on_past: Optional[bool]
         :param ignore_task_deps: Ignore task-specific dependencies such as depends_on_past
             and trigger rule
-        :type ignore_task_deps: bool
+        :type ignore_task_deps: Optional[bool]
         :param ignore_ti_state: Ignore the task instance's previous failure/success
-        :type ignore_ti_state: bool
+        :type ignore_ti_state: Optional[bool]
         :param local: Whether to run the task locally
-        :type local: bool
+        :type local: Optional[bool]
         :param pickle_id: If the DAG was serialized to the DB, the ID
             associated with the pickled DAG
-        :type pickle_id: unicode
+        :type pickle_id: Optional[str]
         :param file_path: path to the file containing the DAG definition
+        :type file_path: Optional[str]
         :param raw: raw mode (needs more details)
+        :type raw: Optional[bool]
         :param job_id: job ID (needs more details)
+        :type job_id: Optional[str]
         :param pool: the Airflow pool that the task should run in
-        :type pool: unicode
+        :type pool: Optional[str]
         :param cfg_path: the Path to the configuration file
-        :type cfg_path: str
+        :type cfg_path: Optional[str]
         :return: shell command that can be used to run the task instance
+        :rtype: list[str]
         """
         iso = execution_date.isoformat()
-        cmd = ["airflow", "tasks", "run", str(dag_id), str(task_id), str(iso)]
-        cmd.extend(["--mark_success"]) if mark_success else None
-        cmd.extend(["--pickle", str(pickle_id)]) if pickle_id else None
-        cmd.extend(["--job_id", str(job_id)]) if job_id else None
-        cmd.extend(["-A"]) if ignore_all_deps else None
-        cmd.extend(["-i"]) if ignore_task_deps else None
-        cmd.extend(["-I"]) if ignore_depends_on_past else None
-        cmd.extend(["--force"]) if ignore_ti_state else None
-        cmd.extend(["--local"]) if local else None
-        cmd.extend(["--pool", pool]) if pool else None
-        cmd.extend(["--raw"]) if raw else None
-        cmd.extend(["-sd", file_path]) if file_path else None
-        cmd.extend(["--cfg_path", cfg_path]) if cfg_path else None
+        cmd = ["airflow", "tasks", "run", dag_id, task_id, iso]
+        if mark_success:
+            cmd.extend(["--mark-success"])
+        if pickle_id:
+            cmd.extend(["--pickle", pickle_id])
+        if job_id:
+            cmd.extend(["--job-id", job_id])
+        if ignore_all_deps:
+            cmd.extend(["--ignore-all-dependencies"])
+        if ignore_task_deps:
+            cmd.extend(["--ignore-dependencies"])
+        if ignore_depends_on_past:
+            cmd.extend(["--ignore-depends-on-past"])
+        if ignore_ti_state:
+            cmd.extend(["--force"])
+        if local:
+            cmd.extend(["--local"])
+        if pool:
+            cmd.extend(["--pool", pool])
+        if raw:
+            cmd.extend(["--raw"])
+        if file_path:
+            cmd.extend(["--subdir", file_path])
+        if cfg_path:
+            cmd.extend(["--cfg-path", cfg_path])
         return cmd
 
     @property

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -32,7 +32,7 @@ PYTHONPATH_VAR = 'PYTHONPATH'
 
 class BaseTaskRunner(LoggingMixin):
     """
-    Runs Airflow task instances by invoking the `airflow run` command with raw
+    Runs Airflow task instances by invoking the `airflow tasks run` command with raw
     mode enabled in a subprocess.
 
     :param local_task_job: The local task job associated with running the

--- a/docs/howto/connection/index.rst
+++ b/docs/howto/connection/index.rst
@@ -106,14 +106,14 @@ Then add connection like so:
 
 .. code-block:: bash
 
-    airflow connections add --conn_id 'my_prod_db' --conn_uri 'my-conn-type://login:password@host:port/schema?param1=val1&param2=val2'
+    airflow connections add --conn-id 'my_prod_db' --conn-uri 'my-conn-type://login:password@host:port/schema?param1=val1&param2=val2'
 
 Alternatively you may specify each parameter individually:
 
 .. code-block:: bash
 
     airflow connections add \
-        --conn_id 'my_prod_db' \
+        --conn-id 'my_prod_db' \
         --login 'login' \
         --password 'password' \
         ...

--- a/docs/howto/tracking-user-activity.rst
+++ b/docs/howto/tracking-user-activity.rst
@@ -24,7 +24,7 @@ You can configure Airflow to route anonymous data to
 
 Edit ``airflow.cfg`` and set the ``webserver`` block to have an ``analytics_tool`` and ``analytics_id``:
 
-.. code-block:: python
+.. code-block:: ini
 
   [webserver]
   # Send anonymous user activity to Google Analytics, Segment, or Metarouter

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -53,7 +53,7 @@ Follow the steps below to enable custom logging config class:
 
 #. Start by setting environment variable to known directory e.g. ``~/airflow/``
 
-    .. code-block:: ini
+    .. code-block:: bash
 
         export PYTHON_PATH=~/airflow/
 
@@ -183,7 +183,7 @@ example:
 
   *** Reading remote log from gs://<bucket where logs should be persisted>/example_bash_operator/run_this_last/2017-10-03T00:00:00/16.log.
   [2017-10-03 21:57:50,056] {cli.py:377} INFO - Running on host chrisr-00532
-  [2017-10-03 21:57:50,093] {base_task_runner.py:115} INFO - Running: ['bash', '-c', 'airflow tasks run example_bash_operator run_this_last 2017-10-03T00:00:00 --job_id 47 --raw -sd DAGS_FOLDER/example_dags/example_bash_operator.py']
+  [2017-10-03 21:57:50,093] {base_task_runner.py:115} INFO - Running: ['bash', '-c', 'airflow tasks run example_bash_operator run_this_last 2017-10-03T00:00:00 --job-id 47 --raw -S DAGS_FOLDER/example_dags/example_bash_operator.py']
   [2017-10-03 21:57:51,264] {base_task_runner.py:98} INFO - Subtask: [2017-10-03 21:57:51,263] {__init__.py:45} INFO - Using executor SequentialExecutor
   [2017-10-03 21:57:51,306] {base_task_runner.py:98} INFO - Subtask: [2017-10-03 21:57:51,306] {models.py:186} INFO - Filling up the DagBag from /airflow/dags/example_dags/example_bash_operator.py
 

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -53,7 +53,7 @@ If you want to redirect metrics to different name, you can configure ``stat_name
 in ``[scheduler]`` section.  It should point to a function that validate the statsd stat name, apply changes
 to the stat name if necessary and return the transformed stat name. The function may looks as follow:
 
-.. code-block:: ini
+.. code-block:: python
 
     def my_custom_stat_name_handler(stat_name: str) -> str:
         return stat_name.lower()[:32]

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -64,7 +64,7 @@ you will need to change ``search_scope`` to "SUBTREE".
 
 Valid search_scope options can be found in the `ldap3 Documentation <http://ldap3.readthedocs.org/searches.html?highlight=search_scope>`_
 
-.. code-block:: bash
+.. code-block:: ini
 
     [webserver]
     authenticate = True
@@ -104,7 +104,7 @@ Airflow uses ``flask_login`` and
 exposes a set of hooks in the ``airflow.default_login`` module. You can
 alter the content and make it part of the ``PYTHONPATH`` and configure it as a backend in ``airflow.cfg``.
 
-.. code-block:: bash
+.. code-block:: ini
 
     [webserver]
     authenticate = True
@@ -182,7 +182,7 @@ To enable kerberos you will need to generate a (service) key tab.
 Now store this file in a location where the airflow user can read it (chmod 600). And then add the following to
 your ``airflow.cfg``
 
-.. code-block:: bash
+.. code-block:: ini
 
     [core]
     security = kerberos
@@ -204,7 +204,7 @@ Hadoop
 
 If want to use impersonation this needs to be enabled in ``core-site.xml`` of your hadoop config.
 
-.. code-block:: bash
+.. code-block:: xml
 
     <property>
       <name>hadoop.proxyuser.airflow.groups</name>
@@ -272,7 +272,7 @@ against an installation of GitHub Enterprise using OAuth2. You can optionally
 specify a team whitelist (composed of slug cased team names) to restrict login
 to only members of those teams.
 
-.. code-block:: bash
+.. code-block:: ini
 
     [webserver]
     authenticate = True
@@ -443,7 +443,7 @@ command, or as a configuration item in your ``airflow.cfg``. For both cases, ple
 
 .. code-block:: bash
 
-    airflow flower --basic_auth=user1:password1,user2:password2
+    airflow flower --basic-auth=user1:password1,user2:password2
 
 .. code-block:: ini
 

--- a/tests/bin/__init__.py
+++ b/tests/bin/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/bin/test_cli.py
+++ b/tests/bin/test_cli.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import re
+from collections import Counter
+from unittest import TestCase
+
+from airflow.bin.cli import CLIFactory
+
+# Can not be `--snake_case` or contain uppercase letter
+ILLEGAL_LONG_OPTION_PATTERN = re.compile("^--[a-z]+_[a-z]+|^--.*[A-Z].*")
+# Only can be `-[a-z]` or `-[A-Z]`
+LEGAL_SHORT_OPTION_PATTERN = re.compile("^-[a-zA-z]$")
+
+
+class TestCli(TestCase):
+
+    def test_arg_option_long_only(self):
+        """
+        Test if the name of CLIFactory.args long option valid
+        """
+        optional_long = [
+            arg for _, arg in CLIFactory.args.items()
+            if len(arg.flags) == 1 and arg.flags[0].startswith("-")
+        ]
+        for arg in optional_long:
+            self.assertIsNone(ILLEGAL_LONG_OPTION_PATTERN.match(arg.flags[0]),
+                              f"{arg.flags[0]} is not match")
+
+    def test_arg_option_mix_short_long(self):
+        """
+        Test if the name of CLIFactory.args mix option (-s, --long) valid
+        """
+        optional_mix = [
+            arg for _, arg in CLIFactory.args.items()
+            if len(arg.flags) == 2 and arg.flags[0].startswith("-")
+        ]
+        for arg in optional_mix:
+            self.assertIsNotNone(LEGAL_SHORT_OPTION_PATTERN.match(arg.flags[0]),
+                                 f"{arg.flags[0]} is not match")
+            self.assertIsNone(ILLEGAL_LONG_OPTION_PATTERN.match(arg.flags[1]),
+                              f"{arg.flags[1]} is not match")
+
+    def test_subcommand_conflict(self):
+        """
+        Test if each of CLIFactory.*_COMMANDS without conflict subcommand
+        """
+        subcommand = {
+            var: CLIFactory.__dict__.get(var)
+            for var in CLIFactory.__dict__
+            if var.isupper() and "COMMANDS" in var
+        }
+        for group_name, sub in subcommand.items():
+            name = [command['name'].lower() for command in sub]
+            self.assertEqual(len(name), len(set(name)),
+                             f"Command group {group_name} have conflict subcommand")
+
+    def test_subcommand_arg_name_conflict(self):
+        """
+        Test if each of CLIFactory.*_COMMANDS.arg name without conflict
+        """
+        subcommand = {
+            var: CLIFactory.__dict__.get(var)
+            for var in CLIFactory.__dict__
+            if var.isupper() and "COMMANDS" in var
+        }
+        for group, command in subcommand.items():
+            for com in command:
+                name = com['name']
+                args = com['args']
+                conflict_arg = [arg for arg, count in Counter(args).items() if count > 1]
+                self.assertListEqual([], conflict_arg,
+                                     f"Command group {group} function {name} have "
+                                     f"conflict args name {conflict_arg}")
+
+    def test_subcommand_arg_flag_conflict(self):
+        """
+        Test if each of CLIFactory.*_COMMANDS.arg flags without conflict
+        """
+
+        def cli_args_flags(arg):
+            """
+            Get CLIFactory args flags
+            """
+            return CLIFactory.args[arg].flags
+
+        subcommand = {
+            var: CLIFactory.__dict__.get(var)
+            for var in CLIFactory.__dict__
+            if var.isupper() and "COMMANDS" in var
+        }
+        for group, command in subcommand.items():
+            for com in command:
+                name = com['name']
+                position = [
+                    cli_args_flags(a)[0]
+                    for a in com['args']
+                    if (len(cli_args_flags(a)) == 1
+                        and not cli_args_flags(a)[0].startswith("-"))
+                ]
+                conflict_position = [arg for arg, count in Counter(position).items() if count > 1]
+                self.assertListEqual([], conflict_position,
+                                     f"Command group {group} function {name} have conflict "
+                                     f"position flags {conflict_position}")
+
+                long_option = [cli_args_flags(a)[0]
+                               for a in com['args']
+                               if (len(cli_args_flags(a)) == 1
+                                   and cli_args_flags(a)[0].startswith("-"))] + \
+                              [cli_args_flags(a)[1]
+                               for a in com['args'] if len(cli_args_flags(a)) == 2]
+                conflict_long_option = [arg for arg, count in Counter(long_option).items() if count > 1]
+                self.assertListEqual([], conflict_long_option,
+                                     f"Command group {group} function {name} have conflict "
+                                     f"long option flags {conflict_long_option}")
+
+                short_option = [
+                    cli_args_flags(a)[0]
+                    for a in com['args'] if len(cli_args_flags(a)) == 2
+                ]
+                conflict_short_option = [arg for arg, count in Counter(short_option).items() if count > 1]
+                self.assertEqual([], conflict_short_option,
+                                 f"Command group {group} function {name} have conflict "
+                                 f"short option flags {conflict_short_option}")

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -80,7 +80,7 @@ class TestWorkerServeLogs(unittest.TestCase):
     @mock.patch('airflow.cli.commands.celery_command.worker_bin')
     def test_serve_logs_on_worker_start(self, mock_worker):
         with mock.patch('airflow.cli.commands.celery_command.Process') as mock_process:
-            args = self.parser.parse_args(['celery', 'worker', '-c', '1'])
+            args = self.parser.parse_args(['celery', 'worker', '--concurrency', '1'])
 
             with mock.patch('celery.platforms.check_privileges') as mock_privil:
                 mock_privil.return_value = 0
@@ -90,7 +90,7 @@ class TestWorkerServeLogs(unittest.TestCase):
     @mock.patch('airflow.cli.commands.celery_command.worker_bin')
     def test_skip_serve_logs_on_worker_start(self, mock_worker):
         with mock.patch('airflow.cli.commands.celery_command.Process') as mock_popen:
-            args = self.parser.parse_args(['celery', 'worker', '-c', '1', '-s'])
+            args = self.parser.parse_args(['celery', 'worker', '--concurrency', '1', '--skip-serve-logs'])
 
             with mock.patch('celery.platforms.check_privileges') as mock_privil:
                 mock_privil.return_value = 0
@@ -141,7 +141,7 @@ class TestCeleryStopCommand(unittest.TestCase):
         mock_read_pid_from_pidfile.return_value = None
 
         # Call worker
-        worker_args = self.parser.parse_args(['celery', 'worker', '-s'])
+        worker_args = self.parser.parse_args(['celery', 'worker', '--skip-serve-logs'])
         celery_command.worker(worker_args)
         run_mock = mock_celery_worker.return_value.run
         assert run_mock.call_args
@@ -181,7 +181,7 @@ class TestWorkerStart(unittest.TestCase):
             autoscale,
             '--concurrency',
             concurrency,
-            '--celery_hostname',
+            '--celery-hostname',
             celery_hostname,
             '--queues',
             queues

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -90,7 +90,7 @@ class TestCliAddConnections(unittest.TestCase):
     @parameterized.expand(
         [
             (
-                ["connections", "add", "new1", "--conn_uri=%s" % TEST_URL],
+                ["connections", "add", "new1", "--conn-uri=%s" % TEST_URL],
                 "\tSuccessfully added `conn_id`=new1 : postgresql://airflow:airflow@host:5432/airflow",
                 {
                     "conn_id": "new1",
@@ -104,7 +104,7 @@ class TestCliAddConnections(unittest.TestCase):
                 },
             ),
             (
-                ["connections", "add", "new2", "--conn_uri=%s" % TEST_URL],
+                ["connections", "add", "new2", "--conn-uri=%s" % TEST_URL],
                 "\tSuccessfully added `conn_id`=new2 : postgresql://airflow:airflow@host:5432/airflow",
                 {
                     "conn_id": "new2",
@@ -122,8 +122,8 @@ class TestCliAddConnections(unittest.TestCase):
                     "connections",
                     "add",
                     "new3",
-                    "--conn_uri=%s" % TEST_URL,
-                    "--conn_extra",
+                    "--conn-uri=%s" % TEST_URL,
+                    "--conn-extra",
                     "{'extra': 'yes'}",
                 ],
                 "\tSuccessfully added `conn_id`=new3 : postgresql://airflow:airflow@host:5432/airflow",
@@ -143,8 +143,8 @@ class TestCliAddConnections(unittest.TestCase):
                     "connections",
                     "add",
                     "new4",
-                    "--conn_uri=%s" % TEST_URL,
-                    "--conn_extra",
+                    "--conn-uri=%s" % TEST_URL,
+                    "--conn-extra",
                     "{'extra': 'yes'}",
                 ],
                 "\tSuccessfully added `conn_id`=new4 : postgresql://airflow:airflow@host:5432/airflow",
@@ -164,12 +164,12 @@ class TestCliAddConnections(unittest.TestCase):
                     "connections",
                     "add",
                     "new5",
-                    "--conn_type=hive_metastore",
-                    "--conn_login=airflow",
-                    "--conn_password=airflow",
-                    "--conn_host=host",
-                    "--conn_port=9083",
-                    "--conn_schema=airflow",
+                    "--conn-type=hive_metastore",
+                    "--conn-login=airflow",
+                    "--conn-password=airflow",
+                    "--conn-host=host",
+                    "--conn-port=9083",
+                    "--conn-schema=airflow",
                 ],
                 "\tSuccessfully added `conn_id`=new5 : hive_metastore://airflow:******@host:9083/airflow",
                 {
@@ -188,10 +188,10 @@ class TestCliAddConnections(unittest.TestCase):
                     "connections",
                     "add",
                     "new6",
-                    "--conn_uri",
+                    "--conn-uri",
                     "",
-                    "--conn_type=google_cloud_platform",
-                    "--conn_extra",
+                    "--conn-type=google_cloud_platform",
+                    "--conn-extra",
                     "{'extra': 'yes'}",
                 ],
                 "\tSuccessfully added `conn_id`=new6 : google_cloud_platform://:@:",
@@ -233,11 +233,11 @@ class TestCliAddConnections(unittest.TestCase):
     def test_cli_connections_add_duplicate(self):
         # Attempt to add duplicate
         connection_command.connections_add(
-            self.parser.parse_args(["connections", "add", "new1", "--conn_uri=%s" % TEST_URL])
+            self.parser.parse_args(["connections", "add", "new1", "--conn-uri=%s" % TEST_URL])
         )
         with redirect_stdout(io.StringIO()) as stdout:
             connection_command.connections_add(
-                self.parser.parse_args(["connections", "add", "new1", "--conn_uri=%s" % TEST_URL])
+                self.parser.parse_args(["connections", "add", "new1", "--conn-uri=%s" % TEST_URL])
             )
             stdout = stdout.getvalue()
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -64,7 +64,7 @@ class TestCliDags(unittest.TestCase):
     def test_backfill(self, mock_run):
         dag_command.dag_backfill(self.parser.parse_args([
             'dags', 'backfill', 'example_bash_operator',
-            '-s', DEFAULT_DATE.isoformat()]))
+            '--start-date', DEFAULT_DATE.isoformat()]))
 
         mock_run.assert_called_once_with(
             start_date=DEFAULT_DATE,
@@ -86,8 +86,8 @@ class TestCliDags(unittest.TestCase):
 
         with contextlib.redirect_stdout(io.StringIO()) as stdout:
             dag_command.dag_backfill(self.parser.parse_args([
-                'dags', 'backfill', 'example_bash_operator', '-t', 'runme_0', '--dry_run',
-                '-s', DEFAULT_DATE.isoformat()]), dag=dag)
+                'dags', 'backfill', 'example_bash_operator', '--task-regex', 'runme_0', '--dry-run',
+                '--start-date', DEFAULT_DATE.isoformat()]), dag=dag)
 
         output = stdout.getvalue()
         self.assertIn("Dry run of DAG example_bash_operator on {}\n".format(DEFAULT_DATE.isoformat()), output)
@@ -96,14 +96,14 @@ class TestCliDags(unittest.TestCase):
         mock_run.assert_not_called()  # Dry run shouldn't run the backfill
 
         dag_command.dag_backfill(self.parser.parse_args([
-            'dags', 'backfill', 'example_bash_operator', '--dry_run',
-            '-s', DEFAULT_DATE.isoformat()]), dag=dag)
+            'dags', 'backfill', 'example_bash_operator', '--dry-run',
+            '--start-date', DEFAULT_DATE.isoformat()]), dag=dag)
 
         mock_run.assert_not_called()  # Dry run shouldn't run the backfill
 
         dag_command.dag_backfill(self.parser.parse_args([
-            'dags', 'backfill', 'example_bash_operator', '-l',
-            '-s', DEFAULT_DATE.isoformat()]), dag=dag)
+            'dags', 'backfill', 'example_bash_operator', '--local',
+            '--start-date', DEFAULT_DATE.isoformat()]), dag=dag)
 
         mock_run.assert_called_once_with(
             start_date=DEFAULT_DATE,
@@ -172,10 +172,10 @@ class TestCliDags(unittest.TestCase):
             'dags',
             'backfill',
             dag_id,
-            '-l',
-            '-s',
+            '--local',
+            '--start-date',
             run_date.isoformat(),
-            '-I',
+            '--ignore-first-depends-on-past',
         ]
         dag = self.dagbag.get_dag(dag_id)
 
@@ -209,13 +209,13 @@ class TestCliDags(unittest.TestCase):
             'dags',
             'backfill',
             dag_id,
-            '-l',
-            '-s',
+            '--local',
+            '--start-date',
             start_date.isoformat(),
-            '-e',
+            '--end-date',
             end_date.isoformat(),
-            '-I',
-            '-B',
+            '--ignore-first-depends-on-past',
+            '--run-backwards',
         ]
         dag = self.dagbag.get_dag(dag_id)
 
@@ -311,17 +311,17 @@ class TestCliDags(unittest.TestCase):
             'dags', 'trigger', 'example_bash_operator', ]))
         args = self.parser.parse_args(['dags',
                                        'list_runs',
-                                       '--dag_id',
+                                       '--dag-id',
                                        'example_bash_operator',
-                                       '--no_backfill',
-                                       '--start_date',
+                                       '--no-backfill',
+                                       '--start-date',
                                        DEFAULT_DATE.isoformat(),
-                                       '--end_date',
+                                       '--end-date',
                                        timezone.make_aware(datetime.max).isoformat()])
         dag_command.dag_list_dag_runs(args)
 
     def test_cli_list_jobs_with_args(self):
-        args = self.parser.parse_args(['dags', 'list_jobs', '--dag_id',
+        args = self.parser.parse_args(['dags', 'list_jobs', '--dag-id',
                                        'example_bash_operator',
                                        '--state', 'success',
                                        '--limit', '100',
@@ -342,14 +342,14 @@ class TestCliDags(unittest.TestCase):
     def test_trigger_dag(self):
         dag_command.dag_trigger(self.parser.parse_args([
             'dags', 'trigger', 'example_bash_operator',
-            '-c', '{"foo": "bar"}']))
+            '--conf', '{"foo": "bar"}']))
         self.assertRaises(
             ValueError,
             dag_command.dag_trigger,
             self.parser.parse_args([
                 'dags', 'trigger', 'example_bash_operator',
-                '--run_id', 'trigger_dag_xxx',
-                '-c', 'NOT JSON'])
+                '--run-id', 'trigger_dag_xxx',
+                '--conf', 'NOT JSON'])
         )
 
     def test_delete_dag(self):

--- a/tests/cli/commands/test_only_use_long_option.py
+++ b/tests/cli/commands/test_only_use_long_option.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import re
+import unittest
+
+
+class TestOnlyUseLongOption(unittest.TestCase):
+
+    def test_command_only_long_option(self):
+        """
+        Make sure all cli.commands test use long option for more clearer intent
+        """
+        pattern_1 = re.compile("\"-[a-zA-Z]\"")
+        pattern_2 = re.compile("'-[a-zA-Z]'")
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        ignore = ["__init__.py", "__pycache__", os.path.basename(__file__)]
+        for test_file in os.listdir(current_dir):
+            if test_file in ignore:
+                continue
+            match = []
+            with open(os.path.join(current_dir, test_file), "r") as f:
+                content = f.read()
+                match.extend(pattern_1.findall(content))
+                match.extend(pattern_2.findall(content))
+                self.assertListEqual(
+                    [],
+                    match,
+                    "Should use long option in test for more clearer intent, "
+                    f"but get {match} in {test_file}"
+                )

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -85,7 +85,7 @@ class TestCliTasks(unittest.TestCase):
         task0_id = 'test_run_dependent_task'
         args0 = ['tasks',
                  'run',
-                 '-A',
+                 '--ignore-all-dependencies',
                  '--local',
                  dag_id,
                  task0_id,
@@ -108,27 +108,27 @@ class TestCliTasks(unittest.TestCase):
             'tasks', 'test', 'example_bash_operator', 'runme_0',
             DEFAULT_DATE.isoformat()]))
         task_command.task_test(self.parser.parse_args([
-            'tasks', 'test', 'example_bash_operator', 'runme_0', '--dry_run',
+            'tasks', 'test', 'example_bash_operator', 'runme_0', '--dry-run',
             DEFAULT_DATE.isoformat()]))
 
     def test_cli_test_with_params(self):
         task_command.task_test(self.parser.parse_args([
             'tasks', 'test', 'example_passing_params_via_test_command', 'run_this',
-            '-tp', '{"foo":"bar"}', DEFAULT_DATE.isoformat()]))
+            '--task-params', '{"foo":"bar"}', DEFAULT_DATE.isoformat()]))
         task_command.task_test(self.parser.parse_args([
             'tasks', 'test', 'example_passing_params_via_test_command', 'also_run_this',
-            '-tp', '{"foo":"bar"}', DEFAULT_DATE.isoformat()]))
+            '--task-params', '{"foo":"bar"}', DEFAULT_DATE.isoformat()]))
 
     def test_cli_run(self):
         task_command.task_run(self.parser.parse_args([
-            'tasks', 'run', 'example_bash_operator', 'runme_0', '-l',
+            'tasks', 'run', 'example_bash_operator', 'runme_0', '--local',
             DEFAULT_DATE.isoformat()]))
 
     @parameterized.expand(
         [
-            ("--ignore_all_dependencies", ),
-            ("--ignore_depends_on_past", ),
-            ("--ignore_dependencies",),
+            ("--ignore-all-dependencies", ),
+            ("--ignore-depends-on-past", ),
+            ("--ignore-dependencies",),
             ("--force",),
         ],
 
@@ -198,7 +198,7 @@ class TestCliTasks(unittest.TestCase):
             'tasks', 'clear', 'example_subdag_operator', '--yes'])
         task_command.task_clear(args)
         args = self.parser.parse_args([
-            'tasks', 'clear', 'example_subdag_operator', '--yes', '--exclude_subdags'])
+            'tasks', 'clear', 'example_subdag_operator', '--yes', '--exclude-subdags'])
         task_command.task_clear(args)
 
     def test_parentdag_downstream_clear(self):
@@ -207,7 +207,7 @@ class TestCliTasks(unittest.TestCase):
         task_command.task_clear(args)
         args = self.parser.parse_args([
             'tasks', 'clear', 'example_subdag_operator.section-1', '--yes',
-            '--exclude_parentdag'])
+            '--exclude-parentdag'])
         task_command.task_clear(args)
 
     def test_local_run(self):
@@ -256,7 +256,7 @@ class TestCliTaskBackfill(unittest.TestCase):
         task0_id = 'test_run_dependent_task'
         args0 = ['tasks',
                  'run',
-                 '-A',
+                 '--ignore-all-dependencies',
                  dag_id,
                  task0_id,
                  DEFAULT_DATE.isoformat()]
@@ -271,7 +271,7 @@ class TestCliTaskBackfill(unittest.TestCase):
         task1_id = 'test_run_dependency_task'
         args1 = ['tasks',
                  'run',
-                 '-A',
+                 '--ignore-all-dependencies',
                  dag_id,
                  task1_id,
                  (DEFAULT_DATE + timedelta(days=1)).isoformat()]
@@ -286,7 +286,7 @@ class TestCliTaskBackfill(unittest.TestCase):
         task2_id = 'test_run_dependent_task'
         args2 = ['tasks',
                  'run',
-                 '-A',
+                 '--ignore-all-dependencies',
                  dag_id,
                  task2_id,
                  (DEFAULT_DATE + timedelta(days=1)).isoformat()]

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -67,7 +67,7 @@ class TestCliUsers(unittest.TestCase):
         args = self.parser.parse_args([
             'users', 'create', '--username', 'test1', '--lastname', 'doe',
             '--firstname', 'jon',
-            '--email', 'jdoe@foo.com', '--role', 'Viewer', '--use_random_password'
+            '--email', 'jdoe@foo.com', '--role', 'Viewer', '--use-random-password'
         ])
         user_command.users_create(args)
 
@@ -83,7 +83,7 @@ class TestCliUsers(unittest.TestCase):
         args = self.parser.parse_args([
             'users', 'create', '--username', 'test3', '--lastname', 'doe',
             '--firstname', 'jon',
-            '--email', 'jdoe@example.com', '--role', 'Viewer', '--use_random_password'
+            '--email', 'jdoe@example.com', '--role', 'Viewer', '--use-random-password'
         ])
         user_command.users_create(args)
         args = self.parser.parse_args([
@@ -97,7 +97,7 @@ class TestCliUsers(unittest.TestCase):
                 'users', 'create', '--username', 'user{}'.format(i), '--lastname',
                 'doe', '--firstname', 'jon',
                 '--email', 'jdoe+{}@gmail.com'.format(i), '--role', 'Viewer',
-                '--use_random_password'
+                '--use-random-password'
             ])
             user_command.users_create(args)
         with redirect_stdout(io.StringIO()) as stdout:
@@ -211,7 +211,7 @@ class TestCliUsers(unittest.TestCase):
         args = self.parser.parse_args([
             'users', 'create', '--username', 'test4', '--lastname', 'doe',
             '--firstname', 'jon',
-            '--email', TEST_USER1_EMAIL, '--role', 'Viewer', '--use_random_password'
+            '--email', TEST_USER1_EMAIL, '--role', 'Viewer', '--use-random-password'
         ])
         user_command.users_create(args)
 
@@ -234,7 +234,7 @@ class TestCliUsers(unittest.TestCase):
         args = self.parser.parse_args([
             'users', 'create', '--username', 'test4', '--lastname', 'doe',
             '--firstname', 'jon',
-            '--email', TEST_USER1_EMAIL, '--role', 'Viewer', '--use_random_password'
+            '--email', TEST_USER1_EMAIL, '--role', 'Viewer', '--use-random-password'
         ])
         user_command.users_create(args)
 

--- a/tests/cli/commands/test_variable_command.py
+++ b/tests/cli/commands/test_variable_command.py
@@ -38,7 +38,7 @@ class TestCliVariables(unittest.TestCase):
         variable_command.variables_get(self.parser.parse_args([
             'variables', 'get', 'foo']))
         variable_command.variables_get(self.parser.parse_args([
-            'variables', 'get', 'baz', '-d', 'bar']))
+            'variables', 'get', 'baz', '--default', 'bar']))
         variable_command.variables_list(self.parser.parse_args([
             'variables', 'list']))
         variable_command.variables_delete(self.parser.parse_args([

--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -75,7 +75,7 @@ class TestCLIGetNumReadyWorkersRunning(unittest.TestCase):
 
     def test_cli_webserver_debug(self):
         env = os.environ.copy()
-        proc = psutil.Popen(["airflow", "webserver", "-d"], env=env)
+        proc = psutil.Popen(["airflow", "webserver", "--debug"], env=env)
         sleep(3)  # wait for webserver to start
         return_code = proc.poll()
         self.assertEqual(
@@ -99,8 +99,8 @@ class TestCliWebServer(unittest.TestCase):
         try:
             # Confirm that webserver hasn't been launched.
             # pgrep returns exit status 1 if no process matched.
-            self.assertEqual(1, subprocess.Popen(["pgrep", "-f", "-c", "airflow webserver"]).wait())
-            self.assertEqual(1, subprocess.Popen(["pgrep", "-c", "gunicorn"]).wait())
+            self.assertEqual(1, subprocess.Popen(["pgrep", "--full", "--count", "airflow webserver"]).wait())
+            self.assertEqual(1, subprocess.Popen(["pgrep", "--count", "gunicorn"]).wait())
         except:  # noqa: E722
             subprocess.Popen(["ps", "-ax"]).wait()
             raise
@@ -151,14 +151,14 @@ class TestCliWebServer(unittest.TestCase):
         pidfile_monitor = setup_locations("webserver-monitor")[0]
 
         # Run webserver as daemon in background. Note that the wait method is not called.
-        subprocess.Popen(["airflow", "webserver", "-D"])
+        subprocess.Popen(["airflow", "webserver", "--daemon"])
 
         pid_monitor = self._wait_pidfile(pidfile_monitor)
         self._wait_pidfile(pidfile_webserver)
 
         # Assert that gunicorn and its monitor are launched.
-        self.assertEqual(0, subprocess.Popen(["pgrep", "-f", "-c", "airflow webserver"]).wait())
-        self.assertEqual(0, subprocess.Popen(["pgrep", "-c", "gunicorn"]).wait())
+        self.assertEqual(0, subprocess.Popen(["pgrep", "--full", "--count", "airflow webserver"]).wait())
+        self.assertEqual(0, subprocess.Popen(["pgrep", "--count", "gunicorn"]).wait())
 
         # Terminate monitor process.
         proc = psutil.Process(pid_monitor)

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -858,7 +858,7 @@ class TestBackfillJob(unittest.TestCase):
             dag_id,
             '-s',
             run_date.isoformat(),
-            '--delay_on_limit',
+            '--delay-on-limit',
             '0.5',
         ]
         parsed_args = self.parser.parse_args(args)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1526,6 +1526,22 @@ class TestTaskInstance(unittest.TestCase):
         ti.refresh_from_db()
         self.assertEqual(ti.state, State.SUCCESS)
 
+    def test_generate_command_default_param(self):
+        dag_id = 'test_generate_command_default_param'
+        task_id = 'task'
+        assert_command = ['airflow', 'tasks', 'run', dag_id, task_id, DEFAULT_DATE.isoformat()]
+        generate_command = TI.generate_command(dag_id=dag_id, task_id=task_id, execution_date=DEFAULT_DATE)
+        assert assert_command == generate_command
+
+    def test_generate_command_specific_param(self):
+        dag_id = 'test_generate_command_specific_param'
+        task_id = 'task'
+        assert_command = ['airflow', 'tasks', 'run', dag_id,
+                          task_id, DEFAULT_DATE.isoformat(), '--mark-success']
+        generate_command = TI.generate_command(dag_id=dag_id, task_id=task_id,
+                                               execution_date=DEFAULT_DATE, mark_success=True)
+        assert assert_command == generate_command
+
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])
 def test_refresh_from_task(pool_override):


### PR DESCRIPTION
* Make Airflow cli short options be single character only
* Make Airflow cli long options be kebab-case style
* Add test for airflow/bin
* Update UPDATING.md

---
Issue link: [AIRFLOW-6472](https://issues.apache.org/jira/browse/AIRFLOW-6472)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
