### PR TITLE
[AIRFLOW-6638] Remove flakiness test from test_serialized_db remove

### DIFF
--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -84,7 +84,7 @@ class SerializedDagModelTest(unittest.TestCase):
             self.assertTrue(serialized_dag.dag_id == dag.dag_id)
             self.assertTrue(set(serialized_dag.task_dict) == set(dag.task_dict))
 
-    def test_remove_dags(self):
+    def test_remove_dags_by_id(self):
         """DAGs can be removed from database."""
         example_dags_list = list(self._write_example_dags().values())
         # Remove SubDags from the list as they are not stored in DB in a separate row
@@ -95,9 +95,16 @@ class SerializedDagModelTest(unittest.TestCase):
         SDM.remove_dag(dag_removed_by_id.dag_id)
         self.assertFalse(SDM.has_dag(dag_removed_by_id.dag_id))
 
+    def test_remove_dags_by_filepath(self):
+        """DAGs can be removed from database."""
+        example_dags_list = list(self._write_example_dags().values())
+        # Remove SubDags from the list as they are not stored in DB in a separate row
+        # and are directly added in Json blob of the main DAG
+        filtered_example_dags_list = [dag for dag in example_dags_list if not dag.is_subdag]
         # Tests removing by file path.
-        dag_removed_by_file = filtered_example_dags_list[1]
-        example_dag_files = [dag.full_filepath for dag in filtered_example_dags_list]
+        dag_removed_by_file = filtered_example_dags_list[0]
+        # remove repeated files for those DAGs that define multiple dags in the same file (set comprehension)
+        example_dag_files = list({dag.full_filepath for dag in filtered_example_dags_list})
         example_dag_files.remove(dag_removed_by_file.full_filepath)
         SDM.remove_deleted_dags(example_dag_files)
         self.assertFalse(SDM.has_dag(dag_removed_by_file.dag_id))


### PR DESCRIPTION
The test was failing randomly because it returned the DAGs in random order and
sometimes it failed because test_serialized_dag was removing only one file
from the list of files but the file could be repeated in
case a dag file had more than one DAG defined.

---
Issue link: [AIRFLOW-6638](https://issues.apache.org/jira/browse/AIRFLOW-6638)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
