### PR TITLE
[AIRFLOW-6839] even more mypy speed improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -286,7 +286,7 @@ repos:
         entry: "./scripts/ci/pre_commit_mypy.sh"
         files: \.py$
         exclude: ^airflow/_vendor/.*$|^dev
-        pass_filenames: false
+        require_serial: true
       - id: pylint
         name: Run pylint for main sources
         language: system


### PR DESCRIPTION
Require_serial:true is better choice than pass_filename: false as it can
speed-up mypy for single file changes.

Significant gains can be achieved for single file changes and no cache for all
other files. This is majority of cases for our users who have pre-commits
installed as hooks because most people change only few files and never run
check with --all-files

When just one file is changed and no cache is built, the difference is drastic:

require_serial: true = 4s

pass_filenames: false =  13s

---
Issue link: [AIRFLOW-6839](https://issues.apache.org/jira/browse/AIRFLOW-6839)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
