### PR TITLE
[AIRFLOW-6765] Add CLI "airflow dags test" command

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -546,6 +546,13 @@ Additionally ``DebugExecutor`` can be used in a fail-fast mode that will make
 all other running or scheduled tasks fail immediately. To enable this option set
 ``AIRFLOW__DEBUG__FAIL_FAST=True`` or adjust ``fail_fast`` option in your ``airflow.cfg``.
 
+Also, with the Airflow CLI command `airflow dags test` you can execute one complete run of a DAG:
+
+.. code-block:: bash
+
+    # airflow dags test [dag_id] [execution_date]
+    airflow dags test example_branch_operator 2018-01-01
+
 
 BASH unit testing (BATS)
 ========================

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -546,7 +546,7 @@ Additionally ``DebugExecutor`` can be used in a fail-fast mode that will make
 all other running or scheduled tasks fail immediately. To enable this option set
 ``AIRFLOW__DEBUG__FAIL_FAST=True`` or adjust ``fail_fast`` option in your ``airflow.cfg``.
 
-Also, with the Airflow CLI command `airflow dags test` you can execute one complete run of a DAG:
+Also, with the Airflow CLI command ``airflow dags test`` you can execute one complete run of a DAG:
 
 .. code-block:: bash
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -61,6 +61,16 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Added `airflow dags test` CLI command
+
+A new command was added to the CLI for executing one full run of a DAG for a given execution date, similar to
+`airflow tasks test`. Example usage:
+
+```
+airflow dags test [dag_id] [execution_date]
+airflow dags test example_branch_operator 2018-01-01
+```
+
 ### Drop plugin support for stat_name_handler
 
 In previous version, you could use plugins mechanism to configure ``stat_name_handler``. You should now use the `stat_name_handler`

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -667,6 +667,12 @@ class CLIFactory:
                 'reset_dag_run', 'rerun_failed_tasks', 'run_backwards'
             ),
         },
+        {
+            "func": lazy_load_command('airflow.cli.commands.dag_command.dag_test'),
+            'name': 'test',
+            'help': "Execute one run of a DAG",
+            'args': ("dag_id", "execution_date", "subdir"),
+        },
     )
     TASKS_COMMANDS = (
         {

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -28,6 +28,7 @@ from tabulate import tabulate
 
 from airflow import DAG, AirflowException, conf, jobs, settings
 from airflow.api.client import get_current_api_client
+from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import get_dag, get_dag_by_file_location, process_subdir, sigint_handler
@@ -320,3 +321,11 @@ def dag_list_dag_runs(args, dag=None):
         tablefmt=args.output
     )
     print(table)
+
+
+@cli_utils.action_logging
+def dag_test(args):
+    """Execute one single DagRun for a given DAG and execution date, using the DebugExecutor."""
+    dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)
+    dag.clear(start_date=args.execution_date, end_date=args.execution_date, reset_dag_runs=True)
+    dag.run(executor=DebugExecutor(), start_date=args.execution_date, end_date=args.execution_date)

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -35,7 +35,7 @@ from datetime import datetime
 from typing import Optional
 
 from airflow import AirflowException, settings
-from airflow.models import DagBag, DagModel, DagPickle, Log
+from airflow.models import DAG, DagBag, DagModel, DagPickle, Log
 from airflow.utils import cli_action_loggers
 from airflow.utils.session import provide_session
 
@@ -149,7 +149,7 @@ def get_dag_by_file_location(dag_id: str):
     return dagbag.dags[dag_id]
 
 
-def get_dag(subdir: Optional[str], dag_id: str):
+def get_dag(subdir: Optional[str], dag_id: str) -> DAG:
     """Returns DAG of a given dag_id"""
     dagbag = DagBag(process_subdir(subdir))
     if dag_id not in dagbag.dags:


### PR DESCRIPTION
This PR adds a CLI command "airflow dags test" for running one run of a DAG. Example usage:

```bash
$ airflow dags test example_branch_operator 2018-01-01

[2020-02-15 11:55:39,525] {executor_loader.py:60} INFO - Using executor DebugExecutor
[2020-02-15 11:55:39,526] {dagbag.py:414} INFO - Filling up the DagBag from ...../airflow/dags
[2020-02-15 11:55:39,642] {base_executor.py:74} INFO - Adding to queue: ['<TaskInstance: example_branch_operator.run_this_first 2018-01-01 00:00:00+00:00 [queued]>']
[2020-02-15 11:55:44,624] {taskinstance.py:1033} INFO - Marking task as SUCCESS.dag_id=example_branch_operator, task_id=run_this_first, execution_date=20180101T000000, start_date=20200215T105539, end_date=20200215T105544
[2020-02-15 11:55:44,650] {backfill_job.py:381} INFO - [backfill progress] | finished run 0 of 1 | tasks waiting: 10 | succeeded: 1 | running: 0 | failed: 0 | skipped: 0 | deadlocked: 0 | not ready: 10
[2020-02-15 11:55:44,662] {base_executor.py:74} INFO - Adding to queue: ['<TaskInstance: example_branch_operator.branching 2018-01-01 00:00:00+00:00 [queued]>']
[2020-02-15 11:55:49,645] {taskinstance.py:1033} INFO - Marking task as SUCCESS.dag_id=example_branch_operator, task_id=branching, execution_date=20180101T000000, start_date=20200215T105539, end_date=20200215T105549
[2020-02-15 11:55:49,668] {backfill_job.py:381} INFO - [backfill progress] | finished run 0 of 1 | tasks waiting: 9 | succeeded: 2 | running: 0 | failed: 0 | skipped: 0 | deadlocked: 0 | not ready: 9
[2020-02-15 11:55:49,686] {base_executor.py:74} INFO - Adding to queue: ['<TaskInstance: example_branch_operator.branch_a 2018-01-01 00:00:00+00:00 [queued]>']
[2020-02-15 11:55:54,636] {taskinstance.py:1033} INFO - Marking task as SUCCESS.dag_id=example_branch_operator, task_id=branch_a, execution_date=20180101T000000, start_date=20200215T105539, end_date=20200215T105554
[2020-02-15 11:55:54,657] {backfill_job.py:381} INFO - [backfill progress] | finished run 0 of 1 | tasks waiting: 5 | succeeded: 3 | running: 0 | failed: 0 | skipped: 3 | deadlocked: 0 | not ready: 5
[2020-02-15 11:55:54,668] {base_executor.py:74} INFO - Adding to queue: ['<TaskInstance: example_branch_operator.follow_branch_a 2018-01-01 00:00:00+00:00 [queued]>']
[2020-02-15 11:55:59,644] {taskinstance.py:1033} INFO - Marking task as SUCCESS.dag_id=example_branch_operator, task_id=follow_branch_a, execution_date=20180101T000000, start_date=20200215T105539, end_date=20200215T105559
[2020-02-15 11:55:59,673] {backfill_job.py:381} INFO - [backfill progress] | finished run 0 of 1 | tasks waiting: 1 | succeeded: 4 | running: 0 | failed: 0 | skipped: 6 | deadlocked: 0 | not ready: 1
[2020-02-15 11:55:59,691] {base_executor.py:74} INFO - Adding to queue: ['<TaskInstance: example_branch_operator.join 2018-01-01 00:00:00+00:00 [queued]>']
[2020-02-15 11:56:04,649] {taskinstance.py:1033} INFO - Marking task as SUCCESS.dag_id=example_branch_operator, task_id=join, execution_date=20180101T000000, start_date=20200215T105539, end_date=20200215T105604
[2020-02-15 11:56:04,671] {dagrun.py:327} INFO - Marking run <DagRun example_branch_operator @ 2018-01-01 00:00:00+00:00: backfill_2018-01-01T00:00:00+00:00, externally triggered: False> successful
[2020-02-15 11:56:04,675] {backfill_job.py:381} INFO - [backfill progress] | finished run 1 of 1 | tasks waiting: 0 | succeeded: 5 | running: 0 | failed: 0 | skipped: 6 | deadlocked: 0 | not ready: 0
[2020-02-15 11:56:04,675] {backfill_job.py:829} INFO - Backfill done. Exiting.
```

The DebugExecutor docs currently suggest to simply call `run()` on a DAG, which would create DagRuns for all intervals between the start_date and end_date/now. I think this is undesirable and for testing purposes you would only want to run one single run of a DAG. Therefore (just like `airflow task test`), it takes a required argument `execution_date` for which a DagRun is created.

---
Issue link: [AIRFLOW-6765](https://issues.apache.org/jira/browse/AIRFLOW-6765)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
