### PR TITLE
[AIRFLOW-6766] Fix "cannot import ensure_text" error for pre-commit

### DIFF
--- a/scripts/ci/ci_before_install.sh
+++ b/scripts/ci/ci_before_install.sh
@@ -33,6 +33,7 @@ KUBERNETES_MODE=${KUBERNETES_MODE:=""}
 
 mkdir -p "${AIRFLOW_SOURCES}/files"
 
-sudo pip install pre-commit
+# We need to install six apparently
+sudo pip install pre-commit six==1.14.0
 
 script_end

--- a/scripts/ci/ci_before_install.sh
+++ b/scripts/ci/ci_before_install.sh
@@ -33,7 +33,7 @@ KUBERNETES_MODE=${KUBERNETES_MODE:=""}
 
 mkdir -p "${AIRFLOW_SOURCES}/files"
 
-# We need to install six apparently
+# We need newer version of six for Travis as they bundle 1.11.0 version
 sudo pip install pre-commit 'six~=1.14'
 
 script_end

--- a/scripts/ci/ci_before_install.sh
+++ b/scripts/ci/ci_before_install.sh
@@ -34,6 +34,6 @@ KUBERNETES_MODE=${KUBERNETES_MODE:=""}
 mkdir -p "${AIRFLOW_SOURCES}/files"
 
 # We need to install six apparently
-sudo pip install pre-commit six==1.14.0
+sudo pip install pre-commit 'six~=1.14'
 
 script_end


### PR DESCRIPTION
As of today Travis bundles six version 1.11.0 with their python
3.6 image and it misses ensure_text method. Bumping to 1.14.0
solves the problem.

---
Issue link: [AIRFLOW-6766](https://issues.apache.org/jira/browse/AIRFLOW-6766)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
