### PR TITLE
[AIRFLOW-6634] Set PYTHONPATH in interactive Breeze

### DIFF
--- a/scripts/ci/in_container/entrypoint_ci.sh
+++ b/scripts/ci/in_container/entrypoint_ci.sh
@@ -209,6 +209,8 @@ if [[ "${ENABLE_KIND_CLUSTER}" == "true" ]]; then
     fi
 fi
 
+export PYTHONPATH=${AIRFLOW_SOURCES}
+
 set +u
 # If we do not want to run tests, we simply drop into bash
 if [[ "${RUN_TESTS}" == "false" ]]; then
@@ -255,8 +257,6 @@ if [[ -n ${RUNTIME} ]]; then
         "${MY_DIR}/deploy_airflow_to_kubernetes.sh"
     fi
 fi
-
-export PYTHONPATH=${AIRFLOW_SOURCES}
 
 ARGS=("${CI_ARGS[@]}" "${TEST_DIR}")
 "${MY_DIR}/run_ci_tests.sh" "${ARGS[@]}"


### PR DESCRIPTION
Breeze did not have PYTHONPATH set in the interactive Breeze
entry - which is different than in tests and makes it difficult
to run tests outside of the main directory.

---
Issue link: [AIRFLOW-6634](https://issues.apache.org/jira/browse/AIRFLOW-6634)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
