### PR TITLE
[AIRFLOW-6698] Add shorthand notation for lineage

### DIFF
--- a/airflow/providers/papermill/operators/papermill.py
+++ b/airflow/providers/papermill/operators/papermill.py
@@ -29,7 +29,7 @@ from airflow.utils.decorators import apply_defaults
 @attr.s(auto_attribs=True)
 class NoteBook(File):
     type_hint: Optional[str] = "jupyter_notebook"
-    parameters: Dict = {}
+    parameters: Optional[Dict] = {}
 
     meta_schema: str = __name__ + '.NoteBook'
 
@@ -45,19 +45,26 @@ class PapermillOperator(BaseOperator):
     :param parameters: the notebook parameters to set
     :type parameters: dict
     """
+    supports_lineage = True
+
     @apply_defaults
     def __init__(self,
-                 input_nb: str,
-                 output_nb: str,
-                 parameters: Dict,
+                 input_nb: Optional[str] = None,
+                 output_nb: Optional[str] = None,
+                 parameters: Optional[Dict] = None,
                  *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.inlets.append(NoteBook(url=input_nb,
-                                    parameters=parameters))
-        self.outlets.append(NoteBook(url=output_nb))
+        if input_nb:
+            self.inlets.append(NoteBook(url=input_nb,
+                                        parameters=parameters))
+        if output_nb:
+            self.outlets.append(NoteBook(url=output_nb))
 
     def execute(self, context):
+        if not self.inlets or not self.outlets:
+            raise ValueError("Input notebook or output notebook is not specified")
+
         for i in range(len(self.inlets)):
             pm.execute_notebook(self.inlets[i].url, self.outlets[i].url,
                                 parameters=self.inlets[i].parameters,

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -80,6 +80,7 @@ def apply_defaults(func):
         for arg in sig_cache.parameters:
             if arg not in kwargs and arg in default_args:
                 kwargs[arg] = default_args[arg]
+
         missing_args = list(non_optional_args - set(kwargs))
         if missing_args:
             msg = "Argument {0} is required".format(missing_args)


### PR DESCRIPTION
This adds shorthand notation to define dags that have lineage
support. | for piping between operators and > and < for setting
(static) lineage defintions.

---
Issue link: [AIRFLOW-6698](https://issues.apache.org/jira/browse/AIRFLOW-6698)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

@potiuk 