### PR TITLE
[AIRFLOW-XXXX] Fix Static Checks on CI

### DIFF
--- a/airflow/providers/amazon/aws/hooks/sagemaker.py
+++ b/airflow/providers/amazon/aws/hooks/sagemaker.py
@@ -332,7 +332,7 @@ class SageMakerHook(AwsHook):
             billable_time = \
                 (describe_response['TrainingEndTime'] - describe_response['TrainingStartTime']) * \
                 describe_response['ResourceConfig']['InstanceCount']
-            self.log.info('Billable seconds:{}'.format(int(billable_time.total_seconds()) + 1))
+            self.log.info('Billable seconds: %d', int(billable_time.total_seconds()) + 1)
 
         return response
 
@@ -635,7 +635,7 @@ class SageMakerHook(AwsHook):
                 response = describe_function(job_name)
                 status = response[key]
                 self.log.info('Job still running for %s seconds... '
-                              'current status is %s' % (sec, status))
+                              'current status is %s', sec, status)
             except KeyError:
                 raise AirflowException('Could not get status of the SageMaker job')
             except ClientError:
@@ -738,4 +738,4 @@ class SageMakerHook(AwsHook):
                 raise AirflowException('Error training {}: {} Reason: {}'.format(job_name, status, reason))
             billable_time = (last_description['TrainingEndTime'] - last_description['TrainingStartTime']) \
                 * instance_count
-            self.log.info('Billable seconds:{}'.format(int(billable_time.total_seconds()) + 1))
+            self.log.info('Billable seconds: %d', int(billable_time.total_seconds()) + 1)


### PR DESCRIPTION
Master is failing https://travis-ci.org/apache/airflow/jobs/645192041


```
************* Module airflow.providers.amazon.aws.hooks.sagemaker
airflow/providers/amazon/aws/hooks/sagemaker.py:338:26: W1202: Use % formatting in logging functions and pass the % parameters as arguments (logging-format-interpolation)
airflow/providers/amazon/aws/hooks/sagemaker.py:640:16: W1201: Specify string format arguments as logging function parameters (logging-not-lazy)
airflow/providers/amazon/aws/hooks/sagemaker.py:744:26: W1202: Use % formatting in logging functions and pass the % parameters as arguments (logging-format-interpolation)
```

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
