### PR TITLE
[AIRFLOW-6837] limit description len of dag in home

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -99,7 +99,7 @@
                 <!-- Column 3: Name -->
                 <td>
                     <span>
-                      <a href="{{ url_for('Airflow.'+ dag.default_view, dag_id=dag.dag_id) }}" title="{{ dag.description }}">
+                      <a href="{{ url_for('Airflow.'+ dag.default_view, dag_id=dag.dag_id) }}" title="{{ dag.description[0:80] + '...' if dag.description|length > 80 else dag.description }}">
                           {{ dag.dag_id }}
                       </a>
                     </span>


### PR DESCRIPTION
as it makes dags link not clickable


The dag with long description:
![image](https://user-images.githubusercontent.com/8662365/74785686-bb8a5f80-525f-11ea-8463-af10b3c1ad40.png)

Before:
![image](https://user-images.githubusercontent.com/8662365/74785702-c6dd8b00-525f-11ea-94af-9710da21baab.png)

After:

![image](https://user-images.githubusercontent.com/8662365/74785710-ca711200-525f-11ea-9e12-6a77ebc9bcad.png)



---
Issue link: [AIRFLOW-6837](https://issues.apache.org/jira/browse/AIRFLOW-6837)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
