### PR TITLE
[AIRFLOW-6589] BAT tests run in pre-commit on bash script changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -293,8 +293,8 @@ repos:
         files: \.py$
         pass_filenames: true
       - id: bat-tests
-        name: Run BATS bash tests
+        name: Run BATS bash tests for changed bash files
         language: system
         entry: "./scripts/ci/pre_commit_bat_tests.sh"
-        files: ^tests/bats/.*\.bats$
-        pass_filenames: true
+        files: ^breeze$|^breeze-complete$|\.sh$|\.bash$
+        pass_filenames: false

--- a/scripts/ci/pre_commit_bat_tests.sh
+++ b/scripts/ci/pre_commit_bat_tests.sh
@@ -22,4 +22,10 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export FORCE_ANSWER_TO_QUESTIONS=${FORCE_ANSWER_TO_QUESTIONS:="quit"}
 export REMEMBER_LAST_ANSWER="true"
 
-"${MY_DIR}/ci_bat_tests.sh" "${@}"
+if [[ $# -eq 0 ]]; then
+    PARAMS=("tests/bats")
+else
+    PARAMS=("${@}")
+fi
+
+"${MY_DIR}/ci_bat_tests.sh" "${PARAMS[@]}"


### PR DESCRIPTION
The previous configuration did not work as intended.

---
Issue link: [AIRFLOW-6589](https://issues.apache.org/jira/browse/AIRFLOW-6589)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
