### PR TITLE
[AIRFLOW-XXXX] Fix email configuration link in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -545,7 +545,7 @@ Step 4: Prepare PR
 
    For example, to address this example JIRA ticket, do the following:
 
-   * Read about `email configuration in Airflow <https://airflow.readthedocs.io/en/latest/concepts.html#email-configuration>`__.
+   * Read about `email configuration in Airflow <https://airflow.readthedocs.io/en/latest/howto/email-config.html>`__.
 
    * Find the class you should modify. For the example ticket,
      this is `email.py <https://github.com/apache/airflow/blob/master/airflow/utils/email.py>`__.


### PR DESCRIPTION
---
Issue link: `Document only change, no JIRA issue`

---
Update the link to the email configuration in CONTRIBUTING.rst.

Make sure to mark the boxes below before creating PR:

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).