### PR TITLE
[AIRFLOW-XXXX] Add mentoring information to contributing docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,6 +23,22 @@ Contributions
 Contributions are welcome and are greatly appreciated! Every little bit helps,
 and credit will always be given.
 
+Get Mentoring Support
+---------------------
+
+If you are new to the project, you might need some help in understanding how the dynamics
+of the community works and you might need to get some mentorship from other members of the
+community - mostly committers. Mentoring new members of the community is part of committers
+job so do not be afraid of asking committers to help you. You can do it
+via comments in your Pull Request, asking on a devlist or via Slack. For your convenience,
+we have a dedicated #newbie-questions Slack channel where you can ask any questions
+you want - it's a safe space where it is expected that people asking questions do not know
+a lot about Airflow (yet!).
+
+If you look for more structured mentoring experience, you can apply to Apache Software Foundation's
+`Official Mentoring Programme <http://community.apache.org/mentoringprogramme.html>`_. Feel free
+to follow it and apply to the programme and follow up with the community.
+
 Report Bugs
 -----------
 


### PR DESCRIPTION
---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
