### PR TITLE
[AIRFLOW-6493] Add SSL configuration to Redis hook connections

### DIFF
--- a/airflow/providers/redis/hooks/redis.py
+++ b/airflow/providers/redis/hooks/redis.py
@@ -29,6 +29,10 @@ from airflow.hooks.base_hook import BaseHook
 class RedisHook(BaseHook):
     """
     Wrapper for connection to interact with Redis in-memory data structure store
+
+    You can set your db in the extra field of your connection as ``{"db": 3}``.
+    Also you can set ssl parameters as:
+    ``{"ssl": true, "ssl_cert_reqs": "require", "ssl_cert_file": "/path/to/cert.pem", etc}``.
     """
     def __init__(self, redis_conn_id='redis_default'):
         """
@@ -54,6 +58,11 @@ class RedisHook(BaseHook):
         self.password = None if str(conn.password).lower() in ['none', 'false', ''] else conn.password
         self.db = conn.extra_dejson.get('db', None)
 
+        # check for ssl parameters in conn.extra
+        ssl_arg_names = ["ssl", "ssl_cert_reqs", "ssl_ca_certs", "ssl_keyfile", "ssl_cert_file",
+                         "ssl_check_hostname"]
+        ssl_args = {name: val for name, val in conn.extra_dejson.items() if name in ssl_arg_names}
+
         if not self.redis:
             self.log.debug(
                 'Initializing redis object for conn_id "%s" on %s:%s:%s',
@@ -63,6 +72,7 @@ class RedisHook(BaseHook):
                 host=self.host,
                 port=self.port,
                 password=self.password,
-                db=self.db)
+                db=self.db,
+                **ssl_args)
 
         return self.redis

--- a/tests/providers/redis/hooks/test_redis.py
+++ b/tests/providers/redis/hooks/test_redis.py
@@ -19,9 +19,11 @@
 
 
 import unittest
+from unittest import mock
 
 import pytest
 
+from airflow.models import Connection
 from airflow.providers.redis.hooks.redis import RedisHook
 
 
@@ -35,6 +37,40 @@ class TestRedisHook(unittest.TestCase):
         self.assertEqual(hook.password, None, 'password initialised as None.')
         self.assertEqual(hook.db, None, 'db initialised as None.')
         self.assertIs(hook.get_conn(), hook.get_conn(), 'Connection initialized only if None.')
+
+    @mock.patch('airflow.providers.redis.hooks.redis.Redis')
+    @mock.patch('airflow.providers.redis.hooks.redis.RedisHook.get_connection',
+                return_value=Connection(
+                    password='password',
+                    host='remote_host',
+                    port=1234,
+                    extra="""{
+                        "db": 2,
+                        "ssl": true,
+                        "ssl_cert_reqs": "required",
+                        "ssl_ca_certs": "/path/to/custom/ca-cert",
+                        "ssl_keyfile": "/path/to/key-file",
+                        "ssl_cert_file": "/path/to/cert-file",
+                        "ssl_check_hostname": true
+                    }"""
+                ))
+    def test_get_conn_with_extra_config(self, mock_get_connection, mock_redis):
+        connection = mock_get_connection.return_value
+        hook = RedisHook()
+
+        hook.get_conn()
+        mock_redis.assert_called_once_with(
+            host=connection.host,
+            password=connection.password,
+            port=connection.port,
+            db=connection.extra_dejson["db"],
+            ssl=connection.extra_dejson["ssl"],
+            ssl_cert_reqs=connection.extra_dejson["ssl_cert_reqs"],
+            ssl_ca_certs=connection.extra_dejson["ssl_ca_certs"],
+            ssl_keyfile=connection.extra_dejson["ssl_keyfile"],
+            ssl_cert_file=connection.extra_dejson["ssl_cert_file"],
+            ssl_check_hostname=connection.extra_dejson["ssl_check_hostname"]
+        )
 
     def test_get_conn_password_stays_none(self):
         hook = RedisHook(redis_conn_id='redis_default')


### PR DESCRIPTION
`redis-py` has support for TLS/SSL connections. This change allows SSL parameters for Redis to be configurable through the connection's extras field.

---
Issue link: [AIRFLOW-6493](https://issues.apache.org/jira/browse/AIRFLOW-6493)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
