### PR TITLE
[AIRFLOW-6530] Allow Custom Statsd Client

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1406,7 +1406,6 @@
         If you want to utilise your own custom Statsd client set the relevant
         module path below.
         Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
-        for Airflow to pick it up
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1404,7 +1404,7 @@
     - name: statsd_custom_client_path
       description: |
         If you want to utilise your own custom Statsd client set the relevant
-        module path below. 
+        module path below.
         Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
         for Airflow to pick it up
       version_added: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1401,6 +1401,15 @@
       type: string
       example: ~
       default: ""
+    - name: statsd_custom_client_path
+      description: |
+        If you want to utilise your own custom Statsd client set the relevant
+        module path below. Note: The module path must exist on your PYTHONPATH
+        for Airflow to pick it up
+      version_added: ~
+      type: string
+      example: ~
+      default: ""
     - name: max_threads
       description: |
         The scheduler can run multiple threads in parallel to schedule dags.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1404,12 +1404,13 @@
     - name: statsd_custom_client_path
       description: |
         If you want to utilise your own custom Statsd client set the relevant
-        module path below. Note: The module path must exist on your PYTHONPATH
+        module path below. 
+        Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
         for Airflow to pick it up
       version_added: ~
       type: string
       example: ~
-      default: ""
+      default: ~
     - name: max_threads
       description: |
         The scheduler can run multiple threads in parallel to schedule dags.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -677,7 +677,7 @@ statsd_datadog_tags =
 # If you want to utilise your own custom Statsd client set the relevant module
 # path below
 # Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
-statsd_custom_client_path =
+# statsd_custom_client_path =
 
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -677,7 +677,6 @@ statsd_datadog_tags =
 # If you want to utilise your own custom Statsd client set the relevant
 # module path below.
 # Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
-# for Airflow to pick it up
 # statsd_custom_client_path =
 
 # The scheduler can run multiple threads in parallel to schedule dags.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -674,9 +674,10 @@ statsd_datadog_enabled = False
 # List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
 statsd_datadog_tags =
 
-# If you want to utilise your own custom Statsd client set the relevant module
-# path below
+# If you want to utilise your own custom Statsd client set the relevant
+# module path below.
 # Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
+# for Airflow to pick it up
 # statsd_custom_client_path =
 
 # The scheduler can run multiple threads in parallel to schedule dags.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -674,6 +674,11 @@ statsd_datadog_enabled = False
 # List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
 statsd_datadog_tags =
 
+# If you want to utilise your own custom Statsd client set the relevant module
+# path below
+# Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
+statsd_custom_client_path =
+
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run.
 max_threads = 2

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -200,6 +200,7 @@ class _Stats(type):
                     self.__class__.instance = DummyStatsLogger()
             except (socket.gaierror, ImportError) as e:
                 log.warning("Could not configure StatsClient: %s, using DummyStatsLogger instead.", e)
+                self.__class__.instance = DummyStatsLogger()
 
     def get_statsd_logger(self):
         if conf.getboolean('scheduler', 'statsd_on'):
@@ -217,6 +218,9 @@ class _Stats(type):
                         raise Exception(
                             """Your custom Statsd client must extend the statsd.StatsClient in order to ensure backwards
                             compatibility.""")
+                    else:
+                        log.info("Successfully loaded custom Statsd client "
+                                 f"from {custom_statsd_module_path}")
 
                 except Exception as err:
                     raise ImportError('Unable to load custom Statsd client from '

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -204,16 +204,13 @@ class _Stats(type):
 
     def get_statsd_logger(self):
         if conf.getboolean('scheduler', 'statsd_on'):
-
             from statsd import StatsClient
 
             if conf.has_option('scheduler', 'statsd_custom_client_path'):
-
                 custom_statsd_module_path = conf.get('scheduler', 'statsd_custom_client_path')
 
                 try:
                     stats_class = import_string(custom_statsd_module_path)
-
                     if not issubclass(stats_class, StatsClient):
                         raise Exception(
                             """Your custom Statsd client must extend the statsd.StatsClient in order to ensure backwards

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -202,8 +202,29 @@ class _Stats(type):
                 log.warning("Could not configure StatsClient: %s, using DummyStatsLogger instead.", e)
 
     def get_statsd_logger(self):
-        from statsd import StatsClient
-        statsd = StatsClient(
+        if conf.getboolean('scheduler', 'statsd_on'):
+
+            from statsd import StatsClient
+
+            if conf.has_option('scheduler', 'statsd_custom_client_path'):
+
+                custom_statsd_module_path = conf.get('scheduler', 'statsd_custom_client_path')
+
+                try:
+                    stats_class = import_string(custom_statsd_module_path)
+
+                    if not issubclass(stats_class, StatsClient):
+                        raise Exception(
+                            """Your custom Statsd client must extend the statsd.StatsClient in order to ensure backwards
+                            compatibility.""")
+
+                except Exception as err:
+                    raise ImportError('Unable to load custom Statsd client from '
+                                      f'{custom_statsd_module_path} due to {err}')
+            else:
+                stats_class = StatsClient
+
+        statsd = stats_class(
             host=conf.get('scheduler', 'statsd_host'),
             port=conf.getint('scheduler', 'statsd_port'),
             prefix=conf.get('scheduler', 'statsd_prefix'))

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -58,6 +58,14 @@ to the stat name if necessary and return the transformed stat name. The function
     def my_custom_stat_name_handler(stat_name: str) -> str:
         return stat_name.lower()[:32]
 
+If you want to use a custom Statsd client outwith the default one provided by Airflow the following key must be added
+to the configuration file alongside the module path of your custom Statsd client. This module must be available on
+your PYTHONPATH.
+
+.. code-block:: ini
+
+    [scheduler]
+    statsd_custom_client_path = x.y.customclient
 
 Counters
 --------


### PR DESCRIPTION
This change allows Airflow users to utilise their own custom Statsd client as discussed [here](https://issues.apache.org/jira/browse/AIRFLOW-6530).

Many companies have their own custom Statsd clients and this change should allow for easier adoption of Airflow by large corporations.

Example usage based off of this change:

1) User adds a module path to their airflow.cfg file next to the 'statsd_custom_client_path' key in the scheduler section of the config.

As such:
`statsd_custom_client_path = company.statsdclient.customclient`

2) Ensure the newly added client exists on the PYTHONPATH.

---
Issue link: [AIRFLOW-6530](https://issues.apache.org/jira/browse/AIRFLOW-6530)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
