### PR TITLE
[AIRFLOW-6575] Entropy source for CI tests is changed to unblocking

### DIFF
--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -32,5 +32,6 @@ services:
       - MYSQL_DATABASE=airflow
     volumes:
       - ../mysql/conf.d:/etc/mysql/conf.d:ro
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
     ports:
       - "${MYSQL_HOST_PORT}:3306"

--- a/scripts/ci/docker-compose/backend-postgres.yml
+++ b/scripts/ci/docker-compose/backend-postgres.yml
@@ -30,5 +30,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=airflow
       - POSTGRES_DB=airflow
+    volumes:
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
     ports:
       - "${POSTGRES_HOST_PORT}:5432"

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -55,3 +55,4 @@ services:
     volumes:
       # Pass docker to inside of the container so that Kind and Moto tests can use it.
       - /var/run/docker.sock:/var/run/docker.sock
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source

--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -19,6 +19,8 @@ version: "2.2"
 services:
   cassandra:
     image: cassandra:3.0
+    volumes:
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
   airflow-testing:
     environment:
       - INTEGRATION_CASSANDRA=true

--- a/scripts/ci/docker-compose/integration-kerberos.yml
+++ b/scripts/ci/docker-compose/integration-kerberos.yml
@@ -21,6 +21,8 @@ services:
     image: godatadriven/krb5-kdc-server
     hostname: kerberos
     domainname: example.com
+    volumes:
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
   airflow-testing:
     depends_on:
       - kerberos

--- a/scripts/ci/docker-compose/integration-mongo.yml
+++ b/scripts/ci/docker-compose/integration-mongo.yml
@@ -19,6 +19,8 @@ version: "2.2"
 services:
   mongo:
     image: mongo:3
+    volumes:
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
   airflow-testing:
     environment:
       - INTEGRATION_MONGO=true

--- a/scripts/ci/docker-compose/integration-openldap.yml
+++ b/scripts/ci/docker-compose/integration-openldap.yml
@@ -26,6 +26,7 @@ services:
       - LDAP_CONFIG_PASSWORD=insecure
     volumes:
       - ../openldap/ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom:ro
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
   airflow-testing:
     environment:
       - INTEGRATION_OPENLDAP=true

--- a/scripts/ci/docker-compose/integration-rabbitmq.yml
+++ b/scripts/ci/docker-compose/integration-rabbitmq.yml
@@ -19,6 +19,8 @@ version: "2.2"
 services:
   rabbitmq:
     image: rabbitmq:3.7
+    volumes:
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
   airflow-testing:
     environment:
       - INTEGRATION_RABBITMQ=true

--- a/scripts/ci/docker-compose/integration-redis.yml
+++ b/scripts/ci/docker-compose/integration-redis.yml
@@ -19,6 +19,8 @@ version: "2.2"
 services:
   redis:
     image: redis:5.0.1
+    volumes:
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
   airflow-testing:
     environment:
       - INTEGRATION_REDIS=true


### PR DESCRIPTION
On Travis CI blocking entropy source slows startup time of a number of
containers. This change changes the entropy source to unblocking one.

---
Issue link: [AIRFLOW-6575](https://issues.apache.org/jira/browse/AIRFLOW-6575)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
