### PR TITLE
[AIRFLOW-5946] Store source code in db

### DIFF
--- a/airflow/api/common/experimental/__init__.py
+++ b/airflow/api/common/experimental/__init__.py
@@ -19,6 +19,7 @@
 from datetime import datetime
 from typing import Optional
 
+from airflow.configuration import conf
 from airflow.exceptions import DagNotFound, DagRunNotFound, TaskNotFound
 from airflow.models import DagBag, DagModel, DagRun
 
@@ -29,12 +30,9 @@ def check_and_get_dag(dag_id: str, task_id: Optional[str] = None) -> DagModel:
     if dag_model is None:
         raise DagNotFound("Dag id {} not found in DagModel".format(dag_id))
 
-    def read_store_serialized_dags():
-        from airflow.configuration import conf
-        return conf.getboolean('core', 'store_serialized_dags')
     dagbag = DagBag(
         dag_folder=dag_model.fileloc,
-        store_serialized_dags=read_store_serialized_dags()
+        store_serialized_dags=conf.getboolean('core', 'store_serialized_dags')
     )
     dag = dagbag.get_dag(dag_id)  # prefetch dag if it is stored serialized
     if dag_id not in dagbag.dags:

--- a/airflow/api/common/experimental/get_code.py
+++ b/airflow/api/common/experimental/get_code.py
@@ -18,6 +18,7 @@
 """Get code APIs."""
 from airflow.api.common.experimental import check_and_get_dag
 from airflow.exceptions import AirflowException, DagCodeNotFound
+from airflow.models.dagcode import DagCode
 
 
 def get_code(dag_id: str) -> str:
@@ -29,7 +30,7 @@ def get_code(dag_id: str) -> str:
     dag = check_and_get_dag(dag_id=dag_id)
 
     try:
-        return dag.code()
+        return DagCode.get_code_by_fileloc(dag.fileloc)
     except (OSError, DagCodeNotFound) as exception:
         error_message = "Error {} while reading Dag id {} Code".format(str(exception), dag_id)
         raise AirflowException(error_message, exception)

--- a/airflow/api/common/experimental/get_code.py
+++ b/airflow/api/common/experimental/get_code.py
@@ -17,8 +17,7 @@
 # under the License.
 """Get code APIs."""
 from airflow.api.common.experimental import check_and_get_dag
-from airflow.exceptions import AirflowException
-from airflow.www import utils as wwwutils
+from airflow.exceptions import AirflowException, DagCodeNotFound
 
 
 def get_code(dag_id: str) -> str:
@@ -30,9 +29,7 @@ def get_code(dag_id: str) -> str:
     dag = check_and_get_dag(dag_id=dag_id)
 
     try:
-        with wwwutils.open_maybe_zipped(dag.fileloc, 'r') as file:
-            code = file.read()
-            return code
-    except OSError as exception:
+        return dag.code()
+    except (OSError, DagCodeNotFound) as exception:
         error_message = "Error {} while reading Dag id {} Code".format(str(exception), dag_id)
-        raise AirflowException(error_message)
+        raise AirflowException(error_message, exception)

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -335,6 +335,15 @@
       type: string
       example: ~
       default: "True"
+    - name: store_dag_code
+      description: |
+        Whether to persist DAG files code in DB.
+        If set to True, Webserver reads file contents from DB instead of
+        trying to access files in a DAG folder.
+      version_added: 2.0.0
+      type: string
+      example: ~
+      default: "False"
 
 - name: logging
   description: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -316,6 +316,16 @@
       type: string
       example: ~
       default: "30"
+    - name: store_dag_code
+      description: |
+        Whether to persist DAG files code in DB.
+        If set to True, Webserver reads file contents from DB instead of
+        trying to access files in a DAG folder. Defaults to same as the
+        store_serialized_dags setting.
+      version_added: 2.0.0
+      type: string
+      example: ~
+      default: "%(store_serialized_dags)s"
     - name: max_num_rendered_ti_fields_per_task
       description: |
         Maximum number of Rendered Task Instance Fields (Template Fields) per task to store
@@ -335,15 +345,6 @@
       type: string
       example: ~
       default: "True"
-    - name: store_dag_code
-      description: |
-        Whether to persist DAG files code in DB.
-        If set to True, Webserver reads file contents from DB instead of
-        trying to access files in a DAG folder.
-      version_added: 2.0.0
-      type: string
-      example: ~
-      default: "False"
 
 - name: logging
   description: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -181,6 +181,12 @@ store_serialized_dags = False
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.
 min_serialized_dag_update_interval = 30
 
+# Whether to persist DAG files code in DB.
+# If set to True, Webserver reads file contents from DB instead of
+# trying to access files in a DAG folder. Defaults to same as the
+# store_serialized_dags setting.
+store_dag_code = %(store_serialized_dags)s
+
 # Maximum number of Rendered Task Instance Fields (Template Fields) per task to store
 # in the Database.
 # When Dag Serialization is enabled (``store_serialized_dags=True``), all the template_fields
@@ -191,11 +197,6 @@ max_num_rendered_ti_fields_per_task = 30
 
 # On each dagrun check against defined SLAs
 check_slas = True
-
-# Whether to persist DAG files code in DB.
-# If set to True, Webserver reads file contents from DB instead of
-# trying to access files in a DAG folder.
-store_dag_code = False
 
 [logging]
 # The folder where airflow should store its log files

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -192,6 +192,11 @@ max_num_rendered_ti_fields_per_task = 30
 # On each dagrun check against defined SLAs
 check_slas = True
 
+# Whether to persist DAG files code in DB.
+# If set to True, Webserver reads file contents from DB instead of
+# trying to access files in a DAG folder.
+store_dag_code = False
+
 [logging]
 # The folder where airflow should store its log files
 # This path must be absolute

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -82,6 +82,10 @@ class DagNotFound(AirflowNotFoundException):
     """Raise when a DAG is not available in the system"""
 
 
+class DagCodeNotFound(AirflowNotFoundException):
+    """Raise when a DAG code is not available in the system"""
+
+
 class DagRunNotFound(AirflowNotFoundException):
     """Raise when a DAG Run is not available in the system"""
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -917,6 +917,7 @@ class DagFileProcessor(LoggingMixin):
             self.log.info("Creating / updating %s in ORM", ti)
             session.merge(ti)
         # commit batch
+
         session.commit()
 
     @provide_session

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -917,7 +917,6 @@ class DagFileProcessor(LoggingMixin):
             self.log.info("Creating / updating %s in ORM", ti)
             session.merge(ti)
         # commit batch
-
         session.commit()
 
     @provide_session

--- a/airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
+++ b/airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""add dag_code table
+
+Revision ID: 952da73b5eff
+Revises: 852ae6c715af
+Create Date: 2020-03-12 12:39:01.797462
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from airflow.models.dagcode import DagCode
+from airflow.models.serialized_dag import SerializedDagModel
+
+revision = '952da73b5eff'
+down_revision = '852ae6c715af'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply add source code table"""
+    op.create_table('dag_code',  # pylint: disable=no-member
+                    sa.Column('fileloc_hash', sa.BigInteger(),
+                              nullable=False, primary_key=True, autoincrement=False),
+                    sa.Column('fileloc', sa.String(length=2000), nullable=False),
+                    sa.Column('source_code', sa.UnicodeText(), nullable=False),
+                    sa.Column('last_updated', sa.TIMESTAMP(timezone=True), nullable=False))
+
+    conn = op.get_bind()
+    if conn.dialect.name not in ('sqlite'):
+        op.drop_index('idx_fileloc_hash', 'serialized_dag')
+        op.alter_column(table_name='serialized_dag', column_name='fileloc_hash',
+                        type_=sa.BigInteger(), nullable=False)
+        op.create_index(   # pylint: disable=no-member
+            'idx_fileloc_hash', 'serialized_dag', ['fileloc_hash'])
+
+    sessionmaker = sa.orm.sessionmaker()
+    session = sessionmaker(bind=conn)
+    serialized_dags = session.query(SerializedDagModel).all()
+    for dag in serialized_dags:
+        dag.fileloc_hash = DagCode.dag_fileloc_hash(dag.fileloc)
+        session.merge(dag)
+    session.commit()
+
+
+def downgrade():
+    """Unapply add source code table"""
+    op.drop_table('dag_code')

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -45,6 +45,7 @@ from airflow.exceptions import (
 from airflow.models.base import ID_LEN, Base
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag
+from airflow.models.dagcode import DagCode
 from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
@@ -1527,6 +1528,9 @@ class DAG(BaseDag, LoggingMixin):
                         dag_tag_orm = DagTag(name=dag_tag, dag_id=dag.dag_id)
                         orm_dag.tags.append(dag_tag_orm)
                         session.add(dag_tag_orm)
+
+        if conf.getboolean('core', 'store_dag_code', fallback=False):
+            DagCode.bulk_sync_to_db([dag.fileloc for dag in orm_dags])
 
         session.commit()
 

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -1,0 +1,220 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+import os
+import struct
+from datetime import datetime, timedelta
+from typing import Iterable, List
+
+from sqlalchemy import BigInteger, Column, String, UnicodeText, and_, exists
+
+from airflow.configuration import conf
+from airflow.exceptions import AirflowException, DagCodeNotFound
+from airflow.models import Base
+from airflow.utils import timezone
+from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
+from airflow.utils.session import provide_session
+from airflow.utils.sqlalchemy import UtcDateTime
+
+log = logging.getLogger(__name__)
+
+
+class DagCode(Base):
+    """A table for DAGs code.
+
+    dag_code table contains code of DAG files synchronized by scheduler.
+    This feature is controlled by:
+
+    * ``[core] store_serialized_dags = True``: enable this feature
+    * ``[core] store_dag_code = True``: enable this feature
+
+    For details on dag serialization see SerializedDagModel
+    """
+    __tablename__ = 'dag_code'
+
+    fileloc_hash = Column(
+        BigInteger, nullable=False, primary_key=True, autoincrement=False)
+    fileloc = Column(String(2000), nullable=False)
+    # The max length of fileloc exceeds the limit of indexing.
+    last_updated = Column(UtcDateTime, nullable=False)
+    source_code = Column(UnicodeText(), nullable=False)
+
+    def __init__(self, full_filepath: str):
+        self.fileloc = full_filepath
+        self.fileloc_hash = DagCode.dag_fileloc_hash(self.fileloc)
+        self.last_updated = timezone.utcnow()
+        self.source_code = DagCode._read_code(self.fileloc)
+
+    @classmethod
+    def _read_code(cls, fileloc: str):
+        with open_maybe_zipped(fileloc, 'r') as source:
+            source_code = source.read()
+        return source_code
+
+    @provide_session
+    def sync_to_db(self, session=None):
+        """Writes code into database.
+
+        :param session: ORM Session
+        """
+        old_version = session.query(
+            DagCode.fileloc, DagCode.fileloc_hash, DagCode.last_updated) \
+            .filter(DagCode.fileloc_hash == self.fileloc_hash) \
+            .first()
+
+        if old_version and old_version.fileloc != self.fileloc:
+            raise AirflowException(
+                "Filename '{}' causes a hash collision in the database with "
+                "'{}'. Please rename the file.".format(
+                    self.fileloc, old_version.fileloc))
+
+        file_modified = datetime.fromtimestamp(
+            os.path.getmtime(correct_maybe_zipped(self.fileloc)), tz=timezone.utc)
+
+        if old_version and (file_modified - timedelta(seconds=120)) < \
+                old_version.last_updated:
+            return
+
+        session.merge(self)
+
+    @classmethod
+    @provide_session
+    def bulk_sync_to_db(cls, filelocs: Iterable[str], session=None):
+        """Writes code in bulk into database.
+
+        :param filelocs: file paths of DAGs to sync
+        :param session: ORM Session
+        """
+        filelocs = set(filelocs)
+        filelocs_to_hashes = {
+            fileloc: DagCode.dag_fileloc_hash(fileloc) for fileloc in filelocs
+        }
+        existing_orm_dag_codes = (
+            session
+            .query(DagCode)
+            .filter(DagCode.fileloc_hash.in_(filelocs_to_hashes.values()))
+            .with_for_update(of=DagCode)
+            .all()
+        )
+
+        existing_filelocs = {
+            dag_code.fileloc for dag_code in existing_orm_dag_codes
+        }
+        missing_filelocs = filelocs.difference(existing_filelocs)
+
+        for fileloc in missing_filelocs:
+            orm_dag_code = DagCode(fileloc)
+            session.add(orm_dag_code)
+
+        existing_orm_dag_codes_by_fileloc_hashes = {
+            orm.fileloc_hash: orm for orm in existing_orm_dag_codes
+        }
+        for fileloc in existing_filelocs:
+            old_version = existing_orm_dag_codes_by_fileloc_hashes[
+                filelocs_to_hashes[fileloc]
+            ]
+            if old_version.fileloc != fileloc:
+                raise AirflowException(
+                    "Filename '{}' causes a hash collision in the database with "
+                    "'{}'. Please rename the file.".format(
+                        fileloc, old_version.fileloc))
+            file_modified = datetime.fromtimestamp(
+                os.path.getmtime(correct_maybe_zipped(fileloc)), tz=timezone.utc)
+
+            if (file_modified - timedelta(seconds=120)) > old_version.last_updated:
+                orm_dag_code.last_updated = timezone.utcnow()
+                orm_dag_code.source_code = DagCode._read_code(orm_dag_code.fileloc)
+                session.update(orm_dag_code)
+
+    @classmethod
+    @provide_session
+    def remove_deleted_code(cls, alive_dag_filelocs: List[str], session=None):
+        """Deletes code not included in alive_dag_filelocs.
+
+        :param alive_dag_filelocs: file paths of alive DAGs
+        :param session: ORM Session
+        """
+        alive_fileloc_hashes = [
+            cls.dag_fileloc_hash(fileloc) for fileloc in alive_dag_filelocs]
+
+        log.debug("Deleting code from %s table ", cls.__tablename__)
+
+        session.execute(
+            session.query(cls).filter(
+                and_(cls.fileloc_hash.notin_(alive_fileloc_hashes),
+                     cls.fileloc.notin_(alive_dag_filelocs))).delete())
+
+    @classmethod
+    @provide_session
+    def has_dag(cls, fileloc: str, session=None) -> bool:
+        """Checks a file exist in dag_code table.
+
+        :param fileloc: the file to check
+        :param session: ORM Session
+        """
+        fileloc_hash = cls.dag_fileloc_hash(fileloc)
+        return session.query(exists().where(cls.fileloc_hash == fileloc_hash))\
+            .scalar()
+
+    @classmethod
+    def get_code_by_fileloc(cls, fileloc: str) -> str:
+        """Returns source code for a given fileloc.
+
+        :param fileloc: file path of a DAG
+        :return: source code as string
+        """
+        return DagCode(fileloc).code()
+
+    def code(self) -> str:
+        """Returns source code for this DagCode object.
+
+        :return: source code as string
+        """
+        if conf.getboolean('core', 'store_dag_code', fallback=False):
+            return self._get_code_from_db()
+        else:
+            return self._get_code_from_file()
+
+    def _get_code_from_file(self):
+        with open_maybe_zipped(self.fileloc, 'r') as f:
+            code = f.read()
+        return code
+
+    @provide_session
+    def _get_code_from_db(self, session=None):
+        dag_code = session.query(DagCode) \
+            .filter(DagCode.fileloc_hash == self.fileloc_hash) \
+            .first()
+        if not dag_code:
+            raise DagCodeNotFound()
+        else:
+            code = dag_code.source_code
+        return code
+
+    @staticmethod
+    def dag_fileloc_hash(full_filepath: str) -> int:
+        """"Hashing file location for indexing.
+
+        :param full_filepath: full filepath of DAG file
+        :return: hashed full_filepath
+        """
+        # Hashing is needed because the length of fileloc is 2000 as an Airflow convention,
+        # which is over the limit of indexing.
+        import hashlib
+        # Only 7 bytes because MySQL BigInteger can hold only 8 bytes (signed).
+        return struct.unpack('>Q', hashlib.sha1(
+            full_filepath.encode('utf-8')).digest()[-8:])[0] >> 8

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -18,17 +18,17 @@
 
 """Serialzed DAG table in database."""
 
-import hashlib
 import logging
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 import sqlalchemy_jsonfield
-from sqlalchemy import Column, Index, Integer, String, and_
+from sqlalchemy import BigInteger, Column, Index, String, and_
 from sqlalchemy.sql import exists
 
 from airflow.models.base import ID_LEN, Base
 from airflow.models.dag import DAG
+from airflow.models.dagcode import DagCode
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.settings import json
 from airflow.utils import timezone
@@ -61,7 +61,7 @@ class SerializedDagModel(Base):
     dag_id = Column(String(ID_LEN), primary_key=True)
     fileloc = Column(String(2000), nullable=False)
     # The max length of fileloc exceeds the limit of indexing.
-    fileloc_hash = Column(Integer, nullable=False)
+    fileloc_hash = Column(BigInteger, nullable=False)
     data = Column(sqlalchemy_jsonfield.JSONField(json=json), nullable=False)
     last_updated = Column(UtcDateTime, nullable=False)
 
@@ -72,22 +72,9 @@ class SerializedDagModel(Base):
     def __init__(self, dag: DAG):
         self.dag_id = dag.dag_id
         self.fileloc = dag.full_filepath
-        self.fileloc_hash = self.dag_fileloc_hash(self.fileloc)
+        self.fileloc_hash = DagCode.dag_fileloc_hash(self.fileloc)
         self.data = SerializedDAG.to_dict(dag)
         self.last_updated = timezone.utcnow()
-
-    @staticmethod
-    def dag_fileloc_hash(full_filepath: str) -> int:
-        """"Hashing file location for indexing.
-
-        :param full_filepath: full filepath of DAG file
-        :return: hashed full_filepath
-        """
-        # hashing is needed because the length of fileloc is 2000 as an Airflow convention,
-        # which is over the limit of indexing. If we can reduce the length of fileloc, then
-        # hashing is not needed.
-        return int.from_bytes(
-            hashlib.sha1(full_filepath.encode('utf-8')).digest()[-2:], byteorder='big', signed=False)
 
     @classmethod
     @provide_session
@@ -164,7 +151,7 @@ class SerializedDagModel(Base):
         :param session: ORM Session
         """
         alive_fileloc_hashes = [
-            cls.dag_fileloc_hash(fileloc) for fileloc in alive_dag_filelocs]
+            DagCode.dag_fileloc_hash(fileloc) for fileloc in alive_dag_filelocs]
 
         log.debug("Deleting Serialized DAGs (for which DAG files are deleted) "
                   "from %s table ", cls.__tablename__)

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -767,6 +767,10 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
                 SerializedDagModel.remove_deleted_dags(self._file_paths)
                 DagModel.deactivate_deleted_dags(self._file_paths)
 
+            if conf.getboolean('core', 'store_dag_code', fallback=False):
+                from airflow.models.dagcode import DagCode
+                DagCode.remove_deleted_code(self._file_paths)
+
     def _print_stat(self):
         """
         Occasionally print out stats about how fast the files are getting processed

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import io
 import logging
 import os
 import re
@@ -59,17 +60,34 @@ def mkdirs(path, mode):
         os.umask(o_umask)
 
 
+ZIP_REGEX = re.compile(r'((.*\.zip){})?(.*)'.format(re.escape(os.sep)))
+
+
 def correct_maybe_zipped(fileloc):
     """
     If the path contains a folder with a .zip suffix, then
     the folder is treated as a zip archive and path to zip is returned.
     """
 
-    _, archive, _ = re.search(r'((.*\.zip){})?(.*)'.format(re.escape(os.sep)), fileloc).groups()
+    _, archive, _ = ZIP_REGEX.search(fileloc).groups()
     if archive and zipfile.is_zipfile(archive):
         return archive
     else:
         return fileloc
+
+
+def open_maybe_zipped(fileloc, mode='r'):
+    """
+    Opens the given file. If the path contains a folder with a .zip suffix, then
+    the folder is treated as a zip archive, opening the file inside the archive.
+
+    :return: a file object, as in `open`, or as in `ZipFile.open`.
+    """
+    _, archive, filename = ZIP_REGEX.search(fileloc).groups()
+    if archive and zipfile.is_zipfile(archive):
+        return zipfile.ZipFile(archive, mode=mode).open(filename)
+    else:
+        return io.open(fileloc, mode=mode)
 
 
 def list_py_file_paths(directory: str,

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -18,12 +18,8 @@
 
 import functools
 import inspect
-import io
 import json
-import os
-import re
 import time
-import zipfile
 from typing import Any, Optional
 from urllib.parse import urlencode
 
@@ -202,24 +198,6 @@ def json_response(obj):
             obj, indent=4, cls=AirflowJsonEncoder),
         status=200,
         mimetype="application/json")
-
-
-ZIP_REGEX = re.compile(r'((.*\.zip){})?(.*)'.format(re.escape(os.sep)))
-
-
-def open_maybe_zipped(f, mode='r'):
-    """
-    Opens the given file. If the path contains a folder with a .zip suffix, then
-    the folder is treated as a zip archive, opening the file inside the archive.
-
-    :return: a file object, as in `open`, or as in `ZipFile.open`.
-    """
-
-    _, archive, filename = ZIP_REGEX.search(f).groups()
-    if archive and zipfile.is_zipfile(archive):
-        return zipfile.ZipFile(archive, mode=mode).open(filename)
-    else:
-        return io.open(f, mode=mode)
 
 
 def make_cache_key(*args, **kwargs):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -527,7 +527,6 @@ class Airflow(AirflowBaseView):
             dag_id = request.args.get('dag_id')
             dag_orm = DagModel.get_dagmodel(dag_id, session=session)
             code = DagCode.get_code_by_fileloc(dag_orm.fileloc)
-            dag = dag_orm.get_dag(STORE_SERIALIZED_DAGS)
             html_code = highlight(
                 code, lexers.PythonLexer(), HtmlFormatter(linenos=True))
 
@@ -540,7 +539,7 @@ class Airflow(AirflowBaseView):
                 escape(all_errors))
 
         return self.render_template(
-            'airflow/dag_code.html', html_code=html_code, dag=dag, title=dag_id,
+            'airflow/dag_code.html', html_code=html_code, dag=dag_orm, title=dag_id,
             root=request.args.get('root'),
             demo_mode=conf.getboolean('webserver', 'demo_mode'),
             wrapped=conf.getboolean('webserver', 'default_wrap'))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -61,6 +61,7 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job import BaseJob
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import Connection, DagModel, DagTag, Log, SlaMiss, TaskFail, XCom, errors
+from airflow.models.dagcode import DagCode
 from airflow.models.dagrun import DagRun, DagRunType
 from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.ti_deps.dep_context import DepContext
@@ -520,17 +521,23 @@ class Airflow(AirflowBaseView):
     @has_access
     @provide_session
     def code(self, session=None):
-        dm = models.DagModel
-        dag_id = request.args.get('dag_id')
-        dag = session.query(dm).filter(dm.dag_id == dag_id).first()
+        all_errors = ""
+
         try:
-            with wwwutils.open_maybe_zipped(dag.fileloc, 'r') as f:
-                code = f.read()
+            dag_id = request.args.get('dag_id')
+            dag_orm = DagModel.get_dagmodel(dag_id, session=session)
+            code = DagCode.get_code_by_fileloc(dag_orm.fileloc)
+            dag = dag_orm.get_dag(STORE_SERIALIZED_DAGS)
             html_code = highlight(
                 code, lexers.PythonLexer(), HtmlFormatter(linenos=True))
-        except OSError as e:
+
+        except Exception as e:
+            all_errors += (
+                "Exception encountered during " +
+                "dag_id retrieval/dag retrieval fallback/code highlighting:\n\n{}\n".format(e)
+            )
             html_code = '<p>Failed to load file.</p><p>Details: {}</p>'.format(
-                escape(str(e)))
+                escape(all_errors))
 
         return self.render_template(
             'airflow/dag_code.html', html_code=html_code, dag=dag, title=dag_id,

--- a/docs/dag-serialization.rst
+++ b/docs/dag-serialization.rst
@@ -63,6 +63,8 @@ Add the following settings in ``airflow.cfg``:
     If set to True, Webserver reads from DB instead of parsing DAG files
 *   ``min_serialized_dag_update_interval``: This flag sets the minimum interval (in seconds) after which
     the serialized DAG in DB should be updated. This helps in reducing database write rate.
+*   ``store_dag_code``: This flag decides whether to persist DAG files code in DB.
+    If set to True, Webserver reads file contents from DB instead of trying to access files in a DAG folder.
 
 If you are updating Airflow from <1.10.7, please do not forget to run ``airflow db upgrade``.
 

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -1,0 +1,104 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+
+from mock import patch
+
+from airflow import AirflowException, example_dags as example_dags_module
+from airflow.models import DagBag
+from airflow.models.dagcode import DagCode
+# To move it to a shared module.
+from airflow.utils.file import open_maybe_zipped
+from airflow.utils.session import create_session
+from tests.test_utils.db import clear_db_dag_code
+
+
+def make_example_dags(module):
+    """Loads DAGs from a module for test."""
+    dagbag = DagBag(module.__path__[0])
+    return dagbag.dags
+
+
+class TestDagCode(unittest.TestCase):
+    """Unit tests for DagCode."""
+
+    def setUp(self):
+        clear_db_dag_code()
+
+    def tearDown(self):
+        clear_db_dag_code()
+
+    def _write_example_dags(self):
+        example_dags = make_example_dags(example_dags_module)
+        for dag in example_dags.values():
+            DagCode(dag.fileloc).sync_to_db()
+        return example_dags
+
+    def test_sync_to_db(self):
+        """Dg code can be written into database."""
+        example_dags = self._write_example_dags()
+
+        self._compare_example_dags(example_dags)
+
+    def test_bulk_sync_to_db(self):
+        """Dg code can be bulk written into database."""
+        example_dags = make_example_dags(example_dags_module)
+        files = [dag.fileloc for dag in example_dags.values()]
+        with create_session() as session:
+            DagCode.bulk_sync_to_db(files, session=session)
+            session.commit()
+
+        self._compare_example_dags(example_dags)
+
+    def test_bulk_sync_to_db_half_files(self):
+        """Dg code can be bulk written into database."""
+        example_dags = make_example_dags(example_dags_module)
+        files = [dag.fileloc for dag in example_dags.values()]
+        half_files = files[:int(len(files) / 2)]
+        with create_session() as session:
+            DagCode.bulk_sync_to_db(half_files, session=session)
+            session.commit()
+        with create_session() as session:
+            DagCode.bulk_sync_to_db(files, session=session)
+            session.commit()
+
+        self._compare_example_dags(example_dags)
+
+    @patch.object(DagCode, 'dag_fileloc_hash')
+    def test_detecting_duplicate_key(self, mock_hash):
+        """Dag code detects duplicate key."""
+        mock_hash.return_value = 0
+
+        with self.assertRaises(AirflowException):
+            self._write_example_dags()
+
+    def _compare_example_dags(self, example_dags):
+        with create_session() as session:
+            for dag in example_dags.values():
+                self.assertTrue(DagCode.has_dag(dag.fileloc))
+                dag_fileloc_hash = DagCode.dag_fileloc_hash(dag.fileloc)
+                result = session.query(
+                    DagCode.fileloc, DagCode.fileloc_hash, DagCode.source_code) \
+                    .filter(DagCode.fileloc == dag.fileloc) \
+                    .filter(DagCode.fileloc_hash == dag_fileloc_hash) \
+                    .one()
+
+                self.assertEqual(result.fileloc, dag.fileloc)
+                with open_maybe_zipped(dag.fileloc, 'r') as source:
+                    source_code = source.read()
+                self.assertEqual(result.source_code, source_code)

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -43,6 +43,14 @@ class TestDagCode(unittest.TestCase):
     def tearDown(self):
         clear_db_dag_code()
 
+    def _write_two_example_dags(self):
+        example_dags = make_example_dags(example_dags_module)
+        bash_dag = example_dags['example_bash_operator']
+        DagCode(bash_dag.fileloc).sync_to_db()
+        xcom_dag = example_dags['example_xcom']
+        DagCode(xcom_dag.fileloc).sync_to_db()
+        return [bash_dag, xcom_dag]
+
     def _write_example_dags(self):
         example_dags = make_example_dags(example_dags_module)
         for dag in example_dags.values():
@@ -85,7 +93,7 @@ class TestDagCode(unittest.TestCase):
         mock_hash.return_value = 0
 
         with self.assertRaises(AirflowException):
-            self._write_example_dags()
+            self._write_two_example_dags()
 
     def _compare_example_dags(self, example_dags):
         with create_session() as session:

--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -22,6 +22,7 @@ import unittest
 
 from airflow import example_dags as example_dags_module
 from airflow.models import DagBag
+from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel as SDM
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.utils.session import create_session
@@ -50,7 +51,8 @@ class SerializedDagModelTest(unittest.TestCase):
 
     def test_dag_fileloc_hash(self):
         """Verifies the correctness of hashing file path."""
-        self.assertTrue(SDM.dag_fileloc_hash('/airflow/dags/test_dag.py') == 60791)
+        self.assertEqual(DagCode.dag_fileloc_hash('/airflow/dags/test_dag.py'),
+                         33826252060516589)
 
     def _write_example_dags(self):
         example_dags = make_example_dags(example_dags_module)

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -18,6 +18,7 @@
 from airflow.models import (
     Connection, DagModel, DagRun, DagTag, Pool, RenderedTaskInstanceFields, SlaMiss, TaskInstance, errors,
 )
+from airflow.models.dagcode import DagCode
 from airflow.utils.db import add_default_pool_if_not_exists, create_default_connections
 from airflow.utils.session import create_session
 
@@ -54,6 +55,11 @@ def clear_db_connections():
     with create_session() as session:
         session.query(Connection).delete()
         create_default_connections(session)
+
+
+def clear_db_dag_code():
+    with create_session() as session:
+        session.query(DagCode).delete()
 
 
 def set_default_pool_slots(slots):

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -34,7 +34,7 @@ from airflow.utils import timezone
 from airflow.utils.dag_processing import (
     DagFileProcessorAgent, DagFileProcessorManager, DagFileStat, FailureCallbackRequest,
 )
-from airflow.utils.file import correct_maybe_zipped
+from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.test_utils.config import conf_vars
@@ -484,3 +484,33 @@ class TestCorrectMaybeZipped(unittest.TestCase):
         self.assertEqual('/path/to/archive.zip', args[0])
 
         self.assertEqual(dag_folder, '/path/to/archive.zip')
+
+
+class TestOpenMaybeZipped(unittest.TestCase):
+    def test_open_maybe_zipped_normal_file(self):
+        with mock.patch(
+            'io.open', mock.mock_open(read_data="data")
+        ) as mock_file:
+            open_maybe_zipped('/path/to/some/file.txt')
+            mock_file.assert_called_once_with('/path/to/some/file.txt', mode='r')
+
+    def test_open_maybe_zipped_normal_file_with_zip_in_name(self):
+        path = '/path/to/fakearchive.zip.other/file.txt'
+        with mock.patch(
+            'io.open', mock.mock_open(read_data="data")
+        ) as mock_file:
+            open_maybe_zipped(path)
+            mock_file.assert_called_once_with(path, mode='r')
+
+    @mock.patch("zipfile.is_zipfile")
+    @mock.patch("zipfile.ZipFile")
+    def test_open_maybe_zipped_archive(self, mocked_zip_file, mocked_is_zipfile):
+        mocked_is_zipfile.return_value = True
+        instance = mocked_zip_file.return_value
+        instance.open.return_value = mock.mock_open(read_data="data")
+
+        open_maybe_zipped('/path/to/archive.zip/deep/path/to/file.txt')
+
+        mocked_is_zipfile.assert_called_once_with('/path/to/archive.zip')
+        mocked_zip_file.assert_called_once_with('/path/to/archive.zip', mode='r')
+        instance.open.assert_called_once_with('deep/path/to/file.txt')

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -29,11 +29,11 @@ from tests.test_utils.config import conf_vars
 
 
 @parameterized_class([
-    {"dag_serialzation": "False"},
-    {"dag_serialzation": "True"},
+    {"dag_serialization": "False"},
+    {"dag_serialization": "True"},
 ])
 class TestDagRunsEndpoint(unittest.TestCase):
-    dag_serialzation = "False"
+    dag_serialization = "False"
 
     @classmethod
     def setUpClass(cls):
@@ -61,7 +61,7 @@ class TestDagRunsEndpoint(unittest.TestCase):
 
     def test_get_dag_runs_success(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs'
             dag_id = 'example_bash_operator'
@@ -80,7 +80,7 @@ class TestDagRunsEndpoint(unittest.TestCase):
 
     def test_get_dag_runs_success_with_state_parameter(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs?state=running'
             dag_id = 'example_bash_operator'
@@ -99,7 +99,7 @@ class TestDagRunsEndpoint(unittest.TestCase):
 
     def test_get_dag_runs_success_with_capital_state_parameter(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs?state=RUNNING'
             dag_id = 'example_bash_operator'
@@ -118,7 +118,7 @@ class TestDagRunsEndpoint(unittest.TestCase):
 
     def test_get_dag_runs_success_with_state_no_result(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs?state=dummy'
             dag_id = 'example_bash_operator'
@@ -134,7 +134,7 @@ class TestDagRunsEndpoint(unittest.TestCase):
 
     def test_get_dag_runs_invalid_dag_id(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs'
             dag_id = 'DUMMY_DAG'
@@ -147,7 +147,7 @@ class TestDagRunsEndpoint(unittest.TestCase):
 
     def test_get_dag_runs_no_runs(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs'
             dag_id = 'example_bash_operator'

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -53,11 +53,11 @@ class TestBase(unittest.TestCase):
 
 
 @parameterized_class([
-    {"dag_serialzation": "False"},
-    {"dag_serialzation": "True"},
+    {"dag_serialization": "False"},
+    {"dag_serialization": "True"},
 ])
 class TestApiExperimental(TestBase):
-    dag_serialzation = "False"
+    dag_serialization = "False"
 
     @classmethod
     def setUpClass(cls):
@@ -91,7 +91,7 @@ class TestApiExperimental(TestBase):
 
     def test_task_info(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/tasks/{}'
 
@@ -116,7 +116,7 @@ class TestApiExperimental(TestBase):
 
     def test_get_dag_code(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/code'
 
@@ -133,7 +133,7 @@ class TestApiExperimental(TestBase):
 
     def test_task_paused(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/paused/{}'
 
@@ -153,7 +153,7 @@ class TestApiExperimental(TestBase):
 
     def test_trigger_dag(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs'
             run_id = 'my_run' + utcnow().isoformat()
@@ -187,7 +187,7 @@ class TestApiExperimental(TestBase):
 
     def test_trigger_dag_for_date(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs'
             dag_id = 'example_bash_operator'
@@ -246,7 +246,7 @@ class TestApiExperimental(TestBase):
 
     def test_task_instance_info(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs/{}/tasks/{}'
             dag_id = 'example_bash_operator'
@@ -301,7 +301,7 @@ class TestApiExperimental(TestBase):
 
     def test_dagrun_status(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/dags/{}/dag_runs/{}'
             dag_id = 'example_bash_operator'
@@ -347,12 +347,12 @@ class TestApiExperimental(TestBase):
 
 
 @parameterized_class([
-    {"dag_serialzation": "False"},
-    {"dag_serialzation": "True"},
+    {"dag_serialization": "False"},
+    {"dag_serialization": "True"},
 ])
 class TestLineageApiExperimental(TestBase):
     PAPERMILL_EXAMPLE_DAGS = os.path.join(ROOT_FOLDER, "airflow", "providers", "papermill", "example_dags")
-    dag_serialzation = "False"
+    dag_serialization = "False"
 
     @classmethod
     def setUpClass(cls):
@@ -371,7 +371,7 @@ class TestLineageApiExperimental(TestBase):
     @mock.patch("airflow.settings.DAGS_FOLDER", PAPERMILL_EXAMPLE_DAGS)
     def test_lineage_info(self):
         with conf_vars(
-            {("core", "store_serialized_dags"): self.dag_serialzation}
+            {("core", "store_serialized_dags"): self.dag_serialization}
         ):
             url_template = '/api/experimental/lineage/{}/{}'
             dag_id = 'example_papermill_operator'

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -18,7 +18,6 @@
 
 import unittest
 from datetime import datetime
-from unittest import mock
 from urllib.parse import parse_qs
 
 from bs4 import BeautifulSoup
@@ -155,32 +154,6 @@ class TestUtils(unittest.TestCase):
     def test_params_escape(self):
         self.assertEqual('search=%27%3E%22%2F%3E%3Cimg+src%3Dx+onerror%3Dalert%281%29%3E',
                          utils.get_params(search="'>\"/><img src=x onerror=alert(1)>"))
-
-    def test_open_maybe_zipped_normal_file(self):
-        with mock.patch(
-                'io.open', mock.mock_open(read_data="data")) as mock_file:
-            utils.open_maybe_zipped('/path/to/some/file.txt')
-            mock_file.assert_called_once_with('/path/to/some/file.txt', mode='r')
-
-    def test_open_maybe_zipped_normal_file_with_zip_in_name(self):
-        path = '/path/to/fakearchive.zip.other/file.txt'
-        with mock.patch(
-                'io.open', mock.mock_open(read_data="data")) as mock_file:
-            utils.open_maybe_zipped(path)
-            mock_file.assert_called_once_with(path, mode='r')
-
-    @mock.patch("zipfile.is_zipfile")
-    @mock.patch("zipfile.ZipFile")
-    def test_open_maybe_zipped_archive(self, mocked_zip_file, mocked_is_zipfile):
-        mocked_is_zipfile.return_value = True
-        instance = mocked_zip_file.return_value
-        instance.open.return_value = mock.mock_open(read_data="data")
-
-        utils.open_maybe_zipped('/path/to/archive.zip/deep/path/to/file.txt')
-
-        mocked_is_zipfile.assert_called_once_with('/path/to/archive.zip')
-        mocked_zip_file.assert_called_once_with('/path/to/archive.zip', mode='r')
-        instance.open.assert_called_once_with('deep/path/to/file.txt')
 
     def test_state_token(self):
         # It's shouldn't possible to set these odd values anymore, but lets


### PR DESCRIPTION
Store DAG's source code in the dag_code table

The web server no longer needs an access to the dags folder in the shared file system.
DAG's code can be shown from dag_code table.
Enabled only if store_dag_code flag is set to true.

https://issues.apache.org/jira/browse/AIRFLOW-5946

