### PR TITLE
[AIRFLOW-XXXX] Add cross-reference between connection and fernet

### DIFF
--- a/docs/howto/connection/index.rst
+++ b/docs/howto/connection/index.rst
@@ -227,7 +227,7 @@ Securing Connections
 Airflow uses `Fernet <https://github.com/fernet/spec/>`__ to encrypt passwords in the connection
 configuration. It guarantees that a password encrypted using it cannot be manipulated or read without the key.
 
-For information on configuring Fernet, look at :ref:`Generating a Connection URI <security/fernet>`.
+For information on configuring Fernet, look at :ref:`security/fernet`.
 
 Connection Types
 ----------------

--- a/docs/howto/connection/index.rst
+++ b/docs/howto/connection/index.rst
@@ -60,7 +60,7 @@ Modify the connection properties and click the ``Save`` button to save your
 changes.
 
 Storing a Connection in Environment Variables
-------------------------------------------------
+---------------------------------------------
 
 The environment variable naming convention is ``AIRFLOW_CONN_<conn_id>``, all uppercase.
 
@@ -221,6 +221,13 @@ To fix this, you can encode with :py:meth:`~urllib.parse.quote_plus`:
     >>> print(c.password)
     my-pa/ssword
 
+Securing Connections
+--------------------
+
+Airflow uses `Fernet <https://github.com/fernet/spec/>`__ to encrypt passwords in the connection
+configuration. It guarantees that a password encrypted using it cannot be manipulated or read without the key.
+
+For information on configuring Fernet, look at :ref:`Generating a Connection URI <security/fernet>`.
 
 Connection Types
 ----------------

--- a/docs/howto/connection/index.rst
+++ b/docs/howto/connection/index.rst
@@ -225,7 +225,7 @@ Securing Connections
 --------------------
 
 Airflow uses `Fernet <https://github.com/fernet/spec/>`__ to encrypt passwords in the connection
-configuration. It guarantees that a password encrypted using it cannot be manipulated or read without the key.
+configuration. It guarantees that without the encryption password, Connection Passwords cannot be manipulated or read without the key.
 
 For information on configuring Fernet, look at :ref:`security/fernet`.
 


### PR DESCRIPTION
The `Manage connection` page contains very detailed information. However, it doesn't contain information about fernet.
 
---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
