### PR TITLE
[AIRFLOW-XXXX] Increease verbosity of static checks in CI

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -4,6 +4,7 @@
 .github/*
 .gitignore
 .gitattributes
+.airflow_db_initialised
 .airflowignore
 .coverage
 .coveragerc

--- a/scripts/ci/ci_run_all_static_tests.sh
+++ b/scripts/ci/ci_run_all_static_tests.sh
@@ -44,6 +44,6 @@ rebuild_ci_image_if_needed
 IMAGES_TO_CHECK=("CI")
 export IMAGES_TO_CHECK
 
-pre-commit run --all-files --show-diff-on-failure
+pre-commit run --all-files --show-diff-on-failure --verbose
 
 script_end

--- a/scripts/ci/pre_commit_check_license.sh
+++ b/scripts/ci/pre_commit_check_license.sh
@@ -22,4 +22,6 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export FORCE_ANSWER_TO_QUESTIONS=${FORCE_ANSWER_TO_QUESTIONS:="quit"}
 export REMEMBER_LAST_ANSWER="true"
 
-"${MY_DIR}/ci_check_license.sh"
+# Hide lines between ****/**** (detailed list of files)
+"${MY_DIR}/ci_check_license.sh" 2>&1 | \
+    sed "/Files with Apache License headers will be marked AL.*$/,/^\**$/d"


### PR DESCRIPTION
The latest version of pre-commit supports showing execution times
for particular checks. This was a feature requested in
https://github.com/pre-commit/pre-commit/issues/1144 and they
finally implemented it after long time saying "no" :).

This commit enables it with --verbose flag - which is also useful
as it shows hook ids and some extra information printed by
some plugins.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
