### PR TITLE
[AIRFLOW-6767] Correct name for default Athena workgroup

### DIFF
--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -54,7 +54,7 @@ class AWSAthenaHook(AwsHook):
         return self.conn
 
     def run_query(self, query, query_context, result_configuration, client_request_token=None,
-                  workgroup='default'):
+                  workgroup='primary'):
         """
         Run Presto query on athena with provided config and return submitted query_execution_id
 
@@ -66,7 +66,7 @@ class AWSAthenaHook(AwsHook):
         :type result_configuration: dict
         :param client_request_token: Unique token created by user to avoid multiple executions of same query
         :type client_request_token: str
-        :param workgroup: Athena workgroup name, when not specified, will be 'default'
+        :param workgroup: Athena workgroup name, when not specified, will be 'primary'
         :type workgroup: str
         :return: str
         """

--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -57,7 +57,7 @@ class AWSAthenaOperator(BaseOperator):
         output_location,
         aws_conn_id="aws_default",
         client_request_token=None,
-        workgroup="default",
+        workgroup="primary",
         query_execution_context=None,
         result_configuration=None,
         sleep_time=30,

--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -35,7 +35,7 @@ MOCK_DATA = {
     'database': 'TEST_DATABASE',
     'outputLocation': 's3://test_s3_bucket/',
     'client_request_token': 'eac427d0-1c6d-4dfb-96aa-2835d3ac6595',
-    'workgroup': 'default'
+    'workgroup': 'primary'
 }
 
 query_context = {


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6767](https://issues.apache.org/jira/browse/AIRFLOW-6767)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
