### PR TITLE
[AIRFLOW-XXXX] Remove trailing slash of JIRA issue link

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -178,7 +178,7 @@ insertIssueLinkInPrDescription:
   matchers:
     jiraIssueMatch:
       titleIssueIdRegexp: \[(AIRFLOW-[0-9]{4})\]
-      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1}/)"
+      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1})"
     docOnlyIssueMatch:
       titleIssueIdRegexp: \[(AIRFLOW-X{4})\]
       descriptionIssueLink: "`Document only change, no JIRA issue`"


### PR DESCRIPTION
Trailing slash causes weird problem. When you enter the issue
via this link, your URL in browser gets updated to an empty one
which results in Error Page when you resolve the ticket.

---
Issue link: `Document only change, no JIRA issue`

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
