### PR TITLE
[AIRFLOW-XXXX] Fix typo in example_bigquery DAG

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_bigquery.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery.py
@@ -139,7 +139,7 @@ with models.DAG(
     )
 
     get_data_result = BashOperator(
-        task_id="get_data_result", bash_command="echo \"{{ task_instance.xcom_pull('get-data') }}\""
+        task_id="get_data_result", bash_command="echo \"{{ task_instance.xcom_pull('get_data') }}\""
     )
 
     create_external_table = BigQueryCreateExternalTableOperator(


### PR DESCRIPTION
Fix typo in example_bigquery DAG. Task id in xcom_pull should match the real task id, which is "get_data".

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
