### PR TITLE
[AIRFLOW-6691] Add tests that protect the deprecated packages

### DIFF
--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -16,3 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+"""This package is deprecated. Please use `airflow.hooks` or `airflow.providers.*.hooks`."""
+
+import warnings
+
+warnings.warn(
+    "This package is deprecated. Please use `airflow.hooks` or `airflow.providers.*.hooks`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/airflow/contrib/operators/__init__.py
+++ b/airflow/contrib/operators/__init__.py
@@ -16,3 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+"""This package is deprecated. Please use `airflow.operators` or `airflow.providers.*.operators`."""
+
+import warnings
+
+warnings.warn(
+    "This package is deprecated. Please use `airflow.operators` or `airflow.providers.*.operators`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/airflow/contrib/sensors/__init__.py
+++ b/airflow/contrib/sensors/__init__.py
@@ -15,3 +15,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This package is deprecated. Please use `airflow.sensors` or `airflow.providers.*.sensors`."""
+
+import warnings
+
+warnings.warn(
+    "This package is deprecated. Please use `airflow.sensors` or `airflow.providers.*.sensors`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/airflow/contrib/task_runner/__init__.py
+++ b/airflow/contrib/task_runner/__init__.py
@@ -15,3 +15,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This package is deprecated. Please use `airflow.task.task_runner`."""

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -27,7 +27,7 @@ ROOT_FOLDER = os.path.realpath(
 
 class TestProjectStructure(unittest.TestCase):
     def test_reference_to_providers_from_core(self):
-        for filename in glob.glob(f"{ROOT_FOLDER}/example_dags/**.py", recursive=True):
+        for filename in glob.glob(f"{ROOT_FOLDER}/example_dags/**/*.py", recursive=True):
             self.assert_file_not_contains(filename, "providers")
 
     def test_deprecated_packages(self):

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -23,15 +23,29 @@ import unittest
 ROOT_FOLDER = os.path.realpath(
     os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir)
 )
-CORE_EXAMPLE_DAGS_FOLDER = os.path.join(ROOT_FOLDER, "airflow", "example_dags")
 
 
-class TestExampleDags(unittest.TestCase):
-    def test_reference_to_providers_is_illegal(self):
-        for filename in glob.glob(f"{CORE_EXAMPLE_DAGS_FOLDER}/**.py"):
+class TestProjectStructure(unittest.TestCase):
+    def test_reference_to_providers_from_core(self):
+        for filename in glob.glob(f"{ROOT_FOLDER}/example_dagss/**.py", recursive=True):
             self.assert_file_not_contains(filename, "providers")
 
-    def assert_file_not_contains(self, filename, pattern):
+    def test_deprecated_packages(self):
+        for directory in ["operator", "hooks", "sensors", "task_runner"]:
+            path_pattern = f"{ROOT_FOLDER}/airflow/contrib/{directory}/*.py"
+
+            for filename in glob.glob(path_pattern, recursive=True):
+                if filename.endswith("/__init__.py"):
+                    self.assert_file_contains(filename, "This package is deprecated.")
+                else:
+                    self.assert_file_contains(filename, "This module is deprecated.")
+
+    def assert_file_not_contains(self, filename: str, pattern: str):
         with open(filename, 'rb', 0) as file, mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as content:
             if content.find(bytes(pattern, 'utf-8')) != -1:
-                self.fail(f"File {filename} contians illegal pattern - {pattern}")
+                self.fail(f"File {filename} not contains pattern - {pattern}")
+
+    def assert_file_contains(self, filename: str, pattern: str):
+        with open(filename, 'rb', 0) as file, mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as content:
+            if content.find(bytes(pattern, 'utf-8')) == -1:
+                self.fail(f"File {filename} contains illegal pattern - {pattern}")

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -27,7 +27,7 @@ ROOT_FOLDER = os.path.realpath(
 
 class TestProjectStructure(unittest.TestCase):
     def test_reference_to_providers_from_core(self):
-        for filename in glob.glob(f"{ROOT_FOLDER}/example_dagss/**.py", recursive=True):
+        for filename in glob.glob(f"{ROOT_FOLDER}/example_dags/**.py", recursive=True):
             self.assert_file_not_contains(filename, "providers")
 
     def test_deprecated_packages(self):


### PR DESCRIPTION
Some people may mistakenly add new changes to a package that is depreccated. We should detect this to avoid confusion and notify the contributor.

---
Issue link: [AIRFLOW-6691](https://issues.apache.org/jira/browse/AIRFLOW-6691)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
