### PR TITLE
[AIRFLOW-2906] Add datadog(dogstatsd) support to send airflow metrics

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1386,6 +1386,20 @@
       type: string
       example: ~
       default: ""
+    - name: statsd_datadog_enabled
+      description: |
+        To enable datadog integration to send airflow metrics.
+      version_added: ~
+      type: string
+      example: ~
+      default: "False"
+    - name: statsd_datadog_tags
+      description: |
+        List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
+      version_added: ~
+      type: string
+      example: ~
+      default: ""
     - name: max_threads
       description: |
         The scheduler can run multiple threads in parallel to schedule dags.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -667,6 +667,12 @@ statsd_allow_list =
 # def func_name(stat_name: str) -> str:
 stat_name_handler =
 
+# To enable datadog integration to send airflow metrics.
+statsd_datadog_enabled = False
+
+# List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
+statsd_datadog_tags =
+
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run.
 max_threads = 2

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -22,7 +22,7 @@ from unittest.mock import Mock
 
 import airflow
 from airflow.exceptions import InvalidStatsNameException
-from airflow.stats import AllowListValidator, SafeStatsdLogger
+from airflow.stats import AllowListValidator, SafeDogStatsdLogger, SafeStatsdLogger
 from tests.test_utils.config import conf_vars
 
 
@@ -48,6 +48,101 @@ class TestStats(unittest.TestCase):
         self.stats.incr('test/$tats')
         self.statsd_client.assert_not_called()
 
+    @conf_vars({
+        ('scheduler', 'statsd_on'): 'True'
+    })
+    @mock.patch("statsd.StatsClient")
+    def test_does_send_stats_using_statsd(self, mock_statsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_statsd.return_value.incr.assert_called_once_with('dummy_key', 1, 1)
+
+    @conf_vars({
+        ('scheduler', 'statsd_on'): 'True'
+    })
+    @mock.patch("datadog.DogStatsd")
+    def test_does_not_send_stats_using_dogstatsd(self, mock_dogstatsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_dogstatsd.return_value.assert_not_called()
+
+    def tearDown(self) -> None:
+        # To avoid side-effect
+        importlib.reload(airflow.stats)
+
+
+class TestDogStats(unittest.TestCase):
+
+    def setUp(self):
+        self.dogstatsd_client = Mock()
+        self.dogstatsd = SafeDogStatsdLogger(self.dogstatsd_client)
+
+    def test_increment_counter_with_valid_name_with_dogstatsd(self):
+        self.dogstatsd.incr('test_stats_run')
+        self.dogstatsd_client.increment.assert_called_once_with(
+            metric='test_stats_run', sample_rate=1, tags=[], value=1
+        )
+
+    def test_stat_name_must_be_a_string_with_dogstatsd(self):
+        self.dogstatsd.incr(list())
+        self.dogstatsd_client.assert_not_called()
+
+    def test_stat_name_must_not_exceed_max_length_with_dogstatsd(self):
+        self.dogstatsd.incr('X' * 300)
+        self.dogstatsd_client.assert_not_called()
+
+    def test_stat_name_must_only_include_whitelisted_characters_with_dogstatsd(self):
+        self.dogstatsd.incr('test/$tats')
+        self.dogstatsd_client.assert_not_called()
+
+    @conf_vars({
+        ('scheduler', 'statsd_datadog_enabled'): 'True'
+    })
+    @mock.patch("datadog.DogStatsd")
+    def test_does_send_stats_using_dogstatsd_when_dogstatsd_on(self, mock_dogstatsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_dogstatsd.return_value.increment.assert_called_once_with(
+            metric='dummy_key', sample_rate=1, tags=[], value=1
+        )
+
+    @conf_vars({
+        ('scheduler', 'statsd_datadog_enabled'): 'True'
+    })
+    @mock.patch("datadog.DogStatsd")
+    def test_does_send_stats_using_dogstatsd_with_tags(self, mock_dogstatsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key", 1, 1, ['key1:value1', 'key2:value2'])
+        mock_dogstatsd.return_value.increment.assert_called_once_with(
+            metric='dummy_key', sample_rate=1, tags=['key1:value1', 'key2:value2'], value=1
+        )
+
+    @conf_vars({
+        ('scheduler', 'statsd_on'): 'True',
+        ('scheduler', 'statsd_datadog_enabled'): 'True'
+    })
+    @mock.patch("datadog.DogStatsd")
+    def test_does_send_stats_using_dogstatsd_when_statsd_and_dogstatsd_both_on(self, mock_dogstatsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_dogstatsd.return_value.increment.assert_called_once_with(
+            metric='dummy_key', sample_rate=1, tags=[], value=1
+        )
+
+    @conf_vars({
+        ('scheduler', 'statsd_on'): 'True',
+        ('scheduler', 'statsd_datadog_enabled'): 'True'
+    })
+    @mock.patch("statsd.StatsClient")
+    def test_does_not_send_stats_using_statsd_when_statsd_and_dogstatsd_both_on(self, mock_statsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_statsd.return_value.assert_not_called()
+
+    def tearDown(self) -> None:
+        # To avoid side-effect
+        importlib.reload(airflow.stats)
+
 
 class TestStatsWithAllowList(unittest.TestCase):
 
@@ -68,6 +163,29 @@ class TestStatsWithAllowList(unittest.TestCase):
         self.statsd_client.assert_not_called()
 
 
+class TestDogStatsWithAllowList(unittest.TestCase):
+
+    def setUp(self):
+        self.dogstatsd_client = Mock()
+        self.dogstats = SafeDogStatsdLogger(self.dogstatsd_client, AllowListValidator("stats_one, stats_two"))
+
+    def test_increment_counter_with_allowed_key(self):
+        self.dogstats.incr('stats_one')
+        self.dogstatsd_client.increment.assert_called_once_with(
+            metric='stats_one', sample_rate=1, tags=[], value=1
+        )
+
+    def test_increment_counter_with_allowed_prefix(self):
+        self.dogstats.incr('stats_two.bla')
+        self.dogstatsd_client.increment.assert_called_once_with(
+            metric='stats_two.bla', sample_rate=1, tags=[], value=1
+        )
+
+    def test_not_increment_counter_if_not_allowed(self):
+        self.dogstats.incr('stats_three')
+        self.dogstatsd_client.assert_not_called()
+
+
 def always_invalid(stat_name):
     raise InvalidStatsNameException("Invalid name: {}".format(stat_name))
 
@@ -82,20 +200,42 @@ class TestCustomStatsName(unittest.TestCase):
         ('scheduler', 'stat_name_handler'): 'tests.test_stats.always_invalid'
     })
     @mock.patch("statsd.StatsClient")
-    def test_does_not_send_stats_when_the_name_is_not_valid(self, mock_statsd):
+    def test_does_not_send_stats_using_statsd_when_the_name_is_not_valid(self, mock_statsd):
         importlib.reload(airflow.stats)
         airflow.stats.Stats.incr("dummy_key")
         mock_statsd.return_value.assert_not_called()
+
+    @conf_vars({
+        ('scheduler', 'statsd_datadog_enabled'): 'True',
+        ('scheduler', 'stat_name_handler'): 'tests.test_stats.always_invalid'
+    })
+    @mock.patch("datadog.DogStatsd")
+    def test_does_not_send_stats_using_dogstatsd_when_the_name_is_not_valid(self, mock_dogstatsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_dogstatsd.return_value.assert_not_called()
 
     @conf_vars({
         ('scheduler', 'statsd_on'): 'True',
         ('scheduler', 'stat_name_handler'): 'tests.test_stats.always_valid'
     })
     @mock.patch("statsd.StatsClient")
-    def test_does_send_stats_when_the_name_is_valid(self, mock_statsd):
+    def test_does_send_stats_using_statsd_when_the_name_is_valid(self, mock_statsd):
         importlib.reload(airflow.stats)
         airflow.stats.Stats.incr("dummy_key")
         mock_statsd.return_value.incr.assert_called_once_with('dummy_key', 1, 1)
+
+    @conf_vars({
+        ('scheduler', 'statsd_datadog_enabled'): 'True',
+        ('scheduler', 'stat_name_handler'): 'tests.test_stats.always_valid'
+    })
+    @mock.patch("datadog.DogStatsd")
+    def test_does_send_stats_using_dogstatsd_when_the_name_is_valid(self, mock_dogstatsd):
+        importlib.reload(airflow.stats)
+        airflow.stats.Stats.incr("dummy_key")
+        mock_dogstatsd.return_value.increment.assert_called_once_with(
+            metric='dummy_key', sample_rate=1, tags=[], value=1
+        )
 
     def tearDown(self) -> None:
         # To avoid side-effect


### PR DESCRIPTION
---
Currently, Airflow sends metric to Datadog using statsd and you won't be able to associated tags to metrics send by airflow. 
This PR has dogstatsd (Datadog) support. After this PR, you can associate constant tags to all metrics as well as tags specific to single metric as well. 

Issue link: [AIRFLOW-2906](https://issues.apache.org/jira/browse/AIRFLOW-2906)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
