### PR TITLE
[AIRFLOW-6642] Make local task job test less flaky

### DIFF
--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -159,10 +159,9 @@ class TestLocalTaskJob(unittest.TestCase):
             for i in range(1, len(heartbeat_records)):
                 time1 = heartbeat_records[i - 1]
                 time2 = heartbeat_records[i]
-                # Assert that difference small enough to avoid:
-                # AssertionError: 1.996401 not greater than or equal to 2
+                # Assert that difference small enough
                 delta = (time2 - time1).total_seconds()
-                self.assertAlmostEqual(delta, job.heartrate, delta=0.006)
+                self.assertAlmostEqual(delta, job.heartrate, delta=0.05)
 
     @pytest.mark.xfail(condition=True, reason="This test might be flaky in postgres/mysql")
     def test_mark_success_no_kill(self):


### PR DESCRIPTION
The heartbeat failed fast test is flaky - sometimes the time needed to run the
test is longer than expected.

---
Issue link: [AIRFLOW-6642](https://issues.apache.org/jira/browse/AIRFLOW-6642)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
