### PR TITLE
[AIRFLOW-6857] Bulk sync DAGs

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -821,8 +821,7 @@ class DagFileProcessor(LoggingMixin):
             return [], len(dagbag.import_errors)
 
         # Save individual DAGs in the ORM and update DagModel.last_scheduled_time
-        for dag in dagbag.dags.values():
-            dag.sync_to_db()
+        dagbag.sync_to_db()
 
         paused_dag_ids = {dag.dag_id for dag in dagbag.dags.values() if dag.is_paused}
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1483,6 +1483,7 @@ class DAG(BaseDag, LoggingMixin):
             .query(DagModel)
             .options(joinedload(DagModel.tags, innerjoin=False))
             .filter(DagModel.dag_id.in_(dag_ids))
+            .with_for_update(of=DagModel)
             .all()
         )
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -26,14 +26,14 @@ import sys
 import traceback
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
-from typing import Callable, Dict, FrozenSet, Iterable, List, Optional, Type, Union
+from typing import Callable, Collection, Dict, FrozenSet, Iterable, List, Optional, Type, Union
 
 import jinja2
 import pendulum
 from croniter import croniter
 from dateutil.relativedelta import relativedelta
 from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, String, Text, func, or_
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import backref, joinedload, relationship
 from sqlalchemy.orm.session import Session
 
 from airflow import settings, utils
@@ -1455,63 +1455,91 @@ class DAG(BaseDag, LoggingMixin):
 
         return run
 
+    @classmethod
     @provide_session
-    def sync_to_db(self, owner=None, sync_time=None, session=None):
+    def bulk_sync_to_db(cls, dags: Collection["DAG"], sync_time=None, session=None):
+        """
+        Save attributes about list of DAG to the DB. Note that this method
+        can be called for both DAGs and SubDAGs. A SubDag is actually a
+        SubDagOperator.
+
+        :param dags: the DAG objects to save to the DB
+        :type dags: List[airflow.models.dag.DAG]
+        :param sync_time: The time that the DAG should be marked as sync'ed
+        :type sync_time: datetime
+        :return: None
+        """
+        if not dags:
+            return
+        from airflow.models.serialized_dag import SerializedDagModel
+
+        if sync_time is None:
+            sync_time = timezone.utcnow()
+        log.info("Sync %s DAGs", len(dags))
+        dag_by_ids = {dag.dag_id: dag for dag in dags}
+        dag_ids = set(dag_by_ids.keys())
+        orm_dags = (
+            session
+            .query(DagModel)
+            .options(joinedload(DagModel.tags, innerjoin=False))
+            .filter(DagModel.dag_id.in_(dag_ids))
+            .all()
+        )
+
+        existing_dag_ids = {orm_dag.dag_id for orm_dag in orm_dags}
+        missing_dag_ids = dag_ids.difference(existing_dag_ids)
+
+        for missing_dag_id in missing_dag_ids:
+            orm_dag = DagModel(dag_id=missing_dag_id)
+            dag = dag_by_ids[missing_dag_id]
+            if dag.is_paused_upon_creation is not None:
+                orm_dag.is_paused = dag.is_paused_upon_creation
+            log.info("Creating ORM DAG for %s", dag.dag_id)
+            session.add(orm_dag)
+            orm_dags.append(orm_dag)
+
+        for orm_dag in sorted(orm_dags, key=lambda d: d.dag_id):
+            dag = dag_by_ids[orm_dag.dag_id]
+            if dag.is_subdag:
+                orm_dag.is_subdag = True
+                orm_dag.fileloc = dag.parent_dag.fileloc  # type: ignore
+                orm_dag.root_dag_id = dag.parent_dag.dag_id  # type: ignore
+                orm_dag.owners = dag.parent_dag.owner  # type: ignore
+            else:
+                orm_dag.is_subdag = False
+                orm_dag.fileloc = dag.fileloc
+                orm_dag.owners = dag.owner
+            orm_dag.is_active = True
+            orm_dag.last_scheduler_run = sync_time
+            orm_dag.default_view = dag._default_view
+            orm_dag.description = dag.description
+            orm_dag.schedule_interval = dag.schedule_interval
+            orm_dag.tags = dag.get_dagtags(session=session)
+
+        session.commit()
+
+        for dag in dags:
+            cls.bulk_sync_to_db(dag.subdags, sync_time=sync_time, session=session)
+
+            if STORE_SERIALIZED_DAGS and not dag.is_subdag:
+                SerializedDagModel.write_dag(
+                    dag,
+                    min_update_interval=MIN_SERIALIZED_DAG_UPDATE_INTERVAL,
+                    session=session
+                )
+
+    @provide_session
+    def sync_to_db(self, sync_time=None, session=None):
         """
         Save attributes about this DAG to the DB. Note that this method
         can be called for both DAGs and SubDAGs. A SubDag is actually a
         SubDagOperator.
 
-        :param dag: the DAG object to save to the DB
-        :type dag: airflow.models.DAG
         :param sync_time: The time that the DAG should be marked as sync'ed
         :type sync_time: datetime
         :return: None
         """
-        from airflow.models.serialized_dag import SerializedDagModel
-
-        if owner is None:
-            owner = self.owner
-        if sync_time is None:
-            sync_time = timezone.utcnow()
-
-        orm_dag = session.query(
-            DagModel).filter(DagModel.dag_id == self.dag_id).first()
-        if not orm_dag:
-            orm_dag = DagModel(dag_id=self.dag_id)
-            if self.is_paused_upon_creation is not None:
-                orm_dag.is_paused = self.is_paused_upon_creation
-            self.log.info("Creating ORM DAG for %s", self.dag_id)
-            session.add(orm_dag)
-        if self.is_subdag:
-            orm_dag.is_subdag = True
-            orm_dag.fileloc = self.parent_dag.fileloc
-            orm_dag.root_dag_id = self.parent_dag.dag_id
-        else:
-            orm_dag.is_subdag = False
-            orm_dag.fileloc = self.fileloc
-        orm_dag.owners = owner
-        orm_dag.is_active = True
-        orm_dag.last_scheduler_run = sync_time
-        orm_dag.default_view = self._default_view
-        orm_dag.description = self.description
-        orm_dag.schedule_interval = self.schedule_interval
-        orm_dag.tags = self.get_dagtags(session=session)
-
-        session.commit()
-
-        for subdag in self.subdags:
-            subdag.sync_to_db(owner=owner, sync_time=sync_time, session=session)
-
-        # Write DAGs to serialized_dag table in DB.
-        # subdags are not written into serialized_dag, because they are not displayed
-        # in the DAG list on UI. They are included in the serialized parent DAG.
-        if STORE_SERIALIZED_DAGS and not self.is_subdag:
-            SerializedDagModel.write_dag(
-                self,
-                min_update_interval=MIN_SERIALIZED_DAG_UPDATE_INTERVAL,
-                session=session
-            )
+        self.bulk_sync_to_db([self], sync_time, session)
 
     @provide_session
     def get_dagtags(self, session=None):

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -455,3 +455,10 @@ class DagBag(BaseDagBag, LoggingMixin):
             task_num=sum([o.task_num for o in stats]),
             table=pprinttable(stats),
         )
+
+    def sync_to_db(self):
+        """
+        Save attributes about list of DAG to the DB.
+        """
+        from airflow.models.dag import DAG
+        DAG.bulk_sync_to_db(self.dags.values())

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -506,9 +506,9 @@ def initdb():
     create_default_connections()
 
     dagbag = DagBag()
-    # Save individual DAGs in the ORM
-    for dag in dagbag.dags.values():
-        dag.sync_to_db()
+    # Save DAGs in the ORM
+    dagbag.sync_to_db()
+
     # Deactivate the unknown ones
     DAG.deactivate_unknown_dags(dagbag.dags.keys())
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -781,13 +781,14 @@ class TestDag(unittest.TestCase):
         )
         with dag:
             DummyOperator(task_id='task', owner='owner1')
+            subdag = DAG('dag.subtask', start_date=DEFAULT_DATE, )
+            # parent_dag and is_subdag was set by DagBag. We don't use DagBag, so this value is not set.
+            subdag.parent_dag = dag
+            subdag.is_subdag = True
             SubDagOperator(
                 task_id='subtask',
                 owner='owner2',
-                subdag=DAG(
-                    'dag.subtask',
-                    start_date=DEFAULT_DATE,
-                )
+                subdag=subdag
             )
         now = datetime.datetime.utcnow().replace(tzinfo=pendulum.timezone('UTC'))
         mock_now.return_value = now

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -322,8 +322,7 @@ class TestAirflowBaseViews(TestBase):
     def setUpClass(cls):
         super().setUpClass()
         dagbag = models.DagBag(include_examples=True)
-        for dag in dagbag.dags.values():
-            dag.sync_to_db()
+        DAG.bulk_sync_to_db(dagbag.dags.values())
 
     def setUp(self):
         super().setUp()
@@ -1226,8 +1225,7 @@ class TestDagACLView(TestBase):
     def setUpClass(cls):
         super().setUpClass()
         dagbag = models.DagBag(include_examples=True)
-        for dag in dagbag.dags.values():
-            dag.sync_to_db()
+        DAG.bulk_sync_to_db(dagbag.dags.values())
 
     def cleanup_dagruns(self):
         DR = models.DagRun
@@ -2250,8 +2248,7 @@ class TestDecorators(TestBase):
     def setUpClass(cls):
         super().setUpClass()
         dagbag = models.DagBag(include_examples=True)
-        for dag in dagbag.dags.values():
-            dag.sync_to_db()
+        DAG.bulk_sync_to_db(dagbag.dags.values())
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
I created the following DAG file:
```python
args = {
    'owner': 'airflow',
    'start_date': days_ago(3),
}


def create_dag(dag_number):
    dag = DAG(
        dag_id=f'perf_50_dag_dummy_tasks_{dag_number}_of_50', default_args=args,
        schedule_interval=None,
        dagrun_timeout=timedelta(minutes=60)
    )

    for j in range(1, 5):
        DummyOperator(
            task_id='task_{}_of_5'.format(j),
            dag=dag
        )

    return dag


for i in range(1, 200):
    globals()[f"dag_{i}"] = create_dag(i)

```
and I used the following code to test performance.
```python
import functools
import logging

import time

from airflow.jobs.scheduler_job import DagFileProcessor


class CountQueries(object):
    def __init__(self):
        self.count = 0

    def __enter__(self):
        from sqlalchemy import event
        from airflow.settings import engine
        event.listen(engine, "after_cursor_execute", self.after_cursor_execute)
        return None

    def after_cursor_execute(self, *args, **kwargs):
        self.count += 1

    def __exit__(self, type, value, traceback):
        from sqlalchemy import event
        from airflow.settings import engine
        event.remove(engine, "after_cursor_execute", self.after_cursor_execute)
        print('Query count: ', self.count)


count_queries = CountQueries

DAG_FILE = "/files/dags/200_dag_5_dummy_tasks.py"

log = logging.getLogger("airflow.processor")
processor = DagFileProcessor([], log)

def timing(f):

    @functools.wraps(f)
    def wrap(*args):
        RETRY_COUNT = 5
        r = []
        for i in range(RETRY_COUNT):
            time1 = time.time()
            f(*args)
            time2 = time.time()
            diff = (time2 - time1) * 1000.0
            r.append(diff)
            # print('Retry %d took %0.3f ms' % (i, diff))
        print('Average took %0.3f ms' % (sum(r) / RETRY_COUNT))

    return wrap


@timing
def slow_case():
    with count_queries():
        processor.process_file(DAG_FILE, None, pickle_dags=False)

slow_case()
```
I also cherry-picked AIRFLOW-6856

As a result, I obtained the following values

**Master**:
Query count: 1792
Average took 4505.891 ms

**AIRFLOW-6856:**
Query count: 1197
Average took 3203.710 ms

**Current:**
Query count: 602 
Average time: 2018.891 ms

**Diff to AIRFLOW-6856**
Query count: -592 (-49%)
Average time: -1185ms (-36%)

**Diff to master**
Query count: -1190 (-66%)
Average time: -2484 ms (-55%)


Thanks for support to @evgenyshulman from Databand!


---
Issue link: [AIRFLOW-6857](https://issues.apache.org/jira/browse/AIRFLOW-6857)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
