### PR TITLE
[AIRFLOW-6645] Pass the TaskHandlers configuration using the constructor

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -53,6 +53,10 @@ FILENAME_TEMPLATE: str = conf.get('logging', 'LOG_FILENAME_TEMPLATE')
 
 PROCESSOR_FILENAME_TEMPLATE: str = conf.get('logging', 'LOG_PROCESSOR_FILENAME_TEMPLATE')
 
+WORKER_SERVER_LOG_PORT = conf.get('celery', 'WORKER_LOG_SERVER_PORT')
+
+LOG_FETCH_TIMEOUT_SEC = conf.getint('webserver', 'log_fetch_timeout_sec', fallback=None)
+
 DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -76,6 +80,8 @@ DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
             'formatter': 'airflow',
             'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
             'filename_template': FILENAME_TEMPLATE,
+            'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+            'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
         },
         'processor': {
             'class': 'airflow.utils.log.file_processor_handler.FileProcessorHandler',
@@ -160,6 +166,8 @@ if REMOTE_LOGGING:
     # just to help Airflow select correct handler
     REMOTE_BASE_LOG_FOLDER: str = conf.get('logging', 'REMOTE_BASE_LOG_FOLDER')
 
+    REMOTE_LOG_CONN_ID: str = conf.get('logging', 'REMOTE_LOG_CONN_ID')
+
     if REMOTE_BASE_LOG_FOLDER.startswith('s3://'):
         S3_REMOTE_HANDLERS: Dict[str, Dict[str, str]] = {
             'task': {
@@ -168,6 +176,9 @@ if REMOTE_LOGGING:
                 'base_log_folder': str(os.path.expanduser(BASE_LOG_FOLDER)),
                 's3_log_folder': REMOTE_BASE_LOG_FOLDER,
                 'filename_template': FILENAME_TEMPLATE,
+                'remote_log_conn_id': REMOTE_LOG_CONN_ID,
+                'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+                'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
             },
         }
 
@@ -180,6 +191,9 @@ if REMOTE_LOGGING:
                 'base_log_folder': str(os.path.expanduser(BASE_LOG_FOLDER)),
                 'gcs_log_folder': REMOTE_BASE_LOG_FOLDER,
                 'filename_template': FILENAME_TEMPLATE,
+                'remote_log_conn_id': REMOTE_LOG_CONN_ID,
+                'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+                'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
             },
         }
 
@@ -194,6 +208,9 @@ if REMOTE_LOGGING:
                 'wasb_container': 'airflow-logs',
                 'filename_template': FILENAME_TEMPLATE,
                 'delete_local_copy': False,
+                'remote_log_conn_id': REMOTE_LOG_CONN_ID,
+                'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+                'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
             },
         }
 
@@ -218,8 +235,9 @@ if REMOTE_LOGGING:
         ELASTICSEARCH_WRITE_STDOUT: bool = conf.getboolean('elasticsearch', 'WRITE_STDOUT')
         ELASTICSEARCH_JSON_FORMAT: bool = conf.getboolean('elasticsearch', 'JSON_FORMAT')
         ELASTICSEARCH_JSON_FIELDS: str = conf.get('elasticsearch', 'JSON_FIELDS')
+        ELASTICSEARCH_CONFIG_KWARGS: Dict[str, Any] = conf.getsection("elasticsearch_configs")
 
-        ELASTIC_REMOTE_HANDLERS: Dict[str, Dict[str, Union[str, bool]]] = {
+        ELASTIC_REMOTE_HANDLERS: Dict[str, Dict[str, Union[str, bool, Dict[str, Any]]]] = {
             'task': {
                 'class': 'airflow.utils.log.es_task_handler.ElasticsearchTaskHandler',
                 'formatter': 'airflow',
@@ -230,7 +248,10 @@ if REMOTE_LOGGING:
                 'host': ELASTICSEARCH_HOST,
                 'write_stdout': ELASTICSEARCH_WRITE_STDOUT,
                 'json_format': ELASTICSEARCH_JSON_FORMAT,
-                'json_fields': ELASTICSEARCH_JSON_FIELDS
+                'json_fields': ELASTICSEARCH_JSON_FIELDS,
+                'es_kwargs': ELASTICSEARCH_CONFIG_KWARGS,
+                'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+                'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
             },
         }
 

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -53,7 +53,7 @@ FILENAME_TEMPLATE: str = conf.get('logging', 'LOG_FILENAME_TEMPLATE')
 
 PROCESSOR_FILENAME_TEMPLATE: str = conf.get('logging', 'LOG_PROCESSOR_FILENAME_TEMPLATE')
 
-WORKER_SERVER_LOG_PORT = conf.get('celery', 'WORKER_LOG_SERVER_PORT')
+WORKER_LOG_SERVER_PORT = conf.get('celery', 'WORKER_LOG_SERVER_PORT')
 
 LOG_FETCH_TIMEOUT_SEC = conf.getint('webserver', 'log_fetch_timeout_sec', fallback=None)
 
@@ -80,7 +80,7 @@ DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
             'formatter': 'airflow',
             'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
             'filename_template': FILENAME_TEMPLATE,
-            'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+            'worker_log_server_port': WORKER_LOG_SERVER_PORT,
             'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
         },
         'processor': {
@@ -177,7 +177,7 @@ if REMOTE_LOGGING:
                 's3_log_folder': REMOTE_BASE_LOG_FOLDER,
                 'filename_template': FILENAME_TEMPLATE,
                 'remote_log_conn_id': REMOTE_LOG_CONN_ID,
-                'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+                'worker_log_server_port': WORKER_LOG_SERVER_PORT,
                 'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
             },
         }
@@ -192,7 +192,7 @@ if REMOTE_LOGGING:
                 'gcs_log_folder': REMOTE_BASE_LOG_FOLDER,
                 'filename_template': FILENAME_TEMPLATE,
                 'remote_log_conn_id': REMOTE_LOG_CONN_ID,
-                'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+                'worker_log_server_port': WORKER_LOG_SERVER_PORT,
                 'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
             },
         }
@@ -209,7 +209,7 @@ if REMOTE_LOGGING:
                 'filename_template': FILENAME_TEMPLATE,
                 'delete_local_copy': False,
                 'remote_log_conn_id': REMOTE_LOG_CONN_ID,
-                'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+                'worker_log_server_port': WORKER_LOG_SERVER_PORT,
                 'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
             },
         }
@@ -250,7 +250,7 @@ if REMOTE_LOGGING:
                 'json_format': ELASTICSEARCH_JSON_FORMAT,
                 'json_fields': ELASTICSEARCH_JSON_FIELDS,
                 'es_kwargs': ELASTICSEARCH_CONFIG_KWARGS,
-                'worker_server_log_port': WORKER_SERVER_LOG_PORT,
+                'worker_log_server_port': WORKER_LOG_SERVER_PORT,
                 'log_fetch_timeout_sec': LOG_FETCH_TIMEOUT_SEC
             },
         }

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -54,14 +54,14 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
     def __init__(self, base_log_folder, filename_template,  # pylint: disable=too-many-arguments
                  log_id_template, end_of_log_mark,
                  write_stdout, json_format, json_fields,
-                 host, es_kwargs, worker_server_log_port, log_fetch_timeout_sec):
+                 host, es_kwargs, worker_log_server_port, log_fetch_timeout_sec):
         """
         :param base_log_folder: base folder to store logs locally
         :param log_id_template: log id template
         :param host: Elasticsearch host name
         """
         es_kwargs = es_kwargs or {}
-        super().__init__(base_log_folder, filename_template, worker_server_log_port, log_fetch_timeout_sec)
+        super().__init__(base_log_folder, filename_template, worker_log_server_port, log_fetch_timeout_sec)
         self.closed = False
 
         self.log_id_template, self.log_id_jinja_template = \

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -24,7 +24,6 @@ import elasticsearch
 import pendulum
 from elasticsearch_dsl import Search
 
-from airflow.configuration import conf
 from airflow.utils import timezone
 from airflow.utils.helpers import parse_template_string
 from airflow.utils.log.file_task_handler import FileTaskHandler
@@ -52,19 +51,17 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
     PAGE = 0
     MAX_LINE_PER_PAGE = 1000
 
-    def __init__(self, base_log_folder, filename_template,
+    def __init__(self, base_log_folder, filename_template,  # pylint: disable=too-many-arguments
                  log_id_template, end_of_log_mark,
                  write_stdout, json_format, json_fields,
-                 host='localhost:9200',
-                 es_kwargs=conf.getsection("elasticsearch_configs")):
+                 host, es_kwargs, worker_server_log_port, log_fetch_timeout_sec):
         """
         :param base_log_folder: base folder to store logs locally
         :param log_id_template: log id template
         :param host: Elasticsearch host name
         """
         es_kwargs = es_kwargs or {}
-        super().__init__(
-            base_log_folder, filename_template)
+        super().__init__(base_log_folder, filename_template, worker_server_log_port, log_fetch_timeout_sec)
         self.closed = False
 
         self.log_id_template, self.log_id_jinja_template = \

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -41,7 +41,7 @@ class FileTaskHandler(logging.Handler):
         self,
         base_log_folder: str,
         filename_template: str,
-        worker_server_log_port: int,
+        worker_log_server_port: int,
         log_fetch_timeout_sec: Optional[int]
     ):
         super().__init__()
@@ -49,7 +49,7 @@ class FileTaskHandler(logging.Handler):
         self.local_base = base_log_folder
         self.filename_template, self.filename_jinja_template = \
             parse_template_string(filename_template)
-        self.worker_server_log_port = worker_server_log_port
+        self.worker_log_server_port = worker_log_server_port
         self.log_fetch_timeout_sec = log_fetch_timeout_sec
 
     def set_context(self, ti: TaskInstance):
@@ -119,7 +119,7 @@ class FileTaskHandler(logging.Handler):
                 "http://{ti.hostname}:{worker_log_server_port}/log", log_relative_path
             ).format(
                 ti=ti,
-                worker_log_server_port=self.worker_server_log_port
+                worker_log_server_port=self.worker_log_server_port
             )
             log += "*** Log file does not exist: {}\n".format(location)
             log += "*** Fetching from: {}\n".format(url)

--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -38,10 +38,10 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         gcs_log_folder,
         filename_template,
         remote_log_conn_id,
-        worker_server_log_port,
+        worker_log_server_port,
         log_fetch_timeout_sec
     ):
-        super().__init__(base_log_folder, filename_template, worker_server_log_port, log_fetch_timeout_sec)
+        super().__init__(base_log_folder, filename_template, worker_log_server_port, log_fetch_timeout_sec)
         self.remote_base = gcs_log_folder
         self.log_relative_path = ''
         self._hook = None

--- a/airflow/utils/log/s3_task_handler.py
+++ b/airflow/utils/log/s3_task_handler.py
@@ -31,10 +31,10 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
     uploads to and reads from S3 remote storage.
     """
     def __init__(
-        self, base_log_folder, s3_log_folder, filename_template, worker_server_log_port,
+        self, base_log_folder, s3_log_folder, filename_template, worker_log_server_port,
         log_fetch_timeout_sec, remote_log_conn_id
     ):
-        super().__init__(base_log_folder, filename_template, worker_server_log_port, log_fetch_timeout_sec)
+        super().__init__(base_log_folder, filename_template, worker_log_server_port, log_fetch_timeout_sec)
         self.remote_base = s3_log_folder
         self.log_relative_path = ''
         self._hook = None

--- a/airflow/utils/log/wasb_task_handler.py
+++ b/airflow/utils/log/wasb_task_handler.py
@@ -33,9 +33,9 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
     """
 
     def __init__(self, base_log_folder, wasb_log_folder, wasb_container,
-                 filename_template, delete_local_copy, remote_log_conn_id, worker_server_log_port,
+                 filename_template, delete_local_copy, remote_log_conn_id, worker_log_server_port,
                  log_fetch_timeout_sec):
-        super().__init__(base_log_folder, filename_template, worker_server_log_port, log_fetch_timeout_sec)
+        super().__init__(base_log_folder, filename_template, worker_log_server_port, log_fetch_timeout_sec)
         self.wasb_container = wasb_container
         self.remote_base = wasb_log_folder
         self.log_relative_path = ''

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -36,7 +36,7 @@ from airflow.utils.timezone import datetime
 from .elasticmock import elasticmock
 
 
-class TestElasticsearchTaskHandler(unittest.TestCase):
+class TestElasticsearchTaskHandler(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
     DAG_ID = 'dag_for_testing_file_task_handler'
     TASK_ID = 'task_for_testing_file_log_handler'
     EXECUTION_DATE = datetime(2016, 1, 1)
@@ -52,14 +52,22 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.write_stdout = False
         self.json_format = False
         self.json_fields = 'asctime,filename,lineno,levelname,message'
+        self.host = 'localhost:9200'
+        self.es_kwargs = {}
+        self.worker_server_log_port = 4222
+        self.log_fetch_timeout_sec = 2
         self.es_task_handler = ElasticsearchTaskHandler(
-            self.local_log_location,
-            self.filename_template,
-            self.log_id_template,
-            self.end_of_log_mark,
-            self.write_stdout,
-            self.json_format,
-            self.json_fields
+            base_log_folder=self.local_log_location,
+            filename_template=self.filename_template,
+            log_id_template=self.log_id_template,
+            end_of_log_mark=self.end_of_log_mark,
+            write_stdout=self.write_stdout,
+            json_format=self.json_format,
+            json_fields=self.json_fields,
+            host=self.host,
+            es_kwargs=self.es_kwargs,
+            worker_server_log_port=self.worker_server_log_port,
+            log_fetch_timeout_sec=self.log_fetch_timeout_sec,
         )
 
         self.es = elasticsearch.Elasticsearch(  # pylint: disable=invalid-name
@@ -96,14 +104,17 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertDictEqual(es_conf, expected_dict)
         # ensure creating with configs does not fail
         ElasticsearchTaskHandler(
-            self.local_log_location,
-            self.filename_template,
-            self.log_id_template,
-            self.end_of_log_mark,
-            self.write_stdout,
-            self.json_format,
-            self.json_fields,
-            es_conf
+            base_log_folder=self.local_log_location,
+            filename_template=self.filename_template,
+            log_id_template=self.log_id_template,
+            end_of_log_mark=self.end_of_log_mark,
+            write_stdout=self.write_stdout,
+            json_format=self.json_format,
+            json_fields=self.json_fields,
+            host=self.host,
+            es_kwargs=self.es_kwargs,
+            worker_server_log_port=self.worker_server_log_port,
+            log_fetch_timeout_sec=self.log_fetch_timeout_sec,
         )
 
     def test_read(self):
@@ -333,13 +344,17 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
 
         # Switch to use jinja template.
         self.es_task_handler = ElasticsearchTaskHandler(
-            self.local_log_location,
-            self.filename_template,
-            '{{ ti.dag_id }}-{{ ti.task_id }}-{{ ts }}-{{ try_number }}',
-            self.end_of_log_mark,
-            self.write_stdout,
-            self.json_format,
-            self.json_fields
+            base_log_folder=self.local_log_location,
+            filename_template=self.filename_template,
+            log_id_template='{{ ti.dag_id }}-{{ ti.task_id }}-{{ ts }}-{{ try_number }}',
+            end_of_log_mark=self.end_of_log_mark,
+            write_stdout=self.write_stdout,
+            json_format=self.json_format,
+            json_fields=self.json_fields,
+            host=self.host,
+            es_kwargs=self.es_kwargs,
+            worker_server_log_port=self.worker_server_log_port,
+            log_fetch_timeout_sec=self.log_fetch_timeout_sec,
         )
         log_id = self.es_task_handler._render_log_id(self.ti, 1)
         self.assertEqual(expected_log_id, log_id)

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -54,7 +54,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):  # pylint: disable=too-ma
         self.json_fields = 'asctime,filename,lineno,levelname,message'
         self.host = 'localhost:9200'
         self.es_kwargs = {}
-        self.worker_server_log_port = 4222
+        self.worker_log_server_port = 4222
         self.log_fetch_timeout_sec = 2
         self.es_task_handler = ElasticsearchTaskHandler(
             base_log_folder=self.local_log_location,
@@ -66,7 +66,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):  # pylint: disable=too-ma
             json_fields=self.json_fields,
             host=self.host,
             es_kwargs=self.es_kwargs,
-            worker_server_log_port=self.worker_server_log_port,
+            worker_log_server_port=self.worker_log_server_port,
             log_fetch_timeout_sec=self.log_fetch_timeout_sec,
         )
 
@@ -113,7 +113,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):  # pylint: disable=too-ma
             json_fields=self.json_fields,
             host=self.host,
             es_kwargs=self.es_kwargs,
-            worker_server_log_port=self.worker_server_log_port,
+            worker_log_server_port=self.worker_log_server_port,
             log_fetch_timeout_sec=self.log_fetch_timeout_sec,
         )
 
@@ -353,7 +353,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):  # pylint: disable=too-ma
             json_fields=self.json_fields,
             host=self.host,
             es_kwargs=self.es_kwargs,
-            worker_server_log_port=self.worker_server_log_port,
+            worker_log_server_port=self.worker_log_server_port,
             log_fetch_timeout_sec=self.log_fetch_timeout_sec,
         )
         log_id = self.es_task_handler._render_log_id(self.ti, 1)

--- a/tests/utils/log/test_s3_task_handler.py
+++ b/tests/utils/log/test_s3_task_handler.py
@@ -47,10 +47,16 @@ class TestS3TaskHandler(unittest.TestCase):
         self.remote_log_key = 'remote/log/location/1.log'
         self.local_log_location = 'local/log/location'
         self.filename_template = '{try_number}.log'
+        self.worker_server_log_port = 4222
+        self.log_fetch_timeout_sec = 2
+        self.remote_log_conn_id = 'aws_default'
         self.s3_task_handler = S3TaskHandler(
-            self.local_log_location,
-            self.remote_log_base,
-            self.filename_template
+            base_log_folder=self.local_log_location,
+            s3_log_folder=self.remote_log_base,
+            filename_template=self.filename_template,
+            worker_server_log_port=self.worker_server_log_port,
+            log_fetch_timeout_sec=self.log_fetch_timeout_sec,
+            remote_log_conn_id=self.remote_log_conn_id
         )
 
         date = datetime(2016, 1, 1)
@@ -88,7 +94,7 @@ class TestS3TaskHandler(unittest.TestCase):
             mock_error.assert_called_once_with(
                 'Could not create an S3Hook with connection id "%s". Please make '
                 'sure that airflow[aws] is installed and the S3 connection exists.',
-                ''
+                self.remote_log_conn_id
             )
 
     def test_log_exists(self):

--- a/tests/utils/log/test_s3_task_handler.py
+++ b/tests/utils/log/test_s3_task_handler.py
@@ -47,14 +47,14 @@ class TestS3TaskHandler(unittest.TestCase):
         self.remote_log_key = 'remote/log/location/1.log'
         self.local_log_location = 'local/log/location'
         self.filename_template = '{try_number}.log'
-        self.worker_server_log_port = 4222
+        self.worker_log_server_port = 4222
         self.log_fetch_timeout_sec = 2
         self.remote_log_conn_id = 'aws_default'
         self.s3_task_handler = S3TaskHandler(
             base_log_folder=self.local_log_location,
             s3_log_folder=self.remote_log_base,
             filename_template=self.filename_template,
-            worker_server_log_port=self.worker_server_log_port,
+            worker_log_server_port=self.worker_log_server_port,
             log_fetch_timeout_sec=self.log_fetch_timeout_sec,
             remote_log_conn_id=self.remote_log_conn_id
         )

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -168,7 +168,7 @@ class TestFilenameRendering(unittest.TestCase):
             'dag_for_testing_filename_rendering/task_for_testing_filename_rendering/%s/42.log' \
             % DEFAULT_DATE.isoformat()
 
-        fth = FileTaskHandler('', '{dag_id}/{task_id}/{execution_date}/{try_number}.log')
+        fth = FileTaskHandler('', '{dag_id}/{task_id}/{execution_date}/{try_number}.log', 4222, None)
         rendered_filename = fth._render_filename(self.ti, 42)
         self.assertEqual(expected_filename, rendered_filename)
 
@@ -177,6 +177,8 @@ class TestFilenameRendering(unittest.TestCase):
             'dag_for_testing_filename_rendering/task_for_testing_filename_rendering/%s/42.log' \
             % DEFAULT_DATE.isoformat()
 
-        fth = FileTaskHandler('', '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log')
+        fth = FileTaskHandler(
+            '', '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log', 4222, None
+        )
         rendered_filename = fth._render_filename(self.ti, 42)
         self.assertEqual(expected_filename, rendered_filename)


### PR DESCRIPTION
It is difficult to understand the configurations of these classes if they contain hidden configuration options. I think that all configuration parameters should be passed by the constructor.

---
Issue link: [AIRFLOW-6645](https://issues.apache.org/jira/browse/AIRFLOW-6645)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
