### PR TITLE
[AIRFLOW-6687] Switch kubernetes tests to example_dags

### DIFF
--- a/airflow/example_dags/example_kubernetes_executor.py
+++ b/airflow/example_dags/example_kubernetes_executor.py
@@ -21,6 +21,8 @@ This is an example dag for using the Kubernetes Executor.
 """
 import os
 
+from libs import print_stuff
+
 from airflow.models import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
@@ -61,9 +63,6 @@ with DAG(
         'operator': 'Equal',
         'value': 'airflow'
     }]
-
-    def print_stuff():  # pylint: disable=missing-docstring
-        print("stuff!")
 
     def use_zip_binary():
         """

--- a/airflow/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/example_dags/example_kubernetes_executor_config.py
@@ -21,6 +21,8 @@ This is an example dag for using a Kubernetes Executor Configuration.
 """
 import os
 
+from libs import print_stuff
+
 from airflow.models import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
@@ -47,12 +49,6 @@ with DAG(
         return_code = os.system("cat /foo/volume_mount_test.txt")
         if return_code != 0:
             raise ValueError(f"Error when checking volume mount. Return code {return_code}")
-
-    def print_stuff():
-        """
-        Dummy function.
-        """
-        print("annotated!")
 
     # You can use annotations on your kubernetes pods!
     start_task = PythonOperator(

--- a/airflow/example_dags/libs/__init__.py
+++ b/airflow/example_dags/libs/__init__.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# -*- coding: utf-8 -*-
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,12 +16,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-set -x
-
-cd /opt/airflow/airflow && \
-cp -R example_dags/* /root/airflow/dags/ && \
-airflow db init && \
-alembic upgrade heads && \
-(airflow users create --username airflow --lastname airflow --firstname jon --email airflow@apache.org --role Admin --password airflow || true) && \
-echo "retrieved from mount" > /root/test_volume/test.txt

--- a/airflow/example_dags/libs/helper.py
+++ b/airflow/example_dags/libs/helper.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# -*- coding: utf-8 -*-
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,11 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -x
 
-cd /opt/airflow/airflow && \
-cp -R example_dags/* /root/airflow/dags/ && \
-airflow db init && \
-alembic upgrade heads && \
-(airflow users create --username airflow --lastname airflow --firstname jon --email airflow@apache.org --role Admin --password airflow || true) && \
-echo "retrieved from mount" > /root/test_volume/test.txt
+# pylint: disable=missing-docstring
+def print_stuff():
+    print("annotated!")

--- a/airflow/providers/qubole/sensors/qubole.py
+++ b/airflow/providers/qubole/sensors/qubole.py
@@ -75,7 +75,7 @@ class QuboleFileSensor(QuboleSensor):
     :type qubole_conn_id: str
     :param data: a JSON object containing payload, whose presence needs to be checked
         Check this `example <https://github.com/apache/airflow/blob/master\
-        /airflow/contrib/example_dags/example_qubole_sensor.py>`_ for sample payload
+        /airflow/providers/qubole/example_dags/example_qubole_sensor.py>`_ for sample payload
         structure.
     :type data: a JSON object
 
@@ -98,7 +98,7 @@ class QubolePartitionSensor(QuboleSensor):
     :type qubole_conn_id: str
     :param data: a JSON object containing payload, whose presence needs to be checked.
         Check this `example <https://github.com/apache/airflow/blob/master\
-        /airflow/contrib/example_dags/example_qubole_sensor.py>`_ for sample payload
+        /airflow/providers/qubole/example_dags/example_qubole_sensor.py>`_ for sample payload
         structure.
     :type data: a JSON object
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,7 +192,6 @@ exclude_patterns = [
     '_api/airflow/config_templates',
     '_api/airflow/configuration',
     '_api/airflow/contrib/auth',
-    '_api/airflow/contrib/example_dags',
     '_api/airflow/contrib/index.rst',
     '_api/airflow/contrib/kubernetes',
     '_api/airflow/contrib/task_runner',

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -959,7 +959,7 @@ function build_image_on_ci() {
     if [[ ${TRAVIS_JOB_NAME:=""} == "Tests"*"Kubernetes"* ]]; then
         match_files_regexp 'airflow/kubernetes/.*\.py' 'tests/kubernetes/.*\.py' \
             'airflow/www/.*\.py' 'airflow/www/.*\.js' 'airflow/www/.*\.html' \
-            'scripts/ci/.*'
+            'scripts/ci/.*' 'airflow/example_dags/.*'
         if [[ ${FILE_MATCHES} == "true" || ${TRAVIS_PULL_REQUEST:=} == "false" ]]; then
             rebuild_ci_image_if_needed
         else
@@ -967,7 +967,7 @@ function build_image_on_ci() {
         fi
     elif [[ ${TRAVIS_JOB_NAME:=""} == "Tests"* ]]; then
         match_files_regexp '.*\.py' 'airflow/www/.*\.py' 'airflow/www/.*\.js' \
-            'airflow/www/.*\.html' 'scripts/ci/.*'
+            'airflow/www/.*\.html' 'scripts/ci/.*' 'airflow/example_dags/.*'
         if [[ ${FILE_MATCHES} == "true" || ${TRAVIS_PULL_REQUEST:=} == "false" ]]; then
             rebuild_ci_image_if_needed
         else

--- a/scripts/ci/in_container/kubernetes/app/deploy_app.sh
+++ b/scripts/ci/in_container/kubernetes/app/deploy_app.sh
@@ -59,7 +59,7 @@ if [[ "${KUBERNETES_MODE}" == "persistent_mode" ]]; then
 else
     INIT_DAGS_VOLUME_NAME=airflow-dags-fake
     POD_AIRFLOW_DAGS_VOLUME_NAME=airflow-dags-git
-    CONFIGMAP_DAGS_FOLDER=/root/airflow/dags/repo/airflow/contrib/example_dags
+    CONFIGMAP_DAGS_FOLDER=/root/airflow/dags/repo/airflow/example_dags
     CONFIGMAP_GIT_DAGS_FOLDER_MOUNT_POINT=/root/airflow/dags
     CONFIGMAP_DAGS_VOLUME_CLAIM=
 fi

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2670,12 +2670,12 @@ class TestSchedulerJob(unittest.TestCase):
         detected_files = set()
         expected_files = set()
         # No_dags is empty, _invalid_ is ignored by .airflowignore
-        ignored_files = [
+        ignored_files = {
             'no_dags.py',
             'test_invalid_cron.py',
             'test_zip_invalid_cron.zip',
             'test_ignore_this.py',
-        ]
+        }
         for root, _, files in os.walk(TEST_DAG_FOLDER):  # pylint: disable=too-many-nested-blocks
             for file_name in files:
                 if file_name.endswith('.py') or file_name.endswith('.zip'):
@@ -2686,11 +2686,14 @@ class TestSchedulerJob(unittest.TestCase):
             detected_files.add(file_path)
         self.assertEqual(detected_files, expected_files)
 
+        ignored_files = {
+            'helper.py',
+        }
         example_dag_folder = airflow.example_dags.__path__[0]
         for root, _, files in os.walk(example_dag_folder):  # pylint: disable=too-many-nested-blocks
             for file_name in files:
                 if file_name.endswith('.py') or file_name.endswith('.zip'):
-                    if file_name not in ['__init__.py']:
+                    if file_name not in ['__init__.py'] and file_name not in ignored_files:
                         expected_files.add(os.path.join(root, file_name))
         detected_files.clear()
         for file_path in list_py_file_paths(TEST_DAG_FOLDER, include_examples=True):


### PR DESCRIPTION
The files were moved during AIP-21 and our tests do not run
kubernetes tests for optimisations that's why it's not been
noticed

---
Issue link: [AIRFLOW-6687](https://issues.apache.org/jira/browse/AIRFLOW-6687)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
