### PR TITLE
[AIRFLOW-6566][AIRFLOW-4029] Replace uses of imp still left with importlib.

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -19,6 +19,7 @@
 
 import hashlib
 import importlib
+import importlib.util
 import os
 import sys
 import textwrap

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -17,7 +17,7 @@
 # under the License.
 """Manages all plugins."""
 # noinspection PyDeprecation
-import imp  # pylint: disable=deprecated-module
+import importlib
 import inspect
 import os
 import re

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -22,6 +22,7 @@ import inspect
 import os
 import re
 import sys
+import types
 from typing import Any, Callable, Dict, List, Optional, Set, Type
 
 import pkg_resources
@@ -182,7 +183,11 @@ for root, dirs, files in os.walk(settings.PLUGINS_FOLDER, followlinks=True):
             # normalize root path as namespace
             namespace = '_'.join([re.sub(norm_pattern, '__', root), mod_name])
 
-            m = imp.load_source(namespace, filepath)
+            loader = importlib.machinery.SourceFileLoader(mod_name, filepath)
+            spec = importlib.util.spec_from_loader(mod_name, loader)
+            m = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = m
+            loader.exec_module(m)
             for obj in list(m.__dict__.values()):
                 if is_valid_plugin(obj, plugins):
                     plugins.append(obj)
@@ -204,7 +209,7 @@ def make_module(name: str, objects: List[Any]):
     """Creates new module."""
     log.debug('Creating module %s', name)
     name = name.lower()
-    module = imp.new_module(name)
+    module = types.ModuleType(name)
     module._name = name.split('.')[-1]  # type: ignore
     module._objects = objects           # type: ignore
     module.__dict__.update((o.__name__, o) for o in objects)


### PR DESCRIPTION
I've replaced a use of `imp` with `importlib` in #7099 but I noticed are still two uses left.
Let's replace them.

---
Issue link: [AIRFLOW-6566](https://issues.apache.org/jira/browse/AIRFLOW-6566)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
