### PR TITLE
[AIRFLOW-6808]: Add GCP GKE Operators and Hooks

### DIFF
--- a/airflow/providers/google/cloud/hooks/container.py
+++ b/airflow/providers/google/cloud/hooks/container.py
@@ -1,0 +1,191 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from google.api_core.gapic_v1.method import DEFAULT
+from google.cloud import container_v1
+from google.cloud.container_v1.gapic.enums import Operation
+
+from airflow.providers.google.cloud.hooks.base import CloudBaseHook
+
+
+class ContainerHook(CloudBaseHook):
+    def __init__(self, gcp_conn_id='google_cloud_default', delegates_to=None):
+        super().__init__(gcp_conn_id, delegates_to)
+        self._client = None
+        self._operation_completion_status = [
+            Operation.Status.DONE
+        ]
+
+    def _get_client(self):
+        if not self._client:
+            self._client = container_v1.ClusterManagerClient()
+        return self._client
+
+    @CloudBaseHook.fallback_to_default_project_id
+    def _wait_for_operation_complete(
+        self,
+        operation,
+        project_id=None
+    ):
+        client = self._get_client()
+        if operation is not None:
+            operation_id = operation.name
+            operation_zone = operation.zone
+            operation_status = operation.status
+            while operation_status not in self._operation_completion_status:
+                op = client.get_operation(
+                    project_id=project_id,
+                    zone=operation_zone,
+                    operation_id=operation_id,
+                )
+                operation_status = op.status
+
+    @CloudBaseHook.fallback_to_default_project_id
+    def create_gke_cluster(
+        self,
+        zone,
+        cluster,
+        wait_for_completion=True,
+        project_id=None,
+        parent=None,
+        retry=DEFAULT,
+        timeout=DEFAULT,
+        metadata=None,
+    ):
+        client = self._get_client()
+        operation = client.create_cluster(
+            project_id=project_id,
+            zone=zone,
+            cluster=cluster,
+            parent=parent,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        if wait_for_completion:
+            self._wait_for_operation_complete(operation=operation, project_id=project_id)
+
+    @CloudBaseHook.fallback_to_default_project_id
+    def create_node_pool(
+        self,
+        zone,
+        cluster_id,
+        node_pool,
+        wait_for_completion=True,
+        project_id=None,
+        parent=None,
+        retry=DEFAULT,
+        timeout=DEFAULT,
+        metadata=None,
+    ):
+        client = self._get_client()
+        operation = client.create_node_pool(
+            project_id=project_id,
+            zone=zone,
+            cluster_id=cluster_id,
+            node_pool=node_pool,
+            parent=parent,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        if wait_for_completion:
+            self._wait_for_operation_complete(operation=operation, project_id=project_id)
+
+    @CloudBaseHook.fallback_to_default_project_id
+    def delete_gke_cluster(
+        self,
+        zone,
+        cluster_id,
+        name=None,
+        wait_for_completion=True,
+        project_id=None,
+        retry=DEFAULT,
+        timeout=DEFAULT,
+        metadata=None,
+    ):
+        client = self._get_client()
+        operation = client.delete_cluster(
+            project_id=project_id,
+            zone=zone,
+            cluster_id=cluster_id,
+            name=name,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        if wait_for_completion:
+            self._wait_for_operation_complete(operation=operation, project_id=project_id)
+
+    @CloudBaseHook.fallback_to_default_project_id
+    def delete_node_pool(
+        self,
+        zone,
+        cluster_id,
+        node_pool_id,
+        name=None,
+        wait_for_completion=True,
+        project_id=None,
+        retry=DEFAULT,
+        timeout=DEFAULT,
+        metadata=None,
+    ):
+        client = self._get_client()
+        operation = client.delete_node_pool(
+            project_id=project_id,
+            zone=zone,
+            cluster_id=cluster_id,
+            node_pool_id=node_pool_id,
+            name=name,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        if wait_for_completion:
+            self._wait_for_operation_complete(operation=operation, project_id=project_id)
+
+    @CloudBaseHook.fallback_to_default_project_id
+    # pylint: disable=too-many-arguments
+    def set_node_pool_size(
+        self,
+        zone,
+        cluster_id,
+        node_pool_id,
+        node_count,
+        wait_for_completion=True,
+        name=None,
+        project_id=None,
+        retry=DEFAULT,
+        timeout=DEFAULT,
+        metadata=None,
+    ):
+        client = self._get_client()
+        operation = client.set_node_pool_size(
+            project_id=project_id,
+            zone=zone,
+            cluster_id=cluster_id,
+            node_pool_id=node_pool_id,
+            node_count=node_count,
+            name=name,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        if wait_for_completion:
+            self._wait_for_operation_complete(operation=operation, project_id=project_id)

--- a/airflow/providers/google/cloud/operators/container.py
+++ b/airflow/providers/google/cloud/operators/container.py
@@ -1,0 +1,277 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Dict, Optional
+
+from google.api_core.gapic_v1.method import DEFAULT
+
+from airflow.models import BaseOperator
+from airflow.providers.google.cloud.hooks.container import ContainerHook
+from airflow.utils.decorators import apply_defaults
+
+
+class ContainerCreateGKEClusterOperator(BaseOperator):
+    template_fields = ()
+    ui_color = ""
+
+    # pylint: disable=too-many-arguments
+    @apply_defaults
+    def __init__(
+        self,
+        zone: str,
+        cluster: Dict,
+        wait_for_completion: Optional[bool] = True,
+        project_id: Optional[str] = None,
+        parent: Optional[str] = None,
+        retry: Optional[str] = DEFAULT,
+        timeout: Optional[float] = DEFAULT,
+        metadata: Optional[str] = None,
+        gcp_conn_id: Optional[str] = 'google_cloud_default',
+        delegates_to: Optional[str] = None,
+        *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.hook = None
+        self.zone = zone
+        self.cluster = cluster
+        self.wait_for_completion = wait_for_completion
+        self.project_id = project_id
+        self.parent = parent
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+        self.delegates_to = delegates_to
+
+    def execute(self, context):
+        if self.hook is None:
+            self.hook = ContainerHook(gcp_conn_id=self.gcp_conn_id, delegates_to=self.delegates_to)
+        self.hook.create_gke_cluster(
+            zone=self.zone,
+            cluster=self.cluster,
+            wait_for_completion=self.wait_for_completion,
+            project_id=self.project_id,
+            parent=self.parent,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+
+
+class ContainerCreateNodePoolOperator(BaseOperator):
+    template_fields = ()
+    ui_color = ""
+
+    # pylint: disable=too-many-arguments
+    @apply_defaults
+    def __init__(
+        self,
+        zone: str,
+        cluster_id: str,
+        node_pool: Dict,
+        wait_for_completion: Optional[bool] = True,
+        project_id: Optional[str] = None,
+        parent: Optional[str] = None,
+        retry: Optional[str] = DEFAULT,
+        timeout: Optional[float] = DEFAULT,
+        metadata: Optional[str] = None,
+        gcp_conn_id: Optional[str] = 'google_cloud_default',
+        delegates_to: Optional[str] = None,
+        *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.hook = None
+        self.zone = zone
+        self.cluster_id = cluster_id
+        self.node_pool = node_pool
+        self.wait_for_completion = wait_for_completion
+        self.project_id = project_id
+        self.parent = parent
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+        self.delegates_to = delegates_to
+
+    def execute(self, context):
+        if self.hook is None:
+            self.hook = ContainerHook(gcp_conn_id=self.gcp_conn_id, delegates_to=self.delegates_to)
+        self.hook.create_node_pool(
+            project_id=self.project_id,
+            zone=self.zone,
+            cluster_id=self.cluster_id,
+            wait_for_completion=self.wait_for_completion,
+            node_pool=self.node_pool,
+            parent=self.parent,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+
+
+class ContainerDeleteGKEClusterOperator(BaseOperator):
+    template_fields = ()
+    ui_color = ""
+
+    # pylint: disable=too-many-arguments
+    @apply_defaults
+    def __init__(
+        self,
+        zone: str,
+        cluster_id: str,
+        name: Optional[str] = None,
+        wait_for_completion: Optional[bool] = True,
+        project_id: Optional[str] = None,
+        retry: Optional[str] = DEFAULT,
+        timeout: Optional[float] = DEFAULT,
+        metadata: Optional[str] = None,
+        gcp_conn_id: Optional[str] = 'google_cloud_default',
+        delegates_to: Optional[str] = None,
+        *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.hook = None
+        self.zone = zone
+        self.cluster_id = cluster_id
+        self.name = name
+        self.wait_for_completion = wait_for_completion
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+        self.delegates_to = delegates_to
+
+    def execute(self, context):
+        if self.hook is None:
+            self.hook = ContainerHook(gcp_conn_id=self.gcp_conn_id, delegates_to=self.delegates_to)
+        self.hook.delete_gke_cluster(
+            project_id=self.project_id,
+            zone=self.zone,
+            cluster_id=self.cluster_id,
+            wait_for_completion=self.wait_for_completion,
+            name=self.name,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+
+
+class ContainerDeleteNodePoolOperator(BaseOperator):
+    template_fields = ()
+    ui_color = ""
+
+    # pylint: disable=too-many-arguments
+    @apply_defaults
+    def __init__(
+        self,
+        zone: str,
+        cluster_id: str,
+        node_pool_id: str,
+        name: Optional[str] = None,
+        wait_for_completion: Optional[bool] = True,
+        project_id: Optional[str] = None,
+        retry: Optional[str] = DEFAULT,
+        timeout: Optional[float] = DEFAULT,
+        metadata: Optional[str] = None,
+        gcp_conn_id: Optional[str] = 'google_cloud_default',
+        delegates_to: Optional[str] = None,
+        *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.hook = None
+        self.zone = zone
+        self.cluster_id = cluster_id
+        self.node_pool_id = node_pool_id
+        self.name = name
+        self.wait_for_completion = wait_for_completion
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+        self.delegates_to = delegates_to
+
+    def execute(self, context):
+        if self.hook is None:
+            self.hook = ContainerHook(gcp_conn_id=self.gcp_conn_id, delegates_to=self.delegates_to)
+        self.hook.delete_node_pool(
+            project_id=self.project_id,
+            zone=self.zone,
+            cluster_id=self.cluster_id,
+            node_pool_id=self.node_pool_id,
+            wait_for_completion=self.wait_for_completion,
+            name=self.name,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+
+
+class ContainerSetNodePoolSizeOperator(BaseOperator):
+    template_fields = ()
+    ui_color = ""
+
+    # pylint: disable=too-many-arguments
+    @apply_defaults
+    def __init__(
+        self,
+        zone: str,
+        cluster_id: str,
+        node_pool_id: str,
+        node_count: int,
+        wait_for_completion: Optional[bool] = True,
+        name: Optional[str] = None,
+        project_id: Optional[str] = None,
+        retry: Optional[str] = DEFAULT,
+        timeout: Optional[str] = DEFAULT,
+        metadata: Optional[str] = None,
+        gcp_conn_id: Optional[str] = 'google_cloud_default',
+        delegates_to: Optional[str] = None,
+        *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.hook = None
+        self.zone = zone
+        self.cluster_id = cluster_id
+        self.node_pool_id = node_pool_id
+        self.node_count = node_count
+        self.wait_for_completion = wait_for_completion
+        self.name = name
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+        self.delegates_to = delegates_to
+
+    def execute(self, context):
+        if self.hook is None:
+            self.hook = ContainerHook(gcp_conn_id=self.gcp_conn_id, delegates_to=self.delegates_to)
+        self.hook.set_node_pool_size(
+            project_id=self.project_id,
+            zone=self.zone,
+            cluster_id=self.cluster_id,
+            node_pool_id=self.node_pool_id,
+            node_count=self.node_count,
+            wait_for_completion=self.wait_for_completion,
+            name=self.name,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )

--- a/tests/providers/google/cloud/hooks/test_container.py
+++ b/tests/providers/google/cloud/hooks/test_container.py
@@ -1,0 +1,366 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+
+import mock
+from google.api_core.gapic_v1.method import DEFAULT
+from google.cloud.container_v1.gapic import enums
+from google.cloud.container_v1.proto import cluster_service_pb2
+
+from airflow.providers.google.cloud.hooks import container
+
+PROJECT_ID = 'test-project'
+CREDENTIALS = 'test-credentials'
+ZONE = 'asia-northeast1-a'
+CLUSTER = {
+    "name": "test-cluster",
+    "nodePools": [
+        {
+            "name": "pool1",
+            "initialNodeCount": 3
+        },
+        {
+            "name": "pool2",
+            "initialNodeCount": 5
+        }
+    ],
+    "locations": [
+        "asia-northeast1-a"
+    ]
+}
+CLUSTER_ID = 'test-cluster'
+NODE_POOL = {
+    "name": "test-pool",
+    "initialNodeCount": 3
+}
+NODE_POOL_ID = 'node-pool-id'
+NODE_COUNT = 3
+
+
+class TestContainerHookMethods(unittest.TestCase):
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_create_gke_cluster_with_wait_for_completion(self, mock_client, _):
+        operation1 = cluster_service_pb2.Operation()
+        operation1.name = 'operation-id'
+        operation1.status = enums.Operation.Status.RUNNING
+        operation1.zone = ZONE
+        mock_client.return_value.create_cluster.return_value = operation1
+
+        operation2 = cluster_service_pb2.Operation()
+        operation2.name = 'operation-id'
+        operation2.status = enums.Operation.Status.DONE
+        operation2.zone = ZONE
+        mock_client.return_value.get_operation.return_value = operation2
+
+        hook = container.ContainerHook()
+        hook.create_gke_cluster(
+            zone=ZONE,
+            cluster=CLUSTER
+        )
+
+        mock_client.return_value.create_cluster.assert_called_once_with(
+            zone=ZONE,
+            cluster=CLUSTER,
+            project_id=PROJECT_ID,
+            parent=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+        mock_client.return_value.get_operation.assert_called_once_with(
+            zone=ZONE,
+            operation_id='operation-id',
+            project_id=PROJECT_ID
+        )
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_create_gke_cluster_without_wait_for_completion(self, mock_client, _):
+        hook = container.ContainerHook()
+        hook.create_gke_cluster(
+            zone=ZONE,
+            cluster=CLUSTER,
+            wait_for_completion=False
+        )
+        mock_client.return_value.create_cluster.assert_called_once_with(
+            zone=ZONE,
+            cluster=CLUSTER,
+            project_id=PROJECT_ID,
+            parent=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+        mock_client.return_value._wait_for_operation_complete.assert_not_called()
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_create_node_pool_with_wait_on_completion(self, mock_client, _):
+        operation1 = cluster_service_pb2.Operation()
+        operation1.name = 'operation-id'
+        operation1.status = enums.Operation.Status.RUNNING
+        operation1.zone = ZONE
+        mock_client.return_value.create_node_pool.return_value = operation1
+
+        operation2 = cluster_service_pb2.Operation()
+        operation2.name = 'operation-id'
+        operation2.status = enums.Operation.Status.DONE
+        operation2.zone = ZONE
+        mock_client.return_value.get_operation.return_value = operation2
+
+        hook = container.ContainerHook()
+        hook.create_node_pool(
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool=NODE_POOL
+        )
+
+        mock_client.return_value.create_node_pool.assert_called_once_with(
+            project_id=PROJECT_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool=NODE_POOL,
+            parent=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+        mock_client.return_value.get_operation.assert_called_once_with(
+            zone=ZONE,
+            operation_id='operation-id',
+            project_id=PROJECT_ID
+        )
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_create_node_pool_without_wait_on_completion(self, mock_client, _):
+        hook = container.ContainerHook()
+        hook.create_node_pool(
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool=NODE_POOL,
+            wait_for_completion=False
+        )
+        mock_client.return_value.create_node_pool.assert_called_once_with(
+            project_id=PROJECT_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool=NODE_POOL,
+            parent=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+        mock_client.return_value._wait_for_operation_complete.assert_not_called()
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_delete_gke_cluster_with_wait_for_completion(self, mock_client, _):
+        operation1 = cluster_service_pb2.Operation()
+        operation1.name = 'operation-id'
+        operation1.status = enums.Operation.Status.RUNNING
+        operation1.zone = ZONE
+        mock_client.return_value.delete_cluster.return_value = operation1
+
+        operation2 = cluster_service_pb2.Operation()
+        operation2.name = 'operation-id'
+        operation2.status = enums.Operation.Status.DONE
+        operation2.zone = ZONE
+        mock_client.return_value.get_operation.return_value = operation2
+
+        hook = container.ContainerHook()
+        hook.delete_gke_cluster(
+            zone=ZONE,
+            cluster_id=CLUSTER_ID
+        )
+
+        mock_client.return_value.delete_cluster.assert_called_once_with(
+            project_id=PROJECT_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+        mock_client.return_value.get_operation.assert_called_once_with(
+            zone=ZONE,
+            operation_id='operation-id',
+            project_id=PROJECT_ID
+        )
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_delete_gke_cluster_without_wait_on_completion(self, mock_client, _):
+        hook = container.ContainerHook()
+        hook.delete_gke_cluster(
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            wait_for_completion=False
+        )
+        mock_client.return_value.delete_cluster.assert_called_once_with(
+            project_id=PROJECT_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+        mock_client.return_value._wait_for_operation_complete.assert_not_called()
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_delete_node_pool_with_wait_for_completion(self, mock_client, _):
+        operation1 = cluster_service_pb2.Operation()
+        operation1.name = 'operation-id'
+        operation1.status = enums.Operation.Status.RUNNING
+        operation1.zone = ZONE
+        mock_client.return_value.delete_node_pool.return_value = operation1
+
+        operation2 = cluster_service_pb2.Operation()
+        operation2.name = 'operation-id'
+        operation2.status = enums.Operation.Status.DONE
+        operation2.zone = ZONE
+        mock_client.return_value.get_operation.return_value = operation2
+
+        hook = container.ContainerHook()
+        hook.delete_node_pool(
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID
+        )
+
+        mock_client.return_value.delete_node_pool.assert_called_once_with(
+            project_id=PROJECT_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+        mock_client.return_value.get_operation.assert_called_once_with(
+            zone=ZONE,
+            operation_id='operation-id',
+            project_id=PROJECT_ID
+        )
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_delete_node_pool_without_wait_on_completion(self, mock_client, _):
+        hook = container.ContainerHook()
+        hook.delete_node_pool(
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            wait_for_completion=False
+        )
+        mock_client.return_value.delete_node_pool.assert_called_once_with(
+            project_id=PROJECT_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+        mock_client.return_value._wait_for_operation_complete.assert_not_called()
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_set_node_pool_size_with_wait_on_completion(self, mock_client, _):
+        operation1 = cluster_service_pb2.Operation()
+        operation1.name = 'operation-id'
+        operation1.status = enums.Operation.Status.RUNNING
+        operation1.zone = ZONE
+        mock_client.return_value.set_node_pool_size.return_value = operation1
+
+        operation2 = cluster_service_pb2.Operation()
+        operation2.name = 'operation-id'
+        operation2.status = enums.Operation.Status.DONE
+        operation2.zone = ZONE
+        mock_client.return_value.get_operation.return_value = operation2
+
+        hook = container.ContainerHook()
+        hook.set_node_pool_size(
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            node_count=NODE_COUNT
+        )
+
+        mock_client.return_value.set_node_pool_size.assert_called_once_with(
+            project_id=PROJECT_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            node_count=NODE_COUNT,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+        mock_client.return_value.get_operation.assert_called_once_with(
+            zone=ZONE,
+            operation_id='operation-id',
+            project_id=PROJECT_ID
+        )
+
+    @mock.patch('airflow.providers.google.cloud.hooks.base.CloudBaseHook._get_credentials_and_project_id',
+                return_value=(CREDENTIALS, PROJECT_ID))
+    @mock.patch('airflow.providers.google.cloud.hooks.container.ContainerHook._get_client')
+    def test_set_node_pool_size_without_wait_on_completion(self, mock_client, _):
+        hook = container.ContainerHook()
+        hook.set_node_pool_size(
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            node_count=NODE_COUNT,
+            wait_for_completion=False
+        )
+        mock_client.return_value.set_node_pool_size.assert_called_once_with(
+            project_id=PROJECT_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            node_count=NODE_COUNT,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+        mock_client.return_value._wait_for_operation_complete.assert_not_called()

--- a/tests/providers/google/cloud/operators/test_container.py
+++ b/tests/providers/google/cloud/operators/test_container.py
@@ -1,0 +1,166 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import mock
+from google.api_core.gapic_v1.method import DEFAULT
+
+from airflow.providers.google.cloud.operators.container import (
+    ContainerCreateGKEClusterOperator, ContainerCreateNodePoolOperator, ContainerDeleteGKEClusterOperator,
+    ContainerDeleteNodePoolOperator, ContainerSetNodePoolSizeOperator,
+)
+
+TASK_ID = 'task-id'
+ZONE = 'asia-northeast1-a'
+CLUSTER = {
+    "name": "test-cluster",
+    "nodePools": [
+        {
+            "name": "pool1",
+            "initialNodeCount": 3
+        },
+        {
+            "name": "pool2",
+            "initialNodeCount": 5
+        }
+    ],
+    "locations": [
+        "asia-northeast1-a"
+    ]
+}
+CLUSTER_ID = 'test-cluster'
+NODE_POOL = {
+    "name": "test-pool",
+    "initialNodeCount": 3
+}
+NODE_POOL_ID = 'node-pool-id'
+NODE_COUNT = 3
+
+
+class TestContainerCreateGKEClusterOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.google.cloud.operators.container.ContainerHook')
+    def test_execute(self, mock_hook):
+        operator = ContainerCreateGKEClusterOperator(
+            task_id=TASK_ID,
+            zone=ZONE,
+            cluster=CLUSTER
+        )
+        operator.execute(None)
+        mock_hook.return_value.create_gke_cluster.assert_called_once_with(
+            project_id=None,
+            zone=ZONE,
+            cluster=CLUSTER,
+            wait_for_completion=True,
+            parent=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+
+class TestContainerCreateNodePoolOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.google.cloud.operators.container.ContainerHook')
+    def test_execute(self, mock_hook):
+        operator = ContainerCreateNodePoolOperator(
+            task_id=TASK_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool=NODE_POOL
+        )
+        operator.execute(None)
+        mock_hook.return_value.create_node_pool.assert_called_once_with(
+            project_id=None,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            wait_for_completion=True,
+            node_pool=NODE_POOL,
+            parent=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+
+class TestDeleteGKEClusterOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.google.cloud.operators.container.ContainerHook')
+    def test_execute(self, mock_hook):
+        operator = ContainerDeleteGKEClusterOperator(
+            task_id=TASK_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID
+        )
+        operator.execute(None)
+        mock_hook.return_value.delete_gke_cluster.assert_called_once_with(
+            project_id=None,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            wait_for_completion=True,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+
+class TestContainerDeleteNodePoolOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.google.cloud.operators.container.ContainerHook')
+    def test_execute(self, mock_hook):
+        operator = ContainerDeleteNodePoolOperator(
+            task_id=TASK_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID
+        )
+        operator.execute(None)
+        mock_hook.return_value.delete_node_pool.assert_called_once_with(
+            project_id=None,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            wait_for_completion=True,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )
+
+
+class TestContainerSetNodePoolSizeOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.google.cloud.operators.container.ContainerHook')
+    def test_execute(self, mock_hook):
+        operator = ContainerSetNodePoolSizeOperator(
+            task_id=TASK_ID,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            node_count=NODE_COUNT
+        )
+        operator.execute(None)
+        mock_hook.return_value.set_node_pool_size.assert_called_once_with(
+            project_id=None,
+            zone=ZONE,
+            cluster_id=CLUSTER_ID,
+            node_pool_id=NODE_POOL_ID,
+            node_count=NODE_COUNT,
+            wait_for_completion=True,
+            name=None,
+            retry=DEFAULT,
+            timeout=DEFAULT,
+            metadata=None
+        )


### PR DESCRIPTION
### Description

Add hooks, operators for GCP Container Management service [GKE](https://cloud.google.com/kubernetes-engine)

---
Issue link: [AIRFLOW-6808](https://issues.apache.org/jira/browse/AIRFLOW-6808)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
