### PR TITLE
[AIRFLOW-XXXX] Move email configuration from the concept page

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -909,35 +909,8 @@ setting ``check_slas=False`` under ``[core]`` section in ``airflow.cfg`` file:
   [core]
   check_slas = False
 
-
-Email Configuration
--------------------
-
-You can configure the email that is being sent in your ``airflow.cfg``
-by setting a ``subject_template`` and/or a ``html_content_template``
-in the ``email`` section.
-
-.. code::
-
-  [email]
-
-  email_backend = airflow.utils.email.send_email_smtp
-
-  subject_template = /path/to/my_subject_template_file
-  html_content_template = /path/to/my_html_content_template_file
-
-To access the task's information you use `Jinja Templating <http://jinja.pocoo.org/docs/dev/>`_  in your template files.
-
-For example a ``html_content_template`` file could look like this:
-
-.. code::
-
-  Try {{try_number}} out of {{max_tries + 1}}<br>
-  Exception:<br>{{exception_html}}<br>
-  Log: <a href="{{ti.log_url}}">Link</a><br>
-  Host: {{ti.hostname}}<br>
-  Log file: {{ti.log_filepath}}<br>
-  Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>
+.. note::
+    For information on the email configuration, see :doc:`howto/email-config`
 
 .. _concepts/trigger_rule:
 

--- a/docs/howto/email-config.rst
+++ b/docs/howto/email-config.rst
@@ -1,0 +1,48 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Email Configuration
+-------------------
+
+You can configure the email that is being sent in your ``airflow.cfg``
+by setting a ``subject_template`` and/or a ``html_content_template``
+in the ``email`` section.
+
+.. code::
+
+  [email]
+
+  email_backend = airflow.utils.email.send_email_smtp
+
+  subject_template = /path/to/my_subject_template_file
+  html_content_template = /path/to/my_html_content_template_file
+
+To access the task's information you use `Jinja Templating <http://jinja.pocoo.org/docs/dev/>`_  in your template files.
+
+For example a ``html_content_template`` file could look like this:
+
+.. code::
+
+  Try {{try_number}} out of {{max_tries + 1}}<br>
+  Exception:<br>{{exception_html}}<br>
+  Log: <a href="{{ti.log_url}}">Link</a><br>
+  Host: {{ti.hostname}}<br>
+  Log file: {{ti.log_filepath}}<br>
+  Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>
+
+.. note::
+    For more information on setting the configuration, see :doc:`set-config`

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -43,3 +43,4 @@ configuring an Airflow environment.
     check-health
     define_extra_link
     tracking-user-activity
+    email-config


### PR DESCRIPTION
Configuration is not a concept. These are two different matters and it is worth separating them.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
