### PR TITLE
[AIRFLOW-6840] Bump up version of future

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -472,7 +472,7 @@ def do_setup():
             'flask-swagger==0.2.13',
             'flask-wtf>=0.14.2, <0.15',
             'funcsigs>=1.0.0, <2.0.0',
-            'future>=0.16.0, <0.17',
+            'future>=0.16.0, <0.19',
             'graphviz>=0.12',
             'gunicorn>=19.5.0, <20.0',
             'iso8601>=0.1.12',


### PR DESCRIPTION
NOTE: This PR is against branch v1-10-test

The `future` package was removed in master, but v1-10-test still needs it. Bumping up the version makes it easier to migrate to python3.8. More specifically this is the change that should be picked up:
- Fix collections.abc import for py38+
See https://github.com/PythonCharmers/python-future/blob/master/docs/whatsnew.rst

---
Issue link: [AIRFLOW-6840](https://issues.apache.org/jira/browse/AIRFLOW-6840)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
