### PR TITLE
[AIRFLOW-6542] add spark-on-k8s operator/hook/sensor

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -61,6 +61,7 @@ CONN_TYPE_TO_HOOK = {
     "hiveserver2": ("airflow.providers.apache.hive.hooks.hive.HiveServer2Hook", "hiveserver2_conn_id"),
     "jdbc": ("airflow.providers.jdbc.hooks.jdbc.JdbcHook", "jdbc_conn_id"),
     "jira": ("airflow.providers.jira.hooks.jira.JiraHook", "jira_conn_id"),
+    "kubernetes": ("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook", "kubernetes_conn_id"),
     "mongo": ("airflow.providers.mongo.hooks.mongo.MongoHook", "conn_id"),
     "mssql": ("airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook", "mssql_conn_id"),
     "mysql": ("airflow.providers.mysql.hooks.mysql.MySqlHook", "mysql_conn_id"),
@@ -161,6 +162,7 @@ class Connection(Base, LoggingMixin):
         ('yandexcloud', 'Yandex Cloud'),
         ('livy', 'Apache Livy'),
         ('tableau', 'Tableau'),
+        ('kubernetes', 'Kubernetes cluster Connection'),
     ]
 
     def __init__(

--- a/airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator.py
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This is an example DAG which uses SparkKubernetesOperator and SparkKubernetesSensor.
+In this example, we create two tasks which execute sequentially.
+The first task is to submit sparkApplication on Kubernetes cluster(the example uses spark-pi application).
+and the second task is to check the final state of the sparkApplication that submitted in the first state.
+
+Spark-on-k8s operator is required to be already installed on Kubernetes
+https://github.com/GoogleCloudPlatform/spark-on-k8s-operator
+"""
+
+from datetime import timedelta
+
+# [START import_module]
+# The DAG object; we'll need this to instantiate a DAG
+from airflow import DAG
+# Operators; we need this to operate!
+from airflow.providers.cncf.kubernetes.operators.spark_kubernetes import SparkKubernetesOperator
+from airflow.providers.cncf.kubernetes.sensors.spark_kubernetes import SparkKubernetesSensor
+from airflow.utils.dates import days_ago
+
+# [END import_module]
+
+# [START default_args]
+# These args will get passed on to each operator
+# You can override them on a per-task basis during operator initialization
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': days_ago(1),
+    'email': ['airflow@example.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'max_active_runs': 1
+}
+# [END default_args]
+
+# [START instantiate_dag]
+
+dag = DAG(
+    'spark_pi',
+    default_args=default_args,
+    description='submit spark-pi as sparkApplication on kubernetes',
+    schedule_interval=timedelta(days=1),
+)
+
+t1 = SparkKubernetesOperator(
+    task_id='spark_pi_submit',
+    namespace="default",
+    application_file="example_spark_kubernetes_operator_spark_pi.yaml",
+    kubernetes_conn_id="kubernetes_default",
+    do_xcom_push=True,
+    dag=dag,
+)
+
+t2 = SparkKubernetesSensor(
+    task_id='spark_pi_monitor',
+    namespace="default",
+    application_name="{{ task_instance.xcom_pull(task_ids='spark_pi_submit')['metadata']['name'] }}",
+    kubernetes_conn_id="kubernetes_default",
+    dag=dag
+)
+t1 >> t2

--- a/airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: "spark-pi-{{ ds }}-{{ task_instance.try_number }}"
+  namespace: default
+spec:
+  type: Scala
+  mode: cluster
+  image: "gcr.io/spark-operator/spark:v2.4.4"
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
+  sparkVersion: "2.4.4"
+  restartPolicy:
+    type: Never
+  volumes:
+    - name: "test-volume"
+      hostPath:
+        path: "/tmp"
+        type: Directory
+  driver:
+    cores: 1
+    coreLimit: "1200m"
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    serviceAccount: default
+    volumeMounts:
+      - name: "test-volume"
+        mountPath: "/tmp"
+  executor:
+    cores: 1
+    instances: 1
+    memory: "512m"
+    labels:
+      version: 2.4.4
+    volumeMounts:
+      - name: "test-volume"
+        mountPath: "/tmp"

--- a/airflow/providers/cncf/kubernetes/hooks/__init__.py
+++ b/airflow/providers/cncf/kubernetes/hooks/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,22 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-include NOTICE
-include LICENSE
-include CHANGELOG.txt
-include README.md
-graft licenses
-graft airflow/www
-graft airflow/www/static
-graft airflow/www/templates
-graft airflow/_vendor/
-include airflow/alembic.ini
-include airflow/git_version
-include airflow/serialization/schema.json
-graft scripts/systemd
-graft scripts/upstart
-graft airflow/config_templates
-recursive-exclude airflow/www/node_modules *
-global-exclude __pycache__  *.pyc
-include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -1,0 +1,150 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tempfile
+from typing import Optional, Union
+
+import yaml
+from kubernetes import client, config
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.base_hook import BaseHook
+
+
+def _load_body_to_dict(body):
+    try:
+        body_dict = yaml.safe_load(body)
+    except yaml.YAMLError as e:
+        raise AirflowException("Exception when loading resource definition: %s\n" % e)
+    return body_dict
+
+
+class KubernetesHook(BaseHook):
+    """
+    Creates Kubernetes API connection.
+
+    :param conn_id: the connection to Kubernetes cluster
+    :type conn_id: str
+    """
+
+    def __init__(
+        self,
+        conn_id: str = "kubernetes_default"
+    ):
+        self.conn_id = conn_id
+
+    def get_conn(self):
+        """
+        Returns kubernetes api session for use with requests
+        """
+        connection = self.get_connection(self.conn_id)
+        extras = connection.extra_dejson
+        if extras.get("extra__kubernetes__in_cluster"):
+            self.log.debug("loading kube_config from: in_cluster configuration")
+            config.load_incluster_config()
+        elif extras.get("extra__kubernetes__kube_config") is None:
+            self.log.debug("loading kube_config from: default file")
+            config.load_kube_config()
+        else:
+            with tempfile.NamedTemporaryFile() as temp_config:
+                self.log.debug("loading kube_config from: connection kube_config")
+                temp_config.write(extras.get("extra__kubernetes__kube_config").encode())
+                temp_config.flush()
+                config.load_kube_config(temp_config.name)
+        return client.ApiClient()
+
+    def create_custom_resource_definition(self,
+                                          group: str,
+                                          version: str,
+                                          plural: str,
+                                          body: Union[str, dict],
+                                          namespace: Optional[str] = None
+                                          ):
+        """
+        Creates custom resource definition object in Kubernetes
+
+        :param group: api group
+        :type group: str
+        :param version: api version
+        :type version: str
+        :param plural: api plural
+        :type plural: str
+        :param body: crd object definition
+        :type body: Union[str, dict]
+        :param namespace: kubernetes namespace
+        :type namespace: str
+        """
+        api = client.CustomObjectsApi(self.get_conn())
+        if namespace is None:
+            namespace = self.get_namespace()
+        if isinstance(body, str):
+            body = _load_body_to_dict(body)
+        try:
+            response = api.create_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                body=body
+            )
+            self.log.debug("Response: %s", response)
+            return response
+        except client.rest.ApiException as e:
+            raise AirflowException("Exception when calling -> create_custom_resource_definition: %s\n" % e)
+
+    def get_custom_resource_definition(self,
+                                       group: str,
+                                       version: str,
+                                       plural: str,
+                                       name: str,
+                                       namespace: Optional[str] = None):
+        """
+        Get custom resource definition object from Kubernetes
+
+        :param group: api group
+        :type group: str
+        :param version: api version
+        :type version: str
+        :param plural: api plural
+        :type plural: str
+        :param name: crd object name
+        :type name: str
+        :param namespace: kubernetes namespace
+        :type namespace: str
+        """
+        custom_resource_definition_api = client.CustomObjectsApi(self.get_conn())
+        if namespace is None:
+            namespace = self.get_namespace()
+        try:
+            response = custom_resource_definition_api.get_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                name=name
+            )
+            return response
+        except client.rest.ApiException as e:
+            raise AirflowException("Exception when calling -> get_custom_resource_definition: %s\n" % e)
+
+    def get_namespace(self):
+        """
+        Returns the namespace that defined in the connection
+        """
+        connection = self.get_connection(self.conn_id)
+        extras = connection.extra_dejson
+        namespace = extras.get("extra__kubernetes__namespace", "default")
+        return namespace

--- a/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Optional
+
+from airflow.models import BaseOperator
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
+from airflow.utils.decorators import apply_defaults
+
+
+class SparkKubernetesOperator(BaseOperator):
+    """
+    Creates sparkApplication object in kubernetes cluster:
+
+    .. seealso::
+        For more detail about Spark Application Object have a look at the reference:
+        https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/v1beta2-1.1.0-2.4.5/docs/api-docs.md#sparkapplication
+
+    :param application_file: filepath to kubernetes custom_resource_definition of sparkApplication
+    :type application_file:  str
+    :param namespace: kubernetes namespace to put sparkApplication
+    :type namespace: str
+    :param kubernetes_conn_id: the connection to Kubernetes cluster
+    :type kubernetes_conn_id: str
+    """
+
+    template_fields = ['application_file', 'namespace']
+    template_ext = ('yaml', 'yml', 'json')
+    ui_color = '#f4a460'
+
+    @apply_defaults
+    def __init__(self,
+                 application_file: str,
+                 namespace: Optional[str] = None,
+                 kubernetes_conn_id: str = 'kubernetes_default',
+                 *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.application_file = application_file
+        self.namespace = namespace
+        self.kubernetes_conn_id = kubernetes_conn_id
+
+    def execute(self, context):
+        self.log.info("Creating sparkApplication")
+        hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
+        response = hook.create_custom_resource_definition(
+            group="sparkoperator.k8s.io",
+            version="v1beta2",
+            plural="sparkapplications",
+            body=self.application_file,
+            namespace=self.namespace)
+        return response

--- a/airflow/providers/cncf/kubernetes/sensors/__init__.py
+++ b/airflow/providers/cncf/kubernetes/sensors/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,22 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-include NOTICE
-include LICENSE
-include CHANGELOG.txt
-include README.md
-graft licenses
-graft airflow/www
-graft airflow/www/static
-graft airflow/www/templates
-graft airflow/_vendor/
-include airflow/alembic.ini
-include airflow/git_version
-include airflow/serialization/schema.json
-graft scripts/systemd
-graft scripts/upstart
-graft airflow/config_templates
-recursive-exclude airflow/www/node_modules *
-global-exclude __pycache__  *.pyc
-include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml

--- a/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
@@ -1,0 +1,77 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Dict, Optional
+
+from airflow.exceptions import AirflowException
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class SparkKubernetesSensor(BaseSensorOperator):
+    """
+    Checks sparkApplication object in kubernetes cluster:
+
+    .. seealso::
+        For more detail about Spark Application Object have a look at the reference:
+        https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/v1beta2-1.1.0-2.4.5/docs/api-docs.md#sparkapplication
+
+    :param application_name: spark Application resource name
+    :type application_name:  str
+    :param namespace: the kubernetes namespace where the sparkApplication reside in
+    :type namespace: str
+    :param kubernetes_conn_id: the connection to Kubernetes cluster
+    :type kubernetes_conn_id: str
+    """
+
+    template_fields = ('application_name', 'namespace')
+    FAILURE_STATES = ('FAILED', 'UNKNOWN')
+    SUCCESS_STATES = ('COMPLETED',)
+
+    @apply_defaults
+    def __init__(self,
+                 application_name: str,
+                 namespace: Optional[str] = None,
+                 kubernetes_conn_id: str = 'kubernetes_default',
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.application_name = application_name
+        self.namespace = namespace
+        self.kubernetes_conn_id = kubernetes_conn_id
+
+    def poke(self, context: Dict):
+        self.log.info("Poking: %s", self.application_name)
+        hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
+        response = hook.get_custom_resource_definition(
+            group="sparkoperator.k8s.io",
+            version="v1beta2",
+            plural="sparkapplications",
+            name=self.application_name,
+            namespace=self.namespace)
+        try:
+            application_state = response['status']['applicationState']['state']
+        except KeyError:
+            return False
+        if application_state in self.FAILURE_STATES:
+            raise AirflowException("Spark application failed with state: %s" % application_state)
+        elif application_state in self.SUCCESS_STATES:
+            self.log.info("Spark application ended successfully")
+            return True
+        else:
+            self.log.info("Spark application is still in state: %s", application_state)
+            return False

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -192,3 +192,11 @@ class ConnectionForm(DynamicForm):
         description='Optional. This key will be placed to all created Compute nodes'
         'to let you have a root shell there',
     )
+    extra__kubernetes__in_cluster = BooleanField(
+        lazy_gettext('In cluster configuration'))
+    extra__kubernetes__kube_config = StringField(
+        lazy_gettext('Kube config (JSON format)'),
+        widget=BS3TextFieldWidget())
+    extra__kubernetes__namespace = StringField(
+        lazy_gettext('Namespace'),
+        widget=BS3TextFieldWidget())

--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -55,6 +55,10 @@ $(document).ready(function () {
         'host': 'https://<env>.qubole.com/api'
       }
     },
+    kubernetes: {
+      hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
+      relabeling: {},
+    },
     ssh: {
       hidden_fields: ['schema'],
       relabeling: {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2235,7 +2235,9 @@ class ConnectionModelView(AirflowModelView):
                     'extra__yandexcloud__oauth',
                     'extra__yandexcloud__public_ssh_key',
                     'extra__yandexcloud__folder_id',
-                    ]
+                    'extra__kubernetes__in_cluster',
+                    'extra__kubernetes__kube_config',
+                    'extra__kubernetes__namespace']
     list_columns = ['conn_id', 'conn_type', 'host', 'port', 'is_encrypted',
                     'is_extra_encrypted']
     add_columns = edit_columns = ['conn_id', 'conn_type', 'host', 'schema',
@@ -2256,7 +2258,7 @@ class ConnectionModelView(AirflowModelView):
 
     def process_form(self, form, is_created):
         formdata = form.data
-        if formdata['conn_type'] in ['jdbc', 'google_cloud_platform', 'grpc', 'yandexcloud']:
+        if formdata['conn_type'] in ['jdbc', 'google_cloud_platform', 'grpc', 'yandexcloud', 'kubernetes']:
             extra = {
                 key: formdata[key]
                 for key in self.extra_fields if key in formdata}

--- a/docs/autoapi_templates/index.rst
+++ b/docs/autoapi_templates/index.rst
@@ -94,6 +94,8 @@ All operators are in the following packages:
 
   airflow/providers/cncf/kubernetes/operators/index
 
+  airflow/providers/cncf/kubernetes/sensors/index
+
   airflow/providers/databricks/operators/index
 
   airflow/providers/datadog/sensors/index
@@ -228,6 +230,8 @@ All hooks are in the following packages:
   airflow/providers/apache/sqoop/hooks/index
 
   airflow/providers/cloudant/hooks/index
+
+  airflow/providers/cncf/kubernetes/hooks/index
 
   airflow/providers/databricks/hooks/index
 

--- a/docs/howto/connection/kubernetes.rst
+++ b/docs/howto/connection/kubernetes.rst
@@ -1,0 +1,53 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _howto/connection:kubernetes:
+
+Kubernetes cluster Connection
+=============================
+
+The Kubernetes cluster Connection type enables connection to Kubernetes cluster.
+
+
+Authenticating to Kubernetes cluster
+------------------------------------
+
+There are three ways to connect to Kubernetes using Airflow.
+
+1. Use kube_config that reside in the default location on the machine(~/.kube/config) - just leave all fields empty.
+2. Use in_cluster config, if Airflow runs inside Kubernetes cluster take the configuration from the cluster - mark:
+   In cluster configuration .
+3. Use kube_config in JSON format from connection configuration - paste  kube_config into ``Kube config (JSON format)`` .
+
+Default Connection IDs
+----------------------
+
+The default connection ID is ``kubernetes_default`` .
+
+Configuring the Connection
+--------------------------
+
+
+In cluster configuration
+  Use in cluster configuration.
+
+Kube config (JSON format)
+  `Kube config <https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/>`_
+  that used to connect to Kubernetes client.
+
+Namespace
+  Default kubernetes namespace for the connection.

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -1136,9 +1136,11 @@ These integrations allow you to perform various operations using various softwar
 
    * - `Kubernetes <https://kubernetes.io/>`__
      - :doc:`How to use <howto/operator/kubernetes>`
-     -
+     - :mod:`airflow.providers.cncf.kubernetes.hooks.kubernetes`
      - :mod:`airflow.providers.cncf.kubernetes.operators.kubernetes_pod`
-     -
+       :mod:`airflow.providers.cncf.kubernetes.operators.spark_kubernetes`
+     - :mod:`airflow.providers.cncf.kubernetes.sensors.spark_kubernetes`
+
 
    * - `Microsoft SQL Server (MSSQL) <https://www.microsoft.com/pl-pl/sql-server/sql-server-downloads>`__
      -

--- a/setup.py
+++ b/setup.py
@@ -451,7 +451,8 @@ def do_setup():
         version=version,
         packages=find_packages(exclude=['tests*']),
         package_data={
-            '': ['airflow/alembic.ini', "airflow/git_version", "*.ipynb"],
+            '': ['airflow/alembic.ini', "airflow/git_version", "*.ipynb",
+                 "airflow/providers/cncf/kubernetes/example_dags/*.yaml"],
             'airflow.serialization': ["*.json"],
         },
         include_package_data=True,

--- a/tests/providers/cncf/__init__.py
+++ b/tests/providers/cncf/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,22 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-include NOTICE
-include LICENSE
-include CHANGELOG.txt
-include README.md
-graft licenses
-graft airflow/www
-graft airflow/www/static
-graft airflow/www/templates
-graft airflow/_vendor/
-include airflow/alembic.ini
-include airflow/git_version
-include airflow/serialization/schema.json
-graft scripts/systemd
-graft scripts/upstart
-graft airflow/config_templates
-recursive-exclude airflow/www/node_modules *
-global-exclude __pycache__  *.pyc
-include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml

--- a/tests/providers/cncf/kubernetes/__init__.py
+++ b/tests/providers/cncf/kubernetes/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,22 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-include NOTICE
-include LICENSE
-include CHANGELOG.txt
-include README.md
-graft licenses
-graft airflow/www
-graft airflow/www/static
-graft airflow/www/templates
-graft airflow/_vendor/
-include airflow/alembic.ini
-include airflow/git_version
-include airflow/serialization/schema.json
-graft scripts/systemd
-graft scripts/upstart
-graft airflow/config_templates
-recursive-exclude airflow/www/node_modules *
-global-exclude __pycache__  *.pyc
-include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml

--- a/tests/providers/cncf/kubernetes/hooks/__init__.py
+++ b/tests/providers/cncf/kubernetes/hooks/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,22 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-include NOTICE
-include LICENSE
-include CHANGELOG.txt
-include README.md
-graft licenses
-graft airflow/www
-graft airflow/www/static
-graft airflow/www/templates
-graft airflow/_vendor/
-include airflow/alembic.ini
-include airflow/git_version
-include airflow/serialization/schema.json
-graft scripts/systemd
-graft scripts/upstart
-graft airflow/config_templates
-recursive-exclude airflow/www/node_modules *
-global-exclude __pycache__  *.pyc
-include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -1,0 +1,93 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import json
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import kubernetes
+
+from airflow.models import Connection
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
+from airflow.utils import db
+
+
+class TestKubernetesHook(unittest.TestCase):
+    def setUp(self):
+        db.merge_conn(
+            Connection(
+                conn_id='kubernetes_in_cluster', conn_type='kubernetes',
+                extra=json.dumps({'extra__kubernetes__in_cluster': True})))
+        db.merge_conn(
+            Connection(
+                conn_id='kubernetes_kube_config', conn_type='kubernetes',
+                extra=json.dumps({'extra__kubernetes__kube_config': '{"test": "kube"}'})))
+        db.merge_conn(
+            Connection(
+                conn_id='kubernetes_default_kube_config', conn_type='kubernetes',
+                extra=json.dumps({})))
+        db.merge_conn(
+            Connection(
+                conn_id='kubernetes_with_namespace', conn_type='kubernetes',
+                extra=json.dumps({'extra__kubernetes__namespace': 'mock_namespace'})))
+
+    @patch("kubernetes.config.incluster_config.InClusterConfigLoader")
+    def test_in_cluster_connection(self, mock_kube_config_loader):
+        kubernetes_hook = KubernetesHook(conn_id='kubernetes_in_cluster')
+        api_conn = kubernetes_hook.get_conn()
+        mock_kube_config_loader.assert_called_once()
+        self.assertIsInstance(api_conn, kubernetes.client.api_client.ApiClient)
+
+    @patch("kubernetes.config.kube_config.KubeConfigLoader")
+    @patch("kubernetes.config.kube_config.KubeConfigMerger")
+    @patch.object(tempfile, 'NamedTemporaryFile')
+    def test_kube_config_connection(self,
+                                    mock_kube_config_loader,
+                                    mock_kube_config_merger,
+                                    mock_tempfile):
+        kubernetes_hook = KubernetesHook(conn_id='kubernetes_kube_config')
+        api_conn = kubernetes_hook.get_conn()
+        mock_tempfile.is_called_once()
+        mock_kube_config_loader.assert_called_once()
+        mock_kube_config_merger.assert_called_once()
+        self.assertIsInstance(api_conn, kubernetes.client.api_client.ApiClient)
+
+    @patch("kubernetes.config.kube_config.KubeConfigLoader")
+    @patch("kubernetes.config.kube_config.KubeConfigMerger")
+    @patch("kubernetes.config.kube_config.KUBE_CONFIG_DEFAULT_LOCATION", "/mock/config")
+    def test_default_kube_config_connection(self,
+                                            mock_kube_config_loader,
+                                            mock_kube_config_merger,
+                                            ):
+        kubernetes_hook = KubernetesHook(conn_id='kubernetes_default_kube_config')
+        api_conn = kubernetes_hook.get_conn()
+        mock_kube_config_loader.assert_called_once_with("/mock/config")
+        mock_kube_config_merger.assert_called_once()
+        self.assertIsInstance(api_conn, kubernetes.client.api_client.ApiClient)
+
+    def test_get_namespace(self):
+        kubernetes_hook_with_namespace = KubernetesHook(conn_id='kubernetes_with_namespace')
+        kubernetes_hook_without_namespace = KubernetesHook(conn_id='kubernetes_default_kube_config')
+        self.assertEqual(kubernetes_hook_with_namespace.get_namespace(), 'mock_namespace')
+        self.assertEqual(kubernetes_hook_without_namespace.get_namespace(), 'default')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/providers/cncf/kubernetes/operators/__init__.py
+++ b/tests/providers/cncf/kubernetes/operators/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,22 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-include NOTICE
-include LICENSE
-include CHANGELOG.txt
-include README.md
-graft licenses
-graft airflow/www
-graft airflow/www/static
-graft airflow/www/templates
-graft airflow/_vendor/
-include airflow/alembic.ini
-include airflow/git_version
-include airflow/serialization/schema.json
-graft scripts/systemd
-graft scripts/upstart
-graft airflow/config_templates
-recursive-exclude airflow/www/node_modules *
-global-exclude __pycache__  *.pyc
-include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -1,0 +1,237 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import json
+import unittest
+from unittest.mock import patch
+
+from airflow import DAG
+from airflow.models import Connection
+from airflow.providers.cncf.kubernetes.operators.spark_kubernetes import SparkKubernetesOperator
+from airflow.utils import db, timezone
+
+TEST_VALID_APPLICATION_YAML = \
+    """
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: spark-pi
+  namespace: default
+spec:
+  type: Scala
+  mode: cluster
+  image: "gcr.io/spark-operator/spark:v2.4.5"
+  imagePullPolicy: Always
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar"
+  sparkVersion: "2.4.5"
+  restartPolicy:
+    type: Never
+  volumes:
+    - name: "test-volume"
+      hostPath:
+        path: "/tmp"
+        type: Directory
+  driver:
+    cores: 1
+    coreLimit: "1200m"
+    memory: "512m"
+    labels:
+      version: 2.4.5
+    serviceAccount: spark
+    volumeMounts:
+      - name: "test-volume"
+        mountPath: "/tmp"
+  executor:
+    cores: 1
+    instances: 1
+    memory: "512m"
+    labels:
+      version: 2.4.5
+    volumeMounts:
+      - name: "test-volume"
+        mountPath: "/tmp"
+"""
+TEST_VALID_APPLICATION_JSON = \
+    """
+{
+   "apiVersion":"sparkoperator.k8s.io/v1beta2",
+   "kind":"SparkApplication",
+   "metadata":{
+      "name":"spark-pi",
+      "namespace":"default"
+   },
+   "spec":{
+      "type":"Scala",
+      "mode":"cluster",
+      "image":"gcr.io/spark-operator/spark:v2.4.5",
+      "imagePullPolicy":"Always",
+      "mainClass":"org.apache.spark.examples.SparkPi",
+      "mainApplicationFile":"local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar",
+      "sparkVersion":"2.4.5",
+      "restartPolicy":{
+         "type":"Never"
+      },
+      "volumes":[
+         {
+            "name":"test-volume",
+            "hostPath":{
+               "path":"/tmp",
+               "type":"Directory"
+            }
+         }
+      ],
+      "driver":{
+         "cores":1,
+         "coreLimit":"1200m",
+         "memory":"512m",
+         "labels":{
+            "version":"2.4.5"
+         },
+         "serviceAccount":"spark",
+         "volumeMounts":[
+            {
+               "name":"test-volume",
+               "mountPath":"/tmp"
+            }
+         ]
+      },
+      "executor":{
+         "cores":1,
+         "instances":1,
+         "memory":"512m",
+         "labels":{
+            "version":"2.4.5"
+         },
+         "volumeMounts":[
+            {
+               "name":"test-volume",
+               "mountPath":"/tmp"
+            }
+         ]
+      }
+   }
+}
+"""
+TEST_APPLICATION_DICT = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {'name': 'spark-pi', 'namespace': 'default'},
+     'spec': {'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'version': '2.4.5'},
+                         'memory': '512m',
+                         'serviceAccount': 'spark',
+                         'volumeMounts': [{'mountPath': '/tmp',
+                                           'name': 'test-volume'}]},
+              'executor': {'cores': 1,
+                           'instances': 1,
+                           'labels': {'version': '2.4.5'},
+                           'memory': '512m',
+                           'volumeMounts': [{'mountPath': '/tmp',
+                                             'name': 'test-volume'}]},
+              'image': 'gcr.io/spark-operator/spark:v2.4.5',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi',
+              'mode': 'cluster',
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.5',
+              'type': 'Scala',
+              'volumes': [{'hostPath': {'path': '/tmp', 'type': 'Directory'},
+                           'name': 'test-volume'}]}}
+
+
+@patch('airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook.get_conn')
+class TestSparkKubernetesOperator(unittest.TestCase):
+    def setUp(self):
+        db.merge_conn(
+            Connection(
+                conn_id='kubernetes_default_kube_config', conn_type='kubernetes',
+                extra=json.dumps({})))
+        db.merge_conn(
+            Connection(
+                conn_id='kubernetes_with_namespace', conn_type='kubernetes',
+                extra=json.dumps({'extra__kubernetes__namespace': 'mock_namespace'})))
+        args = {
+            'owner': 'airflow',
+            'start_date': timezone.datetime(2020, 2, 1)
+        }
+        self.dag = DAG('test_dag_id', default_args=args)
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    def test_create_application_from_yaml(self, mock_create_namespaced_crd, mock_kubernetes_hook):
+        op = SparkKubernetesOperator(application_file=TEST_VALID_APPLICATION_YAML,
+                                     dag=self.dag,
+                                     kubernetes_conn_id='kubernetes_default_kube_config',
+                                     task_id='test_task_id')
+        op.execute(None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_create_namespaced_crd.assert_called_with(body=TEST_APPLICATION_DICT,
+                                                      group='sparkoperator.k8s.io',
+                                                      namespace='default',
+                                                      plural='sparkapplications',
+                                                      version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    def test_create_application_from_json(self, mock_create_namespaced_crd, mock_kubernetes_hook):
+        op = SparkKubernetesOperator(application_file=TEST_VALID_APPLICATION_JSON,
+                                     dag=self.dag,
+                                     kubernetes_conn_id='kubernetes_default_kube_config',
+                                     task_id='test_task_id')
+        op.execute(None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_create_namespaced_crd.assert_called_with(body=TEST_APPLICATION_DICT,
+                                                      group='sparkoperator.k8s.io',
+                                                      namespace='default',
+                                                      plural='sparkapplications',
+                                                      version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    def test_namespace_from_operator(self, mock_create_namespaced_crd, mock_kubernetes_hook):
+        op = SparkKubernetesOperator(application_file=TEST_VALID_APPLICATION_JSON,
+                                     dag=self.dag,
+                                     namespace='operator_namespace',
+                                     kubernetes_conn_id='kubernetes_with_namespace',
+                                     task_id='test_task_id')
+        op.execute(None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_create_namespaced_crd.assert_called_with(body=TEST_APPLICATION_DICT,
+                                                      group='sparkoperator.k8s.io',
+                                                      namespace='operator_namespace',
+                                                      plural='sparkapplications',
+                                                      version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    def test_namespace_from_connection(self, mock_create_namespaced_crd, mock_kubernetes_hook):
+        op = SparkKubernetesOperator(application_file=TEST_VALID_APPLICATION_JSON,
+                                     dag=self.dag,
+                                     kubernetes_conn_id='kubernetes_with_namespace',
+                                     task_id='test_task_id')
+        op.execute(None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_create_namespaced_crd.assert_called_with(body=TEST_APPLICATION_DICT,
+                                                      group='sparkoperator.k8s.io',
+                                                      namespace='mock_namespace',
+                                                      plural='sparkapplications',
+                                                      version='v1beta2')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/providers/cncf/kubernetes/sensors/__init__.py
+++ b/tests/providers/cncf/kubernetes/sensors/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,22 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-include NOTICE
-include LICENSE
-include CHANGELOG.txt
-include README.md
-graft licenses
-graft airflow/www
-graft airflow/www/static
-graft airflow/www/templates
-graft airflow/_vendor/
-include airflow/alembic.ini
-include airflow/git_version
-include airflow/serialization/schema.json
-graft scripts/systemd
-graft scripts/upstart
-graft airflow/config_templates
-recursive-exclude airflow/www/node_modules *
-global-exclude __pycache__  *.pyc
-include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml

--- a/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
@@ -1,0 +1,553 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import json
+import unittest
+from unittest.mock import patch
+
+from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.models import Connection
+from airflow.providers.cncf.kubernetes.sensors.spark_kubernetes import SparkKubernetesSensor
+from airflow.utils import db, timezone
+
+TEST_COMPLETED_APPLICATION = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {'creationTimestamp': '2020-02-24T07:34:22Z',
+                  'generation': 1,
+                  'labels': {'spark_flow_name': 'spark-pi'},
+                  'name': 'spark-pi-2020-02-24-1',
+                  'namespace': 'default',
+                  'resourceVersion': '455577',
+                  'selfLink':
+                      '/apis/sparkoperator.k8s.io/v1beta2/namespaces/default/sparkapplications/spark-pi',
+                  'uid': '9f825516-6e1a-4af1-8967-b05661e8fb08'},
+     'spec': {'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'spark_flow_name': 'spark-pi',
+                                    'version': '2.4.4'},
+                         'memory': '512m',
+                         'serviceAccount': 'default',
+                         'volumeMounts': [{'mountPath': '/tmp',
+                                           'name': 'test-volume'}]},
+              'executor': {'cores': 1,
+                           'instances': 3,
+                           'labels': {'spark_flow_name': 'spark-pi',
+                                      'version': '2.4.4'},
+                           'memory': '512m',
+                           'volumeMounts': [{'mountPath': '/tmp',
+                                             'name': 'test-volume'}]},
+              'image': 'gcr.io/spark-operator/spark:v2.4.4',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi',
+              'mode': 'cluster',
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.4',
+              'type': 'Scala',
+              'volumes': [{'hostPath': {'path': '/tmp', 'type': 'Directory'},
+                           'name': 'test-volume'}]},
+     'status': {'applicationState': {'state': 'COMPLETED'},
+                'driverInfo': {'podName': 'spark-pi-2020-02-24-1-driver',
+                               'webUIAddress': '10.97.130.44:4040',
+                               'webUIPort': 4040,
+                               'webUIServiceName': 'spark-pi-2020-02-24-1-ui-svc'},
+                'executionAttempts': 1,
+                'executorState': {'spark-pi-2020-02-24-1-1582529666227-exec-1': 'FAILED',
+                                  'spark-pi-2020-02-24-1-1582529666227-exec-2': 'FAILED',
+                                  'spark-pi-2020-02-24-1-1582529666227-exec-3': 'FAILED'},
+                'lastSubmissionAttemptTime': '2020-02-24T07:34:30Z',
+                'sparkApplicationId': 'spark-7bb432c422ca46f3854838c419460fec',
+                'submissionAttempts': 1,
+                'submissionID': '1a1f9c5e-6bdd-4824-806f-40a814c1cf43',
+                'terminationTime': '2020-02-24T07:35:01Z'}}
+
+TEST_FAILED_APPLICATION = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {
+         'creationTimestamp': '2020-02-26T11:59:30Z',
+         'generation': 1,
+         'name': 'spark-pi',
+         'namespace': 'default',
+         'resourceVersion': '531657',
+         'selfLink':
+             '/apis/sparkoperator.k8s.io/v1beta2/namespaces/default/sparkapplications/spark-pi',
+         'uid': 'f507ee3a-4461-45ef-86d8-ff42e4211e7d'},
+     'spec': {'arguments': ['100000'],
+              'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'version': '2.4.4'},
+                         'memory': '512m',
+                         'serviceAccount': 'default'},
+              'executor': {'cores': 1,
+                           'instances': 1,
+                           'labels': {'version': '2.4.4'},
+                           'memory': '512m'},
+              'image': 'gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi123',
+              'mode': 'cluster',
+              'monitoring': {'exposeDriverMetrics': True,
+                             'exposeExecutorMetrics': True,
+                             'prometheus':
+                                 {'jmxExporterJar': '/prometheus/jmx_prometheus_javaagent-0.11.0.jar',
+                                  'port': 8090}},
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.4',
+              'type': 'Scala'},
+     'status': {'applicationState': {'errorMessage': 'driver pod failed with '
+                                                     'ExitCode: 101, Reason: Error',
+                                     'state': 'FAILED'},
+                'driverInfo': {'podName': 'spark-pi-driver',
+                               'webUIAddress': '10.108.18.168:4040',
+                               'webUIPort': 4040,
+                               'webUIServiceName': 'spark-pi-ui-svc'},
+                'executionAttempts': 1,
+                'lastSubmissionAttemptTime': '2020-02-26T11:59:38Z',
+                'sparkApplicationId': 'spark-5fb7445d988f434cbe1e86166a0c038a',
+                'submissionAttempts': 1,
+                'submissionID': '26654a75-5bf6-4618-b191-0340280d2d3d',
+                'terminationTime': '2020-02-26T11:59:49Z'}}
+
+TEST_UNKNOWN_APPLICATION = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {'creationTimestamp': '2020-02-24T07:34:22Z',
+                  'generation': 1,
+                  'labels': {'spark_flow_name': 'spark-pi'},
+                  'name': 'spark-pi-2020-02-24-1',
+                  'namespace': 'default',
+                  'resourceVersion': '455577',
+                  'selfLink':
+                      '/apis/sparkoperator.k8s.io/v1beta2/namespaces/default/sparkapplications/spark-pi',
+                  'uid': '9f825516-6e1a-4af1-8967-b05661e8fb08'},
+     'spec': {'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'spark_flow_name': 'spark-pi',
+                                    'version': '2.4.4'},
+                         'memory': '512m',
+                         'serviceAccount': 'default',
+                         'volumeMounts': [{'mountPath': '/tmp',
+                                           'name': 'test-volume'}]},
+              'executor': {'cores': 1,
+                           'instances': 3,
+                           'labels': {'spark_flow_name': 'spark-pi',
+                                      'version': '2.4.4'},
+                           'memory': '512m',
+                           'volumeMounts': [{'mountPath': '/tmp',
+                                             'name': 'test-volume'}]},
+              'image': 'gcr.io/spark-operator/spark:v2.4.4',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi',
+              'mode': 'cluster',
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.4',
+              'type': 'Scala',
+              'volumes': [{'hostPath': {'path': '/tmp', 'type': 'Directory'},
+                           'name': 'test-volume'}]},
+     'status': {'applicationState': {'state': 'UNKNOWN'},
+                'driverInfo': {'podName': 'spark-pi-2020-02-24-1-driver',
+                               'webUIAddress': '10.97.130.44:4040',
+                               'webUIPort': 4040,
+                               'webUIServiceName': 'spark-pi-2020-02-24-1-ui-svc'},
+                'executionAttempts': 1,
+                'executorState': {'spark-pi-2020-02-24-1-1582529666227-exec-1': 'FAILED',
+                                  'spark-pi-2020-02-24-1-1582529666227-exec-2': 'FAILED',
+                                  'spark-pi-2020-02-24-1-1582529666227-exec-3': 'FAILED'},
+                'lastSubmissionAttemptTime': '2020-02-24T07:34:30Z',
+                'sparkApplicationId': 'spark-7bb432c422ca46f3854838c419460fec',
+                'submissionAttempts': 1,
+                'submissionID': '1a1f9c5e-6bdd-4824-806f-40a814c1cf43',
+                'terminationTime': '2020-02-24T07:35:01Z'}}
+TEST_NOT_PROCESSED_APPLICATION = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {
+         'creationTimestamp': '2020-02-26T09:14:48Z',
+         'generation': 1,
+         'name': 'spark-pi',
+         'namespace': 'default',
+         'resourceVersion': '525235',
+         'selfLink':
+             '/apis/sparkoperator.k8s.io/v1beta2/namespaces/default/sparkapplications/spark-pi',
+         'uid': '58da0778-fa72-4e90-8ddc-18b5e658f93d'},
+     'spec': {'arguments': ['100000'],
+              'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'version': '2.4.4'},
+                         'memory': '512m',
+                         'serviceAccount': 'default'},
+              'executor': {'cores': 1,
+                           'instances': 1,
+                           'labels': {'version': '2.4.4'},
+                           'memory': '512m'},
+              'image': 'gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi',
+              'mode': 'cluster',
+              'monitoring': {'exposeDriverMetrics': True,
+                             'exposeExecutorMetrics': True,
+                             'prometheus':
+                                 {'jmxExporterJar': '/prometheus/jmx_prometheus_javaagent-0.11.0.jar',
+                                  'port': 8090}},
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.4',
+              'type': 'Scala'}}
+
+TEST_RUNNING_APPLICATION = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {
+         'creationTimestamp': '2020-02-26T09:11:25Z',
+         'generation': 1,
+         'name': 'spark-pi',
+         'namespace': 'default',
+         'resourceVersion': '525001',
+         'selfLink':
+             '/apis/sparkoperator.k8s.io/v1beta2/namespaces/default/sparkapplications/spark-pi',
+         'uid': '95ff1418-eeb5-454c-b59e-9e021aa3a239'},
+     'spec': {'arguments': ['100000'],
+              'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'version': '2.4.4'},
+                         'memory': '512m',
+                         'serviceAccount': 'default'},
+              'executor': {'cores': 1,
+                           'instances': 1,
+                           'labels': {'version': '2.4.4'},
+                           'memory': '512m'},
+              'image': 'gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi',
+              'mode': 'cluster',
+              'monitoring': {'exposeDriverMetrics': True,
+                             'exposeExecutorMetrics': True,
+                             'prometheus':
+                                 {'jmxExporterJar': '/prometheus/jmx_prometheus_javaagent-0.11.0.jar',
+                                  'port': 8090}},
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.4',
+              'type': 'Scala'},
+     'status': {'applicationState': {'state': 'RUNNING'},
+                'driverInfo': {'podName': 'spark-pi-driver',
+                               'webUIAddress': '10.106.36.53:4040',
+                               'webUIPort': 4040,
+                               'webUIServiceName': 'spark-pi-ui-svc'},
+                'executionAttempts': 1,
+                'executorState': {'spark-pi-1582708290692-exec-1': 'RUNNING'},
+                'lastSubmissionAttemptTime': '2020-02-26T09:11:35Z',
+                'sparkApplicationId': 'spark-a47a002df46448f1a8395d7dd79ba448',
+                'submissionAttempts': 1,
+                'submissionID': 'd4f5a768-b9d1-4a79-92b0-54779124d997',
+                'terminationTime': None}}
+
+TEST_SUBMITTED_APPLICATION = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {
+         'creationTimestamp': '2020-02-26T09:16:53Z',
+         'generation': 1,
+         'name': 'spark-pi',
+         'namespace': 'default',
+         'resourceVersion': '525536',
+         'selfLink':
+             '/apis/sparkoperator.k8s.io/v1beta2/namespaces/default/sparkapplications/spark-pi',
+         'uid': '424a682b-6e5c-40d5-8a41-164253500b58'},
+     'spec': {'arguments': ['100000'],
+              'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'version': '2.4.4'},
+                         'memory': '512m',
+                         'serviceAccount': 'default'},
+              'executor': {'cores': 1,
+                           'instances': 1,
+                           'labels': {'version': '2.4.4'},
+                           'memory': '512m'},
+              'image': 'gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi',
+              'mode': 'cluster',
+              'monitoring': {'exposeDriverMetrics': True,
+                             'exposeExecutorMetrics': True,
+                             'prometheus':
+                                 {'jmxExporterJar': '/prometheus/jmx_prometheus_javaagent-0.11.0.jar',
+                                  'port': 8090}},
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.4',
+              'type': 'Scala'},
+     'status': {'applicationState': {'state': 'SUBMITTED'},
+                'driverInfo': {'podName': 'spark-pi-driver',
+                               'webUIAddress': '10.108.175.17:4040',
+                               'webUIPort': 4040,
+                               'webUIServiceName': 'spark-pi-ui-svc'},
+                'executionAttempts': 1,
+                'lastSubmissionAttemptTime': '2020-02-26T09:17:03Z',
+                'sparkApplicationId': 'spark-ae1a522d200246a99470743e880c5650',
+                'submissionAttempts': 1,
+                'submissionID': 'f8b70b0b-3c81-403f-8c6d-e7f6c3653409',
+                'terminationTime': None}}
+
+TEST_NEW_APPLICATION = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {
+         'creationTimestamp': '2020-02-26T09:16:53Z',
+         'generation': 1,
+         'name': 'spark-pi',
+         'namespace': 'default',
+         'resourceVersion': '525536',
+         'selfLink':
+             '/apis/sparkoperator.k8s.io/v1beta2/namespaces/default/sparkapplications/spark-pi',
+         'uid': '424a682b-6e5c-40d5-8a41-164253500b58'},
+     'spec': {'arguments': ['100000'],
+              'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'version': '2.4.4'},
+                         'memory': '512m',
+                         'serviceAccount': 'default'},
+              'executor': {'cores': 1,
+                           'instances': 1,
+                           'labels': {'version': '2.4.4'},
+                           'memory': '512m'},
+              'image': 'gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi',
+              'mode': 'cluster',
+              'monitoring': {'exposeDriverMetrics': True,
+                             'exposeExecutorMetrics': True,
+                             'prometheus':
+                                 {'jmxExporterJar': '/prometheus/jmx_prometheus_javaagent-0.11.0.jar',
+                                  'port': 8090}},
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.4',
+              'type': 'Scala'},
+     'status': {'applicationState': {'state': ''}}}
+
+TEST_PENDING_RERUN_APPLICATION = \
+    {'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+     'kind': 'SparkApplication',
+     'metadata': {
+         'creationTimestamp': '2020-02-27T08:03:02Z',
+         'generation': 4,
+         'name': 'spark-pi',
+         'namespace': 'default',
+         'resourceVersion': '552073',
+         'selfLink':
+             '/apis/sparkoperator.k8s.io/v1beta2/namespaces/default/sparkapplications/spark-pi',
+         'uid': '0c93527d-4dd9-4006-b40a-1672872e8d6f'},
+     'spec': {'arguments': ['100000'],
+              'driver': {'coreLimit': '1200m',
+                         'cores': 1,
+                         'labels': {'version': '2.4.4'},
+                         'memory': '512m',
+                         'serviceAccount': 'default'},
+              'executor': {'cores': 1,
+                           'instances': 1,
+                           'labels': {'version': '2.4.4'},
+                           'memory': '512m'},
+              'image': 'gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus',
+              'imagePullPolicy': 'Always',
+              'mainApplicationFile': 'local:///opt/spark/examples/jars/spark-examples_2.11-2.4.4.jar',
+              'mainClass': 'org.apache.spark.examples.SparkPi',
+              'mode': 'cluster',
+              'monitoring': {'exposeDriverMetrics': True,
+                             'exposeExecutorMetrics': True,
+                             'prometheus':
+                                 {'jmxExporterJar': '/prometheus/jmx_prometheus_javaagent-0.11.0.jar',
+                                  'port': 8090}},
+              'restartPolicy': {'type': 'Never'},
+              'sparkVersion': '2.4.4',
+              'type': 'Scala'},
+     'status': {'applicationState': {'state': 'PENDING_RERUN'},
+                'driverInfo': {},
+                'lastSubmissionAttemptTime': None,
+                'terminationTime': None}}
+
+
+@patch('airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook.get_conn')
+class TestSparkKubernetesSensor(unittest.TestCase):
+    def setUp(self):
+        db.merge_conn(
+            Connection(
+                conn_id='kubernetes_default', conn_type='kubernetes',
+                extra=json.dumps({})))
+        db.merge_conn(
+            Connection(
+                conn_id='kubernetes_with_namespace', conn_type='kubernetes',
+                extra=json.dumps({'extra__kubernetes__namespace': 'mock_namespace'})))
+        args = {
+            'owner': 'airflow',
+            'start_date': timezone.datetime(2020, 2, 1)
+        }
+        self.dag = DAG('test_dag_id', default_args=args)
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_COMPLETED_APPLICATION)
+    def test_completed_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       task_id='test_task_id')
+        self.assertTrue(sensor.poke(None))
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='default',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_FAILED_APPLICATION)
+    def test_failed_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       task_id='test_task_id')
+        self.assertRaises(AirflowException, sensor.poke, None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='default',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_NOT_PROCESSED_APPLICATION)
+    def test_not_processed_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       task_id='test_task_id')
+        self.assertFalse(sensor.poke(None))
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='default',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_NEW_APPLICATION)
+    def test_new_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       task_id='test_task_id')
+        self.assertFalse(sensor.poke(None))
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='default',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_RUNNING_APPLICATION)
+    def test_running_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       task_id='test_task_id')
+        self.assertFalse(sensor.poke(None))
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='default',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_SUBMITTED_APPLICATION)
+    def test_submitted_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       task_id='test_task_id')
+        self.assertFalse(sensor.poke(None))
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='default',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_PENDING_RERUN_APPLICATION)
+    def test_pending_rerun_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       task_id='test_task_id')
+        self.assertFalse(sensor.poke(None))
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='default',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_UNKNOWN_APPLICATION)
+    def test_unknown_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       task_id='test_task_id')
+        self.assertRaises(AirflowException, sensor.poke, None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='default',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_COMPLETED_APPLICATION)
+    def test_namespace_from_sensor(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       kubernetes_conn_id='kubernetes_with_namespace',
+                                       namespace='sensor_namespace',
+                                       task_id='test_task_id')
+        sensor.poke(None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='sensor_namespace',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object',
+           return_value=TEST_COMPLETED_APPLICATION)
+    def test_namespace_from_connection(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        sensor = SparkKubernetesSensor(application_name='spark_pi',
+                                       dag=self.dag,
+                                       kubernetes_conn_id='kubernetes_with_namespace',
+                                       task_id='test_task_id')
+        sensor.poke(None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(group='sparkoperator.k8s.io',
+                                                        name='spark_pi',
+                                                        namespace='mock_namespace',
+                                                        plural='sparkapplications',
+                                                        version='v1beta2')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a operator and sensor for spark-on-k8s kubernetes operator by GCP https://github.com/GoogleCloudPlatform/spark-on-k8s-operator
to send sparkApplication object to kubernetes cluster then check it's state with a sensor

---
Issue link: [AIRFLOW-6542](https://issues.apache.org/jira/browse/AIRFLOW-6542)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
