### PR TITLE
[AIRFLOW-6855]: Escape project_dataset_table in SQL query in gcs to bq …

### DIFF
--- a/airflow/providers/google/cloud/operators/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/operators/gcs_to_bigquery.py
@@ -298,10 +298,15 @@ class GCSToBigQueryOperator(BaseOperator):
                 cluster_fields=self.cluster_fields,
                 encryption_configuration=self.encryption_configuration)
 
+        if bq_hook.use_legacy_sql:
+            escaped_table_name = '[{}]'.format(self.destination_project_dataset_table)
+        else:
+            escaped_table_name = '`{}`'.format(self.destination_project_dataset_table)
+
         if self.max_id_key:
             cursor.execute('SELECT MAX({}) FROM {}'.format(
                 self.max_id_key,
-                self.destination_project_dataset_table))
+                escaped_table_name))
             row = cursor.fetchone()
             max_id = row[0] if row[0] else 0
             self.log.info(

--- a/airflow/providers/google/cloud/operators/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/operators/gcs_to_bigquery.py
@@ -298,10 +298,10 @@ class GCSToBigQueryOperator(BaseOperator):
                 cluster_fields=self.cluster_fields,
                 encryption_configuration=self.encryption_configuration)
 
-        if bq_hook.use_legacy_sql:
-            escaped_table_name = '[{}]'.format(self.destination_project_dataset_table)
+        if cursor.use_legacy_sql:
+            escaped_table_name = f'[{self.destination_project_dataset_table}]'
         else:
-            escaped_table_name = '`{}`'.format(self.destination_project_dataset_table)
+            escaped_table_name = f'`{self.destination_project_dataset_table}`'
 
         if self.max_id_key:
             cursor.execute('SELECT MAX({}) FROM {}'.format(

--- a/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
@@ -31,10 +31,10 @@ TEST_SOURCE_OBJECTS = ['test/objects/*']
 
 class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
 
-    # gotta be honest, I don't really get this?!
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.BigQueryHook')
     def test_execute_explicit_project_legacy(self, bq_hook):
-        operator = GCSToBigQueryOperator(bucket=TEST_BUCKET,
+        operator = GCSToBigQueryOperator(task_id=TASK_ID,
+                                         bucket=TEST_BUCKET,
                                          source_objects=TEST_SOURCE_OBJECTS,
                                          destination_project_dataset_table=TEST_EXPLICIT_DEST,
                                          max_id_key=MAX_ID_KEY)
@@ -52,7 +52,8 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
 
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.BigQueryHook')
     def test_execute_explicit_project(self, bq_hook):
-        operator = GCSToBigQueryOperator(bucket=TEST_BUCKET,
+        operator = GCSToBigQueryOperator(task_id=TASK_ID,
+                                         bucket=TEST_BUCKET,
                                          source_objects=TEST_SOURCE_OBJECTS,
                                          destination_project_dataset_table=TEST_EXPLICIT_DEST,
                                          max_id_key=MAX_ID_KEY)

--- a/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
@@ -33,7 +33,6 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
 
     # gotta be honest, I don't really get this?!
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.BigQueryHook')
-    @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.GCSHook')
     def test_execute_explicit_project_legacy(self, bq_hook):
         operator = GCSToBigQueryOperator(bucket=TEST_BUCKET,
                                          source_objects=TEST_SOURCE_OBJECTS,
@@ -52,7 +51,6 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
             .assert_called_once_with("SELECT MAX(id) FROM [test-project.dataset.table]")
 
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.BigQueryHook')
-    @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.GCSHook')
     def test_execute_explicit_project(self, bq_hook):
         operator = GCSToBigQueryOperator(bucket=TEST_BUCKET,
                                          source_objects=TEST_SOURCE_OBJECTS,

--- a/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
@@ -17,10 +17,10 @@
 # under the License.
 
 import unittest
+
 import mock
 
 from airflow.providers.google.cloud.operators.gcs_to_bigquery import GCSToBigQueryOperator
-
 
 TASK_ID = 'test-gcs-to-bq-operator'
 TEST_EXPLICIT_DEST = 'test-project.dataset.table'
@@ -34,7 +34,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
     # gotta be honest, I don't really get this?!
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.BigQueryHook')
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.GCSHook')
-    def test_execute_explicit_project_legacy(self, bq_hook, gcs_hook):
+    def test_execute_explicit_project_legacy(self, bq_hook):
         operator = GCSToBigQueryOperator(bucket=TEST_BUCKET,
                                          source_objects=TEST_SOURCE_OBJECTS,
                                          destination_project_dataset_table=TEST_EXPLICIT_DEST,
@@ -53,7 +53,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
 
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.BigQueryHook')
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.GCSHook')
-    def test_execute_explicit_project(self, bq_hook, gcs_hook):
+    def test_execute_explicit_project(self, bq_hook):
         operator = GCSToBigQueryOperator(bucket=TEST_BUCKET,
                                          source_objects=TEST_SOURCE_OBJECTS,
                                          destination_project_dataset_table=TEST_EXPLICIT_DEST,

--- a/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+import mock
+
+from airflow.providers.google.cloud.operators.gcs_to_bigquery import GCSToBigQueryOperator
+
+
+TASK_ID = 'test-gcs-to-bq-operator'
+TEST_EXPLICIT_DEST = 'test-project.dataset.table'
+TEST_BUCKET = 'test-bucket'
+MAX_ID_KEY = 'id'
+TEST_SOURCE_OBJECTS = ['test/objects/*']
+
+
+class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
+
+    # gotta be honest, I don't really get this?!
+    @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.BigQueryHook')
+    @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.GCSHook')
+    def test_execute_explicit_project_legacy(self, bq_hook, gcs_hook):
+        operator = GCSToBigQueryOperator(bucket=TEST_BUCKET,
+                                         source_objects=TEST_SOURCE_OBJECTS,
+                                         destination_project_dataset_table=TEST_EXPLICIT_DEST,
+                                         max_id_key=MAX_ID_KEY)
+
+        # using legacy SQL
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql.return_value = True
+
+        operator.execute(None)
+
+        bq_hook.return_value \
+            .get_conn.return_value \
+            .cursor.return_value \
+            .execute \
+            .assert_called_once_with("SELECT MAX(id) FROM [test-project.dataset.table]")
+
+    @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.BigQueryHook')
+    @mock.patch('airflow.providers.google.cloud.operators.gcs_to_bigquery.GCSHook')
+    def test_execute_explicit_project(self, bq_hook, gcs_hook):
+        operator = GCSToBigQueryOperator(bucket=TEST_BUCKET,
+                                         source_objects=TEST_SOURCE_OBJECTS,
+                                         destination_project_dataset_table=TEST_EXPLICIT_DEST,
+                                         max_id_key=MAX_ID_KEY)
+
+        # using non-legacy SQL
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql.return_value = False
+
+        operator.execute(None)
+
+        bq_hook.return_value \
+            .get_conn.return_value \
+            .cursor.return_value \
+            .execute \
+            .assert_called_once_with("SELECT MAX(id) FROM `test-project.dataset.table`")

--- a/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_gcs_to_bigquery.py
@@ -40,7 +40,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
                                          max_id_key=MAX_ID_KEY)
 
         # using legacy SQL
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql.return_value = True
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql = True
 
         operator.execute(None)
 
@@ -59,7 +59,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
                                          max_id_key=MAX_ID_KEY)
 
         # using non-legacy SQL
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql.return_value = False
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql = False
 
         operator.execute(None)
 

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -35,7 +35,6 @@ MISSING_TEST_FILES = {
     'tests/providers/apache/spark/hooks/test_spark_jdbc_script.py',
     'tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py',
     'tests/providers/google/cloud/operators/test_datastore.py',
-    'tests/providers/google/cloud/operators/test_gcs_to_bigquery.py',
     'tests/providers/google/cloud/operators/test_sql_to_gcs.py',
     'tests/providers/google/cloud/sensors/test_bigquery.py',
     'tests/providers/google/cloud/utils/test_field_sanitizer.py',


### PR DESCRIPTION
…operator

Without escaping, if the project is specified in project_dataset_table and contains a -,
the query will fail with an error.

---
Issue link: [AIRFLOW-6855](https://issues.apache.org/jira/browse/AIRFLOW-6855)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
