### PR TITLE
[AIRFLOW-6818] Fix for old versions of git on Dockerhub builds

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -397,7 +397,7 @@ function filterout_deleted_files {
 }
 
 # This deals with files
-git ls-files -z ':!:airflow/www/static/docs' | filterout_deleted_files | xargs -t -0 chmod og-w
+git ls-files -z -- ./ ':!:airflow/www/static/docs' | filterout_deleted_files | xargs -0 chmod og-w
 # and this deals with directories
 git ls-tree -z -r -d --name-only HEAD | filterout_deleted_files | xargs -t -0 chmod og-w,og+x
 


### PR DESCRIPTION
Dockerhub uses an old version of git (2.7.4 as of our testing in Feb
2020) so needs a slightly different syntax for git ls-files with an
exclusion. This works with current-latest git (2.25.0) too

---
Issue link: [AIRFLOW-6818](https://issues.apache.org/jira/browse/AIRFLOW-6818)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.