### PR TITLE
[AIRFLOW-6686] Fix syntax error constructing list of process ids

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -211,7 +211,7 @@ def reap_process_group(pgid, log, sig=signal.SIGTERM,
             # use sudo -n(--non-interactive) to kill the process
             if err.errno == errno.EPERM:
                 subprocess.check_call(
-                    ["sudo", "-n", "kill", "-" + str(sig)] + map(children, lambda p: str(p.pid))
+                    ["sudo", "-n", "kill", "-" + str(sig)] + [str(p.pid) for p in children]
                 )
             else:
                 raise


### PR DESCRIPTION
Construction of list of pids passed in kill command raises a Syntax error because
ordering of the arguments to `map` function doesn't conform to function
parameter definition.

A list comprehension replaces the existing `map` function to make the code
forward compatible with Python 3 and at the same time expand to a list of pids.

---
Issue link: [AIRFLOW-6686](https://issues.apache.org/jira/browse/AIRFLOW-6686)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] ~Unit tests coverage for changes (not needed for documentation changes)~
- [x] ~Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"~
- [x] ~Relevant documentation is updated including usage instructions.~
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
