### PR TITLE
[AIRFLOW-6720] Detect missing tests for providers package

### DIFF
--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -86,6 +86,9 @@ class TestProjectStructure(unittest.TestCase):
                 self.fail(f"File {filename} contains illegal pattern - {pattern}")
 
     def test_providers_modules_should_have_tests(self):
+        """
+        Assert every module in /airflow/providers has a corresponding test_ file in tests/airflow/providers.
+        """
         # TODO: Should we extend this test to cover other directories?
         expected_test_files = glob.glob(f"{ROOT_FOLDER}/airflow/providers/**/*.py", recursive=True)
         # Make path relative
@@ -115,15 +118,15 @@ class TestProjectStructure(unittest.TestCase):
         current_test_files = set(current_test_files)
 
         missing_tests_files = expected_test_files - expected_test_files.intersection(current_test_files)
-        self.assertEqual(missing_tests_files, MISSING_TEST_FILES)
+        self.assertEqual(set(), missing_tests_files - MISSING_TEST_FILES)
 
     def test_keep_missing_test_files_update(self):
         new_test_files = []
         for test_file in MISSING_TEST_FILES:
             if os.path.isfile(f"{ROOT_FOLDER}/{test_file}"):
                 new_test_files.append(test_file)
-        new_files_text = '\n'.join(new_test_files)
         if new_test_files:
+            new_files_text = '\n'.join(new_test_files)
             self.fail(
                 "It looks like you added a missing test files:\n"
                 f"{new_files_text}"

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -128,7 +128,7 @@ class TestProjectStructure(unittest.TestCase):
         if new_test_files:
             new_files_text = '\n'.join(new_test_files)
             self.fail(
-                "It looks like you added a missing test files:\n"
+                "You've added a test file currently listed as missing:\n"
                 f"{new_files_text}"
                 "\n"
                 "Thank you very much.\n"

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -24,6 +24,41 @@ ROOT_FOLDER = os.path.realpath(
     os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir)
 )
 
+MISSING_TEST_FILES = {
+    'tests/providers/amazon/aws/hooks/test_athena.py',
+    'tests/providers/amazon/aws/hooks/test_s3.py',
+    'tests/providers/apache/cassandra/sensors/test_record.py',
+    'tests/providers/apache/cassandra/sensors/test_table.py',
+    'tests/providers/apache/hdfs/sensors/test_web_hdfs.py',
+    'tests/providers/apache/hive/operators/test_vertica_to_hive.py',
+    'tests/providers/apache/hive/sensors/test_hive_partition.py',
+    'tests/providers/apache/hive/sensors/test_metastore_partition.py',
+    'tests/providers/apache/pig/operators/test_pig.py',
+    'tests/providers/apache/spark/hooks/test_spark_jdbc_script.py',
+    'tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py',
+    'tests/providers/google/cloud/operators/test_datastore.py',
+    'tests/providers/google/cloud/operators/test_gcs_to_bigquery.py',
+    'tests/providers/google/cloud/operators/test_sql_to_gcs.py',
+    'tests/providers/google/cloud/sensors/test_bigquery.py',
+    'tests/providers/google/cloud/utils/test_field_sanitizer.py',
+    'tests/providers/google/cloud/utils/test_field_validator.py',
+    'tests/providers/google/cloud/utils/test_mlengine_operator_utils.py',
+    'tests/providers/google/cloud/utils/test_mlengine_prediction_summary.py',
+    'tests/providers/jenkins/hooks/test_jenkins.py',
+    'tests/providers/microsoft/azure/sensors/test_azure_cosmos.py',
+    'tests/providers/microsoft/mssql/hooks/test_mssql.py',
+    'tests/providers/microsoft/mssql/operators/test_mssql.py',
+    'tests/providers/oracle/operators/test_oracle.py',
+    'tests/providers/presto/operators/test_presto_check.py',
+    'tests/providers/qubole/hooks/test_qubole.py',
+    'tests/providers/samba/hooks/test_samba.py',
+    'tests/providers/snowflake/hooks/test_snowflake.py',
+    'tests/providers/snowflake/operators/test_s3_to_snowflake.py',
+    'tests/providers/snowflake/operators/test_snowflake.py',
+    'tests/providers/sqlite/operators/test_sqlite.py',
+    'tests/providers/vertica/hooks/test_vertica.py'
+}
+
 
 class TestProjectStructure(unittest.TestCase):
     def test_reference_to_providers_from_core(self):
@@ -49,3 +84,50 @@ class TestProjectStructure(unittest.TestCase):
         with open(filename, 'rb', 0) as file, mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as content:
             if content.find(bytes(pattern, 'utf-8')) == -1:
                 self.fail(f"File {filename} contains illegal pattern - {pattern}")
+
+    def test_providers_modules_should_have_tests(self):
+        # TODO: Should we extend this test to cover other directories?
+        expected_test_files = glob.glob(f"{ROOT_FOLDER}/airflow/providers/**/*.py", recursive=True)
+        # Make path relative
+        expected_test_files = (os.path.relpath(f, ROOT_FOLDER) for f in expected_test_files)
+        # Exclude example_dags
+        expected_test_files = (f for f in expected_test_files if "/example_dags/" not in f)
+        # Exclude __init__.py
+        expected_test_files = (f for f in expected_test_files if not f.endswith("__init__.py"))
+        # Change airflow/ to tests/
+        expected_test_files = (
+            f'tests/{f.partition("/")[2]}'
+            for f in expected_test_files if not f.endswith("__init__.py")
+        )
+        # Add test_ prefix to filename
+        expected_test_files = (
+            f'{f.rpartition("/")[0]}/test_{f.rpartition("/")[2]}'
+            for f in expected_test_files if not f.endswith("__init__.py")
+        )
+
+        current_test_files = glob.glob(f"{ROOT_FOLDER}/tests/providers/**/*.py", recursive=True)
+        # Make path relative
+        current_test_files = (os.path.relpath(f, ROOT_FOLDER) for f in current_test_files)
+        # Exclude __init__.py
+        current_test_files = (f for f in current_test_files if not f.endswith("__init__.py"))
+
+        expected_test_files = set(expected_test_files)
+        current_test_files = set(current_test_files)
+
+        missing_tests_files = expected_test_files - expected_test_files.intersection(current_test_files)
+        self.assertEqual(missing_tests_files, MISSING_TEST_FILES)
+
+    def test_keep_missing_test_files_update(self):
+        new_test_files = []
+        for test_file in MISSING_TEST_FILES:
+            if os.path.isfile(f"{ROOT_FOLDER}/{test_file}"):
+                new_test_files.append(test_file)
+        new_files_text = '\n'.join(new_test_files)
+        if new_test_files:
+            self.fail(
+                "It looks like you added a missing test files:\n"
+                f"{new_files_text}"
+                "\n"
+                "Thank you very much.\n"
+                "Can you remove it from the list of missing tests, please?"
+            )


### PR DESCRIPTION
During the introduction of AIP-21, I corrected the test file names. Very often the file name in the application did not match the test file name.  Now I would like to prevent regression, so I add tests that detect typos in names. This will also force you to add tests.

This is an experiment that we can extend to other packages in the project in the future. 

CC: @coopergillan 

---
Issue link: [AIRFLOW-6720](https://issues.apache.org/jira/browse/AIRFLOW-6720)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
