### PR TITLE
[AIRFLOW-6856] Bulk fetch paused_dag_ids

### DIFF
--- a/airflow/dag/base_dag.py
+++ b/airflow/dag/base_dag.py
@@ -63,14 +63,6 @@ class BaseDag(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def is_paused(self):
-        """
-        :return: whether this DAG is paused or not
-        :rtype: bool
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
     def pickle_id(self):
         """
         :return: The pickle ID for this DAG, if it has one. Otherwise None.

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -66,7 +66,6 @@ class SimpleDag(BaseDag):
         self._dag_id: str = dag.dag_id
         self._task_ids: List[str] = [task.task_id for task in dag.tasks]
         self._full_filepath: str = dag.full_filepath
-        self._is_paused: bool = dag.is_paused
         self._concurrency: int = dag.concurrency
         self._pickle_id: Optional[str] = pickle_id
         self._task_special_args: Dict[str, Any] = {}
@@ -108,14 +107,6 @@ class SimpleDag(BaseDag):
         :rtype: int
         """
         return self._concurrency
-
-    @property
-    def is_paused(self) -> bool:    # pylint: disable=invalid-overridden-method
-        """
-        :return: whether this DAG is paused or not
-        :rtype: bool
-        """
-        return self._is_paused
 
     @property
     def pickle_id(self) -> Optional[str]:    # pylint: disable=invalid-overridden-method


### PR DESCRIPTION
I created the following DAG file:
```python
args = {
    'owner': 'airflow',
    'start_date': days_ago(3),
}


def create_dag(dag_number):
    dag = DAG(
        dag_id=f'perf_50_dag_dummy_tasks_{dag_number}_of_50', default_args=args,
        schedule_interval=None,
        dagrun_timeout=timedelta(minutes=60)
    )

    for j in range(1, 5):
        DummyOperator(
            task_id='task_{}_of_5'.format(j),
            dag=dag
        )

    return dag


for i in range(1, 50):
    globals()[f"dag_{i}"] = create_dag(i)

```
and I used the following code to test performance.
```python
import functools
import logging

import time

from airflow.jobs.scheduler_job import DagFileProcessor


class CountQueries(object):
    def __init__(self):
        self.count = 0

    def __enter__(self):
        from sqlalchemy import event
        from airflow.settings import engine
        event.listen(engine, "after_cursor_execute", self.after_cursor_execute)
        return None

    def after_cursor_execute(self, *args, **kwargs):
        self.count += 1

    def __exit__(self, type, value, traceback):
        from sqlalchemy import event
        from airflow.settings import engine
        event.remove(engine, "after_cursor_execute", self.after_cursor_execute)
        print('Query count: ', self.count)


count_queries = CountQueries

DAG_FILE = "/files/dags/50_dag_5_dummy_tasks.py"

log = logging.getLogger("airflow.processor")
processor = DagFileProcessor([], log)

def timing(f):

    @functools.wraps(f)
    def wrap(*args):
        RETRY_COUNT = 5
        r = []
        for i in range(RETRY_COUNT):
            time1 = time.time()
            f(*args)
            time2 = time.time()
            diff = (time2 - time1) * 1000.0
            r.append(diff)
            # print('Retry %d took %0.3f ms' % (i, diff))
        print('Average took %0.3f ms' % (sum(r) / RETRY_COUNT))

    return wrap


@timing
def slow_case():
    with count_queries():
        processor.process_file(DAG_FILE, None, pickle_dags=False)

slow_case()
```

As a result, I obtained the following values
**Before:**
Query count: 442
Average time:  1182.187 ms

**After:**
Query count: 297 
Average time: 769.421 ms  

**Diff:**
Query count: -145 (-32%)
Average time: -413 ms (-34%)

When we have 200 DAGS with 5 tasks each in one file:
**Before:**
Query count:  1792
Average took 4505.891 ms
**After:**
Query count:  1197
Average took 3335.856 ms


Thanks for support to @evgenyshulman from Databand!

---
Issue link: [AIRFLOW-6856](https://issues.apache.org/jira/browse/AIRFLOW-6856)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
