### PR TITLE
[AIRFLOW-6718] Fix more occurrences of utils.dates.days_ago

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -249,6 +249,12 @@ repos:
         entry: "LoggingMixin\\(\\)"
         files: \.py$
         pass_filenames: true
+      - id: daysago-import-check
+        language: pygrep
+        name: Make sure days_ago is imported from airflow.utils.dates
+        entry: "(airflow\\.|)utils\\.dates\\.days_ago"
+        files: \.py$
+        pass_filenames: true
       - id: build
         name: Check if image build is needed
         entry: ./scripts/ci/pre_commit_ci_build.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -252,7 +252,7 @@ repos:
       - id: daysago-import-check
         language: pygrep
         name: Make sure days_ago is imported from airflow.utils.dates
-        entry: "(airflow\\.|)utils\\.dates\\.days_ago"
+        entry: "(airflow\\.){0,1}utils\\.dates\\.days_ago"
         files: \.py$
         pass_filenames: true
       - id: build

--- a/airflow/providers/amazon/aws/example_dags/example_datasync_1.py
+++ b/airflow/providers/amazon/aws/example_dags/example_datasync_1.py
@@ -28,8 +28,9 @@ This DAG relies on the following environment variables:
 
 from os import getenv
 
-from airflow import models, utils
+from airflow import models
 from airflow.providers.amazon.aws.operators.datasync import AWSDataSyncOperator
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_datasync_1_args_1]
 TASK_ARN = getenv(
@@ -44,7 +45,7 @@ DESTINATION_LOCATION_URI = getenv(
     "DESTINATION_LOCATION_URI", "s3://mybucket/prefix")
 # [END howto_operator_datasync_1_args_2]
 
-default_args = {"start_date": utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 
 with models.DAG(
     "example_datasync_1_1",

--- a/airflow/providers/amazon/aws/example_dags/example_datasync_2.py
+++ b/airflow/providers/amazon/aws/example_dags/example_datasync_2.py
@@ -36,8 +36,9 @@ This DAG relies on the following environment variables:
 import json
 from os import getenv
 
-from airflow import models, utils
+from airflow import models
 from airflow.providers.amazon.aws.operators.datasync import AWSDataSyncOperator
+from airflow.utils.dates import days_ago
 
 # [START howto_operator_datasync_2_args]
 SOURCE_LOCATION_URI = getenv(
@@ -74,7 +75,7 @@ UPDATE_TASK_KWARGS = json.loads(
     getenv("UPDATE_TASK_KWARGS", default_update_task_kwargs)
 )
 
-default_args = {"start_date": utils.dates.days_ago(1)}
+default_args = {"start_date": days_ago(1)}
 # [END howto_operator_datasync_2_args]
 
 with models.DAG(

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -21,8 +21,9 @@ This dag only runs some simple tasks to test Airflow's task execution.
 """
 from datetime import datetime, timedelta
 
-from airflow import DAG, utils
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils.dates import days_ago
 
 now = datetime.now()
 now_to_the_hour = (
@@ -34,7 +35,7 @@ DAG_NAME = 'test_dag_v1'
 default_args = {
     'owner': 'airflow',
     'depends_on_past': True,
-    'start_date': utils.dates.days_ago(2)
+    'start_date': days_ago(2)
 }
 dag = DAG(DAG_NAME, schedule_interval='*/10 * * * *', default_args=default_args)
 


### PR DESCRIPTION
There are 3 more occurrences in a different manner in the following files:

- dags/test_dag.py
- example_datasync_1.py
- example_datasync_2.py

This files used "utils.dates.days_ago(1)" instead of "airflow.utils.dates.days_ago(1)" and hence they were not detected in https://github.com/apache/airflow/pull/7007

---
Issue link: [AIRFLOW-6718](https://issues.apache.org/jira/browse/AIRFLOW-6718)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
