### PR TITLE
[AIRFLOW-6608] Change logging level for PythonOperator Env exports

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -130,9 +130,9 @@ class PythonOperator(BaseOperator):
     def execute(self, context: Dict):
         # Export context to make it available for callables to use.
         airflow_context_vars = context_to_airflow_vars(context, in_env_var_format=True)
-        self.log.info("Exporting the following env vars:\n%s",
-                      '\n'.join(["{}={}".format(k, v)
-                                 for k, v in airflow_context_vars.items()]))
+        self.log.debug("Exporting the following env vars:\n%s",
+                       '\n'.join(["{}={}".format(k, v)
+                                  for k, v in airflow_context_vars.items()]))
         os.environ.update(airflow_context_vars)
 
         context.update(self.op_kwargs)


### PR DESCRIPTION
While working on #7229 during resolving conflicts, I updated it for BashOperator instead of PythonOperator.

---
Issue link: [AIRFLOW-6608](https://issues.apache.org/jira/browse/AIRFLOW-6608)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
