### PR TITLE
[AIRFLOW-5629] Implement K8s priorityClassName in KubernetesPo…

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -134,6 +134,8 @@ class PodGenerator:
     :type pod_template_file: Optional[str]
     :param extract_xcom: Whether to bring up a container for xcom
     :type extract_xcom: bool
+    :param priority_class_name: priority class name for the launched Pod
+    :type priority_class_name: str
     """
     def __init__(  # pylint: disable=too-many-arguments,too-many-locals
         self,
@@ -165,6 +167,7 @@ class PodGenerator:
         pod: Optional[k8s.V1Pod] = None,
         pod_template_file: Optional[str] = None,
         extract_xcom: bool = False,
+        priority_class_name: Optional[str] = None,
     ):
         self.validate_pod_generator_args(locals())
 
@@ -228,6 +231,7 @@ class PodGenerator:
         self.spec.volumes = volumes or []
         self.spec.node_selector = node_selectors
         self.spec.restart_policy = restart_policy
+        self.spec.priority_class_name = priority_class_name
 
         self.spec.image_pull_secrets = []
 

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -136,6 +136,8 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     :type do_xcom_push: bool
     :param pod_template_file: path to pod template file
     :type pod_template_file: str
+    :param priority_class_name: priority class name for the launched Pod
+    :type priority_class_name: str
     """
     template_fields = ('cmds', 'arguments', 'env_vars', 'config_file', 'pod_template_file')
 
@@ -177,6 +179,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  log_events_on_failure: bool = False,
                  do_xcom_push: bool = False,
                  pod_template_file: Optional[str] = None,
+                 priority_class_name: Optional[str] = None,
                  *args,
                  **kwargs):
         if kwargs.get('xcom_push') is not None:
@@ -218,6 +221,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.full_pod_spec = full_pod_spec
         self.init_containers = init_containers or []
         self.log_events_on_failure = log_events_on_failure
+        self.priority_class_name = priority_class_name
         self.pod_template_file = pod_template_file
         self.name = self._set_name(name)
 
@@ -263,8 +267,9 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                 schedulername=self.schedulername,
                 init_containers=self.init_containers,
                 restart_policy='Never',
+                priority_class_name=self.priority_class_name,
                 pod_template_file=self.pod_template_file,
-                pod=self.full_pod_spec
+                pod=self.full_pod_spec,
             ).gen_pod()
 
             pod = append_to_pod(

--- a/docs/howto/operator/kubernetes.rst
+++ b/docs/howto/operator/kubernetes.rst
@@ -152,4 +152,5 @@ Pods on Kubernetes. It works with any type of executor.
                               tolerations=tolerations,
                               configmaps=configmaps,
                               init_containers=[init_container],
+                              priority_class_name="medium",
                               )


### PR DESCRIPTION
…dOperator

Changes allow user to specify priority_class_name within KubernetesPodOperator
which sets the Pod.spec value to influence scheduling and preemption behaviour
of workloads generated by Airflow.

pre-commit hook issue with BREEZE.rst adding whitespace - Can't push without committing whitespace change.

---
Issue link: [AIRFLOW-5629](https://issues.apache.org/jira/browse/AIRFLOW-5629)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
