### PR TITLE
[AIRFLOW-XXXX] Prevent Docker cache-busting on when editing www templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -362,11 +362,7 @@ RUN ln -sf /usr/bin/dumb-init /usr/local/bin/dumb-init
 # Rather than after setup.py is added.
 COPY airflow/www/yarn.lock airflow/www/package.json ${AIRFLOW_SOURCES}/airflow/www/
 
-WORKDIR ${AIRFLOW_SOURCES}/airflow/www
-
-RUN yarn install --frozen-lockfile
-
-WORKDIR ${AIRFLOW_SOURCES}
+RUN yarn --cwd airflow/www install --frozen-lockfile --no-cache
 
 # Note! We are copying everything with airflow:airflow user:group even if we use root to run the scripts
 # This is fine as root user will be able to use those dirs anyway.
@@ -386,13 +382,13 @@ COPY airflow/bin/airflow ${AIRFLOW_SOURCES}/airflow/bin/airflow
 # In non-CI optimized build this will install all dependencies before installing sources.
 RUN pip install -e ".[${AIRFLOW_EXTRAS}]"
 
-WORKDIR ${AIRFLOW_SOURCES}/airflow/www
+# Copy all the www/ files we need to compile assets. Done as two separate COPY
+# commands so as otherwise it copies the _contents_ of static/ in to www/
+COPY airflow/www/webpack.config.js ${AIRFLOW_SOURCES}/airflow/www/
+COPY airflow/www/static ${AIRFLOW_SOURCES}/airflow/www/static/
 
-# Copy all www files here so that we can run yarn building for production
-COPY airflow/www/ ${AIRFLOW_SOURCES}/airflow/www/
-
-# Package NPM for production
-RUN yarn run prod
+# Package JS/css for production
+RUN yarn --cwd airflow/www run prod
 
 COPY scripts/docker/entrypoint.sh /entrypoint.sh
 

--- a/common/_files_for_rebuild_check.sh
+++ b/common/_files_for_rebuild_check.sh
@@ -24,5 +24,7 @@ FILES_FOR_REBUILD_CHECK=(
  ".dockerignore"
  "airflow/version.py"
  "airflow/www/package.json"
- "airflow/www/yarn.lock" )
+ "airflow/www/yarn.lock"
+ "airflow/www/webpack.config.js"
+)
 export FILES_FOR_REBUILD_CHECK

--- a/hooks/build
+++ b/hooks/build
@@ -363,10 +363,6 @@ fi
 
 start_step "Creating deployment directory"
 
-STAT_BIN=stat
-if [[ "${OSTYPE}" == "darwin"* ]]; then
-    STAT_BIN=gstat
-fi
 # Build id identifying the build uniquely
 BUILD_ID=${BUILD_ID:="local"}
 
@@ -389,28 +385,14 @@ mkdir -pv "${DEPLOY_DIR}"
 #
 # We fix it by removing write permissions for other/group for all files that are in the Docker context.
 #
-STAT_BIN=stat
-if [[ "${OSTYPE}" == "darwin"* ]]; then
-    STAT_BIN=gstat
-fi
+# Since we can't (easily) tell what dockerignore would restrict, we'll just to
+# it to "all" files in the git repo, making sure to exclude the www/static/docs
+# symlink which is broken until the docs are built.
 
-for FILE in "${FILES_FOR_REBUILD_CHECK[@]}"; do
-    ACCESS_RIGHTS=$("${STAT_BIN}" -c "%A" "${AIRFLOW_SOURCES}/${FILE}" || echo "--------")
-    # check if the file is group/other writeable
-    if [[ "${ACCESS_RIGHTS:5:1}" != "-" || "${ACCESS_RIGHTS:8:1}" != "-" ]]; then
-        if [[ "${VERBOSE_FIX_FILE:="false"}" == "true" ]]; then
-            "${STAT_BIN}" --printf "%a %A %F \t%s \t->    " "${AIRFLOW_SOURCES}/${FILE}"
-        fi
-        chmod og-w "${AIRFLOW_SOURCES}/${FILE}"
-        if [[ "${VERBOSE_FIX_FILE:="false"}" == "true" ]]; then
-            "${STAT_BIN}" --printf "%a %A %F \t%s \t%n\n" "${AIRFLOW_SOURCES}/${FILE}"
-        fi
-    fi
-done
-
-echo "Group/other write access removed for ${FILES_FOR_REBUILD_CHECK[*]}"
-echo
-echo
+# This deals with files
+git ls-files -z ':!:airflow/www/static/docs' | xargs -0 chmod og-w
+# and this deals with directories
+git ls-tree -z -r -d --name-only HEAD | xargs -0 chmod og-wx
 
 if [[ "${AIRFLOW_CONTAINER_SKIP_CI_IMAGE}" == "true" ]]; then
     echo "Skip building the CI full Airflow image"


### PR DESCRIPTION
There is two parts to this PR:

1. Only copying www/webpack.config.js and www/static/ before running the
   asset pipeline
2. Making sure that _all_ files (not just the critical ones) have the
   same permissions.

The goal of both of these is to make sure that the docker build cache for the "expensive" operations (installing NPM modules, running asset pipeline, installing python modules) isn't run when it isn't necessary.

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
