### PR TITLE
[AIRFLOW-6793] Respect env variable in airflow config command

### DIFF
--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 broker_url = conf.get('celery', 'BROKER_URL')
 
-broker_transport_options: Dict[str, Union[str, int]] = conf.getsection(
+broker_transport_options = conf.getsection(
     'celery_broker_transport_options'
 )
 if 'visibility_timeout' not in broker_transport_options:

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -18,7 +18,6 @@
 """Default celery configuration."""
 import logging
 import ssl
-from typing import Dict, Union
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, AirflowException
@@ -32,9 +31,7 @@ log = logging.getLogger(__name__)
 
 broker_url = conf.get('celery', 'BROKER_URL')
 
-broker_transport_options = conf.getsection(
-    'celery_broker_transport_options'
-)
+broker_transport_options = conf.getsection('celery_broker_transport_options') or {}
 if 'visibility_timeout' not in broker_transport_options:
     if _broker_supports_visibility_timeout(broker_url):
         broker_transport_options['visibility_timeout'] = 21600

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -18,6 +18,7 @@
 """Default celery configuration."""
 import logging
 import ssl
+from typing import Dict, Union
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, AirflowException
@@ -31,7 +32,7 @@ log = logging.getLogger(__name__)
 
 broker_url = conf.get('celery', 'BROKER_URL')
 
-broker_transport_options = conf.getsection(
+broker_transport_options: Dict[str, Union[str, int]] = conf.getsection(
     'celery_broker_transport_options'
 )
 if 'visibility_timeout' not in broker_transport_options:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -28,7 +28,7 @@ from base64 import b64encode
 from collections import OrderedDict
 # Ignored Mypy on configparser because it thinks the configparser module has no _UNSET attribute
 from configparser import _UNSET, ConfigParser, NoOptionError, NoSectionError  # type: ignore
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union
 
 import yaml
 from cryptography.fernet import Fernet
@@ -335,7 +335,7 @@ class AirflowConfigParser(ConfigParser):
         if self.airflow_defaults.has_option(section, option) and remove_default:
             self.airflow_defaults.remove_option(section, option)
 
-    def getsection(self, section: str) -> Optional[Dict[str, str]]:
+    def getsection(self, section: str) -> Optional[Dict[str, Union[str, int, float, bool]]]:
         """
         Returns the section as a dict. Values are converted to int, float, bool
         as required.

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -354,7 +354,10 @@ class AirflowConfigParser(ConfigParser):
         section_prefix = 'AIRFLOW__{S}__'.format(S=section.upper())
         for env_var in sorted(os.environ.keys()):
             if env_var.startswith(section_prefix):
-                key = env_var.replace(section_prefix, '').lower()
+                key = env_var.replace(section_prefix, '')
+                if key.endswith("_CMD"):
+                    key = key[:-4]
+                key = key.lower()
                 _section[key] = self._get_env_var_option(section, key)
 
         for key, val in _section.items():  # type: ignore
@@ -372,14 +375,8 @@ class AirflowConfigParser(ConfigParser):
         return _section
 
     def write(self, fp, space_around_delimiters=True):
-        """Write an .ini-format representation of the configuration state.
-
-        If `space_around_delimiters' is True (the default), delimiters
-        between keys and values are surrounded by spaces.
-
-        This is based on the configparsser.RawConfigParser.write method code to add support for
-        reading options from environment variables.
-        """
+        # This is based on the configparser.RawConfigParser.write method code to add support for
+        # reading options from environment variables.
         if space_around_delimiters:
             d = " {} ".format(self._delimiters[0])  # type: ignore
         else:
@@ -387,9 +384,7 @@ class AirflowConfigParser(ConfigParser):
         if self._defaults:
             self._write_section(fp, self.default_section, self._defaults.items(), d)  # type: ignore
         for section in self._sections:
-            self._write_section(  # type: ignore
-                fp, section, self.getsection(section).items(), d
-            )
+            self._write_section(fp, section, self.getsection(section).items(), d)  # type: ignore
 
     def as_dict(
             self, display_source=False, display_sensitive=False, raw=False,

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -28,7 +28,7 @@ from base64 import b64encode
 from collections import OrderedDict
 # Ignored Mypy on configparser because it thinks the configparser module has no _UNSET attribute
 from configparser import _UNSET, ConfigParser, NoOptionError, NoSectionError  # type: ignore
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 import yaml
 from cryptography.fernet import Fernet
@@ -335,7 +335,7 @@ class AirflowConfigParser(ConfigParser):
         if self.airflow_defaults.has_option(section, option) and remove_default:
             self.airflow_defaults.remove_option(section, option)
 
-    def getsection(self, section):
+    def getsection(self, section: str) -> Optional[Dict[str, str]]:
         """
         Returns the section as a dict. Values are converted to int, float, bool
         as required.
@@ -343,14 +343,13 @@ class AirflowConfigParser(ConfigParser):
         :param section: section from the config
         :rtype: dict
         """
-        if (section not in self._sections and
-                section not in self.airflow_defaults._sections):
+        if (section not in self._sections and section not in self.airflow_defaults._sections):  # type: ignore
             return None
 
-        _section = copy.deepcopy(self.airflow_defaults._sections[section])
+        _section = copy.deepcopy(self.airflow_defaults._sections[section])  # type: ignore
 
-        if section in self._sections:
-            _section.update(copy.deepcopy(self._sections[section]))
+        if section in self._sections:  # type: ignore
+            _section.update(copy.deepcopy(self._sections[section]))  # type: ignore
 
         section_prefix = 'AIRFLOW__{S}__'.format(S=section.upper())
         for env_var in sorted(os.environ.keys()):
@@ -358,7 +357,7 @@ class AirflowConfigParser(ConfigParser):
                 key = env_var.replace(section_prefix, '').lower()
                 _section[key] = self._get_env_var_option(section, key)
 
-        for key, val in _section.items():
+        for key, val in _section.items():  # type: ignore
             try:
                 val = int(val)
             except ValueError:
@@ -371,6 +370,26 @@ class AirflowConfigParser(ConfigParser):
                         val = False
             _section[key] = val
         return _section
+
+    def write(self, fp, space_around_delimiters=True):
+        """Write an .ini-format representation of the configuration state.
+
+        If `space_around_delimiters' is True (the default), delimiters
+        between keys and values are surrounded by spaces.
+
+        This is based on the configparsser.RawConfigParser.write method code to add support for
+        reading options from environment variables.
+        """
+        if space_around_delimiters:
+            d = " {} ".format(self._delimiters[0])  # type: ignore
+        else:
+            d = self._delimiters[0]  # type: ignore
+        if self._defaults:
+            self._write_section(fp, self.default_section, self._defaults.items(), d)  # type: ignore
+        for section in self._sections:
+            self._write_section(  # type: ignore
+                fp, section, self.getsection(section).items(), d
+            )
 
     def as_dict(
             self, display_source=False, display_sensitive=False, raw=False,

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -43,10 +43,3 @@ class TestCliConfig(unittest.TestCase):
             config_command.show_config(self.parser.parse_args(['config']))
         self.assertIn('[core]', temp_stdout.getvalue())
         self.assertIn('testkey = test_value', temp_stdout.getvalue())
-
-    @mock.patch.dict("os.environ", {"AIRFLOW__CORE__DAGS_FOLDER": "/tmp/test_folder"})
-    def test_cli_show_config_should_respect_env_variable(self):
-        with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
-            config_command.show_config(self.parser.parse_args(['config']))
-        self.assertIn('[core]', temp_stdout.getvalue())
-        self.assertIn('dags_folder = /tmp/test_folder', temp_stdout.getvalue())

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -43,3 +43,10 @@ class TestCliConfig(unittest.TestCase):
             config_command.show_config(self.parser.parse_args(['config']))
         self.assertIn('[core]', temp_stdout.getvalue())
         self.assertIn('testkey = test_value', temp_stdout.getvalue())
+
+    @mock.patch.dict("os.environ", {"AIRFLOW__CORE__DAGS_FOLDER": "/tmp/test_folder"})
+    def test_cli_show_config_should_respect_env_variable(self):
+        with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+            config_command.show_config(self.parser.parse_args(['config']))
+        self.assertIn('[core]', temp_stdout.getvalue())
+        self.assertIn('dags_folder = /tmp/test_folder', temp_stdout.getvalue())

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import io
 import os
 import unittest
 import warnings
@@ -534,6 +534,13 @@ notacommand = OK
             fernet_key = conf.get('core', 'FERNET_KEY')
 
         self.assertEqual(value, fernet_key)
+
+    @mock.patch.dict("os.environ", {"AIRFLOW__CORE__DAGS_FOLDER": "/tmp/test_folder"})
+    def test_write_should_respect_env_variable(self):
+        with io.StringIO() as string_file:
+            conf.write(string_file)
+            content = string_file.getvalue()
+        self.assertIn("dags_folder = /tmp/test_folder", content)
 
     def test_run_command(self):
         write = r'sys.stdout.buffer.write("\u1000foo".encode("utf8"))'


### PR DESCRIPTION
`airflow config` command always returns a value from a file. It does not read information from environment variables.

This bug was introduced by https://github.com/apache/airflow/pull/7117/files

CC: @anitakar 

---
Issue link: [AIRFLOW-6793](https://issues.apache.org/jira/browse/AIRFLOW-6793)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
