### PR TITLE
[AIRFLOW-6790] Add basic Tableau Integration

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -71,6 +71,7 @@ CONN_TYPE_TO_HOOK = {
     "presto": ("airflow.providers.presto.hooks.presto.PrestoHook", "presto_conn_id"),
     "redis": ("airflow.providers.redis.hooks.redis.RedisHook", "redis_conn_id"),
     "sqlite": ("airflow.providers.sqlite.hooks.sqlite.SqliteHook", "sqlite_conn_id"),
+    "tableau": ("airflow.providers.salesforce.hooks.tableau.TableauHook", "tableau_conn_id"),
     "vertica": ("airflow.providers.vertica.hooks.vertica.VerticaHook", "vertica_conn_id"),
     "wasb": ("airflow.providers.microsoft.azure.hooks.wasb.WasbHook", "wasb_conn_id"),
 }
@@ -159,6 +160,7 @@ class Connection(Base, LoggingMixin):
         ('grpc', 'GRPC Connection'),
         ('yandexcloud', 'Yandex Cloud'),
         ('livy', 'Apache Livy'),
+        ('tableau', 'Tableau'),
     ]
 
     def __init__(

--- a/airflow/providers/salesforce/example_dags/__init__.py
+++ b/airflow/providers/salesforce/example_dags/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/salesforce/example_dags/example_tableau_refresh_workbook.py
+++ b/airflow/providers/salesforce/example_dags/example_tableau_refresh_workbook.py
@@ -49,7 +49,6 @@ with DAG(
         workbook_name='MyWorkbook',
         blocking=True,
         task_id='refresh_tableau_workbook_blocking',
-        dag=dag
     )
     # Refreshes a workbook and does not wait until it succeeds.
     task_refresh_workbook_non_blocking = TableauRefreshWorkbookOperator(
@@ -57,13 +56,11 @@ with DAG(
         workbook_name='MyWorkbook',
         blocking=False,
         task_id='refresh_tableau_workbook_non_blocking',
-        dag=dag
     )
     # The following task queries the status of the workbook refresh job until it succeeds.
     task_check_job_status = TableauJobStatusSensor(
         site_id='my_site',
         job_id="{{ ti.xcom_pull(task_ids='refresh_tableau_workbook') }}",
         task_id='check_tableau_job_status',
-        dag=dag
     )
     task_refresh_workbook_non_blocking >> task_check_job_status

--- a/airflow/providers/salesforce/example_dags/example_tableau_refresh_workbook.py
+++ b/airflow/providers/salesforce/example_dags/example_tableau_refresh_workbook.py
@@ -60,7 +60,7 @@ with DAG(
     # The following task queries the status of the workbook refresh job until it succeeds.
     task_check_job_status = TableauJobStatusSensor(
         site_id='my_site',
-        job_id="{{ ti.xcom_pull(task_ids='refresh_tableau_workbook') }}",
+        job_id="{{ ti.xcom_pull(task_ids='refresh_tableau_workbook_non_blocking') }}",
         task_id='check_tableau_job_status',
     )
     task_refresh_workbook_non_blocking >> task_check_job_status

--- a/airflow/providers/salesforce/example_dags/example_tableau_refresh_workbook.py
+++ b/airflow/providers/salesforce/example_dags/example_tableau_refresh_workbook.py
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This is an example dag that performs two refresh operations on a Tableau Workbook aka Extract. The first one
+waits until it succeeds. The second does not wait since this is an asynchronous operation and we don't know
+when the operation actually finishes. That's why we have another task that checks only that.
+"""
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.providers.salesforce.operators.tableau_refresh_workbook import TableauRefreshWorkbookOperator
+from airflow.providers.salesforce.sensors.tableau_job_status import TableauJobStatusSensor
+from airflow.utils.dates import days_ago
+
+DEFAULT_ARGS = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': days_ago(2),
+    'email': ['airflow@example.com'],
+    'email_on_failure': False,
+    'email_on_retry': False
+}
+
+with DAG(
+    dag_id='example_tableau_refresh_workbook',
+    default_args=DEFAULT_ARGS,
+    dagrun_timeout=timedelta(hours=2),
+    schedule_interval=None,
+    tags=['example'],
+) as dag:
+    # Refreshes a workbook and waits until it succeeds.
+    task_refresh_workbook_blocking = TableauRefreshWorkbookOperator(
+        site_id='my_site',
+        workbook_name='MyWorkbook',
+        blocking=True,
+        task_id='refresh_tableau_workbook_blocking',
+        dag=dag
+    )
+    # Refreshes a workbook and does not wait until it succeeds.
+    task_refresh_workbook_non_blocking = TableauRefreshWorkbookOperator(
+        site_id='my_site',
+        workbook_name='MyWorkbook',
+        blocking=False,
+        task_id='refresh_tableau_workbook_non_blocking',
+        dag=dag
+    )
+    # The following task queries the status of the workbook refresh job until it succeeds.
+    task_check_job_status = TableauJobStatusSensor(
+        site_id='my_site',
+        job_id="{{ ti.xcom_pull(task_ids='refresh_tableau_workbook') }}",
+        task_id='check_tableau_job_status',
+        dag=dag
+    )
+    task_refresh_workbook_non_blocking >> task_check_job_status

--- a/airflow/providers/salesforce/hooks/tableau.py
+++ b/airflow/providers/salesforce/hooks/tableau.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from enum import Enum
+from typing import Optional
+
+from tableauserverclient import Pager, PersonalAccessTokenAuth, Server, TableauAuth
+from tableauserverclient.server import Auth
+
+from airflow.hooks.base_hook import BaseHook
+
+
+class TableauJobFinishCode(Enum):
+    """
+    The finish code indicates the status of the job.
+
+    .. seealso:: https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#query_job
+
+    """
+    PENDING = -1
+    SUCCESS = 0
+    ERROR = 1
+    CANCELED = 2
+
+
+class TableauHook(BaseHook):
+    """
+    Connects to the Tableau Server Instance and allows to communicate with it.
+
+    .. seealso:: https://tableau.github.io/server-client-python/docs/
+
+    :param site_id: The id of the site where the workbook belongs to.
+        It will connect to the default site if you don't provide an id.
+    :type site_id: Optional[str]
+    :param tableau_conn_id: The Tableau Connection id containing the credentials
+        to authenticate to the Tableau Server.
+    :type tableau_conn_id: str
+    """
+
+    def __init__(self, site_id: Optional[str] = None, tableau_conn_id: str = 'tableau_default'):
+        self.tableau_conn_id = tableau_conn_id
+        self.conn = self.get_connection(self.tableau_conn_id)
+        self.site_id = site_id or self.conn.extra_dejson.get('site_id', '')
+        self.server = Server(self.conn.host, use_server_version=True)
+        self.tableau_conn = None
+
+    def __enter__(self):
+        if not self.tableau_conn:
+            self.tableau_conn = self.get_conn()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.server.auth.sign_out()
+
+    def get_conn(self) -> Auth.contextmgr:
+        """
+        Signs in to the Tableau Server and automatically signs out if used as ContextManager.
+
+        :return: an authorized Tableau Server Context Manager object.
+        :rtype: tableauserverclient.server.Auth.contextmgr
+        """
+        if self.conn.login and self.conn.password:
+            return self._auth_via_password()
+        if 'token_name' in self.conn.extra_dejson and 'personal_access_token' in self.conn.extra_dejson:
+            return self._auth_via_token()
+        raise NotImplementedError('No Authentication method found for given Credentials!')
+
+    def _auth_via_password(self) -> Auth.contextmgr:
+        tableau_auth = TableauAuth(
+            username=self.conn.login,
+            password=self.conn.password,
+            site_id=self.site_id
+        )
+        return self.server.auth.sign_in(tableau_auth)
+
+    def _auth_via_token(self) -> Auth.contextmgr:
+        tableau_auth = PersonalAccessTokenAuth(
+            token_name=self.conn.extra_dejson['token_name'],
+            personal_access_token=self.conn.extra_dejson['personal_access_token'],
+            site_id=self.site_id
+        )
+        return self.server.auth.sign_in_with_personal_access_token(tableau_auth)
+
+    def get_all(self, resource_name: str) -> Pager:
+        """
+        Get all items of the given resource.
+
+        .. seealso:: https://tableau.github.io/server-client-python/docs/page-through-results
+
+        :param resource_name: The name of the resource to paginate.
+            For example: jobs or workbooks
+        :type resource_name: str
+        :return: all items by returning a Pager.
+        :rtype: tableauserverclient.Pager
+        """
+        resource = getattr(self.server, resource_name)
+        return Pager(resource.get)

--- a/airflow/providers/salesforce/operators/__init__.py
+++ b/airflow/providers/salesforce/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/salesforce/operators/tableau_refresh_workbook.py
+++ b/airflow/providers/salesforce/operators/tableau_refresh_workbook.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Optional
+
+from tableauserverclient import WorkbookItem
+
+from airflow import AirflowException
+from airflow.models import BaseOperator
+from airflow.providers.salesforce.hooks.tableau import TableauHook
+from airflow.utils.decorators import apply_defaults
+
+
+class TableauRefreshWorkbookOperator(BaseOperator):
+    """
+    Refreshes a Tableau Workbook/Extract
+
+    .. seealso:: https://tableau.github.io/server-client-python/docs/api-ref#workbooks
+
+    :param workbook_name: The name of the workbook to refresh.
+    :type workbook_name: str
+    :param site_id: The id of the site where the workbook belongs to.
+    :type site_id: Optional[str]
+    :param blocking: By default the extract refresh will be blocking means it will wait until it has finished.
+    :type blocking: bool
+    :param tableau_conn_id: The Tableau Connection id containing the credentials
+        to authenticate to the Tableau Server.
+    :type tableau_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(self,
+                 workbook_name: str,
+                 site_id: Optional[str] = None,
+                 blocking: bool = True,
+                 tableau_conn_id: str = 'tableau_default',
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.workbook_name = workbook_name
+        self.site_id = site_id
+        self.blocking = blocking
+        self.tableau_conn_id = tableau_conn_id
+
+    def execute(self, context: dict) -> str:
+        """
+        Executes the Tableau Extract Refresh and pushes the job id to xcom.
+
+        :param context: The task context during execution.
+        :type context: dict
+        :return: the id of the job that executes the extract refresh
+        :rtype: str
+        """
+        with TableauHook(self.site_id, self.tableau_conn_id) as tableau_hook:
+            workbook = self._get_workbook_by_name(tableau_hook)
+
+            job_id = self._refresh_workbook(tableau_hook, workbook.id)
+            if self.blocking:
+                from airflow.providers.salesforce.sensors.tableau_job_status import TableauJobStatusSensor
+                TableauJobStatusSensor(
+                    job_id=job_id,
+                    site_id=self.site_id,
+                    tableau_conn_id=self.tableau_conn_id,
+                    task_id='wait_until_succeeded',
+                    dag=None
+                ).execute(context={})
+                self.log.info('Workbook %s has been successfully refreshed.', self.workbook_name)
+            return job_id
+
+    def _get_workbook_by_name(self, tableau_hook: TableauHook) -> WorkbookItem:
+        for workbook in tableau_hook.get_all(resource_name='workbooks'):
+            if workbook.name == self.workbook_name:
+                self.log.info('Found matching workbook with id %s', workbook.id)
+                return workbook
+
+        raise AirflowException(f'Workbook {self.workbook_name} not found!')
+
+    def _refresh_workbook(self, tableau_hook: TableauHook, workbook_id: str) -> str:
+        job = tableau_hook.server.workbooks.refresh(workbook_id)
+        self.log.info('Refreshing Workbook %s...', self.workbook_name)
+        return job.id

--- a/airflow/providers/salesforce/sensors/__init__.py
+++ b/airflow/providers/salesforce/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/salesforce/sensors/tableau_job_status.py
+++ b/airflow/providers/salesforce/sensors/tableau_job_status.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Optional
+
+from airflow import AirflowException
+from airflow.providers.salesforce.hooks.tableau import TableauHook, TableauJobFinishCode
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class TableauJobFailedException(AirflowException):
+    """
+    An exception that indicates that a Job failed to complete.
+    """
+
+
+class TableauJobStatusSensor(BaseSensorOperator):
+    """
+    Watches the status of a Tableau Server Job.
+
+    .. seealso:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
+
+    :param job_id: The job to watch.
+    :type job_id: str
+    :param site_id: The id of the site where the workbook belongs to.
+    :type site_id: Optional[str]
+    :param tableau_conn_id: The Tableau Connection id containing the credentials
+        to authenticate to the Tableau Server.
+    :type tableau_conn_id: str
+    """
+
+    template_fields = ('job_id',)
+
+    @apply_defaults
+    def __init__(self,
+                 job_id: str,
+                 site_id: Optional[str] = None,
+                 tableau_conn_id: str = 'tableau_default',
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tableau_conn_id = tableau_conn_id
+        self.job_id = job_id
+        self.site_id = site_id
+
+    def poke(self, context: dict) -> bool:
+        """
+        Pokes until the job has successfully finished.
+
+        :param context: The task context during execution.
+        :type context: dict
+        :return: True if it succeeded and False if not.
+        :rtype: bool
+        """
+        with TableauHook(self.site_id, self.tableau_conn_id) as tableau_hook:
+            finish_code = TableauJobFinishCode(
+                int(tableau_hook.server.jobs.get_by_id(self.job_id).finish_code)
+            )
+            self.log.info('Current finishCode is %s (%s)', finish_code.name, finish_code.value)
+            if finish_code in [TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED]:
+                raise TableauJobFailedException('The Tableau Refresh Workbook Job failed!')
+            return finish_code == TableauJobFinishCode.SUCCESS

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -449,6 +449,17 @@ def create_default_connections(session=None):
     )
     merge_conn(
         Connection(
+            conn_id="tableau_default",
+            conn_type="tableau",
+            host="https://tableau.server.url",
+            login="user",
+            password="password",
+            extra='{"site_id": "my_site"}',
+        ),
+        session
+    )
+    merge_conn(
+        Connection(
             conn_id="vertica_default",
             conn_type="vertica",
             host="localhost",

--- a/docs/autoapi_templates/index.rst
+++ b/docs/autoapi_templates/index.rst
@@ -164,6 +164,10 @@ All operators are in the following packages:
 
   airflow/providers/redis/sensors/index
 
+  airflow/providers/salesforce/operators/index
+
+  airflow/providers/salesforce/sensors/index
+
   airflow/providers/segment/operators/index
 
   airflow/providers/sftp/operators/index

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -1013,9 +1013,10 @@ These integrations allow you to perform various operations within various servic
 
    * - `Salesforce <https://www.salesforce.com/>`__
      -
-     - :mod:`airflow.providers.salesforce.hooks.salesforce`
-     -
-     -
+     - :mod:`airflow.providers.salesforce.hooks.salesforce`,
+       :mod:`airflow.providers.salesforce.hooks.tableau`
+     - :mod:`airflow.providers.salesforce.operators.tableau_refresh_workbook`
+     - :mod:`airflow.providers.salesforce.sensors.tableau_job_status`
 
    * - `Segment <https://oapi.dingtalk.com>`__
      -

--- a/setup.py
+++ b/setup.py
@@ -351,6 +351,9 @@ ssh = [
 statsd = [
     'statsd>=3.3.0, <4.0',
 ]
+tableau = [
+    'tableauserverclient==0.9',
+]
 vertica = [
     'vertica-python>=0.5.1',
 ]
@@ -418,11 +421,11 @@ else:
 
 devel_minreq = cgroups + devel + doc + kubernetes + mysql + password
 devel_hadoop = devel_minreq + hdfs + hive + kerberos + presto + webhdfs
-devel_all = (all_dbs + atlas + aws + azure + celery + cgroups + datadog + devel +
-             doc + docker + druid + elasticsearch + gcp + grpc + jdbc + jenkins +
-             kerberos + kubernetes + ldap + odbc + oracle + pagerduty + papermill +
-             password + pinot + redis + salesforce + samba + segment + sendgrid +
-             sentry + slack + snowflake + ssh + statsd + virtualenv + webhdfs + yandexcloud + zendesk)
+devel_all = (all_dbs + atlas + aws + azure + celery + cgroups + datadog + devel + doc + docker + druid +
+             elasticsearch + gcp + grpc + jdbc + jenkins + kerberos + kubernetes + ldap + odbc + oracle +
+             pagerduty + papermill + password + pinot + redis + salesforce + samba + segment + sendgrid +
+             sentry + slack + snowflake + ssh + statsd + tableau + virtualenv + webhdfs + yandexcloud +
+             zendesk)
 
 # Snakebite are not Python 3 compatible :'(
 if PY3:
@@ -567,6 +570,7 @@ def do_setup():
             'snowflake': snowflake,
             'ssh': ssh,
             'statsd': statsd,
+            'tableau': tableau,
             'vertica': vertica,
             'webhdfs': webhdfs,
             'winrm': winrm,

--- a/tests/providers/salesforce/hooks/test_tableau.py
+++ b/tests/providers/salesforce/hooks/test_tableau.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import patch
+
+from airflow import configuration, models
+from airflow.providers.salesforce.hooks.tableau import TableauHook
+from airflow.utils import db
+
+
+class TestTableauHook(unittest.TestCase):
+
+    def setUp(self):
+        configuration.conf.load_test_config()
+
+        db.merge_conn(
+            models.Connection(
+                conn_id='tableau_test_password',
+                conn_type='tableau',
+                host='tableau',
+                login='user',
+                password='password',
+                extra='{"site_id": "my_site"}'
+            )
+        )
+        db.merge_conn(
+            models.Connection(
+                conn_id='tableau_test_token',
+                conn_type='tableau',
+                host='tableau',
+                extra='{"token_name": "my_token", "personal_access_token": "my_personal_access_token"}'
+            )
+        )
+
+    @patch('airflow.providers.salesforce.hooks.tableau.TableauAuth')
+    @patch('airflow.providers.salesforce.hooks.tableau.Server')
+    def test_get_conn_auth_via_password_and_site_in_connection(self, mock_server, mock_tableau_auth):
+        with TableauHook(tableau_conn_id='tableau_test_password') as tableau_hook:
+            mock_server.assert_called_once_with(tableau_hook.conn.host, use_server_version=True)
+            mock_tableau_auth.assert_called_once_with(
+                username=tableau_hook.conn.login,
+                password=tableau_hook.conn.password,
+                site_id=tableau_hook.conn.extra_dejson['site_id']
+            )
+            mock_server.return_value.auth.sign_in.assert_called_once_with(
+                mock_tableau_auth.return_value
+            )
+        mock_server.return_value.auth.sign_out.assert_called_once_with()
+
+    @patch('airflow.providers.salesforce.hooks.tableau.PersonalAccessTokenAuth')
+    @patch('airflow.providers.salesforce.hooks.tableau.Server')
+    def test_get_conn_auth_via_token_and_site_in_init(self, mock_server, mock_tableau_auth):
+        with TableauHook(site_id='test', tableau_conn_id='tableau_test_token') as tableau_hook:
+            mock_server.assert_called_once_with(tableau_hook.conn.host, use_server_version=True)
+            mock_tableau_auth.assert_called_once_with(
+                token_name=tableau_hook.conn.extra_dejson['token_name'],
+                personal_access_token=tableau_hook.conn.extra_dejson['personal_access_token'],
+                site_id=tableau_hook.site_id
+            )
+            mock_server.return_value.auth.sign_in_with_personal_access_token.assert_called_once_with(
+                mock_tableau_auth.return_value
+            )
+        mock_server.return_value.auth.sign_out.assert_called_once_with()
+
+    @patch('airflow.providers.salesforce.hooks.tableau.TableauAuth')
+    @patch('airflow.providers.salesforce.hooks.tableau.Server')
+    @patch('airflow.providers.salesforce.hooks.tableau.Pager', return_value=[1, 2, 3])
+    def test_get_all(
+        self,
+        mock_pager,
+        mock_server,
+        mock_tableau_auth  # pylint: disable=unused-argument
+    ):
+        with TableauHook(tableau_conn_id='tableau_test_password') as tableau_hook:
+            jobs = tableau_hook.get_all(resource_name='jobs')
+            self.assertEqual(jobs, mock_pager.return_value)
+
+        mock_pager.assert_called_once_with(mock_server.return_value.jobs.get)

--- a/tests/providers/salesforce/operators/__init__.py
+++ b/tests/providers/salesforce/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/salesforce/operators/test_tableau_refresh_workbook.py
+++ b/tests/providers/salesforce/operators/test_tableau_refresh_workbook.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock, patch
+
+from airflow import AirflowException
+from airflow.providers.salesforce.operators.tableau_refresh_workbook import TableauRefreshWorkbookOperator
+
+
+class TestTableauRefreshWorkbookOperator(unittest.TestCase):
+
+    def setUp(self):
+        self.mocked_workbooks = []
+        for i in range(3):
+            mock_workbook = Mock()
+            mock_workbook.id = i
+            mock_workbook.name = f'wb_{i}'
+            self.mocked_workbooks.append(mock_workbook)
+        self.kwargs = {
+            'site_id': 'test_site',
+            'task_id': 'task',
+            'dag': None
+        }
+
+    @patch('airflow.providers.salesforce.operators.tableau_refresh_workbook.TableauHook')
+    def test_execute(self, mock_tableau_hook):
+        mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauRefreshWorkbookOperator(blocking=False, workbook_name='wb_2', **self.kwargs)
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
+        self.assertEqual(mock_tableau_hook.server.workbooks.refresh.return_value.id, job_id)
+
+    @patch('airflow.providers.salesforce.sensors.tableau_job_status.TableauJobStatusSensor')
+    @patch('airflow.providers.salesforce.operators.tableau_refresh_workbook.TableauHook')
+    def test_execute_blocking(self, mock_tableau_hook, mock_tableau_job_status_sensor):
+        mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauRefreshWorkbookOperator(workbook_name='wb_2', **self.kwargs)
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
+        self.assertEqual(mock_tableau_hook.server.workbooks.refresh.return_value.id, job_id)
+        mock_tableau_job_status_sensor.assert_called_once_with(
+            job_id=job_id,
+            site_id=self.kwargs['site_id'],
+            tableau_conn_id='tableau_default',
+            task_id='wait_until_succeeded',
+            dag=None
+        )
+
+    @patch('airflow.providers.salesforce.operators.tableau_refresh_workbook.TableauHook')
+    def test_execute_missing_workbook(self, mock_tableau_hook):
+        mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauRefreshWorkbookOperator(workbook_name='test', **self.kwargs)
+
+        self.assertRaises(AirflowException, operator.execute, {})

--- a/tests/providers/salesforce/sensors/__init__.py
+++ b/tests/providers/salesforce/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/salesforce/sensors/test_tableau_job_status.py
+++ b/tests/providers/salesforce/sensors/test_tableau_job_status.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock, patch
+
+from parameterized import parameterized
+
+from airflow.providers.salesforce.sensors.tableau_job_status import (
+    TableauJobFailedException, TableauJobStatusSensor,
+)
+
+
+class TestTableauJobStatusSensor(unittest.TestCase):
+
+    def setUp(self):
+        self.kwargs = {
+            'job_id': 'job_2',
+            'site_id': 'test_site',
+            'task_id': 'task',
+            'dag': None
+        }
+
+    @patch('airflow.providers.salesforce.sensors.tableau_job_status.TableauHook')
+    def test_poke(self, mock_tableau_hook):
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        mock_get = mock_tableau_hook.server.jobs.get_by_id
+        mock_get.return_value.finish_code = '0'
+        sensor = TableauJobStatusSensor(**self.kwargs)
+
+        job_finished = sensor.poke(context={})
+
+        self.assertTrue(job_finished)
+        mock_get.assert_called_once_with(sensor.job_id)
+
+    @parameterized.expand([('1',), ('2',)])
+    @patch('airflow.providers.salesforce.sensors.tableau_job_status.TableauHook')
+    def test_poke_failed(self, finish_code, mock_tableau_hook):
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        mock_get = mock_tableau_hook.server.jobs.get_by_id
+        mock_get.return_value.finish_code = finish_code
+        sensor = TableauJobStatusSensor(**self.kwargs)
+
+        self.assertRaises(TableauJobFailedException, sensor.poke, {})
+        mock_get.assert_called_once_with(sensor.job_id)


### PR DESCRIPTION
This PR adds a **TableauHook** which wraps the tableauserverclient python library in an AirflowHook to connect to a Tableau Server. It also contains a **TableauRefreshWorkbookOperator** which refreshes a Tableau workbook / extract and a **TableauJobStatusSensor** which pokes the status of a Tableau Job until it has finished.

---
Issue link: [AIRFLOW-6790](https://issues.apache.org/jira/browse/AIRFLOW-6790)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
