### PR TITLE
[AIRFLOW-6762] Fix link to "Suggest changes on this page"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -506,22 +506,27 @@ html_context = {
     # For more information look at:
     # https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/layout.html#L222-L232
     'theme_analytics_id': 'UA-140539454-1',
-    # Variables used to build a button for editing the source code
-    #
-    # The path is created according to the following template:
-    #
-    # https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/
-    # {{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}
-    # {{ pagename }}{{ suffix }}
-    #
-    # More information:
-    # https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl#L100-L103
-    # https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/breadcrumbs.html#L45
-    #
-    'theme_vcs_pageview_mode': 'edit',
-    'conf_py_path': '/docs/',
-    'github_user': 'apache',
-    'github_repo': 'airflow',
-    'github_version': os.environ.get('GITHUB_TREE', None),
-    'display_github': os.environ.get('GITHUB_TREE', None) is not None,
 }
+if airflow_theme_is_available:
+    html_context = {
+        # Variables used to build a button for editing the source code
+        #
+        # The path is created according to the following template:
+        #
+        # https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/
+        # {{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}
+        # {{ pagename }}{{ suffix }}
+        #
+        # More information:
+        # https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl#L100-L103
+        # https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/breadcrumbs.html#L45
+        # https://github.com/apache/airflow-site/blob/91f760c/sphinx_airflow_theme/sphinx_airflow_theme/suggest_change_button.html#L36-L40
+        #
+        'theme_vcs_pageview_mode': 'edit',
+        'conf_py_path': '/docs/',
+        'github_user': 'apache',
+        'github_repo': 'airflow',
+        'github_version': 'master',
+        'display_github': 'master',
+        'suffix': '.rst',
+    }


### PR DESCRIPTION
I wanted to give the opportunity for people who don't officially release docs to be able to use this theme. But it does not make sense. This theme is too closely related to our website and protected branding.

---
Issue link: [AIRFLOW-6762](https://issues.apache.org/jira/browse/AIRFLOW-6762)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
