### PR TITLE
[AIRFLOW-XXXX] Adjust celery defaults to work with breeze

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -990,7 +990,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "16"
+      default: "8"
     - name: worker_autoscale
       description: |
         The maximum and minimum concurrency that will be used when starting workers with the
@@ -1023,7 +1023,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "sqla+mysql://airflow:airflow@localhost:3306/airflow"
+      default: "redis://redis:6379/0"
     - name: result_backend
       description: |
         The Celery result_backend. When a job finishes, it needs to update the
@@ -1035,7 +1035,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "db+mysql://airflow:airflow@localhost:3306/airflow"
+      default: "db+postgresql://postgres:airflow@postgres/airflow"
     - name: flower_host
       description: |
         Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -468,7 +468,7 @@ celery_app_name = airflow.executors.celery_executor
 # ``airflow celery worker`` command. This defines the number of task instances that
 # a worker will take, so size up your workers based on the resources on
 # your worker box and the nature of your tasks
-worker_concurrency = 16
+worker_concurrency = 8
 
 # The maximum and minimum concurrency that will be used when starting workers with the
 # ``airflow celery worker`` command (always keep minimum processes, but grow
@@ -490,7 +490,7 @@ worker_log_server_port = 8793
 # a sqlalchemy database. Refer to the Celery documentation for more
 # information.
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-settings
-broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
+broker_url = redis://redis:6379/0
 
 # The Celery result_backend. When a job finishes, it needs to update the
 # metadata of the job. Therefore it will post a message on a message bus,
@@ -498,7 +498,7 @@ broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 # This status is used by the scheduler to update the state of the task
 # The use of a database is highly recommended
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
-result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
+result_backend = db+postgresql://postgres:airflow@postgres/airflow
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
 # it ``airflow celery flower``. This defines the IP that Celery Flower runs on

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -40,7 +40,7 @@ if 'visibility_timeout' not in broker_transport_options:
         broker_transport_options['visibility_timeout'] = 21600
 
 DEFAULT_CELERY_CONFIG = {
-    'accept_content': ['json', 'pickle'],
+    'accept_content': ['json'],
     'event_serializer': 'json',
     'worker_prefetch_multiplier': 1,
     'task_acks_late': True,


### PR DESCRIPTION
This PR changes default Celery configs values to ease working with CeleryExecutor in Breeze.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
