### PR TITLE
[AIRFLOW-6711] Drop plugin support for stat_name_handler

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -61,7 +61,7 @@ https://developers.google.com/style/inclusive-documentation
 
 ### Drop plugin support for stat_name_handler
 
-In previous, you could use plugins mechanism to configure ``stat_name_handler``. You should now use the `stat_name_handler`
+In previous version, you could use plugins mechanism to configure ``stat_name_handler``. You should now use the `stat_name_handler`
 option in `[scheduler]` section to achieve the same effect.
 
 If your plugin looked like this and was available through the `test_plugin` path:

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -59,6 +59,28 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Drop plugin support for stat_name_handler
+
+In previous, you could use plugins mechanism to configure ``stat_name_handler``. You should now use the `stat_name_handler`
+option in `[scheduler]` section to achieve the same effect.
+
+If your plugin looked like this and was available through the `test_plugin` path:
+```python
+def my_stat_name_handler(stat):
+    return stat
+
+class AirflowTestPlugin(AirflowPlugin):
+    name = "test_plugin"
+    stat_name_handler = my_stat_name_handler
+```
+then your `airflow.cfg` file should look like this:
+```ini
+[scheduler]
+stat_name_handler=test_plugin.my_stat_name_handler
+```
+
+This change is intended to simplify the statsd configuration.
+
 ### Failure callback will be called when task is marked failed
 When task is marked failed by user or task fails due to system failures - on failure call back will be called as part of clean up
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1375,6 +1375,17 @@
       type: string
       example: ~
       default: ""
+    - name: stat_name_handler
+      description: |
+        A function that validate the statsd stat name, apply changes to the stat name if necessary and return
+        the transformed stat name.
+
+        The function should have the following signature:
+        def func_name(stat_name: str) -> str:
+      version_added: ~
+      type: string
+      example: ~
+      default: ""
     - name: max_threads
       description: |
         The scheduler can run multiple threads in parallel to schedule dags.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -661,6 +661,13 @@ statsd_prefix = airflow
 # start with the elements of the list (e.g: scheduler,executor,dagrun)
 statsd_allow_list =
 
+# A function that validate the statsd stat name, apply changes to the stat name if necessary and return
+# the transformed stat name.
+#
+# The function should have the following signature:
+# def func_name(stat_name: str) -> str:
+stat_name_handler =
+
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run.
 max_threads = 2

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -23,10 +23,11 @@ import socket
 import string
 import textwrap
 from functools import wraps
-from typing import Any
+from typing import Any, Callable
 
 from airflow.configuration import conf
 from airflow.exceptions import InvalidStatsNameException
+from airflow.utils.module_loading import import_string
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ class DummyStatsLogger:
 ALLOWED_CHARACTERS = set(string.ascii_letters + string.digits + '_.-')
 
 
-def stat_name_default_handler(stat_name, max_length=250):
+def stat_name_default_handler(stat_name, max_length=250) -> str:
     if not isinstance(stat_name, str):
         raise InvalidStatsNameException('The stat_name has to be a string')
     if len(stat_name) > max_length:
@@ -70,20 +71,25 @@ def stat_name_default_handler(stat_name, max_length=250):
     return stat_name
 
 
-def validate_stat(f):
-    @wraps(f)
+def get_current_handle_stat_name_func() -> Callable[[str], str]:
+    stat_name_handler_name = conf.get('scheduler', 'stat_name_handler')
+    if stat_name_handler_name:
+        handle_stat_name_func = import_string(stat_name_handler_name)
+    else:
+        handle_stat_name_func = stat_name_default_handler
+    return handle_stat_name_func
+
+
+def validate_stat(fn):
+    @wraps(fn)
     def wrapper(_self, stat, *args, **kwargs):
         try:
-            from airflow.plugins_manager import stat_name_handler
-            if stat_name_handler:
-                handle_stat_name_func = stat_name_handler
-            else:
-                handle_stat_name_func = stat_name_default_handler
+            handle_stat_name_func = get_current_handle_stat_name_func()
             stat_name = handle_stat_name_func(stat)
+            return fn(_self, stat_name, *args, **kwargs)
         except InvalidStatsNameException:
-            log.warning('Invalid stat name: {}.'.format(stat), exc_info=True)
+            log.warning('Invalid stat name: %s.', stat, exc_info=True)
             return
-        return f(_self, stat_name, *args, **kwargs)
 
     return wrapper
 

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -49,6 +49,16 @@ the metrics that start with the elements of the list:
     [scheduler]
     statsd_allow_list = scheduler,executor,dagrun
 
+If you want to redirect metrics to different name, you can configure ``stat_name_handler`` option
+in ``[scheduler]`` section.  It should point to a function that validate the statsd stat name, apply changes
+to the stat name if necessary and return the transformed stat name. The function may looks as follow:
+
+.. code-block:: ini
+
+    def my_custom_stat_name_handler(stat_name: str) -> str:
+        return stat_name.lower()[:32]
+
+
 Counters
 --------
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -94,12 +94,6 @@ looks like:
         appbuilder_views = []
         # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
         appbuilder_menu_items = []
-        # A function that validate the statsd stat name, apply changes to the stat name if necessary and
-        # return the transformed stat name.
-        #
-        # The function should have the following signature:
-        # def func_name(stat_name: str) -> str:
-        stat_name_handler = None
         # A callback to perform actions when airflow starts and the plugin is loaded.
         # NOTE: Ensure your plugin has *args, and **kwargs in the method definition
         #   to protect against extra parameters injected into the on_load(...)
@@ -215,10 +209,6 @@ definitions in Airflow.
                         "category": "Search",
                         "category_icon": "fa-th",
                         "href": "https://www.google.com"}
-
-    # Validate the statsd stat name
-    def stat_name_dummy_handler(stat_name):
-        return stat_name
 
     # A global operator extra link that redirect you to
     # task logs stored in S3

--- a/setup.py
+++ b/setup.py
@@ -414,9 +414,9 @@ devel_all = (all_dbs + atlas + aws + azure + celery + cgroups + datadog + devel 
              doc + docker + druid + elasticsearch + gcp + grpc + jdbc + jenkins +
              kerberos + kubernetes + ldap + odbc + oracle + pagerduty + papermill +
              password + pinot + redis + salesforce + samba + segment + sendgrid +
-             sentry + slack + snowflake + ssh + virtualenv + webhdfs + zendesk)
+             sentry + slack + snowflake + ssh + statsd + virtualenv + webhdfs + zendesk)
 
-# Snakebite & Google Cloud Dataflow are not Python 3 compatible :'(
+# Snakebite are not Python 3 compatible :'(
 if PY3:
     devel_ci = [package for package in devel_all if package not in
                 ['snakebite>=2.7.8', 'snakebite[kerberos]>=2.7.8']]

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -44,7 +44,7 @@ class TestBaseExecutor(unittest.TestCase):
 
     @mock.patch('airflow.executors.base_executor.BaseExecutor.sync')
     @mock.patch('airflow.executors.base_executor.BaseExecutor.trigger_tasks')
-    @mock.patch('airflow.stats.Stats.gauge')
+    @mock.patch('airflow.executors.base_executor.Stats.gauge')
     def test_gauge_executor_metrics(self, mock_stats_gauge, mock_trigger_tasks, mock_sync):
         executor = BaseExecutor()
         executor.heartbeat()

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -177,7 +177,7 @@ class TestCeleryExecutor(unittest.TestCase):
 
     @mock.patch('airflow.executors.celery_executor.CeleryExecutor.sync')
     @mock.patch('airflow.executors.celery_executor.CeleryExecutor.trigger_tasks')
-    @mock.patch('airflow.stats.Stats.gauge')
+    @mock.patch('airflow.executors.base_executor.Stats.gauge')
     def test_gauge_executor_metrics(self, mock_stats_gauge, mock_trigger_tasks, mock_sync):
         executor = celery_executor.CeleryExecutor()
         executor.heartbeat()

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -151,7 +151,7 @@ class TestDaskExecutorTLS(TestBaseDask):
 
     @mock.patch('airflow.executors.dask_executor.DaskExecutor.sync')
     @mock.patch('airflow.executors.base_executor.BaseExecutor.trigger_tasks')
-    @mock.patch('airflow.stats.Stats.gauge')
+    @mock.patch('airflow.executors.base_executor.Stats.gauge')
     def test_gauge_executor_metrics(self, mock_stats_gauge, mock_trigger_tasks, mock_sync):
         executor = DaskExecutor()
         executor.heartbeat()

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -219,7 +219,7 @@ class TestKubernetesExecutor(unittest.TestCase):
     @mock.patch('airflow.executors.kubernetes_executor.KubeConfig')
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesExecutor.sync')
     @mock.patch('airflow.executors.base_executor.BaseExecutor.trigger_tasks')
-    @mock.patch('airflow.stats.Stats.gauge')
+    @mock.patch('airflow.executors.base_executor.Stats.gauge')
     def test_gauge_executor_metrics(self, mock_stats_gauge, mock_trigger_tasks, mock_sync, mock_kube_config):
         executor = KubernetesExecutor()
         executor.heartbeat()

--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -69,7 +69,7 @@ class TestLocalExecutor(unittest.TestCase):
 
     @mock.patch('airflow.executors.local_executor.LocalExecutor.sync')
     @mock.patch('airflow.executors.base_executor.BaseExecutor.trigger_tasks')
-    @mock.patch('airflow.stats.Stats.gauge')
+    @mock.patch('airflow.executors.base_executor.Stats.gauge')
     def test_gauge_executor_metrics(self, mock_stats_gauge, mock_trigger_tasks, mock_sync):
         executor = LocalExecutor()
         executor.heartbeat()

--- a/tests/executors/test_sequential_executor.py
+++ b/tests/executors/test_sequential_executor.py
@@ -26,7 +26,7 @@ class TestSequentialExecutor(unittest.TestCase):
 
     @mock.patch('airflow.executors.sequential_executor.SequentialExecutor.sync')
     @mock.patch('airflow.executors.base_executor.BaseExecutor.trigger_tasks')
-    @mock.patch('airflow.stats.Stats.gauge')
+    @mock.patch('airflow.executors.base_executor.Stats.gauge')
     def test_gauge_executor_metrics(self, mock_stats_gauge, mock_trigger_tasks, mock_sync):
         executor = SequentialExecutor()
         executor.heartbeat()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1010,7 +1010,7 @@ class TestSchedulerJob(unittest.TestCase):
             old_children)
         self.assertFalse(current_children)
 
-    @mock.patch('airflow.stats.Stats.incr')
+    @mock.patch('airflow.jobs.scheduler_job.Stats.incr')
     def test_process_executor_events(self, mock_stats_incr):
         dag_id = "test_process_executor_events"
         dag_id2 = "test_process_executor_events_2"

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -85,13 +85,6 @@ bp = Blueprint(
     static_url_path='/static/test_plugin')
 
 
-class StatsClass:
-    @staticmethod
-    # Create a handler to validate statsd stat name
-    def stat_name_dummy_handler(stat_name: str) -> str:
-        return stat_name
-
-
 # Defining the plugin class
 class AirflowTestPlugin(AirflowPlugin):
     name = "test_plugin"
@@ -103,7 +96,6 @@ class AirflowTestPlugin(AirflowPlugin):
     flask_blueprints = [bp]
     appbuilder_views = [v_appbuilder_package]
     appbuilder_menu_items = [appbuilder_mitem]
-    stat_name_handler = StatsClass.stat_name_dummy_handler
     global_operator_extra_links = [
         AirflowLink(),
         GithubLink(),

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -16,11 +16,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import importlib
 import unittest
+from unittest import mock
 from unittest.mock import Mock
 
+import airflow
+from airflow.exceptions import InvalidStatsNameException
 from airflow.stats import AllowListValidator, SafeStatsdLogger
+from tests.test_utils.config import conf_vars
 
 
 class TestStats(unittest.TestCase):
@@ -63,3 +67,37 @@ class TestStatsWithAllowList(unittest.TestCase):
     def test_not_increment_counter_if_not_allowed(self):
         self.stats.incr('stats_three')
         self.statsd_client.assert_not_called()
+
+
+def always_invalid(stat_name):
+    raise InvalidStatsNameException("Invalid name: {}".format(stat_name))
+
+
+def always_valid(stat_name):
+    return stat_name
+
+
+class TestCustomStatsName(unittest.TestCase):
+    @conf_vars({
+        ('scheduler', 'statsd_on'): 'True',
+        ('scheduler', 'stat_name_handler'): 'tests.test_stats.always_invalid'
+    })
+    @mock.patch("statsd.StatsClient")
+    def test_does_not_send_stats_when_the_name_is_not_valid(self, mock_statsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_statsd.return_value.assert_not_called()
+
+    @conf_vars({
+        ('scheduler', 'statsd_on'): 'True',
+        ('scheduler', 'stat_name_handler'): 'tests.test_stats.always_valid'
+    })
+    @mock.patch("statsd.StatsClient")
+    def test_does_send_stats_when_the_name_is_valid(self, mock_statsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_statsd.return_value.incr.assert_called_once_with('dummy_key', 1, 1)
+
+    def tearDown(self) -> None:
+        # To avoid side-effect
+        importlib.reload(airflow.stats)


### PR DESCRIPTION
This change is intended to simplify the statsd configuration and unify the configuration. Other components use import path to configure aplication e.g.. `pod_mutation_hook` or `auth_backend`. Configuration through plugins is very strange and may not be readable enough.  The configuration file for the configuration is a proven, stable and widely used solution. Plugins are an interesting idea, but they are not common.

---
Issue link: [AIRFLOW-6711](https://issues.apache.org/jira/browse/AIRFLOW-6711)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
