### PR TITLE
[AIRFLOW-XXXX] Add versions_added field to configs

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -70,7 +70,7 @@
     - name: sql_engine_encoding
       description: |
         The encoding for the databases
-      version_added: ~
+      version_added: 1.10.1
       type: string
       example: ~
       default: "utf-8"
@@ -100,7 +100,7 @@
         and the total number of "sleeping" connections the pool will allow is pool_size.
         max_overflow can be set to -1 to indicate no overflow limit;
         no limit will be placed on the total number of concurrent connections. Defaults to 10.
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "10"
@@ -120,7 +120,7 @@
         Typically, this is a simple statement like "SELECT 1".
         More information here:
         https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
-      version_added: ~
+      version_added: 1.10.6
       type: string
       example: ~
       default: "True"
@@ -128,7 +128,7 @@
       description: |
         The schema to use for the metadata database.
         SqlAlchemy supports databases with the concept of multiple schemas.
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: ""
@@ -212,7 +212,7 @@
     - name: dag_file_processor_timeout
       description: |
         How long before timing out a DagFileProcessor, which processes a dag file
-      version_added: ~
+      version_added: 1.10.6
       type: string
       example: ~
       default: "50"
@@ -282,21 +282,21 @@
     - name: worker_precheck
       description: |
         Worker initialisation check to validate Metadata Database connection
-      version_added: ~
+      version_added: 1.10.1
       type: string
       example: ~
       default: "False"
     - name: dag_discovery_safe_mode
       description: |
         When discovering DAGs, ignore any files that don't contain the strings ``DAG`` and ``airflow``.
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: "True"
     - name: default_task_retries
       description: |
         The number of retries each task is going to have by default. Can be overridden at dag or task level.
-      version_added: ~
+      version_added: 1.10.6
       type: string
       example: ~
       default: "0"
@@ -319,7 +319,7 @@
     - name: check_slas
       description: |
         On each dagrun check against defined SLAs
-      version_added: ~
+      version_added: 1.10.8
       type: string
       example: ~
       default: "True"
@@ -395,14 +395,14 @@
       description: |
         Flag to enable/disable Colored logs in Console
         Colour the logs when the controlling terminal is a TTY.
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "True"
     - name: colored_log_format
       description: |
         Log format for when Colored logs is enabled
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: >-
@@ -410,7 +410,7 @@
         %%(log_color)s%%(levelname)s%%(reset)s - %%(log_color)s%%(message)s%%(reset)s
     - name: colored_formatter_class
       description: ~
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "airflow.utils.log.colored_log.CustomTTYColoredFormatter"
@@ -451,7 +451,7 @@
     - name: dag_processor_manager_log_location
       description: |
         full path of dag_processor_manager logfile
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: "{AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log"
@@ -491,7 +491,7 @@
       description: |
         Used only with DebugExecutor. If set to True DAG will fail with first
         failed task. Helpful for debugging purposes.
-      version_added: ~
+      version_added: 1.10.8
       type: string
       example: ~
       default: "False"
@@ -728,14 +728,14 @@
     - name: expose_hostname
       description: |
         Expose hostname in the web server
-      version_added: ~
+      version_added: 1.10.8
       type: string
       example: ~
       default: "True"
     - name: expose_stacktrace
       description: |
         Expose stacktrace in the web server
-      version_added: ~
+      version_added: 1.10.8
       type: string
       example: ~
       default: "True"
@@ -774,21 +774,21 @@
     - name: log_fetch_delay_sec
       description: |
         Time interval (in secs) to wait before next log fetching.
-      version_added: ~
+      version_added: 1.10.8
       type: int
       example: ~
       default: "2"
     - name: log_auto_tailing_offset
       description: |
         Distance away from page bottom to enable auto tailing.
-      version_added: ~
+      version_added: 1.10.8
       type: int
       example: ~
       default: "30"
     - name: log_animation_speed
       description: |
         Animation speed for auto tailing log display.
-      version_added: ~
+      version_added: 1.10.8
       type: int
       example: ~
       default: "1000"
@@ -824,7 +824,7 @@
     - name: enable_proxy_fix
       description: |
         Enable werkzeug ``ProxyFix`` middleware for reverse proxy
-      version_added: ~
+      version_added: 1.10.1
       type: boolean
       example: ~
       default: "False"
@@ -867,28 +867,28 @@
     - name: cookie_secure
       description: |
         Set secure flag on session cookie
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: "False"
     - name: cookie_samesite
       description: |
         Set samesite policy on session cookie
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: ""
     - name: default_wrap
       description: |
         Default setting for wrap toggle on DAG code and TI log views.
-      version_added: ~
+      version_added: 1.10.4
       type: boolean
       example: ~
       default: "False"
     - name: x_frame_enabled
       description: |
         Allow the UI to be rendered in a frame
-      version_added: ~
+      version_added: 1.10.8
       type: boolean
       example: ~
       default: "True"
@@ -903,7 +903,7 @@
     - name: analytics_id
       description: |
         Unique ID of your account in the analytics tool
-      version_added: ~
+      version_added: 1.10.5
       type: string
       example: ~
       default: ~
@@ -918,7 +918,7 @@
       description: |
         Update FAB permissions and sync security manager roles
         on webserver startup
-      version_added: ~
+      version_added: 1.10.7
       type: string
       example: ~
       default: "True"
@@ -926,14 +926,14 @@
       description: |
         Minutes of non-activity before logged out from UI
         0 means never get forcibly logged out
-      version_added: ~
+      version_added: 1.10.8
       type: string
       example: ~
       default: "0"
     - name: session_lifetime_days
       description: |
         The UI cookie lifetime in days
-      version_added: ~
+      version_added: 1.10.8
       type: string
       example: ~
       default: "30"
@@ -1018,7 +1018,7 @@
   options:
     - name: sentry_dsn
       description: ~
-      version_added: ~
+      version_added: 1.10.6
       type: string
       example: ~
       default: ""
@@ -1115,7 +1115,7 @@
       description: |
         Securing Flower with Basic Authentication
         Accepts user:password pairs separated by a comma
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: "user1:password1,user2:password2"
       default: ""
@@ -1130,7 +1130,7 @@
       description: |
         How many processes CeleryExecutor uses to sync task state.
         0 means to use max(1, number of cores - 1) processes.
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: "0"
@@ -1172,7 +1172,7 @@
         See:
         https://docs.celeryproject.org/en/latest/userguide/workers.html#concurrency
         https://docs.celeryproject.org/en/latest/userguide/concurrency/eventlet.html
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "prefork"
@@ -1180,7 +1180,7 @@
       description: |
         The number of seconds to wait before timing out ``send_task_to_executor`` or
         ``fetch_celery_task_state`` operations.
-      version_added: ~
+      version_added: 1.10.8
       type: int
       example: ~
       default: "2"
@@ -1259,14 +1259,14 @@
       description: |
         The number of times to try to schedule each DAG file
         -1 indicates unlimited number
-      version_added: ~
+      version_added: 1.10.6
       type: string
       example: ~
       default: "-1"
     - name: processor_poll_interval
       description: |
         The number of seconds to wait between consecutive DAG file processing
-      version_added: ~
+      version_added: 1.10.6
       type: string
       example: ~
       default: "1"
@@ -1296,7 +1296,7 @@
         If the last scheduler heartbeat happened more than scheduler_health_check_threshold
         ago (in seconds), scheduler is considered unhealthy.
         This is used by the health check in the "/health" endpoint
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: "30"
@@ -1371,7 +1371,7 @@
         If you want to avoid send all the available metrics to StatsD,
         you can configure an allow list of prefixes to send only the metrics that
         start with the elements of the list (e.g: scheduler,executor,dagrun)
-      version_added: ~
+      version_added: 1.10.6
       type: string
       example: ~
       default: ""
@@ -1404,7 +1404,7 @@
       description: |
         Turn off scheduler use of cron intervals by setting this to False.
         DAGs submitted manually in the web UI or with trigger_dag will still run.
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: "True"
@@ -1412,7 +1412,7 @@
       description: |
         Allow externally triggered DagRuns for Execution Dates in the future
         Only has effect if schedule_interval is set to None in DAG
-      version_added: ~
+      version_added: 1.10.8
       type: string
       example: ~
       default: "False"
@@ -1490,7 +1490,7 @@
       description: |
         This setting allows the use of LDAP servers that either return a
         broken schema, or do not return a schema.
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: "False"
@@ -1553,21 +1553,21 @@
     - name: host
       description: |
         Elasticsearch host
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: ""
     - name: log_id_template
       description: |
         Format of the log_id, which is used to query for a given tasks logs
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "{{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}"
     - name: end_of_log_mark
       description: |
         Used to mark the end of a log stream for a task
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "end_of_log"
@@ -1576,28 +1576,28 @@
         Qualified URL for an elasticsearch frontend (like Kibana) with a template argument for log_id
         Code will construct log_id using the log_id template from the argument above.
         NOTE: The code will prefix the https:// automatically, don't include that here.
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: ""
     - name: write_stdout
       description: |
         Write the task logs to the stdout of the worker, rather than the default files
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "False"
     - name: json_format
       description: |
         Instead of the default log formatter, write the log lines as JSON
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "False"
     - name: json_fields
       description: |
         Log fields to also attach to the json output, if enabled
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: "asctime, filename, lineno, levelname, message"
@@ -1606,13 +1606,13 @@
   options:
     - name: use_ssl
       description: ~
-      version_added: ~
+      version_added: 1.10.5
       type: string
       example: ~
       default: "False"
     - name: verify_certs
       description: ~
-      version_added: ~
+      version_added: 1.10.5
       type: string
       example: ~
       default: "True"
@@ -1636,7 +1636,7 @@
     - name: worker_container_image_pull_policy
       description: |
         The imagePullPolicy of the Kubernetes Image for the Worker to Run
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: "IfNotPresent"
@@ -1654,7 +1654,7 @@
         per-heartbeat. It is HIGHLY recommended that users increase this
         number to match the tolerance of their kubernetes cluster for
         better performance.
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: "1"
@@ -1715,7 +1715,7 @@
                     ...
             airflow.cfg: |
                 ...
-      version_added: ~
+      version_added: 1.10.8
       type: string
       example: "airflow-configmap"
       default: ""
@@ -1723,7 +1723,7 @@
       description: |
         For docker image already contains DAGs, this is set to ``True``, and the worker will
         search for dags in dags_folder, otherwise use git sync or dags volume claim to mount DAGs
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: "False"
@@ -1759,7 +1759,7 @@
       description: |
         For DAGs mounted via a hostPath volume (mutually exclusive with volume claim and git-sync)
         Useful in local environment, discouraged in production
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: ""
@@ -1767,7 +1767,7 @@
       description: |
         A hostPath volume for the logs
         Useful in local environment, discouraged in production
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: ""
@@ -1775,7 +1775,7 @@
       description: |
         A list of configMapsRefs to envFrom. If more than one configMap is
         specified, provide a comma separated list: configmap_a,configmap_b
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: ""
@@ -1783,7 +1783,7 @@
       description: |
         A list of secretRefs to envFrom. If more than one secret is
         specified, provide a comma separated list: secret_a,secret_b
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: ""
@@ -1814,7 +1814,7 @@
       description: |
         The specific rev or hash the git_sync init container will checkout
         This becomes GIT_SYNC_REV environment variable in the git_sync init container for worker pods
-      version_added: ~
+      version_added: 1.10.7
       type: string
       example: ~
       default: ""
@@ -1834,13 +1834,13 @@
       default: ""
     - name: git_sync_root
       description: ~
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: "/git"
     - name: git_sync_dest
       description: ~
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: "repo"
@@ -1848,7 +1848,7 @@
       description: |
         Mount point of the volume if git-sync is being used.
         i.e. {AIRFLOW_HOME}/dags
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: ""
@@ -1868,7 +1868,7 @@
           data:
             # key needs to be gitSshKey
             gitSshKey: <base64_encoded_data>
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: "airflow-secrets"
       default: ""
@@ -1891,7 +1891,7 @@
             airflow.cfg: |
                 ...
 
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: "airflow-configmap"
       default: ""
@@ -1914,7 +1914,7 @@
           data:
             GIT_SYNC_USERNAME: <base64_encoded_git_username>
             GIT_SYNC_PASSWORD: <base64_encoded_git_password>
-      version_added: ~
+      version_added: 1.10.5
       type: string
       example: ~
       default: ""
@@ -1939,7 +1939,7 @@
       default: "git-sync-clone"
     - name: git_sync_run_as_user
       description: ~
-      version_added: ~
+      version_added: 1.10.5
       type: string
       example: ~
       default: "65533"
@@ -1974,14 +1974,14 @@
       description: |
         When running with in_cluster=False change the default cluster_context or config_file
         options to Kubernetes client. Leave blank these to use default behaviour like ``kubectl`` has.
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: ~
     - name: config_file
       description: |
         Path to the kubernetes configfile to be used when ``in_cluster`` is set to False
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: ~
@@ -1990,7 +1990,7 @@
         Affinity configuration as a single line formatted JSON object.
         See the affinity model for top-level key names (e.g. ``nodeAffinity``, etc.):
         https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#affinity-v1-core
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: ""
@@ -1999,7 +1999,7 @@
         A list of toleration objects as a single line formatted JSON array
         See:
         https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#toleration-v1-core
-      version_added: ~
+      version_added: 1.10.2
       type: string
       example: ~
       default: ""
@@ -2010,14 +2010,14 @@
         List of supported params are similar for all core_v1_apis, hence a single config
         variable for all apis. See:
         https://raw.githubusercontent.com/kubernetes-client/python/master/kubernetes/client/apis/core_v1_api.py
-      version_added: ~
+      version_added: 1.10.4
       type: string
       example: ~
       default: ""
     - name: run_as_user
       description: |
         Specifies the uid to run the first process of the worker pods containers as
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: ""
@@ -2026,7 +2026,7 @@
         Specifies a gid to associate with all containers in the worker pods
         if using a git_ssh_key_secret_name use an fs_group
         that allows for the key to be read, e.g. 65533
-      version_added: ~
+      version_added: 1.10.3
       type: string
       example: ~
       default: ""


### PR DESCRIPTION
Add versions_added field to configs until 1.10.1

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
