### PR TITLE
[AIRFLOW-6569] Flush pending Sentry exceptions before exiting forked process

### DIFF
--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -51,6 +51,11 @@ class DummySentry:
         """
         return run
 
+    def flush(self):
+        """
+        Blank function for flushing errors.
+        """
+
 
 class ConfiguredSentry(DummySentry):
     """
@@ -145,6 +150,10 @@ class ConfiguredSentry(DummySentry):
                     raise
 
         return wrapper
+
+    def flush(self):
+        import sentry_sdk
+        sentry_sdk.flush()
 
 
 Sentry = DummySentry()  # type: DummySentry


### PR DESCRIPTION
After switching to `os.fork()` for the task runner, there is the possibility that exceptions queued by Sentry will not be emitted prior to the process exiting.

This fixes AIRFLOW-6569 by explicitly flushing pending exceptions prior to calling `os._exit()` within the forked task runner.

This is covered by existing unit tests within `tests/task/task_runner/test_standard_task_runner.py`.

---
Issue link: [AIRFLOW-6569](https://issues.apache.org/jira/browse/AIRFLOW-6569)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
