### PR TITLE
[AIRFLOW-6619] Add cluster_fields to BigQueryCreateEmptyTableOperator

### DIFF
--- a/airflow/gcp/hooks/bigquery.py
+++ b/airflow/gcp/hooks/bigquery.py
@@ -167,7 +167,7 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
                            table_id: str,
                            schema_fields: Optional[List] = None,
                            time_partitioning: Optional[Dict] = None,
-                           cluster_fields: Optional[List] = None,
+                           cluster_fields: Optional[List[str]] = None,
                            labels: Optional[Dict] = None,
                            view: Optional[Dict] = None,
                            encryption_configuration: Optional[Dict] = None,

--- a/airflow/gcp/operators/bigquery.py
+++ b/airflow/gcp/operators/bigquery.py
@@ -637,10 +637,10 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         .. seealso::
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timePartitioning
     :type time_partitioning: dict
-    :param bigquery_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform and
+    :param bigquery_conn_id: [Optional] The connection ID used to connect to Google Cloud Platform and
         interact with the Bigquery service.
     :type bigquery_conn_id: str
-    :param google_cloud_storage_conn_id: (Optional) The connection ID used to connect to Google Cloud
+    :param google_cloud_storage_conn_id: [Optional] The connection ID used to connect to Google Cloud
         Platform and interact with the Google Cloud Storage service.
     :type google_cloud_storage_conn_id: str
     :param delegate_to: The account to impersonate, if any. For this to
@@ -691,7 +691,9 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
     :type labels: dict
     :param view: [Optional] A dictionary containing definition for the view.
         If set, it will create a view instead of a table:
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ViewDefinition
+
+        .. seealso::
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ViewDefinition
     :type view: dict
     :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
         **Example**: ::
@@ -702,6 +704,13 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
     :type encryption_configuration: dict
     :param location: The location used for the operation.
     :type location: str
+    :param cluster_fields: [Optional] The fields used for clustering.
+            Must be specified with time_partitioning, data in the table will be first
+            partitioned and subsequently clustered.
+
+            .. seealso::
+                https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#clustering.fields
+    :type cluster_fields: list
     """
     template_fields = ('dataset_id', 'table_id', 'project_id',
                        'gcs_schema_object', 'labels', 'view')
@@ -723,6 +732,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                  view: Optional[Dict] = None,
                  encryption_configuration: Optional[Dict] = None,
                  location: Optional[str] = None,
+                 cluster_fields: Optional[List[str]] = None,
                  *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -739,6 +749,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         self.view = view
         self.encryption_configuration = encryption_configuration
         self.location = location
+        self.cluster_fields = cluster_fields
 
     def execute(self, context):
         bq_hook = BigQueryHook(gcp_conn_id=self.bigquery_conn_id,
@@ -767,6 +778,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                 table_id=self.table_id,
                 schema_fields=schema_fields,
                 time_partitioning=self.time_partitioning,
+                cluster_fields=self.cluster_fields,
                 labels=self.labels,
                 view=self.view,
                 encryption_configuration=self.encryption_configuration

--- a/tests/gcp/operators/test_bigquery.py
+++ b/tests/gcp/operators/test_bigquery.py
@@ -74,6 +74,7 @@ class TestBigQueryCreateEmptyTableOperator(unittest.TestCase):
                 table_id=TEST_TABLE_ID,
                 schema_fields=None,
                 time_partitioning={},
+                cluster_fields=None,
                 labels=None,
                 view=None,
                 encryption_configuration=None
@@ -96,8 +97,58 @@ class TestBigQueryCreateEmptyTableOperator(unittest.TestCase):
                 table_id=TEST_TABLE_ID,
                 schema_fields=None,
                 time_partitioning={},
+                cluster_fields=None,
                 labels=None,
                 view=VIEW_DEFINITION,
+                encryption_configuration=None
+            )
+
+    @mock.patch('airflow.gcp.operators.bigquery.BigQueryHook')
+    def test_create_clustered_empty_table(self, mock_hook):
+
+        schema_fields = [
+            {
+                "name": "emp_name",
+                "type": "STRING",
+                "mode": "REQUIRED"
+            },
+            {
+                "name": "date_hired",
+                "type": "DATE",
+                "mode": "REQUIRED"
+            },
+            {
+                "name": "date_birth",
+                "type": "DATE",
+                "mode": "NULLABLE"
+            }
+        ]
+        time_partitioning = {
+            "type": "DAY",
+            "field": "date_hired"
+        }
+        cluster_fields = ["date_birth"]
+        operator = BigQueryCreateEmptyTableOperator(task_id=TASK_ID,
+                                                    dataset_id=TEST_DATASET,
+                                                    project_id=TEST_GCP_PROJECT_ID,
+                                                    table_id=TEST_TABLE_ID,
+                                                    schema_fields=schema_fields,
+                                                    time_partitioning=time_partitioning,
+                                                    cluster_fields=cluster_fields
+                                                    )
+
+        operator.execute(None)
+        mock_hook.return_value \
+            .create_empty_table \
+            .assert_called_once_with(
+                dataset_id=TEST_DATASET,
+                project_id=TEST_GCP_PROJECT_ID,
+                table_id=TEST_TABLE_ID,
+                schema_fields=schema_fields,
+                time_partitioning=time_partitioning,
+                cluster_fields=cluster_fields,
+                labels=None,
+                view=None,
                 encryption_configuration=None
             )
 


### PR DESCRIPTION
This PR is adding cluster_fields to BigQueryCreateEmptyTableOperator that enables BigQuery table to have clustering enabled in new created table.

Contribution thanks to @pgodek @mmpyro @spietrzak

---
Issue link: [AIRFLOW-6619](https://issues.apache.org/jira/browse/AIRFLOW-6619)

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
