### PR TITLE
[AIRFLOW-6717] Remove non-existent field from templated_fields

### DIFF
--- a/airflow/providers/google/cloud/operators/cloud_memorystore.py
+++ b/airflow/providers/google/cloud/operators/cloud_memorystore.py
@@ -683,7 +683,6 @@ class CloudMemorystoreScaleInstanceOperator(BaseOperator):
 
     template_fields = (
         "memory_size_gb",
-        "instance",
         "location",
         "instance_id",
         "project_id",


### PR DESCRIPTION
**CloudMemorystoreScaleInstanceOperator** does not have **instance** field but the field exists in **templated_fields**. We should remove this



---
Issue link: [AIRFLOW-6717](https://issues.apache.org/jira/browse/AIRFLOW-6717)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
