### PR TITLE
[AIRFLOW-6706] Lazy load operator extra links

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -23,7 +23,7 @@ import os
 import re
 import sys
 import types
-from typing import Any, Callable, Dict, List, Optional, Set, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import pkg_resources
 
@@ -111,33 +111,6 @@ def load_entrypoint_plugins(entry_points, airflow_plugins):
                 plugin_obj.on_load()
                 airflow_plugins.append(plugin_obj)
     return airflow_plugins
-
-
-def register_inbuilt_operator_links() -> None:
-    """
-    Register all the Operators Links that are already defined for the operators
-    in the "airflow" project. Example: QDSLink (Operator Link for Qubole Operator)
-
-    This is required to populate the "whitelist" of allowed classes when deserializing operator links
-    """
-    inbuilt_operator_links: Set[Type] = set()
-
-    try:
-        from airflow.providers.google.cloud.operators.bigquery import BigQueryConsoleLink, BigQueryConsoleIndexableLink  # noqa E501 # pylint: disable=R0401,line-too-long
-        inbuilt_operator_links.update([BigQueryConsoleLink, BigQueryConsoleIndexableLink])
-    except ImportError:
-        pass
-
-    try:
-        from airflow.providers.qubole.operators.qubole import QDSLink   # pylint: disable=R0401
-        inbuilt_operator_links.update([QDSLink])
-    except ImportError:
-        pass
-
-    registered_operator_link_classes.update({
-        "{}.{}".format(link.__module__, link.__name__): link
-        for link in inbuilt_operator_links
-    })
 
 
 def is_valid_plugin(plugin_obj, existing_plugins):
@@ -329,4 +302,3 @@ def integrate_plugins() -> None:
     integrate_hook_plugins()
     integrate_executor_plugins()
     integrate_macro_plugins()
-    register_inbuilt_operator_links()

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -20,7 +20,7 @@ import datetime
 import enum
 import logging
 from inspect import Parameter, signature
-from typing import Any, Dict, Iterable, Optional, Set, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
 import cattr
 import pendulum
@@ -32,7 +32,14 @@ from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.json_schema import Validator, load_dag_schema
 from airflow.settings import json
+from airflow.utils.module_loading import import_string
 from airflow.www.utils import get_python_source
+
+WHITELIST_OPERATOR_EXTRA_LINKS: List[str] = [
+    "airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink",
+    "airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink",
+    "airflow.providers.qubole.operators.qubole.QDSLink"
+]
 
 
 class BaseSerialization:
@@ -418,15 +425,16 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             #       }
             #   )
 
-            _operator_link_class, data = list(_operator_links_source.items())[0]
-
-            if _operator_link_class in registered_operator_link_classes:
-                single_op_link_class_name = registered_operator_link_classes[_operator_link_class]
+            _operator_link_class_path, data = list(_operator_links_source.items())[0]
+            if _operator_link_class_path in WHITELIST_OPERATOR_EXTRA_LINKS:
+                single_op_link_class = import_string(_operator_link_class_path)
+            elif _operator_link_class_path in registered_operator_link_classes:
+                single_op_link_class = registered_operator_link_classes[_operator_link_class_path]
             else:
-                raise KeyError("Operator Link class %r not registered" % _operator_link_class)
+                raise KeyError("Operator Link class %r not registered" % _operator_link_class_path)
 
             op_predefined_extra_link: BaseOperatorLink = cattr.structure(
-                data, single_op_link_class_name)
+                data, single_op_link_class)
 
             op_predefined_extra_links.update(
                 {op_predefined_extra_link.name: op_predefined_extra_link}

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -35,7 +35,7 @@ from airflow.settings import json
 from airflow.utils.module_loading import import_string
 from airflow.www.utils import get_python_source
 
-WHITELIST_OPERATOR_EXTRA_LINKS: List[str] = [
+BUILTIN_OPERATOR_EXTRA_LINKS: List[str] = [
     "airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink",
     "airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink",
     "airflow.providers.qubole.operators.qubole.QDSLink"
@@ -426,7 +426,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             #   )
 
             _operator_link_class_path, data = list(_operator_links_source.items())[0]
-            if _operator_link_class_path in WHITELIST_OPERATOR_EXTRA_LINKS:
+            if _operator_link_class_path in BUILTIN_OPERATOR_EXTRA_LINKS:
                 single_op_link_class = import_string(_operator_link_class_path)
             elif _operator_link_class_path in registered_operator_link_classes:
                 single_op_link_class = registered_operator_link_classes[_operator_link_class_path]


### PR DESCRIPTION
When we import the airflow package, many modules are loaded, so I looked at what modules are exactly loaded.  I found a lot of classes that should not be loaded and delay the start of the application very much.  I suggest that some classes be loaded lazily when needed.

Performance benchmark:
```
seq 1 10 | xargs -n 1 -I {} time python -c "import airflow; import sys; print(len(sys.modules));"
```
Before:
```
1521
        3.45 real         1.83 user         0.59 sys
1521
        1.86 real         1.60 user         0.40 sys
1521
        1.87 real         1.61 user         0.40 sys
1521
        1.83 real         1.60 user         0.39 sys
1521
        1.84 real         1.62 user         0.40 sys
1521
        2.00 real         1.71 user         0.42 sys
1521
        1.84 real         1.60 user         0.41 sys
1521
        1.84 real         1.60 user         0.40 sys
1521
        1.90 real         1.64 user         0.41 sys
1521
        1.87 real         1.61 user         0.42 sys
```
After
```
941
        1.79 real         0.95 user         0.27 sys
941
        1.23 real         0.90 user         0.20 sys
941
        1.26 real         0.90 user         0.21 sys
941
        1.25 real         0.89 user         0.20 sys
941
        1.25 real         0.88 user         0.20 sys
941
        1.30 real         0.90 user         0.21 sys
941
        1.23 real         0.88 user         0.20 sys
941
        1.19 real         0.87 user         0.19 sys
941
        1.23 real         0.87 user         0.21 sys
941
        1.20 real         0.87 user         0.20 sys
```
Result:
<img width="518" alt="Screenshot 2020-02-01 at 18 42 24" src="https://user-images.githubusercontent.com/12058428/73596482-a5239a80-4522-11ea-9879-49d158264b81.png">

and 580 fewer modules - 61%

If anyone is interested, I attach an exact log that shows the import process.
https://gist.github.com/mik-laj/002f5a714c221ba04bc638970094519c

CC: @evgenyshulman 

---
Issue link: [AIRFLOW-6706](https://issues.apache.org/jira/browse/AIRFLOW-6706)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
