### PR TITLE
[AIRFLOW-6474] list_dag_runs cli command should allow exec_date between start/end range and print start/end times

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -597,8 +597,12 @@ class CLIFactory:
             'help': "List dag runs given a DAG id. If state option is given, it will only "
                     "search for all the dagruns with the given state. "
                     "If no_backfill option is given, it will filter out "
-                    "all backfill dagruns for given dag id",
-            'args': ('dag_id', 'no_backfill', 'state', 'output',),
+                    "all backfill dagruns for given dag id. "
+                    "If start_date is given, it will filter out "
+                    "all the dagruns that were executed before this date. "
+                    "If end_date is given, it will filter out "
+                    "all the dagruns that were executed after this date. ",
+            'args': ('dag_id_opt', 'no_backfill', 'state', 'output', "start_date", "end_date"),
         },
         {
             'func': lazy_load_command('airflow.cli.commands.dag_command.dag_list_jobs'),

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -48,6 +48,7 @@ def _tabulate_dag_runs(dag_runs: List[DagRun], tablefmt="fancy_grid"):
             'DAG ID': dag_run.dag_id,
             'Execution date': dag_run.execution_date.isoformat(),
             'Start date': dag_run.start_date.isoformat() if dag_run.start_date else '',
+            'End date': dag_run.end_date.isoformat() if dag_run.end_date else '',
         } for dag_run in dag_runs
     )
     return "\n%s" % tabulate(
@@ -303,7 +304,7 @@ def dag_list_dag_runs(args, dag=None):
 
     dagbag = DagBag()
 
-    if args.dag_id not in dagbag.dags:
+    if args.dag_id is not None and args.dag_id not in dagbag.dags:
         error_message = "Dag id {} not found".format(args.dag_id)
         raise AirflowException(error_message)
 
@@ -311,7 +312,9 @@ def dag_list_dag_runs(args, dag=None):
     dag_runs = DagRun.find(
         dag_id=args.dag_id,
         state=state,
-        no_backfills=args.no_backfill
+        no_backfills=args.no_backfill,
+        execution_start_date=args.start_date,
+        execution_end_date=args.end_date,
     )
 
     if not dag_runs:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -127,7 +127,7 @@ class DagRun(Base, LoggingMixin):
     @provide_session
     def find(dag_id=None, run_id=None, execution_date=None,
              state=None, external_trigger=None, no_backfills=False,
-             session=None):
+             session=None, execution_start_date=None, execution_end_date=None):
         """
         Returns a set of dag runs for the given search criteria.
 
@@ -136,7 +136,7 @@ class DagRun(Base, LoggingMixin):
         :param run_id: defines the run id for this dag run
         :type run_id: str
         :param execution_date: the execution date
-        :type execution_date: datetime.datetime
+        :type execution_date: datetime.datetime or list[datetime.datetime]
         :param state: the state of the dag run
         :type state: str
         :param external_trigger: whether this dag run is externally triggered
@@ -146,6 +146,10 @@ class DagRun(Base, LoggingMixin):
         :type no_backfills: bool
         :param session: database session
         :type session: sqlalchemy.orm.session.Session
+        :param execution_start_date: dag run that was executed from this date
+        :type execution_start_date: datetime.datetime
+        :param execution_end_date: dag run that was executed until this date
+        :type execution_end_date: datetime.datetime
         """
         DR = DagRun
 
@@ -159,6 +163,12 @@ class DagRun(Base, LoggingMixin):
                 qry = qry.filter(DR.execution_date.in_(execution_date))
             else:
                 qry = qry.filter(DR.execution_date == execution_date)
+        if execution_start_date and execution_end_date:
+            qry = qry.filter(DR.execution_date.between(execution_start_date, execution_end_date))
+        elif execution_start_date:
+            qry = qry.filter(DR.execution_date >= execution_start_date)
+        elif execution_end_date:
+            qry = qry.filter(DR.execution_date <= execution_end_date)
         if state:
             qry = qry.filter(DR.state == state)
         if external_trigger is not None:

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -309,9 +309,15 @@ class TestCliDags(unittest.TestCase):
     def test_cli_list_dag_runs(self):
         dag_command.dag_trigger(self.parser.parse_args([
             'dags', 'trigger', 'example_bash_operator', ]))
-        args = self.parser.parse_args(['dags', 'list_runs',
+        args = self.parser.parse_args(['dags',
+                                       'list_runs',
+                                       '--dag_id',
                                        'example_bash_operator',
-                                       '--no_backfill'])
+                                       '--no_backfill',
+                                       '--start_date',
+                                       DEFAULT_DATE.isoformat(),
+                                       '--end_date',
+                                       timezone.make_aware(datetime.max).isoformat()])
         dag_command.dag_list_dag_runs(args)
 
     def test_cli_list_jobs_with_args(self):


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6474](https://issues.apache.org/jira/browse/AIRFLOW-6474)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
