### PR TITLE
[AIRFLOW-6720] Enforce alphabetical order for CONN_TYPE_TO_HOOK

### DIFF
--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -26,6 +26,7 @@ from parameterized import parameterized
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import Connection, crypto
+from airflow.models.connection import CONN_TYPE_TO_HOOK
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from tests.test_utils.config import conf_vars
 
@@ -512,3 +513,11 @@ class TestConnection(unittest.TestCase):
         assert conns[0].login == 'username'
         assert conns[0].password == 'password'
         assert conns[0].port == 5432
+
+
+class TestConnTypeToHook(unittest.TestCase):
+    def test_enforce_alphabetical_order(self):
+        current_keys = list(CONN_TYPE_TO_HOOK.keys())
+        expected_keys = sorted(current_keys)
+
+        self.assertEqual(expected_keys, current_keys)


### PR DESCRIPTION
Jarek proposed to add a new test to do so.
https://github.com/apache/airflow/pull/7328#discussion_r373842991


---
Issue link: [AIRFLOW-6720](https://issues.apache.org/jira/browse/AIRFLOW-6720)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
