### PR TITLE
[AIRFLOW-5391] Do not run skipped tasks when they are cleared

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -45,6 +45,7 @@ from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
+from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkippedDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils import timezone
@@ -650,6 +651,7 @@ class BaseOperator(Operator, LoggingMixin):
             NotInRetryPeriodDep(),
             PrevDagrunDep(),
             TriggerRuleDep(),
+            NotPreviouslySkippedDep(),
         }
 
     @property

--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -150,7 +150,6 @@ class SkipMixin(LoggingMixin):
                 self._set_state_to_skipped(
                     dag_run, ti.execution_date, skip_tasks, session=session
                 )
-                session.commit()
                 ti.xcom_push(
                     key=XCOM_SKIPMIXIN_KEY, value={XCOM_SKIPMIXIN_FOLLOWED: branch_task_ids}
                 )

--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -21,24 +21,24 @@ from typing import Iterable, Set, Union
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.session import provide_session
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
+
+# The key used by SkipMixin to store XCom data.
+XCOM_SKIPMIXIN_KEY = "skipmixin_key"
+
+# The dictionary key used to denote task IDs that are skipped
+XCOM_SKIPMIXIN_SKIPPED = "skipped"
+
+# The dictionary key used to denote task IDs that are followed
+XCOM_SKIPMIXIN_FOLLOWED = "followed"
 
 
 class SkipMixin(LoggingMixin):
-    @provide_session
-    def skip(self, dag_run, execution_date, tasks, session=None):
+    def _set_state_to_skipped(self, dag_run, execution_date, tasks, session):
         """
-        Sets tasks instances to skipped from the same dag run.
-
-        :param dag_run: the DagRun for which to set the tasks to skipped
-        :param execution_date: execution_date
-        :param tasks: tasks to skip (not task_ids)
-        :param session: db session to use
+        Used internally to set state of task instances to skipped from the same dag run.
         """
-        if not tasks:
-            return
-
         task_ids = [d.task_id for d in tasks]
         now = timezone.utcnow()
 
@@ -46,12 +46,15 @@ class SkipMixin(LoggingMixin):
             session.query(TaskInstance).filter(
                 TaskInstance.dag_id == dag_run.dag_id,
                 TaskInstance.execution_date == dag_run.execution_date,
-                TaskInstance.task_id.in_(task_ids)
-            ).update({TaskInstance.state: State.SKIPPED,
-                      TaskInstance.start_date: now,
-                      TaskInstance.end_date: now},
-                     synchronize_session=False)
-            session.commit()
+                TaskInstance.task_id.in_(task_ids),
+            ).update(
+                {
+                    TaskInstance.state: State.SKIPPED,
+                    TaskInstance.start_date: now,
+                    TaskInstance.end_date: now,
+                },
+                synchronize_session=False,
+            )
         else:
             if execution_date is None:
                 raise ValueError("Execution date is None and no dag run")
@@ -65,13 +68,56 @@ class SkipMixin(LoggingMixin):
                 ti.end_date = now
                 session.merge(ti)
 
-            session.commit()
+    @provide_session
+    def skip(
+        self, dag_run, execution_date, tasks, session=None,
+    ):
+        """
+        Sets tasks instances to skipped from the same dag run.
 
-    def skip_all_except(self, ti: TaskInstance, branch_task_ids: Union[str, Iterable[str]]):
+        If this instance has a `task_id` attribute, store the list of skipped task IDs to XCom
+        so that NotPreviouslySkippedDep knows these tasks should be skipped when they
+        are cleared.
+
+        :param dag_run: the DagRun for which to set the tasks to skipped
+        :param execution_date: execution_date
+        :param tasks: tasks to skip (not task_ids)
+        :param session: db session to use
+        """
+        if not tasks:
+            return
+
+        self._set_state_to_skipped(dag_run, execution_date, tasks, session)
+        session.commit()
+
+        # SkipMixin may not necessarily have a task_id attribute. Only store to XCom if one is available.
+        try:
+            task_id = self.task_id
+        except AttributeError:
+            task_id = None
+
+        if task_id is not None:
+            from airflow.models.xcom import XCom
+
+            XCom.set(
+                key=XCOM_SKIPMIXIN_KEY,
+                value={XCOM_SKIPMIXIN_SKIPPED: [d.task_id for d in tasks]},
+                task_id=task_id,
+                dag_id=dag_run.dag_id,
+                execution_date=dag_run.execution_date,
+                session=session
+            )
+
+    def skip_all_except(
+        self, ti: TaskInstance, branch_task_ids: Union[str, Iterable[str]]
+    ):
         """
         This method implements the logic for a branching operator; given a single
         task ID or list of task IDs to follow, this skips all other tasks
         immediately downstream of this operator.
+
+        branch_task_ids is stored to XCom so that NotPreviouslySkippedDep knows skipped tasks or
+        newly added tasks should be skipped when they are cleared.
         """
         self.log.info("Following branch %s", branch_task_ids)
         if isinstance(branch_task_ids, str):
@@ -88,13 +134,23 @@ class SkipMixin(LoggingMixin):
             # is also a downstream task of the branch task, we exclude it from skipping.
             branch_downstream_task_ids = set()  # type: Set[str]
             for b in branch_task_ids:
-                branch_downstream_task_ids.update(dag.
-                                                  get_task(b).
-                                                  get_flat_relative_ids(upstream=False))
+                branch_downstream_task_ids.update(
+                    dag.get_task(b).get_flat_relative_ids(upstream=False)
+                )
 
-            skip_tasks = [t for t in downstream_tasks
-                          if t.task_id not in branch_task_ids and
-                          t.task_id not in branch_downstream_task_ids]
+            skip_tasks = [
+                t
+                for t in downstream_tasks
+                if t.task_id not in branch_task_ids
+                and t.task_id not in branch_downstream_task_ids
+            ]
 
             self.log.info("Skipping tasks %s", [t.task_id for t in skip_tasks])
-            self.skip(dag_run, ti.execution_date, skip_tasks)
+            with create_session() as session:
+                self._set_state_to_skipped(
+                    dag_run, ti.execution_date, skip_tasks, session=session
+                )
+                session.commit()
+                ti.xcom_push(
+                    key=XCOM_SKIPMIXIN_KEY, value={XCOM_SKIPMIXIN_FOLLOWED: branch_task_ids}
+                )

--- a/airflow/ti_deps/deps/not_previously_skipped_dep.py
+++ b/airflow/ti_deps/deps/not_previously_skipped_dep.py
@@ -1,0 +1,87 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+
+
+class NotPreviouslySkippedDep(BaseTIDep):
+    """
+    Determines if any of the task's direct upstream relatives have decided this task should
+    be skipped.
+    """
+
+    NAME = "Not Previously Skipped"
+    IGNORABLE = True
+    IS_TASK_DEP = True
+
+    def _get_dep_statuses(
+        self, ti, session, dep_context
+    ):  # pylint: disable=signature-differs
+        from airflow.models.skipmixin import (
+            SkipMixin,
+            XCOM_SKIPMIXIN_KEY,
+            XCOM_SKIPMIXIN_SKIPPED,
+            XCOM_SKIPMIXIN_FOLLOWED,
+        )
+        from airflow.utils.state import State
+
+        upstream = ti.task.get_direct_relatives(upstream=True)
+
+        finished_tasks = dep_context.ensure_finished_tasks(
+            ti.task.dag, ti.execution_date, session
+        )
+
+        finished_task_ids = {t.task_id for t in finished_tasks}
+
+        for parent in upstream:
+            if isinstance(parent, SkipMixin):
+                if parent.task_id not in finished_task_ids:
+                    # This can happen if the parent task has not yet run.
+                    continue
+
+                prev_result = ti.xcom_pull(
+                    task_ids=parent.task_id, key=XCOM_SKIPMIXIN_KEY
+                )
+
+                if prev_result is None:
+                    # This can happen if the parent task has not yet run.
+                    continue
+
+                should_skip = False
+                if (
+                    XCOM_SKIPMIXIN_FOLLOWED in prev_result
+                    and ti.task_id not in prev_result[XCOM_SKIPMIXIN_FOLLOWED]
+                ):
+                    # Skip any tasks that are not in "followed"
+                    should_skip = True
+                elif (
+                    XCOM_SKIPMIXIN_SKIPPED in prev_result
+                    and ti.task_id in prev_result[XCOM_SKIPMIXIN_SKIPPED]
+                ):
+                    # Skip any tasks that are in "skipped"
+                    should_skip = True
+
+                if should_skip:
+                    # If the parent SkipMixin has run, and the XCom result stored indicates this
+                    # ti should be skipped, set ti.state to SKIPPED and fail the rule so that the
+                    # ti does not execute.
+                    ti.set_state(State.SKIPPED, session)
+                    yield self._failing_status(
+                        reason=f"Skipping because of previous XCom result from parent task {parent.task_id}"
+                    )
+                    return

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -32,6 +32,7 @@ import funcsigs
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance as TI
+from airflow.models.taskinstance import clear_task_instances
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import (
     BranchPythonOperator, PythonOperator, PythonVirtualenvOperator, ShortCircuitOperator,
@@ -396,7 +397,7 @@ class TestBranchOperator(unittest.TestCase):
                 elif ti.task_id == 'branch_2':
                     self.assertEqual(ti.state, State.SKIPPED)
                 else:
-                    raise Exception
+                    raise ValueError(f'Invalid task id {ti.task_id} found!')
 
     def test_branch_list_without_dag_run(self):
         """This checks if the BranchPythonOperator supports branching off to a list of tasks."""
@@ -428,7 +429,7 @@ class TestBranchOperator(unittest.TestCase):
                 if ti.task_id in expected:
                     self.assertEqual(ti.state, expected[ti.task_id])
                 else:
-                    raise Exception
+                    raise ValueError(f'Invalid task id {ti.task_id} found!')
 
     def test_with_dag_run(self):
         branch_op = BranchPythonOperator(task_id='make_choice',
@@ -457,7 +458,7 @@ class TestBranchOperator(unittest.TestCase):
             elif ti.task_id == 'branch_2':
                 self.assertEqual(ti.state, State.SKIPPED)
             else:
-                raise Exception
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
 
     def test_with_skip_in_branch_downstream_dependencies(self):
         branch_op = BranchPythonOperator(task_id='make_choice',
@@ -486,7 +487,7 @@ class TestBranchOperator(unittest.TestCase):
             elif ti.task_id == 'branch_2':
                 self.assertEqual(ti.state, State.NONE)
             else:
-                raise Exception
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
 
     def test_with_skip_in_branch_downstream_dependencies2(self):
         branch_op = BranchPythonOperator(task_id='make_choice',
@@ -515,7 +516,7 @@ class TestBranchOperator(unittest.TestCase):
             elif ti.task_id == 'branch_2':
                 self.assertEqual(ti.state, State.NONE)
             else:
-                raise Exception
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
 
     def test_xcom_push(self):
         branch_op = BranchPythonOperator(task_id='make_choice',
@@ -540,6 +541,62 @@ class TestBranchOperator(unittest.TestCase):
             if ti.task_id == 'make_choice':
                 self.assertEqual(
                     ti.xcom_pull(task_ids='make_choice'), 'branch_1')
+
+    def test_clear_skipped_downstream_task(self):
+        """
+        After a downstream task is skipped by BranchPythonOperator, clearing the skipped task
+        should not cause it to be executed.
+        """
+        branch_op = BranchPythonOperator(task_id='make_choice',
+                                         dag=self.dag,
+                                         python_callable=lambda: 'branch_1')
+        branches = [self.branch_1, self.branch_2]
+        branch_op >> branches
+        self.dag.clear()
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING
+        )
+
+        branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        for task in branches:
+            task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        tis = dr.get_task_instances()
+        for ti in tis:
+            if ti.task_id == 'make_choice':
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == 'branch_1':
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == 'branch_2':
+                self.assertEqual(ti.state, State.SKIPPED)
+            else:
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
+
+        children_tis = [ti for ti in tis if ti.task_id in branch_op.get_direct_relative_ids()]
+
+        # Clear the children tasks.
+        with create_session() as session:
+            clear_task_instances(children_tis, session=session, dag=self.dag)
+
+        # Run the cleared tasks again.
+        for task in branches:
+            task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        # Check if the states are correct after children tasks are cleared.
+        for ti in dr.get_task_instances():
+            if ti.task_id == 'make_choice':
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == 'branch_1':
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == 'branch_2':
+                self.assertEqual(ti.state, State.SKIPPED)
+            else:
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
 
 
 class TestShortCircuitOperator(unittest.TestCase):
@@ -591,11 +648,11 @@ class TestShortCircuitOperator(unittest.TestCase):
                     self.assertEqual(ti.state, State.SUCCESS)
                 elif ti.task_id == 'upstream':
                     # should not exist
-                    raise Exception
+                    raise ValueError(f'Invalid task id {ti.task_id} found!')
                 elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
                     self.assertEqual(ti.state, State.SKIPPED)
                 else:
-                    raise Exception
+                    raise ValueError(f'Invalid task id {ti.task_id} found!')
 
             value = True
             dag.clear()
@@ -606,11 +663,11 @@ class TestShortCircuitOperator(unittest.TestCase):
                     self.assertEqual(ti.state, State.SUCCESS)
                 elif ti.task_id == 'upstream':
                     # should not exist
-                    raise Exception
+                    raise ValueError(f'Invalid task id {ti.task_id} found!')
                 elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
                     self.assertEqual(ti.state, State.NONE)
                 else:
-                    raise Exception
+                    raise ValueError(f'Invalid task id {ti.task_id} found!')
 
     def test_with_dag_run(self):
         value = False
@@ -652,7 +709,7 @@ class TestShortCircuitOperator(unittest.TestCase):
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
                 self.assertEqual(ti.state, State.SKIPPED)
             else:
-                raise Exception
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
 
         value = True
         dag.clear()
@@ -670,7 +727,65 @@ class TestShortCircuitOperator(unittest.TestCase):
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
                 self.assertEqual(ti.state, State.NONE)
             else:
-                raise Exception
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
+
+    def test_clear_skipped_downstream_task(self):
+        """
+        After a downstream task is skipped by ShortCircuitOperator, clearing the skipped task
+        should not cause it to be executed.
+        """
+        dag = DAG('shortcircuit_clear_skipped_downstream_task',
+                  default_args={
+                      'owner': 'airflow',
+                      'start_date': DEFAULT_DATE
+                  },
+                  schedule_interval=INTERVAL)
+        short_op = ShortCircuitOperator(task_id='make_choice',
+                                        dag=dag,
+                                        python_callable=lambda: False)
+        downstream = DummyOperator(task_id='downstream', dag=dag)
+
+        short_op >> downstream
+
+        dag.clear()
+
+        dr = dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING
+        )
+
+        short_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        downstream.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        tis = dr.get_task_instances()
+
+        for ti in tis:
+            if ti.task_id == 'make_choice':
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == 'downstream':
+                self.assertEqual(ti.state, State.SKIPPED)
+            else:
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
+
+        # Clear downstream
+        with create_session() as session:
+            clear_task_instances([t for t in tis if t.task_id == "downstream"],
+                                 session=session,
+                                 dag=dag)
+
+        # Run downstream again
+        downstream.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        # Check if the states are correct.
+        for ti in dr.get_task_instances():
+            if ti.task_id == 'make_choice':
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == 'downstream':
+                self.assertEqual(ti.state, State.SKIPPED)
+            else:
+                raise ValueError(f'Invalid task id {ti.task_id} found!')
 
 
 virtualenv_string_args: List[str] = []

--- a/tests/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/tests/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pendulum
+
+from airflow.models import DAG, TaskInstance
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.python_operator import BranchPythonOperator
+from airflow.ti_deps.dep_context import DepContext
+from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkippedDep
+from airflow.utils.session import create_session
+from airflow.utils.state import State
+
+
+def test_no_parent():
+    """
+    A simple DAG with a single task. NotPreviouslySkippedDep is met.
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    dag = DAG("test_test_no_parent_dag", schedule_interval=None, start_date=start_date)
+    op1 = DummyOperator(task_id="op1", dag=dag)
+
+    ti1 = TaskInstance(op1, start_date)
+
+    with create_session() as session:
+        dep = NotPreviouslySkippedDep()
+        assert len(list(dep.get_dep_statuses(ti1, session, DepContext()))) == 0
+        assert dep.is_met(ti1, session)
+        assert ti1.state != State.SKIPPED
+
+
+def test_no_skipmixin_parent():
+    """
+    A simple DAG with no branching. Both op1 and op2 are DummyOperator. NotPreviouslySkippedDep is met.
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    dag = DAG(
+        "test_no_skipmixin_parent_dag", schedule_interval=None, start_date=start_date
+    )
+    op1 = DummyOperator(task_id="op1", dag=dag)
+    op2 = DummyOperator(task_id="op2", dag=dag)
+    op1 >> op2
+
+    ti2 = TaskInstance(op2, start_date)
+
+    with create_session() as session:
+        dep = NotPreviouslySkippedDep()
+        assert len(list(dep.get_dep_statuses(ti2, session, DepContext()))) == 0
+        assert dep.is_met(ti2, session)
+        assert ti2.state != State.SKIPPED
+
+
+def test_parent_follow_branch():
+    """
+    A simple DAG with a BranchPythonOperator that follows op2. NotPreviouslySkippedDep is met.
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    dag = DAG(
+        "test_parent_follow_branch_dag", schedule_interval=None, start_date=start_date
+    )
+    op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op2", dag=dag)
+    op2 = DummyOperator(task_id="op2", dag=dag)
+    op1 >> op2
+
+    TaskInstance(op1, start_date).run()
+    ti2 = TaskInstance(op2, start_date)
+
+    with create_session() as session:
+        dep = NotPreviouslySkippedDep()
+        assert len(list(dep.get_dep_statuses(ti2, session, DepContext()))) == 0
+        assert dep.is_met(ti2, session)
+        assert ti2.state != State.SKIPPED
+
+
+def test_parent_skip_branch():
+    """
+    A simple DAG with a BranchPythonOperator that does not follow op2. NotPreviouslySkippedDep is not met.
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    dag = DAG(
+        "test_parent_skip_branch_dag", schedule_interval=None, start_date=start_date
+    )
+    op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op3", dag=dag)
+    op2 = DummyOperator(task_id="op2", dag=dag)
+    op3 = DummyOperator(task_id="op3", dag=dag)
+    op1 >> [op2, op3]
+
+    TaskInstance(op1, start_date).run()
+    ti2 = TaskInstance(op2, start_date)
+
+    with create_session() as session:
+        dep = NotPreviouslySkippedDep()
+        assert len(list(dep.get_dep_statuses(ti2, session, DepContext()))) == 1
+        assert not dep.is_met(ti2, session)
+        assert ti2.state == State.SKIPPED
+
+
+def test_parent_not_executed():
+    """
+    A simple DAG with a BranchPythonOperator that does not follow op2. Parent task is not yet
+    executed (no xcom data). NotPreviouslySkippedDep is met (no decision).
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    dag = DAG(
+        "test_parent_not_executed_dag", schedule_interval=None, start_date=start_date
+    )
+    op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op3", dag=dag)
+    op2 = DummyOperator(task_id="op2", dag=dag)
+    op3 = DummyOperator(task_id="op3", dag=dag)
+    op1 >> [op2, op3]
+
+    ti2 = TaskInstance(op2, start_date)
+
+    with create_session() as session:
+        dep = NotPreviouslySkippedDep()
+        assert len(list(dep.get_dep_statuses(ti2, session, DepContext()))) == 0
+        assert dep.is_met(ti2, session)
+        assert ti2.state == State.NONE


### PR DESCRIPTION
This PR fixes the following issue:

If a task is skipped by ``BranchPythonOperator``, ``BaseBranchOperator`` orr ``ShortCircuitOperator`` and the user then clears the skipped task, it'll execute. 

After this PR:
The ``NotPreviouslySkippedDep`` rule will first evaluate if a task has a direct ``SkipMixin`` parent that has decided to skip it. This is done by examining the XCom data stored by ``SkipMixin.skip()`` or ``SkipMixin.skip_all_except()``.

The implementation is inspired by the author of [this blog](https://blog.diffractive.io/2018/08/07/replacement-shortcircuitoperator-for-airflow/).

---
Issue link: [AIRFLOW-5391](https://issues.apache.org/jira/browse/AIRFLOW-5391)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
