### PR TITLE
[AIRFLOW-6651] Add Redis Heartbeat option

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2114,3 +2114,25 @@
     to identify the task.
     Should be supplied in the format: ``key = value``
   options: []
+- name: heartbeat
+  description: |
+    options for job heartbeat
+  options:
+    - name: redis_enabled
+      description: ~
+      version_added: 2.0
+      type: boolean
+      example: ~
+      default: "false"
+    - name: redis_mget_batch_size
+      description: ~
+      version_added: 2.0
+      type: int
+      example: ~
+      default: "1000"
+    - name: redis_url
+      description: ~
+      version_added: 2.0
+      type: string
+      example: "redis://localhost:6379/0"
+      default: ""

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2129,7 +2129,7 @@
       version_added: 2.0
       type: int
       example: ~
-      default: "1000"
+      default: "100"
     - name: redis_url
       description: ~
       version_added: 2.0

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2124,7 +2124,7 @@
       type: boolean
       example: ~
       default: "false"
-    - name: redis_mget_batch_size
+    - name: redis_get_batch_size
       description: ~
       version_added: 2.0
       type: int

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1043,3 +1043,11 @@ worker_annotations =
 # The worker pods will be given these static labels, as well as some additional dynamic labels
 # to identify the task.
 # Should be supplied in the format: ``key = value``
+
+[heartbeat]
+
+# options for job heartbeat
+redis_enabled = false
+redis_get_batch_size = 1000
+# Example: redis_url = redis://localhost:6379/0
+redis_url =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1043,7 +1043,3 @@ worker_annotations =
 # The worker pods will be given these static labels, as well as some additional dynamic labels
 # to identify the task.
 # Should be supplied in the format: ``key = value``
-[heartbeat]
-redis_enabled = False
-redis_mget_batch_size = 1000
-redis_url =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1048,6 +1048,6 @@ worker_annotations =
 
 # options for job heartbeat
 redis_enabled = false
-redis_get_batch_size = 1000
+redis_get_batch_size = 100
 # Example: redis_url = redis://localhost:6379/0
 redis_url =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1043,3 +1043,7 @@ worker_annotations =
 # The worker pods will be given these static labels, as well as some additional dynamic labels
 # to identify the task.
 # Should be supplied in the format: ``key = value``
+[heartbeat]
+redis_enabled = False
+redis_mget_batch_size = 1000
+redis_url =

--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -23,7 +23,7 @@ from typing import Optional
 
 from pendulum import utcfromtimestamp
 from redis import Redis
-from sqlalchemy import Column, Index, Integer, String, and_, or_
+from sqlalchemy import Column, Index, Integer, String, and_
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.session import make_transient
 

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -108,7 +108,7 @@ class LocalTaskJob(BaseJob):
                 # If it's been too long since we've heartbeat, then it's possible that
                 # the scheduler rescheduled this task, so kill launched processes.
                 # This can only really happen if the worker can't read the DB for a long time
-                time_since_last_heartbeat = (timezone.utcnow() - self.latest_heartbeat).total_seconds()
+                time_since_last_heartbeat = (timezone.utcnow() - self.get_heartbeat()).total_seconds()
                 if time_since_last_heartbeat > heartbeat_time_limit:
                     Stats.incr('local_task_job_prolonged_heartbeat_failure', 1, 1)
                     self.log.error("Heartbeat time limited exceeded!")

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -31,7 +31,6 @@ from typing import Any, Callable, Dict, KeysView, List, NamedTuple, Optional, Tu
 
 import psutil
 from setproctitle import setproctitle  # pylint: disable=no-name-in-module
-from sqlalchemy import or_
 from tabulate import tabulate
 
 import airflow.models
@@ -48,7 +47,6 @@ from airflow.utils.file import list_py_file_paths
 from airflow.utils.helpers import reap_process_group
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
-from airflow.utils.state import State
 
 
 class SimpleDag(BaseDag):

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -1060,13 +1060,13 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         if not self._last_zombie_query_time or \
                 (now - self._last_zombie_query_time).total_seconds() > self._zombie_query_interval:
             # to avoid circular imports
-            from airflow.jobs import BaseJob
+            from airflow.jobs import LocalTaskJob
             self.log.info("Finding 'running' jobs without a recent heartbeat")
             limit_dttm = timezone.utcnow() - timedelta(
                 seconds=self._zombie_threshold_secs)
             self.log.info("Failing jobs without heartbeat after %s", limit_dttm)
 
-            zombies = BaseJob.get_zombie_running_tis(limit_dttm, session=session)
+            zombies = LocalTaskJob.get_zombie_running_tis(limit_dttm, session=session)
             self._last_zombie_query_time = timezone.utcnow()
             for sti in zombies:
                 self.log.info(

--- a/airflow/www/templates/airflow/master.html
+++ b/airflow/www/templates/airflow/master.html
@@ -38,7 +38,7 @@
     <div class="alert alert-warning">
       <p>The scheduler does not appear to be running.
       {% if scheduler_job %}
-      Last heartbeat was received <time title="{{ scheduler_job.latest_heartbeat.isoformat() }}" datetime="{{ scheduler_job.latest_heartbeat.isoformat() }}">{{ macros.datetime_diff_for_humans(scheduler_job.latest_heartbeat) }}</time>.
+      Last heartbeat was received <time title="{{ scheduler_job.get_heartbeat().isoformat() }}" datetime="{{ scheduler_job.get_heartbeat().isoformat() }}">{{ macros.datetime_diff_for_humans(scheduler_job.get_heartbeat()) }}</time>.
       {% endif %}
       </p>
       <p>The DAGs list may not update, and new tasks will not be scheduled.</p>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2443,10 +2443,10 @@ class JobModelView(AirflowModelView):
     base_permissions = ['can_list']
 
     list_columns = ['id', 'dag_id', 'state', 'job_type', 'start_date',
-                    'end_date', 'latest_heartbeat',
+                    'end_date',
                     'executor_class', 'hostname', 'unixname']
     search_columns = ['id', 'dag_id', 'state', 'job_type', 'start_date',
-                      'end_date', 'latest_heartbeat', 'executor_class',
+                      'end_date', 'executor_class',
                       'hostname', 'unixname']
 
     base_order = ('start_date', 'desc')
@@ -2458,7 +2458,6 @@ class JobModelView(AirflowModelView):
         'end_date': wwwutils.datetime_f('end_date'),
         'hostname': wwwutils.nobr_f('hostname'),
         'state': wwwutils.state_f,
-        'latest_heartbeat': wwwutils.datetime_f('latest_heartbeat'),
     }
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -203,7 +203,7 @@ class Airflow(AirflowBaseView):
             scheduler_job = SchedulerJob.most_recent_job()
 
             if scheduler_job:
-                latest_scheduler_heartbeat = scheduler_job.latest_heartbeat.isoformat()
+                latest_scheduler_heartbeat = scheduler_job.get_heartbeat().isoformat()
                 if scheduler_job.is_alive():
                     scheduler_status = 'healthy'
         except Exception:

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1060,10 +1060,10 @@ class TestSchedulerJob(unittest.TestCase):
         job = SchedulerJob(None, heartrate=10, state=State.RUNNING)
         self.assertTrue(job.is_alive())
 
-        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=20)
+        job.update_heartbeat(timezone.utcnow() - datetime.timedelta(seconds=20))
         self.assertTrue(job.is_alive())
 
-        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=31)
+        job.update_heartbeat(timezone.utcnow() - datetime.timedelta(seconds=31))
         self.assertFalse(job.is_alive())
 
         # test because .seconds was used before instead of total_seconds
@@ -1072,7 +1072,7 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertFalse(job.is_alive())
 
         job.state = State.SUCCESS
-        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
+        job.update_heartbeat(timezone.utcnow() - datetime.timedelta(seconds=10))
         self.assertFalse(job.is_alive(), "Completed jobs even with recent heartbeat should not be alive")
 
     def run_single_scheduler_loop_with_no_dags(self, dags_folder):

--- a/tests/test_config_templates.py
+++ b/tests/test_config_templates.py
@@ -52,7 +52,8 @@ DEFAULT_AIRFLOW_SECTIONS = [
     'kubernetes_node_selectors',
     'kubernetes_environment_variables',
     'kubernetes_secrets',
-    'kubernetes_labels'
+    'kubernetes_labels',
+    'heartbeat'
 ]
 
 DEFAULT_TEST_SECTIONS = [

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -231,10 +231,11 @@ class TestDagFileProcessorManager(unittest.TestCase):
                 ti = TI(task, DEFAULT_DATE, State.RUNNING)
                 local_job = LJ(ti)
                 local_job.state = State.SHUTDOWN
-                local_job.id = 1
+                session.add(local_job)
+                session.commit()
+
                 ti.job_id = local_job.id
 
-                session.add(local_job)
                 session.add(ti)
                 session.commit()
                 fake_zombies = [SimpleTaskInstance(ti)]
@@ -340,7 +341,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
     def tearDown(self):
         # Remove any new modules imported during the test run. This lets us
         # import the same source files for more than one test.
-        for mod in sys.modules:
+        for mod in list(sys.modules.keys()):
             if mod not in self.old_modules:
                 del sys.modules[mod]
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -415,7 +415,7 @@ class TestAirflowBaseViews(TestBase):
                          resp_json['scheduler']['latest_scheduler_heartbeat'])
 
         self.session.query(BaseJob).\
-            filter(BaseJob.job_type == job2.id).\
+            filter(BaseJob.id == job2.id).\
             delete()
         self.session.commit()
 


### PR DESCRIPTION
Adds the option to use Redis to store the heartbeat data. This will reduce load on the DB. All the guarantees a DB provides is not needed for the heartbeat and Redis is pretty simple to use and common.

Unit tests WIP
---
Issue link: [AIRFLOW-6651](https://issues.apache.org/jira/browse/AIRFLOW-6651)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
