### PR TITLE
[AIRFLOW-6702] Dumping kind logs to file.io.

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -65,6 +65,7 @@ def run_command(command):
     """
     Runs command and returns stdout
     """
+    print("Running command: {}".format(command))
     process = subprocess.Popen(
         shlex.split(command),
         stdout=subprocess.PIPE,

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -65,7 +65,6 @@ def run_command(command):
     """
     Runs command and returns stdout
     """
-    print("Running command: {}".format(command))
     process = subprocess.Popen(
         shlex.split(command),
         stdout=subprocess.PIPE,

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -957,7 +957,7 @@ function build_image_on_ci() {
     echo
 
     if [[ ${TRAVIS_JOB_NAME:=""} == "Tests"*"Kubernetes"* ]]; then
-        match_files_regexp 'airflow/kubernetes/.*\.py' 'tests/kubernetes/.*\.py' \
+        match_files_regexp 'airflow/kubernetes/.*\.py' 'tests/runtime/kubernetes/.*\.py' \
             'airflow/www/.*\.py' 'airflow/www/.*\.js' 'airflow/www/.*\.html' \
             'scripts/ci/.*' 'airflow/example_dags/.*'
         if [[ ${FILE_MATCHES} == "true" || ${TRAVIS_PULL_REQUEST:=} == "false" ]]; then


### PR DESCRIPTION
Kubernetes Kind logs are now always dumped to file.io
service.

Kind logs were not dumped on failure because run_command takes
only string now and not list

---
Issue link: [AIRFLOW-6702](https://issues.apache.org/jira/browse/AIRFLOW-6702)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
