### PR TITLE
[AIRFLOW-6817] - Move airflow __init__.py imports to sub-packages

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -61,6 +61,19 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Removed sub-package imports from `airflow/__init__.py`
+
+The imports `LoggingMixin`, `conf`, `AirflowException`, and `DAG` have been removed from `airflow/__init__.py`.
+All implicit references of these objects will no longer be valid. To migrate, all usages of each old path must be
+replaced with its corresponding new path.
+
+| Old Path (Implicit Import)   | New Path (Explicit Import)                       |
+|------------------------------|--------------------------------------------------|
+| ``airflow.LoggingMixin``     | ``airflow.utils.log.logging_mixin.LoggingMixin`` |
+| ``airflow.conf``             | ``airflow.configuration.conf``                   |
+| ``airflow.AirflowException`` | ``airflow.exceptions.AirflowException``          |
+| ``airflow.DAG``              | ``airflow.models.dag.DAG``                  |
+
 ### Success Callback will be called when a task in marked as success from UI
 
 When a task is marked as success by a used from Airflow UI - on_success_callback will be called
@@ -1703,7 +1716,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> from airflow.settings import *
 >>>
 >>> from datetime import datetime
->>> from airflow import DAG
+>>> from airflow.models.dag import DAG
 >>> from airflow.operators.dummy_operator import DummyOperator
 >>>
 >>> dag = DAG('simple_dag', start_date=datetime(2017, 9, 1))

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -30,13 +30,8 @@ isort:skip_file
 # pylint: disable=wrong-import-position
 from typing import Callable, Optional
 
-from airflow import utils
 from airflow import settings
 from airflow import version
-from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.configuration import conf
-from airflow.exceptions import AirflowException
-from airflow.models.dag import DAG
 
 __version__ = version.version
 

--- a/airflow/api/client/__init__.py
+++ b/airflow/api/client/__init__.py
@@ -21,8 +21,9 @@ API Client that allows interacting with Airflow API
 from importlib import import_module
 from typing import Any
 
-from airflow import api, conf
+from airflow import api
 from airflow.api.client.api_client import Client
+from airflow.configuration import conf
 
 
 def get_current_api_client() -> Client:

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -26,10 +26,13 @@ from typing import List
 
 from tabulate import tabulate
 
-from airflow import DAG, AirflowException, conf, jobs, settings
+from airflow import jobs, settings
 from airflow.api.client import get_current_api_client
+from airflow.configuration import conf
+from airflow.exceptions import AirflowException
 from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
+from airflow.models.dag import DAG
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import get_dag, get_dag_by_file_location, process_subdir, sigint_handler
 from airflow.utils.dot_renderer import render_dag

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -20,7 +20,8 @@ import subprocess
 import textwrap
 from tempfile import NamedTemporaryFile
 
-from airflow import AirflowException, settings
+from airflow import settings
+from airflow.exceptions import AirflowException
 from airflow.utils import cli as cli_utils, db
 
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -26,9 +26,12 @@ from typing import List
 
 from tabulate import tabulate
 
-from airflow import DAG, AirflowException, conf, jobs, settings
+from airflow import jobs, settings
+from airflow.configuration import conf
+from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.models import DagPickle, TaskInstance
+from airflow.models.dag import DAG
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies import SCHEDULER_QUEUED_DEPS
 from airflow.utils import cli as cli_utils

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -28,8 +28,9 @@ import daemon
 import psutil
 from daemon.pidfile import TimeoutPIDLockFile
 
-from airflow import AirflowException, conf, settings
-from airflow.exceptions import AirflowWebServerTimeout
+from airflow import settings
+from airflow.configuration import conf
+from airflow.exceptions import AirflowException, AirflowWebServerTimeout
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging
 from airflow.www.app import cached_app, create_app

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -21,7 +21,8 @@ import os
 from typing import Any, Dict, Union
 from urllib.parse import urlparse
 
-from airflow import AirflowException, conf
+from airflow.configuration import conf
+from airflow.exceptions import AirflowException
 from airflow.utils.file import mkdirs
 
 # TODO: Logging format and level should be configured

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -20,7 +20,7 @@
 
 from datetime import timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_trigger_controller_dag.py
+++ b/airflow/example_dags/example_trigger_controller_dag.py
@@ -21,8 +21,7 @@ Example usage of the TriggerDagRunOperator. This example holds 2 DAGs:
 1. 1st DAG (example_trigger_controller_dag) holds a TriggerDagRunOperator, which will trigger the 2nd DAG
 2. 2nd DAG (example_trigger_target_dag) which will be triggered by the TriggerDagRunOperator in the 1st DAG
 """
-
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -17,8 +17,7 @@
 # under the License.
 
 """Example DAG demonstrating the usage of XComs."""
-
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -26,7 +26,7 @@ from datetime import timedelta
 
 # [START import_module]
 # The DAG object; we'll need this to instantiate a DAG
-from airflow import DAG
+from airflow.models.dag import DAG
 # Operators; we need this to operate!
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -20,10 +20,11 @@ Base executor - this is the base class for all the implemented executors.
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from airflow import LoggingMixin, conf
+from airflow.configuration import conf
 from airflow.models import TaskInstance
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKeyType
 from airflow.stats import Stats
+from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
 
 PARALLELISM: int = conf.getint('core', 'PARALLELISM')

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -22,8 +22,8 @@ from typing import Any, Dict, Optional
 from distributed import Client, Future, as_completed
 from distributed.security import Security
 
-from airflow import AirflowException
 from airflow.configuration import conf
+from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import NOT_STARTED_MESSAGE, BaseExecutor, CommandType
 from airflow.models.taskinstance import TaskInstanceKeyType
 

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -23,7 +23,7 @@ process executor meaning it does not use multiprocessing.
 import threading
 from typing import Any, Dict, List, Optional
 
-from airflow import conf
+from airflow.configuration import conf
 from airflow.executors.base_executor import BaseExecutor
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKeyType
 from airflow.utils.state import State

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -48,7 +48,7 @@ from multiprocessing.managers import SyncManager
 from queue import Empty, Queue  # pylint: disable=unused-import  # noqa: F401
 from typing import Any, List, Optional, Tuple, Union  # pylint: disable=unused-import # noqa: F401
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import NOT_STARTED_MESSAGE, PARALLELISM, BaseExecutor, CommandType
 from airflow.models.taskinstance import (  # pylint: disable=unused-import # noqa: F401
     TaskInstanceKeyType, TaskInstanceStateType,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -676,7 +676,7 @@ class BaseOperator(Operator, LoggingMixin):
 
         if not self._dag:
             return self.priority_weight
-        from airflow import DAG
+        from airflow.models.dag import DAG
         dag: DAG = self._dag
         return self.priority_weight + sum(
             map(lambda task_id: dag.task_dict[task_id].priority_weight,
@@ -1003,7 +1003,7 @@ class BaseOperator(Operator, LoggingMixin):
         """
         if not self._dag:
             return set()
-        from airflow import DAG
+        from airflow.models.dag import DAG
         dag: DAG = self._dag
         return list(map(lambda task_id: dag.task_dict[task_id],
                         self.get_flat_relative_ids(upstream)))

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -27,8 +27,8 @@ import sqlalchemy_jsonfield
 from sqlalchemy import Column, Index, Integer, String, and_
 from sqlalchemy.sql import exists
 
-from airflow import DAG
 from airflow.models.base import ID_LEN, Base
+from airflow.models.dag import DAG
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.settings import json
 from airflow.utils import timezone

--- a/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_automatic_steps.py
+++ b/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_automatic_steps.py
@@ -20,7 +20,7 @@ This is an example dag for a AWS EMR Pipeline with auto steps.
 """
 from datetime import timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.emr_create_job_flow import EmrCreateJobFlowOperator
 from airflow.providers.amazon.aws.sensors.emr_job_flow import EmrJobFlowSensor
 from airflow.utils.dates import days_ago

--- a/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.py
+++ b/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.py
@@ -23,7 +23,7 @@ terminating the cluster.
 """
 from datetime import timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.emr_add_steps import EmrAddStepsOperator
 from airflow.providers.amazon.aws.operators.emr_create_job_flow import EmrCreateJobFlowOperator
 from airflow.providers.amazon.aws.operators.emr_terminate_job_flow import EmrTerminateJobFlowOperator

--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -34,9 +34,10 @@ import botocore.client
 import botocore.exceptions
 import botocore.waiter
 
-from airflow import AirflowException, LoggingMixin
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.typing_compat import Protocol, runtime_checkable
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 # Add exceptions to pylint for the boto3 protocol only; ideally the boto3 library could provide
 # protocols for all their dynamically generated classes (try to migrate this to a PR on botocore).

--- a/airflow/providers/amazon/aws/hooks/batch_waiters.py
+++ b/airflow/providers/amazon/aws/hooks/batch_waiters.py
@@ -36,7 +36,7 @@ import botocore.client
 import botocore.exceptions
 import botocore.waiter
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClient
 
 

--- a/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
+++ b/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
@@ -30,7 +30,7 @@ This is an example dag for managing twitter data.
 """
 from datetime import date, timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.providers.apache.hive.operators.hive import HiveOperator

--- a/airflow/providers/apache/livy/example_dags/example_livy.py
+++ b/airflow/providers/apache/livy/example_dags/example_livy.py
@@ -21,7 +21,7 @@ The tasks below trigger the computation of pi on the Spark instance
 using the Java and Python executables provided in the example library.
 """
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.apache.livy.operators.livy import LivyOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/databricks/example_dags/example_databricks.py
+++ b/airflow/providers/databricks/example_dags/example_databricks.py
@@ -31,7 +31,7 @@ For more information about the state of a run refer to
 https://docs.databricks.com/api/latest/jobs.html#runstate
 """
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.databricks.operators.databricks import DatabricksSubmitRunOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/dingding/example_dags/example_dingding.py
+++ b/airflow/providers/dingding/example_dags/example_dingding.py
@@ -20,7 +20,7 @@ This is an example dag for using the DingdingOperator.
 """
 from datetime import timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.dingding.operators.dingding import DingdingOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/dingding/hooks/dingding.py
+++ b/airflow/providers/dingding/hooks/dingding.py
@@ -20,7 +20,7 @@ import json
 
 import requests
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpHook
 
 

--- a/airflow/providers/docker/example_dags/example_docker.py
+++ b/airflow/providers/docker/example_dags/example_docker.py
@@ -17,7 +17,7 @@
 # under the License.
 from datetime import timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.utils.dates import days_ago

--- a/airflow/providers/docker/example_dags/example_docker_copy_data.py
+++ b/airflow/providers/docker/example_dags/example_docker_copy_data.py
@@ -27,7 +27,7 @@ TODO: Review the workflow, change it accordingly to
 
 from datetime import timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.providers.docker.operators.docker import DockerOperator

--- a/airflow/providers/docker/example_dags/example_docker_swarm.py
+++ b/airflow/providers/docker/example_dags/example_docker_swarm.py
@@ -17,7 +17,7 @@
 # under the License.
 from datetime import timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -35,7 +35,7 @@ from pandas_gbq.gbq import (
     _test_google_api_imports as gbq_test_google_api_imports,
 )
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/airflow/providers/google/cloud/hooks/cloud_build.py
+++ b/airflow/providers/google/cloud/hooks/cloud_build.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Optional
 
 from googleapiclient.discovery import build
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 # Time to sleep between active checks of the operation results

--- a/airflow/providers/google/cloud/hooks/cloud_memorystore.py
+++ b/airflow/providers/google/cloud/hooks/cloud_memorystore.py
@@ -27,7 +27,8 @@ from google.cloud.redis_v1.gapic.enums import FailoverInstanceRequest
 from google.cloud.redis_v1.types import FieldMask, InputConfig, Instance, OutputConfig
 from google.protobuf.json_format import ParseDict
 
-from airflow import AirflowException, version
+from airflow import version
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -42,7 +42,7 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from sqlalchemy.orm import Session
 
-from airflow import AirflowException, LoggingMixin
+from airflow.exceptions import AirflowException
 # Number of retries - used by googleapiclient method calls to perform retries
 # For requests that are "retriable"
 from airflow.hooks.base_hook import BaseHook
@@ -50,6 +50,7 @@ from airflow.models import Connection
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
 
 UNIX_PATH_MAX = 108

--- a/airflow/providers/google/cloud/hooks/compute.py
+++ b/airflow/providers/google/cloud/hooks/compute.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, Optional
 
 from googleapiclient.discovery import build
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 # Time to sleep between active checks of the operation results

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -31,7 +31,7 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 from googleapiclient.discovery import build
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.python_virtualenv import prepare_virtualenv

--- a/airflow/providers/google/cloud/hooks/datafusion.py
+++ b/airflow/providers/google/cloud/hooks/datafusion.py
@@ -27,7 +27,7 @@ from urllib.parse import urlencode
 import google.auth
 from googleapiclient.discovery import Resource, build
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 Operation = Dict[str, Any]

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -34,7 +34,7 @@ from google.cloud.dataproc_v1beta2.types import (  # pylint: disable=no-name-in-
     Cluster, Duration, FieldMask, Job, JobStatus, WorkflowTemplate,
 )
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 from airflow.version import version as airflow_version
 

--- a/airflow/providers/google/cloud/hooks/dlp.py
+++ b/airflow/providers/google/cloud/hooks/dlp.py
@@ -34,7 +34,7 @@ from google.cloud.dlp_v2.types import (
     RiskAnalysisJobConfig, StoredInfoType, StoredInfoTypeConfig,
 )
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 DLP_JOB_PATH_PATTERN = "^projects/[^/]+/dlpJobs/(?P<job>.*?)$"

--- a/airflow/providers/google/cloud/hooks/functions.py
+++ b/airflow/providers/google/cloud/hooks/functions.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Optional
 import requests
 from googleapiclient.discovery import build
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 # Time to sleep between active checks of the operation results

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -32,7 +32,8 @@ from google.cloud.container_v1.gapic.enums import Operation
 from google.cloud.container_v1.types import Cluster
 from google.protobuf.json_format import ParseDict
 
-from airflow import AirflowException, version
+from airflow import version
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 OPERATIONAL_POLL_INTERVAL = 15

--- a/airflow/providers/google/cloud/hooks/spanner.py
+++ b/airflow/providers/google/cloud/hooks/spanner.py
@@ -27,7 +27,7 @@ from google.cloud.spanner_v1.instance import Instance
 from google.cloud.spanner_v1.transaction import Transaction
 from google.longrunning.operations_grpc_pb2 import Operation  # noqa: F401
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 

--- a/airflow/providers/google/cloud/hooks/tasks.py
+++ b/airflow/providers/google/cloud/hooks/tasks.py
@@ -27,7 +27,7 @@ from google.api_core.retry import Retry
 from google.cloud.tasks_v2 import CloudTasksClient, enums
 from google.cloud.tasks_v2.types import FieldMask, Queue, Task
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 

--- a/airflow/providers/google/cloud/hooks/vision.py
+++ b/airflow/providers/google/cloud/hooks/vision.py
@@ -30,7 +30,7 @@ from google.cloud.vision_v1.types import (
 )
 from google.protobuf.json_format import MessageToDict
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 
 ERR_DIFF_NAMES = \

--- a/airflow/providers/google/cloud/operators/bigtable.py
+++ b/airflow/providers/google/cloud/operators/bigtable.py
@@ -24,7 +24,7 @@ from typing import Dict, Iterable, List, Optional
 import google.api_core.exceptions
 from google.cloud.bigtable.column_family import GarbageCollectionRule
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.bigtable import BigtableHook
 from airflow.utils.decorators import apply_defaults

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 from typing import Any, Dict, Iterable, Optional
 from urllib.parse import unquote, urlparse
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.cloud_build import CloudBuildHook
 from airflow.utils.decorators import apply_defaults

--- a/airflow/providers/google/cloud/operators/cloud_sql.py
+++ b/airflow/providers/google/cloud/operators/cloud_sql.py
@@ -22,7 +22,7 @@ from typing import Dict, Iterable, List, Optional, Union
 
 from googleapiclient.errors import HttpError
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.cloud_sql import CloudSQLDatabaseHook, CloudSQLHook

--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -24,7 +24,7 @@ from copy import deepcopy
 from datetime import date, time
 from typing import Dict, Optional
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     ACCESS_KEY_ID, AWS_ACCESS_KEY, AWS_S3_DATA_SOURCE, BUCKET_NAME, DAY, DESCRIPTION, GCS_DATA_SINK,

--- a/airflow/providers/google/cloud/operators/compute.py
+++ b/airflow/providers/google/cloud/operators/compute.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional
 from googleapiclient.errors import HttpError
 from json_merge_patch import merge
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.compute import ComputeEngineHook
 from airflow.providers.google.cloud.utils.field_sanitizer import GcpBodyFieldSanitizer

--- a/airflow/providers/google/cloud/operators/functions.py
+++ b/airflow/providers/google/cloud/operators/functions.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Optional
 
 from googleapiclient.errors import HttpError
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.functions import CloudFunctionsHook
 from airflow.providers.google.cloud.utils.field_validator import (

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -24,7 +24,7 @@ import warnings
 from tempfile import NamedTemporaryFile
 from typing import Dict, Iterable, List, Optional, Union
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.models.xcom import MAX_XCOM_SIZE
 from airflow.providers.google.cloud.hooks.gcs import GCSHook

--- a/airflow/providers/google/cloud/operators/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/operators/gcs_to_bigquery.py
@@ -21,7 +21,7 @@ This module contains a Google Cloud Storage to BigQuery operator.
 
 import json
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook

--- a/airflow/providers/google/cloud/operators/gcs_to_sftp.py
+++ b/airflow/providers/google/cloud/operators/gcs_to_sftp.py
@@ -22,7 +22,7 @@ import os
 from tempfile import NamedTemporaryFile
 from typing import Optional
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.sftp.hooks.sftp import SFTPHook

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -27,7 +27,7 @@ from typing import Dict, Optional, Union
 
 from google.cloud.container_v1.types import Cluster
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook

--- a/airflow/providers/google/cloud/operators/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/operators/sftp_to_gcs.py
@@ -22,7 +22,7 @@ import os
 from tempfile import NamedTemporaryFile
 from typing import Optional, Union
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.sftp.hooks.sftp import SFTPHook

--- a/airflow/providers/google/cloud/operators/spanner.py
+++ b/airflow/providers/google/cloud/operators/spanner.py
@@ -20,7 +20,7 @@ This module contains Google Spanner operators.
 """
 from typing import List, Optional, Union
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.spanner import SpannerHook
 from airflow.utils.decorators import apply_defaults

--- a/airflow/providers/google/cloud/operators/speech_to_text.py
+++ b/airflow/providers/google/cloud/operators/speech_to_text.py
@@ -23,7 +23,7 @@ from typing import Optional
 from google.api_core.retry import Retry
 from google.cloud.speech_v1.types import RecognitionConfig
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.speech_to_text import CloudSpeechToTextHook, RecognitionAudio
 from airflow.utils.decorators import apply_defaults

--- a/airflow/providers/google/cloud/operators/text_to_speech.py
+++ b/airflow/providers/google/cloud/operators/text_to_speech.py
@@ -25,7 +25,7 @@ from typing import Dict, Optional, Union
 from google.api_core.retry import Retry
 from google.cloud.texttospeech_v1.types import AudioConfig, SynthesisInput, VoiceSelectionParams
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.cloud.hooks.text_to_speech import CloudTextToSpeechHook

--- a/airflow/providers/google/cloud/operators/translate.py
+++ b/airflow/providers/google/cloud/operators/translate.py
@@ -20,7 +20,7 @@ This module contains Google Translate operators.
 """
 from typing import List, Union
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.translate import CloudTranslateHook
 from airflow.utils.decorators import apply_defaults

--- a/airflow/providers/google/cloud/operators/translate_speech.py
+++ b/airflow/providers/google/cloud/operators/translate_speech.py
@@ -23,7 +23,7 @@ from typing import Optional
 from google.cloud.speech_v1.types import RecognitionAudio, RecognitionConfig
 from google.protobuf.json_format import MessageToDict
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.speech_to_text import CloudSpeechToTextHook
 from airflow.providers.google.cloud.hooks.translate import CloudTranslateHook

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -23,7 +23,7 @@ import os
 from datetime import datetime
 from typing import Callable, List, Optional
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults

--- a/airflow/providers/google/cloud/utils/field_sanitizer.py
+++ b/airflow/providers/google/cloud/utils/field_sanitizer.py
@@ -99,7 +99,8 @@ components in all elements of the array.
 
 from typing import List
 
-from airflow import AirflowException, LoggingMixin
+from airflow.exceptions import AirflowException
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 class GcpFieldSanitizerException(AirflowException):

--- a/airflow/providers/google/cloud/utils/field_validator.py
+++ b/airflow/providers/google/cloud/utils/field_validator.py
@@ -133,7 +133,8 @@ Here are the guidelines that you should follow to make validation forward-compat
 import re
 from typing import Callable, Dict, Sequence
 
-from airflow import AirflowException, LoggingMixin
+from airflow.exceptions import AirflowException
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 COMPOSITE_FIELD_TYPES = ['union', 'dict', 'list']
 

--- a/airflow/providers/google/marketing_platform/operators/campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/operators/campaign_manager.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Optional
 
 from googleapiclient import http
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.marketing_platform.hooks.campaign_manager import GoogleCampaignManagerHook

--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -24,7 +24,7 @@ import urllib.request
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.marketing_platform.hooks.display_video import GoogleDisplayVideo360Hook

--- a/airflow/providers/google/marketing_platform/operators/search_ads.py
+++ b/airflow/providers/google/marketing_platform/operators/search_ads.py
@@ -21,7 +21,7 @@ This module contains Google Search Ads operators.
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Optional
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.marketing_platform.hooks.search_ads import GoogleSearchAdsHook

--- a/airflow/providers/http/example_dags/example_http.py
+++ b/airflow/providers/http/example_dags/example_http.py
@@ -21,7 +21,7 @@
 import json
 from datetime import timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.http.operators.http import SimpleHttpOperator
 from airflow.providers.http.sensors.http import HttpSensor
 from airflow.utils.dates import days_ago

--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -25,8 +25,9 @@ import imaplib
 import os
 import re
 
-from airflow import AirflowException, LoggingMixin
+from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 class ImapHook(BaseHook):

--- a/airflow/providers/jenkins/example_dags/example_jenkins_job_trigger.py
+++ b/airflow/providers/jenkins/example_dags/example_jenkins_job_trigger.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 
 from six.moves.urllib.request import Request
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.python import PythonOperator
 from airflow.providers.jenkins.hooks.jenkins import JenkinsHook
 from airflow.providers.jenkins.operators.jenkins_job_trigger import JenkinsJobTriggerOperator

--- a/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
@@ -20,7 +20,7 @@ This is an example dag for using the AzureContainerInstancesOperator.
 """
 from datetime import datetime, timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.operators.azure_container_instances import (
     AzureContainerInstancesOperator,
 )

--- a/airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py
@@ -26,7 +26,7 @@ You can trigger this manually with `airflow dags trigger example_cosmosdb_sensor
 this example.*
 """
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.operators.azure_cosmos import AzureCosmosInsertDocumentOperator
 from airflow.providers.microsoft.azure.sensors.azure_cosmos import AzureCosmosDocumentSensor
 from airflow.utils import dates

--- a/airflow/providers/microsoft/mssql/operators/mssql.py
+++ b/airflow/providers/microsoft/mssql/operators/mssql.py
@@ -17,7 +17,7 @@
 # under the License.
 from typing import Iterable, Mapping, Optional, Union
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
 from airflow.providers.odbc.hooks.odbc import OdbcHook

--- a/airflow/providers/openfass/hooks/openfaas.py
+++ b/airflow/providers/openfass/hooks/openfaas.py
@@ -18,7 +18,7 @@
 
 import requests
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 
 OK_STATUS_CODE = 202

--- a/airflow/providers/opsgenie/hooks/opsgenie_alert.py
+++ b/airflow/providers/opsgenie/hooks/opsgenie_alert.py
@@ -21,7 +21,7 @@ import json
 
 import requests
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpHook
 
 

--- a/airflow/providers/qubole/example_dags/example_qubole.py
+++ b/airflow/providers/qubole/example_dags/example_qubole.py
@@ -20,7 +20,7 @@ import filecmp
 import random
 import textwrap
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.providers.qubole.operators.qubole import QuboleOperator

--- a/airflow/providers/yandex/example_dags/example_yandexcloud_dataproc.py
+++ b/airflow/providers/yandex/example_dags/example_yandexcloud_dataproc.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.yandex.operators.yandexcloud_dataproc import (
     DataprocCreateClusterOperator, DataprocCreateHiveJobOperator, DataprocCreateMapReduceJobOperator,
     DataprocCreatePysparkJobOperator, DataprocCreateSparkJobOperator, DataprocDeleteClusterOperator,

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -26,9 +26,10 @@ import cattr
 import pendulum
 from dateutil import relativedelta
 
-from airflow import DAG, AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+from airflow.models.dag import DAG
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.json_schema import Validator, load_dag_schema
 from airflow.settings import json

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -34,7 +34,8 @@ from argparse import Namespace
 from datetime import datetime
 from typing import Optional
 
-from airflow import AirflowException, settings
+from airflow import settings
+from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagBag, DagModel, DagPickle, Log
 from airflow.utils import cli_action_loggers
 from airflow.utils.session import provide_session

--- a/airflow/utils/dot_renderer.py
+++ b/airflow/utils/dot_renderer.py
@@ -22,7 +22,7 @@ Renderer DAG (tasks and dependencies) to the graphviz object.
 
 import graphviz
 
-from airflow import DAG
+from airflow.models.dag import DAG
 
 
 def _refine_color(color: str):

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -21,7 +21,7 @@ import re
 import zipfile
 from typing import Dict, List, Optional, Pattern
 
-from airflow import conf
+from airflow.configuration import conf
 
 log = logging.getLogger(__name__)
 

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -20,7 +20,7 @@ This dag only runs some simple tasks to test Airflow's task execution.
 """
 from datetime import datetime, timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
 

--- a/docs/dag-run.rst
+++ b/docs/dag-run.rst
@@ -90,7 +90,7 @@ in the configuration file. When turned off, the scheduler creates a DAG run only
     Code that goes along with the Airflow tutorial located at:
     https://github.com/apache/airflow/blob/master/airflow/example_dags/tutorial.py
     """
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.operators.bash import BashOperator
     from datetime import datetime, timedelta
 

--- a/scripts/perf/dags/sql_perf_dag.py
+++ b/scripts/perf/dags/sql_perf_dag.py
@@ -17,7 +17,7 @@
 
 from datetime import datetime, timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.python_operator import PythonOperator
 
 default_args = {

--- a/tests/api/client/test_local_client.py
+++ b/tests/api/client/test_local_client.py
@@ -22,10 +22,10 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
-from airflow import AirflowException, models
 from airflow.api.client.local_client import Client
 from airflow.example_dags import example_bash_operator
-from airflow.models import DagBag, DagModel
+from airflow.exceptions import AirflowException
+from airflow.models import DAG, DagBag, DagModel, Pool
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -52,10 +52,10 @@ class TestLocalClient(unittest.TestCase):
         clear_db_pools()
         super().tearDown()
 
-    @patch.object(models.DAG, 'create_dagrun')
+    @patch.object(DAG, 'create_dagrun')
     def test_trigger_dag(self, mock):
         test_dag_id = "example_bash_operator"
-        models.DagBag(include_examples=True)
+        DagBag(include_examples=True)
 
         # non existent
         with self.assertRaises(AirflowException):
@@ -129,12 +129,12 @@ class TestLocalClient(unittest.TestCase):
         pool = self.client.create_pool(name='foo', slots=1, description='')
         self.assertEqual(pool, ('foo', 1, ''))
         with create_session() as session:
-            self.assertEqual(session.query(models.Pool).count(), 2)
+            self.assertEqual(session.query(Pool).count(), 2)
 
     def test_delete_pool(self):
         self.client.create_pool(name='foo', slots=1, description='')
         with create_session() as session:
-            self.assertEqual(session.query(models.Pool).count(), 2)
+            self.assertEqual(session.query(Pool).count(), 2)
         self.client.delete_pool(name='foo')
         with create_session() as session:
-            self.assertEqual(session.query(models.Pool).count(), 1)
+            self.assertEqual(session.query(Pool).count(), 1)

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -27,9 +27,10 @@ import mock
 import pytz
 
 import airflow.bin.cli as cli
-from airflow import AirflowException, models, settings
+from airflow import settings
 from airflow.cli.commands import dag_command
-from airflow.models import DagModel
+from airflow.exceptions import AirflowException
+from airflow.models import DagBag, DagModel, DagRun
 from airflow.settings import Session
 from airflow.utils import timezone
 from airflow.utils.state import State
@@ -56,7 +57,7 @@ class TestCliDags(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
+        cls.dagbag = DagBag(include_examples=True)
         cls.parser = cli.CLIFactory.get_parser()
 
     @mock.patch("airflow.cli.commands.dag_command.DAG.run")
@@ -239,7 +240,7 @@ class TestCliDags(unittest.TestCase):
         # A scaffolding function
         def reset_dr_db(dag_id):
             session = Session()
-            dr = session.query(models.DagRun).filter_by(dag_id=dag_id)
+            dr = session.query(DagRun).filter_by(dag_id=dag_id)
             dr.delete()
             session.commit()
             session.close()

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -20,9 +20,9 @@ from unittest import mock
 
 from sqlalchemy.engine.url import make_url
 
-from airflow import AirflowException
 from airflow.bin import cli
 from airflow.cli.commands import db_command
+from airflow.exceptions import AirflowException
 
 
 class TestCliDb(unittest.TestCase):

--- a/tests/cli/commands/test_sync_perm_command.py
+++ b/tests/cli/commands/test_sync_perm_command.py
@@ -19,16 +19,17 @@
 import unittest
 from unittest import mock
 
-from airflow import DAG, models
 from airflow.bin import cli
 from airflow.cli.commands import sync_perm_command
+from airflow.models.dag import DAG
+from airflow.models.dagbag import DagBag
 from airflow.settings import Session
 
 
 class TestCliSyncPerm(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
+        cls.dagbag = DagBag(include_examples=True)
         cls.parser = cli.CLIFactory.get_parser()
 
     def setUp(self):

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -25,9 +25,9 @@ from unittest import mock
 from parameterized import parameterized
 from tabulate import tabulate
 
-from airflow import AirflowException, models
 from airflow.bin import cli
 from airflow.cli.commands import task_command
+from airflow.exceptions import AirflowException
 from airflow.models import DagBag, TaskInstance
 from airflow.settings import Session
 from airflow.utils import timezone
@@ -40,7 +40,7 @@ DEFAULT_DATE = timezone.make_aware(datetime(2016, 1, 1))
 
 def reset(dag_id):
     session = Session()
-    tis = session.query(models.TaskInstance).filter_by(dag_id=dag_id)
+    tis = session.query(TaskInstance).filter_by(dag_id=dag_id)
     tis.delete()
     session.commit()
     session.close()
@@ -49,7 +49,7 @@ def reset(dag_id):
 class TestCliTasks(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
+        cls.dagbag = DagBag(include_examples=True)
         cls.parser = cli.CLIFactory.get_parser()
 
     def test_cli_list_tasks(self):

--- a/tests/contrib/utils/logging_command_executor.py
+++ b/tests/contrib/utils/logging_command_executor.py
@@ -18,7 +18,8 @@
 import os
 import subprocess
 
-from airflow import AirflowException, LoggingMixin
+from airflow.exceptions import AirflowException
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 class LoggingCommandExecutor(LoggingMixin):

--- a/tests/dags/test_retry_handling_job.py
+++ b/tests/dags/test_retry_handling_job.py
@@ -18,7 +18,7 @@
 
 from datetime import datetime, timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 
 default_args = {

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -32,10 +32,10 @@ from celery.contrib.testing.worker import start_worker
 from kombu.asynchronous import set_event_loop
 from parameterized import parameterized
 
-from airflow import DAG
 from airflow.configuration import conf
 from airflow.executors import celery_executor
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.operators.bash import BashOperator
 from airflow.utils.state import State

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -28,10 +28,11 @@ import sqlalchemy
 from mock import Mock, patch
 from parameterized import parameterized
 
-from airflow import AirflowException, settings
+from airflow import settings
 from airflow.bin import cli
 from airflow.exceptions import (
-    AirflowTaskTimeout, DagConcurrencyLimitReached, NoAvailablePoolSlot, TaskConcurrencyLimitReached,
+    AirflowException, AirflowTaskTimeout, DagConcurrencyLimitReached, NoAvailablePoolSlot,
+    TaskConcurrencyLimitReached,
 )
 from airflow.jobs.backfill_job import BackfillJob
 from airflow.jobs.scheduler_job import DagFileProcessor

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -32,12 +32,13 @@ from mock import MagicMock, Mock, patch
 from parameterized import parameterized
 
 import airflow.example_dags
-from airflow import AirflowException, models, settings
+from airflow import settings
 from airflow.configuration import conf
+from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
 from airflow.jobs import BackfillJob, SchedulerJob
 from airflow.jobs.scheduler_job import DagFileProcessor
-from airflow.models import DAG, DagBag, DagModel, DagRun, Pool, SlaMiss, TaskInstance as TI, errors
+from airflow.models import DAG, DagBag, DagModel, DagRun, Pool, SlaMiss, TaskInstance, errors
 from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
@@ -128,13 +129,9 @@ class TestDagFileProcessor(unittest.TestCase):
                              dag=dag,
                              owner='airflow')
 
-        session.merge(models.TaskInstance(task=task,
-                                          execution_date=test_start_date,
-                                          state='success'))
+        session.merge(TaskInstance(task=task, execution_date=test_start_date, state='success'))
 
-        session.merge(SlaMiss(task_id='dummy',
-                              dag_id='test_sla_miss',
-                              execution_date=test_start_date))
+        session.merge(SlaMiss(task_id='dummy', dag_id='test_sla_miss', execution_date=test_start_date))
 
         dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
         dag_file_processor.manage_slas(dag=dag, session=session)
@@ -159,17 +156,12 @@ class TestDagFileProcessor(unittest.TestCase):
                   default_args={'start_date': test_start_date,
                                 'sla': None})
 
-        task = DummyOperator(task_id='dummy',
-                             dag=dag,
-                             owner='airflow')
+        task = DummyOperator(task_id='dummy', dag=dag, owner='airflow')
 
-        session.merge(models.TaskInstance(task=task,
-                                          execution_date=test_start_date,
-                                          state='success'))
+        session.merge(TaskInstance(task=task, execution_date=test_start_date, state='success'))
 
-        session.merge(SlaMiss(task_id='dummy',
-                              dag_id='test_sla_miss',
-                              execution_date=test_start_date))
+        session.merge(SlaMiss(task_id='dummy', dag_id='test_sla_miss', execution_date=test_start_date))
+
         dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
         dag_file_processor.manage_slas(dag=dag, session=session)
         sla_callback.assert_not_called()
@@ -192,7 +184,7 @@ class TestDagFileProcessor(unittest.TestCase):
                 owner='airflow')
             tis = []
             for i in range(1, 10):
-                ti = TI(task, DEFAULT_DATE + timedelta(days=i))
+                ti = TaskInstance(task, DEFAULT_DATE + timedelta(days=i))
                 ti.state = State.SCHEDULED
                 tis.append(ti)
                 session.merge(ti)
@@ -240,14 +232,10 @@ class TestDagFileProcessor(unittest.TestCase):
                   default_args={'start_date': test_start_date,
                                 'sla': datetime.timedelta(days=1)})
 
-        task = DummyOperator(task_id='dummy',
-                             dag=dag,
-                             owner='airflow')
+        task = DummyOperator(task_id='dummy', dag=dag, owner='airflow')
 
         # Create a TaskInstance for two days ago
-        session.merge(models.TaskInstance(task=task,
-                                          execution_date=test_start_date,
-                                          state='success'))
+        session.merge(TaskInstance(task=task, execution_date=test_start_date, state='success'))
 
         # Create an SlaMiss where notification was sent, but email was not
         session.merge(SlaMiss(task_id='dummy',
@@ -281,9 +269,7 @@ class TestDagFileProcessor(unittest.TestCase):
                              owner='airflow',
                              sla=datetime.timedelta(hours=1))
 
-        session.merge(models.TaskInstance(task=task,
-                                          execution_date=test_start_date,
-                                          state='Success'))
+        session.merge(TaskInstance(task=task, execution_date=test_start_date, state='Success'))
 
         # Create an SlaMiss where notification was sent, but email was not
         session.merge(SlaMiss(task_id='dummy',
@@ -315,9 +301,7 @@ class TestDagFileProcessor(unittest.TestCase):
                              email=email1,
                              sla=datetime.timedelta(hours=1))
 
-        session.merge(models.TaskInstance(task=task,
-                                          execution_date=test_start_date,
-                                          state='Success'))
+        session.merge(TaskInstance(task=task, execution_date=test_start_date, state='Success'))
 
         email2 = 'test2@test.com'
         DummyOperator(task_id='sla_not_missed',
@@ -325,9 +309,7 @@ class TestDagFileProcessor(unittest.TestCase):
                       owner='airflow',
                       email=email2)
 
-        session.merge(SlaMiss(task_id='sla_missed',
-                              dag_id='test_sla_miss',
-                              execution_date=test_start_date))
+        session.merge(SlaMiss(task_id='sla_missed', dag_id='test_sla_miss', execution_date=test_start_date))
 
         dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
 
@@ -361,14 +343,10 @@ class TestDagFileProcessor(unittest.TestCase):
                              email='test@test.com',
                              sla=datetime.timedelta(hours=1))
 
-        session.merge(models.TaskInstance(task=task,
-                                          execution_date=test_start_date,
-                                          state='Success'))
+        session.merge(TaskInstance(task=task, execution_date=test_start_date, state='Success'))
 
         # Create an SlaMiss where notification was sent, but email was not
-        session.merge(SlaMiss(task_id='dummy',
-                              dag_id='test_sla_miss',
-                              execution_date=test_start_date))
+        session.merge(SlaMiss(task_id='dummy', dag_id='test_sla_miss', execution_date=test_start_date))
 
         mock_log = mock.MagicMock()
         dag_file_processor = DagFileProcessor(dag_ids=[], log=mock_log)
@@ -396,13 +374,10 @@ class TestDagFileProcessor(unittest.TestCase):
                              email='test@test.com',
                              sla=datetime.timedelta(hours=1))
 
-        session.merge(models.TaskInstance(task=task,
-                                          execution_date=test_start_date,
-                                          state='Success'))
+        session.merge(TaskInstance(task=task, execution_date=test_start_date, state='Success'))
 
         # Create an SlaMiss where notification was sent, but email was not
-        session.merge(SlaMiss(task_id='dummy_deleted',
-                              dag_id='test_sla_miss',
+        session.merge(SlaMiss(task_id='dummy_deleted', dag_id='test_sla_miss',
                               execution_date=test_start_date))
 
         mock_log = mock.MagicMock()
@@ -1014,36 +989,30 @@ class TestDagFileProcessor(unittest.TestCase):
 
         with create_session() as session:
             sub_dagruns = (
-                session
-                .query(DagRun)
-                .filter(DagRun.dag_id == dag.subdags[0].dag_id)
-                .count()
+                session.query(DagRun).filter(DagRun.dag_id == dag.subdags[0].dag_id).count()
             )
 
             self.assertEqual(0, sub_dagruns)
 
             parent_dagruns = (
-                session
-                .query(DagRun)
-                .filter(DagRun.dag_id == dag.dag_id)
-                .count()
+                session.query(DagRun).filter(DagRun.dag_id == dag.dag_id).count()
             )
 
             self.assertGreater(parent_dagruns, 0)
 
-    @patch.object(TI, 'handle_failure')
+    @patch.object(TaskInstance, 'handle_failure')
     def test_kill_zombies(self, mock_ti_handle_failure):
         """
-        Test that kill zombies call TIs failure handler with proper context
+        Test that kill zombies call TaskInstances failure handler with proper context
         """
-        dagbag = models.DagBag(dag_folder="/dev/null", include_examples=True)
+        dagbag = DagBag(dag_folder="/dev/null", include_examples=True)
         dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
         with create_session() as session:
-            session.query(TI).delete()
+            session.query(TaskInstance).delete()
             dag = dagbag.get_dag('example_branch_operator')
             task = dag.get_task(task_id='run_this_first')
 
-            ti = TI(task, DEFAULT_DATE, State.RUNNING)
+            ti = TaskInstance(task, DEFAULT_DATE, State.RUNNING)
 
             session.add(ti)
             session.commit()
@@ -1152,7 +1121,7 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler = SchedulerJob()
         session = settings.Session()
 
-        ti1 = TI(task1, DEFAULT_DATE)
+        ti1 = TaskInstance(task1, DEFAULT_DATE)
         ti1.state = State.QUEUED
         session.merge(ti1)
         session.commit()
@@ -1196,10 +1165,10 @@ class TestSchedulerJob(unittest.TestCase):
         session = settings.Session()
 
         dr1 = dag_file_processor.create_dag_run(dag)
-        ti1 = TI(task1, DEFAULT_DATE)
+        ti1 = TaskInstance(task1, DEFAULT_DATE)
         ti1.state = State.SCHEDULED
         dr1.state = State.RUNNING
-        dagmodel = models.DagModel()
+        dagmodel = DagModel()
         dagmodel.dag_id = dag_id
         dagmodel.is_paused = True
         session.merge(ti1)
@@ -1227,7 +1196,7 @@ class TestSchedulerJob(unittest.TestCase):
         session = settings.Session()
 
         dag_file_processor.create_dag_run(dag)
-        ti1 = TI(task1, DEFAULT_DATE)
+        ti1 = TaskInstance(task1, DEFAULT_DATE)
         ti1.state = State.SCHEDULED
         ti1.execution_date = ti1.execution_date + datetime.timedelta(days=1)
         session.merge(ti1)
@@ -1254,7 +1223,7 @@ class TestSchedulerJob(unittest.TestCase):
 
         dr1 = dag_file_processor.create_dag_run(dag)
         dr1.run_id = BackfillJob.ID_PREFIX + '_blah'
-        ti1 = TI(task1, dr1.execution_date)
+        ti1 = TaskInstance(task1, dr1.execution_date)
         ti1.refresh_from_db()
         ti1.state = State.SCHEDULED
         session.merge(ti1)
@@ -1282,9 +1251,9 @@ class TestSchedulerJob(unittest.TestCase):
         dr2 = dag_file_processor.create_dag_run(dag)
         dr2.run_id = BackfillJob.ID_PREFIX + 'asdf'
 
-        ti_no_dagrun = TI(task1, DEFAULT_DATE - datetime.timedelta(days=1))
-        ti_backfill = TI(task1, dr2.execution_date)
-        ti_with_dagrun = TI(task1, dr1.execution_date)
+        ti_no_dagrun = TaskInstance(task1, DEFAULT_DATE - datetime.timedelta(days=1))
+        ti_backfill = TaskInstance(task1, dr2.execution_date)
+        ti_with_dagrun = TaskInstance(task1, dr1.execution_date)
         # ti_with_paused
         ti_no_dagrun.state = State.SCHEDULED
         ti_backfill.state = State.SCHEDULED
@@ -1323,16 +1292,16 @@ class TestSchedulerJob(unittest.TestCase):
         dr2 = dag_file_processor.create_dag_run(dag)
 
         tis = ([
-            TI(task1, dr1.execution_date),
-            TI(task2, dr1.execution_date),
-            TI(task1, dr2.execution_date),
-            TI(task2, dr2.execution_date)
+            TaskInstance(task1, dr1.execution_date),
+            TaskInstance(task2, dr1.execution_date),
+            TaskInstance(task1, dr2.execution_date),
+            TaskInstance(task2, dr2.execution_date)
         ])
         for ti in tis:
             ti.state = State.SCHEDULED
             session.merge(ti)
-        pool = models.Pool(pool='a', slots=1, description='haha')
-        pool2 = models.Pool(pool='b', slots=100, description='haha')
+        pool = Pool(pool='a', slots=1, description='haha')
+        pool2 = Pool(pool='b', slots=100, description='haha')
         session.add(pool)
         session.add(pool2)
         session.commit()
@@ -1365,8 +1334,8 @@ class TestSchedulerJob(unittest.TestCase):
         dr1 = dag_file_processor.create_dag_run(dag)
         dr2 = dag_file_processor.create_dag_run(dag)
 
-        ti1 = TI(task=op1, execution_date=dr1.execution_date)
-        ti2 = TI(task=op2, execution_date=dr2.execution_date)
+        ti1 = TaskInstance(task=op1, execution_date=dr1.execution_date)
+        ti2 = TaskInstance(task=op2, execution_date=dr2.execution_date)
         ti1.state = State.SCHEDULED
         ti2.state = State.SCHEDULED
 
@@ -1408,7 +1377,7 @@ class TestSchedulerJob(unittest.TestCase):
 
         dr = dag_file_processor.create_dag_run(dag)
 
-        ti = TI(task, dr.execution_date)
+        ti = TaskInstance(task, dr.execution_date)
         ti.state = State.SCHEDULED
         session.merge(ti)
         session.commit()
@@ -1454,9 +1423,9 @@ class TestSchedulerJob(unittest.TestCase):
         dr2 = dag_file_processor.create_dag_run(dag)
         dr3 = dag_file_processor.create_dag_run(dag)
 
-        ti1 = TI(task1, dr1.execution_date)
-        ti2 = TI(task1, dr2.execution_date)
-        ti3 = TI(task1, dr3.execution_date)
+        ti1 = TaskInstance(task1, dr1.execution_date)
+        ti2 = TaskInstance(task1, dr2.execution_date)
+        ti3 = TaskInstance(task1, dr3.execution_date)
         ti1.state = State.RUNNING
         ti2.state = State.SCHEDULED
         ti3.state = State.SCHEDULED
@@ -1499,9 +1468,9 @@ class TestSchedulerJob(unittest.TestCase):
         session = settings.Session()
         dag_run = dag_file_processor.create_dag_run(dag)
 
-        ti1 = TI(task1, dag_run.execution_date)
-        ti2 = TI(task2, dag_run.execution_date)
-        ti3 = TI(task3, dag_run.execution_date)
+        ti1 = TaskInstance(task1, dag_run.execution_date)
+        ti2 = TaskInstance(task2, dag_run.execution_date)
+        ti3 = TaskInstance(task3, dag_run.execution_date)
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
         ti3.state = State.SCHEDULED
@@ -1538,8 +1507,8 @@ class TestSchedulerJob(unittest.TestCase):
         dr2 = dag_file_processor.create_dag_run(dag)
         dr3 = dag_file_processor.create_dag_run(dag)
 
-        ti1_1 = TI(task1, dr1.execution_date)
-        ti2 = TI(task2, dr1.execution_date)
+        ti1_1 = TaskInstance(task1, dr1.execution_date)
+        ti2 = TaskInstance(task2, dr1.execution_date)
 
         ti1_1.state = State.SCHEDULED
         ti2.state = State.SCHEDULED
@@ -1556,7 +1525,7 @@ class TestSchedulerJob(unittest.TestCase):
 
         ti1_1.state = State.RUNNING
         ti2.state = State.RUNNING
-        ti1_2 = TI(task1, dr2.execution_date)
+        ti1_2 = TaskInstance(task1, dr2.execution_date)
         ti1_2.state = State.SCHEDULED
         session.merge(ti1_1)
         session.merge(ti2)
@@ -1571,7 +1540,7 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertEqual(1, len(res))
 
         ti1_2.state = State.RUNNING
-        ti1_3 = TI(task1, dr3.execution_date)
+        ti1_3 = TaskInstance(task1, dr3.execution_date)
         ti1_3.state = State.SCHEDULED
         session.merge(ti1_2)
         session.merge(ti1_3)
@@ -1653,9 +1622,9 @@ class TestSchedulerJob(unittest.TestCase):
         dr2 = dag_file_processor.create_dag_run(dag)
         dr3 = dag_file_processor.create_dag_run(dag)
 
-        ti1 = TI(task1, dr1.execution_date)
-        ti2 = TI(task1, dr2.execution_date)
-        ti3 = TI(task1, dr3.execution_date)
+        ti1 = TaskInstance(task1, dr1.execution_date)
+        ti2 = TaskInstance(task1, dr2.execution_date)
+        ti3 = TaskInstance(task1, dr3.execution_date)
         ti1.state = State.SCHEDULED
         ti2.state = State.SCHEDULED
         ti3.state = State.SCHEDULED
@@ -1686,9 +1655,9 @@ class TestSchedulerJob(unittest.TestCase):
         dr2 = dag_file_processor.create_dag_run(dag)
         dr3 = dag_file_processor.create_dag_run(dag)
 
-        ti1 = TI(task1, dr1.execution_date)
-        ti2 = TI(task1, dr2.execution_date)
-        ti3 = TI(task1, dr3.execution_date)
+        ti1 = TaskInstance(task1, dr1.execution_date)
+        ti2 = TaskInstance(task1, dr2.execution_date)
+        ti3 = TaskInstance(task1, dr3.execution_date)
         ti1.state = State.SCHEDULED
         ti2.state = State.QUEUED
         ti3.state = State.NONE
@@ -1721,7 +1690,7 @@ class TestSchedulerJob(unittest.TestCase):
 
         dr1 = dag_file_processor.create_dag_run(dag)
 
-        ti1 = TI(task1, dr1.execution_date)
+        ti1 = TaskInstance(task1, dr1.execution_date)
         session.merge(ti1)
         session.commit()
 
@@ -1742,7 +1711,7 @@ class TestSchedulerJob(unittest.TestCase):
         session = settings.Session()
 
         dr1 = dag_file_processor.create_dag_run(dag)
-        ti1 = TI(task1, dr1.execution_date)
+        ti1 = TaskInstance(task1, dr1.execution_date)
         ti1.state = State.SCHEDULED
         session.merge(ti1)
         session.commit()
@@ -1768,8 +1737,8 @@ class TestSchedulerJob(unittest.TestCase):
 
         # create first dag run with 1 running and 1 queued
         dr1 = dag_file_processor.create_dag_run(dag)
-        ti1 = TI(task1, dr1.execution_date)
-        ti2 = TI(task2, dr1.execution_date)
+        ti1 = TaskInstance(task1, dr1.execution_date)
+        ti2 = TaskInstance(task2, dr1.execution_date)
         ti1.refresh_from_db()
         ti2.refresh_from_db()
         ti1.state = State.RUNNING
@@ -1788,8 +1757,8 @@ class TestSchedulerJob(unittest.TestCase):
 
         # create second dag run
         dr2 = dag_file_processor.create_dag_run(dag)
-        ti3 = TI(task1, dr2.execution_date)
-        ti4 = TI(task2, dr2.execution_date)
+        ti3 = TaskInstance(task1, dr2.execution_date)
+        ti4 = TaskInstance(task2, dr2.execution_date)
         ti3.refresh_from_db()
         ti4.refresh_from_db()
         # manually set to scheduled so we can pick them up
@@ -1840,8 +1809,8 @@ class TestSchedulerJob(unittest.TestCase):
         tis = []
         for _ in range(0, 4):
             dr = dag_file_processor.create_dag_run(dag)
-            ti1 = TI(task1, dr.execution_date)
-            ti2 = TI(task2, dr.execution_date)
+            ti1 = TaskInstance(task1, dr.execution_date)
+            ti2 = TaskInstance(task2, dr.execution_date)
             tis.append(ti1)
             tis.append(ti2)
             ti1.refresh_from_db()
@@ -1897,7 +1866,7 @@ class TestSchedulerJob(unittest.TestCase):
         ti2.state = State.SCHEDULED
         session.commit()
 
-        ti3 = TI(dag3.get_task('dummy'), DEFAULT_DATE)
+        ti3 = TaskInstance(dag3.get_task('dummy'), DEFAULT_DATE)
         ti3.state = State.SCHEDULED
         session.merge(ti3)
         session.commit()
@@ -1969,11 +1938,11 @@ class TestSchedulerJob(unittest.TestCase):
         mock_logger.info.assert_not_called()
 
         # Tasks failed to execute with QUEUED state will be set to SCHEDULED state.
-        session.query(TI).delete()
+        session.query(TaskInstance).delete()
         session.commit()
         key = 'dag_id', 'task_id', DEFAULT_DATE, 1
         test_executor.queued_tasks[key] = 'value'
-        ti = TI(task, DEFAULT_DATE)
+        ti = TaskInstance(task, DEFAULT_DATE)
         ti.state = State.QUEUED
         session.merge(ti)  # pylint: disable=no-value-for-parameter
         session.commit()
@@ -1984,7 +1953,7 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertEqual(State.SCHEDULED, ti.state)
 
         # Tasks failed to execute with RUNNING state will not be set to SCHEDULED state.
-        session.query(TI).delete()
+        session.query(TaskInstance).delete()
         session.commit()
         ti.state = State.RUNNING
 
@@ -2044,8 +2013,9 @@ class TestSchedulerJob(unittest.TestCase):
         [State.SCHEDULED, State.NONE],
         [State.UP_FOR_RESCHEDULE, State.NONE],
     ])
-    def test_execute_helper_should_change_state_for_tis_without_dagrun(
-            self, initial_task_state, expected_task_state):
+    def test_execute_helper_should_change_state_for_tis_without_dagrun(self,
+                                                                       initial_task_state,
+                                                                       expected_task_state):
         session = settings.Session()
         dag = DAG(
             'test_execute_helper_should_change_state_for_tis_without_dagrun',
@@ -2122,7 +2092,7 @@ class TestSchedulerJob(unittest.TestCase):
         # test tasks
         for task_id, expected_state in expected_task_states.items():
             task = dag.get_task(task_id)
-            ti = TI(task, ex_date)
+            ti = TaskInstance(task, ex_date)
             ti.refresh_from_db()
             self.assertEqual(ti.state, expected_state)
 
@@ -2266,7 +2236,7 @@ class TestSchedulerJob(unittest.TestCase):
 
             # zero tasks ran
             self.assertEqual(
-                len(session.query(TI).filter(TI.dag_id == dag_id).all()), 0)
+                len(session.query(TaskInstance).filter(TaskInstance.dag_id == dag_id).all()), 0)
             session.commit()
             self.assertListEqual([], self.null_exec.sorted_tasks)
 
@@ -2284,7 +2254,7 @@ class TestSchedulerJob(unittest.TestCase):
 
             # one task ran
             self.assertEqual(
-                len(session.query(TI).filter(TI.dag_id == dag_id).all()), 1)
+                len(session.query(TaskInstance).filter(TaskInstance.dag_id == dag_id).all()), 1)
             self.assertListEqual(
                 [
                     ((dag.dag_id, 'dummy', DEFAULT_DATE, 1), State.SUCCESS),
@@ -2301,7 +2271,7 @@ class TestSchedulerJob(unittest.TestCase):
 
             # still one task
             self.assertEqual(
-                len(session.query(TI).filter(TI.dag_id == dag_id).all()), 1)
+                len(session.query(TaskInstance).filter(TaskInstance.dag_id == dag_id).all()), 1)
             session.commit()
             self.assertListEqual([], self.null_exec.sorted_tasks)
 
@@ -2320,9 +2290,9 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler.run()
 
         session = settings.Session()
-        tiq = session.query(TI).filter(TI.dag_id == dag_id)
-        ti1s = tiq.filter(TI.task_id == 'dummy1').all()
-        ti2s = tiq.filter(TI.task_id == 'dummy2').all()
+        tiq = session.query(TaskInstance).filter(TaskInstance.dag_id == dag_id)
+        ti1s = tiq.filter(TaskInstance.task_id == 'dummy1').all()
+        ti2s = tiq.filter(TaskInstance.task_id == 'dummy2').all()
         self.assertEqual(len(ti1s), 0)
         self.assertEqual(len(ti2s), 2)
         for task in ti2s:
@@ -2347,7 +2317,7 @@ class TestSchedulerJob(unittest.TestCase):
         dag_id = 'test_start_date_scheduling'
         session = settings.Session()
         self.assertEqual(
-            len(session.query(TI).filter(TI.dag_id == dag_id).all()), 0)
+            len(session.query(TaskInstance).filter(TaskInstance.dag_id == dag_id).all()), 0)
 
     def test_scheduler_verify_pool_full(self):
         """
@@ -2389,7 +2359,7 @@ class TestSchedulerJob(unittest.TestCase):
         # Recreated part of the scheduler here, to kick off tasks -> executor
         for ti_key in task_instances_list:
             task = dag.get_task(ti_key[1])
-            ti = TI(task, ti_key[2])
+            ti = TaskInstance(task, ti_key[2])
             # Task starts out in the scheduled state. All tasks in the
             # scheduled state will be sent to the executor
             ti.state = State.SCHEDULED
@@ -2447,8 +2417,8 @@ class TestSchedulerJob(unittest.TestCase):
 
         do_schedule()  # pylint: disable=no-value-for-parameter
         with create_session() as session:
-            ti = session.query(TI).filter(TI.dag_id == dag.dag_id,
-                                          TI.task_id == dummy_task.task_id).first()
+            ti = session.query(TaskInstance).filter(TaskInstance.dag_id == dag.dag_id,
+                                                    TaskInstance.task_id == dummy_task.task_id).first()
         self.assertEqual(0, len(executor.queued_tasks))
         self.assertEqual(State.SCHEDULED, ti.state)
 
@@ -2503,8 +2473,8 @@ class TestSchedulerJob(unittest.TestCase):
 
         do_schedule()  # pylint: disable=no-value-for-parameter
         with create_session() as session:
-            ti = session.query(TI).filter(TI.dag_id == 'test_retry_still_in_executor',
-                                          TI.task_id == 'test_retry_handling_op').first()
+            ti = session.query(TaskInstance).filter(TaskInstance.dag_id == 'test_retry_still_in_executor',
+                                                    TaskInstance.task_id == 'test_retry_handling_op').first()
         ti.task = dag_task1
 
         # Nothing should be left in the queued_tasks as we don't do update in MockExecutor yet,
@@ -2521,7 +2491,7 @@ class TestSchedulerJob(unittest.TestCase):
         # At this point, scheduler has tried to schedule the task once and
         # heartbeated the executor once, which moved the state of the task from
         # SCHEDULED to QUEUED and then to SCHEDULED, to fail the task execution
-        # we need to ignore the TI state as SCHEDULED is not a valid state to start
+        # we need to ignore the TaskInstance state as SCHEDULED is not a valid state to start
         # executing task.
         run_with_error(ti, ignore_ti_state=True)
         self.assertEqual(ti.state, State.UP_FOR_RETRY)
@@ -2534,8 +2504,8 @@ class TestSchedulerJob(unittest.TestCase):
 
         # do schedule
         do_schedule()  # pylint: disable=no-value-for-parameter
-        # MockExecutor is not aware of the TI since we don't do update yet
-        # and no trace of this TI will be left in the executor.
+        # MockExecutor is not aware of the TaskInstance since we don't do update yet
+        # and no trace of this TaskInstance will be left in the executor.
         self.assertFalse(executor.has_task(ti))
         self.assertEqual(ti.state, State.SCHEDULED)
 
@@ -2561,8 +2531,8 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler.run()
 
         session = settings.Session()
-        ti = session.query(TI).filter(TI.dag_id == dag.dag_id,
-                                      TI.task_id == dag_task1.task_id).first()
+        ti = session.query(TaskInstance).filter(TaskInstance.dag_id == dag.dag_id,
+                                                TaskInstance.task_id == dag_task1.task_id).first()
 
         # make sure the counter has increased
         self.assertEqual(ti.try_number, 2)
@@ -2591,7 +2561,7 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler.run()
         with create_session() as session:
             self.assertEqual(
-                len(session.query(TI).filter(TI.dag_id == dag_id).all()), 1)
+                len(session.query(TaskInstance).filter(TaskInstance.dag_id == dag_id).all()), 1)
 
     def test_dag_get_active_runs(self):
         """
@@ -2911,7 +2881,7 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler = SchedulerJob()
         session = settings.Session()
 
-        ti = models.TaskInstance(task=task, execution_date=DEFAULT_DATE)
+        ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         session.add(ti)
         session.commit()
 
@@ -2999,8 +2969,8 @@ class TestSchedulerJob(unittest.TestCase):
         dr1_tis = []
         dr2_tis = []
         for i, (task, state) in enumerate(zip(tasks, states)):
-            ti1 = TI(task, dr1.execution_date)
-            ti2 = TI(task, dr2.execution_date)
+            ti1 = TaskInstance(task, dr1.execution_date)
+            ti2 = TaskInstance(task, dr2.execution_date)
             ti1.refresh_from_db()
             ti2.refresh_from_db()
             ti1.state = state

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -19,7 +19,7 @@ import unittest
 import mock
 from requests.exceptions import BaseHTTPError
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.kubernetes.pod_launcher import PodLauncher
 
 

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -24,7 +24,8 @@ from tempfile import NamedTemporaryFile
 
 import mock
 
-from airflow import DAG, AirflowException
+from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils import timezone
 from airflow.utils.state import State

--- a/tests/operators/test_generic_transfer.py
+++ b/tests/operators/test_generic_transfer.py
@@ -20,7 +20,7 @@ import unittest
 
 import pytest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.generic_transfer import GenericTransfer
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.postgres.hooks.postgres import PostgresHook

--- a/tests/operators/test_latest_only_operator.py
+++ b/tests/operators/test_latest_only_operator.py
@@ -21,8 +21,9 @@ import unittest
 
 from freezegun import freeze_time
 
-from airflow import DAG, settings
+from airflow import settings
 from airflow.models import DagRun, TaskInstance
+from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 from airflow.utils import db, timezone

--- a/tests/providers/amazon/aws/hooks/test_batch_waiters.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_waiters.py
@@ -44,7 +44,7 @@ import mock
 import pytest
 from moto import mock_batch, mock_ec2, mock_ecs, mock_iam, mock_logs
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.batch_waiters import AwsBatchWaiters
 
 # Use dummy AWS credentials

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -23,7 +23,7 @@ import mock
 import pytest
 from botocore.exceptions import NoCredentialsError
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook, provide_bucket_name
 

--- a/tests/providers/amazon/aws/operators/test_cloud_formation.py
+++ b/tests/providers/amazon/aws/operators/test_cloud_formation.py
@@ -18,7 +18,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.cloud_formation import (
     CloudFormationCreateStackOperator, CloudFormationDeleteStackOperator,
 )

--- a/tests/providers/amazon/aws/operators/test_emr_add_steps.py
+++ b/tests/providers/amazon/aws/operators/test_emr_add_steps.py
@@ -20,9 +20,9 @@ import unittest
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.emr_add_steps import EmrAddStepsOperator
 from airflow.utils import timezone
 

--- a/tests/providers/amazon/aws/operators/test_emr_create_job_flow.py
+++ b/tests/providers/amazon/aws/operators/test_emr_create_job_flow.py
@@ -21,8 +21,8 @@ import unittest
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from airflow import DAG
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.emr_create_job_flow import EmrCreateJobFlowOperator
 from airflow.utils import timezone
 

--- a/tests/providers/amazon/aws/operators/test_emr_modify_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_emr_modify_cluster.py
@@ -19,8 +19,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from airflow import DAG
 from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.emr_modify_cluster import EmrModifyClusterOperator
 from airflow.utils import timezone
 

--- a/tests/providers/amazon/aws/operators/test_hive_to_dynamodb.py
+++ b/tests/providers/amazon/aws/operators/test_hive_to_dynamodb.py
@@ -25,7 +25,7 @@ from unittest import mock
 import pandas as pd
 
 import airflow.providers.amazon.aws.operators.hive_to_dynamodb
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.aws_dynamodb import AwsDynamoDBHook
 
 DEFAULT_DATE = datetime.datetime(2015, 1, 1)

--- a/tests/providers/amazon/aws/operators/test_mongo_to_s3.py
+++ b/tests/providers/amazon/aws/operators/test_mongo_to_s3.py
@@ -19,8 +19,8 @@ import unittest
 
 import mock
 
-from airflow import DAG
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.mongo_to_s3 import MongoToS3Operator
 from airflow.utils import timezone
 

--- a/tests/providers/amazon/aws/operators/test_sqs.py
+++ b/tests/providers/amazon/aws/operators/test_sqs.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 
 from moto import mock_sqs
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.sqs import SQSHook
 from airflow.providers.amazon.aws.operators.sqs import SQSPublishOperator
 from airflow.utils import timezone

--- a/tests/providers/amazon/aws/sensors/test_athena.py
+++ b/tests/providers/amazon/aws/sensors/test_athena.py
@@ -20,7 +20,7 @@ import unittest
 
 import mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.athena import AWSAthenaHook
 from airflow.providers.amazon.aws.sensors.athena import AthenaSensor
 

--- a/tests/providers/amazon/aws/sensors/test_emr_job_flow.py
+++ b/tests/providers/amazon/aws/sensors/test_emr_job_flow.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 from dateutil.tz import tzlocal
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.sensors.emr_job_flow import EmrJobFlowSensor
 
 DESCRIBE_CLUSTER_STARTING_RETURN = {

--- a/tests/providers/amazon/aws/sensors/test_emr_step.py
+++ b/tests/providers/amazon/aws/sensors/test_emr_step.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 from dateutil.tz import tzlocal
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.sensors.emr_step import EmrStepSensor
 
 DESCRIBE_JOB_STEP_RUNNING_RETURN = {

--- a/tests/providers/amazon/aws/sensors/test_sqs.py
+++ b/tests/providers/amazon/aws/sensors/test_sqs.py
@@ -22,8 +22,8 @@ from unittest.mock import MagicMock, patch
 
 from moto import mock_sqs
 
-from airflow import DAG
 from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.sqs import SQSHook
 from airflow.providers.amazon.aws.sensors.sqs import SQSSensor
 from airflow.utils import timezone

--- a/tests/providers/apache/druid/operators/test_druid.py
+++ b/tests/providers/apache/druid/operators/test_druid.py
@@ -19,8 +19,8 @@
 
 import unittest
 
-from airflow import DAG
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.providers.apache.druid.operators.druid import DruidOperator
 from airflow.utils import timezone
 

--- a/tests/providers/apache/druid/operators/test_hive_to_druid.py
+++ b/tests/providers/apache/druid/operators/test_hive_to_druid.py
@@ -22,7 +22,7 @@ import unittest
 import requests
 import requests_mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.apache.druid.operators.hive_to_druid import HiveToDruidTransfer
 
 

--- a/tests/providers/apache/hive/__init__.py
+++ b/tests/providers/apache/hive/__init__.py
@@ -19,7 +19,7 @@
 from datetime import datetime
 from unittest import TestCase
 
-from airflow import DAG
+from airflow.models.dag import DAG
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -28,9 +28,9 @@ from unittest import mock
 import pandas as pd
 from hmsclient import HMSClient
 
-from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
+from airflow.models.dag import DAG
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook, HiveMetastoreHook, HiveServer2Hook
 from airflow.providers.apache.hive.operators.hive import HiveOperator
 from airflow.utils import timezone

--- a/tests/providers/apache/hive/operators/test_hive_stats.py
+++ b/tests/providers/apache/hive/operators/test_hive_stats.py
@@ -21,7 +21,7 @@ import unittest
 from collections import OrderedDict
 from unittest.mock import patch
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.apache.hive.operators.hive_stats import HiveStatsCollectionOperator
 from tests.providers.apache.hive import DEFAULT_DATE, DEFAULT_DATE_DS, TestHiveEnvironment
 

--- a/tests/providers/apache/hive/operators/test_mysql_to_hive.py
+++ b/tests/providers/apache/hive/operators/test_mysql_to_hive.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import pytest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
 from airflow.providers.apache.hive.operators.mysql_to_hive import MySqlToHiveTransfer
 from airflow.providers.mysql.hooks.mysql import MySqlHook

--- a/tests/providers/apache/hive/sensors/test_named_hive_partition.py
+++ b/tests/providers/apache/hive/sensors/test_named_hive_partition.py
@@ -20,8 +20,8 @@ import random
 import unittest
 from datetime import timedelta
 
-from airflow import DAG
 from airflow.exceptions import AirflowSensorTimeout
+from airflow.models.dag import DAG
 from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
 from airflow.providers.apache.hive.operators.hive import HiveOperator
 from airflow.providers.apache.hive.sensors.named_hive_partition import NamedHivePartitionSensor

--- a/tests/providers/apache/livy/hooks/test_livy.py
+++ b/tests/providers/apache/livy/hooks/test_livy.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 import requests_mock
 from requests.exceptions import RequestException
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
 from airflow.utils import db

--- a/tests/providers/apache/livy/operators/test_livy.py
+++ b/tests/providers/apache/livy/operators/test_livy.py
@@ -19,8 +19,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from airflow import DAG, AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
+from airflow.models.dag import DAG
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
 from airflow.providers.apache.livy.operators.livy import LivyOperator
 from airflow.utils import db, timezone

--- a/tests/providers/apache/livy/sensors/test_livy.py
+++ b/tests/providers/apache/livy/sensors/test_livy.py
@@ -19,8 +19,8 @@
 import unittest
 from unittest.mock import patch
 
-from airflow import DAG
 from airflow.models import Connection
+from airflow.models.dag import DAG
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
 from airflow.providers.apache.livy.sensors.livy import LivySensor
 from airflow.utils import db, timezone

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -20,7 +20,7 @@ import io
 import unittest
 from unittest.mock import call, patch
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.apache.spark.hooks.spark_submit import SparkSubmitHook
 from airflow.utils import db

--- a/tests/providers/apache/spark/operators/test_spark_jdbc.py
+++ b/tests/providers/apache/spark/operators/test_spark_jdbc.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.apache.spark.operators.spark_jdbc import SparkJDBCOperator
 from airflow.utils import timezone
 

--- a/tests/providers/apache/spark/operators/test_spark_sql.py
+++ b/tests/providers/apache/spark/operators/test_spark_sql.py
@@ -20,7 +20,7 @@
 import datetime
 import unittest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.apache.spark.operators.spark_sql import SparkSqlOperator
 
 DEFAULT_DATE = datetime.datetime(2017, 1, 1)

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -20,8 +20,8 @@
 import unittest
 from datetime import timedelta
 
-from airflow import DAG
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
 from airflow.utils import timezone
 

--- a/tests/providers/apache/sqoop/operators/test_sqoop.py
+++ b/tests/providers/apache/sqoop/operators/test_sqoop.py
@@ -20,8 +20,8 @@
 import datetime
 import unittest
 
-from airflow import DAG
 from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
 from airflow.providers.apache.sqoop.operators.sqoop import SqoopOperator
 
 

--- a/tests/providers/dingding/operators/test_dingding.py
+++ b/tests/providers/dingding/operators/test_dingding.py
@@ -19,7 +19,7 @@
 import unittest
 from unittest import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.dingding.operators.dingding import DingdingOperator
 from airflow.utils import timezone
 

--- a/tests/providers/discord/hooks/test_discord_webhook.py
+++ b/tests/providers/discord/hooks/test_discord_webhook.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.discord.hooks.discord_webhook import DiscordWebhookHook
 from airflow.utils import db

--- a/tests/providers/discord/operators/test_discord_webhook.py
+++ b/tests/providers/discord/operators/test_discord_webhook.py
@@ -18,7 +18,7 @@
 #
 import unittest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.discord.operators.discord_webhook import DiscordWebhookOperator
 from airflow.utils import timezone
 

--- a/tests/providers/email/operators/test_email.py
+++ b/tests/providers/email/operators/test_email.py
@@ -20,7 +20,7 @@ import datetime
 import unittest
 from unittest import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.email.operators.email import EmailOperator
 from airflow.utils import timezone
 from tests.test_utils.config import conf_vars

--- a/tests/providers/google/cloud/hooks/test_base.py
+++ b/tests/providers/google/cloud/hooks/test_base.py
@@ -32,9 +32,11 @@ from google.cloud.exceptions import Forbidden, MovedPermanently
 from googleapiclient.errors import HttpError
 from parameterized import parameterized
 
-from airflow import AirflowException, LoggingMixin, version
+from airflow import version
+from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.providers.google.cloud.hooks import base as hook
+from airflow.utils.log.logging_mixin import LoggingMixin
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 default_creds_available = True

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -22,7 +22,7 @@ from unittest import mock
 from googleapiclient.errors import HttpError
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks import bigquery as hook
 from airflow.providers.google.cloud.hooks.bigquery import (
     _api_resource_configs_duplication_check, _cleanse_time_partitioning, _validate_src_fmt_configs,

--- a/tests/providers/google/cloud/hooks/test_bigtable.py
+++ b/tests/providers/google/cloud/hooks/test_bigtable.py
@@ -24,7 +24,7 @@ from google.cloud.bigtable import Client
 from google.cloud.bigtable.instance import Instance
 from mock import PropertyMock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.bigtable import BigtableHook
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_cloud_build.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_build.py
@@ -24,7 +24,7 @@ from unittest import mock
 
 from mock import PropertyMock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_build import CloudBuildHook
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
@@ -23,7 +23,8 @@ from google.cloud.exceptions import NotFound
 from google.cloud.redis_v1.types import Instance
 from mock import PropertyMock
 
-from airflow import AirflowException, version
+from airflow import version
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_memorystore import CloudMemorystoreHook
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
@@ -24,7 +24,7 @@ import mock
 from mock import PropertyMock
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     DESCRIPTION, FILTER_JOB_NAMES, FILTER_PROJECT_ID, METADATA, OPERATIONS, PROJECT_ID, STATUS,
     TIME_TO_SLEEP_IN_SECONDS, TRANSFER_JOB, TRANSFER_JOB_FIELD_MASK, TRANSFER_JOBS,

--- a/tests/providers/google/cloud/hooks/test_compute.py
+++ b/tests/providers/google/cloud/hooks/test_compute.py
@@ -23,7 +23,7 @@ import unittest
 import mock
 from mock import PropertyMock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.compute import ComputeEngineHook, GceOperationStatus
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -24,7 +24,7 @@ import mock
 from mock import MagicMock
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dataflow import (
     DataflowHook, DataflowJobStatus, DataflowJobType, _DataflowJobsController, _DataflowRunner,
     _fallback_to_project_id_from_variables,

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -21,7 +21,7 @@ import unittest
 import mock
 from google.cloud.dataproc_v1beta2.types import JobStatus  # pylint: disable=no-name-in-module
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dataproc import DataprocHook, DataProcJobBuilder
 from airflow.version import version
 

--- a/tests/providers/google/cloud/hooks/test_datastore.py
+++ b/tests/providers/google/cloud/hooks/test_datastore.py
@@ -22,7 +22,7 @@ from unittest.mock import call, patch
 
 import mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.datastore import DatastoreHook
 
 GCP_PROJECT_ID = "test"

--- a/tests/providers/google/cloud/hooks/test_dlp.py
+++ b/tests/providers/google/cloud/hooks/test_dlp.py
@@ -29,7 +29,7 @@ import mock
 from google.cloud.dlp_v2.types import DlpJob
 from mock import PropertyMock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dlp import CloudDLPHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 

--- a/tests/providers/google/cloud/hooks/test_functions.py
+++ b/tests/providers/google/cloud/hooks/test_functions.py
@@ -21,7 +21,7 @@ import unittest
 import mock
 from mock import PropertyMock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.functions import CloudFunctionsHook
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, get_open_mock, mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -22,7 +22,7 @@ import mock
 from google.cloud.container_v1.types import Cluster
 from mock import PropertyMock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.kubernetes_engine import GKEHook
 
 TASK_ID = 'test-gke-cluster-operator'

--- a/tests/providers/google/cloud/hooks/test_mlengine.py
+++ b/tests/providers/google/cloud/hooks/test_mlengine.py
@@ -22,7 +22,7 @@ from unittest import mock
 from googleapiclient.errors import HttpError
 from mock import PropertyMock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks import mlengine as hook
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_spanner.py
+++ b/tests/providers/google/cloud/hooks/test_spanner.py
@@ -21,7 +21,7 @@ import unittest
 import mock
 from mock import PropertyMock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.spanner import SpannerHook
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_vision.py
+++ b/tests/providers/google/cloud/hooks/test_vision.py
@@ -27,7 +27,7 @@ from google.cloud.vision_v1.proto.product_search_service_pb2 import Product, Pro
 from google.protobuf.json_format import MessageToDict
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.vision import ERR_DIFF_NAMES, ERR_UNABLE_TO_CREATE, CloudVisionHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 

--- a/tests/providers/google/cloud/operators/test_bigtable.py
+++ b/tests/providers/google/cloud/operators/test_bigtable.py
@@ -25,7 +25,7 @@ from google.cloud.bigtable.column_family import MaxVersionsGCRule
 from google.cloud.bigtable.instance import Instance
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.bigtable import (
     BigtableCreateInstanceOperator, BigtableCreateTableOperator, BigtableDeleteInstanceOperator,
     BigtableDeleteTableOperator, BigtableUpdateClusterOperator,

--- a/tests/providers/google/cloud/operators/test_cloud_build.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build.py
@@ -23,7 +23,7 @@ from unittest import TestCase
 import mock
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.cloud_build import BuildProcessor, CloudBuildCreateOperator
 
 TEST_CREATE_BODY = {

--- a/tests/providers/google/cloud/operators/test_cloud_sql.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql.py
@@ -24,7 +24,7 @@ import unittest
 import mock
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.google.cloud.operators.cloud_sql import (
     CloudSQLCreateInstanceDatabaseOperator, CloudSQLCreateInstanceOperator,

--- a/tests/providers/google/cloud/operators/test_cloud_sql_operatorquery_system.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql_operatorquery_system.py
@@ -22,7 +22,7 @@ import time
 
 import pytest
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_sql import CloudSqlProxyRunner
 from tests.providers.google.cloud.operators.test_cloud_sql_system_helper import CloudSqlQueryTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_CLOUDSQL_KEY

--- a/tests/providers/google/cloud/operators/test_cloud_sql_system.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql_system.py
@@ -19,7 +19,7 @@ import os
 
 import pytest
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from tests.providers.google.cloud.operators.test_cloud_sql_system_helper import CloudSqlQueryTestHelper
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_CLOUDSQL_KEY
 from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, provide_gcp_context

--- a/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
@@ -26,7 +26,7 @@ from botocore.credentials import Credentials
 from freezegun import freeze_time
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import DAG, TaskInstance
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     ACCESS_KEY_ID, AWS_ACCESS_KEY, AWS_S3_DATA_SOURCE, BUCKET_NAME, FILTER_JOB_NAMES, GCS_DATA_SINK,

--- a/tests/providers/google/cloud/operators/test_compute.py
+++ b/tests/providers/google/cloud/operators/test_compute.py
@@ -26,7 +26,7 @@ import httplib2
 import mock
 from googleapiclient.errors import HttpError
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import DAG, TaskInstance
 from airflow.providers.google.cloud.operators.compute import (
     ComputeEngineCopyInstanceTemplateOperator, ComputeEngineInstanceGroupUpdateManagerTemplateOperator,

--- a/tests/providers/google/cloud/operators/test_functions.py
+++ b/tests/providers/google/cloud/operators/test_functions.py
@@ -23,7 +23,7 @@ import mock
 from googleapiclient.errors import HttpError
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.functions import (
     FUNCTION_NAME_PATTERN, CloudFunctionDeleteFunctionOperator, CloudFunctionDeployFunctionOperator,
     CloudFunctionInvokeFunctionOperator,

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -24,7 +24,7 @@ from google.auth.environment_vars import CREDENTIALS
 from mock import PropertyMock
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.providers.google.cloud.operators.kubernetes_engine import (

--- a/tests/providers/google/cloud/operators/test_local_to_gcs.py
+++ b/tests/providers/google/cloud/operators/test_local_to_gcs.py
@@ -22,7 +22,7 @@ import unittest
 
 import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.local_to_gcs import LocalFilesystemToGCSOperator
 
 

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -23,8 +23,8 @@ from unittest.mock import ANY, patch
 import httplib2
 from googleapiclient.errors import HttpError
 
-from airflow import DAG
 from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.mlengine import (
     MLEngineCreateModelOperator, MLEngineCreateVersionOperator, MLEngineDeleteModelOperator,
     MLEngineDeleteVersionOperator, MLEngineGetModelOperator, MLEngineListVersionsOperator,

--- a/tests/providers/google/cloud/operators/test_mlengine_utils.py
+++ b/tests/providers/google/cloud/operators/test_mlengine_utils.py
@@ -19,8 +19,8 @@ import datetime
 import unittest
 from unittest.mock import ANY, patch
 
-from airflow import DAG
 from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
 from airflow.providers.google.cloud.utils import mlengine_operator_utils
 from airflow.version import version
 

--- a/tests/providers/google/cloud/operators/test_spanner.py
+++ b/tests/providers/google/cloud/operators/test_spanner.py
@@ -20,7 +20,7 @@ import unittest
 import mock
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.spanner import (
     SpannerDeleteDatabaseInstanceOperator, SpannerDeleteInstanceOperator,
     SpannerDeployDatabaseInstanceOperator, SpannerDeployInstanceOperator,

--- a/tests/providers/google/cloud/operators/test_speech_to_text.py
+++ b/tests/providers/google/cloud/operators/test_speech_to_text.py
@@ -20,7 +20,7 @@ import unittest
 
 from mock import Mock, patch
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.speech_to_text import CloudSpeechToTextRecognizeSpeechOperator
 
 PROJECT_ID = "project-id"

--- a/tests/providers/google/cloud/operators/test_text_to_speech.py
+++ b/tests/providers/google/cloud/operators/test_text_to_speech.py
@@ -21,7 +21,7 @@ import unittest
 from mock import ANY, Mock, PropertyMock, patch
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.text_to_speech import CloudTextToSpeechSynthesizeOperator
 
 PROJECT_ID = "project-id"

--- a/tests/providers/google/cloud/operators/test_translate_speech.py
+++ b/tests/providers/google/cloud/operators/test_translate_speech.py
@@ -23,7 +23,7 @@ from google.cloud.speech_v1.proto.cloud_speech_pb2 import (
     RecognizeResponse, SpeechRecognitionAlternative, SpeechRecognitionResult,
 )
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.translate_speech import GcpTranslateSpeechOperator
 
 GCP_CONN_ID = 'google_cloud_default'

--- a/tests/providers/google/cloud/sensors/test_bigtable.py
+++ b/tests/providers/google/cloud/sensors/test_bigtable.py
@@ -24,7 +24,7 @@ from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import ClusterState
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.sensors.bigtable import BigtableTableReplicationCompletedSensor
 
 PROJECT_ID = 'test_project_id'

--- a/tests/providers/google/cloud/sensors/test_gcs.py
+++ b/tests/providers/google/cloud/sensors/test_gcs.py
@@ -20,8 +20,8 @@ from unittest import TestCase, mock
 
 import pendulum
 
-from airflow import DAG, AirflowException
 from airflow.exceptions import AirflowSensorTimeout
+from airflow.models.dag import DAG, AirflowException
 from airflow.providers.google.cloud.sensors.gcs import (
     GCSObjectExistenceSensor, GCSObjectsWtihPrefixExistenceSensor, GCSObjectUpdateSensor,
     GCSUploadSessionCompleteSensor, ts_function,

--- a/tests/providers/google/cloud/utils/gcp_authenticator.py
+++ b/tests/providers/google/cloud/utils/gcp_authenticator.py
@@ -20,7 +20,8 @@ import os
 import subprocess
 from typing import Optional  # noqa: W0611
 
-from airflow import AirflowException, settings
+from airflow import settings
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from tests.contrib.utils.logging_command_executor import LoggingCommandExecutor
 # Please keep these variables in alphabetical order.

--- a/tests/providers/google/suite/hooks/test_sheets.py
+++ b/tests/providers/google/suite/hooks/test_sheets.py
@@ -24,7 +24,7 @@ import unittest
 
 import mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.suite.hooks.sheets import GSheetsHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 

--- a/tests/providers/google/suite/operators/test_gcs_to_gdrive.py
+++ b/tests/providers/google/suite/operators/test_gcs_to_gdrive.py
@@ -18,7 +18,7 @@
 import unittest
 from unittest import mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.google.suite.operators.gcs_to_gdrive import GCSToGoogleDriveOperator
 
 MODULE = "airflow.providers.google.suite.operators.gcs_to_gdrive"

--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -21,9 +21,9 @@ from unittest.mock import patch
 import mock
 import requests
 
-from airflow import DAG
 from airflow.exceptions import AirflowException, AirflowSensorTimeout
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.providers.http.operators.http import SimpleHttpOperator
 from airflow.providers.http.sensors.http import HttpSensor
 from airflow.utils.timezone import datetime

--- a/tests/providers/imap/hooks/test_imap.py
+++ b/tests/providers/imap/hooks/test_imap.py
@@ -20,7 +20,7 @@ import imaplib
 import unittest
 from unittest.mock import Mock, mock_open, patch
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.imap.hooks.imap import ImapHook
 from airflow.utils import db

--- a/tests/providers/jira/operators/test_jira.py
+++ b/tests/providers/jira/operators/test_jira.py
@@ -20,8 +20,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from airflow import DAG
 from airflow.models import Connection
+from airflow.models.dag import DAG
 from airflow.providers.jira.operators.jira import JiraOperator
 from airflow.utils import db, timezone
 

--- a/tests/providers/jira/sensors/test_jira.py
+++ b/tests/providers/jira/sensors/test_jira.py
@@ -20,8 +20,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from airflow import DAG
 from airflow.models import Connection
+from airflow.models.dag import DAG
 from airflow.providers.jira.sensors.jira import JiraTicketSensor
 from airflow.utils import db, timezone
 

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -24,7 +24,7 @@ from collections import namedtuple
 
 import mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from airflow.utils import db

--- a/tests/providers/microsoft/azure/operators/test_file_to_wasb.py
+++ b/tests/providers/microsoft/azure/operators/test_file_to_wasb.py
@@ -22,7 +22,7 @@ import unittest
 
 import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.operators.file_to_wasb import FileToWasbOperator
 
 

--- a/tests/providers/microsoft/azure/operators/test_wasb_delete_blob.py
+++ b/tests/providers/microsoft/azure/operators/test_wasb_delete_blob.py
@@ -22,7 +22,7 @@ import unittest
 
 import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.operators.wasb_delete_blob import WasbDeleteBlobOperator
 
 

--- a/tests/providers/microsoft/azure/sensors/test_wasb.py
+++ b/tests/providers/microsoft/azure/sensors/test_wasb.py
@@ -22,7 +22,7 @@ import unittest
 
 import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.sensors.wasb import WasbBlobSensor, WasbPrefixSensor
 
 

--- a/tests/providers/microsoft/winrm/hooks/test_winrm.py
+++ b/tests/providers/microsoft/winrm/hooks/test_winrm.py
@@ -20,7 +20,7 @@
 import unittest
 from unittest.mock import patch
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 

--- a/tests/providers/mongo/sensors/test_mongo.py
+++ b/tests/providers/mongo/sensors/test_mongo.py
@@ -21,8 +21,8 @@ import unittest
 
 import pytest
 
-from airflow import DAG
 from airflow.models import Connection
+from airflow.models.dag import DAG
 from airflow.providers.mongo.hooks.mongo import MongoHook
 from airflow.providers.mongo.sensors.mongo import MongoSensor
 from airflow.utils import db, timezone

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -25,8 +25,8 @@ from unittest import mock
 import MySQLdb.cursors
 import pytest
 
-from airflow import DAG
 from airflow.models import Connection
+from airflow.models.dag import DAG
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.utils import timezone
 

--- a/tests/providers/mysql/operators/test_mysql.py
+++ b/tests/providers/mysql/operators/test_mysql.py
@@ -19,7 +19,7 @@ import unittest
 
 import pytest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.mysql.operators.mysql import MySqlOperator
 from airflow.utils import timezone

--- a/tests/providers/mysql/operators/test_vertica_to_mysql.py
+++ b/tests/providers/mysql/operators/test_vertica_to_mysql.py
@@ -20,7 +20,7 @@ import datetime
 import unittest
 from unittest import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.mysql.operators.vertica_to_mysql import VerticaToMySqlTransfer
 
 

--- a/tests/providers/openfass/hooks/test_openfaas.py
+++ b/tests/providers/openfass/hooks/test_openfaas.py
@@ -22,7 +22,7 @@ import unittest
 import mock
 import requests_mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import Connection
 from airflow.providers.openfass.hooks.openfaas import OpenFaasHook

--- a/tests/providers/opsgenie/hooks/test_opsgenie_alert.py
+++ b/tests/providers/opsgenie/hooks/test_opsgenie_alert.py
@@ -21,7 +21,7 @@ import unittest
 
 import requests_mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.opsgenie.hooks.opsgenie_alert import OpsgenieAlertHook
 from airflow.utils import db

--- a/tests/providers/opsgenie/operators/test_opsgenie_alert.py
+++ b/tests/providers/opsgenie/operators/test_opsgenie_alert.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.opsgenie.operators.opsgenie_alert import OpsgenieAlertOperator
 from airflow.utils import timezone
 

--- a/tests/providers/postgres/operators/test_postgres.py
+++ b/tests/providers/postgres/operators/test_postgres.py
@@ -20,7 +20,7 @@ import unittest
 
 import pytest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.utils import timezone
 

--- a/tests/providers/redis/operators/test_redis_publish.py
+++ b/tests/providers/redis/operators/test_redis_publish.py
@@ -22,7 +22,7 @@ import unittest
 import pytest
 from mock import MagicMock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.redis.hooks.redis import RedisHook
 from airflow.providers.redis.operators.redis_publish import RedisPublishOperator
 from airflow.utils import timezone

--- a/tests/providers/redis/sensors/test_redis_key.py
+++ b/tests/providers/redis/sensors/test_redis_key.py
@@ -21,7 +21,7 @@ import unittest
 
 import pytest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.redis.hooks.redis import RedisHook
 from airflow.providers.redis.sensors.redis_key import RedisKeySensor
 from airflow.utils import timezone

--- a/tests/providers/redis/sensors/test_redis_pub_sub.py
+++ b/tests/providers/redis/sensors/test_redis_pub_sub.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.redis.hooks.redis import RedisHook
 from airflow.providers.redis.sensors.redis_pub_sub import RedisPubSubSensor
 from airflow.utils import timezone

--- a/tests/providers/segment/hooks/test_segment.py
+++ b/tests/providers/segment/hooks/test_segment.py
@@ -19,7 +19,7 @@
 import unittest
 from unittest import mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.segment.hooks.segment import SegmentHook
 
 TEST_CONN_ID = 'test_segment'

--- a/tests/providers/segment/operators/test_segment_track_event.py
+++ b/tests/providers/segment/operators/test_segment_track_event.py
@@ -19,7 +19,7 @@
 import unittest
 from unittest import mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.providers.segment.hooks.segment import SegmentHook
 from airflow.providers.segment.operators.segment_track_event import SegmentTrackEventOperator
 

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -21,7 +21,7 @@ import unittest
 from base64 import b64encode
 from unittest import mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import DAG, TaskInstance
 from airflow.providers.sftp.operators.sftp import SFTPOperation, SFTPOperator
 from airflow.providers.ssh.operators.ssh import SSHOperator

--- a/tests/providers/slack/operators/test_slack_webhook.py
+++ b/tests/providers/slack/operators/test_slack_webhook.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 from airflow.utils import timezone
 

--- a/tests/providers/snowflake/operators/test_snowflake.py
+++ b/tests/providers/snowflake/operators/test_snowflake.py
@@ -20,7 +20,7 @@ import unittest
 
 import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 from airflow.utils import timezone
 

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -21,7 +21,7 @@ from base64 import b64encode
 
 from parameterized import parameterized
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.models import DAG, TaskInstance
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.utils import timezone

--- a/tests/providers/yandex/operators/test_yandexcloud_dataproc.py
+++ b/tests/providers/yandex/operators/test_yandexcloud_dataproc.py
@@ -20,7 +20,7 @@ import datetime
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.yandex.operators.yandexcloud_dataproc import (
     DataprocCreateClusterOperator, DataprocCreateHiveJobOperator, DataprocCreateMapReduceJobOperator,
     DataprocCreatePysparkJobOperator, DataprocCreateSparkJobOperator, DataprocDeleteClusterOperator,

--- a/tests/runtime/kubernetes/test_kubernetes_pod_operator.py
+++ b/tests/runtime/kubernetes/test_kubernetes_pod_operator.py
@@ -27,7 +27,7 @@ import pytest
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.rest import ApiException
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.kubernetes.pod import Port
 from airflow.kubernetes.pod_generator import PodDefaults
 from airflow.kubernetes.pod_launcher import PodLauncher

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -23,9 +23,9 @@ from unittest.mock import Mock, patch
 
 from freezegun import freeze_time
 
-from airflow import DAG, settings
 from airflow.exceptions import AirflowException, AirflowRescheduleException, AirflowSensorTimeout
 from airflow.models import DagRun, TaskInstance, TaskReschedule
+from airflow.models.dag import DAG, settings
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep

--- a/tests/sensors/test_bash.py
+++ b/tests/sensors/test_bash.py
@@ -20,8 +20,8 @@
 import datetime
 import unittest
 
-from airflow import DAG
 from airflow.exceptions import AirflowSensorTimeout
+from airflow.models.dag import DAG
 from airflow.sensors.bash import BashSensor
 
 

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -20,9 +20,10 @@ from datetime import time, timedelta
 
 import pytest
 
-from airflow import DAG, exceptions, settings
+from airflow import exceptions, settings
 from airflow.exceptions import AirflowException, AirflowSensorTimeout
 from airflow.models import DagBag, TaskInstance
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.sensors.external_task_sensor import ExternalTaskMarker, ExternalTaskSensor

--- a/tests/sensors/test_filesystem.py
+++ b/tests/sensors/test_filesystem.py
@@ -22,8 +22,8 @@ import shutil
 import tempfile
 import unittest
 
-from airflow import DAG
 from airflow.exceptions import AirflowSensorTimeout
+from airflow.models.dag import DAG
 from airflow.sensors.filesystem import FileSensor
 from airflow.utils.timezone import datetime
 

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -21,8 +21,8 @@ from unittest import mock
 
 import pytest
 
-from airflow import DAG
 from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
 from airflow.sensors.sql_sensor import SqlSensor
 from airflow.utils.timezone import datetime
 from tests.providers.apache.hive import TestHiveEnvironment

--- a/tests/sensors/test_timedelta_sensor.py
+++ b/tests/sensors/test_timedelta_sensor.py
@@ -18,7 +18,8 @@
 import unittest
 from datetime import timedelta
 
-from airflow import DAG, models
+from airflow.models import DagBag
+from airflow.models.dag import DAG
 from airflow.sensors.time_delta_sensor import TimeDeltaSensor
 from airflow.utils.timezone import datetime
 
@@ -29,7 +30,7 @@ TEST_DAG_ID = 'unit_tests'
 
 class TestTimedeltaSensor(unittest.TestCase):
     def setUp(self):
-        self.dagbag = models.DagBag(
+        self.dagbag = DagBag(
             dag_folder=DEV_NULL, include_examples=True)
         self.args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         self.dag = DAG(TEST_DAG_ID, default_args=self.args)

--- a/tests/sensors/test_timeout_sensor.py
+++ b/tests/sensors/test_timeout_sensor.py
@@ -19,8 +19,8 @@ import time
 import unittest
 from datetime import timedelta
 
-from airflow import DAG
 from airflow.exceptions import AirflowSensorTimeout, AirflowSkipException
+from airflow.models.dag import DAG
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults

--- a/tests/sensors/test_weekday_sensor.py
+++ b/tests/sensors/test_weekday_sensor.py
@@ -21,10 +21,10 @@ import unittest
 
 from parameterized import parameterized
 
-from airflow import DAG, models
 from airflow.contrib.utils.weekday import WeekDay
 from airflow.exceptions import AirflowSensorTimeout
-from airflow.models import DagBag, TaskFail
+from airflow.models import DagBag, TaskFail, TaskInstance
+from airflow.models.dag import DAG
 from airflow.sensors.weekday_sensor import DayOfWeekSensor
 from airflow.settings import Session
 from airflow.utils.timezone import datetime
@@ -52,7 +52,7 @@ class TestDayOfWeekSensor(unittest.TestCase):
 
     def tearDown(self):
         session = Session()
-        session.query(models.TaskInstance).filter_by(
+        session.query(TaskInstance).filter_by(
             dag_id=TEST_DAG_ID).delete()
         session.query(TaskFail).filter_by(
             dag_id=TEST_DAG_ID).delete()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,12 +26,13 @@ from time import sleep
 from dateutil.relativedelta import relativedelta
 from numpy.testing import assert_array_almost_equal
 
-from airflow import DAG, exceptions, settings
-from airflow.exceptions import AirflowException
+from airflow import settings
+from airflow.exceptions import AirflowException, AirflowTaskTimeout
 from airflow.hooks.base_hook import BaseHook
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models import DagBag, DagRun, TaskFail, TaskInstance
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
 from airflow.operators.dummy_operator import DummyOperator
@@ -176,7 +177,7 @@ class TestCore(unittest.TestCase):
             bash_command="/bin/bash -c 'sleep %s'" % sleep_time,
             dag=self.dag)
         self.assertRaises(
-            exceptions.AirflowTaskTimeout,
+            AirflowTaskTimeout,
             op.run,
             start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         sleep(2)
@@ -203,7 +204,7 @@ class TestCore(unittest.TestCase):
             dag=self.dag,
             on_failure_callback=check_failure)
         self.assertRaises(
-            exceptions.AirflowException,
+            AirflowException,
             op.run,
             start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
         self.assertTrue(data['called'])
@@ -230,7 +231,7 @@ class TestCore(unittest.TestCase):
             python_callable=lambda: sleep(5),
             dag=self.dag)
         self.assertRaises(
-            exceptions.AirflowTaskTimeout,
+            AirflowTaskTimeout,
             op.run,
             start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 

--- a/tests/test_utils/system_tests_class.py
+++ b/tests/test_utils/system_tests_class.py
@@ -23,8 +23,9 @@ from shutil import move
 from tempfile import mkdtemp
 from unittest import TestCase
 
-from airflow import AirflowException, models
 from airflow.configuration import AIRFLOW_HOME, AirflowConfigParser, get_airflow_config
+from airflow.exceptions import AirflowException
+from airflow.models.dagbag import DagBag
 from airflow.utils.file import mkdirs
 from airflow.utils.log.logging_mixin import LoggingMixin
 from tests.test_utils import AIRFLOW_MAIN_FOLDER
@@ -212,7 +213,7 @@ class SystemTest(TestCase, LoggingMixin):
             dag_folder = temp_dir
             self.correct_imports_for_airflow_1_10(temp_dir)
         self.log.info("Looking for DAG: %s in %s", dag_id, dag_folder)
-        dag_bag = models.DagBag(dag_folder=dag_folder, include_examples=False)
+        dag_bag = DagBag(dag_folder=dag_folder, include_examples=False)
         dag = dag_bag.get_dag(dag_id)
         if dag is None:
             raise AirflowException(

--- a/tests/ti_deps/deps/test_valid_state_dep.py
+++ b/tests/ti_deps/deps/test_valid_state_dep.py
@@ -20,7 +20,7 @@ import unittest
 from datetime import datetime
 from unittest.mock import Mock
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.ti_deps.deps.valid_state_dep import ValidStateDep
 from airflow.utils.state import State
 

--- a/tests/utils/log/test_stackdriver_task_handler.py
+++ b/tests/utils/log/test_stackdriver_task_handler.py
@@ -22,8 +22,8 @@ from unittest import mock
 
 from google.cloud.logging.resource import Resource
 
-from airflow import DAG
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.log.stackdriver_task_handler import StackdriverTaskHandler
 from airflow.utils.state import State

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -23,7 +23,8 @@ from argparse import Namespace
 from contextlib import contextmanager
 from datetime import datetime
 
-from airflow import AirflowException, settings
+from airflow import settings
+from airflow.exceptions import AirflowException
 from airflow.utils import cli, cli_action_loggers
 
 

--- a/tests/utils/test_dot_renderer.py
+++ b/tests/utils/test_dot_renderer.py
@@ -21,7 +21,7 @@ import unittest
 
 import mock
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils import dot_renderer

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -26,8 +26,8 @@ from datetime import datetime
 
 import psutil
 
-from airflow import DAG
 from airflow.models import TaskInstance
+from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import helpers
 from airflow.utils.helpers import merge_dicts

--- a/tests/utils/test_serve_logs.py
+++ b/tests/utils/test_serve_logs.py
@@ -23,7 +23,7 @@ from time import sleep
 
 import requests
 
-from airflow import conf
+from airflow.configuration import conf
 from airflow.utils.serve_logs import serve_logs
 
 LOG_DATA = "Airflow log data" * 20


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6817](https://issues.apache.org/jira/browse/AIRFLOW-6817)

Moved `airflow/__init__.py` imports to respective sub-packages with the exception of the `settings.initialize()` and `integrate_plugins()`

All breeze unit and integration tests are passing locally.

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
