### PR TITLE
[AIRFLOW-XXXX] Fix typo commiter => committer

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -907,7 +907,7 @@ Doc-only changes
 - [AIRFLOW-XXX] Reduce log spam in tests (#5174)
 - [AIRFLOW-XXX] Speed up tests for PythonSensor (#5158)
 - [AIRFLOW-XXX] Add Bas Harenslak to committer list (#5157)
-- [AIRFLOW-XXX] Add Jarek Potiuk to commiter list (#5132)
+- [AIRFLOW-XXX] Add Jarek Potiuk to committer list (#5132)
 - [AIRFLOW-XXX] Update docstring for SchedulerJob (#5105)
 - [AIRFLOW-XXX] Fix docstrings for CassandraToGoogleCloudStorageOperator (#5103)
 - [AIRFLOW-XXX] update SlackWebhookHook and SlackWebhookOperator docstring (#5074)


### PR DESCRIPTION
On the apache/airflow-site repo, we're trying to get rid of a typo that slipped through the codebase. Here is the related PR https://github.com/apache/airflow-site/pull/247#discussion_r376796844 .

Some of them come from a commit message in the CHANGELOG that should be tackled on this side.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
