### PR TITLE
[AIRFLOW-6585] Fixed Timestamp bug in RefreshKubeConfigLoader

### DIFF
--- a/airflow/kubernetes/refresh_config.py
+++ b/airflow/kubernetes/refresh_config.py
@@ -57,6 +57,8 @@ class RefreshKubeConfigLoader(KubeConfigLoader):
             self.token = "Bearer %s" % status['token']  # pylint: disable=W0201
             ts_str = status.get('expirationTimestamp')
             if ts_str:
+                if ts_str[-1] == 'Z':
+                    ts_str = ts_str[:-1] + '+0000'
                 self.api_key_expire_ts = calendar.timegm(
                     datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S%z").timetuple(),
                 )

--- a/tests/kubernetes/test_refresh_config.py
+++ b/tests/kubernetes/test_refresh_config.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from unittest import TestCase
 
 from airflow.kubernetes.refresh_config import _parse_timestamp

--- a/tests/kubernetes/test_refresh_config.py
+++ b/tests/kubernetes/test_refresh_config.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from airflow.kubernetes.refresh_config import _parse_timestamp
+
+
+class TestRefreshKubeConfigLoader(TestCase):
+
+    def test_parse_timestamp_should_convert_Z_timezone_to_unix_timestamp(self):
+        ts = _parse_timestamp("2020-01-13T13:42:20Z")
+        self.assertEqual(1578922940, ts)
+
+    def test_parse_timestamp_should_convert_regular_timezone_to_unix_timestamp(self):
+        ts = _parse_timestamp("2020-01-13T13:42:20+0600")
+        self.assertEqual(1578922940, ts)

--- a/tests/kubernetes/test_refresh_config.py
+++ b/tests/kubernetes/test_refresh_config.py
@@ -5,7 +5,7 @@ from airflow.kubernetes.refresh_config import _parse_timestamp
 
 class TestRefreshKubeConfigLoader(TestCase):
 
-    def test_parse_timestamp_should_convert_Z_timezone_to_unix_timestamp(self):
+    def test_parse_timestamp_should_convert_z_timezone_to_unix_timestamp(self):
         ts = _parse_timestamp("2020-01-13T13:42:20Z")
         self.assertEqual(1578922940, ts)
 


### PR DESCRIPTION
## JIRA
https://issues.apache.org/jira/browse/AIRFLOW-6585

## Description
When using the KubernetesPodOperator on an aws kubernetes cluster, the aws-iam-authenticator is used to obtain kubernetes authentication tokens. The aws tokens contain ISO-8601 formatted timestamps, which couldn't be parsed in case of a "Z" (Zulu Time) timezone. This PR fixes this problem by converting the "Z" timezone into a regular "+0000" format.

Upon further review this is only a problem with python version <= 3.6. But that should not keep the issue from being fixed.
