### PR TITLE
[AIRFLOW-5974] AIP-21 Change import paths for celery modules

### DIFF
--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,14 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.providers.celery.sensors.celery`."""
-
-import warnings
-
-# pylint: disable=unused-import
-from airflow.providers.celery.sensors.celery import CeleryQueueSensor  # noqa
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.celery.sensors.celery`.",
-    DeprecationWarning, stacklevel=2
-)

--- a/airflow/providers/celery/sensors/__init__.py
+++ b/airflow/providers/celery/sensors/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,14 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.providers.celery.sensors.celery`."""
-
-import warnings
-
-# pylint: disable=unused-import
-from airflow.providers.celery.sensors.celery import CeleryQueueSensor  # noqa
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.celery.sensors.celery`.",
-    DeprecationWarning, stacklevel=2
-)

--- a/airflow/providers/celery/sensors/celery.py
+++ b/airflow/providers/celery/sensors/celery.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from celery.app import control
+
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class CeleryQueueSensor(BaseSensorOperator):
+    """
+    Waits for a Celery queue to be empty. By default, in order to be considered
+    empty, the queue must not have any tasks in the ``reserved``, ``scheduled``
+    or ``active`` states.
+
+    :param celery_queue: The name of the Celery queue to wait for.
+    :type celery_queue: str
+    :param target_task_id: Task id for checking
+    :type target_task_id: str
+    """
+    @apply_defaults
+    def __init__(
+            self,
+            celery_queue,
+            target_task_id=None,
+            *args,
+            **kwargs):
+
+        super().__init__(*args, **kwargs)
+        self.celery_queue = celery_queue
+        self.target_task_id = target_task_id
+
+    def _check_task_id(self, context):
+        """
+        Gets the returned Celery result from the Airflow task
+        ID provided to the sensor, and returns True if the
+        celery result has been finished execution.
+
+        :param context: Airflow's execution context
+        :type context: dict
+        :return: True if task has been executed, otherwise False
+        :rtype: bool
+        """
+        ti = context['ti']
+        celery_result = ti.xcom_pull(task_ids=self.target_task_id)
+        return celery_result.ready()
+
+    def poke(self, context):
+
+        if self.target_task_id:
+            return self._check_task_id(context)
+
+        inspect_result = control.Inspect()
+        reserved = inspect_result.reserved()
+        scheduled = inspect_result.scheduled()
+        active = inspect_result.active()
+
+        try:
+            reserved = len(reserved[self.celery_queue])
+            scheduled = len(scheduled[self.celery_queue])
+            active = len(active[self.celery_queue])
+
+            self.log.info(
+                'Checking if celery queue %s is empty.', self.celery_queue
+            )
+
+            return reserved == 0 and scheduled == 0 and active == 0
+        except KeyError:
+            raise KeyError(
+                'Could not locate Celery queue {0}'.format(
+                    self.celery_queue
+                )
+            )

--- a/docs/autoapi_templates/index.rst
+++ b/docs/autoapi_templates/index.rst
@@ -132,6 +132,8 @@ All operators are in the following packages:
 
   airflow/providers/sftp/sensors/index
 
+  airflow/providers/celery/sensors/index
+
 .. _pythonapi:hooks:
 
 Hooks

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -252,6 +252,7 @@ exclude_patterns = [
     '_api/airflow/providers/microsoft/index.rst',
     '_api/airflow/providers/microsoft/azure/index.rst',
     '_api/airflow/providers/sftp/index.rst',
+    '_api/airflow/providers/celery/index.rst',
     '_api/enums/index.rst',
     '_api/json_schema/index.rst',
     '_api/base_serialization/index.rst',

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -1031,7 +1031,7 @@ These integrations allow you to perform various operations using various softwar
      -
      -
      -
-     - :mod:`airflow.contrib.sensors.celery_queue_sensor`
+     - :mod:`airflow.providers.celery.sensors.celery`
 
    * - `Docker <https://docs.docker.com/install/>`__
      -

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -78,7 +78,7 @@
 ./airflow/contrib/sensors/aws_glue_catalog_partition_sensor.py
 ./airflow/providers/microsoft/azure/sensors/azure_cosmos.py
 ./airflow/contrib/sensors/bash_sensor.py
-./airflow/contrib/sensors/celery_queue_sensor.py
+./airflow/providers/celery/sensors/celery.py
 ./airflow/contrib/sensors/datadog_sensor.py
 ./airflow/contrib/sensors/emr_base_sensor.py
 ./airflow/contrib/sensors/emr_job_flow_sensor.py

--- a/tests/providers/celery/__init__.py
+++ b/tests/providers/celery/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,14 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.providers.celery.sensors.celery`."""
-
-import warnings
-
-# pylint: disable=unused-import
-from airflow.providers.celery.sensors.celery import CeleryQueueSensor  # noqa
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.celery.sensors.celery`.",
-    DeprecationWarning, stacklevel=2
-)

--- a/tests/providers/celery/sensors/__init__.py
+++ b/tests/providers/celery/sensors/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,14 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.providers.celery.sensors.celery`."""
-
-import warnings
-
-# pylint: disable=unused-import
-from airflow.providers.celery.sensors.celery import CeleryQueueSensor  # noqa
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.celery.sensors.celery`.",
-    DeprecationWarning, stacklevel=2
-)

--- a/tests/providers/celery/sensors/test_celery.py
+++ b/tests/providers/celery/sensors/test_celery.py
@@ -20,7 +20,7 @@
 import unittest
 from unittest.mock import patch
 
-from airflow.contrib.sensors.celery_queue_sensor import CeleryQueueSensor
+from airflow.providers.celery.sensors.celery import CeleryQueueSensor
 
 
 class TestCeleryQueueSensor(unittest.TestCase):


### PR DESCRIPTION
part of AIP-21, Change import paths for celery modules
---
Issue link: [AIRFLOW-5974](https://issues.apache.org/jira/browse/AIRFLOW-5974)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
