### PR TITLE
[AIRFLOW-XXXX]: Set test env vars in confttest.py, not Breeze entrypoint

### DIFF
--- a/scripts/ci/in_container/entrypoint_ci.sh
+++ b/scripts/ci/in_container/entrypoint_ci.sh
@@ -94,15 +94,8 @@ if [[ ${AIRFLOW_CI_VERBOSE} == "true" ]]; then
     echo
 fi
 
-export AIRFLOW__CORE__DAGS_FOLDER="${AIRFLOW_SOURCES}/tests/dags"
-
 # Added to have run-tests on path
 export PATH=${PATH}:${AIRFLOW_SOURCES}
-
-export AIRFLOW__CORE__UNIT_TEST_MODE=True
-
-# Make sure all AWS API calls default to the us-east-1 region
-export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:='us-east-1'}
 
 # Fix codecov build path
 # TODO: Check this - this should be made travis-independent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,13 @@ import sys
 
 import pytest
 
-from airflow.utils import db
+# We should set these before loading _any_ of the rest of airlow so that the
+# unit test mode config is set as early as possible.
+tests_directory = os.path.dirname(os.path.realpath(__file__))
+
+os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.path.join(tests_directory, "dags")
+os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
+os.environ["AWS_DEFAULT_REGION"] = (os.environ.get("AWS_DEFAULT_REGION") or "us-east-1")
 
 
 @pytest.fixture()
@@ -44,6 +50,8 @@ def reset_db():
     """
     Resets Airflow db.
     """
+
+    from airflow.utils import db
     db.resetdb()
     yield
 
@@ -98,15 +106,10 @@ def breeze_test_helper(request):
     # Setup test environment for breeze
     home = os.path.expanduser("~")
     airflow_home = os.environ.get("AIRFLOW_HOME") or os.path.join(home, "airflow")
-    tests_directory = os.path.dirname(os.path.realpath(__file__))
-
-    os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.path.join(tests_directory, "dags")
-    os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
-    os.environ["AWS_DEFAULT_REGION"] = (
-        os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
-    )
 
     print(f"Home of the user: {home}\nAirflow home {airflow_home}")
+
+    from airflow.utils import db
 
     # Initialize Airflow db if required
     lock_file = os.path.join(airflow_home, ".airflow_db_initialised")


### PR DESCRIPTION
These environment variables need to be set before
collection/file-parsing happens otherwise the test collection will fail
with a KeyError.

When running under breeze these were set in the entrypoint, but to make
non-breeze behave the same I have moved them out of there and to the top
level of conftest.py. (This makes it work for workflows outside of Breeze.)

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.