### PR TITLE
[AIRFLOW-6693] Make page titles distinguishable from another

### DIFF
--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -18,7 +18,8 @@
 #}
 
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+
+{% block page_title %}{{ dag.dag_id }} - {{ tab_title }} - Airflow{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/code.html
+++ b/airflow/www/templates/airflow/code.html
@@ -19,7 +19,7 @@
 
 {% extends "airflow/master.html" %}
 
-{% block page_title %}{{ dag.dag_id }} - code - Airflow{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - Code - Airflow{% endblock %}
 
 {% block content %}
     {{ super() }}

--- a/airflow/www/templates/airflow/code.html
+++ b/airflow/www/templates/airflow/code.html
@@ -19,9 +19,7 @@
 
 {% extends "airflow/master.html" %}
 
-{% block title %}
-    {{ title }}
-{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - code - Airflow{% endblock %}
 
 {% block content %}
     {{ super() }}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -19,7 +19,7 @@
 
 {% extends "airflow/master.html" %}
 
-{% block title %}Airflow - DAG {{ dag.dag_id }}{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - Airflow{% endblock %}
 
 {% block head_css %}
   {{ super() }}

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -18,7 +18,8 @@
 #}
 
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+
+{% block page_title %}{{ dag.dag_id }} - code - Airflow{% endblock %}
 
 {% block content %}
     {{ super() }}

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -19,7 +19,7 @@
 
 {% extends "airflow/dag.html" %}
 
-{% block page_title %}{{ dag.dag_id }} - code - Airflow{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - Code - Airflow{% endblock %}
 
 {% block content %}
     {{ super() }}

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -19,9 +19,7 @@
 
 {% extends "airflow/dag.html" %}
 
-{% block title %}
-    {{ title }}
-{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - details - Airflow{% endblock %}
 
 {% block content %}
     {{ super() }}

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -19,7 +19,7 @@
 
 {% extends "airflow/dag.html" %}
 
-{% block page_title %}{{ dag.dag_id }} - details - Airflow{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - DAG Details - Airflow{% endblock %}
 
 {% block content %}
     {{ super() }}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -19,7 +19,13 @@
 
 {% extends "airflow/master.html" %}
 
-{% block title %}Airflow - DAGs{% endblock %}
+{% block page_title %}
+  {% if search_query %}
+    "{{ search_query }}" - DAGs - Airflow
+  {% else %}
+    DAGs - Airflow
+  {% endif %}
+{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/duration_chart.html
+++ b/airflow/www/templates/airflow/duration_chart.html
@@ -18,7 +18,7 @@
 #}
 
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - duration - Airflow{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/duration_chart.html
+++ b/airflow/www/templates/airflow/duration_chart.html
@@ -18,7 +18,7 @@
 #}
 
 {% extends "airflow/dag.html" %}
-{% block page_title %}{{ dag.dag_id }} - duration - Airflow{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - Duration chart - Airflow{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -19,6 +19,8 @@
 
 {% extends "airflow/dag.html" %}
 
+{% block page_title %}{{ dag.dag_id }} - Gantt - Airflow{% endblock %}
+
 {% block head_css %}
 {{ super() }}
 <link rel="stylesheet" type="text/css"

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -19,7 +19,7 @@
 
 {% extends "airflow/dag.html" %}
 
-{% block page_title %}{{ dag.dag_id }} - graph - Airflow{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - Graph - Airflow{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -19,7 +19,7 @@
 
 {% extends "airflow/dag.html" %}
 
-{% block title %}Airflow - DAGs{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - graph - Airflow{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -18,7 +18,7 @@
 #}
 
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - tree - Airflow{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -18,7 +18,7 @@
 #}
 
 {% extends "airflow/dag.html" %}
-{% block page_title %}{{ dag.dag_id }} - tree - Airflow{% endblock %}
+{% block page_title %}{{ dag.dag_id }} - Tree - Airflow{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1709,7 +1709,8 @@ class Airflow(AirflowBaseView):
             demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
-            chart=chart.htmlcontent
+            chart=chart.htmlcontent,
+            tab_title='tries',
         )
 
     @expose('/landing_times')
@@ -1788,6 +1789,7 @@ class Airflow(AirflowBaseView):
             demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
+            tab_title='landing times',
         )
 
     @expose('/paused', methods=['POST'])

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1710,7 +1710,7 @@ class Airflow(AirflowBaseView):
             root=root,
             form=form,
             chart=chart.htmlcontent,
-            tab_title='tries',
+            tab_title='Tries',
         )
 
     @expose('/landing_times')
@@ -1789,7 +1789,7 @@ class Airflow(AirflowBaseView):
             demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
-            tab_title='landing times',
+            tab_title='Landing times',
         )
 
     @expose('/paused', methods=['POST'])


### PR DESCRIPTION
Improve navigation in the browser history and when having many open
Airflow tabs in the browser. This patch includes the DAG name in the
title (where applicable) and puts it in front so that tabs can be
told apart even when having many tabs open. Likewise, if the index page
is filtered, the search term is added in front.

Before:
![2020-01-29-095730_1916x1041_scrot](https://user-images.githubusercontent.com/10650966/73547332-fa867b80-443e-11ea-8cff-51484608dc4d.png)

After:
![2020-01-31-145742_3840x1080_scrot](https://user-images.githubusercontent.com/10650966/73547352-05d9a700-443f-11ea-8863-2cc012f43943.png)


---
Issue link: [AIRFLOW-6693](https://issues.apache.org/jira/browse/AIRFLOW-6693)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
