### PR TITLE
[AIRFLOW-6802] honor dag.max_active_run in scheduler

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -635,7 +635,7 @@ class DagFileProcessor(LoggingMixin):
 
         # update the state of the previously active dag runs
         dag_runs = DagRun.find(dag_id=dag.dag_id, state=State.RUNNING, session=session)
-        active_dag_runs = []
+        active_dag_runs = 0
         for run in dag_runs:
             self.log.info("Examining DAG run %s", run)
             # don't consider runs that are executed in the future unless
@@ -647,7 +647,7 @@ class DagFileProcessor(LoggingMixin):
                 )
                 continue
 
-            if len(active_dag_runs) >= dag.max_active_runs:
+            if active_dag_runs >= dag.max_active_runs:
                 self.log.info("Number of active dag runs reached max_active_run.")
                 break
 
@@ -661,6 +661,7 @@ class DagFileProcessor(LoggingMixin):
             run.verify_integrity(session=session)
             ready_tis = run.update_state(session=session)
             if run.state == State.RUNNING:
+                active_dag_runs += 1
                 self.log.debug("Examining active DAG run: %s", run)
                 for ti in ready_tis:
                     self.log.debug('Queuing task: %s', ti)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -740,7 +740,10 @@ class TestDagFileProcessor(unittest.TestCase):
         dag.clear()
 
         # First create up to 3 dagruns in RUNNING state.
-        dag_file_processor.create_dag_run(dag)
+        assert dag_file_processor.create_dag_run(dag) is not None
+        assert dag_file_processor.create_dag_run(dag) is not None
+        assert dag_file_processor.create_dag_run(dag) is not None
+        assert len(DagRun.find(dag_id=dag.dag_id, state=State.RUNNING, session=session)) == 3
 
         # Reduce max_active_runs to 1
         dag.max_active_runs = 1


### PR DESCRIPTION
commit 50efda5c69c1ddfaa869b408540182fb19f1a286 introduced a bug that
prevents the scheduler from enforcing max active run config for all
DAGs.

this commit fixes the regression as well as the test.

---
Issue link: [AIRFLOW-6802](https://issues.apache.org/jira/browse/AIRFLOW-6802)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
