### PR TITLE
[AIRFLOW-6530] Add Custom Statsd Client

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -387,7 +387,7 @@ smtp_mail_from = airflow@example.com
 
 [sentry]
 # Sentry (https://docs.sentry.io) integration
-sentry_dsn = 
+sentry_dsn =
 
 
 [celery]
@@ -572,6 +572,11 @@ statsd_prefix = airflow
 # you can configure an allow list of prefixes to send only the metrics that
 # start with the elements of the list (e.g: scheduler,executor,dagrun)
 statsd_allow_list =
+
+# If you want to utilise your own custom Statsd client set the relevant module
+# path below
+# Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
+statsd_custom_client_path =
 
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run.

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -49,6 +49,15 @@ the metrics that start with the elements of the list:
     [scheduler]
     statsd_allow_list = scheduler,executor,dagrun
 
+If you want to use a custom Statsd client outwith the default one provided by Airflow the following key must be added
+to the configuration file alongside the module path of your custom Statsd client. This module must be available on
+your PYTHONPATH.
+
+.. code-block:: ini
+
+    [scheduler]
+    statsd_custom_client_path = x.y.customclient
+
 Counters
 --------
 


### PR DESCRIPTION
This change allows Airflow users to utilise their own custom Statsd client as discussed [here](https://issues.apache.org/jira/browse/AIRFLOW-6530).

Many companies have their own custom Statsd clients and this change should allow for easier adoption of Airflow by large corporations.

Example usage based off of this change:

1) User adds a module path to their airflow.cfg file next to the 'statsd_custom_client_path' key in the scheduler section of the config.

As such:
`statsd_custom_client_path = company.statsdclient.customclient`

2) Ensure the newly added client exists on the PYTHONPATH.

---
Issue link: [AIRFLOW-6530](https://issues.apache.org/jira/browse/AIRFLOW-6530)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
