### PR TITLE
[AIRFLOW-6861] Remove pool full on TaskInstance

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -43,7 +43,6 @@ from airflow.exceptions import (
 )
 from airflow.models.base import ID_LEN, Base
 from airflow.models.log import Log
-from airflow.models.pool import Pool
 from airflow.models.taskfail import TaskFail
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.variable import Variable
@@ -697,27 +696,6 @@ class TaskInstance(Base, LoggingMixin):
         """
         return (self.state == State.UP_FOR_RETRY and
                 self.next_retry_datetime() < timezone.utcnow())
-
-    @provide_session
-    def pool_full(self, session):
-        """
-        Returns a boolean as to whether the slot pool has room for this
-        task to run
-        """
-        if not self.task.pool:
-            return False
-
-        pool = (
-            session
-            .query(Pool)
-            .filter(Pool.pool == self.task.pool)
-            .first()
-        )
-        if not pool:
-            return False
-        open_slots = pool.open_slots(session=session)
-
-        return open_slots <= 0
 
     @provide_session
     def get_dagrun(self, session):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2324,13 +2324,10 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertEqual(
             len(session.query(TI).filter(TI.dag_id == dag_id).all()), 0)
 
-    @patch.object(TI, 'pool_full')
-    def test_scheduler_verify_pool_full(self, mock_pool_full):
+    def test_scheduler_verify_pool_full(self):
         """
         Test task instances not queued when pool is full
         """
-        mock_pool_full.return_value = False
-
         dag = DAG(
             dag_id='test_scheduler_verify_pool_full',
             start_date=DEFAULT_DATE)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -606,8 +606,7 @@ class TestTaskInstance(unittest.TestCase):
         period = ti.end_date.add(seconds=1) - ti.end_date.add(seconds=15)
         self.assertTrue(date in period)
 
-    @patch.object(TI, 'pool_full')
-    def test_reschedule_handling(self, mock_pool_full):
+    def test_reschedule_handling(self):
         """
         Test that task reschedules are handled properly
         """
@@ -702,8 +701,7 @@ class TestTaskInstance(unittest.TestCase):
         done, fail = True, False
         run_ti_and_assert(date4, date3, date4, 60, State.SUCCESS, 3, 0)
 
-    @patch.object(TI, 'pool_full')
-    def test_reschedule_handling_clear_reschedules(self, mock_pool_full):
+    def test_reschedule_handling_clear_reschedules(self):
         """
         Test that task reschedules clearing are handled properly
         """

--- a/tests/ti_deps/deps/fake_models.py
+++ b/tests/ti_deps/deps/fake_models.py
@@ -24,15 +24,6 @@ class FakeTI:
     def __init__(self, **kwds):
         self.__dict__.update(kwds)
 
-    def pool_full(self):
-        # Allow users of this fake to set pool_filled in the constructor to make this
-        # return True
-        try:
-            return self.pool_filled  # pylint: disable=no-member
-        except AttributeError:
-            # If pool_filled was not set default to false
-            return False
-
     def get_dagrun(self, _):
         return self.dagrun  # pylint: disable=no-member
 


### PR DESCRIPTION
It's a dead code.

---
Issue link: [AIRFLOW-6861](https://issues.apache.org/jira/browse/AIRFLOW-6861)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
