### PR TITLE
[AIRFLOW-6694] Fixed import to print_stuff in kubernetes tests

### DIFF
--- a/airflow/example_dags/example_kubernetes_executor.py
+++ b/airflow/example_dags/example_kubernetes_executor.py
@@ -21,7 +21,7 @@ This is an example dag for using the Kubernetes Executor.
 """
 import os
 
-from libs import print_stuff
+from libs.helper import print_stuff
 
 from airflow.models import DAG
 from airflow.operators.python import PythonOperator

--- a/airflow/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/example_dags/example_kubernetes_executor_config.py
@@ -21,7 +21,7 @@ This is an example dag for using a Kubernetes Executor Configuration.
 """
 import os
 
-from libs import print_stuff
+from libs.helper import print_stuff
 
 from airflow.models import DAG
 from airflow.operators.python import PythonOperator

--- a/scripts/ci/in_container/kubernetes/docker/airflow-test-env-init.sh
+++ b/scripts/ci/in_container/kubernetes/docker/airflow-test-env-init.sh
@@ -20,6 +20,7 @@ set -x
 
 cd /opt/airflow/airflow && \
 cp -R example_dags/* /root/airflow/dags/ && \
+find /root/airflow/dags/ && \
 airflow db init && \
 alembic upgrade heads && \
 (airflow users create --username airflow --lastname airflow --firstname jon --email airflow@apache.org --role Admin --password airflow || true) && \


### PR DESCRIPTION
The import was missing helper.

---
Issue link: [AIRFLOW-6694](https://issues.apache.org/jira/browse/AIRFLOW-6694)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
