### PR TITLE
[AIRFLOW-XXXX] Adds branching strategy to documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -157,10 +157,14 @@ Airflow Git Branches
 
 All new development in Airflow happens in ``master`` branch. All PRs should target that branch.
 We also have ``v1-10-test`` branch which is used to test ``1.10.x`` series of Airflow and where committers
-(and only committers) cherry-pick selected commits from the master branch. The ``v1-10-test`` branch might be
-broken at times - during testing. Expect force-pushes there so committers should coordinate between themselves
-on who is working on the ``v1-10-test`` branch - usually those will be people with the role of the
-release manager. Once the branch is stable - the ``v1-10-stable`` branch is synchronized with ``v1-10-test``.
+(and only committers) cherry-pick selected commits from the master branch. 
+Cherry-picking is done with -x flag.
+
+The ``v1-10-test`` branch might be broken at times during testing. Expect force-pushes there so 
+committers should coordinate between themselves on who is working on the ``v1-10-test`` branch - 
+usually those will be people with the role of the release manager.
+
+Once the branch is stable - the ``v1-10-stable`` branch is synchronized with ``v1-10-test``.
 The ``v1-10-stable`` branch is used to relsease ``1.10.x`` releases.
 
 Development Environments

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -165,7 +165,7 @@ committers should coordinate between themselves on who is working on the ``v1-10
 usually those will be people with the role of the release manager.
 
 Once the branch is stable - the ``v1-10-stable`` branch is synchronized with ``v1-10-test``.
-The ``v1-10-stable`` branch is used to relsease ``1.10.x`` releases.
+The ``v1-10-stable`` branch is used to release ``1.10.x`` releases.
 
 Development Environments
 ========================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -157,11 +157,11 @@ Airflow Git Branches
 
 All new development in Airflow happens in ``master`` branch. All PRs should target that branch.
 We also have ``v1-10-test`` branch which is used to test ``1.10.x`` series of Airflow and where committers
-(and only committers) cherry-pick selected commits from the master branch. 
+(and only committers) cherry-pick selected commits from the master branch.
 Cherry-picking is done with -x flag.
 
-The ``v1-10-test`` branch might be broken at times during testing. Expect force-pushes there so 
-committers should coordinate between themselves on who is working on the ``v1-10-test`` branch - 
+The ``v1-10-test`` branch might be broken at times during testing. Expect force-pushes there so
+committers should coordinate between themselves on who is working on the ``v1-10-test`` branch -
 usually those will be people with the role of the release manager.
 
 Once the branch is stable - the ``v1-10-stable`` branch is synchronized with ``v1-10-test``.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -152,6 +152,17 @@ these guidelines:
 -   Adhere to guidelines for commit messages described in this `article <http://chris.beams.io/posts/git-commit/>`__.
     This makes the lives of those who come after you a lot easier.
 
+Airflow Git Branches
+====================
+
+All new development in Airflow happens in ``master`` branch. All PRs should target that branch.
+We also have ``v1-10-test`` branch which is used to test ``1.10.x`` series of Airflow and where committers
+(and only committers) cherry-pick selected commits from the master branch. The ``v1-10-test`` branch might be
+broken at times - during testing. Expect force-pushes there so committers should coordinate between themselves
+on who is working on the ``v1-10-test`` branch - usually those will be people with the role of the
+release manager. Once the branch is stable - the ``v1-10-stable`` branch is synchronized with ``v1-10-test``.
+The ``v1-10-stable`` branch is used to relsease ``1.10.x`` releases.
+
 Development Environments
 ========================
 


### PR DESCRIPTION
---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
