### PR TITLE
[AIRFLOW-6548] Restore GCS tests removed by migration

### DIFF
--- a/tests/gcp/sensors/test_gcs.py
+++ b/tests/gcp/sensors/test_gcs.py
@@ -21,10 +21,11 @@ from unittest import TestCase, mock
 
 import pendulum
 
-from airflow import DAG
+from airflow import DAG, AirflowException
 from airflow.exceptions import AirflowSensorTimeout
 from airflow.gcp.sensors.gcs import (
-    GCSObjectExistenceSensor, GCSObjectsWtihPrefixExistenceSensor, GCSObjectUpdateSensor, ts_function,
+    GCSObjectExistenceSensor, GCSObjectsWtihPrefixExistenceSensor, GCSObjectUpdateSensor,
+    GCSUploadSessionCompleteSensor, ts_function,
 )
 
 TEST_BUCKET = "TEST_BUCKET"
@@ -43,6 +44,17 @@ DEFAULT_DATE = datetime(2015, 1, 1)
 
 MOCK_DATE_ARRAY = [datetime(2019, 2, 24, 12, 0, 0) - i * timedelta(seconds=10)
                    for i in range(20)]
+
+
+def next_time_side_effect():
+    """
+    This each time this is called mock a time 10 seconds later
+    than the previous call.
+    """
+    return MOCK_DATE_ARRAY.pop()
+
+
+mock_time = mock.Mock(side_effect=next_time_side_effect)
 
 
 class TestGoogleCloudStorageObjectSensor(TestCase):
@@ -180,3 +192,91 @@ class TestGoogleCloudStoragePrefixSensor(TestCase):
             task.execute(mock.MagicMock)
             mock_hook.return_value.list.assert_called_once_with(
                 TEST_BUCKET, prefix=TEST_PREFIX)
+
+
+class TestGCSUploadSessionCompleteSensor(TestCase):
+
+    def setUp(self):
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE,
+        }
+        dag = DAG(TEST_DAG_ID + 'test_schedule_dag_once', default_args=args)
+        dag.schedule_interval = '@once'
+        self.dag = dag
+
+        self.sensor = GCSUploadSessionCompleteSensor(
+            task_id='sensor',
+            bucket='test-bucket',
+            prefix='test-prefix/path',
+            inactivity_period=12,
+            poke_interval=10,
+            min_objects=1,
+            allow_delete=False,
+            previous_num_objects=0,
+            dag=self.dag
+        )
+
+        self.last_mocked_date = datetime(2019, 4, 24, 0, 0, 0)
+
+    @mock.patch('airflow.gcp.sensors.gcs.get_time', mock_time)
+    def test_files_deleted_between_pokes_throw_error(self):
+        self.sensor.is_bucket_updated(2)
+        with self.assertRaises(AirflowException):
+            self.sensor.is_bucket_updated(1)
+
+    @mock.patch('airflow.gcp.sensors.gcs.get_time', mock_time)
+    def test_files_deleted_between_pokes_allow_delete(self):
+        self.sensor = GCSUploadSessionCompleteSensor(
+            task_id='sensor',
+            bucket='test-bucket',
+            prefix='test-prefix/path',
+            inactivity_period=12,
+            poke_interval=10,
+            min_objects=1,
+            allow_delete=True,
+            previous_num_objects=0,
+            dag=self.dag
+        )
+        self.sensor.is_bucket_updated(2)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+        self.sensor.is_bucket_updated(1)
+        self.assertEqual(self.sensor.previous_num_objects, 1)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+        self.sensor.is_bucket_updated(2)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+        self.sensor.is_bucket_updated(2)
+        self.assertEqual(self.sensor.inactivity_seconds, 10)
+        self.assertTrue(self.sensor.is_bucket_updated(2))
+
+    @mock.patch('airflow.gcp.sensors.gcs.get_time', mock_time)
+    def test_incoming_data(self):
+        self.sensor.is_bucket_updated(2)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+        self.sensor.is_bucket_updated(3)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+        self.sensor.is_bucket_updated(4)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+
+    @mock.patch('airflow.gcp.sensors.gcs.get_time', mock_time)
+    def test_no_new_data(self):
+        self.sensor.is_bucket_updated(2)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+        self.sensor.is_bucket_updated(2)
+        self.assertEqual(self.sensor.inactivity_seconds, 10)
+
+    @mock.patch('airflow.gcp.sensors.gcs.get_time', mock_time)
+    def test_no_new_data_success_criteria(self):
+        self.sensor.is_bucket_updated(2)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+        self.sensor.is_bucket_updated(2)
+        self.assertEqual(self.sensor.inactivity_seconds, 10)
+        self.assertTrue(self.sensor.is_bucket_updated(2))
+
+    @mock.patch('airflow.gcp.sensors.gcs.get_time', mock_time)
+    def test_not_enough_objects(self):
+        self.sensor.is_bucket_updated(0)
+        self.assertEqual(self.sensor.inactivity_seconds, 0)
+        self.sensor.is_bucket_updated(0)
+        self.assertEqual(self.sensor.inactivity_seconds, 10)
+        self.assertFalse(self.sensor.is_bucket_updated(0))


### PR DESCRIPTION
This PR restores tests that were accidentally removed in
https://github.com/apache/airflow/pull/6077

Thanks @jaketf !

---
Issue link: [AIRFLOW-6548](https://issues.apache.org/jira/browse/AIRFLOW-6548/)

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
