### PR TITLE
[AIRFLOW-6660] Fix deprecation warning in check_environment.sh

### DIFF
--- a/scripts/ci/in_container/check_environment.sh
+++ b/scripts/ci/in_container/check_environment.sh
@@ -177,7 +177,7 @@ if [[ -n ${BACKEND:=} ]]; then
     MAX_CHECK=3
     while true
     do
-        AIRFLOW__CORE__LOGGING_LEVEL=error airflow db check
+        AIRFLOW__LOGGING__LOGGING_LEVEL=error airflow db check
         RES=$?
         if [[ ${RES} == 0 ]]; then
             break


### PR DESCRIPTION
```
/opt/airflow/airflow/config_templates/airflow_local_settings.py:30: DeprecationWarning: The logging_level option in [core] has been moved to the logging_level option in [logging] - the old setting has been used, but please update your config.
```

---
Issue link: [AIRFLOW-6660](https://issues.apache.org/jira/browse/AIRFLOW-6660)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
