### PR TITLE
[AIRFLOW-6565] BigQuery - replace deprecated connection parameters

### DIFF
--- a/airflow/gcp/operators/bigquery.py
+++ b/airflow/gcp/operators/bigquery.py
@@ -535,7 +535,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
         if self.hook is None:
             self.log.info('Executing: %s', self.sql)
             self.hook = BigQueryHook(
-                bigquery_conn_id=self.gcp_conn_id,
+                gcp_conn_id=self.gcp_conn_id,
                 use_legacy_sql=self.use_legacy_sql,
                 delegate_to=self.delegate_to,
                 location=self.location,
@@ -741,7 +741,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         self.location = location
 
     def execute(self, context):
-        bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
+        bq_hook = BigQueryHook(gcp_conn_id=self.bigquery_conn_id,
                                delegate_to=self.delegate_to,
                                location=self.location)
 
@@ -922,7 +922,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         self.location = location
 
     def execute(self, context):
-        bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
+        bq_hook = BigQueryHook(gcp_conn_id=self.bigquery_conn_id,
                                delegate_to=self.delegate_to,
                                location=self.location)
 
@@ -1021,7 +1021,7 @@ class BigQueryDeleteDatasetOperator(BaseOperator):
     def execute(self, context):
         self.log.info('Dataset id: %s Project id: %s', self.dataset_id, self.project_id)
 
-        bq_hook = BigQueryHook(bigquery_conn_id=self.gcp_conn_id,
+        bq_hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id,
                                delegate_to=self.delegate_to)
 
         bq_hook.delete_dataset(
@@ -1099,7 +1099,7 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
     def execute(self, context):
         self.log.info('Dataset id: %s Project id: %s', self.dataset_id, self.project_id)
 
-        bq_hook = BigQueryHook(bigquery_conn_id=self.gcp_conn_id,
+        bq_hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id,
                                delegate_to=self.delegate_to,
                                location=self.location)
 
@@ -1150,7 +1150,7 @@ class BigQueryGetDatasetOperator(BaseOperator):
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
-        bq_hook = BigQueryHook(bigquery_conn_id=self.gcp_conn_id,
+        bq_hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id,
                                delegate_to=self.delegate_to)
 
         self.log.info('Start getting dataset: %s:%s', self.project_id, self.dataset_id)
@@ -1205,7 +1205,7 @@ class BigQueryGetDatasetTablesOperator(BaseOperator):
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
-        bq_hook = BigQueryHook(bigquery_conn_id=self.gcp_conn_id,
+        bq_hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id,
                                delegate_to=self.delegate_to)
 
         self.log.info('Start getting tables list from dataset: %s:%s', self.project_id, self.dataset_id)
@@ -1256,7 +1256,7 @@ class BigQueryPatchDatasetOperator(BaseOperator):
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
-        bq_hook = BigQueryHook(bigquery_conn_id=self.gcp_conn_id,
+        bq_hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id,
                                delegate_to=self.delegate_to)
 
         self.log.info('Start patching dataset: %s:%s', self.project_id, self.dataset_id)
@@ -1307,7 +1307,7 @@ class BigQueryUpdateDatasetOperator(BaseOperator):
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
-        bq_hook = BigQueryHook(bigquery_conn_id=self.gcp_conn_id,
+        bq_hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id,
                                delegate_to=self.delegate_to)
 
         self.log.info('Start updating dataset: %s:%s', self.project_id, self.dataset_id)
@@ -1370,7 +1370,7 @@ class BigQueryDeleteTableOperator(BaseOperator):
 
     def execute(self, context):
         self.log.info('Deleting: %s', self.deletion_dataset_table)
-        hook = BigQueryHook(bigquery_conn_id=self.gcp_conn_id,
+        hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id,
                             delegate_to=self.delegate_to,
                             location=self.location)
         hook.run_table_delete(


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6565](https://issues.apache.org/jira/browse/AIRFLOW-6565)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
