### PR TITLE
[AIRFLOW-6627] Email with incorrect DAG not delivered

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1369,6 +1369,15 @@ class TaskInstance(Base, LoggingMixin):
             'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
         )
 
+        default_html_content_err = (
+            'Try {{try_number}} out of {{max_tries + 1}}<br>'
+            'Exception:<br>Failed attempt to attach error logs<br>'
+            'Log: <a href="{{ti.log_url}}">Link</a><br>'
+            'Host: {{ti.hostname}}<br>'
+            'Log file: {{ti.log_filepath}}<br>'
+            'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
+        )
+
         def render(key, content):
             if conf.has_option('email', key):
                 path = conf.get('email', key)
@@ -1379,7 +1388,12 @@ class TaskInstance(Base, LoggingMixin):
 
         subject = render('subject_template', default_subject)
         html_content = render('html_content_template', default_html_content)
-        send_email(self.task.email, subject, html_content)
+        html_content_err = render('html_content_template', default_html_content_err)
+        try:
+            send_email(self.task.email, subject, html_content)
+        except Exception as err:
+            send_email(self.task.email, subject, html_content_err)
+            self.log.info('err')
 
     def set_duration(self) -> None:
         if self.end_date and self.start_date:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1391,9 +1391,8 @@ class TaskInstance(Base, LoggingMixin):
         html_content_err = render('html_content_template', default_html_content_err)
         try:
             send_email(self.task.email, subject, html_content)
-        except Exception as err:
+        except Exception:
             send_email(self.task.email, subject, html_content_err)
-            self.log.info('err')
 
     def set_duration(self) -> None:
         if self.end_date and self.start_date:


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6627](https://issues.apache.org/jira/browse/AIRFLOW-6627)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change

In case of incorrect DAG execution, I did not receive a notification about the erroneous task completion. This was caused by an incorrect encode of the character

I introduced a lock that tries to send an email with an error, adding the exception that when the email fails, it sends information that the logs could not be thrown into the email.

- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>

Link: https://issues.apache.org/jira/browse/AIRFLOW-6627

- [X] Unit tests coverage for changes (not needed for documentation changes)

Not needed

- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.


