### PR TITLE
[AIRFLOW-6608] Change logging level for PythonOperator Env exports

### DIFF
--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -96,10 +96,9 @@ class BashOperator(BaseOperator):
             env = os.environ.copy()
 
         airflow_context_vars = context_to_airflow_vars(context, in_env_var_format=True)
-        self.log.info('Exporting the following env vars:\n%s',
-                      '\n'.join(["{}={}".format(k, v)
-                                 for k, v in
-                                 airflow_context_vars.items()]))
+        self.log.debug('Exporting the following env vars:\n%s',
+                       '\n'.join(["{}={}".format(k, v)
+                                  for k, v in airflow_context_vars.items()]))
         env.update(airflow_context_vars)
 
         self.lineage_data = self.bash_command


### PR DESCRIPTION
The following logs just create noise and add nothing for the end-users. 

We should change this to DEBUG

```
[2020-01-20 17:58:27,364] {python_operator.py:105} INFO - Exporting the following env vars:
AIRFLOW_CTX_DAG_EMAIL=aaaaaaaa@mail.com
AIRFLOW_CTX_DAG_OWNER=me
AIRFLOW_CTX_DAG_ID=my_dag_id
AIRFLOW_CTX_TASK_ID=my_task_id
AIRFLOW_CTX_EXECUTION_DATE=2020-01-20T12:27:48.408593+00:00
AIRFLOW_CTX_DAG_RUN_ID=manual__2020-01-20T12:27:48.408593+00:00
```

---
Issue link: [AIRFLOW-6608](https://issues.apache.org/jira/browse/AIRFLOW-6608)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
