### PR TITLE
[AIRFLOW-6553] [UI] Add upstream_failed in instance state filter

### DIFF
--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -64,6 +64,7 @@
     <div class="legend_item state" style="border-color:grey;">queued</div>
     <div class="legend_item state" style="border-color:gold;">up_for_retry</div>
     <div class="legend_item state" style="border-color:turquoise;">up_for_reschedule</div>
+    <div class="legend_item state" style="border-color:orange;">upstream_failed</div>
     <div class="legend_item state" style="border-color:pink;">skipped</div>
     <div class="legend_item state" style="border-color:red;">failed</div>
     <div class="legend_item state" style="border-color:lime;">running</div>
@@ -124,6 +125,7 @@
         'running':false,
         'failed':false,
         'skipped': false,
+        'upstream_failed': false,
         'up_for_reschedule': false,
         'up_for_retry': false,
         'queued': false,

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -50,6 +50,8 @@
   <div class="square" style="background: gold;"></div>
   <div class="legend_item" style="border: none;">up_for_reschedule</div>
   <div class="square" style="background: turquoise;"></div>
+  <div class="legend_item" style="border: none;">upstream_failed</div>
+  <div class="square" style="background: orange;"></div>
   <div class="legend_item" style="border: none;">skipped</div>
   <div class="square" style="background: pink;"></div>
   <div class="legend_item" style="border: none;">failed</div>


### PR DESCRIPTION
### JIRA Issue
https://issues.apache.org/jira/browse/AIRFLOW-6553

### Description
Current Airflow Web UI doesn't show `upstream_failed` status filter in graph and tree view of the executed task.

**Example**:
<img width="488" alt="Screen Shot 2020-01-13 at 15 03 50" src="https://user-images.githubusercontent.com/13610191/72310195-7dc87300-36c4-11ea-9146-cce59e58c389.png">

---
Issue link: [AIRFLOW-6553](https://issues.apache.org/jira/browse/AIRFLOW-6553)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
