### PR TITLE
[AIRFLOW-6703] The base_log_folder option moved to logging in ci

### DIFF
--- a/scripts/ci/in_container/airflow_ci.cfg
+++ b/scripts/ci/in_container/airflow_ci.cfg
@@ -18,7 +18,6 @@
 
 [core]
 dags_folder = ~/airflow/dags
-base_log_folder = ~/airflow/logs
 executor = LocalExecutor
 sql_alchemy_conn = # overridden by the startup scripts
 unit_test_mode = True
@@ -31,6 +30,9 @@ fernet_key = af7CN0q6ag5U3g08IsPsw3K45U7Xa0axgVFhoh-3zB8=
 
 [hive]
 default_hive_mapred_queue = airflow
+
+[logging]
+base_log_folder = ~/airflow/logs
 
 [smtp]
 smtp_user = airflow

--- a/scripts/ci/in_container/kubernetes/app/templates/configmaps.template.yaml
+++ b/scripts/ci/in_container/kubernetes/app/templates/configmaps.template.yaml
@@ -24,13 +24,15 @@ data:
   airflow.cfg: |
     [core]
     dags_folder = {{CONFIGMAP_DAGS_FOLDER}}
-    base_log_folder = /root/airflow/logs
-    logging_level = INFO
     executor = KubernetesExecutor
     parallelism = 32
     load_examples = False
     plugins_folder = /root/airflow/plugins
     sql_alchemy_conn = $SQL_ALCHEMY_CONN
+
+    [logging]
+    base_log_folder = /root/airflow/logs
+    logging_level = INFO
 
     [scheduler]
     dag_dir_list_interval = 300

--- a/tests/utils/test_serve_logs.py
+++ b/tests/utils/test_serve_logs.py
@@ -31,7 +31,7 @@ LOG_DATA = "Airflow log data" * 20
 
 class TestServeLogs(unittest.TestCase):
     def test_should_serve_file(self):
-        log_dir = os.path.expanduser(conf.get('core', 'BASE_LOG_FOLDER'))
+        log_dir = os.path.expanduser(conf.get('logging', 'BASE_LOG_FOLDER'))
         log_port = conf.get('celery', 'WORKER_LOG_SERVER_PORT')
         with NamedTemporaryFile(dir=log_dir) as f:
             f.write(LOG_DATA.encode())


### PR DESCRIPTION
The option is raising deprecation warnings currently

---
Issue link: [AIRFLOW-6703](https://issues.apache.org/jira/browse/AIRFLOW-6703)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
