### PR TITLE
[AIRFLOW-XXXX] Fix url in new contributors message

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -147,28 +147,34 @@ labelPRBasedOnFilePath:
     - docs/dag-serialization.rst
 
 # Comment to be posted to welcome users when they open their first PR
-firstPRWelcomeComment: |
+firstPRWelcomeComment: >
   Congratulations on your first Pull Request and welcome to the Apache Airflow community!
   If you have any issues or are unsure about any anything please check our
   Contribution Guide (https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst)
 
   Here are some useful points:
+
   - Pay attention to the quality of your code (flake8, pylint and type annotations). Our [pre-commits](
   https://github.com/apache/airflow/blob/master/STATIC_CODE_CHECKS.rst#prerequisites-for-pre-commit-hooks)
   will help you with that.
+
   - In case of a new feature add useful documentation (in docstrings or in `docs/` directory).
-  Adding a new operator? Check this short [guide](https://github
-  .com/apache/airflow/blob/master/docs/howto/custom-operator.rst) Consider adding an example DAG that shows
-  how users should use it.
+  Adding a new operator? Check this short
+  [guide](https://github.com/apache/airflow/blob/master/docs/howto/custom-operator.rst)
+  Consider adding an example DAG that shows how users should use it.
+
   - Consider using [Breeze environment](https://github.com/apache/airflow/blob/master/BREEZE.rst) for testing
   locally, it’s a heavy docker but it ships with a working Airflow and a lot of integrations.
+
   - Be patient and persistent. It might take some time to get a review or get the final approval from
   Committers.
 
   Apache Airflow is a community-driven project and together we are making it better 🚀.
 
   In case of doubts contact the developers at:
+
   Mailing List: dev@airflow.apache.org
+
   Slack: https://apache-airflow-slack.herokuapp.com/
 
 # Comment to be posted to congratulate user on their first merged PR


### PR DESCRIPTION
I've changed line break and block scalar type to >.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
