### PR TITLE
[AIRFLOW-6763] Make systems tests ready for backport tests

### DIFF
--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -84,7 +84,6 @@ function print_info() {
 # Simple (?) no-dependency needed Yaml PARSER
 # From https://stackoverflow.com/questions/5014632/how-can-i-parse-a-yaml-file-from-a-linux-shell-script
 function parse_yaml {
-
     if [[ -z $1 ]]; then
         echo "Please provide yaml filename as first parameter."
         exit 1
@@ -119,6 +118,7 @@ function parse_yaml {
 # from airflow-testing section to "-v" "volume mapping" series of options
 function convert_docker_mounts_to_docker_params() {
     ESCAPED_AIRFLOW_SOURCES=$(echo "${AIRFLOW_SOURCES}" | sed -e 's/[\/&]/\\&/g')
+    ESCAPED_HOME=$(echo "${HOME}" | sed -e 's/[\/&]/\\&/g')
     # shellcheck disable=2046
     while IFS= read -r LINE; do
         echo "-v"
@@ -126,6 +126,7 @@ function convert_docker_mounts_to_docker_params() {
     done < <(parse_yaml scripts/ci/docker-compose/local.yml COMPOSE_ | \
             grep "COMPOSE_services_airflow-testing_volumes_" | \
             sed "s/..\/..\/../${ESCAPED_AIRFLOW_SOURCES}/" | \
+            sed "s/\${HOME}/${ESCAPED_HOME}/" | \
             sed "s/COMPOSE_services_airflow-testing_volumes_//" | \
             sort -t "=" -k 1 -n | \
             cut -d "=" -f 2- | \

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -55,6 +55,9 @@ services:
       - ENABLED_INTEGRATIONS
       - RUN_INTEGRATION_TESTS
       - BREEZE
+      - SYSTEM_TESTS_AIRFLOW_VERSION
+      - ENABLED_SYSTEMS
+      - RUN_SYSTEM_TESTS
     volumes:
       # Pass docker to inside of the container so that Kind and Moto tests can use it.
       - /var/run/docker.sock:/var/run/docker.sock

--- a/scripts/ci/docker-compose/local.yml
+++ b/scripts/ci/docker-compose/local.yml
@@ -53,7 +53,9 @@ services:
       - ../../../setup.cfg:/opt/airflow/setup.cfg:cached
       - ../../../setup.py:/opt/airflow/setup.py:cached
       - ../../../tests:/opt/airflow/tests:cached
+      - ../../../tests:/opt/airflow-backport/tests:cached
       - ../../../tmp:/opt/airflow/tmp:cached
+      - ${HOME}/.config:/root/.config
     environment:
       - HOST_USER_ID
       - HOST_GROUP_ID

--- a/scripts/ci/in_container/entrypoint_ci.sh
+++ b/scripts/ci/in_container/entrypoint_ci.sh
@@ -176,6 +176,18 @@ if [[ "${ENABLE_KIND_CLUSTER}" == "true" ]]; then
     fi
 fi
 
+export FILES_DIR="/files"
+export AIRFLOW_BREEZE_CONFIG_DIR="${FILES_DIR}/airflow-breeze-config"
+VARIABLES_ENV_FILE="${AIRFLOW_BREEZE_CONFIG_DIR}/variables.env"
+
+if [[ -f ${VARIABLES_ENV_FILE} ]]; then
+    echo
+    echo "Sourcing environment variables from ${VARIABLES_ENV_FILE}"
+    echo
+     # shellcheck disable=1090
+    source "${VARIABLES_ENV_FILE}"
+fi
+
 set +u
 # If we do not want to run tests, we simply drop into bash
 if [[ "${RUN_TESTS}" == "false" ]]; then
@@ -220,7 +232,13 @@ if [[ -n ${RUNTIME} ]]; then
     fi
 fi
 
+
 ARGS=("${CI_ARGS[@]}" "${TEST_DIR}")
-"${MY_DIR}/run_ci_tests.sh" "${ARGS[@]}"
+
+if [[ ${RUN_SYSTEM_TESTS:="false"} == "true" ]]; then
+    "${MY_DIR}/run_system_tests.sh" "${ARGS[@]}"
+else
+    "${MY_DIR}/run_ci_tests.sh" "${ARGS[@]}"
+fi
 
 in_container_script_end

--- a/tests/bats/test_yaml_parser.bats
+++ b/tests/bats/test_yaml_parser.bats
@@ -60,7 +60,9 @@ services_airflow-testing_volumes_26="../../../scripts/ci/in_container/entrypoint
 services_airflow-testing_volumes_27="../../../setup.cfg:/opt/airflow/setup.cfg:cached"
 services_airflow-testing_volumes_28="../../../setup.py:/opt/airflow/setup.py:cached"
 services_airflow-testing_volumes_29="../../../tests:/opt/airflow/tests:cached"
-services_airflow-testing_volumes_30="../../../tmp:/opt/airflow/tmp:cached"
+services_airflow-testing_volumes_30="../../../tests:/opt/airflow-backport/tests:cached"
+services_airflow-testing_volumes_31="../../../tmp:/opt/airflow/tmp:cached"
+services_airflow-testing_volumes_32="${HOME}/.config:/root/.config"
 services_airflow-testing_environment_1="HOST_USER_ID"
 services_airflow-testing_environment_2="HOST_GROUP_ID"
 services_airflow-testing_environment_3="PYTHONDONTWRITEBYTECODE"
@@ -132,6 +134,10 @@ ${AIRFLOW_SOURCES}/setup.py:/opt/airflow/setup.py:cached
 -v
 ${AIRFLOW_SOURCES}/tests:/opt/airflow/tests:cached
 -v
+${AIRFLOW_SOURCES}/tests:/opt/airflow-backport/tests:cached
+-v
 ${AIRFLOW_SOURCES}/tmp:/opt/airflow/tmp:cached
+-v
+${HOME}/.config:/root/.config
 EOF
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ tests_directory = os.path.dirname(os.path.realpath(__file__))
 os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.path.join(tests_directory, "dags")
 os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
 os.environ["AWS_DEFAULT_REGION"] = (os.environ.get("AWS_DEFAULT_REGION") or "us-east-1")
+os.environ["CREDENTIALS_DIR"] = (os.environ.get('CREDENTIALS_DIR') or "/files/airflow-breeze-config/keys")
 
 
 @pytest.fixture()
@@ -87,6 +88,26 @@ def pytest_addoption(parser):
         metavar="RUNTIME",
         help="only run tests matching the runtime: [kubernetes].",
     )
+    group.addoption(
+        "--systems",
+        action="store",
+        metavar="SYSTEMS",
+        help="only run tests matching the systems specified [google.cloud, google.marketing_platform]",
+    )
+    group.addoption(
+        "--include-long-lasting",
+        action="store_true",
+        help="Includes long-lasting tests (marked with long_lasting) marker ",
+    )
+
+
+def initial_db_init():
+    if os.environ.get("RUN_TESTS_FOR_AIRFLOW_1_10"):
+        print("Attempting to reset the db using airflow command")
+        os.system("airflow resetdb -y")
+    else:
+        from airflow.utils import db
+        db.resetdb()
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -101,6 +122,10 @@ def breeze_test_helper(request):
         print("Skipping db initialization. Tests do not require database")
         return
 
+    from airflow import __version__
+    if __version__.startswith("1.10"):
+        os.environ['RUN_TESTS_FOR_AIRFLOW_1_10'] = "true"
+
     print(" AIRFLOW ".center(60, "="))
 
     # Setup test environment for breeze
@@ -109,27 +134,17 @@ def breeze_test_helper(request):
 
     print(f"Home of the user: {home}\nAirflow home {airflow_home}")
 
-    from airflow.utils import db
-
     # Initialize Airflow db if required
     lock_file = os.path.join(airflow_home, ".airflow_db_initialised")
     if request.config.option.db_init:
         print("Initializing the DB - forced with --with-db-init switch.")
-        try:
-            db.initdb()
-        except:  # pylint: disable=bare-except # noqa
-            print("Skipping db initialization because database already exists.")
-        db.resetdb()
+        initial_db_init()
     elif not os.path.exists(lock_file):
         print(
             "Initializing the DB - first time after entering the container.\n"
             "You can force re-initialization the database by adding --with-db-init switch to run-tests."
         )
-        try:
-            db.initdb()
-        except:  # pylint: disable=bare-except # noqa
-            print("Skipping db initialization because database already exists.")
-        db.resetdb()
+        initial_db_init()
         # Create pid file
         with open(lock_file, "w+"):
             pass
@@ -159,6 +174,15 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "runtime(name): mark test to run with named runtime"
     )
+    config.addinivalue_line(
+        "markers", "system(name): mark test to run with named system"
+    )
+    config.addinivalue_line(
+        "markers", "long_lasting(name): mark test that run for a long time (many minutes)"
+    )
+    config.addinivalue_line(
+        "markers", "credential_file(name): mark tests that require credential file in CREDENTIALS_DIR"
+    )
 
 
 def skip_if_not_marked_with_integration(selected_integrations, item):
@@ -168,8 +192,8 @@ def skip_if_not_marked_with_integration(selected_integrations, item):
             return
     pytest.skip("The test is skipped because it does not have the right integration marker. "
                 "Only tests marked with pytest.mark.integration(INTEGRATION) are run with INTEGRATION"
-                " being one of {}. {item}".
-                format(selected_integrations, item=item))
+                " being one of {integration}. {item}".
+                format(integration=selected_integrations, item=item))
 
 
 def skip_if_not_marked_with_backend(selected_backend, item):
@@ -178,9 +202,9 @@ def skip_if_not_marked_with_backend(selected_backend, item):
         if selected_backend in backend_names:
             return
     pytest.skip("The test is skipped because it does not have the right backend marker "
-                "Only tests marked with pytest.mark.backend('{}') are run"
+                "Only tests marked with pytest.mark.backend('{backend}') are run"
                 ": {item}".
-                format(selected_backend, item=item))
+                format(backend=selected_backend, item=item))
 
 
 def skip_if_not_marked_with_runtime(selected_runtime, item):
@@ -189,8 +213,35 @@ def skip_if_not_marked_with_runtime(selected_runtime, item):
         if runtime_name == selected_runtime:
             return
     pytest.skip("The test is skipped because it has not been selected via --runtime switch. "
-                "Only tests marked with pytest.mark.runtime('{}') are run: {item}".
-                format(selected_runtime, item=item))
+                "Only tests marked with pytest.mark.runtime('{runtime}') are run: {item}".
+                format(runtime=selected_runtime, item=item))
+
+
+def skip_if_not_marked_with_system(selected_systems, item):
+    for marker in item.iter_markers(name="system"):
+        systems_name = marker.args[0]
+        if systems_name in selected_systems or "all" in selected_systems:
+            return
+    pytest.skip("The test is skipped because it does not have the right system marker. "
+                "Only tests marked with pytest.mark.system(SYSTEM) are run with SYSTEM"
+                " being one of {systems}. {item}".
+                format(systems=selected_systems, item=item))
+
+
+def skip_system_test(item):
+    for _ in item.iter_markers(name="system"):
+        pytest.skip("The test is skipped because it has system marker. "
+                    "And system tests are only run when --systems flag "
+                    "is passed to pytest. {item}".
+                    format(item=item))
+
+
+def skip_long_lasting_test(item):
+    for _ in item.iter_markers(name="long_lasting"):
+        pytest.skip("The test is skipped because it has long_lasting marker. "
+                    "And system tests are only run when --long-lasting flag "
+                    "is passed to pytest. {item}".
+                    format(item=item))
 
 
 def skip_if_integration_disabled(marker, item):
@@ -199,10 +250,10 @@ def skip_if_integration_disabled(marker, item):
     environment_variable_value = os.environ.get(environment_variable_name)
     if not environment_variable_value or environment_variable_value != "true":
         pytest.skip("The test requires {integration_name} integration started and "
-                    "{} environment variable to be set to true (it is '{}')."
+                    "{name} environment variable to be set to true (it is '{value}')."
                     " It can be set by specifying '--integration {integration_name}' at breeze startup"
                     ": {item}".
-                    format(environment_variable_name, environment_variable_value,
+                    format(name=environment_variable_name, value=environment_variable_value,
                            integration_name=integration_name, item=item))
 
 
@@ -212,10 +263,10 @@ def skip_if_runtime_disabled(marker, item):
     environment_variable_value = os.environ.get(environment_variable_name)
     if not environment_variable_value or environment_variable_value != runtime_name:
         pytest.skip("The test requires {runtime_name} integration started and "
-                    "{} environment variable to be set to true (it is '{}')."
+                    "{name} environment variable to be set to true (it is '{value}')."
                     " It can be set by specifying '--environment {runtime_name}' at breeze startup"
                     ": {item}".
-                    format(environment_variable_name, environment_variable_value,
+                    format(name=environment_variable_name, value=environment_variable_value,
                            runtime_name=runtime_name, item=item))
 
 
@@ -225,20 +276,36 @@ def skip_if_wrong_backend(marker, item):
     environment_variable_value = os.environ.get(environment_variable_name)
     if not environment_variable_value or environment_variable_value not in valid_backend_names:
         pytest.skip("The test requires one of {valid_backend_names} backend started and "
-                    "{} environment variable to be set to true (it is '{}')."
+                    "{name} environment variable to be set to 'true' (it is '{value}')."
                     " It can be set by specifying backend at breeze startup"
                     ": {item}".
-                    format(environment_variable_name, environment_variable_value,
+                    format(name=environment_variable_name, value=environment_variable_value,
                            valid_backend_names=valid_backend_names, item=item))
+
+
+def skip_if_credential_file_missing(item):
+    for marker in item.iter_markers(name="credential_file"):
+        credential_file = marker.args[0]
+        credential_path = os.path.join(os.environ.get('CREDENTIALS_DIR'), credential_file)
+        if not os.path.exists(credential_path):
+            pytest.skip("The test requires credential file {path}: {item}".
+                        format(path=credential_path, item=item))
 
 
 def pytest_runtest_setup(item):
     selected_integrations = item.config.getoption("--integrations")
     selected_integrations_list = selected_integrations.split(",") if selected_integrations else []
+    selected_systems = item.config.getoption("--systems")
+    selected_systems_list = selected_systems.split(",") if selected_systems else []
+    include_long_lasting = item.config.getoption("--include-long-lasting")
     for marker in item.iter_markers(name="integration"):
         skip_if_integration_disabled(marker, item)
     if selected_integrations_list:
-        skip_if_not_marked_with_integration(selected_integrations, item)
+        skip_if_not_marked_with_integration(selected_integrations_list, item)
+    if selected_systems_list:
+        skip_if_not_marked_with_system(selected_systems_list, item)
+    else:
+        skip_system_test(item)
     for marker in item.iter_markers(name="backend"):
         skip_if_wrong_backend(marker, item)
     selected_backend = item.config.getoption("--backend")
@@ -249,3 +316,6 @@ def pytest_runtest_setup(item):
     selected_runtime = item.config.getoption("--runtime")
     if selected_runtime:
         skip_if_not_marked_with_runtime(selected_runtime, item)
+    if not include_long_lasting:
+        skip_long_lasting_test(item)
+    skip_if_credential_file_missing(item)

--- a/tests/providers/google/cloud/hooks/test_bigquery_system.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery_system.py
@@ -19,12 +19,14 @@
 
 import unittest
 
+import pytest
+
 from airflow.providers.google.cloud.hooks import bigquery as hook
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_BIGQUERY_KEY
-from tests.test_utils.gcp_system_helpers import skip_gcp_system
 
 
-@skip_gcp_system(GCP_BIGQUERY_KEY)
+@pytest.mark.system("google.cloud")
+@pytest.mark.credentials_file(GCP_BIGQUERY_KEY)
 class BigQueryDataframeResultsSystemTest(unittest.TestCase):
     def setUp(self):
         self.instance = hook.BigQueryHook()

--- a/tests/providers/google/cloud/operators/test_automl_system.py
+++ b/tests/providers/google/cloud/operators/test_automl_system.py
@@ -15,21 +15,27 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_AUTOML_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_AUTOML_KEY, require_local_executor=True, long_lasting=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_AUTOML_KEY)
+@pytest.mark.long_lasting
 class AutoMLDatasetOperationsSystemTest(SystemTest):
     @provide_gcp_context(GCP_AUTOML_KEY)
     def test_run_example_dag(self):
         self.run_dag('example_automl_dataset', CLOUD_DAG_FOLDER)
 
 
-@skip_gcp_system(GCP_AUTOML_KEY, require_local_executor=True, long_lasting=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_AUTOML_KEY)
+@pytest.mark.long_lasting
 class AutoMLModelOperationsSystemTest(SystemTest):
     @provide_gcp_context(GCP_AUTOML_KEY)
     def test_run_example_dag(self):

--- a/tests/providers/google/cloud/operators/test_bigquery_dts_system.py
+++ b/tests/providers/google/cloud/operators/test_bigquery_dts_system.py
@@ -15,17 +15,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from airflow.providers.google.cloud.example_dags.example_bigquery_dts import (
     BUCKET_URI, GCP_DTS_BQ_DATASET, GCP_DTS_BQ_TABLE, GCP_PROJECT_ID,
 )
 from tests.providers.google.cloud.operators.test_bigquery_dts_system_helper import GcpBigqueryDtsTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_BIGQUERY_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_BIGQUERY_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_BIGQUERY_KEY)
 class GcpBigqueryDtsSystemTest(SystemTest):
     helper = GcpBigqueryDtsTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_bigquery_system.py
+++ b/tests/providers/google/cloud/operators/test_bigquery_system.py
@@ -16,14 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 """System tests for Google Cloud Build operators"""
+import pytest
 
 from tests.providers.google.cloud.operators.test_bigquery_system_helper import GCPBigQueryTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_BIGQUERY_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_BIGQUERY_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_BIGQUERY_KEY)
 class BigQueryExampleDagsSystemTest(SystemTest):
     """
     System tests for Google BigQuery operators

--- a/tests/providers/google/cloud/operators/test_bigtable_system.py
+++ b/tests/providers/google/cloud/operators/test_bigtable_system.py
@@ -15,15 +15,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.operators.test_bigtable_system_helper import GCPBigtableTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_BIGTABLE_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_BIGTABLE_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_BIGTABLE_KEY)
 class BigTableExampleDagsSystemTest(SystemTest):
     helper = GCPBigtableTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_cloud_build_operator_system.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build_operator_system.py
@@ -16,14 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 """System tests for Google Cloud Build operators"""
+import pytest
 
 from tests.providers.google.cloud.operators.test_cloud_build_system_helper import GCPCloudBuildTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_CLOUD_BUILD_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_CLOUD_BUILD_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_CLOUD_BUILD_KEY)
 class CloudBuildExampleDagsSystemTest(SystemTest):
     """
     System tests for Google Cloud Build operators

--- a/tests/providers/google/cloud/operators/test_cloud_memorystore_system.py
+++ b/tests/providers/google/cloud/operators/test_cloud_memorystore_system.py
@@ -16,16 +16,19 @@
 # specific language governing permissions and limitations
 # under the License.
 """System tests for Google Cloud Memorystore operators"""
+import pytest
 
 from tests.providers.google.cloud.operators.test_cloud_memorystore_system_helper import (
     GCPCloudMemorystoreTestHelper,
 )
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_MEMORYSTORE  # TODO: Update it
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_MEMORYSTORE, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_MEMORYSTORE)
 class CloudBuildExampleDagsSystemTest(SystemTest):
     """
     System tests for Google Cloud Memorystore operators

--- a/tests/providers/google/cloud/operators/test_cloud_sql_operatorquery_system.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql_operatorquery_system.py
@@ -20,11 +20,13 @@ import random
 import string
 import time
 
+import pytest
+
 from airflow import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_sql import CloudSqlProxyRunner
 from tests.providers.google.cloud.operators.test_cloud_sql_system_helper import CloudSqlQueryTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_CLOUDSQL_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'project-id')
@@ -32,7 +34,8 @@ GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'project-id')
 SQL_QUERY_TEST_HELPER = CloudSqlQueryTestHelper()
 
 
-@skip_gcp_system(GCP_CLOUDSQL_KEY)
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_CLOUDSQL_KEY)
 class CloudSqlProxySystemTest(SystemTest):
     @provide_gcp_context(GCP_CLOUDSQL_KEY)
     def setUp(self):
@@ -95,7 +98,8 @@ class CloudSqlProxySystemTest(SystemTest):
         self.assertEqual(runner.get_proxy_version(), "1.13")
 
 
-@skip_gcp_system(GCP_CLOUDSQL_KEY)
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_CLOUDSQL_KEY)
 class CloudSqlQueryExampleDagsSystemTest(SystemTest):
     @provide_gcp_context(GCP_CLOUDSQL_KEY)
     def setUp(self):

--- a/tests/providers/google/cloud/operators/test_cloud_sql_system.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql_system.py
@@ -17,10 +17,12 @@
 # under the License.
 import os
 
+import pytest
+
 from airflow import AirflowException
 from tests.providers.google.cloud.operators.test_cloud_sql_system_helper import CloudSqlQueryTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_CLOUDSQL_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'project-id')
@@ -28,7 +30,9 @@ GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'project-id')
 SQL_QUERY_TEST_HELPER = CloudSqlQueryTestHelper()
 
 
-@skip_gcp_system(GCP_CLOUDSQL_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_CLOUDSQL_KEY)
 class CloudSqlExampleDagsIntegrationTest(SystemTest):
     @provide_gcp_context(GCP_CLOUDSQL_KEY)
     def tearDown(self):

--- a/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service_system.py
+++ b/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service_system.py
@@ -15,16 +15,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.operators.test_cloud_storage_transfer_service_system_helper import (
     GCPTransferTestHelper,
 )
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_TRANSFER_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_GCS_TRANSFER_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_GCS_TRANSFER_KEY)
 class GcpTransferExampleDagsSystemTest(SystemTest):
     helper = GCPTransferTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_compute_system.py
+++ b/tests/providers/google/cloud/operators/test_compute_system.py
@@ -15,17 +15,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.operators.test_compute_system_helper import GCPComputeTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_COMPUTE_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_COMPUTE_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_COMPUTE_KEY)
 class GcpComputeExampleDagsSystemTest(SystemTest):
     helper = GCPComputeTestHelper()
+
     @provide_gcp_context(GCP_COMPUTE_KEY)
     def setUp(self):
         super().setUp()
@@ -42,7 +45,9 @@ class GcpComputeExampleDagsSystemTest(SystemTest):
         self.run_dag('example_gcp_compute', CLOUD_DAG_FOLDER)
 
 
-@skip_gcp_system(GCP_COMPUTE_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_COMPUTE_KEY)
 class GcpComputeIgmExampleDagsSystemTest(SystemTest):
     helper = GCPComputeTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_dataflow_system.py
+++ b/tests/providers/google/cloud/operators/test_dataflow_system.py
@@ -15,14 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_DATAFLOW_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_DATAFLOW_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_DATAFLOW_KEY)
 class CloudDataflowExampleDagsSystemTest(SystemTest):
     @provide_gcp_context(GCP_DATAFLOW_KEY)
     def test_run_example_dag_function(self):

--- a/tests/providers/google/cloud/operators/test_dataproc_system.py
+++ b/tests/providers/google/cloud/operators/test_dataproc_system.py
@@ -17,9 +17,11 @@
 # under the License.
 import os
 
+import pytest
+
 from tests.providers.google.cloud.operators.test_dataproc_operator_system_helper import DataprocTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_DATAPROC_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 BUCKET = os.environ.get("GCP_DATAPROC_BUCKET", "dataproc-system-tests")
@@ -27,7 +29,9 @@ PYSPARK_MAIN = os.environ.get("PYSPARK_MAIN", "hello_world.py")
 PYSPARK_URI = "gs://{}/{}".format(BUCKET, PYSPARK_MAIN)
 
 
-@skip_gcp_system(GCP_DATAPROC_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_DATAPROC_KEY)
 class DataprocExampleDagsTest(SystemTest):
     helper = DataprocTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_datastore_system.py
+++ b/tests/providers/google/cloud/operators/test_datastore_system.py
@@ -15,15 +15,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.operators.test_datastore_system_helper import GcpDatastoreSystemTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_DATASTORE_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_DATASTORE_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_DATASTORE_KEY)
 class GcpDatastoreSystemTest(SystemTest):
     helper = GcpDatastoreSystemTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_dlp_system.py
+++ b/tests/providers/google/cloud/operators/test_dlp_system.py
@@ -21,13 +21,16 @@
 This module contains various unit tests for
 example_gcp_dlp DAG
 """
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_DLP_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_DLP_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_DLP_KEY)
 class GcpDLPExampleDagsSystemTest(SystemTest):
     @provide_gcp_context(GCP_DLP_KEY)
     def test_run_example_dag_function(self):

--- a/tests/providers/google/cloud/operators/test_functions_system.py
+++ b/tests/providers/google/cloud/operators/test_functions_system.py
@@ -15,13 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_FUNCTION_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_FUNCTION_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_FUNCTION_KEY)
 class GcpFunctionExampleDagsSystemTest(SystemTest):
     @provide_gcp_context(GCP_FUNCTION_KEY)
     def test_run_example_dag_function(self):

--- a/tests/providers/google/cloud/operators/test_gcs_system.py
+++ b/tests/providers/google/cloud/operators/test_gcs_system.py
@@ -15,15 +15,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.operators.test_gcs_system_helper import GcsSystemTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_GCS_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_GCS_KEY)
 class GoogleCloudStorageExampleDagsTest(SystemTest):
     helper = GcsSystemTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_gcs_to_gcs_operator_system.py
+++ b/tests/providers/google/cloud/operators/test_gcs_to_gcs_operator_system.py
@@ -16,15 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 """System tests for Google Cloud Build operators"""
-
+import pytest
 
 from tests.providers.google.cloud.operators.test_gcs_to_gcs_system_helper import GcsToGcsTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_GCS_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_GCS_KEY)
 class GcsToGcsExampleDagsSystemTest(SystemTest):
     """
     System tests for Google Cloud Storage to Google Cloud Storage transfer operators

--- a/tests/providers/google/cloud/operators/test_gcs_to_sftp_system.py
+++ b/tests/providers/google/cloud/operators/test_gcs_to_sftp_system.py
@@ -16,14 +16,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """System tests for Google Cloud Build operators"""
+import pytest
 
 from tests.providers.google.cloud.operators.test_gcs_to_sftp_system_helper import GcsToSFTPTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_GCS_KEY)
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_GCS_KEY)
 class GcsToSftpExampleDagsSystemTest(SystemTest):
     """
     System tests for Google Cloud Storage to SFTP transfer operator

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine_system.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine_system.py
@@ -15,14 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GKE_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_GKE_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_GKE_KEY)
 class KubernetesEngineExampleDagTest(SystemTest):
     @provide_gcp_context(GCP_GKE_KEY)
     def test_run_example_dag(self):

--- a/tests/providers/google/cloud/operators/test_mlengine_system.py
+++ b/tests/providers/google/cloud/operators/test_mlengine_system.py
@@ -15,13 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
+
 from tests.providers.google.cloud.operators.test_mlengine_system_helper import MlEngineSystemTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_AI_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_AI_KEY)
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_AI_KEY)
 class MlEngineExampleDagTest(SystemTest):
     helper = MlEngineSystemTestHelper()
     @provide_gcp_context(GCP_AI_KEY)

--- a/tests/providers/google/cloud/operators/test_natural_language_system.py
+++ b/tests/providers/google/cloud/operators/test_natural_language_system.py
@@ -15,13 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_AI_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_AI_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_AI_KEY)
 class CloudNaturalLanguageExampleDagsTest(SystemTest):
     @provide_gcp_context(GCP_AI_KEY)
     def test_run_example_dag(self):

--- a/tests/providers/google/cloud/operators/test_postgres_to_gcs_system.py
+++ b/tests/providers/google/cloud/operators/test_postgres_to_gcs_system.py
@@ -15,13 +15,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 from psycopg2 import ProgrammingError
 
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from tests.contrib.utils.logging_command_executor import LoggingCommandExecutor
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
-from tests.test_utils.gcp_system_helpers import provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 GCS_BUCKET = "postgres_to_gcs_example"
@@ -80,7 +80,9 @@ class GcsHelper(LoggingCommandExecutor):
         self.execute_cmd(["gsutil", "-m", "rm", "-r", "gs://{}".format(GCS_BUCKET)])
 
 
-@skip_gcp_system(GCP_GCS_KEY, require_local_executor=True)
+@pytest.mark.backend("postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_GCS_KEY)
 class PostgresToGCSSystemTest(SystemTest):
     helper = GcsHelper()
 

--- a/tests/providers/google/cloud/operators/test_pubsub_system.py
+++ b/tests/providers/google/cloud/operators/test_pubsub_system.py
@@ -15,14 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_PUBSUB_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_PUBSUB_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_PUBSUB_KEY)
 class PubSubSystemTest(SystemTest):
     @provide_gcp_context(GCP_PUBSUB_KEY)
     def test_run_example_dag(self):

--- a/tests/providers/google/cloud/operators/test_sftp_to_gcs_system.py
+++ b/tests/providers/google/cloud/operators/test_sftp_to_gcs_system.py
@@ -16,14 +16,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """System tests for Google Cloud Build operators"""
+import pytest
 
 from tests.providers.google.cloud.operators.test_sftp_to_gcs_system_helper import SFTPtoGcsTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_GCS_KEY)
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_GCS_KEY)
 class SFTPToGcsExampleDagsSystemTest(SystemTest):
     """
     System tests for SFTP to Google Cloud Storage transfer operator

--- a/tests/providers/google/cloud/operators/test_spanner_system.py
+++ b/tests/providers/google/cloud/operators/test_spanner_system.py
@@ -15,14 +15,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.operators.test_spanner_system_helper import GCPSpannerTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_SPANNER_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_SPANNER_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_SPANNER_KEY)
 class CloudSpannerExampleDagsTest(SystemTest):
     helper = GCPSpannerTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_speech_system.py
+++ b/tests/providers/google/cloud/operators/test_speech_system.py
@@ -15,15 +15,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.operators.test_speech_system_helper import GCPTextToSpeechTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_GCS_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_GCS_KEY)
 class GCPTextToSpeechExampleDagSystemTest(SystemTest):
     helper = GCPTextToSpeechTestHelper()
 

--- a/tests/providers/google/cloud/operators/test_tasks_system.py
+++ b/tests/providers/google/cloud/operators/test_tasks_system.py
@@ -15,13 +15,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_TASKS_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_TASKS_KEY)
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_TASKS_KEY)
 class GcpTasksExampleDagsSystemTest(SystemTest):
     @provide_gcp_context(GCP_TASKS_KEY)
     def test_run_example_dag_function(self):

--- a/tests/providers/google/cloud/operators/test_translate_system.py
+++ b/tests/providers/google/cloud/operators/test_translate_system.py
@@ -15,14 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_AI_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_AI_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_AI_KEY)
 class CloudTranslateExampleDagsSystemTest(SystemTest):
     @provide_gcp_context(GCP_AI_KEY)
     def test_run_example_dag_function(self):

--- a/tests/providers/google/cloud/operators/test_video_intelligence_system.py
+++ b/tests/providers/google/cloud/operators/test_video_intelligence_system.py
@@ -15,17 +15,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import pytest
 
 from tests.providers.google.cloud.operators.test_video_intelligence_system_helper import (
     GCPVideoIntelligenceHelper,
 )
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_AI_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_AI_KEY, require_local_executor=True)
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_AI_KEY)
 class CloudVideoIntelligenceExampleDagsTest(SystemTest):
     helper = GCPVideoIntelligenceHelper()
 

--- a/tests/providers/google/cloud/operators/test_vision_system.py
+++ b/tests/providers/google/cloud/operators/test_vision_system.py
@@ -15,16 +15,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.operators.test_vision_system_helper import GCPVisionTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_AI_KEY
-from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 VISION_HELPER = GCPVisionTestHelper()
 
 
-@skip_gcp_system(GCP_AI_KEY)
+@pytest.mark.system("google.cloud")
+@pytest.mark.credential_file(GCP_AI_KEY)
 class CloudVisionExampleDagsSystemTest(SystemTest):
     @provide_gcp_context(GCP_AI_KEY)
     def setUp(self):

--- a/tests/providers/google/marketing_platform/operators/test_campaign_manager_system.py
+++ b/tests/providers/google/marketing_platform/operators/test_campaign_manager_system.py
@@ -15,12 +15,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GOOGLE_CAMPAIGN_MANAGER_KEY
 from tests.providers.google.marketing_platform.operators.test_campaign_manager_system_helper import (
     GoogleCampaignManagerTestHelper,
 )
-from tests.test_utils.gcp_system_helpers import provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 # Required scopes
@@ -31,7 +32,8 @@ SCOPES = [
 ]
 
 
-@skip_gcp_system(GOOGLE_CAMPAIGN_MANAGER_KEY)
+@pytest.mark.system("google.marketing_platform")
+@pytest.mark.credential_file(GOOGLE_CAMPAIGN_MANAGER_KEY)
 class CampaignManagerSystemTest(SystemTest):
     helper = GoogleCampaignManagerTestHelper()
 

--- a/tests/providers/google/marketing_platform/operators/test_display_video_system.py
+++ b/tests/providers/google/marketing_platform/operators/test_display_video_system.py
@@ -14,19 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_DISPLAY_VIDEO_KEY
 from tests.providers.google.marketing_platform.operators.test_display_video_system_helper import (
     GcpDisplayVideoSystemTestHelper,
 )
-from tests.test_utils.gcp_system_helpers import provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 # Requires the following scope:
 SCOPES = ["https://www.googleapis.com/auth/doubleclickbidmanager"]
 
 
-@skip_gcp_system(GCP_DISPLAY_VIDEO_KEY)
+@pytest.mark.system("google.marketing_platform")
+@pytest.mark.credential_file(GCP_DISPLAY_VIDEO_KEY)
 class DisplayVideoSystemTest(SystemTest):
     helper = GcpDisplayVideoSystemTestHelper()
 

--- a/tests/providers/google/marketing_platform/operators/test_search_ads_system.py
+++ b/tests/providers/google/marketing_platform/operators/test_search_ads_system.py
@@ -15,16 +15,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_SEARCHADS_KEY
 from tests.providers.google.marketing_platform.operators.test_search_ads_system_helper import (
     GoogleSearchAdsSystemTestHelper,
 )
-from tests.test_utils.gcp_system_helpers import provide_gcp_context, skip_gcp_system
+from tests.test_utils.gcp_system_helpers import provide_gcp_context
 from tests.test_utils.system_tests_class import SystemTest
 
 
-@skip_gcp_system(GCP_SEARCHADS_KEY)
+@pytest.mark.system("google.marketing_platform")
+@pytest.mark.credential_file(GCP_SEARCHADS_KEY)
 class SearchAdsSystemTest(SystemTest):
     helper = GoogleSearchAdsSystemTestHelper()
 

--- a/tests/test_utils/gcp_system_helpers.py
+++ b/tests/test_utils/gcp_system_helpers.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
-import unittest
 from typing import Optional, Sequence
 
 from airflow.providers.google.cloud.utils.credentials_provider import provide_gcp_conn_and_credentials
@@ -32,43 +31,6 @@ POSTGRES_LOCAL_EXECUTOR = os.path.join(
 )
 
 
-SKIP_TEST_WARNING = """
-The test is only run when the test is run in environment with GCP-system-tests enabled
-environment. You can enable it in one of two ways:
-
-* Set GCP_CONFIG_DIR environment variable to point to the GCP configuration
-  directory which keeps the {} key.
-* Run this test within automated environment variable workspace where
-  config directory is checked out next to the airflow one.
-
-"""
-
-SKIP_LONG_TEST_WARNING = """
-The test is only run when the test is run in with GCP-system-tests enabled
-environment. And environment variable GCP_ENABLE_LONG_TESTS is set to True.
-You can enable it in one of two ways:
-
-* Set GCP_CONFIG_DIR environment variable to point to the GCP configuration
-  directory which keeps variables.env file with environment variables to set
-  and keys directory which keeps service account keys in .json format and
-  set GCP_ENABLE_LONG_TESTS to True
-* Run this test within automated environment variable workspace where
-  config directory is checked out next to the airflow one.
-"""
-
-
-LOCAL_EXECUTOR_WARNING = """
-The test requires local executor. Please set AIRFLOW_CONFIG variable to '{}'
-and make sure you have a Postgres server running locally and
-airflow/airflow.db database created.
-
-You can create the database via these commands:
-'createuser root'
-'createdb airflow/airflow.db`
-
-"""
-
-
 def resolve_full_gcp_key_path(key: str) -> str:
     """
     Returns path full path to provided GCP key.
@@ -77,40 +39,9 @@ def resolve_full_gcp_key_path(key: str) -> str:
     :type key: str
     :returns: Full path to the key
     """
-    path = os.environ.get("GCP_CONFIG_DIR", "/config")
-    key = os.path.join(path, "keys", key)
+    path = os.environ.get("CREDENTIALS_DIR", "/files/airflow-breeze-config/keys")
+    key = os.path.join(path, key)
     return key
-
-
-def skip_gcp_system(
-    service_key: str, long_lasting: bool = False, require_local_executor: bool = False
-):
-    """
-    Decorator for skipping GCP system tests.
-
-    :param service_key: name of the service key that will be used to provide credentials
-    :type service_key: str
-    :param long_lasting: set True if a test take relatively long time
-    :type long_lasting: bool
-    :param require_local_executor: set True if test config must use local executor
-    :type require_local_executor: bool
-    """
-    try:
-        full_key_path = resolve_full_gcp_key_path(service_key)
-        with open(full_key_path):
-            pass
-    except FileNotFoundError:
-        return unittest.skip(SKIP_TEST_WARNING.format(service_key))
-
-    if long_lasting and os.environ.get("GCP_ENABLE_LONG_TESTS") == "True":
-        return unittest.skip(SKIP_LONG_TEST_WARNING)
-
-    if require_local_executor and POSTGRES_LOCAL_EXECUTOR != os.environ.get(
-        "AIRFLOW_CONFIG"
-    ):
-        return unittest.skip(LOCAL_EXECUTOR_WARNING.format(POSTGRES_LOCAL_EXECUTOR))
-
-    return lambda cls: cls
 
 
 def provide_gcp_context(

--- a/tests/test_utils/system_tests_class.py
+++ b/tests/test_utils/system_tests_class.py
@@ -16,24 +16,22 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+import shutil
 from contextlib import ContextDecorator
+from datetime import datetime
 from shutil import move
 from tempfile import mkdtemp
-from unittest import SkipTest, TestCase
+from unittest import TestCase
 
 from airflow import AirflowException, models
 from airflow.configuration import AIRFLOW_HOME, AirflowConfigParser, get_airflow_config
-from airflow.utils import db
+from airflow.utils.file import mkdirs
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 AIRFLOW_MAIN_FOLDER = os.path.realpath(
     os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir)
 )
 DEFAULT_DAG_FOLDER = os.path.join(AIRFLOW_MAIN_FOLDER, "airflow", "example_dags")
-
-SKIP_SYSTEM_TEST_WARNING = """Skipping system test.
-To allow system test set ENABLE_SYSTEM_TESTS=true.
-"""
 
 
 def resolve_dags_folder() -> str:
@@ -50,7 +48,24 @@ def resolve_dags_folder() -> str:
     return dags
 
 
-class empty_dags_directory(  # pylint: disable=invalid-name
+def resolve_logs_folder() -> str:
+    """
+    Returns LOGS folder specified in current Airflow config.
+    """
+    config_file = get_airflow_config(AIRFLOW_HOME)
+    conf = AirflowConfigParser()
+    conf.read(config_file)
+    try:
+        logs = conf.get("logging", "base_log_folder")
+    except AirflowException:
+        try:
+            logs = conf.get("core", "base_log_folder")
+        except AirflowException:
+            logs = os.path.join(AIRFLOW_HOME, 'logs')
+    return logs
+
+
+class EmptyDagsDirectory(  # pylint: disable=invalid-name
     ContextDecorator, LoggingMixin
 ):
     """
@@ -93,22 +108,92 @@ class empty_dags_directory(  # pylint: disable=invalid-name
 
 
 class SystemTest(TestCase, LoggingMixin):
-    def run(self, result=None):
-        if os.environ.get('ENABLE_SYSTEM_TESTS') != 'true':
-            raise SkipTest(SKIP_SYSTEM_TEST_WARNING)
-        return super().run(result)
 
     def setUp(self) -> None:
         """
         We want to avoid random errors while database got reset - those
         Are apparently triggered by parser trying to parse DAGs while
         The tables are dropped. We move the dags temporarily out of the dags folder
-        and move them back after reset
+        and move them back after reset.
+
+        We also remove all logs from logs directory to have a clear log state and see only logs from this
+        test.
         """
         dag_folder = resolve_dags_folder()
-        with empty_dags_directory(dag_folder):
-            db.resetdb()
+        with EmptyDagsDirectory(dag_folder):
+            self.initial_db_init()
+        print()
+        print("Removing all log files except previous_runs")
+        print()
+        logs_folder = resolve_logs_folder()
+        files = os.listdir(logs_folder)
+        for file in files:
+            file_path = os.path.join(logs_folder, file)
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+            elif os.path.isdir(file) and not file == "previous_runs":
+                shutil.rmtree(file_path, ignore_errors=True)
         super().setUp()
+
+    def tearDown(self) -> None:
+        """
+        We save the logs to a separate directory so that we can see them later.
+        """
+        date_str = datetime.now().strftime("%Y-%m-%d_%H_%M_%S")
+        logs_folder = resolve_logs_folder()
+        print()
+        print(f"Saving all log files to {logs_folder}/previous_runs/{date_str}")
+        print()
+        target_dir = os.path.join(logs_folder, "previous_runs", date_str)
+        mkdirs(target_dir, 0o755)
+        files = os.listdir(logs_folder)
+        for file in files:
+            if file != "previous_runs":
+                file_path = os.path.join(logs_folder, file)
+                shutil.move(file_path, target_dir)
+        super().setUp()
+
+    def initial_db_init(self):
+        if os.environ.get("RUN_TESTS_FOR_AIRFLOW_1_10"):
+            print("Attempting to reset the db using airflow command")
+            os.system("airflow resetdb -y")
+        else:
+            from airflow.utils import db
+            db.resetdb()
+
+    def _print_all_log_files(self):
+        print()
+        print("Printing all log files")
+        print()
+        logs_folder = resolve_logs_folder()
+        for dirpath, _, filenames in os.walk(logs_folder):
+            if "/previous_runs" not in dirpath:
+                for name in filenames:
+                    filepath = os.path.join(dirpath, name)
+                    print()
+                    print(f" ================ Content of {filepath} ===============================")
+                    print()
+                    with open(filepath, "r") as f:
+                        print(f.read())
+
+    def correct_imports_for_airflow_1_10(self, directory):
+        for dirpath, _, filenames in os.walk(directory):
+            for filename in filenames:
+                filepath = os.path.join(dirpath, filename)
+                if filepath.endswith(".py"):
+                    self.replace_airflow_1_10_imports(filepath)
+
+    def replace_airflow_1_10_imports(self, filepath):
+        replacements = [
+            ("airflow.operators.bash", "airflow.operators.bash_operator"),
+            ("airflow.operators.bash", "airflow.operators.bash_operator"),
+        ]
+        with open(filepath, "rt") as file:
+            data = file.read()
+        for replacement in replacements:
+            data = data.replace(replacement[0], replacement[1])
+        with open(filepath, "wt") as file:
+            file.write(data)
 
     def run_dag(self, dag_id: str, dag_folder: str = DEFAULT_DAG_FOLDER) -> None:
         """
@@ -119,6 +204,13 @@ class SystemTest(TestCase, LoggingMixin):
         :param dag_folder: directory where to look for the specific DAG. Relative to AIRFLOW_HOME.
         :type dag_folder: str
         """
+        if os.environ.get("RUN_TESTS_FOR_AIRFLOW_1_10"):
+            dag_folder = dag_folder.replace("/opt/airflow-backport", "/opt/airflow")
+            temp_dir = mkdtemp()
+            os.rmdir(temp_dir)
+            shutil.copytree(dag_folder, temp_dir)
+            dag_folder = temp_dir
+            self.correct_imports_for_airflow_1_10(temp_dir)
         self.log.info("Looking for DAG: %s in %s", dag_id, dag_folder)
         dag_bag = models.DagBag(dag_folder=dag_folder, include_examples=False)
         dag = dag_bag.get_dag(dag_id)
@@ -135,4 +227,8 @@ class SystemTest(TestCase, LoggingMixin):
 
         self.log.info("Attempting to run DAG: %s", dag_id)
         dag.clear(reset_dag_runs=True)
-        dag.run(ignore_first_depends_on_past=True, verbose=True)
+        try:
+            dag.run(ignore_first_depends_on_past=True, verbose=True)
+        except Exception:
+            self._print_all_log_files()
+            raise


### PR DESCRIPTION
We will run system test on back-ported operators for 1.10* series of airflow
and for that we need to have support for running system tests using pytest's
markers and reading environment variables passed from HOST machine (to pass
credentials). 

This is the first step to automate system tests execution.

---
Issue link: [AIRFLOW-6763](https://issues.apache.org/jira/browse/AIRFLOW-6763)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
