### PR TITLE
[AIRFLOW-6854] Fix missing typing_extensions on python 3.8

### DIFF
--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -26,10 +26,9 @@
 
 import warnings
 
-from typing_extensions import Protocol, runtime_checkable
-
 from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchProtocol
 from airflow.providers.amazon.aws.operators.batch import AwsBatchOperator
+from airflow.typing_compat import Protocol, runtime_checkable
 
 warnings.warn(
     "This module is deprecated. "

--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -20,9 +20,8 @@
 import warnings
 
 # pylint: disable=unused-import
-from typing_extensions import Protocol, runtime_checkable
-
 from airflow.providers.amazon.aws.operators.ecs import ECSOperator, ECSProtocol as NewECSProtocol  # noqa
+from airflow.typing_compat import Protocol, runtime_checkable
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.ecs`.",

--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -33,10 +33,10 @@ from typing import Dict, List, Optional, Union
 import botocore.client
 import botocore.exceptions
 import botocore.waiter
-from typing_extensions import Protocol, runtime_checkable
 
 from airflow import AirflowException, LoggingMixin
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.typing_compat import Protocol, runtime_checkable
 
 # Add exceptions to pylint for the boto3 protocol only; ideally the boto3 library could provide
 # protocols for all their dynamically generated classes (try to migrate this to a PR on botocore).

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -20,13 +20,11 @@ import sys
 from datetime import datetime
 from typing import Dict, Optional
 
-from typing_extensions import runtime_checkable
-
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
-from airflow.typing_compat import Protocol
+from airflow.typing_compat import Protocol, runtime_checkable
 from airflow.utils.decorators import apply_defaults
 
 

--- a/airflow/serialization/json_schema.py
+++ b/airflow/serialization/json_schema.py
@@ -22,10 +22,10 @@ import pkgutil
 from typing import Iterable
 
 import jsonschema
-from typing_extensions import Protocol
 
 from airflow.exceptions import AirflowException
 from airflow.settings import json
+from airflow.typing_compat import Protocol
 
 
 class Validator(Protocol):

--- a/airflow/typing_compat.py
+++ b/airflow/typing_compat.py
@@ -25,6 +25,6 @@ try:
     # Protocol is only added to typing module starting from python 3.8
     # we can safely remove this shim import after Airflow drops support for
     # <3.8
-    from typing import Protocol  # noqa # pylint: disable=unused-import
+    from typing import Protocol, runtime_checkable  # noqa # pylint: disable=unused-import
 except ImportError:
-    from typing_extensions import Protocol  # type: ignore # noqa
+    from typing_extensions import Protocol, runtime_checkable  # type: ignore # noqa


### PR DESCRIPTION
All import from `typing_extensions` should be done through
`airflow.typing_compat` to avoid breakage under python >= 3.8

---
Issue link: [AIRFLOW-6854](https://issues.apache.org/jira/browse/AIRFLOW-6854)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
