### PR TITLE
[AIRFLOW-6710] Lazy create custom executor modules

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -73,7 +73,6 @@ class ExecutorLoader:
             return executor()
         else:
             # Load plugins here for executors as at that time the plugins might not have been initialized yet
-            # TODO: verify the above and remove two lines below in case plugins are always initialized first
             from airflow import plugins_manager
             plugins_manager.integrate_executor_plugins()
             executor_path = executor_name.split('.')

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -327,6 +327,5 @@ def integrate_plugins() -> None:
     integrate_operator_plugins()
     integrate_sensor_plugins()
     integrate_hook_plugins()
-    integrate_executor_plugins()
     integrate_macro_plugins()
     register_inbuilt_operator_links()


### PR DESCRIPTION
Currently, modules for the executor are initialized when loading the airflow module and when calling the `ExecutorLoader.get_default_executor` method. I think the second case is sufficient.

---
Issue link: [AIRFLOW-6710](https://issues.apache.org/jira/browse/AIRFLOW-6710)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
