### PR TITLE
[AIRFLOW-6574] Adding private_environment to docker operator.

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -67,7 +67,7 @@ class DockerOperator(BaseOperator):
     :param environment: Environment variables to set in the container. (templated)
     :type environment: dict
     :param private_environment: Private environment variables to set in the container.
-        These variables will not be shown on the task instance view in the browser. (templated)
+        These variables will not be shown on the task instance view in the browser.
     :type private_environment: dict
     :param force_pull: Pull the docker image on every run. Default is False.
     :type force_pull: bool

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -67,7 +67,7 @@ class DockerOperator(BaseOperator):
     :param environment: Environment variables to set in the container. (templated)
     :type environment: dict
     :param private_environment: Private environment variables to set in the container.
-        These variables will not be shown on the task instance view in the browser.
+        These are not templated, and hidden from the website.
     :type private_environment: dict
     :param force_pull: Pull the docker image on every run. Default is False.
     :type force_pull: bool
@@ -194,7 +194,8 @@ class DockerOperator(BaseOperator):
         self.shm_size = shm_size
         self.tty = tty
         if kwargs.get('xcom_push') is not None:
-            raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
+            raise AirflowException(
+                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
         self.cli = None
         self.container = None
@@ -256,7 +257,8 @@ class DockerOperator(BaseOperator):
 
             result = self.cli.wait(self.container['Id'])
             if result['StatusCode'] != 0:
-                raise AirflowException('docker container failed: ' + repr(result))
+                raise AirflowException(
+                    'docker container failed: ' + repr(result))
 
             # duplicated conditional logic because of expensive operation
             if self.do_xcom_push:

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -66,6 +66,9 @@ class DockerOperator(BaseOperator):
     :type docker_url: str
     :param environment: Environment variables to set in the container. (templated)
     :type environment: dict
+    :param private_environment: Private environment variables to set in the container.
+        These variables will not be shown on the task instance view in the browser. (templated)
+    :type private_environment: dict
     :param force_pull: Pull the docker image on every run. Default is False.
     :type force_pull: bool
     :param mem_limit: Maximum amount of memory the container can use.
@@ -137,6 +140,7 @@ class DockerOperator(BaseOperator):
             cpus: float = 1.0,
             docker_url: str = 'unix://var/run/docker.sock',
             environment: Optional[Dict] = None,
+            private_environment: Optional[Dict] = None,
             force_pull: bool = False,
             mem_limit: Optional[Union[float, str]] = None,
             host_tmp_dir: Optional[str] = None,
@@ -170,6 +174,7 @@ class DockerOperator(BaseOperator):
         self.dns_search = dns_search
         self.docker_url = docker_url
         self.environment = environment or {}
+        self._private_environment = private_environment or {}
         self.force_pull = force_pull
         self.image = image
         self.mem_limit = mem_limit
@@ -219,7 +224,7 @@ class DockerOperator(BaseOperator):
             self.container = self.cli.create_container(
                 command=self.get_command(),
                 name=self.container_name,
-                environment=self.environment,
+                environment={**self.environment, **self._private_environment},
                 host_config=self.cli.create_host_config(
                     auto_remove=self.auto_remove,
                     binds=self.volumes,

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -51,8 +51,9 @@ class TestDockerOperator(unittest.TestCase):
         client_class_mock.return_value = client_mock
 
         operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
-                                  image='ubuntu:latest', network_mode='bridge', owner='unittest',
-                                  task_id='unittest', volumes=['/host/path:/container/path'],
+                                  private_environment={'SUPER':'SECRET'}, image='ubuntu:latest',
+                                  network_mode='bridge', owner='unittest', task_id='unittest',
+                                  volumes=['/host/path:/container/path'],
                                   working_dir='/container/path', shm_size=1000,
                                   host_tmp_dir='/host/airflow', container_name='test_container',
                                   tty=True)
@@ -65,7 +66,8 @@ class TestDockerOperator(unittest.TestCase):
                                                              name='test_container',
                                                              environment={
                                                                  'AIRFLOW_TMP_DIR': '/tmp/airflow',
-                                                                 'UNIT': 'TEST'
+                                                                 'UNIT': 'TEST',
+                                                                 'SUPER': 'SECRET'
                                                              },
                                                              host_config=host_config,
                                                              image='ubuntu:latest',
@@ -259,6 +261,7 @@ class TestDockerOperator(unittest.TestCase):
             'api_version': '1.19',
             'command': 'env',
             'environment': {'UNIT': 'TEST'},
+            'private_environment': {'SUPER': 'SECRET'},
             'image': 'ubuntu:latest',
             'network_mode': 'bridge',
             'owner': 'unittest',

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -46,7 +46,7 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.attach.return_value = ['container log']
         client_mock.logs.return_value = ['container log']
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.wait.return_value = {"StatusCode": 0}
+        client_mock.wait.return_value = {'StatusCode': 0}
 
         client_class_mock.return_value = client_mock
 

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -51,7 +51,7 @@ class TestDockerOperator(unittest.TestCase):
         client_class_mock.return_value = client_mock
 
         operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
-                                  private_environment={'SUPER':'SECRET'}, image='ubuntu:latest',
+                                  private_environment={'SUPER': 'SECRET'}, image='ubuntu:latest',
                                   network_mode='bridge', owner='unittest', task_id='unittest',
                                   volumes=['/host/path:/container/path'],
                                   working_dir='/container/path', shm_size=1000,

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -51,7 +51,7 @@ class TestDockerOperator(unittest.TestCase):
         client_class_mock.return_value = client_mock
 
         operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
-                                  private_environment={'SUPER': 'SECRET'}, image='ubuntu:latest',
+                                  private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest',
                                   network_mode='bridge', owner='unittest', task_id='unittest',
                                   volumes=['/host/path:/container/path'],
                                   working_dir='/container/path', shm_size=1000,
@@ -67,7 +67,7 @@ class TestDockerOperator(unittest.TestCase):
                                                              environment={
                                                                  'AIRFLOW_TMP_DIR': '/tmp/airflow',
                                                                  'UNIT': 'TEST',
-                                                                 'SUPER': 'SECRET'
+                                                                 'PRIVATE': 'MESSAGE'
                                                              },
                                                              host_config=host_config,
                                                              image='ubuntu:latest',
@@ -90,6 +90,16 @@ class TestDockerOperator(unittest.TestCase):
                                                    stderr=True, stream=True)
         client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True)
         client_mock.wait.assert_called_once_with('some_id')
+
+    def test_private_environment_is_private(self):
+        operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
+                                  private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest',
+                                  network_mode='bridge', owner='unittest', task_id='unittest',
+                                  volumes=['/host/path:/container/path'],
+                                  working_dir='/container/path', shm_size=1000,
+                                  host_tmp_dir='/host/airflow', container_name='test_container',
+                                  tty=True)
+        self.assertEqual(getattr(operator, '_private_environment'), {'PRIVATE': 'MESSAGE'})
 
     @mock.patch('airflow.operators.docker_operator.tls.TLSConfig')
     @mock.patch('airflow.operators.docker_operator.APIClient')
@@ -253,7 +263,7 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = ['container log']
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.wait.return_value = {"StatusCode": 0}
+        client_mock.wait.return_value = {'StatusCode': 0}
 
         client_class_mock.return_value = client_mock
 
@@ -261,7 +271,7 @@ class TestDockerOperator(unittest.TestCase):
             'api_version': '1.19',
             'command': 'env',
             'environment': {'UNIT': 'TEST'},
-            'private_environment': {'SUPER': 'SECRET'},
+            'private_environment': {'PRIVATE': 'MESSAGE'},
             'image': 'ubuntu:latest',
             'network_mode': 'bridge',
             'owner': 'unittest',


### PR DESCRIPTION
The docker operator currently does not have a means to pass in an environment dict that is not exposed by the frontend's task instance view, along with all the other Task instance attributes. 

This PR proposes a private_environment parameter that should prevent the frontend from exposes this attribute. This would be useful for the cases where the docker container will be getting the passwords by the environment variables.

https://issues.apache.org/jira/browse/AIRFLOW-6574