### PR TITLE
[AIRFLOW-XXXX] Add explicit info about JIRAs for code-related PRs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -142,9 +142,9 @@ these guidelines:
     ticket. The JIRA link should also be added to the PR description. In case of documentation only changes
     the JIRA ticket is not necessary.
 
--   Preface your commit's subject & PR title with **[AIRFLOW-XXXX] COMMIT_MSG** where *XXXX*
+-   Preface your commit's subject & PR title with **[AIRFLOW-NNNN] COMMIT_MSG** where *NNNN*
     is the JIRA number. For example: [AIRFLOW-5574] Fix Google Analytics script loading. In case of
-    documentation only changes you can omit JIRA issue and leave the "XXXX".
+    documentation only changes you should put "[AIRFLOW-XXXX]" instead.
     We compose Airflow release notes from all commit titles in a release. By placing the JIRA number in the
     commit title and hence in the release notes, we let Airflow users look into
     JIRA and GitHub PRs for more details about a particular change.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -137,12 +137,14 @@ these guidelines:
 
 -   When merging PRs, wherever possible try to use **Squash and Merge** instead of **Rebase and Merge**.
 
--   Make sure every pull request has an associated
+-   Make sure every pull request introducing code changes has an associated
     `JIRA <https://issues.apache.org/jira/browse/AIRFLOW/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel>`__
-    ticket. The JIRA link should also be added to the PR description.
+    ticket. The JIRA link should also be added to the PR description. In case of documentation only changes
+    the JIRA ticket is not necessary.
 
--   Preface your commit's subject & PR title with **[AIRFLOW-XXX] COMMIT_MSG** where *XXX*
-    is the JIRA number. For example: [AIRFLOW-5574] Fix Google Analytics script loading.
+-   Preface your commit's subject & PR title with **[AIRFLOW-XXXX] COMMIT_MSG** where *XXXX*
+    is the JIRA number. For example: [AIRFLOW-5574] Fix Google Analytics script loading. In case of
+    documentation only changes you can omit JIRA issue and leave the "XXXX".
     We compose Airflow release notes from all commit titles in a release. By placing the JIRA number in the
     commit title and hence in the release notes, we let Airflow users look into
     JIRA and GitHub PRs for more details about a particular change.


### PR DESCRIPTION
Add explicit info about JIRAs for code-related PRs.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
