### PR TITLE
[AIRFLOW-6636] Avoid exceptions when printing task instance

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1021,9 +1021,15 @@ class TaskInstance(Base, LoggingMixin):
             'dag_id=%s, task_id=%s, execution_date=%s, start_date=%s, end_date=%s',
             self.dag_id,
             self.task_id,
-            self.execution_date.strftime('%Y%m%dT%H%M%S') if self.execution_date else '',
-            self.start_date.strftime('%Y%m%dT%H%M%S') if self.start_date else '',
-            self.end_date.strftime('%Y%m%dT%H%M%S') if self.end_date else '')
+            self.execution_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                self,
+                'execution_date') and self.execution_date else '',
+            self.start_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                self,
+                'start_date') and self.start_date else '',
+            self.end_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                self,
+                'end_date') and self.end_date else '')
         self.set_duration()
         if not test_mode:
             session.add(Log(self.state, self))
@@ -1137,18 +1143,30 @@ class TaskInstance(Base, LoggingMixin):
                         'dag_id=%s, task_id=%s, execution_date=%s, start_date=%s, end_date=%s',
                         self.dag_id,
                         self.task_id,
-                        self.execution_date.strftime('%Y%m%dT%H%M%S'),
-                        self.start_date.strftime('%Y%m%dT%H%M%S'),
-                        self.end_date.strftime('%Y%m%dT%H%M%S'))
+                        self.execution_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                            self,
+                            'execution_date') and self.execution_date else '',
+                        self.start_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                            self,
+                            'start_date') and self.start_date else '',
+                        self.end_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                            self,
+                            'end_date') and self.end_date else '')
                 else:
                     self.log.info(
                         'Marking task as FAILED.'
                         'dag_id=%s, task_id=%s, execution_date=%s, start_date=%s, end_date=%s',
                         self.dag_id,
                         self.task_id,
-                        self.execution_date.strftime('%Y%m%dT%H%M%S'),
-                        self.start_date.strftime('%Y%m%dT%H%M%S'),
-                        self.end_date.strftime('%Y%m%dT%H%M%S'))
+                        self.execution_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                            self,
+                            'execution_date') and self.execution_date else '',
+                        self.start_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                            self,
+                            'start_date') and self.start_date else '',
+                        self.end_date.strftime('%Y%m%dT%H%M%S') if hasattr(
+                            self,
+                            'end_date') and self.end_date else '')
                 if task.email_on_failure and task.email:
                     self.email_alert(error)
         except Exception as e2:


### PR DESCRIPTION
Sometimes (mainly in tests) tasks do not have start/execution/end date set and
printing task instance information throws an exception which cover the real
problems and makes diagnostics difficult.

---
Issue link: [AIRFLOW-6636](https://issues.apache.org/jira/browse/AIRFLOW-6636)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
