### PR TITLE
[AIRFLOW-6727] Fix minor bugs in Release Management scripts

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,4 +1,4 @@
-click>=6.6,<7
+click~=7.0
 jira>=2.0.0
 keyring==10.1
 gitpython

--- a/dev/send_email.py
+++ b/dev/send_email.py
@@ -78,7 +78,8 @@ def render_template(template_file: str, **kwargs) -> str:
     :kwargs: Named parameters to use when rendering the template
     :return: Rendered template
     """
-    template = jinja2.Template(open(template_file).read())
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    template = jinja2.Template(open(os.path.join(dir_path, template_file)).read())
     return template.render(kwargs)
 
 

--- a/dev/templates/vote_email.j2
+++ b/dev/templates/vote_email.j2
@@ -34,7 +34,7 @@ with INSTALL instructions.
 Public keys are available at: https://www.apache.org/dist/{{ project_module }}/KEYS
 
 The Change Log for the release:
-https://github.com/apache/{{ project_module }}/blob/{{ version_rc }}/CHANGELOG.md
+https://github.com/apache/{{ project_module }}/blob/{{ version_rc }}/CHANGELOG.txt
 
 The vote will be open for at least 72 hours or until the necessary number
 of votes are reached.


### PR DESCRIPTION
There are some minor issues:

- Click needs to be >= 7.0
- Path of CHANGELOG.txt
- Path of template files to send automated emails

---
Issue link: [AIRFLOW-6727](https://issues.apache.org/jira/browse/AIRFLOW-6727)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
