### PR TITLE
[AIRFLOW-6568] Add some more entries (Emacs related files) to .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,6 @@ node_modules
 npm-debug.log*
 derby.log
 metastore_db
-yarn.lock
 
 # Airflow log files when airflow is run locally
 airflow-*.err

--- a/.gitignore
+++ b/.gitignore
@@ -130,9 +130,14 @@ ENV/
 *.swp
 
 # Emacs
-*.~
-*#*#
-*.#*
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
 
 # OSX
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,11 @@ ENV/
 # vim
 *.swp
 
+# Emacs
+*.~
+*#*#
+*.#*
+
 # OSX
 .DS_Store
 
@@ -152,6 +157,7 @@ node_modules
 npm-debug.log*
 derby.log
 metastore_db
+yarn.lock
 
 # Airflow log files when airflow is run locally
 airflow-*.err

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
-
-
 [metadata]
 name = Airflow
 summary = Airflow is a system to programmatically author, schedule and monitor data pipelines.

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
+
+
 [metadata]
 name = Airflow
 summary = Airflow is a system to programmatically author, schedule and monitor data pipelines.


### PR DESCRIPTION
Emacs generates some types of backup files.
They should be ignored by the repository.

---
Issue link: [AIRFLOW-6568](https://issues.apache.org/jira/browse/AIRFLOW-6568)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
