### PR TITLE
[AIRFLOW-6596] Enforce description should not be empty

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -39,6 +39,9 @@ mergeable:
           message: There are incomplete TODO task(s) unchecked.
         no_empty:
           enabled: true
+        must_include:
+          regex: ^(\w+)
+          message: Must include description for the PR
         or:
           - must_include:
               regex: (\[AIRFLOW-XXXX\])


### PR DESCRIPTION
Enforce description should not be empty. This is so that contributors not only just ticks "Description above provides context of the change" but adds the actual details

---
Issue link: [AIRFLOW-6596](https://issues.apache.org/jira/browse/AIRFLOW-6596)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
