### PR TITLE
[AIRFLOW-6834] Fix some flaky tests in test_scheduler_job.py

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -202,7 +202,7 @@ class DagRun(Base, LoggingMixin):
 
         if self.dag and self.dag.partial:
             tis = tis.filter(TaskInstance.task_id.in_(self.dag.task_ids))
-        return tis.all()
+        return tis.order_by(TaskInstance.execution_date, TaskInstance.dag_id, TaskInstance.task_id).all()
 
     @provide_session
     def get_task_instance(self, task_id, session=None):

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -202,7 +202,7 @@ class DagRun(Base, LoggingMixin):
 
         if self.dag and self.dag.partial:
             tis = tis.filter(TaskInstance.task_id.in_(self.dag.task_ids))
-        return tis.order_by(TaskInstance.execution_date, TaskInstance.dag_id, TaskInstance.task_id).all()
+        return tis.all()
 
     @provide_session
     def get_task_instance(self, task_id, session=None):

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -29,7 +29,7 @@ from airflow.bin import cli
 from airflow.cli.commands import task_command
 from airflow.exceptions import AirflowException
 from airflow.models import DagBag, TaskInstance
-from airflow.settings import Session
+from airflow.settings import Session, configure_orm
 from airflow.utils import timezone
 from airflow.utils.cli import get_dag
 from airflow.utils.state import State
@@ -51,6 +51,12 @@ class TestCliTasks(unittest.TestCase):
     def setUpClass(cls):
         cls.dagbag = DagBag(include_examples=True)
         cls.parser = cli.CLIFactory.get_parser()
+
+    @classmethod
+    def tearDownClass(cls):
+        # task_run() calls configure_orm with disable_connection_pool=True.
+        # Call configure_orm again to restore orm configuration to avoid interfering with other tests.
+        configure_orm()
 
     def test_cli_list_tasks(self):
         for dag_id in self.dagbag.dags:

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -44,6 +44,17 @@ TEST_DAG_FOLDER = os.environ['AIRFLOW__CORE__DAGS_FOLDER']
 
 
 class TestLocalTaskJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # The tests in this class which use multiprocessing and session can only work
+        # when connection pool is disabled.
+        settings.configure_orm(disable_connection_pool=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Restore connection pool so this test does not interfere with other tests.
+        settings.configure_orm()
+
     def setUp(self):
         clear_db_runs()
         patcher = patch('airflow.jobs.base_job.sleep')

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -537,10 +537,10 @@ class TestDagFileProcessor(unittest.TestCase):
         ti_to_schedule = []
         dag_file_processor._process_task_instances(dag, task_instances_list=ti_to_schedule)
 
-        assert ti_to_schedule == [
+        assert set(ti_to_schedule) == {
             (dag.dag_id, dag_task1.task_id, DEFAULT_DATE, TRY_NUMBER),
             (dag.dag_id, dag_task2.task_id, DEFAULT_DATE, TRY_NUMBER),
-        ]
+        }
 
     def test_dag_file_processor_do_not_schedule_removed_task(self):
         dag = DAG(

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -64,6 +64,7 @@ LOGGING_CONFIG = {
 class TestStandardTaskRunner(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        settings.configure_orm()
         dictConfig(LOGGING_CONFIG)
 
     @classmethod


### PR DESCRIPTION
- Fix `test_dag_file_processor_process_task_instances_depends_on_past` that sometimes fails because `TaskInstance` are returned in non-deterministic order:
```
test_scheduler_job.py::TestDagFileProcessor::test_dag_file_processor_process_task_instances_depends_on_past
```
- Fix test_task_commands.py `test_run_ignores_all_dependencies` so that it restores orm setting when done to avoid interfering with other tests.

---
Issue link: [AIRFLOW-6834](https://issues.apache.org/jira/browse/AIRFLOW-6834)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
