### PR TITLE
[AIRFLOW-6852] Force reschedule mode for sensors when running on SequentialExecutor

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -909,7 +909,7 @@ class TaskInstance(Base, LoggingMixin):
                 # with single process executor, thus we change the mode to`reschedule`
                 # to allow parallel task being scheduled and executed
                 if isinstance(task_copy, BaseSensorOperator) and \
-                        conf.get('core', 'executor') == "DebugExecutor":
+                        conf.get('core', 'executor') in ["DebugExecutor", "SequentialExecutor"]:
                     self.log.warning("DebugExecutor changes sensor mode to 'reschedule'.")
                     task_copy.mode = 'reschedule'
 


### PR DESCRIPTION
Force reschedule mode for sensors when running on SequentialExecutor to avoid deadlocks.
---
Issue link: [AIRFLOW-6852](https://issues.apache.org/jira/browse/AIRFLOW-6852)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
