### PR TITLE
[AIRFLOW-XXXX] Add notes about airflow.providers and docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,7 +113,12 @@ To generate a local version:
 
 .. note::
     The docs build script ``build.sh`` requires bash 4.0 or greater.
-    If you are building on mac, you can install latest version of bash with homebrew.
+    If you are building on Mac OS, you can install latest version of bash with homebrew.
+
+**Known issue:**
+
+If you are creating a new directory in the ``airflow.providers`` package, you should also 
+update ``docs/autoapi_templates/index.rst`` file.
 
 
 Pull Request Guidelines

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -115,11 +115,14 @@ To generate a local version:
     The docs build script ``build.sh`` requires bash 4.0 or greater.
     If you are building on Mac OS, you can install latest version of bash with homebrew.
 
-**Known issue:**
+**Known issues:**
 
-If you are creating a new directory in the ``airflow.providers`` package, you should also
-update ``docs/autoapi_templates/index.rst`` file.
+If you are creating a new directory for new integration in the ``airflow.providers`` package,
+you should also update the ``docs/autoapi_templates/index.rst`` file.
 
+If you are createing a `hooks`, `sensors`, `operators` directory in
+the ``airflow.providers`` package, you should also update
+the ``docs/operators-and-hooks-ref.rst`` file.
 
 Pull Request Guidelines
 =======================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -120,7 +120,7 @@ To generate a local version:
 If you are creating a new directory for new integration in the ``airflow.providers`` package,
 you should also update the ``docs/autoapi_templates/index.rst`` file.
 
-If you are createing a `hooks`, `sensors`, `operators` directory in
+If you are createing a ``hooks``, ``sensors``, ``operators`` directory in
 the ``airflow.providers`` package, you should also update
 the ``docs/operators-and-hooks-ref.rst`` file.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -120,7 +120,7 @@ To generate a local version:
 If you are creating a new directory for new integration in the ``airflow.providers`` package,
 you should also update the ``docs/autoapi_templates/index.rst`` file.
 
-If you are createing a ``hooks``, ``sensors``, ``operators`` directory in
+If you are creating a ``hooks``, ``sensors``, ``operators`` directory in
 the ``airflow.providers`` package, you should also update
 the ``docs/operators-and-hooks-ref.rst`` file.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -117,7 +117,7 @@ To generate a local version:
 
 **Known issue:**
 
-If you are creating a new directory in the ``airflow.providers`` package, you should also 
+If you are creating a new directory in the ``airflow.providers`` package, you should also
 update ``docs/autoapi_templates/index.rst`` file.
 
 


### PR DESCRIPTION
CC: @blcksrx  

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [XI will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
