### PR TITLE
[AIRFLOW-6583] (BigQuery) Add query_params to templated_fields

### DIFF
--- a/airflow/gcp/operators/bigquery.py
+++ b/airflow/gcp/operators/bigquery.py
@@ -424,7 +424,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
         'queryParameters' in Google BigQuery Jobs API:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs.
         For example, [{ 'name': 'corpus', 'parameterType': { 'type': 'STRING' },
-        'parameterValue': { 'value': 'romeoandjuliet' } }].
+        'parameterValue': { 'value': 'romeoandjuliet' } }]. (templated)
     :type query_params: list
     :param labels: a dictionary containing labels for the job/query,
         passed to BigQuery
@@ -453,7 +453,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
     :type encryption_configuration: dict
     """
 
-    template_fields = ('sql', 'destination_dataset_table', 'labels')
+    template_fields = ('sql', 'destination_dataset_table', 'labels', 'query_params')
     template_ext = ('.sql', )
     ui_color = '#e4f0e8'
 


### PR DESCRIPTION
### JIRA Issue
https://issues.apache.org/jira/browse/AIRFLOW-6583

### Description
Add **query_params** to _template_field_ in GCP's BigQuery Execute Query Operator.

---
Issue link: [AIRFLOW-6583](https://issues.apache.org/jira/browse/AIRFLOW-6583)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
