### PR TITLE
[AIRFLOW-6683] Make REST API respect store_serialized_dag setting

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -47,10 +47,10 @@ def _trigger_dag(
     :param replace_microseconds: whether microseconds should be zeroed
     :return: list of triggered dags
     """
+    dag = dag_bag.get_dag(dag_id)  # prefetch dag if it is stored serialized
+
     if dag_id not in dag_bag.dags:
         raise DagNotFound("Dag id {} not found".format(dag_id))
-
-    dag = dag_bag.get_dag(dag_id)
 
     execution_date = execution_date if execution_date else timezone.utcnow()
 
@@ -122,7 +122,14 @@ def trigger_dag(
     dag_model = DagModel.get_current(dag_id)
     if dag_model is None:
         raise DagNotFound("Dag id {} not found in DagModel".format(dag_id))
-    dagbag = DagBag(dag_folder=dag_model.fileloc)
+
+    def read_store_serialized_dags():
+        from airflow.configuration import conf
+        return conf.getboolean('core', 'store_serialized_dags')
+    dagbag = DagBag(
+        dag_folder=dag_model.fileloc,
+        store_serialized_dags=read_store_serialized_dags()
+    )
     dag_run = DagRun()
     triggers = _trigger_dag(
         dag_id=dag_id,

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -19,13 +19,22 @@
 import json
 import unittest
 
+from parameterized import parameterized_class
+
 from airflow.api.common.experimental.trigger_dag import trigger_dag
 from airflow.models import DagBag, DagRun
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.settings import Session
 from airflow.www import app as application
+from tests.test_utils.config import conf_vars
 
 
+@parameterized_class([
+    {"dag_serialzation": "False"},
+    {"dag_serialzation": "True"},
+])
 class TestDagRunsEndpoint(unittest.TestCase):
+    dag_serialzation = "False"
 
     @classmethod
     def setUpClass(cls):
@@ -37,6 +46,7 @@ class TestDagRunsEndpoint(unittest.TestCase):
         dagbag = DagBag(include_examples=True)
         for dag in dagbag.dags.values():
             dag.sync_to_db()
+            SerializedDagModel.write_dag(dag)
 
     def setUp(self):
         super().setUp()
@@ -51,80 +61,105 @@ class TestDagRunsEndpoint(unittest.TestCase):
         super().tearDown()
 
     def test_get_dag_runs_success(self):
-        url_template = '/api/experimental/dags/{}/dag_runs'
-        dag_id = 'example_bash_operator'
-        # Create DagRun
-        dag_run = trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
+        with conf_vars(
+            {("core", "store_serialized_dags"): self.dag_serialzation}
+        ):
+            url_template = '/api/experimental/dags/{}/dag_runs'
+            dag_id = 'example_bash_operator'
+            # Create DagRun
+            dag_run = trigger_dag(
+                dag_id=dag_id, run_id='test_get_dag_runs_success')
 
-        response = self.app.get(url_template.format(dag_id))
-        self.assertEqual(200, response.status_code)
-        data = json.loads(response.data.decode('utf-8'))
+            response = self.app.get(url_template.format(dag_id))
+            self.assertEqual(200, response.status_code)
+            data = json.loads(response.data.decode('utf-8'))
 
-        self.assertIsInstance(data, list)
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['dag_id'], dag_id)
-        self.assertEqual(data[0]['id'], dag_run.id)
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]['dag_id'], dag_id)
+            self.assertEqual(data[0]['id'], dag_run.id)
 
     def test_get_dag_runs_success_with_state_parameter(self):
-        url_template = '/api/experimental/dags/{}/dag_runs?state=running'
-        dag_id = 'example_bash_operator'
-        # Create DagRun
-        dag_run = trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
+        with conf_vars(
+            {("core", "store_serialized_dags"): self.dag_serialzation}
+        ):
+            url_template = '/api/experimental/dags/{}/dag_runs?state=running'
+            dag_id = 'example_bash_operator'
+            # Create DagRun
+            dag_run = trigger_dag(
+                dag_id=dag_id, run_id='test_get_dag_runs_success')
 
-        response = self.app.get(url_template.format(dag_id))
-        self.assertEqual(200, response.status_code)
-        data = json.loads(response.data.decode('utf-8'))
+            response = self.app.get(url_template.format(dag_id))
+            self.assertEqual(200, response.status_code)
+            data = json.loads(response.data.decode('utf-8'))
 
-        self.assertIsInstance(data, list)
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['dag_id'], dag_id)
-        self.assertEqual(data[0]['id'], dag_run.id)
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]['dag_id'], dag_id)
+            self.assertEqual(data[0]['id'], dag_run.id)
 
     def test_get_dag_runs_success_with_capital_state_parameter(self):
-        url_template = '/api/experimental/dags/{}/dag_runs?state=RUNNING'
-        dag_id = 'example_bash_operator'
-        # Create DagRun
-        dag_run = trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
+        with conf_vars(
+            {("core", "store_serialized_dags"): self.dag_serialzation}
+        ):
+            url_template = '/api/experimental/dags/{}/dag_runs?state=RUNNING'
+            dag_id = 'example_bash_operator'
+            # Create DagRun
+            dag_run = trigger_dag(
+                dag_id=dag_id, run_id='test_get_dag_runs_success')
 
-        response = self.app.get(url_template.format(dag_id))
-        self.assertEqual(200, response.status_code)
-        data = json.loads(response.data.decode('utf-8'))
+            response = self.app.get(url_template.format(dag_id))
+            self.assertEqual(200, response.status_code)
+            data = json.loads(response.data.decode('utf-8'))
 
-        self.assertIsInstance(data, list)
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['dag_id'], dag_id)
-        self.assertEqual(data[0]['id'], dag_run.id)
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]['dag_id'], dag_id)
+            self.assertEqual(data[0]['id'], dag_run.id)
 
     def test_get_dag_runs_success_with_state_no_result(self):
-        url_template = '/api/experimental/dags/{}/dag_runs?state=dummy'
-        dag_id = 'example_bash_operator'
-        # Create DagRun
-        trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
+        with conf_vars(
+            {("core", "store_serialized_dags"): self.dag_serialzation}
+        ):
+            url_template = '/api/experimental/dags/{}/dag_runs?state=dummy'
+            dag_id = 'example_bash_operator'
+            # Create DagRun
+            trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
 
-        response = self.app.get(url_template.format(dag_id))
-        self.assertEqual(200, response.status_code)
-        data = json.loads(response.data.decode('utf-8'))
+            response = self.app.get(url_template.format(dag_id))
+            self.assertEqual(200, response.status_code)
+            data = json.loads(response.data.decode('utf-8'))
 
-        self.assertIsInstance(data, list)
-        self.assertEqual(len(data), 0)
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 0)
 
     def test_get_dag_runs_invalid_dag_id(self):
-        url_template = '/api/experimental/dags/{}/dag_runs'
-        dag_id = 'DUMMY_DAG'
+        with conf_vars(
+            {("core", "store_serialized_dags"): self.dag_serialzation}
+        ):
+            url_template = '/api/experimental/dags/{}/dag_runs'
+            dag_id = 'DUMMY_DAG'
 
-        response = self.app.get(url_template.format(dag_id))
-        self.assertEqual(400, response.status_code)
-        data = json.loads(response.data.decode('utf-8'))
+            response = self.app.get(url_template.format(dag_id))
+            self.assertEqual(400, response.status_code)
+            data = json.loads(response.data.decode('utf-8'))
 
-        self.assertNotIsInstance(data, list)
+            self.assertNotIsInstance(data, list)
 
     def test_get_dag_runs_no_runs(self):
-        url_template = '/api/experimental/dags/{}/dag_runs'
-        dag_id = 'example_bash_operator'
+        with conf_vars(
+            {("core", "store_serialized_dags"): self.dag_serialzation}
+        ):
+            url_template = '/api/experimental/dags/{}/dag_runs'
+            dag_id = 'example_bash_operator'
 
-        response = self.app.get(url_template.format(dag_id))
-        self.assertEqual(200, response.status_code)
-        data = json.loads(response.data.decode('utf-8'))
+            response = self.app.get(url_template.format(dag_id))
+            self.assertEqual(200, response.status_code)
+            data = json.loads(response.data.decode('utf-8'))
 
-        self.assertIsInstance(data, list)
-        self.assertEqual(len(data), 0)
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6683](https://issues.apache.org/jira/browse/AIRFLOW-6683)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
