### PR TITLE
[AIRFLOW-6829][WIP] Auto-apply apply_default

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -49,6 +49,10 @@ assists users migrating to a new version.
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Airflow Master
+### Change in `AutoMLPredictOperator`
+
+The `params` parameter in ``airflow.providers.google.cloud.operators.automl.AutoMLPredictOperator`` class
+was renamed `operation_params` because it conflicted with a ``param`` parameter in the ``BaseOperator`` class.
 
 ### Change to Permissions
 

--- a/airflow/contrib/operators/adls_to_gcs.py
+++ b/airflow/contrib/operators/adls_to_gcs.py
@@ -37,6 +37,6 @@ class AdlsToGoogleCloudStorageOperator(ADLSToGCSOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.adls_to_gcs.ADLSToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -51,7 +51,7 @@ class AWSBatchOperator(AwsBatchOperator):
             """This class is deprecated.
             Please use `airflow.providers.amazon.aws.operators.batch.AwsBatchOperator`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -45,6 +45,6 @@ class BigQueryOperator(BigQueryExecuteQueryOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.bigquery.BigQueryExecuteQueryOperator`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/bigquery_table_delete_operator.py
+++ b/airflow/contrib/operators/bigquery_table_delete_operator.py
@@ -39,6 +39,6 @@ class BigQueryTableDeleteOperator(BigQueryDeleteTableOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.bigquery.BigQueryDeleteTableOperator`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -37,6 +37,6 @@ class BigQueryToCloudStorageOperator(BigQueryToGCSOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.bigquery_to_gcs.BigQueryToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/cassandra_to_gcs.py
+++ b/airflow/contrib/operators/cassandra_to_gcs.py
@@ -39,6 +39,6 @@ class CassandraToGoogleCloudStorageOperator(CassandraToGCSOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.cassandra_to_gcs.CassandraToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -39,7 +39,7 @@ class DataFlowJavaOperator(DataflowCreateJavaJobOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dataflow.DataflowCreateJavaJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -55,7 +55,7 @@ class DataFlowPythonOperator(DataflowCreatePythonJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataflow.DataflowCreatePythonJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -71,6 +71,6 @@ class DataflowTemplateOperator(DataflowTemplatedJobStartOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataflow.DataflowTemplatedJobStartOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -44,7 +44,7 @@ class DataprocClusterCreateOperator(DataprocCreateClusterOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dataproc.DataprocCreateClusterOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -59,7 +59,7 @@ class DataprocClusterDeleteOperator(DataprocDeleteClusterOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dataproc.DataprocDeleteClusterOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -74,7 +74,7 @@ class DataprocClusterScaleOperator(DataprocScaleClusterOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dataproc.DataprocScaleClusterOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -90,7 +90,7 @@ class DataProcHadoopOperator(DataprocSubmitHadoopJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitHadoopJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -106,7 +106,7 @@ class DataProcHiveOperator(DataprocSubmitHiveJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitHiveJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -121,7 +121,7 @@ class DataProcJobBaseOperator(DataprocJobBaseOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dataproc.DataprocJobBaseOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -136,7 +136,7 @@ class DataProcPigOperator(DataprocSubmitPigJobOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitPigJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -152,7 +152,7 @@ class DataProcPySparkOperator(DataprocSubmitPySparkJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitPySparkJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -168,7 +168,7 @@ class DataProcSparkOperator(DataprocSubmitSparkJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitSparkJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -184,7 +184,7 @@ class DataProcSparkSqlOperator(DataprocSubmitSparkSqlJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitSparkSqlJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -202,7 +202,7 @@ class DataprocWorkflowTemplateInstantiateInlineOperator(DataprocInstantiateInlin
             Please use
             `airflow.providers.google.cloud.operators.dataproc
             .DataprocInstantiateInlineWorkflowTemplateOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -220,6 +220,6 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocInstantiateWorkflowTem
             Please use
             `airflow.providers.google.cloud.operators.dataproc
             .DataprocInstantiateWorkflowTemplateOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/datastore_export_operator.py
+++ b/airflow/contrib/operators/datastore_export_operator.py
@@ -38,6 +38,6 @@ class DatastoreExportOperator(CloudDatastoreExportEntitiesOperator):
             """This class is deprecated.l
             Please use
             `airflow.providers.google.cloud.operators.datastore.CloudDatastoreExportEntitiesOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/datastore_import_operator.py
+++ b/airflow/contrib/operators/datastore_import_operator.py
@@ -38,6 +38,6 @@ class DatastoreImportOperator(CloudDatastoreImportEntitiesOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.datastore.CloudDatastoreImportEntitiesOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/file_to_gcs.py
+++ b/airflow/contrib/operators/file_to_gcs.py
@@ -40,6 +40,6 @@ class FileToGoogleCloudStorageOperator(LocalFilesystemToGCSOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.transfers.local_to_gcs.LocalFilesystemToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_bigtable_operator.py
+++ b/airflow/contrib/operators/gcp_bigtable_operator.py
@@ -45,7 +45,7 @@ class BigtableClusterUpdateOperator(BigtableUpdateClusterOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.bigtable.BigtableUpdateClusterOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -60,7 +60,7 @@ class BigtableInstanceCreateOperator(BigtableCreateInstanceOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.bigtable.BigtableCreateInstanceOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -75,7 +75,7 @@ class BigtableInstanceDeleteOperator(BigtableDeleteInstanceOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.bigtable.BigtableDeleteInstanceOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -90,7 +90,7 @@ class BigtableTableCreateOperator(BigtableCreateTableOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.bigtable.BigtableCreateTableOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -105,7 +105,7 @@ class BigtableTableDeleteOperator(BigtableDeleteTableOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.bigtable.BigtableDeleteTableOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -122,6 +122,6 @@ class BigtableTableWaitForReplicationSensor(BigtableTableReplicationCompletedSen
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.sensors.bigtable.BigtableTableReplicationCompletedSensor`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_compute_operator.py
+++ b/airflow/contrib/operators/gcp_compute_operator.py
@@ -41,7 +41,7 @@ class GceBaseOperator(ComputeEngineBaseOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.compute.ComputeEngineBaseOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -58,7 +58,7 @@ class GceInstanceGroupManagerUpdateTemplateOperator(ComputeEngineInstanceGroupUp
             """This class is deprecated. Please use
             `airflow.providers.google.cloud.operators.compute
             .ComputeEngineInstanceGroupUpdateManagerTemplateOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -75,7 +75,7 @@ class GceInstanceStartOperator(ComputeEngineStartInstanceOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.compute
             .ComputeEngineStartInstanceOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -91,7 +91,7 @@ class GceInstanceStopOperator(ComputeEngineStopInstanceOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.compute
             .ComputeEngineStopInstanceOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -107,7 +107,7 @@ class GceInstanceTemplateCopyOperator(ComputeEngineCopyInstanceTemplateOperator)
             """"This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.compute
             .ComputeEngineCopyInstanceTemplateOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -123,6 +123,6 @@ class GceSetMachineTypeOperator(ComputeEngineSetMachineTypeOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.compute
             .ComputeEngineSetMachineTypeOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_container_operator.py
+++ b/airflow/contrib/operators/gcp_container_operator.py
@@ -41,7 +41,7 @@ class GKEClusterCreateOperator(GKECreateClusterOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.container.GKECreateClusterOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -56,7 +56,7 @@ class GKEClusterDeleteOperator(GKEDeleteClusterOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.container.GKEDeleteClusterOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -71,6 +71,6 @@ class GKEPodOperator(GKEStartPodOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.container.GKEStartPodOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_dlp_operator.py
+++ b/airflow/contrib/operators/gcp_dlp_operator.py
@@ -52,7 +52,7 @@ class CloudDLPDeleteDlpJobOperator(CloudDLPDeleteDLPJobOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dlp.CloudDLPDeleteDLPJobOperator`.""",
 
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -67,7 +67,7 @@ class CloudDLPGetDlpJobOperator(CloudDLPGetDLPJobOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dlp.CloudDLPGetDLPJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -82,7 +82,7 @@ class CloudDLPGetJobTripperOperator(CloudDLPGetDLPJobTriggerOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dlp.CloudDLPGetDLPJobTriggerOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -97,6 +97,6 @@ class CloudDLPListDlpJobsOperator(CloudDLPListDLPJobsOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.dlp.CloudDLPListDLPJobsOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_function_operator.py
+++ b/airflow/contrib/operators/gcp_function_operator.py
@@ -40,7 +40,7 @@ class GcfFunctionDeleteOperator(CloudFunctionDeleteFunctionOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.function.CloudFunctionDeleteFunctionOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -56,6 +56,6 @@ class GcfFunctionDeployOperator(CloudFunctionDeployFunctionOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.function.CloudFunctionDeployFunctionOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_natural_language_operator.py
+++ b/airflow/contrib/operators/gcp_natural_language_operator.py
@@ -48,7 +48,7 @@ class CloudLanguageAnalyzeEntitiesOperator(CloudNaturalLanguageAnalyzeEntitiesOp
             `airflow.providers.google.cloud.operators.natural_language
             .CloudNaturalLanguageAnalyzeEntitiesOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -68,7 +68,7 @@ class CloudLanguageAnalyzeEntitySentimentOperator(CloudNaturalLanguageAnalyzeEnt
             `airflow.providers.google.cloud.operators.natural_language
             .CloudNaturalLanguageAnalyzeEntitySentimentOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -86,7 +86,7 @@ class CloudLanguageAnalyzeSentimentOperator(CloudNaturalLanguageAnalyzeSentiment
             Please use `airflow.providers.google.cloud.operators.natural_language
             .CloudNaturalLanguageAnalyzeSentimentOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -104,6 +104,6 @@ class CloudLanguageClassifyTextOperator(CloudNaturalLanguageClassifyTextOperator
             Please use `airflow.providers.google.cloud.operators.natural_language
             .CloudNaturalLanguageClassifyTextOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_spanner_operator.py
+++ b/airflow/contrib/operators/gcp_spanner_operator.py
@@ -40,7 +40,7 @@ class CloudSpannerInstanceDatabaseDeleteOperator(SpannerDeleteDatabaseInstanceOp
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            self.__doc__, DeprecationWarning, stacklevel=3,
+            self.__doc__, DeprecationWarning, stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -53,7 +53,7 @@ class CloudSpannerInstanceDatabaseDeployOperator(SpannerDeployDatabaseInstanceOp
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            self.__doc__, DeprecationWarning, stacklevel=3,
+            self.__doc__, DeprecationWarning, stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -66,7 +66,7 @@ class CloudSpannerInstanceDatabaseQueryOperator(SpannerQueryDatabaseInstanceOper
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            self.__doc__, DeprecationWarning, stacklevel=3,
+            self.__doc__, DeprecationWarning, stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -79,7 +79,7 @@ class CloudSpannerInstanceDatabaseUpdateOperator(SpannerUpdateDatabaseInstanceOp
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            self.__doc__, DeprecationWarning, stacklevel=3,
+            self.__doc__, DeprecationWarning, stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -92,7 +92,7 @@ class CloudSpannerInstanceDeleteOperator(SpannerDeleteInstanceOperator):
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            self.__doc__, DeprecationWarning, stacklevel=3,
+            self.__doc__, DeprecationWarning, stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -105,6 +105,6 @@ class CloudSpannerInstanceDeployOperator(SpannerDeployInstanceOperator):
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            self.__doc__, DeprecationWarning, stacklevel=3,
+            self.__doc__, DeprecationWarning, stacklevel=4,
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_speech_to_text_operator.py
+++ b/airflow/contrib/operators/gcp_speech_to_text_operator.py
@@ -42,6 +42,6 @@ class GcpSpeechToTextRecognizeSpeechOperator(CloudSpeechToTextRecognizeSpeechOpe
             Please use
             `airflow.providers.google.cloud.operators.speech_to_text
             .CloudSpeechToTextRecognizeSpeechOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_sql_operator.py
+++ b/airflow/contrib/operators/gcp_sql_operator.py
@@ -40,7 +40,7 @@ class CloudSqlBaseOperator(CloudSQLBaseOperator):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -51,7 +51,7 @@ class CloudSqlInstanceCreateOperator(CloudSQLCreateInstanceOperator):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -62,7 +62,7 @@ class CloudSqlInstanceDatabaseCreateOperator(CloudSQLCreateInstanceDatabaseOpera
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -73,7 +73,7 @@ class CloudSqlInstanceDatabaseDeleteOperator(CloudSQLDeleteInstanceDatabaseOpera
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -84,7 +84,7 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSQLPatchInstanceDatabaseOperato
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -95,7 +95,7 @@ class CloudSqlInstanceDeleteOperator(CloudSQLDeleteInstanceOperator):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -106,7 +106,7 @@ class CloudSqlInstanceExportOperator(CloudSQLExportInstanceOperator):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -117,7 +117,7 @@ class CloudSqlInstanceImportOperator(CloudSQLImportInstanceOperator):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -128,7 +128,7 @@ class CloudSqlInstancePatchOperator(CloudSQLInstancePatchOperator):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)
 
 
@@ -139,5 +139,5 @@ class CloudSqlQueryOperator(CloudSQLExecuteQueryOperator):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=3)
+        warnings.warn(self.__doc__, DeprecationWarning, stacklevel=4)
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_text_to_speech_operator.py
+++ b/airflow/contrib/operators/gcp_text_to_speech_operator.py
@@ -40,6 +40,6 @@ class GcpTextToSpeechSynthesizeOperator(CloudTextToSpeechSynthesizeOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.text_to_speech.CloudTextToSpeechSynthesizeOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_transfer_operator.py
+++ b/airflow/contrib/operators/gcp_transfer_operator.py
@@ -49,7 +49,7 @@ class GcpTransferServiceJobCreateOperator(CloudDataTransferServiceCreateJobOpera
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceCreateJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -66,7 +66,7 @@ class GcpTransferServiceJobDeleteOperator(CloudDataTransferServiceDeleteJobOpera
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceDeleteJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -83,7 +83,7 @@ class GcpTransferServiceJobUpdateOperator(CloudDataTransferServiceUpdateJobOpera
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceUpdateJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -101,7 +101,7 @@ class GcpTransferServiceOperationCancelOperator(CloudDataTransferServiceCancelOp
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceCancelOperationOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -118,7 +118,7 @@ class GcpTransferServiceOperationGetOperator(CloudDataTransferServiceGetOperatio
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceGetOperationOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -136,7 +136,7 @@ class GcpTransferServiceOperationPauseOperator(CloudDataTransferServicePauseOper
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServicePauseOperationOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -154,7 +154,7 @@ class GcpTransferServiceOperationResumeOperator(CloudDataTransferServiceResumeOp
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceResumeOperationOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -172,7 +172,7 @@ class GcpTransferServiceOperationsListOperator(CloudDataTransferServiceListOpera
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceListOperationsOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -190,7 +190,7 @@ class GoogleCloudStorageToGoogleCloudStorageTransferOperator(CloudDataTransferSe
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceGCSToGCSOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -208,6 +208,6 @@ class S3ToGoogleCloudStorageTransferOperator(CloudDataTransferServiceS3ToGCSOper
             Please use `airflow.providers.google.cloud.operators.data_transfer
             .CloudDataTransferServiceS3ToGCSOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_translate_speech_operator.py
+++ b/airflow/contrib/operators/gcp_translate_speech_operator.py
@@ -40,6 +40,6 @@ class GcpTranslateSpeechOperator(CloudTranslateSpeechOperator):
             Please use
             `airflow.providers.google.cloud.operators.translate_speech.CloudTranslateSpeechOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcp_vision_operator.py
+++ b/airflow/contrib/operators/gcp_vision_operator.py
@@ -47,7 +47,7 @@ class CloudVisionAnnotateImageOperator(CloudVisionImageAnnotateOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.vision.CloudVisionImageAnnotateOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -62,7 +62,7 @@ class CloudVisionDetectDocumentTextOperator(CloudVisionTextDetectOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.vision.CloudVisionTextDetectOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -77,7 +77,7 @@ class CloudVisionProductCreateOperator(CloudVisionCreateProductOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.vision.CloudVisionCreateProductOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -92,7 +92,7 @@ class CloudVisionProductDeleteOperator(CloudVisionDeleteProductOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.vision.CloudVisionDeleteProductOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -107,7 +107,7 @@ class CloudVisionProductGetOperator(CloudVisionGetProductOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.vision.CloudVisionGetProductOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -123,7 +123,7 @@ class CloudVisionProductSetCreateOperator(CloudVisionCreateProductSetOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.vision.CloudVisionCreateProductSetOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -139,7 +139,7 @@ class CloudVisionProductSetDeleteOperator(CloudVisionDeleteProductSetOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.vision.CloudVisionDeleteProductSetOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -155,7 +155,7 @@ class CloudVisionProductSetGetOperator(CloudVisionGetProductSetOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.vision.CloudVisionGetProductSetOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -171,7 +171,7 @@ class CloudVisionProductSetUpdateOperator(CloudVisionUpdateProductSetOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.vision.CloudVisionUpdateProductSetOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -187,7 +187,7 @@ class CloudVisionProductUpdateOperator(CloudVisionUpdateProductOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.vision.CloudVisionUpdateProductOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -203,6 +203,6 @@ class CloudVisionReferenceImageCreateOperator(CloudVisionCreateReferenceImageOpe
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.vision.CloudVisionCreateReferenceImageOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_acl_operator.py
+++ b/airflow/contrib/operators/gcs_acl_operator.py
@@ -41,7 +41,7 @@ class GoogleCloudStorageBucketCreateAclEntryOperator(GCSBucketCreateAclEntryOper
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.gcs.GCSBucketCreateAclEntryOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -56,6 +56,6 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(GCSObjectCreateAclEntryOper
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.gcs.GCSObjectCreateAclEntryOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_delete_operator.py
+++ b/airflow/contrib/operators/gcs_delete_operator.py
@@ -39,6 +39,6 @@ class GoogleCloudStorageDeleteOperator(GCSDeleteObjectsOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.gcs.GCSDeleteObjectsOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -39,6 +39,6 @@ class GoogleCloudStorageDownloadOperator(GCSToLocalFilesystemOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.gcs.GCSToLocalFilesystemOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -39,6 +39,6 @@ class GoogleCloudStorageListOperator(GCSListObjectsOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.gcs.GCSListObjectsOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -39,6 +39,6 @@ class GoogleCloudStorageCreateBucketOperator(GCSCreateBucketOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.gcs.GCSCreateBucketOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -39,6 +39,6 @@ class GoogleCloudStorageToBigQueryOperator(GCSToBigQueryOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.gcs_to_bq.GCSToBigQueryOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -39,6 +39,6 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(GCSToGCSOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -38,6 +38,6 @@ class GoogleCloudStorageToS3Operator(GCSToS3Operator):
         warnings.warn(
             "This class is deprecated. "
             "Please use `airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator`.",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -41,7 +41,7 @@ class MLEngineBatchPredictionOperator(MLEngineStartBatchPredictionJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.mlengine.MLEngineStartBatchPredictionJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -56,7 +56,7 @@ class MLEngineModelOperator(MLEngineManageModelOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.mlengine.MLEngineManageModelOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -72,7 +72,7 @@ class MLEngineTrainingOperator(MLEngineStartTrainingJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.mlengine.MLEngineStartTrainingJobOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -88,6 +88,6 @@ class MLEngineVersionOperator(MLEngineManageVersionOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.mlengine.MLEngineManageVersionOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/mssql_to_gcs.py
+++ b/airflow/contrib/operators/mssql_to_gcs.py
@@ -37,6 +37,6 @@ class MsSqlToGoogleCloudStorageOperator(MSSQLToGCSOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.mssql_to_gcs.MSSQLToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -37,6 +37,6 @@ class MySqlToGoogleCloudStorageOperator(MySQLToGCSOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.mysql_to_gcs.MySQLToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/oracle_to_oracle_transfer.py
+++ b/airflow/contrib/operators/oracle_to_oracle_transfer.py
@@ -43,6 +43,6 @@ class OracleToOracleTransfer(OracleToOracleOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.oracle.transfers.oracle_to_oracle.OracleToOracleOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -37,6 +37,6 @@ class PostgresToGoogleCloudStorageOperator(PostgresToGCSOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.postgres_to_gcs.PostgresToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/pubsub_operator.py
+++ b/airflow/contrib/operators/pubsub_operator.py
@@ -46,7 +46,7 @@ class PubSubPublishOperator(PubSubPublishMessageOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.pubsub.PubSubPublishMessageOperator`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -62,7 +62,7 @@ class PubSubSubscriptionCreateOperator(PubSubCreateSubscriptionOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.pubsub.PubSubCreateSubscriptionOperator`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -78,7 +78,7 @@ class PubSubSubscriptionDeleteOperator(PubSubDeleteSubscriptionOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.pubsub.PubSubDeleteSubscriptionOperator`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -94,7 +94,7 @@ class PubSubTopicCreateOperator(PubSubCreateTopicOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.pubsub.PubSubCreateTopicOperator`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)
 
@@ -110,6 +110,6 @@ class PubSubTopicDeleteOperator(PubSubDeleteTopicOperator):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.operators.pubsub.PubSubDeleteTopicOperator`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/sql_to_gcs.py
+++ b/airflow/contrib/operators/sql_to_gcs.py
@@ -37,6 +37,6 @@ class BaseSQLToGoogleCloudStorageOperator(BaseSQLToGCSOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.transfers.sql_to_gcs.BaseSQLToGCSOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/vertica_to_hive.py
+++ b/airflow/contrib/operators/vertica_to_hive.py
@@ -42,6 +42,6 @@ class VerticaToHiveTransfer(VerticaToHiveOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.apache.hive.transfers.vertica_to_hive.VerticaToHiveOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/vertica_to_mysql.py
+++ b/airflow/contrib/operators/vertica_to_mysql.py
@@ -43,6 +43,6 @@ class VerticaToMySqlTransfer(VerticaToMySqlOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.mysql.transfers.vertica_to_mysql.VerticaToMySqlOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/sensors/bigquery_sensor.py
+++ b/airflow/contrib/sensors/bigquery_sensor.py
@@ -39,6 +39,6 @@ class BigQueryTableSensor(BigQueryTableExistenceSensor):
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.sensors.bigquery.BigQueryTableExistenceSensor`.""",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=4,
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/sensors/gcp_transfer_sensor.py
+++ b/airflow/contrib/sensors/gcp_transfer_sensor.py
@@ -44,6 +44,6 @@ class GCPTransferServiceWaitForJobStatusSensor(CloudDataTransferServiceJobStatus
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.sensors.transfer.CloudDataTransferServiceJobStatusSensor`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -40,7 +40,7 @@ class GoogleCloudStorageObjectSensor(GCSObjectExistenceSensor):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.sensors.gcs.GCSObjectExistenceSensor`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -55,7 +55,7 @@ class GoogleCloudStorageObjectUpdatedSensor(GCSObjectUpdateSensor):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.sensors.gcs.GCSObjectUpdateSensor`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -70,7 +70,7 @@ class GoogleCloudStoragePrefixSensor(GCSObjectsWtihPrefixExistenceSensor):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.sensors.gcs.GCSObjectsWtihPrefixExistenceSensor`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -85,6 +85,6 @@ class GoogleCloudStorageUploadSessionCompleteSensor(GCSUploadSessionCompleteSens
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.google.cloud.sensors.gcs.GCSUploadSessionCompleteSensor`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/sensors/hdfs_sensor.py
+++ b/airflow/contrib/sensors/hdfs_sensor.py
@@ -44,7 +44,7 @@ class HdfsSensorFolder(HdfsFolderSensor):
             """This class is deprecated.
             Please use
             `airflow.providers.apache.hdfs.sensors.hdfs.HdfsFolderSensor`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)
 
@@ -62,6 +62,6 @@ class HdfsSensorRegex(HdfsRegexSensor):
             """This class is deprecated.
             Please use
             `airflow.providers.apache.hdfs.sensors.hdfs.HdfsRegexSensor`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(*args, **kwargs)

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -51,7 +51,7 @@ from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkipped
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils import timezone
-from airflow.utils.decorators import apply_defaults
+from airflow.utils.decorators import _apply_defaults
 from airflow.utils.helpers import validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.operator_resources import Resources
@@ -71,6 +71,11 @@ class BaseOperatorMeta(abc.ABCMeta):
     """
     Base metaclass of BaseOperator.
     """
+
+    def __new__(cls, name, bases, namespace):
+        new_cls = super().__new__(cls, name, bases, namespace)
+        new_cls.__init__ = _apply_defaults(new_cls.__init__)
+        return new_cls
 
     def __call__(cls, *args, **kwargs):
         """
@@ -330,7 +335,6 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
     _lock_for_execution = False
 
     # pylint: disable=too-many-arguments,too-many-locals, too-many-statements
-    @apply_defaults
     def __init__(
         self,
         task_id: str,

--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -40,7 +40,7 @@ class CheckOperator(SQLCheckOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.operators.sql.SQLCheckOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(**kwargs)
 
@@ -55,7 +55,7 @@ class IntervalCheckOperator(SQLIntervalCheckOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.operators.sql.SQLIntervalCheckOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(**kwargs)
 
@@ -70,7 +70,7 @@ class ThresholdCheckOperator(SQLThresholdCheckOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.operators.sql.SQLThresholdCheckOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(**kwargs)
 
@@ -85,6 +85,6 @@ class ValueCheckOperator(SQLValueCheckOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.operators.sql.SQLValueCheckOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(**kwargs)

--- a/airflow/operators/presto_check_operator.py
+++ b/airflow/operators/presto_check_operator.py
@@ -38,7 +38,7 @@ class PrestoCheckOperator(SQLCheckOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.operators.sql.SQLCheckOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(**kwargs)
 
@@ -55,7 +55,7 @@ class PrestoIntervalCheckOperator(SQLIntervalCheckOperator):
             This class is deprecated.l
             Please use `airflow.operators.sql.SQLIntervalCheckOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(**kwargs)
 
@@ -72,6 +72,6 @@ class PrestoValueCheckOperator(SQLValueCheckOperator):
             This class is deprecated.l
             Please use `airflow.operators.sql.SQLValueCheckOperator`.
             """,
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(**kwargs)

--- a/airflow/operators/sql_branch_operator.py
+++ b/airflow/operators/sql_branch_operator.py
@@ -35,6 +35,6 @@ class BranchSqlOperator(BranchSQLOperator):
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.operators.sql.BranchSQLOperator`.""",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=4
         )
         super().__init__(**kwargs)

--- a/airflow/providers/google/cloud/operators/automl.py
+++ b/airflow/providers/google/cloud/operators/automl.py
@@ -177,7 +177,7 @@ class AutoMLPredictOperator(BaseOperator):
         model_id: str,
         location: str,
         payload: dict,
-        params: Optional[Dict[str, str]] = None,
+        operation_params: Optional[Dict[str, str]] = None,
         project_id: Optional[str] = None,
         metadata: Optional[MetaData] = None,
         timeout: Optional[float] = None,
@@ -189,7 +189,7 @@ class AutoMLPredictOperator(BaseOperator):
         super().__init__(**kwargs)
 
         self.model_id = model_id
-        self.params = params  # type: ignore
+        self.operation_params = operation_params  # type: ignore
         self.location = location
         self.project_id = project_id
         self.metadata = metadata
@@ -209,7 +209,7 @@ class AutoMLPredictOperator(BaseOperator):
             payload=self.payload,
             location=self.location,
             project_id=self.project_id,
-            params=self.params,
+            params=self.operation_params,
             retry=self.retry,
             timeout=self.timeout,
             metadata=self.metadata,

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -19,6 +19,7 @@
 
 import inspect
 import os
+import warnings
 from copy import copy
 from functools import wraps
 from typing import Any, Callable, Dict, TypeVar, cast
@@ -30,7 +31,7 @@ signature = inspect.signature
 T = TypeVar('T', bound=Callable)  # pylint: disable=invalid-name
 
 
-def apply_defaults(func: T) -> T:
+def _apply_defaults(func: T) -> T:
     """
     Function decorator that Looks for an argument named "default_args", and
     fills the unspecified arguments from it.
@@ -94,7 +95,28 @@ def apply_defaults(func: T) -> T:
     return cast(T, wrapper)
 
 
+def apply_defaults(func: T) -> T:
+    """
+    This decorator is deprecated.
+
+    In previous versions, all subclasses of BaseOperator must use apply_default decorator for the"
+    `default_args` feature to work properly.
+
+    In current version, it is optional. The decorator is applied automatically using the metaclass.
+    """
+    warnings.warn(
+        "This decorator is deprecated. \n"
+        "\n"
+        "In previous versions, all subclasses of BaseOperator must use apply_default decorator for the"
+        "`default_args` feature to work properly.\n"
+        "\n"
+        "In current version, it is optional. The decorator is applied automatically using the metaclass.\n",
+        DeprecationWarning, stacklevel=3
+    )
+    return func
+
+
 if 'BUILDING_AIRFLOW_DOCS' in os.environ:
     # flake8: noqa: F811
     # Monkey patch hook to get good function headers while building docs
-    apply_defaults = lambda x: x
+    _apply_defaults = lambda x: x

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -88,7 +88,8 @@ def _apply_defaults(func: T) -> T:
             msg = "Argument {0} is required".format(missing_args)
             raise AirflowException(msg)
 
-        kwargs['params'] = dag_params
+        if dag_params:
+            kwargs['params'] = dag_params
 
         result = func(*args, **kwargs)
         return result

--- a/tests/providers/google/cloud/operators/test_automl.py
+++ b/tests/providers/google/cloud/operators/test_automl.py
@@ -119,7 +119,7 @@ class TestAutoMLPredictOperator(unittest.TestCase):
             project_id=GCP_PROJECT_ID,
             payload=PAYLOAD,
             task_id=TASK_ID,
-            operation_params={"TEST_KEY": "TEST_VALUE"}
+            operation_params={"TEST_KEY": "TEST_VALUE"},
         )
         op.execute(context=None)
         mock_hook.return_value.predict.assert_called_once_with(

--- a/tests/providers/google/cloud/operators/test_automl.py
+++ b/tests/providers/google/cloud/operators/test_automl.py
@@ -119,13 +119,14 @@ class TestAutoMLPredictOperator(unittest.TestCase):
             project_id=GCP_PROJECT_ID,
             payload=PAYLOAD,
             task_id=TASK_ID,
+            operation_params={"TEST_KEY": "TEST_VALUE"}
         )
         op.execute(context=None)
         mock_hook.return_value.predict.assert_called_once_with(
             location=GCP_LOCATION,
             metadata=None,
             model_id=MODEL_ID,
-            params=None,
+            params={"TEST_KEY": "TEST_VALUE"},
             payload=PAYLOAD,
             project_id=GCP_PROJECT_ID,
             retry=None,

--- a/tests/providers/google/cloud/operators/test_automl.py
+++ b/tests/providers/google/cloud/operators/test_automl.py
@@ -125,7 +125,7 @@ class TestAutoMLPredictOperator(unittest.TestCase):
             location=GCP_LOCATION,
             metadata=None,
             model_id=MODEL_ID,
-            params={},
+            params=None,
             payload=PAYLOAD,
             project_id=GCP_PROJECT_ID,
             retry=None,

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -19,18 +19,27 @@
 import unittest
 
 from airflow.exceptions import AirflowException
-from airflow.utils.decorators import apply_defaults
+from airflow.utils.decorators import _apply_defaults
 
 
-# Essentially similar to airflow.models.BaseOperator
-class DummyClass:
-    @apply_defaults
+# Essentially similar to airflow.models.baseoperator.BaseOperatorMetaClass
+class DummyMetaClass(type):
+    """
+    A metaclass that automatically decorates the constructor with apply_default for all child classes
+    """
+    def __new__(cls, name, bases, namespace):
+        new_cls = super().__new__(cls, name, bases, namespace)
+        new_cls.__init__ = _apply_defaults(new_cls.__init__)
+        return new_cls
+
+
+# Essentially similar to airflow.models.baseoperator.BaseOperator
+class DummyClass(metaclass=DummyMetaClass):
     def __init__(self, test_param, params=None, default_args=None):  # pylint: disable=unused-argument
         self.test_param = test_param
 
 
 class DummySubClass(DummyClass):
-    @apply_defaults
     def __init__(self, test_sub_param, **kwargs):
         super().__init__(**kwargs)
         self.test_sub_param = test_sub_param


### PR DESCRIPTION
This decorator is confusing to new users. However, it can be applied automatically without the need to involve users through the use of metaclass.

---
Issue link: [AIRFLOW-6829](https://issues.apache.org/jira/browse/AIRFLOW-6829)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
