### PR TITLE
[AIRFLOW-XXXX] Remove travis config warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@
 ---
 dist: bionic
 language: python
+os: linux
 env:
   global:
     - BUILD_ID=${TRAVIS_BUILD_ID}
@@ -30,6 +31,8 @@ python: "3.6"
 stages:
   - pre-test
   - test
+services:
+  - docker
 jobs:
   include:
     - name: "Static checks"
@@ -107,8 +110,6 @@ jobs:
         PYTHON_VERSION=3.7
         ENABLED_INTEGRATIONS="kerberos"
       stage: test
-  services:
-    - docker
 before_install:
   - ./scripts/ci/ci_before_install.sh
 script: ./scripts/ci/ci_run_airflow_testing.sh


### PR DESCRIPTION
Building on my fork on travis-ci.com I noticed that there is a new
config validation feature and these two things were giving warnings

Nothing seemed broken without it, but we may as well fix these warnings now

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.