### PR TITLE
[AIRFLOW-6715] Fix Google Cloud DLP Example DAG

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_dlp_operator.py
+++ b/airflow/providers/google/cloud/example_dags/example_dlp_operator.py
@@ -83,4 +83,4 @@ with DAG(
         dag=dag,
     )
 
-    create_template > inspect_content > delete_template
+    create_template >> inspect_content >> delete_template


### PR DESCRIPTION
The example DAG for DLP operator has a wrong way of setting task dependencies



---
Issue link: [AIRFLOW-6715](https://issues.apache.org/jira/browse/AIRFLOW-6715)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
