### PR TITLE
[AIRFLOW-6628] DAG auto-complete now suggests from all acessible DAGs

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -297,26 +297,26 @@
         });
       });
 
-      var $input = $(".typeahead");
-      unique_options_search = new Set([
-        {% for token in auto_complete_data %}"{{token}}", {% endfor %}
-      ]);
-
-      $input.typeahead({
-        source: [...unique_options_search],
+      $(".typeahead").typeahead({
+        source: function (query, callback) {
+          return $.ajax("{{ url_for('DagModelView.autocomplete') }}",
+            {
+              data: {
+                "query": encodeURIComponent(query),
+                "showPaused": "{{ not hide_paused }}"
+              },
+              success: callback
+            });
+        },
         autoSelect: false,
         afterSelect: function(value) {
-          search_query = value.trim()
+          var search_query = value.trim();
           if (search_query) {
             var query = new URLSearchParams(window.location.search);
-            query.set("search", search_query)
+            query.set("search", search_query);
             window.location = DAGS_INDEX + "?" + query;
           }
         }
-      });
-
-      $input.change(function() {
-        var current = $input.typeahead("getActive");
       });
 
       $('#dags').dataTable({

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -37,13 +37,13 @@ from flask import (
     Markup, Response, escape, flash, jsonify, make_response, redirect, render_template, request,
     session as flask_session, url_for,
 )
-from flask_appbuilder import BaseView, ModelView, expose, has_access
+from flask_appbuilder import BaseView, ModelView, expose, has_access, permission_name
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.filters import BaseFilter
 from flask_babel import lazy_gettext
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
-from sqlalchemy import and_, desc, or_, union_all
+from sqlalchemy import and_, desc, func, or_, union_all
 from sqlalchemy.orm import joinedload
 from wtforms import SelectField, validators
 
@@ -306,11 +306,6 @@ class Airflow(AirflowBaseView):
         num_of_all_dags = dags_query.count()
         num_of_pages = int(math.ceil(num_of_all_dags / float(dags_per_page)))
 
-        auto_complete_data = set()
-        for row in dags_query.with_entities(DagModel.dag_id, DagModel.owners):
-            auto_complete_data.add(row.dag_id)
-            auto_complete_data.add(row.owners)
-
         return self.render_template(
             'airflow/dags.html',
             dags=dags,
@@ -325,7 +320,6 @@ class Airflow(AirflowBaseView):
             paging=wwwutils.generate_pages(current_page, num_of_pages,
                                            search=escape(arg_search_query) if arg_search_query else None,
                                            showPaused=not hide_paused),
-            auto_complete_data=auto_complete_data,
             num_runs=num_runs,
             tags=tags)
 
@@ -2720,3 +2714,36 @@ class DagModelView(AirflowModelView):
             .filter(models.DagModel.is_active)
             .filter(~models.DagModel.is_subdag)
         )
+
+    @has_access
+    @permission_name("list")
+    @provide_session
+    @expose('/autocomplete')
+    def autocomplete(self, session=None):
+        query = unquote(request.args.get('query', ''))
+
+        if not query:
+            wwwutils.json_response([])
+
+        # Provide suggestions of dag_ids and owners
+        dag_ids_query = session.query(DagModel.dag_id.label('item')).filter(
+            ~DagModel.is_subdag, DagModel.is_active,
+            DagModel.dag_id.ilike('%' + query + '%'))
+
+        owners_query = session.query(func.distinct(DagModel.owners).label('item')).filter(
+            ~DagModel.is_subdag, DagModel.is_active,
+            DagModel.owners.ilike('%' + query + '%'))
+
+        # Hide paused dags
+        if request.args.get('showPaused', 'True').lower() == 'false':
+            dag_ids_query = dag_ids_query.filter(~DagModel.is_paused)
+            owners_query = owners_query.filter(~DagModel.is_paused)
+
+        filter_dag_ids = appbuilder.sm.get_accessible_dag_ids()
+        if 'all_dags' not in filter_dag_ids:
+            dag_ids_query = dag_ids_query.filter(DagModel.dag_id.in_(filter_dag_ids))
+            owners_query = owners_query.filter(DagModel.dag_id.in_(filter_dag_ids))
+
+        payload = [row[0] for row in dag_ids_query.union(owners_query).limit(10).all()]
+
+        return wwwutils.json_response(payload)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1421,6 +1421,15 @@ class TestDagACLView(TestBase):
         self.check_content_in_response('example_subdag_operator', resp)
         self.check_content_in_response('example_bash_operator', resp)
 
+    def test_dag_autocomplete_success(self):
+        self.login(username='all_dag_user',
+                   password='all_dag_user')
+        resp = self.client.get(
+            'dagmodel/autocomplete?query=example_bash&showPaused=True',
+            follow_redirects=False)
+        self.check_content_in_response('example_bash_operator', resp)
+        self.check_content_not_in_response('example_subdag_operator', resp)
+
     def test_dag_stats_success(self):
         self.logout()
         self.login()


### PR DESCRIPTION
The auto complete on the dag search box utilises the page search context
which prevents auto completing dags which dont match the current query.

On the dags page with no search provided it executes a query that loads
every dag_id in the system to pass to the typeahead widget. On systems
with a lot of dags this makes the page large and slow.

Add a JSON endpoint to provide correct auto complete behaviour and
reduce page load time.

Issue link: [AIRFLOW-6628](https://issues.apache.org/jira/browse/AIRFLOW-6628)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).