### PR TITLE
[AIRFLOW-XXXX] Add user and DAGs folder notes to BREEZE.rst

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -354,6 +354,9 @@ After you run Breeze for the first time, you will have an empty directory ``file
 which will be mapped to ``/files`` in your Docker container. You can pass there any files you need to
 configure and run Docker. They will not be removed between Docker runs.
 
+If you wish to add local DAGs that can be run by Breeze, you can add the dags to ``/files/dags`` and then
+run ``export AIRFLOW__CORE__DAGS_FOLDER="/files/dags"`` once the container has started.
+
 Adding/Modifying Dependencies
 -----------------------------
 
@@ -407,7 +410,12 @@ You can connect to these ports/databases using:
 * Mysql: ``jdbc:mysql://localhost:23306/airflow?user=root``
 
 Start the webserver manually with the ``airflow webserver`` command if you want to connect
-to the webserver. You can use ``tmux`` to multiply terminals.
+to the webserver. You can use ``tmux`` to multiply terminals. You may need to create a user prior to
+running the webserver in order to log in. This can be done with the following command:
+
+.. code-block:: bash
+
+    airflow users create --role Admin --username admin --password admin --email admin@example.com --firstname foo --lastname bar
 
 For databases, you need to run ``airflow db reset`` at least once (or run some tests) after you started
 Airflow Breeze to get the database/tables created. You can connect to databases with IDE or any other


### PR DESCRIPTION
This PR adds some additional documentation to the `BREEZE.rst` file for reading in external DAGs and accessing the webserver.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
