### PR TITLE
[AIRFLOW-6761] Fix WorkGroup param in AWSAthenaHook

### DIFF
--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -74,7 +74,7 @@ class AWSAthenaHook(AwsHook):
                                                          ClientRequestToken=client_request_token,
                                                          QueryExecutionContext=query_context,
                                                          ResultConfiguration=result_configuration,
-                                                         Workgroup=workgroup)
+                                                         WorkGroup=workgroup)
         query_execution_id = response['QueryExecutionId']
         return query_execution_id
 


### PR DESCRIPTION
Maybe a typo error at run_query function in aws_athena_hook.py

```
Unknown parameter in input: "Workgroup", must be one of: QueryString, ClientRequestToken, QueryExecutionContext, ResultConfiguration, WorkGroup
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 966, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/opt/airflow/dags/operators/athena_result_operator.py", line 14, in execute
    query_execution_id = super().execute(context)
  File "/usr/local/lib/python3.7/site-packages/airflow/contrib/operators/aws_athena_operator.py", line 85, in execute
    self.workgroup)
  File "/usr/local/lib/python3.7/site-packages/airflow/contrib/hooks/aws_athena_hook.py", line 77, in run_query
    Workgroup=workgroup)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 276, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 559, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 607, in _convert_to_request_dict
    api_params, operation_model)
  File "/usr/local/lib/python3.7/site-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Unknown parameter in input: "Workgroup", must be one of: QueryString, ClientRequestToken, QueryExecutionContext, ResultConfiguration, WorkGroup
```

According to [boto3's docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/athena.html#Athena.Client.start_query_execution), it's should be WorkGroup

---
Issue link: [AIRFLOW-6761](https://issues.apache.org/jira/browse/AIRFLOW-6761)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
