### PR TITLE
[AIRFLOW-6643] Fix flakiness of kerberos tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,10 +102,11 @@ jobs:
         RUN_INTEGRATION_TESTS=all
       stage: test
       script: ./scripts/ci/ci_run_airflow_testing.sh tests/tests_core.py
-    - name: "Tests [MySQL][3.7][kerberos-temporarily-disabled]"
+    - name: "Tests [MySQL][3.7][kerberos]"
       env: >-
         BACKEND=mysql
         PYTHON_VERSION=3.7
+        ENABLED_INTEGRATIONS="kerberos"
       stage: test
   services:
     - docker

--- a/scripts/ci/in_container/_in_container_utils.sh
+++ b/scripts/ci/in_container/_in_container_utils.sh
@@ -197,3 +197,34 @@ function stop_output_heartbeat() {
     kill "${HEARTBEAT_PID}"
     wait "${HEARTBEAT_PID}" || true 2> /dev/null
 }
+
+function setup_kerberos() {
+    FQDN=$(hostname)
+    ADMIN="admin"
+    PASS="airflow"
+    KRB5_KTNAME=/etc/airflow.keytab
+
+    sudo cp "${MY_DIR}/krb5/krb5.conf" /etc/krb5.conf
+
+    echo -e "${PASS}\n${PASS}" | \
+        sudo kadmin -p "${ADMIN}/admin" -w "${PASS}" -q "addprinc -randkey airflow/${FQDN}" 2>&1 \
+          | sudo tee "${AIRFLOW_HOME}/logs/kadmin_1.log" >/dev/null
+    RES_1=$?
+
+    sudo kadmin -p "${ADMIN}/admin" -w "${PASS}" -q "ktadd -k ${KRB5_KTNAME} airflow" 2>&1 \
+          | sudo tee "${AIRFLOW_HOME}/logs/kadmin_2.log" >/dev/null
+    RES_2=$?
+
+    sudo kadmin -p "${ADMIN}/admin" -w "${PASS}" -q "ktadd -k ${KRB5_KTNAME} airflow/${FQDN}" 2>&1 \
+          | sudo tee "${AIRFLOW_HOME}/logs``/kadmin_3.log" >/dev/null
+    RES_3=$?
+
+    if [[ ${RES_1} != 0 || ${RES_2} != 0 || ${RES_3} != 0 ]]; then
+        exit 1
+    else
+        echo
+        echo "Kerberos enabled and working."
+        echo
+        sudo chmod 0644 "${KRB5_KTNAME}"
+    fi
+}

--- a/scripts/ci/in_container/check_environment.sh
+++ b/scripts/ci/in_container/check_environment.sh
@@ -217,7 +217,7 @@ else
 fi
 
 
-check_integration kerberos "kinit -Vkt '${KRB5_KTNAME:=}' airflow" 30
+check_integration kerberos "nc -zvv kerberos 88" 30
 check_integration mongo "nc -zvv mongo 27017" 20
 check_integration redis "nc -zvv redis 6379" 20
 check_integration rabbitmq "nc -zvv rabbitmq 5672" 20


### PR DESCRIPTION
Kerberos test were still flaky because checking for kerberos token happens
before active waiting for kerberos to be ready.

---
Issue link: [AIRFLOW-6643](https://issues.apache.org/jira/browse/AIRFLOW-6643)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
