### PR TITLE
[AIRFLOW-6547] remove unnecessary bunch of codes on pinot hook

### DIFF
--- a/airflow/providers/apache/pinot/hooks/pinot.py
+++ b/airflow/providers/apache/pinot/hooks/pinot.py
@@ -251,30 +251,6 @@ class PinotDbApiHook(DbApiHook):
         return '{conn_type}://{host}/{endpoint}'.format(
             conn_type=conn_type, host=host, endpoint=endpoint)
 
-    def get_records(self, sql):
-        """
-        Executes the sql and returns a set of records.
-
-        :param sql: the sql statement to be executed (str) or a list of
-            sql statements to execute
-        :type sql: str
-        """
-        with self.get_conn() as cur:
-            cur.execute(sql)
-            return cur.fetchall()
-
-    def get_first(self, sql):
-        """
-        Executes the sql and returns the first resulting row.
-
-        :param sql: the sql statement to be executed (str) or a list of
-            sql statements to execute
-        :type sql: str or list
-        """
-        with self.get_conn() as cur:
-            cur.execute(sql)
-            return cur.fetchone()
-
     def set_autocommit(self, conn, autocommit):
         raise NotImplementedError()
 


### PR DESCRIPTION
---
Pinot hook has been implemented by pinotdb and it uses sqlalchmey to interact with pinot. so in this hook the get_records and get_first methods are unnecessary

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
