### PR TITLE
[AIRFLOW-6759] Added MLEngine operator/hook to cancel MLEngine jobs

### DIFF
--- a/airflow/providers/google/cloud/hooks/mlengine.py
+++ b/airflow/providers/google/cloud/hooks/mlengine.py
@@ -159,7 +159,7 @@ class MLEngineHook(CloudBaseHook):
         Cancels a MLEngine job.
 
         :param project_id: The Google Cloud project id within which MLEngine
-            job will be launched. If set to None or missing, the default project_id from the GCP
+            job will be cancelled. If set to None or missing, the default project_id from the GCP
             connection is used.
         :type project_id: str
         :param job_id: A unique id for the want-to-be cancelled Google MLEngine training job.

--- a/airflow/providers/google/cloud/hooks/mlengine.py
+++ b/airflow/providers/google/cloud/hooks/mlengine.py
@@ -176,7 +176,7 @@ class MLEngineHook(CloudBaseHook):
         hook = self.get_conn()
 
         request = hook.projects().jobs().cancel(  # pylint: disable=no-member
-            name='projects/{}/jobs/{}'.format(project_id, job_id))
+            name=f'projects/{project_id}/jobs/{job_id}')
 
         try:
             return request.execute()

--- a/airflow/providers/google/cloud/hooks/mlengine.py
+++ b/airflow/providers/google/cloud/hooks/mlengine.py
@@ -151,7 +151,7 @@ class MLEngineHook(CloudBaseHook):
     @CloudBaseHook.fallback_to_default_project_id
     def cancel_job(
         self,
-        job_id,
+        job_id: str,
         project_id: Optional[str] = None
     ) -> Dict:
 

--- a/airflow/providers/google/cloud/hooks/mlengine.py
+++ b/airflow/providers/google/cloud/hooks/mlengine.py
@@ -148,6 +148,51 @@ class MLEngineHook(CloudBaseHook):
 
         return self._wait_for_job_done(project_id, job_id)
 
+    @CloudBaseHook.fallback_to_default_project_id
+    def cancel_job(
+        self,
+        job_id,
+        project_id: Optional[str] = None
+    ) -> Dict:
+
+        """
+        Cancels a MLEngine job.
+
+        :param project_id: The Google Cloud project id within which MLEngine
+            job will be launched. If set to None or missing, the default project_id from the GCP
+            connection is used.
+        :type project_id: str
+        :param job_id: A unique id for the want-to-be cancelled Google MLEngine training job.
+        :type job_id: str
+
+        :return: Empty dict if cancelled successfully
+        :rtype: dict
+        :raises: googleapiclient.errors.HttpError
+        """
+
+        if not project_id:
+            raise ValueError("The project_id should be set")
+
+        hook = self.get_conn()
+
+        request = hook.projects().jobs().cancel(  # pylint: disable=no-member
+            name='projects/{}/jobs/{}'.format(project_id, job_id))
+
+        try:
+            return request.execute()
+        except HttpError as e:
+            if e.resp.status == 404:
+                self.log.error('Job with job_id %s does not exist. ', job_id)
+                raise
+            elif e.resp.status == 400:
+                self.log.info(
+                    'Job with job_id %s is already complete, cancellation aborted.',
+                    job_id)
+                return {}
+            else:
+                self.log.error('Failed to cancel MLEngine job: %s', e)
+                raise
+
     def _get_job(self, project_id: str, job_id: str) -> Dict:
         """
         Gets a MLEngine job based on the job id.

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1057,10 +1057,6 @@ class MLEngineTrainingJobFailureOperator(BaseOperator):
 
         if not self._project_id:
             raise AirflowException('Google Cloud project id is required.')
-        if not self._job_id:
-            raise AirflowException(
-                'An unique job id is required for Google MLEngine training '
-                'job.')
 
     def execute(self, context):
 

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1015,3 +1015,58 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         if finished_training_job['state'] != 'SUCCEEDED':
             self.log.error('MLEngine training job failed: %s', str(finished_training_job))
             raise RuntimeError(finished_training_job['errorMessage'])
+
+
+class MLEngineTrainingJobFailureOperator(BaseOperator):
+
+    """
+    Operator for cleaning up failed MLEngine training job.
+
+    :param job_id: A unique templated id for the submitted Google MLEngine
+        training job. (templated)
+    :type job_id: str
+    :param project_id: The Google Cloud project name within which MLEngine training job should run.
+        If set to None or missing, the default project_id from the GCP connection is used. (templated)
+    :type project_id: str
+    :param gcp_conn_id: The connection ID to use when fetching connection info.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+
+    template_fields = [
+        '_project_id',
+        '_job_id',
+    ]
+
+    @apply_defaults
+    def __init__(self,
+                 job_id: str,
+                 project_id: Optional[str] = None,
+                 gcp_conn_id: str = 'google_cloud_default',
+                 delegate_to: Optional[str] = None,
+                 *args,
+                 **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._project_id = project_id
+        self._job_id = job_id
+        self._gcp_conn_id = gcp_conn_id
+        self._delegate_to = delegate_to
+
+        if not self._project_id:
+            raise AirflowException('Google Cloud project id is required.')
+        if not self._job_id:
+            raise AirflowException(
+                'An unique job id is required for Google MLEngine training '
+                'job.')
+
+    def execute(self, context):
+
+        hook = MLEngineHook(
+            gcp_conn_id=self._gcp_conn_id,
+            delegate_to=self._delegate_to
+        )
+
+        hook.cancel_job(project_id=self._project_id, job_id=_normalize_mlengine_job_id(self._job_id))


### PR DESCRIPTION
Added `MLEngineTrainingJobFailureOperator` with `cancel_job` hook for MLEngine. 

---
Issue link: [AIRFLOW-6759](https://issues.apache.org/jira/browse/AIRFLOW-6759)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
