### PR TITLE
[AIRFLOW-6424] Added a operator to modify EMR cluster

### DIFF
--- a/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
+++ b/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from airflow.contrib.hooks.emr_hook import EmrHook
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class EmrModifyClusterOperator(BaseOperator):
+    """
+    An operator that modifies an existing EMR cluster.
+    :param cluster_id: cluster identifier
+    :type cluster_id: str
+    :param step_concurrency_level: Concurrency of the cluster
+    :type step_concurrency_level: int
+    :param aws_conn_id: aws connection to uses
+    :type aws_conn_id: str
+    :param do_xcom_push: if True, job_flow_id is pushed to XCom with key job_flow_id.
+    :type do_xcom_push: bool
+    """
+    template_fields = ['cluster_id', 'step_concurrency_level']
+    template_ext = ()
+    ui_color = '#f9c915'
+
+    @apply_defaults
+    def __init__(
+            self,
+            cluster_id=None,
+            step_concurrency_level=None,
+            aws_conn_id='aws_default',
+            *args, **kwargs):
+        if kwargs.get('xcom_push') is not None:
+            raise AirflowException("'xcom_push' was deprecated, use 'do_xcom_push' instead")
+        super().__init__(*args, **kwargs)
+        self.aws_conn_id = aws_conn_id
+        self.cluster_id = cluster_id
+        self.step_concurrency_level = step_concurrency_level
+
+    def execute(self, context):
+        emr_hook = EmrHook(aws_conn_id=self.aws_conn_id)
+
+        emr = emr_hook.get_conn()
+
+        if self.do_xcom_push:
+            context['ti'].xcom_push(key='cluster_id', value=self.cluster_id)
+
+        self.log.info('Modifying cluster %s', self.cluster_id)
+        response = emr.modify_cluster(ClusterId=self.cluster_id,
+                                      StepConcurrencyLevel=self.step_concurrency_level)
+
+        if not response['ResponseMetadata']['HTTPStatusCode'] == 200:
+            raise AirflowException('Modify cluster failed: %s' % response)
+        else:
+            self.log.info('Steps concurrency level %d', response['StepConcurrencyLevel'])
+            return response['StepConcurrencyLevel']

--- a/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
+++ b/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
@@ -47,8 +47,6 @@ class EmrModifyClusterOperator(BaseOperator):
             *args, **kwargs):
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'do_xcom_push' instead")
-        if cluster_id is None or step_concurrency_level is None:
-            raise AirflowException("'cluster_id' or 'step_concurrency_level' not passed")
         super().__init__(*args, **kwargs)
         self.aws_conn_id = aws_conn_id
         self.cluster_id = cluster_id

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -354,7 +354,8 @@ These integrations allow you to perform various operations within the Amazon Web
      - :mod:`airflow.providers.amazon.aws.hooks.emr`
      - :mod:`airflow.providers.amazon.aws.operators.emr_add_steps`,
        :mod:`airflow.providers.amazon.aws.operators.emr_create_job_flow`,
-       :mod:`airflow.providers.amazon.aws.operators.emr_terminate_job_flow`
+       :mod:`airflow.providers.amazon.aws.operators.emr_terminate_job_flow`,
+       :mod:`airflow.providers.amazon.aws.operators.emr_modify_cluster`
      - :mod:`airflow.providers.amazon.aws.sensors.emr_base`,
        :mod:`airflow.providers.amazon.aws.sensors.emr_job_flow`,
        :mod:`airflow.providers.amazon.aws.sensors.emr_step`

--- a/tests/providers/amazon/aws/operators/test_emr_modify_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_emr_modify_cluster.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.operators.emr_modify_cluster import EmrModifyClusterOperator
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+
+MODIFY_CLUSTER_SUCCESS_RETURN = {
+    'ResponseMetadata': {
+        'HTTPStatusCode': 200
+    },
+    'StepConcurrencyLevel': 1
+}
+
+MODIFY_CLUSTER_ERROR_RETURN = {
+    'ResponseMetadata': {
+        'HTTPStatusCode': 400
+    }
+}
+
+
+class TestEmrModifyClusterOperator(unittest.TestCase):
+    # When
+
+    def setUp(self):
+        self.args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+
+        # Mock out the emr_client (moto has incorrect response)
+        self.emr_client_mock = MagicMock()
+
+        # Mock out the emr_client creator
+        emr_session_mock = MagicMock()
+        emr_session_mock.client.return_value = self.emr_client_mock
+        self.boto3_session_mock = MagicMock(return_value=emr_session_mock)
+
+        self.mock_context = MagicMock()
+
+        self.operator = EmrModifyClusterOperator(
+            task_id='test_task',
+            cluster_id='j-8989898989',
+            step_concurrency_level=1,
+            aws_conn_id='aws_default',
+            dag=DAG('test_dag_id', default_args=self.args)
+        )
+
+    def test_init(self):
+        self.assertEqual(self.operator.cluster_id, 'j-8989898989')
+        self.assertEqual(self.operator.step_concurrency_level, 1)
+        self.assertEqual(self.operator.aws_conn_id, 'aws_default')
+
+    def test_execute_returns_step_concurrency(self):
+        self.emr_client_mock.modify_cluster.return_value = MODIFY_CLUSTER_SUCCESS_RETURN
+
+        with patch('boto3.session.Session', self.boto3_session_mock):
+            self.assertEqual(self.operator.execute(self.mock_context), 1)
+
+    def test_execute_returns_error(self):
+        self.emr_client_mock.modify_cluster.return_value = MODIFY_CLUSTER_ERROR_RETURN
+
+        with patch('boto3.session.Session', self.boto3_session_mock):
+            self.assertRaises(AirflowException, self.operator.execute, self.mock_context)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/providers/amazon/aws/operators/test_emr_modify_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_emr_modify_cluster.py
@@ -42,8 +42,6 @@ MODIFY_CLUSTER_ERROR_RETURN = {
 
 
 class TestEmrModifyClusterOperator(unittest.TestCase):
-    # When
-
     def setUp(self):
         self.args = {
             'owner': 'airflow',


### PR DESCRIPTION
With the addition of this operator, users would be able to modify the EMR step level concurrency of an existing cluster.

---
Issue link: [AIRFLOW-6424](https://issues.apache.org/jira/browse/AIRFLOW-6424)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
