### PR TITLE
[AIRFLOW-6830] Add Subject/MessageAttributes to SNS hook and operator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/sns.py
+++ b/airflow/providers/amazon/aws/hooks/sns.py
@@ -27,15 +27,14 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 def _get_message_attribute(o):
     if isinstance(o, bytes):
         return {'DataType': 'Binary', 'BinaryValue': o}
-    elif isinstance(o, str):
+    if isinstance(o, str):
         return {'DataType': 'String', 'StringValue': o}
-    elif isinstance(o, (int, float)):
+    if isinstance(o, (int, float)):
         return {'DataType': 'Number', 'StringValue': str(o)}
-    elif hasattr(o, '__iter__'):
+    if hasattr(o, '__iter__'):
         return {'DataType': 'String.Array', 'StringValue': json.dumps(o)}
-    else:
-        raise TypeError('Values in MessageAttributes must be one of bytes, str, int, float, or iterable; '
-                        f'got {type(o)}')
+    raise TypeError('Values in MessageAttributes must be one of bytes, str, int, float, or iterable; '
+                    f'got {type(o)}')
 
 
 class AwsSnsHook(AwsBaseHook):
@@ -65,12 +64,12 @@ class AwsSnsHook(AwsBaseHook):
         :param subject: subject of message
         :type subject: str
         :param message_attributes: additional attributes to publish for message filtering. This should be
-                                   a flat dict; the DataType to be sent depends on the type of the value
+            a flat dict; the DataType to be sent depends on the type of the value:
 
-                                   - bytes = Binary
-                                   - str = String
-                                   - int, float = Number
-                                   - iterable = String.Array
+            - bytes = Binary
+            - str = String
+            - int, float = Number
+            - iterable = String.Array
 
         :type message_attributes: mapping
         """

--- a/airflow/providers/amazon/aws/hooks/sns.py
+++ b/airflow/providers/amazon/aws/hooks/sns.py
@@ -71,7 +71,7 @@ class AwsSnsHook(AwsBaseHook):
             - int, float = Number
             - iterable = String.Array
 
-        :type message_attributes: mapping
+        :type message_attributes: dict
         """
 
         conn = self.get_conn()

--- a/airflow/providers/amazon/aws/hooks/sns.py
+++ b/airflow/providers/amazon/aws/hooks/sns.py
@@ -24,6 +24,20 @@ import json
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 
+def _get_message_attribute(o):
+    if isinstance(o, bytes):
+        return {'DataType': 'Binary', 'BinaryValue': o}
+    elif isinstance(o, str):
+        return {'DataType': 'String', 'StringValue': o}
+    elif isinstance(o, (int, float)):
+        return {'DataType': 'Number', 'StringValue': str(o)}
+    elif hasattr(o, '__iter__'):
+        return {'DataType': 'String.Array', 'StringValue': json.dumps(o)}
+    else:
+        raise TypeError('Values in MessageAttributes must be one of bytes, str, int, float, or iterable; '
+                        f'got {type(o)}')
+
+
 class AwsSnsHook(AwsBaseHook):
     """
     Interact with Amazon Simple Notification Service.
@@ -40,7 +54,7 @@ class AwsSnsHook(AwsBaseHook):
         self.conn = self.get_client_type('sns')
         return self.conn
 
-    def publish_to_target(self, target_arn, message, subject=None):
+    def publish_to_target(self, target_arn, message, subject=None, message_attributes=None):
         """
         Publish a message to a topic or an endpoint.
 
@@ -50,24 +64,33 @@ class AwsSnsHook(AwsBaseHook):
         :param message: str
         :param subject: subject of message
         :type subject: str
+        :param message_attributes: additional attributes to publish for message filtering. This should be
+                                   a flat dict; the DataType to be sent depends on the type of the value
+
+                                   - bytes = Binary
+                                   - str = String
+                                   - int, float = Number
+                                   - iterable = String.Array
+
+        :type message_attributes: mapping
         """
 
         conn = self.get_conn()
 
-        messages = {
-            'default': message
+        publish_kwargs = {
+            'TargetArn': target_arn,
+            'MessageStructure': 'json',
+            'Message': json.dumps({
+                'default': message
+            }),
         }
 
-        if subject is None:
-            return conn.publish(
-                TargetArn=target_arn,
-                Message=json.dumps(messages),
-                MessageStructure='json'
-            )
+        # Construct args this way because boto3 distinguishes from missing args and those set to None
+        if subject:
+            publish_kwargs['Subject'] = subject
+        if message_attributes:
+            publish_kwargs['MessageAttributes'] = {
+                key: _get_message_attribute(val) for key, val in message_attributes.items()
+            }
 
-        return conn.publish(
-            TargetArn=target_arn,
-            Message=json.dumps(messages),
-            MessageStructure='json',
-            Subject=subject
-        )
+        return conn.publish(**publish_kwargs)

--- a/airflow/providers/amazon/aws/operators/sns.py
+++ b/airflow/providers/amazon/aws/operators/sns.py
@@ -33,8 +33,13 @@ class SnsPublishOperator(BaseOperator):
     :type target_arn: str
     :param message: the default message you want to send (templated)
     :type message: str
+    :param subject: the message subject you want to send (templated)
+    :type subject: str
+    :param message_attributes: the message attributes you want to send as a flat dict (data type will be
+                               determined automatically)
+    :type message_attributes: mapping
     """
-    template_fields = ['message']
+    template_fields = ['message', 'subject', 'message_attributes']
     template_ext = ()
 
     @apply_defaults
@@ -43,23 +48,31 @@ class SnsPublishOperator(BaseOperator):
             target_arn,
             message,
             aws_conn_id='aws_default',
+            subject=None,
+            message_attributes=None,
             *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.target_arn = target_arn
         self.message = message
+        self.subject = subject
+        self.message_attributes = message_attributes
         self.aws_conn_id = aws_conn_id
 
     def execute(self, context):
         sns = AwsSnsHook(aws_conn_id=self.aws_conn_id)
 
         self.log.info(
-            'Sending SNS notification to %s using %s:\n%s',
+            'Sending SNS notification to %s using %s:\nsubject=%s\nattributes=%s\nmessage=%s',
             self.target_arn,
             self.aws_conn_id,
-            self.message
+            self.subject,
+            self.message_attributes,
+            self.message,
         )
 
         return sns.publish_to_target(
             target_arn=self.target_arn,
-            message=self.message
+            message=self.message,
+            subject=self.subject,
+            message_attributes=self.message_attributes,
         )

--- a/airflow/providers/amazon/aws/operators/sns.py
+++ b/airflow/providers/amazon/aws/operators/sns.py
@@ -36,7 +36,7 @@ class SnsPublishOperator(BaseOperator):
     :param subject: the message subject you want to send (templated)
     :type subject: str
     :param message_attributes: the message attributes you want to send as a flat dict (data type will be
-                               determined automatically)
+        determined automatically)
     :type message_attributes: mapping
     """
     template_fields = ['message', 'subject', 'message_attributes']

--- a/airflow/providers/amazon/aws/operators/sns.py
+++ b/airflow/providers/amazon/aws/operators/sns.py
@@ -37,7 +37,7 @@ class SnsPublishOperator(BaseOperator):
     :type subject: str
     :param message_attributes: the message attributes you want to send as a flat dict (data type will be
         determined automatically)
-    :type message_attributes: mapping
+    :type message_attributes: dict
     """
     template_fields = ['message', 'subject', 'message_attributes']
     template_ext = ()

--- a/tests/providers/amazon/aws/hooks/test_sns.py
+++ b/tests/providers/amazon/aws/hooks/test_sns.py
@@ -36,7 +36,7 @@ class TestAwsSnsHook(unittest.TestCase):
         self.assertIsNotNone(hook.get_conn())
 
     @mock_sns
-    def test_publish_to_target(self):
+    def test_publish_to_target_with_subject(self):
         hook = AwsSnsHook(aws_conn_id='aws_default')
 
         message = "Hello world"
@@ -49,7 +49,24 @@ class TestAwsSnsHook(unittest.TestCase):
         self.assertTrue('MessageId' in response)
 
     @mock_sns
-    def test_publish_to_target_without_subject(self):
+    def test_publish_to_target_with_attributes(self):
+        hook = AwsSnsHook(aws_conn_id='aws_default')
+
+        message = "Hello world"
+        topic_name = "test-topic"
+        target = hook.get_conn().create_topic(Name=topic_name).get('TopicArn')
+
+        response = hook.publish_to_target(target, message, message_attributes={
+            'test-string': 'string-value',
+            'test-number': 123456,
+            'test-array': ['first', 'second', 'third'],
+            'test-binary': b'binary-value',
+        })
+
+        self.assertTrue('MessageId' in response)
+
+    @mock_sns
+    def test_publish_to_target_plain(self):
         hook = AwsSnsHook(aws_conn_id='aws_default')
 
         message = "Hello world"

--- a/tests/providers/amazon/aws/hooks/test_sns.py
+++ b/tests/providers/amazon/aws/hooks/test_sns.py
@@ -46,7 +46,7 @@ class TestAwsSnsHook(unittest.TestCase):
 
         response = hook.publish_to_target(target, message, subject)
 
-        self.assertTrue('MessageId' in response)
+        assert 'MessageId' in response
 
     @mock_sns
     def test_publish_to_target_with_attributes(self):
@@ -63,7 +63,7 @@ class TestAwsSnsHook(unittest.TestCase):
             'test-binary': b'binary-value',
         })
 
-        self.assertTrue('MessageId' in response)
+        assert 'MessageId' in response
 
     @mock_sns
     def test_publish_to_target_plain(self):
@@ -75,7 +75,7 @@ class TestAwsSnsHook(unittest.TestCase):
 
         response = hook.publish_to_target(target, message)
 
-        self.assertTrue('MessageId' in response)
+        assert 'MessageId' in response
 
 
 if __name__ == '__main__':

--- a/tests/providers/amazon/aws/operators/test_sns.py
+++ b/tests/providers/amazon/aws/operators/test_sns.py
@@ -26,6 +26,8 @@ TASK_ID = "sns_publish_job"
 AWS_CONN_ID = "custom_aws_conn"
 TARGET_ARN = "arn:aws:sns:eu-central-1:1234567890:test-topic"
 MESSAGE = "Message to send"
+SUBJECT = "Subject to send"
+MESSAGE_ATTRIBUTES = {"test-attribute": "Attribute to send"}
 
 
 class TestSnsPublishOperator(unittest.TestCase):
@@ -36,7 +38,9 @@ class TestSnsPublishOperator(unittest.TestCase):
             task_id=TASK_ID,
             aws_conn_id=AWS_CONN_ID,
             target_arn=TARGET_ARN,
-            message=MESSAGE
+            message=MESSAGE,
+            subject=SUBJECT,
+            message_attributes=MESSAGE_ATTRIBUTES,
         )
 
         # Then
@@ -44,6 +48,8 @@ class TestSnsPublishOperator(unittest.TestCase):
         self.assertEqual(AWS_CONN_ID, operator.aws_conn_id)
         self.assertEqual(TARGET_ARN, operator.target_arn)
         self.assertEqual(MESSAGE, operator.message)
+        self.assertEqual(SUBJECT, operator.subject)
+        self.assertEqual(MESSAGE_ATTRIBUTES, operator.message_attributes)
 
     @mock.patch('airflow.providers.amazon.aws.operators.sns.AwsSnsHook')
     def test_execute(self, mock_hook):
@@ -57,7 +63,9 @@ class TestSnsPublishOperator(unittest.TestCase):
             task_id=TASK_ID,
             aws_conn_id=AWS_CONN_ID,
             target_arn=TARGET_ARN,
-            message=MESSAGE
+            message=MESSAGE,
+            subject=SUBJECT,
+            message_attributes=MESSAGE_ATTRIBUTES,
         )
 
         # When


### PR DESCRIPTION
Add `subject` and `message_attributes` as possible parameters for `AwsSnsHook` and `SnsPublishOperator`. Both defaults to none and are backwards compatible.

---
Issue link: [AIRFLOW-6830](https://issues.apache.org/jira/browse/AIRFLOW-6830)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
