### PR TITLE
[AIRFLOW-XXXX] clarify dag_id parameter

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -89,7 +89,8 @@ class DAG(BaseDag, LoggingMixin):
     DAGs essentially act as namespaces for tasks. A task_id can only be
     added once to a DAG.
 
-    :param dag_id: The id of the DAG
+    :param dag_id: The id of the DAG; must consist exclusively of alphanumeric
+        characters, dashes, dots and underscores (all ASCII) exclusively
     :type dag_id: str
     :param description: The description for the DAG to e.g. be shown on the webserver
     :type description: str


### PR DESCRIPTION
[AIRFLOW-XXXX]

Re-filing #7462 here:

I spent a while chasing this just now, wondering whether `:` is valid before finding `validate_key()` in helpers.

I think it's helpful to surface this here directly.

Trivial change so eschewing the other formality required in the PR template