### PR TITLE
[AIRFLOW-6659] Move AWS Transfer operators to providers package

### DIFF
--- a/airflow/contrib/operators/dynamodb_to_s3.py
+++ b/airflow/contrib/operators/dynamodb_to_s3.py
@@ -16,132 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.dynamodb_to_s3`."""
 
-"""
-This module contains operators to replicate records from
-DynamoDB table to S3.
-"""
+import warnings
 
-from copy import copy
-from os.path import getsize
-from tempfile import NamedTemporaryFile
-from typing import Any, Callable, Dict, Optional
-from uuid import uuid4
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.dynamodb_to_s3 import DynamoDBToS3Operator  # noqa
 
-from boto.compat import json  # type: ignore
-
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.aws_dynamodb_hook import AwsDynamoDBHook
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-
-
-def _convert_item_to_json_bytes(item):
-    return (json.dumps(item) + '\n').encode('utf-8')
-
-
-def _upload_file_to_s3(file_obj, bucket_name, s3_key_prefix):
-    s3_client = S3Hook().get_conn()
-    file_obj.seek(0)
-    s3_client.upload_file(
-        Filename=file_obj.name,
-        Bucket=bucket_name,
-        Key=s3_key_prefix + str(uuid4()),
-    )
-
-
-class DynamoDBToS3Operator(BaseOperator):
-    """
-    Replicates records from a DynamoDB table to S3.
-    It scans a DynamoDB table and write the received records to a file
-    on the local filesystem. It flushes the file to S3 once the file size
-    exceeds the file size limit specified by the user.
-
-    Users can also specify a filtering criteria using dynamodb_scan_kwargs
-    to only replicate records that satisfy the criteria.
-
-    To parallelize the replication, users can create multiple tasks of DynamoDBToS3Operator.
-    For instance to replicate with parallelism of 2, create two tasks like:
-
-    .. code-block::
-
-        op1 = DynamoDBToS3Operator(
-            task_id='replicator-1',
-            dynamodb_table_name='hello',
-            dynamodb_scan_kwargs={
-                'TotalSegments': 2,
-                'Segment': 0,
-            },
-            ...
-        )
-
-        op2 = DynamoDBToS3Operator(
-            task_id='replicator-2',
-            dynamodb_table_name='hello',
-            dynamodb_scan_kwargs={
-                'TotalSegments': 2,
-                'Segment': 1,
-            },
-            ...
-        )
-
-    :param dynamodb_table_name: Dynamodb table to replicate data from
-    :param s3_bucket_name: S3 bucket to replicate data to
-    :param file_size: Flush file to s3 if file size >= file_size
-    :param dynamodb_scan_kwargs: kwargs pass to <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Table.scan>  # noqa: E501 pylint: disable=line-too-long
-    :param s3_key_prefix: Prefix of s3 object key
-    :param process_func: How we transforms a dynamodb item to bytes. By default we dump the json
-    """
-
-    def __init__(self,
-                 dynamodb_table_name: str,
-                 s3_bucket_name: str,
-                 file_size: int,
-                 dynamodb_scan_kwargs: Optional[Dict[str, Any]] = None,
-                 s3_key_prefix: str = '',
-                 process_func: Callable[[Dict[str, Any]], bytes] = _convert_item_to_json_bytes,
-                 *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.file_size = file_size
-        self.process_func = process_func
-        self.dynamodb_table_name = dynamodb_table_name
-        self.dynamodb_scan_kwargs = dynamodb_scan_kwargs
-        self.s3_bucket_name = s3_bucket_name
-        self.s3_key_prefix = s3_key_prefix
-
-    def execute(self, context):
-        table = AwsDynamoDBHook().get_conn().Table(self.dynamodb_table_name)
-        scan_kwargs = copy(self.dynamodb_scan_kwargs) if self.dynamodb_scan_kwargs else {}
-        err = None
-        f = NamedTemporaryFile()
-        try:
-            f = self._scan_dynamodb_and_upload_to_s3(f, scan_kwargs, table)
-        except Exception as e:
-            err = e
-            raise e
-        finally:
-            if err is None:
-                _upload_file_to_s3(f, self.s3_bucket_name, self.s3_key_prefix)
-            f.close()
-
-    def _scan_dynamodb_and_upload_to_s3(self, temp_file, scan_kwargs, table):
-        while True:
-            response = table.scan(**scan_kwargs)
-            items = response['Items']
-            for item in items:
-                temp_file.write(self.process_func(item))
-
-            if 'LastEvaluatedKey' not in response:
-                # no more items to scan
-                break
-
-            last_evaluated_key = response['LastEvaluatedKey']
-            scan_kwargs['ExclusiveStartKey'] = last_evaluated_key
-
-            # Upload the file to S3 if reach file size limit
-            if getsize(temp_file.name) >= self.file_size:
-                _upload_file_to_s3(temp_file, self.s3_bucket_name,
-                                   self.s3_key_prefix)
-                temp_file.close()
-                temp_file = NamedTemporaryFile()
-        return temp_file
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.dynamodb_to_s3`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -17,26 +17,27 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-This module is deprecated. Please use `airflow.operators.gcs_to_s3`.
+This module is deprecated. Please use `airflow.providers.amazon.aws.operators.gcs_to_s3`.
 """
 
 import warnings
 
-from airflow.operators.gcs_to_s3 import GCSToS3Operator
+from airflow.providers.amazon.aws.operators.gcs_to_s3 import GCSToS3Operator
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.operators.gcs_to_s3`.",
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.gcs_to_s3`.",
     DeprecationWarning, stacklevel=2
 )
 
 
 class GoogleCloudStorageToS3Operator(GCSToS3Operator):
     """
-    This class is deprecated. Please use `airflow.operators.gcs_to_s3.GCSToS3Operator`.
+    This class is deprecated. Please use `airflow.providers.amazon.aws.operators.gcs_to_s3.GCSToS3Operator`.
     """
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            "This class is deprecated. Please use `airflow.operators.gcs_to_s3.GCSToS3Operator`.",
+            "This class is deprecated. "
+            "Please use `airflow.providers.amazon.aws.operators.gcs_to_s3.GCSToS3Operator`.",
             DeprecationWarning, stacklevel=2
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/hive_to_dynamodb.py
+++ b/airflow/contrib/operators/hive_to_dynamodb.py
@@ -16,98 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.hive_to_dynamodb`."""
 
-"""
-This module contains operator to move data from Hive to DynamoDB.
-"""
+import warnings
 
-import json
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.hive_to_dynamodb import HiveToDynamoDBTransferOperator  # noqa
 
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.aws_dynamodb_hook import AwsDynamoDBHook
-from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
-from airflow.utils.decorators import apply_defaults
-
-
-class HiveToDynamoDBTransferOperator(BaseOperator):
-    """
-    Moves data from Hive to DynamoDB, note that for now the data is loaded
-    into memory before being pushed to DynamoDB, so this operator should
-    be used for smallish amount of data.
-
-    :param sql: SQL query to execute against the hive database. (templated)
-    :type sql: str
-    :param table_name: target DynamoDB table
-    :type table_name: str
-    :param table_keys: partition key and sort key
-    :type table_keys: list
-    :param pre_process: implement pre-processing of source data
-    :type pre_process: function
-    :param pre_process_args: list of pre_process function arguments
-    :type pre_process_args: list
-    :param pre_process_kwargs: dict of pre_process function arguments
-    :type pre_process_kwargs: dict
-    :param region_name: aws region name (example: us-east-1)
-    :type region_name: str
-    :param schema: hive database schema
-    :type schema: str
-    :param hiveserver2_conn_id: source hive connection
-    :type hiveserver2_conn_id: str
-    :param aws_conn_id: aws connection
-    :type aws_conn_id: str
-    """
-
-    template_fields = ('sql',)
-    template_ext = ('.sql',)
-    ui_color = '#a0e08c'
-
-    @apply_defaults
-    def __init__(  # pylint: disable=too-many-arguments
-            self,
-            sql,
-            table_name,
-            table_keys,
-            pre_process=None,
-            pre_process_args=None,
-            pre_process_kwargs=None,
-            region_name=None,
-            schema='default',
-            hiveserver2_conn_id='hiveserver2_default',
-            aws_conn_id='aws_default',
-            *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.sql = sql
-        self.table_name = table_name
-        self.table_keys = table_keys
-        self.pre_process = pre_process
-        self.pre_process_args = pre_process_args
-        self.pre_process_kwargs = pre_process_kwargs
-        self.region_name = region_name
-        self.schema = schema
-        self.hiveserver2_conn_id = hiveserver2_conn_id
-        self.aws_conn_id = aws_conn_id
-
-    def execute(self, context):
-        hive = HiveServer2Hook(hiveserver2_conn_id=self.hiveserver2_conn_id)
-
-        self.log.info('Extracting data from Hive')
-        self.log.info(self.sql)
-
-        data = hive.get_pandas_df(self.sql, schema=self.schema)
-        dynamodb = AwsDynamoDBHook(aws_conn_id=self.aws_conn_id,
-                                   table_name=self.table_name,
-                                   table_keys=self.table_keys,
-                                   region_name=self.region_name)
-
-        self.log.info('Inserting rows into dynamodb')
-
-        if self.pre_process is None:
-            dynamodb.write_batch_data(
-                json.loads(data.to_json(orient='records')))
-        else:
-            dynamodb.write_batch_data(
-                self.pre_process(data=data,
-                                 args=self.pre_process_args,
-                                 kwargs=self.pre_process_kwargs))
-
-        self.log.info('Done.')
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.hive_to_dynamodb`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/operators/imap_attachment_to_s3_operator.py
+++ b/airflow/contrib/operators/imap_attachment_to_s3_operator.py
@@ -16,83 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-This module allows you to transfer mail attachments from a mail server into s3 bucket.
-"""
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.imap.hooks.imap import ImapHook
-from airflow.utils.decorators import apply_defaults
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.imap_attachment_to_s3`."""
 
+import warnings
 
-class ImapAttachmentToS3Operator(BaseOperator):
-    """
-    Transfers a mail attachment from a mail server into s3 bucket.
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.imap_attachment_to_s3 import ImapAttachmentToS3Operator  # noqa
 
-    :param imap_attachment_name: The file name of the mail attachment that you want to transfer.
-    :type imap_attachment_name: str
-    :param s3_key: The destination file name in the s3 bucket for the attachment.
-    :type s3_key: str
-    :param imap_check_regex: If set checks the `imap_attachment_name` for a regular expression.
-    :type imap_check_regex: bool
-    :param imap_mail_folder: The folder on the mail server to look for the attachment.
-    :type imap_mail_folder: str
-    :param imap_mail_filter: If set other than 'All' only specific mails will be checked.
-        See :py:meth:`imaplib.IMAP4.search` for details.
-    :type imap_mail_filter: str
-    :param s3_overwrite: If set overwrites the s3 key if already exists.
-    :type s3_overwrite: bool
-    :param imap_conn_id: The reference to the connection details of the mail server.
-    :type imap_conn_id: str
-    :param s3_conn_id: The reference to the s3 connection details.
-    :type s3_conn_id: str
-    """
-    template_fields = ('imap_attachment_name', 's3_key', 'imap_mail_filter')
-
-    @apply_defaults
-    def __init__(self,
-                 imap_attachment_name,
-                 s3_key,
-                 imap_check_regex=False,
-                 imap_mail_folder='INBOX',
-                 imap_mail_filter='All',
-                 s3_overwrite=False,
-                 imap_conn_id='imap_default',
-                 s3_conn_id='aws_default',
-                 *args,
-                 **kwargs):
-        super().__init__(*args, **kwargs)
-        self.imap_attachment_name = imap_attachment_name
-        self.s3_key = s3_key
-        self.imap_check_regex = imap_check_regex
-        self.imap_mail_folder = imap_mail_folder
-        self.imap_mail_filter = imap_mail_filter
-        self.s3_overwrite = s3_overwrite
-        self.imap_conn_id = imap_conn_id
-        self.s3_conn_id = s3_conn_id
-
-    def execute(self, context):
-        """
-        This function executes the transfer from the email server (via imap) into s3.
-
-        :param context: The context while executing.
-        :type context: dict
-        """
-        self.log.info(
-            'Transferring mail attachment %s from mail server via imap to s3 key %s...',
-            self.imap_attachment_name, self.s3_key
-        )
-
-        with ImapHook(imap_conn_id=self.imap_conn_id) as imap_hook:
-            imap_mail_attachments = imap_hook.retrieve_mail_attachments(
-                name=self.imap_attachment_name,
-                check_regex=self.imap_check_regex,
-                latest_only=True,
-                mail_folder=self.imap_mail_folder,
-                mail_filter=self.imap_mail_filter,
-            )
-
-        s3_hook = S3Hook(aws_conn_id=self.s3_conn_id)
-        s3_hook.load_bytes(bytes_data=imap_mail_attachments[0][1],
-                           key=self.s3_key,
-                           replace=self.s3_overwrite)
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.imap_attachment_to_s3`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/operators/mongo_to_s3.py
+++ b/airflow/contrib/operators/mongo_to_s3.py
@@ -16,113 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import json
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.mongo_to_s3`."""
 
-from bson import json_util
+import warnings
 
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.mongo.hooks.mongo import MongoHook
-from airflow.utils.decorators import apply_defaults
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.mongo_to_s3 import MongoToS3Operator  # noqa
 
-
-class MongoToS3Operator(BaseOperator):
-    """
-    Mongo -> S3
-        A more specific baseOperator meant to move data
-        from mongo via pymongo to s3 via boto
-
-        things to note
-                .execute() is written to depend on .transform()
-                .transform() is meant to be extended by child classes
-                to perform transformations unique to those operators needs
-    """
-
-    template_fields = ['s3_key', 'mongo_query']
-    # pylint: disable=too-many-instance-attributes
-
-    @apply_defaults
-    def __init__(self,
-                 mongo_conn_id,
-                 s3_conn_id,
-                 mongo_collection,
-                 mongo_query,
-                 s3_bucket,
-                 s3_key,
-                 mongo_db=None,
-                 replace=False,
-                 *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Conn Ids
-        self.mongo_conn_id = mongo_conn_id
-        self.s3_conn_id = s3_conn_id
-        # Mongo Query Settings
-        self.mongo_db = mongo_db
-        self.mongo_collection = mongo_collection
-        # Grab query and determine if we need to run an aggregate pipeline
-        self.mongo_query = mongo_query
-        self.is_pipeline = True if isinstance(
-            self.mongo_query, list) else False
-
-        # S3 Settings
-        self.s3_bucket = s3_bucket
-        self.s3_key = s3_key
-        self.replace = replace
-
-    def execute(self, context):
-        """
-        Executed by task_instance at runtime
-        """
-        s3_conn = S3Hook(self.s3_conn_id)
-
-        # Grab collection and execute query according to whether or not it is a pipeline
-        if self.is_pipeline:
-            results = MongoHook(self.mongo_conn_id).aggregate(
-                mongo_collection=self.mongo_collection,
-                aggregate_query=self.mongo_query,
-                mongo_db=self.mongo_db
-            )
-
-        else:
-            results = MongoHook(self.mongo_conn_id).find(
-                mongo_collection=self.mongo_collection,
-                query=self.mongo_query,
-                mongo_db=self.mongo_db
-            )
-
-        # Performs transform then stringifies the docs results into json format
-        docs_str = self._stringify(self.transform(results))
-
-        # Load Into S3
-        s3_conn.load_string(
-            string_data=docs_str,
-            key=self.s3_key,
-            bucket_name=self.s3_bucket,
-            replace=self.replace
-        )
-
-        return True
-
-    @staticmethod
-    def _stringify(iterable, joinable='\n'):
-        """
-        Takes an iterable (pymongo Cursor or Array) containing dictionaries and
-        returns a stringified version using python join
-        """
-        return joinable.join(
-            [json.dumps(doc, default=json_util.default) for doc in iterable]
-        )
-
-    @staticmethod
-    def transform(docs):
-        """
-        Processes pyMongo cursor and returns an iterable with each element being
-                a JSON serializable dictionary
-
-        Base transform() assumes no processing is needed
-        ie. docs is a pyMongo cursor of documents and cursor just
-        needs to be passed through
-
-        Override this method for custom transformations
-        """
-        return docs
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.mongo_to_s3`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/operators/s3_to_sftp_operator.py
+++ b/airflow/contrib/operators/s3_to_sftp_operator.py
@@ -16,71 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.s3_to_sftp`."""
 
-from tempfile import NamedTemporaryFile
-from urllib.parse import urlparse
+import warnings
 
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.ssh.hooks.ssh import SSHHook
-from airflow.utils.decorators import apply_defaults
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.s3_to_sftp import S3ToSFTPOperator  # noqa
 
-
-class S3ToSFTPOperator(BaseOperator):
-    """
-    This operator enables the transferring of files from S3 to a SFTP server.
-
-    :param sftp_conn_id: The sftp connection id. The name or identifier for
-        establishing a connection to the SFTP server.
-    :type sftp_conn_id: str
-    :param sftp_path: The sftp remote path. This is the specified file path for
-        uploading file to the SFTP server.
-    :type sftp_path: str
-    :param s3_conn_id: The s3 connection id. The name or identifier for
-        establishing a connection to S3
-    :type s3_conn_id: str
-    :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
-        where the file is downloaded.
-    :type s3_bucket: str
-    :param s3_key: The targeted s3 key. This is the specified file path for
-        downloading the file from S3.
-    :type s3_key: str
-    """
-
-    template_fields = ('s3_key', 'sftp_path')
-
-    @apply_defaults
-    def __init__(self,
-                 s3_bucket,
-                 s3_key,
-                 sftp_path,
-                 sftp_conn_id='ssh_default',
-                 s3_conn_id='aws_default',
-                 *args,
-                 **kwargs):
-        super().__init__(*args, **kwargs)
-        self.sftp_conn_id = sftp_conn_id
-        self.sftp_path = sftp_path
-        self.s3_bucket = s3_bucket
-        self.s3_key = s3_key
-        self.s3_conn_id = s3_conn_id
-
-    @staticmethod
-    def get_s3_key(s3_key):
-        """This parses the correct format for S3 keys
-            regardless of how the S3 url is passed."""
-
-        parsed_s3_key = urlparse(s3_key)
-        return parsed_s3_key.path.lstrip('/')
-
-    def execute(self, context):
-        self.s3_key = self.get_s3_key(self.s3_key)
-        ssh_hook = SSHHook(ssh_conn_id=self.sftp_conn_id)
-        s3_hook = S3Hook(self.s3_conn_id)
-
-        s3_client = s3_hook.get_conn()
-        sftp_client = ssh_hook.get_conn().open_sftp()
-
-        with NamedTemporaryFile("w") as f:
-            s3_client.download_file(self.s3_bucket, self.s3_key, f.name)
-            sftp_client.put(f.name, self.sftp_path)
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.s3_to_sftp`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/operators/sftp_to_s3_operator.py
+++ b/airflow/contrib/operators/sftp_to_s3_operator.py
@@ -16,77 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.sftp_to_s3`."""
 
-from tempfile import NamedTemporaryFile
-from urllib.parse import urlparse
+import warnings
 
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.ssh.hooks.ssh import SSHHook
-from airflow.utils.decorators import apply_defaults
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.sftp_to_s3 import SFTPToS3Operator  # noqa
 
-
-class SFTPToS3Operator(BaseOperator):
-    """
-    This operator enables the transferring of files from a SFTP server to
-    Amazon S3.
-
-    :param sftp_conn_id: The sftp connection id. The name or identifier for
-        establishing a connection to the SFTP server.
-    :type sftp_conn_id: str
-    :param sftp_path: The sftp remote path. This is the specified file path
-        for downloading the file from the SFTP server.
-    :type sftp_path: str
-    :param s3_conn_id: The s3 connection id. The name or identifier for
-        establishing a connection to S3
-    :type s3_conn_id: str
-    :param s3_bucket: The targeted s3 bucket. This is the S3 bucket to where
-        the file is uploaded.
-    :type s3_bucket: str
-    :param s3_key: The targeted s3 key. This is the specified path for
-        uploading the file to S3.
-    :type s3_key: str
-    """
-
-    template_fields = ('s3_key', 'sftp_path')
-
-    @apply_defaults
-    def __init__(self,
-                 s3_bucket,
-                 s3_key,
-                 sftp_path,
-                 sftp_conn_id='ssh_default',
-                 s3_conn_id='aws_default',
-                 *args,
-                 **kwargs):
-        super().__init__(*args, **kwargs)
-        self.sftp_conn_id = sftp_conn_id
-        self.sftp_path = sftp_path
-        self.s3_bucket = s3_bucket
-        self.s3_key = s3_key
-        self.s3_conn_id = s3_conn_id
-
-    @staticmethod
-    def get_s3_key(s3_key):
-        """This parses the correct format for S3 keys
-            regardless of how the S3 url is passed."""
-
-        parsed_s3_key = urlparse(s3_key)
-        return parsed_s3_key.path.lstrip('/')
-
-    def execute(self, context):
-        self.s3_key = self.get_s3_key(self.s3_key)
-        ssh_hook = SSHHook(ssh_conn_id=self.sftp_conn_id)
-        s3_hook = S3Hook(self.s3_conn_id)
-
-        sftp_client = ssh_hook.get_conn().open_sftp()
-
-        with NamedTemporaryFile("w") as f:
-            sftp_client.get(self.sftp_path, f.name)
-
-            s3_hook.load_file(
-                filename=f.name,
-                key=self.s3_key,
-                bucket_name=self.s3_bucket,
-                replace=True
-            )
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.sftp_to_s3`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/operators/gcs_to_s3.py
+++ b/airflow/operators/gcs_to_s3.py
@@ -16,140 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-This module contains Google Cloud Storage to S3 operator.
-"""
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.gcs_to_s3`."""
+
 import warnings
 
-from airflow.gcp.hooks.gcs import GCSHook
-from airflow.gcp.operators.gcs import GCSListObjectsOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.utils.decorators import apply_defaults
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.gcs_to_s3 import GCSToS3Operator  # noqa
 
-
-class GCSToS3Operator(GCSListObjectsOperator):
-    """
-    Synchronizes a Google Cloud Storage bucket with an S3 bucket.
-
-    :param bucket: The Google Cloud Storage bucket to find the objects. (templated)
-    :type bucket: str
-    :param prefix: Prefix string which filters objects whose name begin with
-        this prefix. (templated)
-    :type prefix: str
-    :param delimiter: The delimiter by which you want to filter the objects. (templated)
-        For e.g to lists the CSV files from in a directory in GCS you would use
-        delimiter='.csv'.
-    :type delimiter: str
-    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
-    :type gcp_conn_id: str
-    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
-        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
-    :type google_cloud_storage_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have
-        domain-wide delegation enabled.
-    :type delegate_to: str
-    :param dest_aws_conn_id: The destination S3 connection
-    :type dest_aws_conn_id: str
-    :param dest_s3_key: The base S3 key to be used to store the files. (templated)
-    :type dest_s3_key: str
-    :param dest_verify: Whether or not to verify SSL certificates for S3 connection.
-        By default SSL certificates are verified.
-        You can provide the following values:
-
-        - ``False``: do not validate SSL certificates. SSL will still be used
-                 (unless use_ssl is False), but SSL certificates will not be
-                 verified.
-        - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
-                 You can specify this argument if you want to use a different
-                 CA cert bundle than the one used by botocore.
-
-    :type dest_verify: bool or str
-    :param replace: Whether or not to verify the existence of the files in the
-        destination bucket.
-        By default is set to False
-        If set to True, will upload all the files replacing the existing ones in
-        the destination bucket.
-        If set to False, will upload only the files that are in the origin but not
-        in the destination bucket.
-    :type replace: bool
-    """
-    template_fields = ('bucket', 'prefix', 'delimiter', 'dest_s3_key')
-    ui_color = '#f0eee4'
-
-    @apply_defaults
-    def __init__(self,  # pylint: disable=too-many-arguments
-                 bucket,
-                 prefix=None,
-                 delimiter=None,
-                 gcp_conn_id='google_cloud_default',
-                 google_cloud_storage_conn_id=None,
-                 delegate_to=None,
-                 dest_aws_conn_id=None,
-                 dest_s3_key=None,
-                 dest_verify=None,
-                 replace=False,
-                 *args,
-                 **kwargs):
-
-        if google_cloud_storage_conn_id:
-            warnings.warn(
-                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
-                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
-            gcp_conn_id = google_cloud_storage_conn_id
-
-        super().__init__(
-            bucket=bucket,
-            prefix=prefix,
-            delimiter=delimiter,
-            gcp_conn_id=gcp_conn_id,
-            delegate_to=delegate_to,
-            *args,
-            **kwargs
-        )
-
-        self.dest_aws_conn_id = dest_aws_conn_id
-        self.dest_s3_key = dest_s3_key
-        self.dest_verify = dest_verify
-        self.replace = replace
-
-    def execute(self, context):
-        # use the super to list all files in an Google Cloud Storage bucket
-        files = super().execute(context)
-        s3_hook = S3Hook(aws_conn_id=self.dest_aws_conn_id, verify=self.dest_verify)
-
-        if not self.replace:
-            # if we are not replacing -> list all files in the S3 bucket
-            # and only keep those files which are present in
-            # Google Cloud Storage and not in S3
-            bucket_name, prefix = S3Hook.parse_s3_url(self.dest_s3_key)
-            # look for the bucket and the prefix to avoid look into
-            # parent directories/keys
-            existing_files = s3_hook.list_keys(bucket_name, prefix=prefix)
-            # in case that no files exists, return an empty array to avoid errors
-            existing_files = existing_files if existing_files is not None else []
-            # remove the prefix for the existing files to allow the match
-            existing_files = [file.replace(prefix, '', 1) for file in existing_files]
-            files = list(set(files) - set(existing_files))
-
-        if files:
-            hook = GCSHook(
-                google_cloud_storage_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to
-            )
-
-            for file in files:
-                file_bytes = hook.download(self.bucket, file)
-
-                dest_key = self.dest_s3_key + file
-                self.log.info("Saving file to %s", dest_key)
-
-                s3_hook.load_bytes(file_bytes,
-                                   key=dest_key,
-                                   replace=self.replace)
-
-            self.log.info("All done, uploaded %d files to S3", len(files))
-        else:
-            self.log.info("In sync, no files needed to be uploaded to S3")
-
-        return files
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.gcs_to_s3`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/operators/google_api_to_s3_transfer.py
+++ b/airflow/operators/google_api_to_s3_transfer.py
@@ -16,161 +16,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
 """
-This module allows you to transfer data from any Google API endpoint into a S3 Bucket.
+This module is deprecated.
+Please use `airflow.providers.amazon.aws.operators.google_api_to_s3_transfer`.
 """
-import json
-import sys
 
-from airflow.gcp.hooks.discovery_api import GoogleDiscoveryApiHook
-from airflow.models import BaseOperator
-from airflow.models.xcom import MAX_XCOM_SIZE
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.utils.decorators import apply_defaults
+import warnings
 
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer  # noqa
 
-class GoogleApiToS3Transfer(BaseOperator):
-    """
-    Basic class for transferring data from a Google API endpoint into a S3 Bucket.
-
-    :param google_api_service_name: The specific API service that is being requested.
-    :type google_api_service_name: str
-    :param google_api_service_version: The version of the API that is being requested.
-    :type google_api_service_version: str
-    :param google_api_endpoint_path: The client libraries path to the api call's executing method.
-        For example: 'analyticsreporting.reports.batchGet'
-
-        .. note:: See https://developers.google.com/apis-explorer
-            for more information on which methods are available.
-
-    :type google_api_endpoint_path: str
-    :param google_api_endpoint_params: The params to control the corresponding endpoint result.
-    :type google_api_endpoint_params: dict
-    :param s3_destination_key: The url where to put the data retrieved from the endpoint in S3.
-    :type s3_destination_key: str
-    :param google_api_response_via_xcom: Can be set to expose the google api response to xcom.
-    :type google_api_response_via_xcom: str
-    :param google_api_endpoint_params_via_xcom: If set to a value this value will be used as a key
-        for pulling from xcom and updating the google api endpoint params.
-    :type google_api_endpoint_params_via_xcom: str
-    :param google_api_endpoint_params_via_xcom_task_ids: Task ids to filter xcom by.
-    :type google_api_endpoint_params_via_xcom_task_ids: str or list of str
-    :param google_api_pagination: If set to True Pagination will be enabled for this request
-        to retrieve all data.
-
-        .. note:: This means the response will be a list of responses.
-
-    :type google_api_pagination: bool
-    :param google_api_num_retries: Define the number of retries for the google api requests being made
-        if it fails.
-    :type google_api_num_retries: int
-    :param s3_overwrite: Specifies whether the s3 file will be overwritten if exists.
-    :type s3_overwrite: bool
-    :param gcp_conn_id: The connection ID to use when fetching connection info.
-    :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have
-        domain-wide delegation enabled.
-    :type delegate_to: str
-    :param aws_conn_id: The connection id specifying the authentication information for the S3 Bucket.
-    :type aws_conn_id: str
-    """
-
-    template_fields = (
-        'google_api_endpoint_params',
-        's3_destination_key',
-    )
-    template_ext = ()
-    ui_color = '#cc181e'
-
-    @apply_defaults
-    def __init__(
-        self,
-        google_api_service_name,
-        google_api_service_version,
-        google_api_endpoint_path,
-        google_api_endpoint_params,
-        s3_destination_key,
-        *args,
-        google_api_response_via_xcom=None,
-        google_api_endpoint_params_via_xcom=None,
-        google_api_endpoint_params_via_xcom_task_ids=None,
-        google_api_pagination=False,
-        google_api_num_retries=0,
-        s3_overwrite=False,
-        gcp_conn_id='google_cloud_default',
-        delegate_to=None,
-        aws_conn_id='aws_default',
-        **kwargs
-    ):
-        super().__init__(*args, **kwargs)
-        self.google_api_service_name = google_api_service_name
-        self.google_api_service_version = google_api_service_version
-        self.google_api_endpoint_path = google_api_endpoint_path
-        self.google_api_endpoint_params = google_api_endpoint_params
-        self.s3_destination_key = s3_destination_key
-        self.google_api_response_via_xcom = google_api_response_via_xcom
-        self.google_api_endpoint_params_via_xcom = google_api_endpoint_params_via_xcom
-        self.google_api_endpoint_params_via_xcom_task_ids = google_api_endpoint_params_via_xcom_task_ids
-        self.google_api_pagination = google_api_pagination
-        self.google_api_num_retries = google_api_num_retries
-        self.s3_overwrite = s3_overwrite
-        self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
-        self.aws_conn_id = aws_conn_id
-
-    def execute(self, context):
-        """
-        Transfers Google APIs json data to S3.
-
-        :param context: The context that is being provided when executing.
-        :type context: dict
-        """
-        self.log.info('Transferring data from %s to s3', self.google_api_service_name)
-
-        if self.google_api_endpoint_params_via_xcom:
-            self._update_google_api_endpoint_params_via_xcom(context['task_instance'])
-
-        data = self._retrieve_data_from_google_api()
-
-        self._load_data_to_s3(data)
-
-        if self.google_api_response_via_xcom:
-            self._expose_google_api_response_via_xcom(context['task_instance'], data)
-
-    def _retrieve_data_from_google_api(self):
-        google_discovery_api_hook = GoogleDiscoveryApiHook(
-            gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
-            api_service_name=self.google_api_service_name,
-            api_version=self.google_api_service_version
-        )
-        google_api_response = google_discovery_api_hook.query(
-            endpoint=self.google_api_endpoint_path,
-            data=self.google_api_endpoint_params,
-            paginate=self.google_api_pagination,
-            num_retries=self.google_api_num_retries
-        )
-        return google_api_response
-
-    def _load_data_to_s3(self, data):
-        s3_hook = S3Hook(aws_conn_id=self.aws_conn_id)
-        s3_hook.load_string(
-            string_data=json.dumps(data),
-            key=self.s3_destination_key,
-            replace=self.s3_overwrite
-        )
-
-    def _update_google_api_endpoint_params_via_xcom(self, task_instance):
-        google_api_endpoint_params = task_instance.xcom_pull(
-            task_ids=self.google_api_endpoint_params_via_xcom_task_ids,
-            key=self.google_api_endpoint_params_via_xcom
-        )
-        self.google_api_endpoint_params.update(google_api_endpoint_params)
-
-    def _expose_google_api_response_via_xcom(self, task_instance, data):
-        if sys.getsizeof(data) < MAX_XCOM_SIZE:
-            task_instance.xcom_push(key=self.google_api_response_via_xcom, value=data)
-        else:
-            raise RuntimeError('The size of the downloaded data is too large to push to XCom!')
+warnings.warn(
+    "This module is deprecated. "
+    "Please use `airflow.providers.amazon.aws.operators.google_api_to_s3_transfer`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -16,112 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-Transfers data from AWS Redshift into a S3 Bucket.
-"""
-from typing import List, Optional, Union
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.redshift_to_s3`."""
 
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.utils.decorators import apply_defaults
+import warnings
 
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.redshift_to_s3 import RedshiftToS3Transfer  # noqa
 
-class RedshiftToS3Transfer(BaseOperator):
-    """
-    Executes an UNLOAD command to s3 as a CSV with headers
-
-    :param schema: reference to a specific schema in redshift database
-    :type schema: str
-    :param table: reference to a specific table in redshift database
-    :type table: str
-    :param s3_bucket: reference to a specific S3 bucket
-    :type s3_bucket: str
-    :param s3_key: reference to a specific S3 key. If ``table_as_file_name`` is set
-        to False, this param must include the desired file name
-    :type s3_key: str
-    :param redshift_conn_id: reference to a specific redshift database
-    :type redshift_conn_id: str
-    :param aws_conn_id: reference to a specific S3 connection
-    :type aws_conn_id: str
-    :param verify: Whether or not to verify SSL certificates for S3 connection.
-        By default SSL certificates are verified.
-        You can provide the following values:
-
-        - ``False``: do not validate SSL certificates. SSL will still be used
-                 (unless use_ssl is False), but SSL certificates will not be
-                 verified.
-        - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
-                 You can specify this argument if you want to use a different
-                 CA cert bundle than the one used by botocore.
-    :type verify: bool or str
-    :param unload_options: reference to a list of UNLOAD options
-    :type unload_options: list
-    :param autocommit: If set to True it will automatically commit the UNLOAD statement.
-        Otherwise it will be committed right before the redshift connection gets closed.
-    :type autocommit: bool
-    :param include_header: If set to True the s3 file contains the header columns.
-    :type include_header: bool
-    :param table_as_file_name: If set to True, the s3 file will be named as the table
-    :type table_as_file_name: bool
-    """
-
-    template_fields = ()
-    template_ext = ()
-    ui_color = '#ededed'
-
-    @apply_defaults
-    def __init__(  # pylint: disable=too-many-arguments
-            self,
-            schema: str,
-            table: str,
-            s3_bucket: str,
-            s3_key: str,
-            redshift_conn_id: str = 'redshift_default',
-            aws_conn_id: str = 'aws_default',
-            verify: Optional[Union[bool, str]] = None,
-            unload_options: Optional[List] = None,
-            autocommit: bool = False,
-            include_header: bool = False,
-            table_as_file_name: bool = True,  # Set to True by default for not breaking current workflows
-            *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self.schema = schema
-        self.table = table
-        self.s3_bucket = s3_bucket
-        self.s3_key = s3_key
-        self.redshift_conn_id = redshift_conn_id
-        self.aws_conn_id = aws_conn_id
-        self.verify = verify
-        self.unload_options = unload_options or []  # type: List
-        self.autocommit = autocommit
-        self.include_header = include_header
-        self.table_as_file_name = table_as_file_name
-
-        if self.include_header and 'HEADER' not in [uo.upper().strip() for uo in self.unload_options]:
-            self.unload_options = list(self.unload_options) + ['HEADER', ]
-
-    def execute(self, context):
-        postgres_hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)
-        s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
-
-        credentials = s3_hook.get_credentials()
-        unload_options = '\n\t\t\t'.join(self.unload_options)
-        s3_key = '{}/{}_'.format(self.s3_key, self.table) if self.table_as_file_name else self.s3_key
-        select_query = "SELECT * FROM {schema}.{table}".format(schema=self.schema, table=self.table)
-        unload_query = """
-                    UNLOAD ('{select_query}')
-                    TO 's3://{s3_bucket}/{s3_key}'
-                    with credentials
-                    'aws_access_key_id={access_key};aws_secret_access_key={secret_key}'
-                    {unload_options};
-                    """.format(select_query=select_query,
-                               s3_bucket=self.s3_bucket,
-                               s3_key=s3_key,
-                               access_key=credentials.access_key,
-                               secret_key=credentials.secret_key,
-                               unload_options=unload_options)
-
-        self.log.info('Executing UNLOAD command...')
-        postgres_hook.run(unload_query, self.autocommit)
-        self.log.info("UNLOAD command complete...")
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.redshift_to_s3`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/operators/s3_to_redshift_operator.py
+++ b/airflow/operators/s3_to_redshift_operator.py
@@ -16,93 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import List, Optional, Union
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.operators.s3_to_redshift`."""
 
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.utils.decorators import apply_defaults
+import warnings
 
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.operators.s3_to_redshift import S3ToRedshiftTransfer  # noqa
 
-class S3ToRedshiftTransfer(BaseOperator):
-    """
-    Executes an COPY command to load files from s3 to Redshift
-
-    :param schema: reference to a specific schema in redshift database
-    :type schema: str
-    :param table: reference to a specific table in redshift database
-    :type table: str
-    :param s3_bucket: reference to a specific S3 bucket
-    :type s3_bucket: str
-    :param s3_key: reference to a specific S3 key
-    :type s3_key: str
-    :param redshift_conn_id: reference to a specific redshift database
-    :type redshift_conn_id: str
-    :param aws_conn_id: reference to a specific S3 connection
-    :type aws_conn_id: str
-    :param verify: Whether or not to verify SSL certificates for S3 connection.
-        By default SSL certificates are verified.
-        You can provide the following values:
-
-        - ``False``: do not validate SSL certificates. SSL will still be used
-                 (unless use_ssl is False), but SSL certificates will not be
-                 verified.
-        - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
-                 You can specify this argument if you want to use a different
-                 CA cert bundle than the one used by botocore.
-    :type verify: bool or str
-    :param copy_options: reference to a list of COPY options
-    :type copy_options: list
-    """
-
-    template_fields = ()
-    template_ext = ()
-    ui_color = '#ededed'
-
-    @apply_defaults
-    def __init__(
-            self,
-            schema: str,
-            table: str,
-            s3_bucket: str,
-            s3_key: str,
-            redshift_conn_id: str = 'redshift_default',
-            aws_conn_id: str = 'aws_default',
-            verify: Optional[Union[bool, str]] = None,
-            copy_options: Optional[List] = None,
-            autocommit: bool = False,
-            *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self.schema = schema
-        self.table = table
-        self.s3_bucket = s3_bucket
-        self.s3_key = s3_key
-        self.redshift_conn_id = redshift_conn_id
-        self.aws_conn_id = aws_conn_id
-        self.verify = verify
-        self.copy_options = copy_options or []
-        self.autocommit = autocommit
-
-    def execute(self, context):
-        self.hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)
-        self.s3 = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
-        credentials = self.s3.get_credentials()
-        copy_options = '\n\t\t\t'.join(self.copy_options)
-
-        copy_query = """
-            COPY {schema}.{table}
-            FROM 's3://{s3_bucket}/{s3_key}/{table}'
-            with credentials
-            'aws_access_key_id={access_key};aws_secret_access_key={secret_key}'
-            {copy_options};
-        """.format(schema=self.schema,
-                   table=self.table,
-                   s3_bucket=self.s3_bucket,
-                   s3_key=self.s3_key,
-                   access_key=credentials.access_key,
-                   secret_key=credentials.secret_key,
-                   copy_options=copy_options)
-
-        self.log.info('Executing COPY command...')
-        self.hook.run(copy_query, self.autocommit)
-        self.log.info("COPY command complete...")
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.s3_to_redshift`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/providers/amazon/aws/operators/dynamodb_to_s3.py
+++ b/airflow/providers/amazon/aws/operators/dynamodb_to_s3.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""
+This module contains operators to replicate records from
+DynamoDB table to S3.
+"""
+
+from copy import copy
+from os.path import getsize
+from tempfile import NamedTemporaryFile
+from typing import Any, Callable, Dict, Optional
+from uuid import uuid4
+
+from boto.compat import json  # type: ignore
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.aws_dynamodb_hook import AwsDynamoDBHook
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
+
+def _convert_item_to_json_bytes(item):
+    return (json.dumps(item) + '\n').encode('utf-8')
+
+
+def _upload_file_to_s3(file_obj, bucket_name, s3_key_prefix):
+    s3_client = S3Hook().get_conn()
+    file_obj.seek(0)
+    s3_client.upload_file(
+        Filename=file_obj.name,
+        Bucket=bucket_name,
+        Key=s3_key_prefix + str(uuid4()),
+    )
+
+
+class DynamoDBToS3Operator(BaseOperator):
+    """
+    Replicates records from a DynamoDB table to S3.
+    It scans a DynamoDB table and write the received records to a file
+    on the local filesystem. It flushes the file to S3 once the file size
+    exceeds the file size limit specified by the user.
+
+    Users can also specify a filtering criteria using dynamodb_scan_kwargs
+    to only replicate records that satisfy the criteria.
+
+    To parallelize the replication, users can create multiple tasks of DynamoDBToS3Operator.
+    For instance to replicate with parallelism of 2, create two tasks like:
+
+    .. code-block::
+
+        op1 = DynamoDBToS3Operator(
+            task_id='replicator-1',
+            dynamodb_table_name='hello',
+            dynamodb_scan_kwargs={
+                'TotalSegments': 2,
+                'Segment': 0,
+            },
+            ...
+        )
+
+        op2 = DynamoDBToS3Operator(
+            task_id='replicator-2',
+            dynamodb_table_name='hello',
+            dynamodb_scan_kwargs={
+                'TotalSegments': 2,
+                'Segment': 1,
+            },
+            ...
+        )
+
+    :param dynamodb_table_name: Dynamodb table to replicate data from
+    :param s3_bucket_name: S3 bucket to replicate data to
+    :param file_size: Flush file to s3 if file size >= file_size
+    :param dynamodb_scan_kwargs: kwargs pass to <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Table.scan>  # noqa: E501 pylint: disable=line-too-long
+    :param s3_key_prefix: Prefix of s3 object key
+    :param process_func: How we transforms a dynamodb item to bytes. By default we dump the json
+    """
+
+    def __init__(self,
+                 dynamodb_table_name: str,
+                 s3_bucket_name: str,
+                 file_size: int,
+                 dynamodb_scan_kwargs: Optional[Dict[str, Any]] = None,
+                 s3_key_prefix: str = '',
+                 process_func: Callable[[Dict[str, Any]], bytes] = _convert_item_to_json_bytes,
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.file_size = file_size
+        self.process_func = process_func
+        self.dynamodb_table_name = dynamodb_table_name
+        self.dynamodb_scan_kwargs = dynamodb_scan_kwargs
+        self.s3_bucket_name = s3_bucket_name
+        self.s3_key_prefix = s3_key_prefix
+
+    def execute(self, context):
+        table = AwsDynamoDBHook().get_conn().Table(self.dynamodb_table_name)
+        scan_kwargs = copy(self.dynamodb_scan_kwargs) if self.dynamodb_scan_kwargs else {}
+        err = None
+        f = NamedTemporaryFile()
+        try:
+            f = self._scan_dynamodb_and_upload_to_s3(f, scan_kwargs, table)
+        except Exception as e:
+            err = e
+            raise e
+        finally:
+            if err is None:
+                _upload_file_to_s3(f, self.s3_bucket_name, self.s3_key_prefix)
+            f.close()
+
+    def _scan_dynamodb_and_upload_to_s3(self, temp_file, scan_kwargs, table):
+        while True:
+            response = table.scan(**scan_kwargs)
+            items = response['Items']
+            for item in items:
+                temp_file.write(self.process_func(item))
+
+            if 'LastEvaluatedKey' not in response:
+                # no more items to scan
+                break
+
+            last_evaluated_key = response['LastEvaluatedKey']
+            scan_kwargs['ExclusiveStartKey'] = last_evaluated_key
+
+            # Upload the file to S3 if reach file size limit
+            if getsize(temp_file.name) >= self.file_size:
+                _upload_file_to_s3(temp_file, self.s3_bucket_name,
+                                   self.s3_key_prefix)
+                temp_file.close()
+                temp_file = NamedTemporaryFile()
+        return temp_file

--- a/airflow/providers/amazon/aws/operators/gcs_to_s3.py
+++ b/airflow/providers/amazon/aws/operators/gcs_to_s3.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This module contains Google Cloud Storage to S3 operator.
+"""
+import warnings
+
+from airflow.gcp.hooks.gcs import GCSHook
+from airflow.gcp.operators.gcs import GCSListObjectsOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.utils.decorators import apply_defaults
+
+
+class GCSToS3Operator(GCSListObjectsOperator):
+    """
+    Synchronizes a Google Cloud Storage bucket with an S3 bucket.
+
+    :param bucket: The Google Cloud Storage bucket to find the objects. (templated)
+    :type bucket: str
+    :param prefix: Prefix string which filters objects whose name begin with
+        this prefix. (templated)
+    :type prefix: str
+    :param delimiter: The delimiter by which you want to filter the objects. (templated)
+        For e.g to lists the CSV files from in a directory in GCS you would use
+        delimiter='.csv'.
+    :type delimiter: str
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
+    :type google_cloud_storage_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param dest_aws_conn_id: The destination S3 connection
+    :type dest_aws_conn_id: str
+    :param dest_s3_key: The base S3 key to be used to store the files. (templated)
+    :type dest_s3_key: str
+    :param dest_verify: Whether or not to verify SSL certificates for S3 connection.
+        By default SSL certificates are verified.
+        You can provide the following values:
+
+        - ``False``: do not validate SSL certificates. SSL will still be used
+                 (unless use_ssl is False), but SSL certificates will not be
+                 verified.
+        - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
+                 You can specify this argument if you want to use a different
+                 CA cert bundle than the one used by botocore.
+
+    :type dest_verify: bool or str
+    :param replace: Whether or not to verify the existence of the files in the
+        destination bucket.
+        By default is set to False
+        If set to True, will upload all the files replacing the existing ones in
+        the destination bucket.
+        If set to False, will upload only the files that are in the origin but not
+        in the destination bucket.
+    :type replace: bool
+    """
+    template_fields = ('bucket', 'prefix', 'delimiter', 'dest_s3_key')
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,  # pylint: disable=too-many-arguments
+                 bucket,
+                 prefix=None,
+                 delimiter=None,
+                 gcp_conn_id='google_cloud_default',
+                 google_cloud_storage_conn_id=None,
+                 delegate_to=None,
+                 dest_aws_conn_id=None,
+                 dest_s3_key=None,
+                 dest_verify=None,
+                 replace=False,
+                 *args,
+                 **kwargs):
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
+        super().__init__(
+            bucket=bucket,
+            prefix=prefix,
+            delimiter=delimiter,
+            gcp_conn_id=gcp_conn_id,
+            delegate_to=delegate_to,
+            *args,
+            **kwargs
+        )
+
+        self.dest_aws_conn_id = dest_aws_conn_id
+        self.dest_s3_key = dest_s3_key
+        self.dest_verify = dest_verify
+        self.replace = replace
+
+    def execute(self, context):
+        # use the super to list all files in an Google Cloud Storage bucket
+        files = super().execute(context)
+        s3_hook = S3Hook(aws_conn_id=self.dest_aws_conn_id, verify=self.dest_verify)
+
+        if not self.replace:
+            # if we are not replacing -> list all files in the S3 bucket
+            # and only keep those files which are present in
+            # Google Cloud Storage and not in S3
+            bucket_name, prefix = S3Hook.parse_s3_url(self.dest_s3_key)
+            # look for the bucket and the prefix to avoid look into
+            # parent directories/keys
+            existing_files = s3_hook.list_keys(bucket_name, prefix=prefix)
+            # in case that no files exists, return an empty array to avoid errors
+            existing_files = existing_files if existing_files is not None else []
+            # remove the prefix for the existing files to allow the match
+            existing_files = [file.replace(prefix, '', 1) for file in existing_files]
+            files = list(set(files) - set(existing_files))
+
+        if files:
+            hook = GCSHook(
+                google_cloud_storage_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to
+            )
+
+            for file in files:
+                file_bytes = hook.download(self.bucket, file)
+
+                dest_key = self.dest_s3_key + file
+                self.log.info("Saving file to %s", dest_key)
+
+                s3_hook.load_bytes(file_bytes,
+                                   key=dest_key,
+                                   replace=self.replace)
+
+            self.log.info("All done, uploaded %d files to S3", len(files))
+        else:
+            self.log.info("In sync, no files needed to be uploaded to S3")
+
+        return files

--- a/airflow/providers/amazon/aws/operators/google_api_to_s3_transfer.py
+++ b/airflow/providers/amazon/aws/operators/google_api_to_s3_transfer.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""
+This module allows you to transfer data from any Google API endpoint into a S3 Bucket.
+"""
+import json
+import sys
+
+from airflow.gcp.hooks.discovery_api import GoogleDiscoveryApiHook
+from airflow.models import BaseOperator
+from airflow.models.xcom import MAX_XCOM_SIZE
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.utils.decorators import apply_defaults
+
+
+class GoogleApiToS3Transfer(BaseOperator):
+    """
+    Basic class for transferring data from a Google API endpoint into a S3 Bucket.
+
+    :param google_api_service_name: The specific API service that is being requested.
+    :type google_api_service_name: str
+    :param google_api_service_version: The version of the API that is being requested.
+    :type google_api_service_version: str
+    :param google_api_endpoint_path: The client libraries path to the api call's executing method.
+        For example: 'analyticsreporting.reports.batchGet'
+
+        .. note:: See https://developers.google.com/apis-explorer
+            for more information on which methods are available.
+
+    :type google_api_endpoint_path: str
+    :param google_api_endpoint_params: The params to control the corresponding endpoint result.
+    :type google_api_endpoint_params: dict
+    :param s3_destination_key: The url where to put the data retrieved from the endpoint in S3.
+    :type s3_destination_key: str
+    :param google_api_response_via_xcom: Can be set to expose the google api response to xcom.
+    :type google_api_response_via_xcom: str
+    :param google_api_endpoint_params_via_xcom: If set to a value this value will be used as a key
+        for pulling from xcom and updating the google api endpoint params.
+    :type google_api_endpoint_params_via_xcom: str
+    :param google_api_endpoint_params_via_xcom_task_ids: Task ids to filter xcom by.
+    :type google_api_endpoint_params_via_xcom_task_ids: str or list of str
+    :param google_api_pagination: If set to True Pagination will be enabled for this request
+        to retrieve all data.
+
+        .. note:: This means the response will be a list of responses.
+
+    :type google_api_pagination: bool
+    :param google_api_num_retries: Define the number of retries for the google api requests being made
+        if it fails.
+    :type google_api_num_retries: int
+    :param s3_overwrite: Specifies whether the s3 file will be overwritten if exists.
+    :type s3_overwrite: bool
+    :param gcp_conn_id: The connection ID to use when fetching connection info.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param aws_conn_id: The connection id specifying the authentication information for the S3 Bucket.
+    :type aws_conn_id: str
+    """
+
+    template_fields = (
+        'google_api_endpoint_params',
+        's3_destination_key',
+    )
+    template_ext = ()
+    ui_color = '#cc181e'
+
+    @apply_defaults
+    def __init__(
+        self,
+        google_api_service_name,
+        google_api_service_version,
+        google_api_endpoint_path,
+        google_api_endpoint_params,
+        s3_destination_key,
+        *args,
+        google_api_response_via_xcom=None,
+        google_api_endpoint_params_via_xcom=None,
+        google_api_endpoint_params_via_xcom_task_ids=None,
+        google_api_pagination=False,
+        google_api_num_retries=0,
+        s3_overwrite=False,
+        gcp_conn_id='google_cloud_default',
+        delegate_to=None,
+        aws_conn_id='aws_default',
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.google_api_service_name = google_api_service_name
+        self.google_api_service_version = google_api_service_version
+        self.google_api_endpoint_path = google_api_endpoint_path
+        self.google_api_endpoint_params = google_api_endpoint_params
+        self.s3_destination_key = s3_destination_key
+        self.google_api_response_via_xcom = google_api_response_via_xcom
+        self.google_api_endpoint_params_via_xcom = google_api_endpoint_params_via_xcom
+        self.google_api_endpoint_params_via_xcom_task_ids = google_api_endpoint_params_via_xcom_task_ids
+        self.google_api_pagination = google_api_pagination
+        self.google_api_num_retries = google_api_num_retries
+        self.s3_overwrite = s3_overwrite
+        self.gcp_conn_id = gcp_conn_id
+        self.delegate_to = delegate_to
+        self.aws_conn_id = aws_conn_id
+
+    def execute(self, context):
+        """
+        Transfers Google APIs json data to S3.
+
+        :param context: The context that is being provided when executing.
+        :type context: dict
+        """
+        self.log.info('Transferring data from %s to s3', self.google_api_service_name)
+
+        if self.google_api_endpoint_params_via_xcom:
+            self._update_google_api_endpoint_params_via_xcom(context['task_instance'])
+
+        data = self._retrieve_data_from_google_api()
+
+        self._load_data_to_s3(data)
+
+        if self.google_api_response_via_xcom:
+            self._expose_google_api_response_via_xcom(context['task_instance'], data)
+
+    def _retrieve_data_from_google_api(self):
+        google_discovery_api_hook = GoogleDiscoveryApiHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            api_service_name=self.google_api_service_name,
+            api_version=self.google_api_service_version
+        )
+        google_api_response = google_discovery_api_hook.query(
+            endpoint=self.google_api_endpoint_path,
+            data=self.google_api_endpoint_params,
+            paginate=self.google_api_pagination,
+            num_retries=self.google_api_num_retries
+        )
+        return google_api_response
+
+    def _load_data_to_s3(self, data):
+        s3_hook = S3Hook(aws_conn_id=self.aws_conn_id)
+        s3_hook.load_string(
+            string_data=json.dumps(data),
+            key=self.s3_destination_key,
+            replace=self.s3_overwrite
+        )
+
+    def _update_google_api_endpoint_params_via_xcom(self, task_instance):
+        google_api_endpoint_params = task_instance.xcom_pull(
+            task_ids=self.google_api_endpoint_params_via_xcom_task_ids,
+            key=self.google_api_endpoint_params_via_xcom
+        )
+        self.google_api_endpoint_params.update(google_api_endpoint_params)
+
+    def _expose_google_api_response_via_xcom(self, task_instance, data):
+        if sys.getsizeof(data) < MAX_XCOM_SIZE:
+            task_instance.xcom_push(key=self.google_api_response_via_xcom, value=data)
+        else:
+            raise RuntimeError('The size of the downloaded data is too large to push to XCom!')

--- a/airflow/providers/amazon/aws/operators/hive_to_dynamodb.py
+++ b/airflow/providers/amazon/aws/operators/hive_to_dynamodb.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This module contains operator to move data from Hive to DynamoDB.
+"""
+
+import json
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.aws_dynamodb_hook import AwsDynamoDBHook
+from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
+from airflow.utils.decorators import apply_defaults
+
+
+class HiveToDynamoDBTransferOperator(BaseOperator):
+    """
+    Moves data from Hive to DynamoDB, note that for now the data is loaded
+    into memory before being pushed to DynamoDB, so this operator should
+    be used for smallish amount of data.
+
+    :param sql: SQL query to execute against the hive database. (templated)
+    :type sql: str
+    :param table_name: target DynamoDB table
+    :type table_name: str
+    :param table_keys: partition key and sort key
+    :type table_keys: list
+    :param pre_process: implement pre-processing of source data
+    :type pre_process: function
+    :param pre_process_args: list of pre_process function arguments
+    :type pre_process_args: list
+    :param pre_process_kwargs: dict of pre_process function arguments
+    :type pre_process_kwargs: dict
+    :param region_name: aws region name (example: us-east-1)
+    :type region_name: str
+    :param schema: hive database schema
+    :type schema: str
+    :param hiveserver2_conn_id: source hive connection
+    :type hiveserver2_conn_id: str
+    :param aws_conn_id: aws connection
+    :type aws_conn_id: str
+    """
+
+    template_fields = ('sql',)
+    template_ext = ('.sql',)
+    ui_color = '#a0e08c'
+
+    @apply_defaults
+    def __init__(  # pylint: disable=too-many-arguments
+            self,
+            sql,
+            table_name,
+            table_keys,
+            pre_process=None,
+            pre_process_args=None,
+            pre_process_kwargs=None,
+            region_name=None,
+            schema='default',
+            hiveserver2_conn_id='hiveserver2_default',
+            aws_conn_id='aws_default',
+            *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sql = sql
+        self.table_name = table_name
+        self.table_keys = table_keys
+        self.pre_process = pre_process
+        self.pre_process_args = pre_process_args
+        self.pre_process_kwargs = pre_process_kwargs
+        self.region_name = region_name
+        self.schema = schema
+        self.hiveserver2_conn_id = hiveserver2_conn_id
+        self.aws_conn_id = aws_conn_id
+
+    def execute(self, context):
+        hive = HiveServer2Hook(hiveserver2_conn_id=self.hiveserver2_conn_id)
+
+        self.log.info('Extracting data from Hive')
+        self.log.info(self.sql)
+
+        data = hive.get_pandas_df(self.sql, schema=self.schema)
+        dynamodb = AwsDynamoDBHook(aws_conn_id=self.aws_conn_id,
+                                   table_name=self.table_name,
+                                   table_keys=self.table_keys,
+                                   region_name=self.region_name)
+
+        self.log.info('Inserting rows into dynamodb')
+
+        if self.pre_process is None:
+            dynamodb.write_batch_data(
+                json.loads(data.to_json(orient='records')))
+        else:
+            dynamodb.write_batch_data(
+                self.pre_process(data=data,
+                                 args=self.pre_process_args,
+                                 kwargs=self.pre_process_kwargs))
+
+        self.log.info('Done.')

--- a/airflow/providers/amazon/aws/operators/imap_attachment_to_s3.py
+++ b/airflow/providers/amazon/aws/operators/imap_attachment_to_s3.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This module allows you to transfer mail attachments from a mail server into s3 bucket.
+"""
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.imap.hooks.imap import ImapHook
+from airflow.utils.decorators import apply_defaults
+
+
+class ImapAttachmentToS3Operator(BaseOperator):
+    """
+    Transfers a mail attachment from a mail server into s3 bucket.
+
+    :param imap_attachment_name: The file name of the mail attachment that you want to transfer.
+    :type imap_attachment_name: str
+    :param s3_key: The destination file name in the s3 bucket for the attachment.
+    :type s3_key: str
+    :param imap_check_regex: If set checks the `imap_attachment_name` for a regular expression.
+    :type imap_check_regex: bool
+    :param imap_mail_folder: The folder on the mail server to look for the attachment.
+    :type imap_mail_folder: str
+    :param imap_mail_filter: If set other than 'All' only specific mails will be checked.
+        See :py:meth:`imaplib.IMAP4.search` for details.
+    :type imap_mail_filter: str
+    :param s3_overwrite: If set overwrites the s3 key if already exists.
+    :type s3_overwrite: bool
+    :param imap_conn_id: The reference to the connection details of the mail server.
+    :type imap_conn_id: str
+    :param s3_conn_id: The reference to the s3 connection details.
+    :type s3_conn_id: str
+    """
+    template_fields = ('imap_attachment_name', 's3_key', 'imap_mail_filter')
+
+    @apply_defaults
+    def __init__(self,
+                 imap_attachment_name,
+                 s3_key,
+                 imap_check_regex=False,
+                 imap_mail_folder='INBOX',
+                 imap_mail_filter='All',
+                 s3_overwrite=False,
+                 imap_conn_id='imap_default',
+                 s3_conn_id='aws_default',
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.imap_attachment_name = imap_attachment_name
+        self.s3_key = s3_key
+        self.imap_check_regex = imap_check_regex
+        self.imap_mail_folder = imap_mail_folder
+        self.imap_mail_filter = imap_mail_filter
+        self.s3_overwrite = s3_overwrite
+        self.imap_conn_id = imap_conn_id
+        self.s3_conn_id = s3_conn_id
+
+    def execute(self, context):
+        """
+        This function executes the transfer from the email server (via imap) into s3.
+
+        :param context: The context while executing.
+        :type context: dict
+        """
+        self.log.info(
+            'Transferring mail attachment %s from mail server via imap to s3 key %s...',
+            self.imap_attachment_name, self.s3_key
+        )
+
+        with ImapHook(imap_conn_id=self.imap_conn_id) as imap_hook:
+            imap_mail_attachments = imap_hook.retrieve_mail_attachments(
+                name=self.imap_attachment_name,
+                check_regex=self.imap_check_regex,
+                latest_only=True,
+                mail_folder=self.imap_mail_folder,
+                mail_filter=self.imap_mail_filter,
+            )
+
+        s3_hook = S3Hook(aws_conn_id=self.s3_conn_id)
+        s3_hook.load_bytes(bytes_data=imap_mail_attachments[0][1],
+                           key=self.s3_key,
+                           replace=self.s3_overwrite)

--- a/airflow/providers/amazon/aws/operators/mongo_to_s3.py
+++ b/airflow/providers/amazon/aws/operators/mongo_to_s3.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+
+from bson import json_util
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.mongo.hooks.mongo import MongoHook
+from airflow.utils.decorators import apply_defaults
+
+
+class MongoToS3Operator(BaseOperator):
+    """
+    Mongo -> S3
+        A more specific baseOperator meant to move data
+        from mongo via pymongo to s3 via boto
+
+        things to note
+                .execute() is written to depend on .transform()
+                .transform() is meant to be extended by child classes
+                to perform transformations unique to those operators needs
+    """
+
+    template_fields = ['s3_key', 'mongo_query']
+    # pylint: disable=too-many-instance-attributes
+
+    @apply_defaults
+    def __init__(self,
+                 mongo_conn_id,
+                 s3_conn_id,
+                 mongo_collection,
+                 mongo_query,
+                 s3_bucket,
+                 s3_key,
+                 mongo_db=None,
+                 replace=False,
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Conn Ids
+        self.mongo_conn_id = mongo_conn_id
+        self.s3_conn_id = s3_conn_id
+        # Mongo Query Settings
+        self.mongo_db = mongo_db
+        self.mongo_collection = mongo_collection
+        # Grab query and determine if we need to run an aggregate pipeline
+        self.mongo_query = mongo_query
+        self.is_pipeline = True if isinstance(
+            self.mongo_query, list) else False
+
+        # S3 Settings
+        self.s3_bucket = s3_bucket
+        self.s3_key = s3_key
+        self.replace = replace
+
+    def execute(self, context):
+        """
+        Executed by task_instance at runtime
+        """
+        s3_conn = S3Hook(self.s3_conn_id)
+
+        # Grab collection and execute query according to whether or not it is a pipeline
+        if self.is_pipeline:
+            results = MongoHook(self.mongo_conn_id).aggregate(
+                mongo_collection=self.mongo_collection,
+                aggregate_query=self.mongo_query,
+                mongo_db=self.mongo_db
+            )
+
+        else:
+            results = MongoHook(self.mongo_conn_id).find(
+                mongo_collection=self.mongo_collection,
+                query=self.mongo_query,
+                mongo_db=self.mongo_db
+            )
+
+        # Performs transform then stringifies the docs results into json format
+        docs_str = self._stringify(self.transform(results))
+
+        # Load Into S3
+        s3_conn.load_string(
+            string_data=docs_str,
+            key=self.s3_key,
+            bucket_name=self.s3_bucket,
+            replace=self.replace
+        )
+
+        return True
+
+    @staticmethod
+    def _stringify(iterable, joinable='\n'):
+        """
+        Takes an iterable (pymongo Cursor or Array) containing dictionaries and
+        returns a stringified version using python join
+        """
+        return joinable.join(
+            [json.dumps(doc, default=json_util.default) for doc in iterable]
+        )
+
+    @staticmethod
+    def transform(docs):
+        """
+        Processes pyMongo cursor and returns an iterable with each element being
+                a JSON serializable dictionary
+
+        Base transform() assumes no processing is needed
+        ie. docs is a pyMongo cursor of documents and cursor just
+        needs to be passed through
+
+        Override this method for custom transformations
+        """
+        return docs

--- a/airflow/providers/amazon/aws/operators/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/operators/redshift_to_s3.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Transfers data from AWS Redshift into a S3 Bucket.
+"""
+from typing import List, Optional, Union
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.utils.decorators import apply_defaults
+
+
+class RedshiftToS3Transfer(BaseOperator):
+    """
+    Executes an UNLOAD command to s3 as a CSV with headers
+
+    :param schema: reference to a specific schema in redshift database
+    :type schema: str
+    :param table: reference to a specific table in redshift database
+    :type table: str
+    :param s3_bucket: reference to a specific S3 bucket
+    :type s3_bucket: str
+    :param s3_key: reference to a specific S3 key. If ``table_as_file_name`` is set
+        to False, this param must include the desired file name
+    :type s3_key: str
+    :param redshift_conn_id: reference to a specific redshift database
+    :type redshift_conn_id: str
+    :param aws_conn_id: reference to a specific S3 connection
+    :type aws_conn_id: str
+    :param verify: Whether or not to verify SSL certificates for S3 connection.
+        By default SSL certificates are verified.
+        You can provide the following values:
+
+        - ``False``: do not validate SSL certificates. SSL will still be used
+                 (unless use_ssl is False), but SSL certificates will not be
+                 verified.
+        - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
+                 You can specify this argument if you want to use a different
+                 CA cert bundle than the one used by botocore.
+    :type verify: bool or str
+    :param unload_options: reference to a list of UNLOAD options
+    :type unload_options: list
+    :param autocommit: If set to True it will automatically commit the UNLOAD statement.
+        Otherwise it will be committed right before the redshift connection gets closed.
+    :type autocommit: bool
+    :param include_header: If set to True the s3 file contains the header columns.
+    :type include_header: bool
+    :param table_as_file_name: If set to True, the s3 file will be named as the table
+    :type table_as_file_name: bool
+    """
+
+    template_fields = ()
+    template_ext = ()
+    ui_color = '#ededed'
+
+    @apply_defaults
+    def __init__(  # pylint: disable=too-many-arguments
+            self,
+            schema: str,
+            table: str,
+            s3_bucket: str,
+            s3_key: str,
+            redshift_conn_id: str = 'redshift_default',
+            aws_conn_id: str = 'aws_default',
+            verify: Optional[Union[bool, str]] = None,
+            unload_options: Optional[List] = None,
+            autocommit: bool = False,
+            include_header: bool = False,
+            table_as_file_name: bool = True,  # Set to True by default for not breaking current workflows
+            *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.schema = schema
+        self.table = table
+        self.s3_bucket = s3_bucket
+        self.s3_key = s3_key
+        self.redshift_conn_id = redshift_conn_id
+        self.aws_conn_id = aws_conn_id
+        self.verify = verify
+        self.unload_options = unload_options or []  # type: List
+        self.autocommit = autocommit
+        self.include_header = include_header
+        self.table_as_file_name = table_as_file_name
+
+        if self.include_header and 'HEADER' not in [uo.upper().strip() for uo in self.unload_options]:
+            self.unload_options = list(self.unload_options) + ['HEADER', ]
+
+    def execute(self, context):
+        postgres_hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)
+        s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
+
+        credentials = s3_hook.get_credentials()
+        unload_options = '\n\t\t\t'.join(self.unload_options)
+        s3_key = '{}/{}_'.format(self.s3_key, self.table) if self.table_as_file_name else self.s3_key
+        select_query = "SELECT * FROM {schema}.{table}".format(schema=self.schema, table=self.table)
+        unload_query = """
+                    UNLOAD ('{select_query}')
+                    TO 's3://{s3_bucket}/{s3_key}'
+                    with credentials
+                    'aws_access_key_id={access_key};aws_secret_access_key={secret_key}'
+                    {unload_options};
+                    """.format(select_query=select_query,
+                               s3_bucket=self.s3_bucket,
+                               s3_key=s3_key,
+                               access_key=credentials.access_key,
+                               secret_key=credentials.secret_key,
+                               unload_options=unload_options)
+
+        self.log.info('Executing UNLOAD command...')
+        postgres_hook.run(unload_query, self.autocommit)
+        self.log.info("UNLOAD command complete...")

--- a/airflow/providers/amazon/aws/operators/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/operators/s3_to_redshift.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import List, Optional, Union
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.utils.decorators import apply_defaults
+
+
+class S3ToRedshiftTransfer(BaseOperator):
+    """
+    Executes an COPY command to load files from s3 to Redshift
+
+    :param schema: reference to a specific schema in redshift database
+    :type schema: str
+    :param table: reference to a specific table in redshift database
+    :type table: str
+    :param s3_bucket: reference to a specific S3 bucket
+    :type s3_bucket: str
+    :param s3_key: reference to a specific S3 key
+    :type s3_key: str
+    :param redshift_conn_id: reference to a specific redshift database
+    :type redshift_conn_id: str
+    :param aws_conn_id: reference to a specific S3 connection
+    :type aws_conn_id: str
+    :param verify: Whether or not to verify SSL certificates for S3 connection.
+        By default SSL certificates are verified.
+        You can provide the following values:
+
+        - ``False``: do not validate SSL certificates. SSL will still be used
+                 (unless use_ssl is False), but SSL certificates will not be
+                 verified.
+        - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
+                 You can specify this argument if you want to use a different
+                 CA cert bundle than the one used by botocore.
+    :type verify: bool or str
+    :param copy_options: reference to a list of COPY options
+    :type copy_options: list
+    """
+
+    template_fields = ()
+    template_ext = ()
+    ui_color = '#ededed'
+
+    @apply_defaults
+    def __init__(
+            self,
+            schema: str,
+            table: str,
+            s3_bucket: str,
+            s3_key: str,
+            redshift_conn_id: str = 'redshift_default',
+            aws_conn_id: str = 'aws_default',
+            verify: Optional[Union[bool, str]] = None,
+            copy_options: Optional[List] = None,
+            autocommit: bool = False,
+            *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.schema = schema
+        self.table = table
+        self.s3_bucket = s3_bucket
+        self.s3_key = s3_key
+        self.redshift_conn_id = redshift_conn_id
+        self.aws_conn_id = aws_conn_id
+        self.verify = verify
+        self.copy_options = copy_options or []
+        self.autocommit = autocommit
+
+    def execute(self, context):
+        self.hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)
+        self.s3 = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
+        credentials = self.s3.get_credentials()
+        copy_options = '\n\t\t\t'.join(self.copy_options)
+
+        copy_query = """
+            COPY {schema}.{table}
+            FROM 's3://{s3_bucket}/{s3_key}/{table}'
+            with credentials
+            'aws_access_key_id={access_key};aws_secret_access_key={secret_key}'
+            {copy_options};
+        """.format(schema=self.schema,
+                   table=self.table,
+                   s3_bucket=self.s3_bucket,
+                   s3_key=self.s3_key,
+                   access_key=credentials.access_key,
+                   secret_key=credentials.secret_key,
+                   copy_options=copy_options)
+
+        self.log.info('Executing COPY command...')
+        self.hook.run(copy_query, self.autocommit)
+        self.log.info("COPY command complete...")

--- a/airflow/providers/amazon/aws/operators/s3_to_sftp.py
+++ b/airflow/providers/amazon/aws/operators/s3_to_sftp.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from tempfile import NamedTemporaryFile
+from urllib.parse import urlparse
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.utils.decorators import apply_defaults
+
+
+class S3ToSFTPOperator(BaseOperator):
+    """
+    This operator enables the transferring of files from S3 to a SFTP server.
+
+    :param sftp_conn_id: The sftp connection id. The name or identifier for
+        establishing a connection to the SFTP server.
+    :type sftp_conn_id: str
+    :param sftp_path: The sftp remote path. This is the specified file path for
+        uploading file to the SFTP server.
+    :type sftp_path: str
+    :param s3_conn_id: The s3 connection id. The name or identifier for
+        establishing a connection to S3
+    :type s3_conn_id: str
+    :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
+        where the file is downloaded.
+    :type s3_bucket: str
+    :param s3_key: The targeted s3 key. This is the specified file path for
+        downloading the file from S3.
+    :type s3_key: str
+    """
+
+    template_fields = ('s3_key', 'sftp_path')
+
+    @apply_defaults
+    def __init__(self,
+                 s3_bucket,
+                 s3_key,
+                 sftp_path,
+                 sftp_conn_id='ssh_default',
+                 s3_conn_id='aws_default',
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sftp_conn_id = sftp_conn_id
+        self.sftp_path = sftp_path
+        self.s3_bucket = s3_bucket
+        self.s3_key = s3_key
+        self.s3_conn_id = s3_conn_id
+
+    @staticmethod
+    def get_s3_key(s3_key):
+        """This parses the correct format for S3 keys
+            regardless of how the S3 url is passed."""
+
+        parsed_s3_key = urlparse(s3_key)
+        return parsed_s3_key.path.lstrip('/')
+
+    def execute(self, context):
+        self.s3_key = self.get_s3_key(self.s3_key)
+        ssh_hook = SSHHook(ssh_conn_id=self.sftp_conn_id)
+        s3_hook = S3Hook(self.s3_conn_id)
+
+        s3_client = s3_hook.get_conn()
+        sftp_client = ssh_hook.get_conn().open_sftp()
+
+        with NamedTemporaryFile("w") as f:
+            s3_client.download_file(self.s3_bucket, self.s3_key, f.name)
+            sftp_client.put(f.name, self.sftp_path)

--- a/airflow/providers/amazon/aws/operators/sftp_to_s3.py
+++ b/airflow/providers/amazon/aws/operators/sftp_to_s3.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from tempfile import NamedTemporaryFile
+from urllib.parse import urlparse
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.utils.decorators import apply_defaults
+
+
+class SFTPToS3Operator(BaseOperator):
+    """
+    This operator enables the transferring of files from a SFTP server to
+    Amazon S3.
+
+    :param sftp_conn_id: The sftp connection id. The name or identifier for
+        establishing a connection to the SFTP server.
+    :type sftp_conn_id: str
+    :param sftp_path: The sftp remote path. This is the specified file path
+        for downloading the file from the SFTP server.
+    :type sftp_path: str
+    :param s3_conn_id: The s3 connection id. The name or identifier for
+        establishing a connection to S3
+    :type s3_conn_id: str
+    :param s3_bucket: The targeted s3 bucket. This is the S3 bucket to where
+        the file is uploaded.
+    :type s3_bucket: str
+    :param s3_key: The targeted s3 key. This is the specified path for
+        uploading the file to S3.
+    :type s3_key: str
+    """
+
+    template_fields = ('s3_key', 'sftp_path')
+
+    @apply_defaults
+    def __init__(self,
+                 s3_bucket,
+                 s3_key,
+                 sftp_path,
+                 sftp_conn_id='ssh_default',
+                 s3_conn_id='aws_default',
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sftp_conn_id = sftp_conn_id
+        self.sftp_path = sftp_path
+        self.s3_bucket = s3_bucket
+        self.s3_key = s3_key
+        self.s3_conn_id = s3_conn_id
+
+    @staticmethod
+    def get_s3_key(s3_key):
+        """This parses the correct format for S3 keys
+            regardless of how the S3 url is passed."""
+
+        parsed_s3_key = urlparse(s3_key)
+        return parsed_s3_key.path.lstrip('/')
+
+    def execute(self, context):
+        self.s3_key = self.get_s3_key(self.s3_key)
+        ssh_hook = SSHHook(ssh_conn_id=self.sftp_conn_id)
+        s3_hook = S3Hook(self.s3_conn_id)
+
+        sftp_client = ssh_hook.get_conn().open_sftp()
+
+        with NamedTemporaryFile("w") as f:
+            sftp_client.get(self.sftp_path, f.name)
+
+            s3_hook.load_file(
+                filename=f.name,
+                key=self.s3_key,
+                bucket_name=self.s3_bucket,
+                replace=True
+            )

--- a/docs/howto/define_extra_link.rst
+++ b/docs/howto/define_extra_link.rst
@@ -66,7 +66,7 @@ You can also add (or override) an extra link to an existing operators
 through an Airflow plugin.
 
 For example, the following Airflow plugin will add an Operator Link on all
-tasks using :class:`~airflow.operators.gcs_to_s3.GCSToS3Operator` operator.
+tasks using :class:`~airflow.providers.amazon.aws.operators.gcs_to_s3.GCSToS3Operator` operator.
 
 **Adding Operator Links to Existing Operators**
 ``plugins/extra_link.py``:
@@ -75,7 +75,7 @@ tasks using :class:`~airflow.operators.gcs_to_s3.GCSToS3Operator` operator.
 
   from airflow.plugins_manager import AirflowPlugin
   from airflow.models.baseoperator import BaseOperatorLink
-  from airflow.operators.gcs_to_s3 import GCSToS3Operator
+  from airflow.providers.amazon.aws.operators.gcs_to_s3 import GCSToS3Operator
 
   class S3LogLink(BaseOperatorLink):
       name = 'S3'

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -167,7 +167,7 @@ Foundation.
    * - `Apache Hive <https://hive.apache.org/>`__
      - `Amazon DynamoDB <https://aws.amazon.com/dynamodb/>`__
      -
-     - :mod:`airflow.contrib.operators.hive_to_dynamodb`
+     - :mod:`airflow.providers.amazon.aws.operators.hive_to_dynamodb`
 
    * - `Apache Hive <https://hive.apache.org/>`__
      - `Apache Druid <https://druid.apache.org/>`__
@@ -475,7 +475,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `Apache Hive <https://hive.apache.org/>`__
      - `Amazon DynamoDB <https://aws.amazon.com/dynamodb/>`__
      -
-     - :mod:`airflow.contrib.operators.hive_to_dynamodb`
+     - :mod:`airflow.providers.amazon.aws.operators.hive_to_dynamodb`
 
    * - `Google Cloud Storage (GCS) <https://cloud.google.com/gcs/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -470,7 +470,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      - `SSH File Transfer Protocol (SFTP) <https://tools.ietf.org/wg/secsh/draft-ietf-secsh-filexfer/>`__
      -
-     - :mod:`airflow.contrib.operators.s3_to_sftp_operator`
+     - :mod:`airflow.providers.amazon.aws.operators.s3_to_sftp`
 
    * - `Apache Hive <https://hive.apache.org/>`__
      - `Amazon DynamoDB <https://aws.amazon.com/dynamodb/>`__
@@ -1320,7 +1320,7 @@ These integrations allow you to copy data.
    * - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      - `SSH File Transfer Protocol (SFTP) <https://tools.ietf.org/wg/secsh/draft-ietf-secsh-filexfer/>`__
      -
-     - :mod:`airflow.contrib.operators.s3_to_sftp_operator`
+     - :mod:`airflow.providers.amazon.aws.operators.s3_to_sftp`
 
    * - Filesystem
      - `Azure Blob Storage <https://azure.microsoft.com/en-us/services/storage/blobs/>`__

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -480,7 +480,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `Google Cloud Storage (GCS) <https://cloud.google.com/gcs/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.operators.gcs_to_s3`
+     - :mod:`airflow.providers.amazon.aws.operators.gcs_to_s3`
 
    * - `Internet Message Access Protocol (IMAP) <https://tools.ietf.org/html/rfc3501>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
@@ -755,7 +755,7 @@ These integrations allow you to copy data from/to Google Cloud Platform.
    * - `Google Cloud Storage (GCS) <https://cloud.google.com/gcs/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.operators.gcs_to_s3`
+     - :mod:`airflow.providers.amazon.aws.operators.gcs_to_s3`
 
    * - `Google Cloud Storage (GCS) <https://cloud.google.com/gcs/>`__
      - `Google BigQuery <https://cloud.google.com/bigquery/>`__

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -490,7 +490,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `MongoDB <https://www.mongodb.com/what-is-mongodb>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.contrib.operators.mongo_to_s3`
+     - :mod:`airflow.providers.amazon.aws.operators.mongo_to_s3`
 
    * - `SSH File Transfer Protocol (SFTP) <https://tools.ietf.org/wg/secsh/draft-ietf-secsh-filexfer/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
@@ -1177,7 +1177,7 @@ These integrations allow you to copy data.
    * - `MongoDB <https://www.mongodb.com/what-is-mongodb>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.contrib.operators.mongo_to_s3`
+     - :mod:`airflow.providers.amazon.aws.operators.mongo_to_s3`
 
    * - `MySQL <https://www.mysql.com/>`__
      - `Apache Hive <https://hive.apache.org/>`__

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -485,7 +485,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `Internet Message Access Protocol (IMAP) <https://tools.ietf.org/html/rfc3501>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.contrib.operators.imap_attachment_to_s3_operator`
+     - :mod:`airflow.providers.amazon.aws.operators.imap_attachment_to_s3`
 
    * - `MongoDB <https://www.mongodb.com/what-is-mongodb>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
@@ -1335,7 +1335,7 @@ These integrations allow you to copy data.
    * - `Internet Message Access Protocol (IMAP) <https://tools.ietf.org/html/rfc3501>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.contrib.operators.imap_attachment_to_s3_operator`
+     - :mod:`airflow.providers.amazon.aws.operators.imap_attachment_to_s3`
 
    * - `SSH File Transfer Protocol (SFTP) <https://tools.ietf.org/wg/secsh/draft-ietf-secsh-filexfer/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -429,7 +429,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
        All GCP services :ref:`[1] <integration:GCP-Discovery>`
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.operators.google_api_to_s3_transfer`
+     - :mod:`airflow.providers.amazon.aws.operators.google_api_to_s3_transfer`
 
    * - `Amazon DataSync <https://aws.amazon.com/datasync/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
@@ -719,7 +719,7 @@ These integrations allow you to copy data from/to Google Cloud Platform.
        All services :ref:`[1] <integration:GCP-Discovery>`
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.operators.google_api_to_s3_transfer`
+     - :mod:`airflow.providers.amazon.aws.operators.google_api_to_s3_transfer`
 
    * - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      - `Google Cloud Storage (GCS) <https://cloud.google.com/gcs/>`__

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -444,7 +444,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `Amazon Redshift <https://aws.amazon.com/redshift/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      -
-     - :mod:`airflow.operators.redshift_to_s3_operator`
+     - :mod:`airflow.providers.amazon.aws.operators.redshift_to_s3`
 
    * - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      - `Amazon Redshift <https://aws.amazon.com/redshift/>`__

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -495,7 +495,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `SSH File Transfer Protocol (SFTP) <https://tools.ietf.org/wg/secsh/draft-ietf-secsh-filexfer/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      -
-     - :mod:`airflow.contrib.operators.sftp_to_s3_operator`
+     - :mod:`airflow.providers.amazon.aws.operators.sftp_to_s3`
 
 :ref:`[1] <integration:AWS-Discovery-ref>` Those discovery-based operators use
 :class:`airflow.gcp.hooks.discovery_api.GoogleDiscoveryApiHook` to communicate with Google
@@ -1340,4 +1340,4 @@ These integrations allow you to copy data.
    * - `SSH File Transfer Protocol (SFTP) <https://tools.ietf.org/wg/secsh/draft-ietf-secsh-filexfer/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      -
-     - :mod:`airflow.contrib.operators.sftp_to_s3_operator`
+     - :mod:`airflow.providers.amazon.aws.operators.sftp_to_s3`

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -439,7 +439,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `Amazon DynamoDB <https://aws.amazon.com/dynamodb/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      -
-     - :mod:`airflow.contrib.operators.dynamodb_to_s3`
+     - :mod:`airflow.providers.amazon.aws.operators.dynamodb_to_s3`
 
    * - `Amazon Redshift <https://aws.amazon.com/redshift/>`__
      - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -449,7 +449,7 @@ These integrations allow you to copy data from/to Amazon Web Services.
    * - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      - `Amazon Redshift <https://aws.amazon.com/redshift/>`__
      -
-     - :mod:`airflow.operators.s3_to_redshift_operator`
+     - :mod:`airflow.providers.amazon.aws.operators.s3_to_redshift`
 
    * - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`_
      - `Snowflake <https://snowflake.com/>`__

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -165,7 +165,7 @@ definitions in Airflow.
     from airflow.hooks.base_hook import BaseHook
     from airflow.models import BaseOperator
     from airflow.models.baseoperator import BaseOperatorLink
-    from airflow.operators.gcs_to_s3 import GCSToS3Operator
+    from airflow.providers.amazon.aws.operators.gcs_to_s3 import GCSToS3Operator
     from airflow.sensors.base_sensor_operator import BaseSensorOperator
     from airflow.executors.base_executor import BaseExecutor
 

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -159,7 +159,7 @@
 ./airflow/operators/presto_to_mysql.py
 ./airflow/operators/python.py
 ./airflow/providers/amazon/aws/operators/s3_file_transform.py
-./airflow/operators/s3_to_redshift_operator.py
+./airflow/providers/amazon/aws/operators/s3_to_redshift.py
 ./airflow/providers/slack/operators/slack.py
 ./airflow/providers/sqlite/operators/sqlite.py
 ./airflow/providers/amazon/aws/hooks/redshift.py

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -62,7 +62,7 @@
 ./airflow/providers/amazon/aws/operators/sagemaker_transform.py
 ./airflow/providers/amazon/aws/operators/sagemaker_tuning.py
 ./airflow/providers/segment/operators/segment_track_event.py
-./airflow/contrib/operators/sftp_to_s3_operator.py
+./airflow/providers/amazon/aws/operators/sftp_to_s3.py
 ./airflow/providers/slack/operators/slack_webhook.py
 ./airflow/providers/apache/spark/operators/spark_jdbc.py
 ./airflow/providers/apache/spark/operators/spark_sql.py

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -53,7 +53,7 @@
 ./airflow/providers/amazon/aws/operators/s3_delete_objects.py
 ./airflow/providers/amazon/aws/operators/s3_list.py
 ./airflow/contrib/operators/s3_to_gcs_operator.py
-./airflow/contrib/operators/s3_to_sftp_operator.py
+./airflow/providers/amazon/aws/operators/s3_to_sftp.py
 ./airflow/providers/amazon/aws/operators/sagemaker_base.py
 ./airflow/providers/amazon/aws/operators/sagemaker_endpoint_config.py
 ./airflow/providers/amazon/aws/operators/sagemaker_endpoint.py

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -43,7 +43,7 @@
 ./airflow/providers/grpc/operators/grpc.py
 ./airflow/providers/jenkins/operators/jenkins_job_trigger.py
 ./airflow/providers/jira/operators/jira.py
-./airflow/contrib/operators/mongo_to_s3.py
+./airflow/providers/amazon/aws/operators/mongo_to_s3.py
 ./airflow/providers/opsgenie/operators/opsgenie_alert.py
 ./airflow/contrib/operators/oracle_to_azure_data_lake_transfer.py
 ./airflow/contrib/operators/oracle_to_oracle_transfer.py

--- a/tests/providers/amazon/aws/operators/test_dynamodb_to_s3.py
+++ b/tests/providers/amazon/aws/operators/test_dynamodb_to_s3.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock, patch
 
 from boto.compat import json  # type: ignore
 
-from airflow.contrib.operators.dynamodb_to_s3 import DynamoDBToS3Operator
+from airflow.providers.amazon.aws.operators.dynamodb_to_s3 import DynamoDBToS3Operator
 
 
 class DynamodbToS3Test(unittest.TestCase):
@@ -37,8 +37,8 @@ class DynamodbToS3Test(unittest.TestCase):
             for line in lines:
                 self.output_queue.append(json.loads(line))
 
-    @patch('airflow.contrib.operators.dynamodb_to_s3.S3Hook')
-    @patch('airflow.contrib.operators.dynamodb_to_s3.AwsDynamoDBHook')
+    @patch('airflow.providers.amazon.aws.operators.dynamodb_to_s3.S3Hook')
+    @patch('airflow.providers.amazon.aws.operators.dynamodb_to_s3.AwsDynamoDBHook')
     def test_dynamodb_to_s3_success(self, mock_aws_dynamodb_hook, mock_s3_hook):
         responses = [
             {

--- a/tests/providers/amazon/aws/operators/test_gcs_to_s3.py
+++ b/tests/providers/amazon/aws/operators/test_gcs_to_s3.py
@@ -21,8 +21,8 @@ import unittest
 
 import mock
 
-from airflow.operators.gcs_to_s3 import GCSToS3Operator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.amazon.aws.operators.gcs_to_s3 import GCSToS3Operator
 
 try:
     from moto import mock_s3
@@ -42,7 +42,7 @@ class TestGCSToS3Operator(unittest.TestCase):
     # Test1: incremental behaviour (just some files missing)
     @mock_s3
     @mock.patch('airflow.gcp.operators.gcs.GCSHook')
-    @mock.patch('airflow.operators.gcs_to_s3.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.operators.gcs_to_s3.GCSHook')
     def test_execute_incremental(self, mock_hook, mock_hook2):
         mock_hook.return_value.list.return_value = MOCK_FILES
         mock_hook.return_value.download.return_value = b"testing"
@@ -72,7 +72,7 @@ class TestGCSToS3Operator(unittest.TestCase):
     # Test2: All the files are already in origin and destination without replace
     @mock_s3
     @mock.patch('airflow.gcp.operators.gcs.GCSHook')
-    @mock.patch('airflow.operators.gcs_to_s3.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.operators.gcs_to_s3.GCSHook')
     def test_execute_without_replace(self, mock_hook, mock_hook2):
         mock_hook.return_value.list.return_value = MOCK_FILES
         mock_hook.return_value.download.return_value = b"testing"
@@ -103,7 +103,7 @@ class TestGCSToS3Operator(unittest.TestCase):
     # Test3: There are no files in destination bucket
     @mock_s3
     @mock.patch('airflow.gcp.operators.gcs.GCSHook')
-    @mock.patch('airflow.operators.gcs_to_s3.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.operators.gcs_to_s3.GCSHook')
     def test_execute(self, mock_hook, mock_hook2):
         mock_hook.return_value.list.return_value = MOCK_FILES
         mock_hook.return_value.download.return_value = b"testing"
@@ -132,7 +132,7 @@ class TestGCSToS3Operator(unittest.TestCase):
     # Test4: Destination and Origin are in sync but replace all files in destination
     @mock_s3
     @mock.patch('airflow.gcp.operators.gcs.GCSHook')
-    @mock.patch('airflow.operators.gcs_to_s3.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.operators.gcs_to_s3.GCSHook')
     def test_execute_with_replace(self, mock_hook, mock_hook2):
         mock_hook.return_value.list.return_value = MOCK_FILES
         mock_hook.return_value.download.return_value = b"testing"
@@ -163,7 +163,7 @@ class TestGCSToS3Operator(unittest.TestCase):
     # Test5: Incremental sync with replace
     @mock_s3
     @mock.patch('airflow.gcp.operators.gcs.GCSHook')
-    @mock.patch('airflow.operators.gcs_to_s3.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.operators.gcs_to_s3.GCSHook')
     def test_execute_incremental_with_replace(self, mock_hook, mock_hook2):
         mock_hook.return_value.list.return_value = MOCK_FILES
         mock_hook.return_value.download.return_value = b"testing"

--- a/tests/providers/amazon/aws/operators/test_google_api_to_s3_transfer.py
+++ b/tests/providers/amazon/aws/operators/test_google_api_to_s3_transfer.py
@@ -23,7 +23,7 @@ from unittest.mock import Mock, patch
 from airflow import models
 from airflow.configuration import load_test_config
 from airflow.models.xcom import MAX_XCOM_SIZE
-from airflow.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+from airflow.providers.amazon.aws.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
 from airflow.utils import db
 
 
@@ -66,9 +66,9 @@ class TestGoogleApiToS3Transfer(unittest.TestCase):
             'dag': None
         }
 
-    @patch('airflow.operators.google_api_to_s3_transfer.GoogleDiscoveryApiHook.query')
-    @patch('airflow.operators.google_api_to_s3_transfer.S3Hook.load_string')
-    @patch('airflow.operators.google_api_to_s3_transfer.json.dumps')
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.GoogleDiscoveryApiHook.query')
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.S3Hook.load_string')
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.json.dumps')
     def test_execute(self, mock_json_dumps, mock_s3_hook_load_string, mock_google_api_hook_query):
         context = {'task_instance': Mock()}
 
@@ -89,9 +89,9 @@ class TestGoogleApiToS3Transfer(unittest.TestCase):
         context['task_instance'].xcom_pull.assert_not_called()
         context['task_instance'].xcom_push.assert_not_called()
 
-    @patch('airflow.operators.google_api_to_s3_transfer.GoogleDiscoveryApiHook.query')
-    @patch('airflow.operators.google_api_to_s3_transfer.S3Hook.load_string')
-    @patch('airflow.operators.google_api_to_s3_transfer.json.dumps')
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.GoogleDiscoveryApiHook.query')
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.S3Hook.load_string')
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.json.dumps')
     def test_execute_with_xcom(self, mock_json_dumps, mock_s3_hook_load_string, mock_google_api_hook_query):
         context = {'task_instance': Mock()}
         xcom_kwargs = {
@@ -124,10 +124,13 @@ class TestGoogleApiToS3Transfer(unittest.TestCase):
             value=mock_google_api_hook_query.return_value
         )
 
-    @patch('airflow.operators.google_api_to_s3_transfer.GoogleDiscoveryApiHook.query')
-    @patch('airflow.operators.google_api_to_s3_transfer.S3Hook.load_string')
-    @patch('airflow.operators.google_api_to_s3_transfer.json.dumps')
-    @patch('airflow.operators.google_api_to_s3_transfer.sys.getsizeof', return_value=MAX_XCOM_SIZE)
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.GoogleDiscoveryApiHook.query')
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.S3Hook.load_string')
+    @patch('airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.json.dumps')
+    @patch(
+        'airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.sys.getsizeof',
+        return_value=MAX_XCOM_SIZE
+    )
     def test_execute_with_xcom_exceeded_max_xcom_size(
         self,
         mock_sys_getsizeof,

--- a/tests/providers/amazon/aws/operators/test_hive_to_dynamodb.py
+++ b/tests/providers/amazon/aws/operators/test_hive_to_dynamodb.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 import pandas as pd
 
-import airflow.contrib.operators.hive_to_dynamodb
+import airflow.providers.amazon.aws.operators.hive_to_dynamodb
 from airflow import DAG
 from airflow.providers.amazon.aws.hooks.aws_dynamodb_hook import AwsDynamoDBHook
 
@@ -85,7 +85,7 @@ class TestHiveToDynamoDBTransferOperator(unittest.TestCase):
             }
         )
 
-        operator = airflow.contrib.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator(
+        operator = airflow.providers.amazon.aws.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator(
             sql=self.sql,
             table_name="test_airflow",
             task_id='hive_to_dynamodb_check',
@@ -125,7 +125,7 @@ class TestHiveToDynamoDBTransferOperator(unittest.TestCase):
             }
         )
 
-        operator = airflow.contrib.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator(
+        operator = airflow.providers.amazon.aws.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator(
             sql=self.sql,
             table_name='test_airflow',
             task_id='hive_to_dynamodb_check',

--- a/tests/providers/amazon/aws/operators/test_imap_attachment_to_s3.py
+++ b/tests/providers/amazon/aws/operators/test_imap_attachment_to_s3.py
@@ -20,7 +20,7 @@
 import unittest
 from unittest.mock import patch
 
-from airflow.contrib.operators.imap_attachment_to_s3_operator import ImapAttachmentToS3Operator
+from airflow.providers.amazon.aws.operators.imap_attachment_to_s3 import ImapAttachmentToS3Operator
 
 
 class TestImapAttachmentToS3Operator(unittest.TestCase):
@@ -37,8 +37,8 @@ class TestImapAttachmentToS3Operator(unittest.TestCase):
             dag=None
         )
 
-    @patch('airflow.contrib.operators.imap_attachment_to_s3_operator.S3Hook')
-    @patch('airflow.contrib.operators.imap_attachment_to_s3_operator.ImapHook')
+    @patch('airflow.providers.amazon.aws.operators.imap_attachment_to_s3.S3Hook')
+    @patch('airflow.providers.amazon.aws.operators.imap_attachment_to_s3.ImapHook')
     def test_execute(self, mock_imap_hook, mock_s3_hook):
         mock_imap_hook.return_value.__enter__ = mock_imap_hook
         mock_imap_hook.return_value.retrieve_mail_attachments.return_value = [('test_file', b'Hello World')]

--- a/tests/providers/amazon/aws/operators/test_mongo_to_s3.py
+++ b/tests/providers/amazon/aws/operators/test_mongo_to_s3.py
@@ -21,8 +21,8 @@ import unittest
 import mock
 
 from airflow import DAG
-from airflow.contrib.operators.mongo_to_s3 import MongoToS3Operator
 from airflow.models import TaskInstance
+from airflow.providers.amazon.aws.operators.mongo_to_s3 import MongoToS3Operator
 from airflow.utils import timezone
 
 TASK_ID = 'test_mongo_to_s3_operator'
@@ -84,8 +84,8 @@ class TestMongoToS3Operator(unittest.TestCase):
             getattr(self.mock_operator, 'mongo_query')
         )
 
-    @mock.patch('airflow.contrib.operators.mongo_to_s3.MongoHook')
-    @mock.patch('airflow.contrib.operators.mongo_to_s3.S3Hook')
+    @mock.patch('airflow.providers.amazon.aws.operators.mongo_to_s3.MongoHook')
+    @mock.patch('airflow.providers.amazon.aws.operators.mongo_to_s3.S3Hook')
     def test_execute(self, mock_s3_hook, mock_mongo_hook):
         operator = self.mock_operator
 

--- a/tests/providers/amazon/aws/operators/test_redshift_to_s3.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_to_s3.py
@@ -24,7 +24,7 @@ from unittest import mock
 from boto3.session import Session
 from parameterized import parameterized
 
-from airflow.operators.redshift_to_s3_operator import RedshiftToS3Transfer
+from airflow.providers.amazon.aws.operators.redshift_to_s3 import RedshiftToS3Transfer
 from tests.test_utils.asserts import assert_equal_ignore_multiple_spaces
 
 

--- a/tests/providers/amazon/aws/operators/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/operators/test_s3_to_redshift.py
@@ -23,7 +23,7 @@ from unittest import mock
 
 from boto3.session import Session
 
-from airflow.operators.s3_to_redshift_operator import S3ToRedshiftTransfer
+from airflow.providers.amazon.aws.operators.s3_to_redshift import S3ToRedshiftTransfer
 from tests.test_utils.asserts import assert_equal_ignore_multiple_spaces
 
 

--- a/tests/providers/amazon/aws/operators/test_s3_to_sftp.py
+++ b/tests/providers/amazon/aws/operators/test_s3_to_sftp.py
@@ -23,8 +23,8 @@ import boto3
 from moto import mock_s3
 
 from airflow.configuration import conf
-from airflow.contrib.operators.s3_to_sftp_operator import S3ToSFTPOperator
 from airflow.models import DAG, TaskInstance
+from airflow.providers.amazon.aws.operators.s3_to_sftp import S3ToSFTPOperator
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.utils import timezone
 from airflow.utils.timezone import datetime

--- a/tests/providers/amazon/aws/operators/test_sftp_to_s3.py
+++ b/tests/providers/amazon/aws/operators/test_sftp_to_s3.py
@@ -22,9 +22,9 @@ import unittest
 import boto3
 from moto import mock_s3
 
-from airflow.contrib.operators.sftp_to_s3_operator import SFTPToS3Operator
 from airflow.models import DAG, TaskInstance
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.amazon.aws.operators.sftp_to_s3 import SFTPToS3Operator
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.utils import timezone

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1317,6 +1317,10 @@ OPERATOR = [
         'airflow.providers.amazon.aws.operators.mongo_to_s3.MongoToS3Operator',
         'airflow.contrib.operators.mongo_to_s3.MongoToS3Operator',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.s3_to_sftp.S3ToSFTPOperator',
+        'airflow.contrib.operators.s3_to_sftp_operator.S3ToSFTPOperator',
+    ),
 ]
 
 SENSOR = [

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1301,6 +1301,10 @@ OPERATOR = [
         'airflow.providers.sftp.operators.sftp.SFTPOperator',
         'airflow.contrib.operators.sftp_operator.SFTPOperator',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.dynamodb_to_s3.DynamoDBToS3Operator',
+        'airflow.contrib.operators.dynamodb_to_s3.DynamoDBToS3Operator',
+    ),
 ]
 
 SENSOR = [

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1329,6 +1329,10 @@ OPERATOR = [
         'airflow.providers.amazon.aws.operators.gcs_to_s3.GCSToS3Operator',
         'airflow.operators.gcs_to_s3.GCSToS3Operator',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer',
+        'airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer',
+    ),
 ]
 
 SENSOR = [

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -841,7 +841,7 @@ OPERATOR = [
         "airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageToGoogleCloudStorageOperator",
     ),
     (
-        "airflow.operators.gcs_to_s3.GCSToS3Operator",
+        "airflow.providers.amazon.aws.operators.gcs_to_s3.GCSToS3Operator",
         "airflow.contrib.operators.gcs_to_s3.GoogleCloudStorageToS3Operator",
     ),
     (
@@ -1324,6 +1324,10 @@ OPERATOR = [
     (
         'airflow.providers.amazon.aws.operators.sftp_to_s3.SFTPToS3Operator',
         'airflow.contrib.operators.sftp_to_s3_operator.SFTPToS3Operator',
+    ),
+    (
+        'airflow.providers.amazon.aws.operators.gcs_to_s3.GCSToS3Operator',
+        'airflow.operators.gcs_to_s3.GCSToS3Operator',
     ),
 ]
 

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1321,6 +1321,10 @@ OPERATOR = [
         'airflow.providers.amazon.aws.operators.s3_to_sftp.S3ToSFTPOperator',
         'airflow.contrib.operators.s3_to_sftp_operator.S3ToSFTPOperator',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.sftp_to_s3.SFTPToS3Operator',
+        'airflow.contrib.operators.sftp_to_s3_operator.SFTPToS3Operator',
+    ),
 ]
 
 SENSOR = [

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1333,6 +1333,10 @@ OPERATOR = [
         'airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer',
         'airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.redshift_to_s3.RedshiftToS3Transfer',
+        'airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer',
+    ),
 ]
 
 SENSOR = [

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1337,6 +1337,10 @@ OPERATOR = [
         'airflow.providers.amazon.aws.operators.redshift_to_s3.RedshiftToS3Transfer',
         'airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.s3_to_redshift.S3ToRedshiftTransfer',
+        'airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer',
+    ),
 ]
 
 SENSOR = [

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1313,6 +1313,10 @@ OPERATOR = [
         'airflow.providers.amazon.aws.operators.imap_attachment_to_s3.ImapAttachmentToS3Operator',
         'airflow.contrib.operators.imap_attachment_to_s3_operator.ImapAttachmentToS3Operator',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.mongo_to_s3.MongoToS3Operator',
+        'airflow.contrib.operators.mongo_to_s3.MongoToS3Operator',
+    ),
 ]
 
 SENSOR = [

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1305,6 +1305,10 @@ OPERATOR = [
         'airflow.providers.amazon.aws.operators.dynamodb_to_s3.DynamoDBToS3Operator',
         'airflow.contrib.operators.dynamodb_to_s3.DynamoDBToS3Operator',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator',
+        'airflow.contrib.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator',
+    ),
 ]
 
 SENSOR = [

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1309,6 +1309,10 @@ OPERATOR = [
         'airflow.providers.amazon.aws.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator',
         'airflow.contrib.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator',
     ),
+    (
+        'airflow.providers.amazon.aws.operators.imap_attachment_to_s3.ImapAttachmentToS3Operator',
+        'airflow.contrib.operators.imap_attachment_to_s3_operator.ImapAttachmentToS3Operator',
+    ),
 ]
 
 SENSOR = [


### PR DESCRIPTION
More information: https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths

---
Issue link: [AIRFLOW-6659](https://issues.apache.org/jira/browse/AIRFLOW-6659)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
