### PR TITLE
[AIRFLOW-XXXX] Update committers list

### DIFF
--- a/docs/project.rst
+++ b/docs/project.rst
@@ -63,6 +63,8 @@ Committers
 - @aijamalnk (Aizhamal Nurmamat kyzy)
 - @milton0825 (Chao-Han Tsai)
 - @feluelle (Felix Uellendall)
+- @sekikn (Kengo Seki)
+- @nuclearpinguin (Tomasz Urbaszek)
 
 
 For the full list of contributors, take a look at `Airflow's Github


### PR DESCRIPTION
I updated the list of committers according to:
http://people.apache.org/phonebook.html?unix=airflow

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
