### PR TITLE
[AIRFLOW-6561] Add possibility to specify default resources for airfl…

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2148,6 +2148,13 @@
       type: string
       example: ~
       default: ""
+    - name: worker_resources
+      description: |
+        Worker resources configuration as a single line formatted JSON object.
+      version_added: ~
+      type: string
+      example: '{ "limit_cpu": 0.25, "limit_memory": "64Mi", "request_cpu": "250m", "request_memory": "64Mi"}'
+      default: ""
 - name: kubernetes_node_selectors
   description: |
     The Key-value pairs to be given to worker pods.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1044,6 +1044,10 @@ fs_group =
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 worker_annotations =
 
+# Worker resources configuration as a single line formatted JSON object.
+# Example: worker_resources = {{ "limit_cpu": 0.25, "limit_memory": "64Mi", "request_cpu": "250m", "request_memory": "64Mi"}}
+worker_resources =
+
 [kubernetes_node_selectors]
 
 # The Key-value pairs to be given to worker pods.

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -114,6 +114,12 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
         self.worker_run_as_user = self._get_security_context_val('run_as_user')
         self.worker_fs_group = self._get_security_context_val('fs_group')
 
+        kube_worker_resources = conf.get(self.kubernetes_section, 'worker_resources')
+        if kube_worker_resources:
+            self.worker_resources = json.loads(kube_worker_resources)
+        else:
+            self.worker_resources = None
+
         # NOTE: `git_repo` and `git_branch` must be specified together as a pair
         # The http URL of the git repository to clone from
         self.git_repo = conf.get(self.kubernetes_section, 'git_repo')

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -387,6 +387,29 @@ class WorkerConfiguration(LoggingMixin):
 
         return self.kube_config.git_dags_folder_mount_point
 
+    def _get_resources(self) -> k8s.V1ResourceRequirements:
+        if self.kube_config.worker_resources is None:
+            return None
+        resources_dict = self.kube_config.worker_resources
+
+        requests = {}
+        request_cpu = resources_dict.get('request_cpu', None)
+        if request_cpu is not None:
+            requests["cpu"] = request_cpu
+        request_memory = resources_dict.get('request_memory', None)
+        if request_memory is not None:
+            requests["memory"] = request_memory
+
+        limits = {}
+        limit_cpu = resources_dict.get('limit_cpu', None)
+        if limit_cpu is not None:
+            limits["cpu"] = limit_cpu
+        limit_memory = resources_dict.get('limit_memory', None)
+        if limit_memory is not None:
+            limits["memory"] = limit_memory
+
+        return k8s.V1ResourceRequirements(requests=requests, limits=limits)
+
     def as_pod(self) -> k8s.V1Pod:
         """Creates POD."""
         if self.kube_config.pod_template_file:
@@ -405,7 +428,8 @@ class WorkerConfiguration(LoggingMixin):
             envs=self._get_environment(),
             node_selectors=self.kube_config.kube_node_selectors,
             service_account_name=self.kube_config.worker_service_account_name or 'default',
-            restart_policy='Never'
+            restart_policy='Never',
+            resources=self._get_resources(),
         ).gen_pod()
 
         pod.spec.containers[0].env_from = pod.spec.containers[0].env_from or []

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -903,3 +903,14 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         pod = worker_config.as_pod()
 
         self.assertEqual(2, len(pod.spec.image_pull_secrets))
+
+    def test_get_resources(self):
+        self.kube_config.worker_resources = {'limit_cpu': 0.25, 'limit_memory': '64Mi', 'request_cpu': '250m',
+                                             'request_memory': '64Mi'}
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        resources = worker_config._get_resources()
+        self.assertEqual(resources.limits["cpu"], 0.25)
+        self.assertEqual(resources.limits["memory"], "64Mi")
+        self.assertEqual(resources.requests["cpu"], "250m")
+        self.assertEqual(resources.requests["memory"], "64Mi")


### PR DESCRIPTION
…ow k8s workers

---
Issue link: [AIRFLOW-6561](https://issues.apache.org/jira/browse/AIRFLOW-6561)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
