### PR TITLE
[AIRFLOW-6740] Remove Undocumented, Deprecated, Dysfunctional PROXY_FIX_NUM_PROXIES

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -51,7 +51,6 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     if conf.getboolean('webserver', 'ENABLE_PROXY_FIX'):
         app.wsgi_app = ProxyFix(
             app.wsgi_app,
-            num_proxies=conf.get("webserver", "PROXY_FIX_NUM_PROXIES", fallback=None),
             x_for=conf.getint("webserver", "PROXY_FIX_X_FOR", fallback=1),
             x_proto=conf.getint("webserver", "PROXY_FIX_X_PROTO", fallback=1),
             x_host=conf.getint("webserver", "PROXY_FIX_X_HOST", fallback=1),


### PR DESCRIPTION
This parameter is deprecated by werkzeug, see: https://github.com/pallets/werkzeug/blob/0.16.1/src/werkzeug/middleware/proxy_fix.py#L113-L120

However, it is also broken. The value is acquired as string from the config, while it should be int like the other `x_*` attributes. Those were fixed in #6901, but `num_proxies` was forgotten.

I think we can safely remove it because:

* There is virtually no possibility that someone is using that parameter   in their config without raising an exception.
* The configuration variable is not present in Airflow's docs or anywhere else anymore. The removed line is the only trace of it.

https://issues.apache.org/jira/browse/AIRFLOW-6740