### PR TITLE
[AIRFLOW-6728] Change various DAG info methods to POST

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -281,11 +281,11 @@
         return false;
       }
 
-      var encoded_dag_ids = [];
+      var encoded_dag_ids = new URLSearchParams();
 
       $.each($("[id^=toggle]"), function(i, v) {
         var dag_id = $(v).attr('dag_id');
-        encoded_dag_ids.push(encodeURIComponent(dag_id));
+        encoded_dag_ids.append('dag_ids', dag_id);
 
         $(v).change (function() {
           if ($(v).prop('checked')) {
@@ -522,20 +522,20 @@
         });
       }
 
-      if (encoded_dag_ids.length > 0) {
+      if (encoded_dag_ids.has('dag_ids')) {
         // dags on page fetch stats
         d3.json("{{ url_for('Airflow.blocked') }}")
           .header("X-CSRFToken", "{{ csrf_token() }}")
-          .post("dag_ids="  + (encoded_dag_ids.join(',')), blockedHandler);
+          .post(encoded_dag_ids, blockedHandler);
         d3.json("{{ url_for('Airflow.last_dagruns') }}")
           .header("X-CSRFToken", "{{ csrf_token() }}")
-          .post("dag_ids="  + (encoded_dag_ids.join(',')), lastDagRunsHandler);
+          .post(encoded_dag_ids, lastDagRunsHandler);
         d3.json("{{ url_for('Airflow.dag_stats') }}")
           .header("X-CSRFToken", "{{ csrf_token() }}")
-          .post("dag_ids="  + (encoded_dag_ids.join(',')), dagStatsHandler);
+          .post(encoded_dag_ids, dagStatsHandler);
         d3.json("{{ url_for('Airflow.task_stats') }}")
           .header("X-CSRFToken", "{{ csrf_token() }}")
-          .post("dag_ids="  + (encoded_dag_ids.join(',')), taskStatsHandler);
+          .post(encoded_dag_ids, taskStatsHandler);
       }
       else {
         // no dags, hide the loading gifs

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -524,10 +524,18 @@
 
       if (encoded_dag_ids.length > 0) {
         // dags on page fetch stats
-        d3.json("{{ url_for('Airflow.blocked') }}?dag_ids="  + (encoded_dag_ids.join(',')), blockedHandler);
-        d3.json("{{ url_for('Airflow.last_dagruns') }}?dag_ids=" + (encoded_dag_ids.join(',')), lastDagRunsHandler);
-        d3.json("{{ url_for('Airflow.dag_stats') }}?dag_ids=" + (encoded_dag_ids.join(',')), dagStatsHandler);
-        d3.json("{{ url_for('Airflow.task_stats') }}?dag_ids=" + (encoded_dag_ids.join(',')), taskStatsHandler);
+        d3.json("{{ url_for('Airflow.blocked') }}")
+          .header("X-CSRFToken", "{{ csrf_token() }}")
+          .post(JSON.stringify({'dag_ids': encoded_dag_ids}), blockedHandler);
+        d3.json("{{ url_for('Airflow.last_dagruns') }}")
+          .header("X-CSRFToken", "{{ csrf_token() }}")
+          .post(JSON.stringify({'dag_ids': encoded_dag_ids}), lastDagRunsHandler);
+        d3.json("{{ url_for('Airflow.dag_stats') }}")
+          .header("X-CSRFToken", "{{ csrf_token() }}")
+          .post(JSON.stringify({'dag_ids': encoded_dag_ids}), dagStatsHandler);
+        d3.json("{{ url_for('Airflow.task_stats') }}")
+          .header("X-CSRFToken", "{{ csrf_token() }}")
+          .post(JSON.stringify({'dag_ids': encoded_dag_ids}), taskStatsHandler);
       }
       else {
         // no dags, hide the loading gifs

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -526,16 +526,16 @@
         // dags on page fetch stats
         d3.json("{{ url_for('Airflow.blocked') }}")
           .header("X-CSRFToken", "{{ csrf_token() }}")
-          .post(JSON.stringify({'dag_ids': encoded_dag_ids}), blockedHandler);
+          .post("dag_ids="  + (encoded_dag_ids.join(',')), blockedHandler);
         d3.json("{{ url_for('Airflow.last_dagruns') }}")
           .header("X-CSRFToken", "{{ csrf_token() }}")
-          .post(JSON.stringify({'dag_ids': encoded_dag_ids}), lastDagRunsHandler);
+          .post("dag_ids="  + (encoded_dag_ids.join(',')), lastDagRunsHandler);
         d3.json("{{ url_for('Airflow.dag_stats') }}")
           .header("X-CSRFToken", "{{ csrf_token() }}")
-          .post(JSON.stringify({'dag_ids': encoded_dag_ids}), dagStatsHandler);
+          .post("dag_ids="  + (encoded_dag_ids.join(',')), dagStatsHandler);
         d3.json("{{ url_for('Airflow.task_stats') }}")
           .header("X-CSRFToken", "{{ csrf_token() }}")
-          .post(JSON.stringify({'dag_ids': encoded_dag_ids}), taskStatsHandler);
+          .post("dag_ids="  + (encoded_dag_ids.join(',')), taskStatsHandler);
       }
       else {
         // no dags, hide the loading gifs

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -342,9 +342,8 @@ class Airflow(AirflowBaseView):
             .group_by(dr.dag_id, dr.state)
 
         # Filter by post parameters
-        request_dag_ids = request.get_json() or {}
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request_dag_ids.get('dag_ids', []) if dag_id
+            unquote(dag_id) for dag_id in request.form.getlist('dag_ids') if dag_id
         }
 
         if selected_dag_ids:
@@ -394,9 +393,8 @@ class Airflow(AirflowBaseView):
             allowed_dag_ids = {dag_id for dag_id, in session.query(models.DagModel.dag_id)}
 
         # Filter by post parameters
-        request_dag_ids = request.get_json() or {}
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request_dag_ids.get('dag_ids', []) if dag_id
+            unquote(dag_id) for dag_id in request.form.getlist('dag_ids') if dag_id
         }
 
         if selected_dag_ids:
@@ -490,9 +488,8 @@ class Airflow(AirflowBaseView):
             allowed_dag_ids = [dag_id for dag_id, in session.query(models.DagModel.dag_id)]
 
         # Filter by post parameters
-        request_dag_ids = request.get_json() or {}
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request_dag_ids.get('dag_ids', []) if dag_id
+            unquote(dag_id) for dag_id in request.form.getlist('dag_ids') if dag_id
         }
 
         if selected_dag_ids:
@@ -1114,9 +1111,8 @@ class Airflow(AirflowBaseView):
             allowed_dag_ids = [dag_id for dag_id, in session.query(models.DagModel.dag_id)]
 
         # Filter by post parameters
-        request_dag_ids = request.get_json() or {}
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request_dag_ids.get('dag_ids', []) if dag_id
+            unquote(dag_id) for dag_id in request.form.getlist('dag_ids') if dag_id
         }
 
         if selected_dag_ids:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -328,7 +328,7 @@ class Airflow(AirflowBaseView):
             num_runs=num_runs,
             tags=tags)
 
-    @expose('/dag_stats')
+    @expose('/dag_stats', methods=['POST'])
     @has_access
     @provide_session
     def dag_stats(self, session=None):
@@ -341,9 +341,10 @@ class Airflow(AirflowBaseView):
         dag_state_stats = session.query(dr.dag_id, dr.state, sqla.func.count(dr.state))\
             .group_by(dr.dag_id, dr.state)
 
-        # Filter by get parameters
+        # Filter by post parameters
+        request_dag_ids = request.get_json() or {}
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request.args.get('dag_ids', '').split(',') if dag_id
+            unquote(dag_id) for dag_id in request_dag_ids.get('dag_ids', []) if dag_id
         }
 
         if selected_dag_ids:
@@ -376,7 +377,7 @@ class Airflow(AirflowBaseView):
 
         return wwwutils.json_response(payload)
 
-    @expose('/task_stats')
+    @expose('/task_stats', methods=['POST'])
     @has_access
     @provide_session
     def task_stats(self, session=None):
@@ -392,9 +393,10 @@ class Airflow(AirflowBaseView):
         if 'all_dags' in allowed_dag_ids:
             allowed_dag_ids = {dag_id for dag_id, in session.query(models.DagModel.dag_id)}
 
-        # Filter by get parameters
+        # Filter by post parameters
+        request_dag_ids = request.get_json() or {}
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request.args.get('dag_ids', '').split(',') if dag_id
+            unquote(dag_id) for dag_id in request_dag_ids.get('dag_ids', []) if dag_id
         }
 
         if selected_dag_ids:
@@ -476,7 +478,7 @@ class Airflow(AirflowBaseView):
                 })
         return wwwutils.json_response(payload)
 
-    @expose('/last_dagruns')
+    @expose('/last_dagruns', methods=['POST'])
     @has_access
     @provide_session
     def last_dagruns(self, session=None):
@@ -487,8 +489,10 @@ class Airflow(AirflowBaseView):
         if 'all_dags' in allowed_dag_ids:
             allowed_dag_ids = [dag_id for dag_id, in session.query(models.DagModel.dag_id)]
 
+        # Filter by post parameters
+        request_dag_ids = request.get_json() or {}
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request.args.get('dag_ids', '').split(',') if dag_id
+            unquote(dag_id) for dag_id in request_dag_ids.get('dag_ids', []) if dag_id
         }
 
         if selected_dag_ids:
@@ -1100,7 +1104,7 @@ class Airflow(AirflowBaseView):
         return self._clear_dag_tis(dag, start_date, end_date, origin,
                                    recursive=True, confirmed=confirmed)
 
-    @expose('/blocked')
+    @expose('/blocked', methods=['POST'])
     @has_access
     @provide_session
     def blocked(self, session=None):
@@ -1109,8 +1113,10 @@ class Airflow(AirflowBaseView):
         if 'all_dags' in allowed_dag_ids:
             allowed_dag_ids = [dag_id for dag_id, in session.query(models.DagModel.dag_id)]
 
+        # Filter by post parameters
+        request_dag_ids = request.get_json() or {}
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request.args.get('dag_ids', '').split(',') if dag_id
+            unquote(dag_id) for dag_id in request_dag_ids.get('dag_ids', []) if dag_id
         }
 
         if selected_dag_ids:

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -475,20 +475,20 @@ class TestAirflowBaseViews(TestBase):
 
     def test_blocked(self):
         url = 'blocked'
-        resp = self.client.get(url, follow_redirects=True)
+        resp = self.client.post(url, follow_redirects=True)
         self.assertEqual(200, resp.status_code)
 
     def test_dag_stats(self):
-        resp = self.client.get('dag_stats', follow_redirects=True)
+        resp = self.client.post('dag_stats', follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
 
     def test_task_stats(self):
-        resp = self.client.get('task_stats', follow_redirects=True)
+        resp = self.client.post('task_stats', follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
 
     def test_task_stats_only_noncompleted(self):
         conf.set("webserver", "show_recent_stats_for_completed_runs", "False")
-        resp = self.client.get('task_stats', follow_redirects=True)
+        resp = self.client.post('task_stats', follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
 
     def test_dag_details(self):
@@ -507,19 +507,22 @@ class TestAirflowBaseViews(TestBase):
         self.check_content_in_response('runme_1', resp)
 
     def test_last_dagruns(self):
-        resp = self.client.get('last_dagruns', follow_redirects=True)
+        resp = self.client.post('last_dagruns', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
 
     def test_last_dagruns_success_when_selecting_dags(self):
-        resp = self.client.get('last_dagruns?dag_ids=example_subdag_operator', follow_redirects=True)
+        resp = self.client.post('last_dagruns',
+                                json={'dag_ids': ['example_subdag_operator']},
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertNotIn('example_bash_operator', stats)
         self.assertIn('example_subdag_operator', stats)
 
         # Multiple
-        resp = self.client.get('last_dagruns?dag_ids=example_subdag_operator,example_bash_operator',
-                               follow_redirects=True)
+        resp = self.client.post('last_dagruns',
+                                json={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertIn('example_bash_operator', stats)
@@ -1413,33 +1416,36 @@ class TestDagACLView(TestBase):
     def test_dag_stats_success(self):
         self.logout()
         self.login()
-        resp = self.client.get('dag_stats', follow_redirects=True)
+        resp = self.client.post('dag_stats', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
 
     def test_dag_stats_failure(self):
         self.logout()
         self.login()
-        resp = self.client.get('dag_stats', follow_redirects=True)
+        resp = self.client.post('dag_stats', follow_redirects=True)
         self.check_content_not_in_response('example_subdag_operator', resp)
 
     def test_dag_stats_success_for_all_dag_user(self):
         self.logout()
         self.login(username='all_dag_user',
                    password='all_dag_user')
-        resp = self.client.get('dag_stats', follow_redirects=True)
+        resp = self.client.post('dag_stats', follow_redirects=True)
         self.check_content_in_response('example_subdag_operator', resp)
         self.check_content_in_response('example_bash_operator', resp)
 
     def test_dag_stats_success_when_selecting_dags(self):
-        resp = self.client.get('dag_stats?dag_ids=example_subdag_operator', follow_redirects=True)
+        resp = self.client.post('dag_stats',
+                                json={'dag_ids': ['example_subdag_operator']},
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertNotIn('example_bash_operator', stats)
         self.assertIn('example_subdag_operator', stats)
 
         # Multiple
-        resp = self.client.get('dag_stats?dag_ids=example_subdag_operator,example_bash_operator',
-                               follow_redirects=True)
+        resp = self.client.post('dag_stats',
+                                json={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertIn('example_bash_operator', stats)
@@ -1449,20 +1455,20 @@ class TestDagACLView(TestBase):
     def test_task_stats_success(self):
         self.logout()
         self.login()
-        resp = self.client.get('task_stats', follow_redirects=True)
+        resp = self.client.post('task_stats', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
 
     def test_task_stats_failure(self):
         self.logout()
         self.login()
-        resp = self.client.get('task_stats', follow_redirects=True)
+        resp = self.client.post('task_stats', follow_redirects=True)
         self.check_content_not_in_response('example_subdag_operator', resp)
 
     def test_task_stats_success_for_all_dag_user(self):
         self.logout()
         self.login(username='all_dag_user',
                    password='all_dag_user')
-        resp = self.client.get('task_stats', follow_redirects=True)
+        resp = self.client.post('task_stats', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
         self.check_content_in_response('example_subdag_operator', resp)
 
@@ -1471,15 +1477,18 @@ class TestDagACLView(TestBase):
         self.login(username='all_dag_user',
                    password='all_dag_user')
 
-        resp = self.client.get('task_stats?dag_ids=example_subdag_operator', follow_redirects=True)
+        resp = self.client.post('task_stats',
+                                json={'dag_ids': ['example_subdag_operator']},
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertNotIn('example_bash_operator', stats)
         self.assertIn('example_subdag_operator', stats)
 
         # Multiple
-        resp = self.client.get('task_stats?dag_ids=example_subdag_operator,example_bash_operator',
-                               follow_redirects=True)
+        resp = self.client.post('task_stats',
+                                json={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertIn('example_bash_operator', stats)
@@ -1649,7 +1658,7 @@ class TestDagACLView(TestBase):
         url = 'blocked'
         self.logout()
         self.login()
-        resp = self.client.get(url, follow_redirects=True)
+        resp = self.client.post(url, follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
 
     def test_blocked_success_for_all_dag_user(self):
@@ -1657,20 +1666,23 @@ class TestDagACLView(TestBase):
         self.logout()
         self.login(username='all_dag_user',
                    password='all_dag_user')
-        resp = self.client.get(url, follow_redirects=True)
+        resp = self.client.post(url, follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
         self.check_content_in_response('example_subdag_operator', resp)
 
     def test_blocked_success_when_selecting_dags(self):
-        resp = self.client.get('blocked?dag_ids=example_subdag_operator', follow_redirects=True)
+        resp = self.client.post('blocked',
+                                json={'dag_ids': ['example_subdag_operator']},
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         blocked_dags = {blocked['dag_id'] for blocked in json.loads(resp.data.decode('utf-8'))}
         self.assertNotIn('example_bash_operator', blocked_dags)
         self.assertIn('example_subdag_operator', blocked_dags)
 
         # Multiple
-        resp = self.client.get('blocked?dag_ids=example_subdag_operator,example_bash_operator',
-                               follow_redirects=True)
+        resp = self.client.post('blocked',
+                                json={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
+                                follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         blocked_dags = {blocked['dag_id'] for blocked in json.loads(resp.data.decode('utf-8'))}
         self.assertIn('example_bash_operator', blocked_dags)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -512,7 +512,7 @@ class TestAirflowBaseViews(TestBase):
 
     def test_last_dagruns_success_when_selecting_dags(self):
         resp = self.client.post('last_dagruns',
-                                json={'dag_ids': ['example_subdag_operator']},
+                                data={'dag_ids': ['example_subdag_operator']},
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
@@ -521,7 +521,7 @@ class TestAirflowBaseViews(TestBase):
 
         # Multiple
         resp = self.client.post('last_dagruns',
-                                json={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
+                                data={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
@@ -1435,7 +1435,7 @@ class TestDagACLView(TestBase):
 
     def test_dag_stats_success_when_selecting_dags(self):
         resp = self.client.post('dag_stats',
-                                json={'dag_ids': ['example_subdag_operator']},
+                                data={'dag_ids': ['example_subdag_operator']},
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
@@ -1444,7 +1444,7 @@ class TestDagACLView(TestBase):
 
         # Multiple
         resp = self.client.post('dag_stats',
-                                json={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
+                                data={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
@@ -1478,7 +1478,7 @@ class TestDagACLView(TestBase):
                    password='all_dag_user')
 
         resp = self.client.post('task_stats',
-                                json={'dag_ids': ['example_subdag_operator']},
+                                data={'dag_ids': ['example_subdag_operator']},
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
@@ -1487,7 +1487,7 @@ class TestDagACLView(TestBase):
 
         # Multiple
         resp = self.client.post('task_stats',
-                                json={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
+                                data={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
@@ -1672,7 +1672,7 @@ class TestDagACLView(TestBase):
 
     def test_blocked_success_when_selecting_dags(self):
         resp = self.client.post('blocked',
-                                json={'dag_ids': ['example_subdag_operator']},
+                                data={'dag_ids': ['example_subdag_operator']},
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         blocked_dags = {blocked['dag_id'] for blocked in json.loads(resp.data.decode('utf-8'))}
@@ -1681,7 +1681,7 @@ class TestDagACLView(TestBase):
 
         # Multiple
         resp = self.client.post('blocked',
-                                json={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
+                                data={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
                                 follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         blocked_dags = {blocked['dag_id'] for blocked in json.loads(resp.data.decode('utf-8'))}


### PR DESCRIPTION
This PR changes the following DAG info methods to POST:
* `/dag_stats`
* `/task_stats`
* `/last_dagruns`
* `/blocked`

The reason for this is described in the JIRA ticket:

 > It appears that the URL uses a `dag_ids` parameter that is a comma separated list in the GET request. Since DAGs can have a `dag_id` length of [250 characters](https://github.com/apache/airflow/blob/97a429f9d0cf740c5698060ad55f11e93cb57b55/airflow/models/base.py#L35) and the UI will show up to 100 DAGs per page, this means that the URL parameters alone could be 25,000 characters (not including domain, etc.). It seems that it might be best to switch this request over to POST to accommodate the potentially large request body.

Here is a small DAG file I used to generate DAGs with excessively large names:

<details><summary>EXPAND FOR CODE</summary>

```python
from datetime import datetime

from airflow import DAG

from airflow.operators.dummy_operator import DummyOperator


def create_dag(dag_id,
               schedule,
               default_args):


    dag = DAG(dag_id,
              schedule_interval=schedule,
              default_args=default_args)

    with dag:
        t1 = DummyOperator(task_id='dummy_task')

    return dag


# build a dag for each number in range(100)
for n in range(0, 100):
    dag_id = 'long_name_dag__' + f"{n}".zfill(235)

    default_args = {'owner': 'airflow',
                    'start_date': datetime(2018, 1, 1)
                    }

    schedule = None

    globals()[dag_id] = create_dag(dag_id,
                                  schedule,
                                  default_args)
```

</details>

I was able to verify that the page loads correctly with the new changes. (BTW Breeze was extremely helpful for this 😀)


---
Issue link: [AIRFLOW-6728](https://issues.apache.org/jira/browse/AIRFLOW-6728)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
