### PR TITLE
[AIRFLOW-6102] [AIP-21] Rename Dataproc operators

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -483,19 +483,19 @@ The following table shows changes in import paths.
 |airflow.contrib.operators.dataflow_operator.DataFlowJavaOperator                                                  |airflow.gcp.operators.dataflow.DataFlowJavaOperator                                                        |
 |airflow.contrib.operators.dataflow_operator.DataFlowPythonOperator                                                |airflow.gcp.operators.dataflow.DataFlowPythonOperator                                                      |
 |airflow.contrib.operators.dataflow_operator.DataflowTemplateOperator                                              |airflow.gcp.operators.dataflow.DataflowTemplateOperator                                                    |
-|airflow.contrib.operators.dataproc_operator.DataProcHadoopOperator                                                |airflow.gcp.operators.dataproc.DataProcHadoopOperator                                                      |
-|airflow.contrib.operators.dataproc_operator.DataProcHiveOperator                                                  |airflow.gcp.operators.dataproc.DataProcHiveOperator                                                        |
-|airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator                                               |airflow.gcp.operators.dataproc.DataProcJobBaseOperator                                                     |
-|airflow.contrib.operators.dataproc_operator.DataProcPigOperator                                                   |airflow.gcp.operators.dataproc.DataProcPigOperator                                                         |
-|airflow.contrib.operators.dataproc_operator.DataProcPySparkOperator                                               |airflow.gcp.operators.dataproc.DataProcPySparkOperator                                                     |
-|airflow.contrib.operators.dataproc_operator.DataProcSparkOperator                                                 |airflow.gcp.operators.dataproc.DataProcSparkOperator                                                       |
-|airflow.contrib.operators.dataproc_operator.DataProcSparkSqlOperator                                              |airflow.gcp.operators.dataproc.DataProcSparkSqlOperator                                                    |
-|airflow.contrib.operators.dataproc_operator.DataprocClusterCreateOperator                                         |airflow.gcp.operators.dataproc.DataprocClusterCreateOperator                                               |
-|airflow.contrib.operators.dataproc_operator.DataprocClusterDeleteOperator                                         |airflow.gcp.operators.dataproc.DataprocClusterDeleteOperator                                               |
-|airflow.contrib.operators.dataproc_operator.DataprocClusterScaleOperator                                          |airflow.gcp.operators.dataproc.DataprocClusterScaleOperator                                                |
+|airflow.contrib.operators.dataproc_operator.DataProcHadoopOperator                                                |airflow.gcp.operators.dataproc.DataprocSubmitHadoopJobOperator                                                      |
+|airflow.contrib.operators.dataproc_operator.DataProcHiveOperator                                                  |airflow.gcp.operators.dataproc.DataprocSubmitHiveJobOperator                                                        |
+|airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator                                               |airflow.gcp.operators.dataproc.DataprocJobBaseOperator                                                     |
+|airflow.contrib.operators.dataproc_operator.DataProcPigOperator                                                   |airflow.gcp.operators.dataproc.DataprocSubmitPigJobOperator                                                         |
+|airflow.contrib.operators.dataproc_operator.DataProcPySparkOperator                                               |airflow.gcp.operators.dataproc.DataprocSubmitPySparkJobOperator                                                     |
+|airflow.contrib.operators.dataproc_operator.DataProcSparkOperator                                                 |airflow.gcp.operators.dataproc.DataprocSubmitSparkJobOperator                                                       |
+|airflow.contrib.operators.dataproc_operator.DataProcSparkSqlOperator                                              |airflow.gcp.operators.dataproc.DataprocSubmitSparkSqlJobOperator                                                    |
+|airflow.contrib.operators.dataproc_operator.DataprocClusterCreateOperator                                         |airflow.gcp.operators.dataproc.DataprocCreateClusterOperator                                               |
+|airflow.contrib.operators.dataproc_operator.DataprocClusterDeleteOperator                                         |airflow.gcp.operators.dataproc.DataprocDeleteClusterOperator                                               |
+|airflow.contrib.operators.dataproc_operator.DataprocClusterScaleOperator                                          |airflow.gcp.operators.dataproc.DataprocScaleClusterOperator                                                |
 |airflow.contrib.operators.dataproc_operator.DataprocOperationBaseOperator                                         |airflow.gcp.operators.dataproc.DataprocOperationBaseOperator                                               |
-|airflow.contrib.operators.dataproc_operator.DataprocWorkflowTemplateInstantiateInlineOperator                     |airflow.gcp.operators.dataproc.DataprocWorkflowTemplateInstantiateInlineOperator                           |
-|airflow.contrib.operators.dataproc_operator.DataprocWorkflowTemplateInstantiateOperator                           |airflow.gcp.operators.dataproc.DataprocWorkflowTemplateInstantiateOperator                                 |
+|airflow.contrib.operators.dataproc_operator.DataprocWorkflowTemplateInstantiateInlineOperator                     |airflow.gcp.operators.dataproc.DataprocInstantiateInlineWorkflowTemplateOperator                           |
+|airflow.contrib.operators.dataproc_operator.DataprocWorkflowTemplateInstantiateOperator                           |airflow.gcp.operators.dataproc.DataprocInstantiateWorkflowTemplateOperator                                 |
 |airflow.contrib.operators.datastore_export_operator.DatastoreExportOperator                                       |airflow.gcp.operators.datastore.DatastoreExportOperator                                                    |
 |airflow.contrib.operators.datastore_import_operator.DatastoreImportOperator                                       |airflow.gcp.operators.datastore.DatastoreImportOperator                                                    |
 |airflow.contrib.operators.file_to_gcs.FileToGoogleCloudStorageOperator                                            |airflow.operators.local_to_gcs.FileToGoogleCloudStorageOperator                                            |
@@ -741,7 +741,7 @@ The Mesos Executor is removed from the code base as it was not widely used and n
 It is highly recommended to have 1TB+ disk size for Dataproc to have sufficient throughput:
 https://cloud.google.com/compute/docs/disks/performance
 
-Hence, the default value for `master_disk_size` in DataprocClusterCreateOperator has beeen changes from 500GB to 1TB.
+Hence, the default value for `master_disk_size` in DataprocCreateClusterOperator has beeen changes from 500GB to 1TB.
 
 ### Changes to SalesforceHook
 
@@ -1303,7 +1303,7 @@ Installation and upgrading requires setting `SLUGIFY_USES_TEXT_UNIDECODE=yes` in
 `AIRFLOW_GPL_UNIDECODE=yes`. In case of the latter a GPL runtime dependency will be installed due to a
 dependency (python-nvd3 -> python-slugify -> unidecode).
 
-### Replace DataProcHook.await calls to DataProcHook.wait
+### Replace DataprocHook.await calls to DataprocHook.wait
 
 The method name was changed to be compatible with the Python 3.7 async/await keywords
 

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -20,8 +20,7 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.providers.google.cloud.hooks.dataproc import DataprocHook  # noqa
+from airflow.providers.google.cloud.hooks.dataproc import DataprocHook
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.google.cloud.hooks.dataproc`.",
@@ -31,13 +30,14 @@ warnings.warn(
 
 class DataProcHook(DataprocHook):
     """
-    This class is deprecated. Please use `airflow.providers.google.cloud.hooks.dataproc.DataprocHook`.
+    This class is deprecated.
+    Please use `airflow.providers.google.cloud.hooks.dataproc.DataprocHook`.
     """
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            "This class is deprecated. Please use `airflow.providers.google."
-            "cloud.hooks.dataproc.DataprocHook`.",
+            """This class is deprecated.
+            Please use `airflow.providers.google.cloud.hooks.dataproc.DataprocHook`.""",
             DeprecationWarning, stacklevel=2
         )
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -20,13 +20,12 @@
 
 import warnings
 
-# pylint: disable=unused-import
-from airflow.providers.google.cloud.operators.dataproc import (  # noqa
-    DataprocClusterCreateOperator, DataprocClusterDeleteOperator, DataprocClusterScaleOperator,
-    DataProcHadoopOperator, DataProcHiveOperator, DataProcJobBaseOperator, DataProcJobBuilder,
-    DataProcPigOperator, DataProcPySparkOperator, DataProcSparkOperator, DataProcSparkSqlOperator,
-    DataprocSubmitJobOperator, DataprocUpdateClusterOperator,
-    DataprocWorkflowTemplateInstantiateInlineOperator, DataprocWorkflowTemplateInstantiateOperator,
+from airflow.providers.google.cloud.operators.dataproc import (
+    DataprocCreateClusterOperator, DataprocDeleteClusterOperator,
+    DataprocInstantiateInlineWorkflowTemplateOperator, DataprocInstantiateWorkflowTemplateOperator,
+    DataprocJobBaseOperator, DataprocScaleClusterOperator, DataprocSubmitHadoopJobOperator,
+    DataprocSubmitHiveJobOperator, DataprocSubmitPigJobOperator, DataprocSubmitPySparkJobOperator,
+    DataprocSubmitSparkJobOperator, DataprocSubmitSparkSqlJobOperator,
 )
 
 warnings.warn(
@@ -34,3 +33,183 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+
+class DataprocClusterCreateOperator(DataprocCreateClusterOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocCreateClusterOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocCreateClusterOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataprocClusterDeleteOperator(DataprocDeleteClusterOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocDeleteClusterOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocDeleteClusterOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataprocClusterScaleOperator(DataprocScaleClusterOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocScaleClusterOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocScaleClusterOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataProcHadoopOperator(DataprocSubmitHadoopJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocSubmitHadoopJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocSubmitHadoopJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataProcHiveOperator(DataprocSubmitHiveJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocSubmitHiveJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocSubmitHiveJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataProcJobBaseOperator(DataprocJobBaseOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocJobBaseOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocJobBaseOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataProcPigOperator(DataprocSubmitPigJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocSubmitPigJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocSubmitPigJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataProcPySparkOperator(DataprocSubmitPySparkJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocSubmitPySparkJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocSubmitPySparkJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataProcSparkOperator(DataprocSubmitSparkJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocSubmitSparkJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocSubmitSparkJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataProcSparkSqlOperator(DataprocSubmitSparkSqlJobOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocSubmitSparkSqlJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocSubmitSparkSqlJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataprocWorkflowTemplateInstantiateInlineOperator(DataprocInstantiateInlineWorkflowTemplateOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocInstantiateInlineWorkflowTemplateOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocInstantiateInlineWorkflowTemplateOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+
+class DataprocWorkflowTemplateInstantiateOperator(DataprocInstantiateWorkflowTemplateOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.gcp.operators.dataproc.DataprocInstantiateWorkflowTemplateOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.gcp.operators.dataproc.DataprocInstantiateWorkflowTemplateOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -25,7 +25,7 @@ import os
 
 from airflow import models
 from airflow.providers.google.cloud.operators.dataproc import (
-    DataprocClusterCreateOperator, DataprocClusterDeleteOperator, DataprocSubmitJobOperator,
+    DataprocCreateClusterOperator, DataprocDeleteClusterOperator, DataprocSubmitJobOperator,
     DataprocUpdateClusterOperator,
 )
 from airflow.utils.dates import days_ago
@@ -125,7 +125,7 @@ with models.DAG(
     default_args={"start_date": days_ago(1)},
     schedule_interval=None,
 ) as dag:
-    create_cluster = DataprocClusterCreateOperator(
+    create_cluster = DataprocCreateClusterOperator(
         task_id="create_cluster", project_id=PROJECT_ID, cluster=CLUSTER, region=REGION
     )
 
@@ -166,7 +166,7 @@ with models.DAG(
         task_id="hadoop_task", job=HADOOP_JOB, location=REGION, project_id=PROJECT_ID
     )
 
-    delete_cluster = DataprocClusterDeleteOperator(
+    delete_cluster = DataprocDeleteClusterOperator(
         task_id="delete_cluster",
         project_id=PROJECT_ID,
         cluster_name=CLUSTER_NAME,

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -417,7 +417,7 @@ class ClusterGenerator:
 
 
 # pylint: disable=too-many-instance-attributes
-class DataprocClusterCreateOperator(BaseOperator):
+class DataprocCreateClusterOperator(BaseOperator):
     """
     Create a new cluster on Google Cloud Dataproc. The operator will wait until the
     creation is successful or an error occurs in the creation process.
@@ -528,7 +528,7 @@ class DataprocClusterCreateOperator(BaseOperator):
         return MessageToDict(cluster)
 
 
-class DataprocClusterScaleOperator(BaseOperator):
+class DataprocScaleClusterOperator(BaseOperator):
     """
     Scale, up or down, a cluster on Google Cloud Dataproc.
     The operator will wait until the cluster is re-scaled.
@@ -664,7 +664,7 @@ class DataprocClusterScaleOperator(BaseOperator):
         self.log.info("Cluster scaling finished")
 
 
-class DataprocClusterDeleteOperator(BaseOperator):
+class DataprocDeleteClusterOperator(BaseOperator):
     """
     Deletes a cluster in a project.
 
@@ -736,7 +736,7 @@ class DataprocClusterDeleteOperator(BaseOperator):
         self.log.info("Cluster deleted.")
 
 
-class DataProcJobBaseOperator(BaseOperator):
+class DataprocJobBaseOperator(BaseOperator):
     """
     The base class for operators that launch job on DataProc.
 
@@ -863,7 +863,7 @@ class DataProcJobBaseOperator(BaseOperator):
             )
 
 
-class DataProcPigOperator(DataProcJobBaseOperator):
+class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
     """
     Start a Pig query Job on a Cloud DataProc cluster. The parameters of the operation
     will be passed to the cluster.
@@ -960,7 +960,7 @@ class DataProcPigOperator(DataProcJobBaseOperator):
         super().execute(context)
 
 
-class DataProcHiveOperator(DataProcJobBaseOperator):
+class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
     """
     Start a Hive query Job on a Cloud DataProc cluster.
 
@@ -1026,7 +1026,7 @@ class DataProcHiveOperator(DataProcJobBaseOperator):
         super().execute(context)
 
 
-class DataProcSparkSqlOperator(DataProcJobBaseOperator):
+class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
     """
     Start a Spark SQL query Job on a Cloud DataProc cluster.
 
@@ -1092,7 +1092,7 @@ class DataProcSparkSqlOperator(DataProcJobBaseOperator):
         super().execute(context)
 
 
-class DataProcSparkOperator(DataProcJobBaseOperator):
+class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
     """
     Start a Spark Job on a Cloud DataProc cluster.
 
@@ -1165,7 +1165,7 @@ class DataProcSparkOperator(DataProcJobBaseOperator):
         super().execute(context)
 
 
-class DataProcHadoopOperator(DataProcJobBaseOperator):
+class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
     """
     Start a Hadoop Job on a Cloud DataProc cluster.
 
@@ -1238,7 +1238,7 @@ class DataProcHadoopOperator(DataProcJobBaseOperator):
         super().execute(context)
 
 
-class DataProcPySparkOperator(DataProcJobBaseOperator):
+class DataprocSubmitPySparkJobOperator(DataprocJobBaseOperator):
     """
     Start a PySpark Job on a Cloud DataProc cluster.
 
@@ -1360,7 +1360,7 @@ class DataProcPySparkOperator(DataProcJobBaseOperator):
         super().execute(context)
 
 
-class DataprocWorkflowTemplateInstantiateOperator(BaseOperator):
+class DataprocInstantiateWorkflowTemplateOperator(BaseOperator):
     """
     Instantiate a WorkflowTemplate on Google Cloud Dataproc. The operator will wait
     until the WorkflowTemplate is finished executing.
@@ -1455,7 +1455,7 @@ class DataprocWorkflowTemplateInstantiateOperator(BaseOperator):
         self.log.info('Template instantiated.')
 
 
-class DataprocWorkflowTemplateInstantiateInlineOperator(BaseOperator):
+class DataprocInstantiateInlineWorkflowTemplateOperator(BaseOperator):
     """
     Instantiate a WorkflowTemplate Inline on Google Cloud Dataproc. The operator will
     wait until the WorkflowTemplate is finished executing.

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -25,11 +25,11 @@ from google.api_core.exceptions import AlreadyExists
 from google.api_core.retry import Retry
 
 from airflow.providers.google.cloud.operators.dataproc import (
-    ClusterGenerator, DataprocClusterCreateOperator, DataprocClusterDeleteOperator,
-    DataprocClusterScaleOperator, DataProcHadoopOperator, DataProcHiveOperator, DataProcPigOperator,
-    DataProcPySparkOperator, DataProcSparkOperator, DataProcSparkSqlOperator, DataprocSubmitJobOperator,
-    DataprocUpdateClusterOperator, DataprocWorkflowTemplateInstantiateInlineOperator,
-    DataprocWorkflowTemplateInstantiateOperator,
+    ClusterGenerator, DataprocCreateClusterOperator, DataprocDeleteClusterOperator,
+    DataprocInstantiateInlineWorkflowTemplateOperator, DataprocInstantiateWorkflowTemplateOperator,
+    DataprocScaleClusterOperator, DataprocSubmitHadoopJobOperator, DataprocSubmitHiveJobOperator,
+    DataprocSubmitJobOperator, DataprocSubmitPigJobOperator, DataprocSubmitPySparkJobOperator,
+    DataprocSubmitSparkJobOperator, DataprocSubmitSparkSqlJobOperator, DataprocUpdateClusterOperator,
 )
 from airflow.version import version as airflow_version
 
@@ -184,7 +184,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
     def test_depreciation_warning(self, mock_generator, mock_signature):
         mock_signature.return_value.parameters = cluster_params
         with self.assertWarns(DeprecationWarning) as warning:
-            DataprocClusterCreateOperator(
+            DataprocCreateClusterOperator(
                 task_id=TASK_ID,
                 region=GCP_LOCATION,
                 project_id=GCP_PROJECT,
@@ -204,7 +204,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute(self, mock_hook):
-        op = DataprocClusterCreateOperator(
+        op = DataprocCreateClusterOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -230,7 +230,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_if_cluster_exists(self, mock_hook):
         mock_hook.return_value.create_cluster.side_effect = [AlreadyExists("test")]
-        op = DataprocClusterCreateOperator(
+        op = DataprocCreateClusterOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -265,7 +265,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
 class TestDataprocClusterScaleOperator(unittest.TestCase):
     def test_depreciation_warning(self):
         with self.assertWarns(DeprecationWarning) as warning:
-            DataprocClusterScaleOperator(
+            DataprocScaleClusterOperator(
                 task_id=TASK_ID, cluster_name=CLUSTER_NAME, project_id=GCP_PROJECT
             )
         assert_warning("DataprocUpdateClusterOperator", warning)
@@ -279,7 +279,7 @@ class TestDataprocClusterScaleOperator(unittest.TestCase):
             }
         }
 
-        op = DataprocClusterScaleOperator(
+        op = DataprocScaleClusterOperator(
             task_id=TASK_ID,
             cluster_name=CLUSTER_NAME,
             project_id=GCP_PROJECT,
@@ -305,7 +305,7 @@ class TestDataprocClusterScaleOperator(unittest.TestCase):
 class TestDataprocClusterDeleteOperator(unittest.TestCase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute(self, mock_hook):
-        op = DataprocClusterDeleteOperator(
+        op = DataprocDeleteClusterOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -406,7 +406,7 @@ class TestDataprocWorkflowTemplateInstantiateOperator(unittest.TestCase):
         version = 6
         parameters = {}
 
-        op = DataprocWorkflowTemplateInstantiateOperator(
+        op = DataprocInstantiateWorkflowTemplateOperator(
             task_id=TASK_ID,
             template_id=template_id,
             region=GCP_LOCATION,
@@ -439,7 +439,7 @@ class TestDataprocWorkflowTemplateInstantiateInlineOperator(unittest.TestCase):
     def test_execute(self, mock_hook):
         template = {}
 
-        op = DataprocWorkflowTemplateInstantiateInlineOperator(
+        op = DataprocInstantiateInlineWorkflowTemplateOperator(
             task_id=TASK_ID,
             template=template,
             region=GCP_LOCATION,
@@ -480,7 +480,7 @@ class TestDataProcHiveOperator(unittest.TestCase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_depreciation_warning(self, mock_hook):
         with self.assertWarns(DeprecationWarning) as warning:
-            DataProcHiveOperator(
+            DataprocSubmitHiveJobOperator(
                 task_id=TASK_ID,
                 region=GCP_LOCATION,
                 query="query",
@@ -495,7 +495,7 @@ class TestDataProcHiveOperator(unittest.TestCase):
         mock_hook.return_value.wait_for_job.return_value = None
         mock_hook.return_value.submit_job.return_value.reference.job_id = self.job_id
 
-        op = DataProcHiveOperator(
+        op = DataprocSubmitHiveJobOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             gcp_conn_id=GCP_CONN_ID,
@@ -517,7 +517,7 @@ class TestDataProcHiveOperator(unittest.TestCase):
         mock_hook.return_value.project_id = GCP_PROJECT
         mock_uuid.return_value = self.job_id
 
-        op = DataProcHiveOperator(
+        op = DataprocSubmitHiveJobOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             gcp_conn_id=GCP_CONN_ID,
@@ -545,7 +545,7 @@ class TestDataProcPigOperator(unittest.TestCase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_depreciation_warning(self, mock_hook):
         with self.assertWarns(DeprecationWarning) as warning:
-            DataProcPigOperator(
+            DataprocSubmitPigJobOperator(
                 task_id=TASK_ID,
                 region=GCP_LOCATION,
                 query="query",
@@ -560,7 +560,7 @@ class TestDataProcPigOperator(unittest.TestCase):
         mock_hook.return_value.wait_for_job.return_value = None
         mock_hook.return_value.submit_job.return_value.reference.job_id = self.job_id
 
-        op = DataProcPigOperator(
+        op = DataprocSubmitPigJobOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             gcp_conn_id=GCP_CONN_ID,
@@ -582,7 +582,7 @@ class TestDataProcPigOperator(unittest.TestCase):
         mock_hook.return_value.project_id = GCP_PROJECT
         mock_uuid.return_value = self.job_id
 
-        op = DataProcPigOperator(
+        op = DataprocSubmitPigJobOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             gcp_conn_id=GCP_CONN_ID,
@@ -613,7 +613,7 @@ class TestDataProcSparkSqlOperator(unittest.TestCase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_depreciation_warning(self, mock_hook):
         with self.assertWarns(DeprecationWarning) as warning:
-            DataProcSparkSqlOperator(
+            DataprocSubmitSparkSqlJobOperator(
                 task_id=TASK_ID,
                 region=GCP_LOCATION,
                 query="query",
@@ -628,7 +628,7 @@ class TestDataProcSparkSqlOperator(unittest.TestCase):
         mock_hook.return_value.wait_for_job.return_value = None
         mock_hook.return_value.submit_job.return_value.reference.job_id = self.job_id
 
-        op = DataProcSparkSqlOperator(
+        op = DataprocSubmitSparkSqlJobOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             gcp_conn_id=GCP_CONN_ID,
@@ -650,7 +650,7 @@ class TestDataProcSparkSqlOperator(unittest.TestCase):
         mock_hook.return_value.project_id = GCP_PROJECT
         mock_uuid.return_value = self.job_id
 
-        op = DataProcSparkSqlOperator(
+        op = DataprocSubmitSparkSqlJobOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             gcp_conn_id=GCP_CONN_ID,
@@ -678,7 +678,7 @@ class TestDataProcSparkOperator(unittest.TestCase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_depreciation_warning(self, mock_hook):
         with self.assertWarns(DeprecationWarning) as warning:
-            DataProcSparkOperator(
+            DataprocSubmitSparkJobOperator(
                 task_id=TASK_ID,
                 region=GCP_LOCATION,
                 main_class=self.main_class,
@@ -693,7 +693,7 @@ class TestDataProcSparkOperator(unittest.TestCase):
         mock_hook.return_value.project_id = GCP_PROJECT
         mock_uuid.return_value = self.job_id
 
-        op = DataProcSparkOperator(
+        op = DataprocSubmitSparkJobOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             gcp_conn_id=GCP_CONN_ID,
@@ -721,7 +721,7 @@ class TestDataProcHadoopOperator(unittest.TestCase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_depreciation_warning(self, mock_hook):
         with self.assertWarns(DeprecationWarning) as warning:
-            DataProcHadoopOperator(
+            DataprocSubmitHadoopJobOperator(
                 task_id=TASK_ID,
                 region=GCP_LOCATION,
                 main_jar=self.jar,
@@ -736,7 +736,7 @@ class TestDataProcHadoopOperator(unittest.TestCase):
         mock_hook.return_value.project_id = GCP_PROJECT
         mock_uuid.return_value = self.job_id
 
-        op = DataProcHadoopOperator(
+        op = DataprocSubmitHadoopJobOperator(
             task_id=TASK_ID,
             region=GCP_LOCATION,
             gcp_conn_id=GCP_CONN_ID,
@@ -763,7 +763,7 @@ class TestDataProcPySparkOperator(unittest.TestCase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_depreciation_warning(self, mock_hook):
         with self.assertWarns(DeprecationWarning) as warning:
-            DataProcPySparkOperator(
+            DataprocSubmitPySparkJobOperator(
                 task_id=TASK_ID,
                 region=GCP_LOCATION,
                 main=self.uri,
@@ -776,7 +776,7 @@ class TestDataProcPySparkOperator(unittest.TestCase):
         mock_hook.return_value.project_id = GCP_PROJECT
         mock_uuid.return_value = self.job_id
 
-        op = DataProcPySparkOperator(
+        op = DataprocSubmitPySparkJobOperator(
             task_id=TASK_ID, region=GCP_LOCATION, gcp_conn_id=GCP_CONN_ID, main=self.uri
         )
         job = op.generate_job()

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -693,63 +693,63 @@ OPERATOR = [
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataprocClusterCreateOperator",
+        "operators.dataproc.DataprocCreateClusterOperator",
         "airflow.contrib.operators.dataproc_operator.DataprocClusterCreateOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataprocClusterDeleteOperator",
+        "operators.dataproc.DataprocDeleteClusterOperator",
         "airflow.contrib.operators.dataproc_operator.DataprocClusterDeleteOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataprocClusterScaleOperator",
+        "operators.dataproc.DataprocScaleClusterOperator",
         "airflow.contrib.operators.dataproc_operator.DataprocClusterScaleOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataProcHadoopOperator",
+        "operators.dataproc.DataprocSubmitHadoopJobOperator",
         "airflow.contrib.operators.dataproc_operator.DataProcHadoopOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataProcHiveOperator",
+        "operators.dataproc.DataprocSubmitHiveJobOperator",
         "airflow.contrib.operators.dataproc_operator.DataProcHiveOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataProcJobBaseOperator",
+        "operators.dataproc.DataprocJobBaseOperator",
         "airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataProcPigOperator",
+        "operators.dataproc.DataprocSubmitPigJobOperator",
         "airflow.contrib.operators.dataproc_operator.DataProcPigOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataProcPySparkOperator",
+        "operators.dataproc.DataprocSubmitPySparkJobOperator",
         "airflow.contrib.operators.dataproc_operator.DataProcPySparkOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataProcSparkOperator",
+        "operators.dataproc.DataprocSubmitSparkJobOperator",
         "airflow.contrib.operators.dataproc_operator.DataProcSparkOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataProcSparkSqlOperator",
+        "operators.dataproc.DataprocSubmitSparkSqlJobOperator",
         "airflow.contrib.operators.dataproc_operator.DataProcSparkSqlOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataprocWorkflowTemplateInstantiateInlineOperator",
+        "operators.dataproc.DataprocInstantiateInlineWorkflowTemplateOperator",
         "airflow.contrib.operators.dataproc_operator."
         "DataprocWorkflowTemplateInstantiateInlineOperator",
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataprocWorkflowTemplateInstantiateOperator",
+        "operators.dataproc.DataprocInstantiateWorkflowTemplateOperator",
         "airflow.contrib.operators.dataproc_operator."
         "DataprocWorkflowTemplateInstantiateOperator",
     ),


### PR DESCRIPTION
PR contains changes regarding AIP-21 (renaming GCP operators and hooks):
* renamed GCP modules
* adde deprecation warnings to the contrib modules
* fixed tests
* updated UPDATING.md

---
Issue link: [AIRFLOW-6102](https://issues.apache.org/jira/browse/AIRFLOW-6102/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
