### PR TITLE
[AIRFLOW-6833] HA for webhdfs connection

### DIFF
--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -77,10 +77,10 @@ class WebHDFSHook(BaseHook):
                     client = self._get_client(connection)
                     client.status('/')
                     self.log.info('Using namenode %s for hook', connection.host)
-                    host_socket.close()
                     return client
                 else:
                     self.log.info("Could not connect to %s:%s", connection.host, connection.port)
+                host_socket.close()
             except HdfsError as hdfs_error:
                 self.log.info('Read operation on namenode %s failed with error: %s',
                               connection.host, hdfs_error)

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -77,6 +77,7 @@ class WebHDFSHook(BaseHook):
                     client = self._get_client(connection)
                     client.status('/')
                     self.log.info('Using namenode %s for hook', connection.host)
+                    host_socket.close()
                     return client
                 else:
                     self.log.info("Could not connect to %s:%s", connection.host, connection.port)

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -17,6 +17,7 @@
 # under the License.
 """Hook for Web HDFS"""
 import logging
+import socket
 
 from hdfs import HdfsError, InsecureClient
 

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -83,7 +83,7 @@ class WebHDFSHook(BaseHook):
                                   connection.host, hdfs_error)
             else:
                 self.log.info("Could not connect to %s:%s", connection.host, connection.port)
-        host_socket.close()
+        return None
 
     def _get_client(self, connection):
         connection_str = 'http://{host}:{port}'.format(host=connection.host, port=connection.port)

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -56,27 +56,36 @@ class WebHDFSHook(BaseHook):
     def get_conn(self):
         """
         Establishes a connection depending on the security mode set via config or environment variable.
-
         :return: a hdfscli InsecureClient or KerberosClient object.
         :rtype: hdfs.InsecureClient or hdfs.ext.kerberos.KerberosClient
         """
+        connection = self._find_valid_server()
+        if connection is None:
+            raise AirflowException("Failed to locate the valid server.")
+        return connection
+
+    def _find_valid_server(self):
         connections = self.get_connections(self.webhdfs_conn_id)
-
         for connection in connections:
+            host_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.log.info("Trying to connect to %s:%s", connection.host, connection.port)
             try:
-                self.log.debug('Trying namenode %s', connection.host)
-                client = self._get_client(connection)
-                client.status('/')
-                self.log.debug('Using namenode %s for hook', connection.host)
-                return client
-            except HdfsError as hdfs_error:
-                self.log.debug('Read operation on namenode %s failed with error: %s',
-                               connection.host, hdfs_error)
-
-        hosts = [connection.host for connection in connections]
-        error_message = 'Read operations failed on the namenodes below:\n{hosts}'.format(
-            hosts='\n'.join(hosts))
-        raise AirflowWebHDFSHookException(error_message)
+                conn_check = host_socket.connect_ex((connection.host, connection.port))
+                if conn_check == 0:
+                    try:
+                        self.log.info('Trying namenode %s', connection.host)
+                        client = self._get_client(connection)
+                        client.status('/')
+                        self.log.info('Using namenode %s for hook', connection.host)
+                        return client
+                    except HdfsError as hdfs_error:
+                        logging.info('Read operation on namenode %s failed with error: %s',
+                                     connection.host, hdfs_error)
+                else:
+                    self.log.info("Could not connect to %s:%s", connection.host, connection.port)
+            except Exception as err:
+                self.log.info(err)
+            host_socket.close()
 
     def _get_client(self, connection):
         connection_str = 'http://{host}:{port}'.format(host=connection.host, port=connection.port)

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -70,19 +70,19 @@ class WebHDFSHook(BaseHook):
         for connection in connections:
             host_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.log.info("Trying to connect to %s:%s", connection.host, connection.port)
-            conn_check = host_socket.connect_ex((connection.host, connection.port))
-            if conn_check == 0:
-                try:
+            try:
+                conn_check = host_socket.connect_ex((connection.host, connection.port))
+                if conn_check == 0:
                     self.log.info('Trying namenode %s', connection.host)
                     client = self._get_client(connection)
                     client.status('/')
                     self.log.info('Using namenode %s for hook', connection.host)
                     return client
-                except HdfsError as hdfs_error:
-                    self.log.info('Read operation on namenode %s failed with error: %s',
-                                  connection.host, hdfs_error)
-            else:
-                self.log.info("Could not connect to %s:%s", connection.host, connection.port)
+                else:
+                    self.log.info("Could not connect to %s:%s", connection.host, connection.port)
+            except HdfsError as hdfs_error:
+                self.log.info('Read operation on namenode %s failed with error: %s',
+                              connection.host, hdfs_error)
         return None
 
     def _get_client(self, connection):

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -62,7 +62,7 @@ class WebHDFSHook(BaseHook):
         """
         connection = self._find_valid_server()
         if connection is None:
-            raise AirflowException("Failed to locate the valid server.")
+            raise AirflowWebHDFSHookException("Failed to locate the valid server.")
         return connection
 
     def _find_valid_server(self):

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -70,23 +70,20 @@ class WebHDFSHook(BaseHook):
         for connection in connections:
             host_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.log.info("Trying to connect to %s:%s", connection.host, connection.port)
-            try:
-                conn_check = host_socket.connect_ex((connection.host, connection.port))
-                if conn_check == 0:
-                    try:
-                        self.log.info('Trying namenode %s', connection.host)
-                        client = self._get_client(connection)
-                        client.status('/')
-                        self.log.info('Using namenode %s for hook', connection.host)
-                        return client
-                    except HdfsError as hdfs_error:
-                        logging.info('Read operation on namenode %s failed with error: %s',
-                                     connection.host, hdfs_error)
-                else:
-                    self.log.info("Could not connect to %s:%s", connection.host, connection.port)
-            except Exception as err:
-                self.log.info(err)
-            host_socket.close()
+            conn_check = host_socket.connect_ex((connection.host, connection.port))
+            if conn_check == 0:
+                try:
+                    self.log.info('Trying namenode %s', connection.host)
+                    client = self._get_client(connection)
+                    client.status('/')
+                    self.log.info('Using namenode %s for hook', connection.host)
+                    return client
+                except HdfsError as hdfs_error:
+                    self.log.info('Read operation on namenode %s failed with error: %s',
+                                  connection.host, hdfs_error)
+            else:
+                self.log.info("Could not connect to %s:%s", connection.host, connection.port)
+        host_socket.close()
 
     def _get_client(self, connection):
         connection_str = 'http://{host}:{port}'.format(host=connection.host, port=connection.port)

--- a/tests/providers/apache/hdfs/hooks/test_webhdfs.py
+++ b/tests/providers/apache/hdfs/hooks/test_webhdfs.py
@@ -32,10 +32,10 @@ class TestWebHDFSHook(unittest.TestCase):
 
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.InsecureClient')
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook.get_connections', return_value=[
-        Connection(host='localhost', port=50070),
-        Connection(host='localhost', port=50071, login='user')
+        Connection(host='host_1', port=123),
+        Connection(host='host_2', port=321, login='user')
     ])
-    @patch("airflow.providers.apache.hive.hooks.hive.socket")
+    @patch("airflow.providers.apache.hdfs.hooks.webhdfs.socket")
     def test_get_conn(self, socket_mock, mock_get_connections, mock_insecure_client):
         mock_insecure_client.side_effect = [HdfsError('Error'), mock_insecure_client.return_value]
         socket_mock.socket.return_value.connect_ex.return_value = 0
@@ -51,14 +51,14 @@ class TestWebHDFSHook(unittest.TestCase):
 
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.KerberosClient', create=True)
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook.get_connections', return_value=[
-        Connection(host='localhost', port=50070)
+        Connection(host='host_1', port=123)
     ])
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs._kerberos_security_mode', return_value=True)
-    @patch("airflow.providers.apache.hive.hooks.hive.socket")
+    @patch("airflow.providers.apache.hdfs.hooks.webhdfs.socket")
     def test_get_conn_kerberos_security_mode(self,
+                                             socket_mock,
                                              mock_kerberos_security_mode,
                                              mock_get_connections,
-                                             socket_mock,
                                              mock_kerberos_client):
         socket_mock.socket.return_value.connect_ex.return_value = 0
         conn = self.webhdfs_hook.get_conn()

--- a/tests/providers/apache/hdfs/hooks/test_webhdfs.py
+++ b/tests/providers/apache/hdfs/hooks/test_webhdfs.py
@@ -37,7 +37,7 @@ class TestWebHDFSHook(unittest.TestCase):
     ])
     def test_get_conn(self, mock_get_connections, mock_insecure_client):
         mock_insecure_client.side_effect = [HdfsError('Error'), mock_insecure_client.return_value]
-        conn = self.webhdfs_hook.get_conn()
+        conn = self.webhdfs_hook._find_valid_server()
 
         mock_insecure_client.assert_has_calls([
             call('http://{host}:{port}'.format(host=connection.host, port=connection.port),
@@ -56,14 +56,14 @@ class TestWebHDFSHook(unittest.TestCase):
                                              mock_kerberos_security_mode,
                                              mock_get_connections,
                                              mock_kerberos_client):
-        conn = self.webhdfs_hook.get_conn()
+        conn = self.webhdfs_hook._find_valid_server()
 
         connection = mock_get_connections.return_value[0]
         mock_kerberos_client.assert_called_once_with(
             'http://{host}:{port}'.format(host=connection.host, port=connection.port))
         self.assertEqual(conn, mock_kerberos_client.return_value)
 
-    @patch('airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook.get_connections', return_value=[])
+    @patch('airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook._find_valid_server', return_value=None)
     def test_get_conn_no_connection_found(self, mock_get_connection):
         with self.assertRaises(AirflowWebHDFSHookException):
             self.webhdfs_hook.get_conn()

--- a/tests/providers/apache/hdfs/hooks/test_webhdfs.py
+++ b/tests/providers/apache/hdfs/hooks/test_webhdfs.py
@@ -32,8 +32,8 @@ class TestWebHDFSHook(unittest.TestCase):
 
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.InsecureClient')
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook.get_connections', return_value=[
-        Connection(host='localhost', port=123),
-        Connection(host='localhost', port=321, login='user')
+        Connection(host='localhost', port=50070),
+        Connection(host='localhost', port=50071, login='user')
     ])
     def test_get_conn(self, mock_get_connections, mock_insecure_client):
         mock_insecure_client.side_effect = [HdfsError('Error'), mock_insecure_client.return_value]
@@ -49,7 +49,7 @@ class TestWebHDFSHook(unittest.TestCase):
 
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.KerberosClient', create=True)
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook.get_connections', return_value=[
-        Connection(host='localhost', port=123)
+        Connection(host='localhost', port=50070)
     ])
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs._kerberos_security_mode', return_value=True)
     def test_get_conn_kerberos_security_mode(self,

--- a/tests/providers/apache/hdfs/hooks/test_webhdfs.py
+++ b/tests/providers/apache/hdfs/hooks/test_webhdfs.py
@@ -32,8 +32,8 @@ class TestWebHDFSHook(unittest.TestCase):
 
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.InsecureClient')
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook.get_connections', return_value=[
-        Connection(host='host_1', port=123),
-        Connection(host='host_2', port=321, login='user')
+        Connection(host='localhost', port=123),
+        Connection(host='localhost', port=321, login='user')
     ])
     def test_get_conn(self, mock_get_connections, mock_insecure_client):
         mock_insecure_client.side_effect = [HdfsError('Error'), mock_insecure_client.return_value]
@@ -49,7 +49,7 @@ class TestWebHDFSHook(unittest.TestCase):
 
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.KerberosClient', create=True)
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook.get_connections', return_value=[
-        Connection(host='host_1', port=123)
+        Connection(host='localhost', port=123)
     ])
     @patch('airflow.providers.apache.hdfs.hooks.webhdfs._kerberos_security_mode', return_value=True)
     def test_get_conn_kerberos_security_mode(self,


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6833](https://issues.apache.org/jira/browse/AIRFLOW-6833)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change

Creating a connection to a webhdfs with two hosts for high availability (eg connection 1, connection 2) is not possible because the entire value entered is taken. For our needs, it is necessary to go through subsequent hosts and connect to the first working.

This change allows you to check and then connect to a working webhdfs.


- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)

I think I don't have to write new tests

- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
