### PR TITLE
[AIRFLOW-6615] Remove double sorted in task_list CLI

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -234,7 +234,7 @@ def task_list(args, dag=None):
         dag.tree_view()
     else:
         tasks = sorted([t.task_id for t in dag.tasks])
-        print("\n".join(sorted(tasks)))
+        print("\n".join(tasks))
 
 
 SUPPORTED_DEBUGGER_MODULES: List[str] = [


### PR DESCRIPTION
 Remove double sorted in task_list CLI

---
Issue link: [AIRFLOW-6615](https://issues.apache.org/jira/browse/AIRFLOW-6615)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
