### PR TITLE
[AIRFLOW-XXXX] Update installation doc to suggest installing globally as fallback

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,9 +36,9 @@ You can also install Airflow with support for extra features like ``gcp`` or ``p
     pip install 'apache-airflow[postgres,gcp]'
 
 Airflow require that your operating system has ``libffi-dev`` installed.
-    
-If the ``airflow`` command is not getting recognized, then ensure that ``~/.local/bin`` is in your
-``PATH`` environment variable, and add it in if necessary:
+
+If the ``airflow`` command is not getting recognized (can happen on Windows when using WSL), then 
+ensure that ``~/.local/bin`` is in your ``PATH`` environment variable, and add it in if necessary:
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,7 +37,7 @@ You can also install Airflow with support for extra features like ``gcp`` or ``p
 
 Airflow require that your operating system has ``libffi-dev`` installed.
 
-If the ``airflow`` command is not getting recognized (can happen on Windows when using WSL), then 
+If the ``airflow`` command is not getting recognized (can happen on Windows when using WSL), then
 ensure that ``~/.local/bin`` is in your ``PATH`` environment variable, and add it in if necessary:
 
 .. code-block:: bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,8 +37,8 @@ You can also install Airflow with support for extra features like ``gcp`` or ``p
 
 Airflow require that your operating system has ``libffi-dev`` installed.
     
-If the ``airflow`` command is not getting recognized, then ensure that `~/.local/bin` is in your
-`PATH` environment variable, and add it in if necessary:
+If the ``airflow`` command is not getting recognized, then ensure that ``~/.local/bin`` is in your
+``PATH`` environment variable, and add it in if necessary:
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,6 +36,13 @@ You can also install Airflow with support for extra features like ``gcp`` or ``p
     pip install 'apache-airflow[postgres,gcp]'
 
 Airflow require that your operating system has ``libffi-dev`` installed.
+    
+If the `airflow` command is not getting recognized, then ensure that `~/.local/bin` is in your
+`PATH` environment variable, and add it in if necessary:
+
+.. code-block:: bash
+
+    PATH=$PATH:~/.local/bin
 
 Extra Packages
 ''''''''''''''

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,7 +37,7 @@ You can also install Airflow with support for extra features like ``gcp`` or ``p
 
 Airflow require that your operating system has ``libffi-dev`` installed.
     
-If the `airflow` command is not getting recognized, then ensure that `~/.local/bin` is in your
+If the ``airflow`` command is not getting recognized, then ensure that `~/.local/bin` is in your
 `PATH` environment variable, and add it in if necessary:
 
 .. code-block:: bash


### PR DESCRIPTION
I was having an installation issue on Windows Subsystem for Linux (Ubuntu) where the `airflow` command was not being recognized. I was able to fix this by installing apache-airflow globally with the following command `sudo -H pip install apache-airflow`. Had this been written in the docs, I would've saved myself a lot of wasted time searching Google and StackOverflow for the solution, so I wrote it in the doc as a fallback suggestion.

https://stackoverflow.com/questions/32378494/how-to-run-airflow-on-windows/59828890#59828890

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
