### PR TITLE
[AIRFLOW-XXXX] Temporarily disable Kerberos to get test stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,10 +95,9 @@ jobs:
         RUN_INTEGRATION_TESTS=all
       stage: test
       script: ./scripts/ci/ci_run_airflow_testing.sh tests/tests_core.py
-    - name: "Tests [MySQL][3.7][kerberos]"
+    - name: "Tests [MySQL][3.7][kerberos-temporarily-disabled]"
       env: >-
         BACKEND=mysql
-        ENABLED_INTEGRATIONS="kerberos"
         PYTHON_VERSION=3.7
       stage: test
   services:


### PR DESCRIPTION
Kerberos causes various stability issues while CI tests are run,
so we are disabling the Kerberos-only test so that we can add
more diagnostics information.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
