### PR TITLE
[AIRFLOW-6734] Use configured base_template instead of hard-coding

### DIFF
--- a/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/base.html
+++ b/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/base.html
@@ -17,7 +17,7 @@
  under the License.
 #}
 
-{% extends 'airflow/master.html' %}
+{% extends base_template %}
 
 {% block body %}
 <div>

--- a/airflow/www/templates/airflow/code.html
+++ b/airflow/www/templates/airflow/code.html
@@ -17,7 +17,7 @@
  under the License.
 #}
 
-{% extends "airflow/master.html" %}
+{% extends base_template %}
 
 {% block page_title %}{{ dag.dag_id }} - Code - Airflow{% endblock %}
 

--- a/airflow/www/templates/airflow/config.html
+++ b/airflow/www/templates/airflow/config.html
@@ -17,7 +17,7 @@
  under the License.
 #}
 
-{% extends "airflow/master.html" %}
+{% extends base_template %}
 
 {% block title %}
     {{ title }}

--- a/airflow/www/templates/airflow/confirm.html
+++ b/airflow/www/templates/airflow/confirm.html
@@ -17,7 +17,7 @@
  under the License.
 #}
 
-{% extends "airflow/master.html" %}
+{% extends base_template %}
 
 {% block content %}
     {{ super() }}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -17,7 +17,7 @@
  under the License.
 #}
 
-{% extends "airflow/master.html" %}
+{% extends base_template %}
 
 {% block page_title %}{{ dag.dag_id }} - Airflow{% endblock %}
 

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -17,7 +17,7 @@
  under the License.
 #}
 
-{% extends "airflow/master.html" %}
+{% extends base_template %}
 
 {% block page_title %}
   {% if search_query %}

--- a/airflow/www/templates/airflow/noaccess.html
+++ b/airflow/www/templates/airflow/noaccess.html
@@ -17,7 +17,7 @@
  under the License.
 #}
 
-{% extends "airflow/master.html" %}
+{% extends base_template %}
 
 {% block title %}{{ title }}{% endblock %}
 

--- a/airflow/www/templates/airflow/version.html
+++ b/airflow/www/templates/airflow/version.html
@@ -17,7 +17,7 @@
  under the License.
 #}
 
-{% extends "airflow/master.html" %}
+{% extends base_template %}
 
 {% block content %}
     {{ super() }}


### PR DESCRIPTION
Flask/FAB gives us a `base_template` variable that we should use instead
of hard-coding a specific template to extend.

At the time this PR was submitted, airflow/master.html is empty apart from a call to extend the customized appbuilder/baselayout.html, which is the current value of base_template. That is tidied up in AIRFLOW-6733/#7366, but this change has been done separately as they can be merged in either order without any ill-effect.

---
Issue link: [AIRFLOW-6734](https://issues.apache.org/jira/browse/AIRFLOW-6734)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.