### PR TITLE
[AIRFLOW-3126] Add option to specify additional K8s volumes

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1853,6 +1853,22 @@
       type: string
       example: ~
       default: ""
+    - name: extra_volume_mounts
+      description: |
+        Extra volumes to be mounted in worker pods.  Volumes are specified as
+        keys in a JSON object with nested JSON values specifying each volume's
+        options.  Recognized options are `claim_name` or `secret_name`
+        (required), `mount_path` (required), `read_only` (boolean, default
+        null), `sub_path` (default null), `secret_key` (string, default null),
+        `secret_mode` (string, default null).
+      version_added: ~
+      type: string
+      example: >-
+        "{{\"secret_vol\": {{\"secret_name\": \"some-secret\",
+        \"mount_path\": \"/dir1\", \"sub_path\": \"subpath1\",
+        \"secret_mode\": \"440\"}},
+        \"pvc\": {{\"claim_name\": \"some-pvc\", \"mount_path\": \"/dir2\"}}}}"
+      default: ""
     - name: dags_volume_host
       description: |
         For DAGs mounted via a hostPath volume (mutually exclusive with volume claim and git-sync)

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -881,6 +881,15 @@ logs_volume_subpath =
 # A shared volume claim for the logs
 logs_volume_claim =
 
+# Extra volumes to be mounted in worker pods.  Volumes are specified as
+# keys in a JSON object with nested JSON values specifying each volume's
+# options.  Recognized options are `claim_name` or `secret_name`
+# (required), `mount_path` (required), `read_only` (boolean, default
+# null), `sub_path` (default null), `secret_key` (string, default null),
+# `secret_mode` (string, default null).
+# Example: extra_volume_mounts = "{{{{\"secret_vol\": {{{{\"secret_name\": \"some-secret\", \"mount_path\": \"/dir1\", \"sub_path\": \"subpath1\", \"secret_mode\": \"440\"}}}}, \"pvc\": {{{{\"claim_name\": \"some-pvc\", \"mount_path\": \"/dir2\"}}}}}}}}"
+extra_volume_mounts =
+
 # For DAGs mounted via a hostPath volume (mutually exclusive with volume claim and git-sync)
 # Useful in local environment, discouraged in production
 dags_volume_host =

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -22,6 +22,7 @@ import json
 import multiprocessing
 import re
 import time
+from json import JSONDecodeError
 from queue import Empty, Queue  # pylint: disable=unused-import
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -154,6 +155,9 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
         self.dags_volume_subpath = conf.get(
             self.kubernetes_section, 'dags_volume_subpath')
 
+        # This prop may optionally be set for the addition of extra volume mounts
+        self.extra_volume_mounts = self._parse_extra_volume_mounts()
+
         # This prop may optionally be set for PV Claims and is used to locate logs
         # on a SubPath
         self.logs_volume_subpath = conf.get(
@@ -240,6 +244,69 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
             return ""
         else:
             return int(val)
+
+    def _parse_extra_volume_mounts(self) -> Dict[str, Dict[str, Any]]:
+        res: Dict[str, Dict[str, Any]] = {}
+
+        extra_volume_mounts = conf.get(self.kubernetes_section, 'extra_volume_mounts')
+
+        if extra_volume_mounts:  # pylint: disable=too-many-nested-blocks
+
+            try:
+                res = json.loads(extra_volume_mounts)
+            except JSONDecodeError as e:
+                raise AirflowConfigException(
+                    'Error parsing config option'
+                    ' `extra_volume_mounts`: {}.'.format(e))
+
+            for pvc_name, pvc_settings in res.items():
+                if 'mount_path' not in pvc_settings:
+                    raise AirflowConfigException(
+                        'Missing `mount_path` in config option'
+                        ' `extra_volume_mounts`: {}.'.format(pvc_name))
+
+                pvc_settings.setdefault('sub_path', None)
+
+                read_only = pvc_settings.setdefault('read_only', None)
+                if not isinstance(read_only, (bool, type(None))):
+                    raise AirflowConfigException(
+                        'Value of `read_only` is not boolean in config option'
+                        ' `extra_volume_mounts`: {}.'.format(read_only))
+
+                secret_mode = pvc_settings.setdefault('secret_mode', None)
+                if secret_mode is not None:
+                    try:
+                        pvc_settings['secret_mode'] = int(secret_mode, 8)
+                        pvc_settings['secret'] = True
+                    except TypeError as e:
+                        raise AirflowConfigException(
+                            'Error converting `secret_mode` in config option'
+                            ' `extra_volume_mounts`: {}.'.format(e))
+
+                secret_key = pvc_settings.setdefault('secret_key', None)
+                if secret_key is not None:
+                    pvc_settings['secret'] = True
+
+                    if 'secret_key_path' not in pvc_settings:
+                        raise AirflowConfigException(
+                            'Missing `secret_key_path` in config option'
+                            ' `extra_volume_mounts`: {}.'.format(pvc_name))
+
+                claim_name = pvc_settings.setdefault('claim_name', None)
+                secret_name = pvc_settings.setdefault('secret_name', None)
+
+                if secret_name is None and \
+                   (secret_key is not None or secret_mode is not None):
+                    raise AirflowConfigException(
+                        'Missing `secret_name` in config option'
+                        ' `extra_volume_mounts`: {}.'.format(read_only))
+                elif not (secret_name or claim_name):
+                    raise AirflowConfigException(
+                        'Missing `claim_name` or `secret_name` value'
+                        ' in config option'
+                        ' `extra_volume_mounts`: {}.'.format(read_only))
+
+        return res
 
     def _validate(self):
         if self.pod_template_file:

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -143,6 +143,75 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         }):
             self.assertEqual(KubeConfig().delete_option_kwargs, expected_value)
 
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'):
+        '{"pvc1": {"claim_name": "c1", "mount_path": "/volume1", "sub_path": "subpath1"},'
+        ' "pvc2": {"claim_name": "c2", "mount_path": "/volume2", "read_only": true},'
+        ' "pvc3": {"secret_name": "s1", "mount_path": "/volume3", "secret": true},'
+        ' "pvc4": {"secret_name": "s2", "mount_path": "/volume4", "secret_mode": "440"},'
+        ' "pvc5": {"secret_name": "s3", "mount_path": "/volume5", "secret_mode": "440",'
+        ' "secret_key": "key", "secret_key_path": "path"}}',
+    })
+    def test_worker_extra_volume_mounts(self):
+        kube_config = KubeConfig()
+
+        assert kube_config.extra_volume_mounts
+
+        worker_config = WorkerConfiguration(kube_config)
+        volume_mounts = worker_config._get_volume_mounts()
+        volume_mounts = {v.name: v for v in volume_mounts}
+
+        assert 'pvc1' in volume_mounts
+        assert 'pvc2' in volume_mounts
+        assert 'pvc3' in volume_mounts
+        assert 'pvc4' in volume_mounts
+        assert volume_mounts['pvc1'].mount_path == '/volume1'
+        assert volume_mounts['pvc1'].read_only is None
+        assert volume_mounts['pvc1'].sub_path == 'subpath1'
+        assert volume_mounts['pvc2'].mount_path == '/volume2'
+        assert volume_mounts['pvc2'].read_only is True
+        assert volume_mounts['pvc2'].sub_path is None
+        assert volume_mounts['pvc3'].mount_path == '/volume3'
+        assert volume_mounts['pvc3'].read_only is None
+        assert volume_mounts['pvc3'].sub_path is None
+        assert volume_mounts['pvc4'].mount_path == '/volume4'
+        assert volume_mounts['pvc4'].read_only is None
+        assert volume_mounts['pvc4'].sub_path is None
+        assert volume_mounts['pvc5'].mount_path == '/volume5'
+        assert volume_mounts['pvc5'].read_only is None
+        assert volume_mounts['pvc5'].sub_path is None
+
+        volumes = {v.name: v for v in worker_config._get_volumes()}
+        assert 'pvc1' in volumes
+        assert 'pvc2' in volumes
+        assert 'pvc3' in volumes
+        assert 'pvc4' in volumes
+        assert 'pvc5' in volumes
+        assert volumes['pvc1'].persistent_volume_claim.claim_name == 'c1'
+        assert volumes['pvc2'].persistent_volume_claim.claim_name == 'c2'
+
+        assert volumes['pvc3'].persistent_volume_claim is None
+        assert volumes['pvc3'].secret.secret_name == 's1'
+        assert volumes['pvc3'].secret.default_mode is None
+        assert volumes['pvc3'].secret.items is None
+
+        assert volumes['pvc4'].persistent_volume_claim is None
+        assert volumes['pvc4'].secret.secret_name == 's2'
+        assert volumes['pvc4'].secret.default_mode == 0o440
+        assert volumes['pvc4'].secret.items is None
+
+        assert volumes['pvc5'].persistent_volume_claim is None
+        assert volumes['pvc5'].secret.secret_name == 's3'
+        assert volumes['pvc5'].secret.default_mode is None
+        assert len(volumes['pvc5'].secret.items) == 1
+        assert volumes['pvc5'].secret.items[0].key == 'key'
+        assert volumes['pvc5'].secret.items[0].path == 'path'
+        assert volumes['pvc5'].secret.items[0].mode == 0o440
+
     def test_worker_with_subpaths(self):
         self.kube_config.dags_volume_subpath = 'dags'
         self.kube_config.logs_volume_subpath = 'logs'


### PR DESCRIPTION
This PR introduces a new config option, `kubernetes.extra_volume_mounts`, that allows users to specify multiple Kubernetes volumes to be mounted in each generated worker pod.

---
Issue link: [AIRFLOW-3126](https://issues.apache.org/jira/browse/AIRFLOW-3126)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
