### PR TITLE
[AIRFLOW-6864] Make airflow/jobs pylint compatible

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,6 @@ max-line-length = 110
 ignore = E731,W504,I001,W503
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.eggs,*.egg,*/_vendor/*,node_modules
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+per-file-ignores =
+    airflow/models/__init__.py:F401
+    airflow/models/sqla_models.py:F401

--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -22,7 +22,7 @@ from typing import Iterable
 
 from sqlalchemy import or_
 
-from airflow.jobs import BackfillJob
+from airflow.jobs.backfill_job import BackfillJob
 from airflow.models import DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.operators.subdag_operator import SubDagOperator

--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -24,6 +24,7 @@ from airflow.exceptions import DagNotFound, DagRunAlreadyExists
 from airflow.models import DagBag, DagModel, DagRun
 from airflow.utils import timezone
 from airflow.utils.state import State
+from airflow.utils.types import DagRunType
 
 
 def _trigger_dag(
@@ -68,7 +69,7 @@ def _trigger_dag(
                     min_dag_start_date.isoformat()))
 
     if not run_id:
-        run_id = "manual__{0}".format(execution_date.isoformat())
+        run_id = "{}{}".format(DagRunType.MANUAL.value, execution_date.isoformat())
 
     dag_run_id = dag_run.find(dag_id=dag_id, run_id=run_id)
     if dag_run_id:

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -26,11 +26,12 @@ from typing import List
 
 from tabulate import tabulate
 
-from airflow import jobs, settings
+from airflow import settings
 from airflow.api.client import get_current_api_client
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.debug_executor import DebugExecutor
+from airflow.jobs.base_job import BaseJob
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.models.dag import DAG
 from airflow.utils import cli as cli_utils
@@ -276,16 +277,16 @@ def dag_list_jobs(args, dag=None):
         if args.dag_id not in dagbag.dags:
             error_message = "Dag id {} not found".format(args.dag_id)
             raise AirflowException(error_message)
-        queries.append(jobs.BaseJob.dag_id == args.dag_id)
+        queries.append(BaseJob.dag_id == args.dag_id)
 
     if args.state:
-        queries.append(jobs.BaseJob.state == args.state)
+        queries.append(BaseJob.state == args.state)
 
     with create_session() as session:
         all_jobs = (session
-                    .query(jobs.BaseJob)
+                    .query(BaseJob)
                     .filter(*queries)
-                    .order_by(jobs.BaseJob.start_date.desc())
+                    .order_by(BaseJob.start_date.desc())
                     .limit(args.limit)
                     .all())
         fields = ['dag_id', 'state', 'job_type', 'start_date', 'end_date']

--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -21,7 +21,8 @@ import signal
 import daemon
 from daemon.pidfile import TimeoutPIDLockFile
 
-from airflow import jobs, settings
+from airflow import settings
+from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import process_subdir, setup_locations, setup_logging, sigint_handler, sigquit_handler
 
@@ -30,7 +31,7 @@ from airflow.utils.cli import process_subdir, setup_locations, setup_logging, si
 def scheduler(args):
     """Starts Airflow Scheduler"""
     print(settings.HEADER)
-    job = jobs.SchedulerJob(
+    job = SchedulerJob(
         dag_id=args.dag_id,
         subdir=process_subdir(args.subdir),
         num_runs=args.num_runs,

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -26,10 +26,11 @@ from typing import List
 
 from tabulate import tabulate
 
-from airflow import jobs, settings
+from airflow import settings
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
+from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models import DagPickle, TaskInstance
 from airflow.models.dag import DAG
 from airflow.ti_deps.dep_context import DepContext
@@ -102,7 +103,7 @@ def _run_task_by_local_task_job(args, ti):
     """
     Run LocalTaskJob, which monitors the raw task execution process
     """
-    run_job = jobs.LocalTaskJob(
+    run_job = LocalTaskJob(
         task_instance=ti,
         mark_success=args.mark_success,
         pickle_id=args.pickle,

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -33,7 +33,8 @@ from airflow.exceptions import (
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.jobs.base_job import BaseJob
-from airflow.models import DAG, DagPickle, DagRun
+from airflow.models import DAG, DagPickle
+from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKeyType
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies import BACKFILL_QUEUED_DEPS
@@ -41,6 +42,7 @@ from airflow.utils import timezone
 from airflow.utils.configuration import tmp_configuration_copy
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
+from airflow.utils.types import DagRunType
 
 
 class BackfillJob(BaseJob):
@@ -49,7 +51,7 @@ class BackfillJob(BaseJob):
     triggers a set of task instance runs, in the right order and lasts for
     as long as it takes for the set of task instance to be completed.
     """
-    ID_PREFIX = 'backfill_'
+    ID_PREFIX = DagRunType.BACKFILL_JOB.value
     ID_FORMAT_PREFIX = ID_PREFIX + '{0}'
     STATES_COUNT_AS_RUNNING = (State.RUNNING, State.QUEUED)
 
@@ -91,7 +93,7 @@ class BackfillJob(BaseJob):
         :type total_runs: int
         """
         # TODO(edgarRd): AIRFLOW-1444: Add consistency check on counts
-        def __init__(self,
+        def __init__(self,  # pylint: disable=too-many-arguments
                      to_run=None,
                      running=None,
                      skipped=None,
@@ -116,7 +118,7 @@ class BackfillJob(BaseJob):
             self.finished_runs = finished_runs
             self.total_runs = total_runs
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
             self,
             dag,
             start_date=None,
@@ -203,18 +205,18 @@ class BackfillJob(BaseJob):
                 self.log.debug("Task instance %s succeeded. Don't rerun.", ti)
                 ti_status.running.pop(key)
                 continue
-            elif ti.state == State.SKIPPED:
+            if ti.state == State.SKIPPED:
                 ti_status.skipped.add(key)
                 self.log.debug("Task instance %s skipped. Don't rerun.", ti)
                 ti_status.running.pop(key)
                 continue
-            elif ti.state == State.FAILED:
+            if ti.state == State.FAILED:
                 self.log.error("Task instance %s failed", ti)
                 ti_status.failed.add(key)
                 ti_status.running.pop(key)
                 continue
             # special case: if the task needs to run again put it back
-            elif ti.state == State.UP_FOR_RETRY:
+            if ti.state == State.UP_FOR_RETRY:
                 self.log.warning("Task instance %s is up for retry", ti)
                 ti_status.running.pop(key)
                 ti_status.to_run[key] = ti
@@ -268,7 +270,7 @@ class BackfillJob(BaseJob):
 
             self.log.debug("Executor state: %s task %s", state, ti)
 
-            if state == State.FAILED or state == State.SUCCESS:
+            if state in (State.FAILED, State.SUCCESS):
                 if ti.state == State.RUNNING or ti.state == State.QUEUED:
                     msg = ("Executor reports task instance {} finished ({}) "
                            "although the task says its {}. Was the task "
@@ -291,10 +293,7 @@ class BackfillJob(BaseJob):
         run_id = BackfillJob.ID_FORMAT_PREFIX.format(run_date.isoformat())
 
         # consider max_active_runs but ignore when running subdags
-        respect_dag_max_active_limit = (True
-                                        if (dag.schedule_interval and
-                                            not dag.is_subdag)
-                                        else False)
+        respect_dag_max_active_limit = bool(dag.schedule_interval and not dag.is_subdag)
 
         current_active_dag_count = dag.get_num_active_runs(external_trigger=False)
 
@@ -388,7 +387,7 @@ class BackfillJob(BaseJob):
         )
 
     @provide_session
-    def _process_backfill_task_instances(self,
+    def _process_backfill_task_instances(self,  # pylint: disable=too-many-statements
                                          ti_status,
                                          executor,
                                          pickle_id,
@@ -424,7 +423,7 @@ class BackfillJob(BaseJob):
             # determined deadlocked while they are actually
             # waiting for their upstream to finish
             @provide_session
-            def _per_task_process(task, key, ti, session=None):
+            def _per_task_process(task, key, ti, session=None):  # pylint: disable=too-many-return-statements
                 ti.refresh_from_db(lock_for_update=True, session=session)
 
                 task = self.dag.get_task(ti.task_id, include_subdags=True)
@@ -464,9 +463,7 @@ class BackfillJob(BaseJob):
                 if self.rerun_failed_tasks:
                     # Rerun failed tasks or upstreamed failed tasks
                     if ti.state in (State.FAILED, State.UPSTREAM_FAILED):
-                        self.log.error("Task instance {ti} "
-                                       "with state {state}".format(ti=ti,
-                                                                   state=ti.state))
+                        self.log.error("Task instance %s with state %s", ti, ti.state)
                         if key in ti_status.running:
                             ti_status.running.pop(key)
                         # Reset the failed task in backfill to scheduled state
@@ -474,9 +471,7 @@ class BackfillJob(BaseJob):
                 else:
                     # Default behaviour which works for subdag.
                     if ti.state in (State.FAILED, State.UPSTREAM_FAILED):
-                        self.log.error("Task instance {ti} "
-                                       "with {state} state".format(ti=ti,
-                                                                   state=ti.state))
+                        self.log.error("Task instance %s with state %s", ti, ti.state)
                         ti_status.failed.add(key)
                         ti_status.to_run.pop(key)
                         if key in ti_status.running:
@@ -557,7 +552,7 @@ class BackfillJob(BaseJob):
                 self.log.debug('Adding %s to not_ready', ti)
                 ti_status.not_ready.add(key)
 
-            try:
+            try:  # pylint: disable=too-many-nested-blocks
                 for task in self.dag.topological_sort(include_subdag_tasks=True):
                     for key, ti in list(ti_status.to_run.items()):
                         if task.task_id != ti.task_id:
@@ -790,11 +785,11 @@ class BackfillJob(BaseJob):
 
         ti_status.total_runs = len(run_dates)  # total dag runs in backfill
 
-        try:
+        try:  # pylint: disable=too-many-nested-blocks
             remaining_dates = ti_status.total_runs
             while remaining_dates > 0:
-                dates_to_process = [run_date for run_date in run_dates
-                                    if run_date not in ti_status.executed_dag_run_dates]
+                dates_to_process = [run_date for run_date in run_dates if run_date not in
+                                    ti_status.executed_dag_run_dates]
 
                 self._execute_for_run_dates(run_dates=dates_to_process,
                                             ti_status=ti_status,

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -16,30 +16,25 @@
 # specific language governing permissions and limitations
 # under the License.
 """Airflow models"""
-from airflow.models.base import ID_LEN, Base  # noqa: F401
-from airflow.models.baseoperator import BaseOperator, BaseOperatorLink  # noqa: F401
-from airflow.models.connection import Connection  # noqa: F401
-from airflow.models.dag import DAG, DagModel, DagTag  # noqa: F401
-from airflow.models.dagbag import DagBag  # noqa: F401
-from airflow.models.dagpickle import DagPickle  # noqa: F401
-from airflow.models.dagrun import DagRun  # noqa: F401
-from airflow.models.errors import ImportError  # noqa: F401, pylint: disable=redefined-builtin
-from airflow.models.log import Log  # noqa: F401
-from airflow.models.pool import Pool  # noqa: F401
-from airflow.models.skipmixin import SkipMixin  # noqa: F401
-from airflow.models.slamiss import SlaMiss  # noqa: F401
-from airflow.models.taskfail import TaskFail  # noqa: F401
-from airflow.models.taskinstance import TaskInstance, clear_task_instances  # noqa: F401
-from airflow.models.taskreschedule import TaskReschedule  # noqa: F401
-from airflow.models.variable import Variable  # noqa: F401
-from airflow.models.xcom import XCOM_RETURN_KEY, XCom  # noqa: F401
+from airflow.models.base import ID_LEN, Base
+from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+from airflow.models.connection import Connection
+from airflow.models.dag import DAG, DagModel, DagTag
+from airflow.models.dagbag import DagBag
+from airflow.models.dagpickle import DagPickle
+from airflow.models.dagrun import DagRun
+from airflow.models.errors import ImportError  # pylint: disable=redefined-builtin
+from airflow.models.log import Log
+from airflow.models.pool import Pool
+from airflow.models.skipmixin import SkipMixin
+from airflow.models.slamiss import SlaMiss
+from airflow.models.taskfail import TaskFail
+from airflow.models.taskinstance import TaskInstance, clear_task_instances
+from airflow.models.taskreschedule import TaskReschedule
+from airflow.models.variable import Variable
+from airflow.models.xcom import XCOM_RETURN_KEY, XCom
 
 try:
-    from airflow.models.kubernetes import KubeResourceVersion, KubeWorkerIdentifier  # noqa: F401
+    from airflow.models.kubernetes import KubeResourceVersion, KubeWorkerIdentifier
 except ImportError:
     pass
-
-# Load SQLAlchemy models during package initialization
-# Must be loaded after loading DAG model.
-# noinspection PyUnresolvedReferences
-import airflow.jobs  # noqa: F401 isort # isort:skip

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1374,7 +1374,7 @@ class DAG(BaseDag, LoggingMixin):
         :type: bool
 
         """
-        from airflow.jobs import BackfillJob
+        from airflow.jobs.backfill_job import BackfillJob
         if not executor and local:
             from airflow.executors.local_executor import LocalExecutor
             executor = LocalExecutor()

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -107,7 +107,7 @@ def clear_task_instances(tis,
         ).delete()
 
     if job_ids:
-        from airflow.jobs import BaseJob as BJ
+        from airflow.jobs.base_job import BaseJob as BJ
         for job in session.query(BJ).filter(BJ.id.in_(job_ids)).all():
             job.state = State.SHUTDOWN
 
@@ -728,7 +728,7 @@ class TaskInstance(Base, LoggingMixin):
         return dr
 
     @provide_session
-    def _check_and_change_state_before_execution(
+    def check_and_change_state_before_execution(
             self,
             verbose: bool = True,
             ignore_all_deps: bool = False,
@@ -1038,7 +1038,7 @@ class TaskInstance(Base, LoggingMixin):
             job_id: Optional[str] = None,
             pool: Optional[str] = None,
             session=None) -> None:
-        res = self._check_and_change_state_before_execution(
+        res = self.check_and_change_state_before_execution(
             verbose=verbose,
             ignore_all_deps=ignore_all_deps,
             ignore_depends_on_past=ignore_depends_on_past,

--- a/airflow/task/task_runner/__init__.py
+++ b/airflow/task/task_runner/__init__.py
@@ -31,7 +31,7 @@ def get_task_runner(local_task_job):
 
     :param local_task_job: The LocalTaskJob associated with the TaskInstance
         that needs to be executed.
-    :type local_task_job: airflow.jobs.LocalTaskJob
+    :type local_task_job: airflow.jobs.local_task_job.LocalTaskJob
     :return: The task runner to use to run the task.
     :rtype: airflow.task.task_runner.base_task_runner.BaseTaskRunner
     """

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -37,7 +37,7 @@ class BaseTaskRunner(LoggingMixin):
 
     :param local_task_job: The local task job associated with running the
         associated task instance.
-    :type local_task_job: airflow.jobs.LocalTaskJob
+    :type local_task_job: airflow.jobs.local_task_job.LocalTaskJob
     """
 
     def __init__(self, local_task_job):

--- a/airflow/ti_deps/deps/dagrun_id_dep.py
+++ b/airflow/ti_deps/deps/dagrun_id_dep.py
@@ -22,6 +22,7 @@ from re import match
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.utils.session import provide_session
+from airflow.utils.types import DagRunType
 
 
 class DagrunIdDep(BaseTIDep):
@@ -44,14 +45,13 @@ class DagrunIdDep(BaseTIDep):
         :type dep_context: DepContext
         :return: True if DagRun ID is valid for scheduling from scheduler.
         """
-        from airflow.jobs import BackfillJob  # To avoid a circular dependency
         dagrun = ti.get_dagrun(session)
 
-        if not dagrun.run_id or not match(BackfillJob.ID_PREFIX + '.*', dagrun.run_id):
+        if not dagrun.run_id or not match(DagRunType.BACKFILL_JOB.value + '.*', dagrun.run_id):
             yield self._passing_status(
-                reason="Task's DagRun run_id is either NULL "
-                       "or doesn't start with {}".format(BackfillJob.ID_PREFIX))
+                reason=f"Task's DagRun run_id is either NULL "
+                       f"or doesn't start with {DagRunType.BACKFILL_JOB.value}")
         else:
             yield self._failing_status(
-                reason="Task's DagRun run_id is not NULL "
-                       "and starts with {}".format(BackfillJob.ID_PREFIX))
+                reason=f"Task's DagRun run_id is not NULL "
+                       f"and starts with {DagRunType.BACKFILL_JOB.value}")

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -38,6 +38,7 @@ import airflow.models
 from airflow.configuration import conf
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.exceptions import AirflowException
+from airflow.jobs.local_task_job import LocalTaskJob as LJ
 from airflow.models import Connection, errors
 from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.settings import STORE_SERIALIZED_DAGS
@@ -1075,7 +1076,6 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         if not self._last_zombie_query_time or \
                 (now - self._last_zombie_query_time).total_seconds() > self._zombie_query_interval:
             # to avoid circular imports
-            from airflow.jobs import LocalTaskJob as LJ
             self.log.info("Finding 'running' jobs without a recent heartbeat")
             TI = airflow.models.TaskInstance
             limit_dttm = timezone.utcnow() - timedelta(

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -23,7 +23,7 @@ from sqlalchemy import Table
 from airflow import settings
 from airflow.configuration import conf
 # noinspection PyUnresolvedReferences
-from airflow.jobs.base_job import BaseJob  # noqa: F401  # pylint: disable=unused-import
+from airflow.jobs.base_job import BaseJob  # noqa: F401 # pylint: disable=unused-import
 # noinspection PyUnresolvedReferences
 from airflow.models import (  # noqa: F401 # pylint: disable=unused-import
     DAG, XCOM_RETURN_KEY, BaseOperator, BaseOperatorLink, Connection, DagBag, DagModel, DagPickle, DagRun,
@@ -32,7 +32,10 @@ from airflow.models import (  # noqa: F401 # pylint: disable=unused-import
 # We need to add this model manually to get reset working well
 # noinspection PyUnresolvedReferences
 from airflow.models.serialized_dag import SerializedDagModel  # noqa: F401  # pylint: disable=unused-import
-from airflow.utils.session import create_session, provide_session  # noqa  # pylint: disable=unused-import
+# TODO: remove create_session once we decide to break backward compatibility
+from airflow.utils.session import (  # noqa: F401 # pylint: disable=unused-import
+    create_session, provide_session,
+)
 
 log = logging.getLogger(__name__)
 

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,4 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+import enum
+
+
+class DagRunType(enum.Enum):
+    """Class with DagRun types"""
+    BACKFILL_JOB = "backfill_"
+    SCHEDULED = "scheduled__"
+    MANUAL = "manual__"

--- a/pylintrc
+++ b/pylintrc
@@ -18,7 +18,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=setproctitle
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -460,7 +460,8 @@ good-names=e,
            df,  # Commonly used as shorthand for DataFrame
            cm,  # Commonly used as shorthand for context manager
            ds,  # Used in Airflow templates
-           ts   # Used in Airflow templates
+           ts,  # Used in Airflow templates
+           id   # Commonly used as shorthand for identifier
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -5,10 +5,6 @@
 ./airflow/contrib/auth/backends/ldap_auth.py
 ./airflow/hooks/dbapi_hook.py
 ./airflow/hooks/filesystem.py
-./airflow/jobs/backfill_job.py
-./airflow/jobs/base_job.py
-./airflow/jobs/local_task_job.py
-./airflow/jobs/scheduler_job.py
 ./airflow/lineage/backend/atlas/typedefs.py
 ./airflow/lineage/datasets.py
 ./airflow/logging_config.py

--- a/scripts/perf/scheduler_ops_metrics.py
+++ b/scripts/perf/scheduler_ops_metrics.py
@@ -23,7 +23,7 @@ import pandas as pd
 
 from airflow import settings
 from airflow.configuration import conf
-from airflow.jobs import SchedulerJob
+from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.utils import timezone
 from airflow.utils.state import State

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -72,7 +72,7 @@ class TestCliTasks(unittest.TestCase):
         # Check that prints, and log messages, are shown
         self.assertIn("'example_python_operator__print_the_context__20180101'", stdout.getvalue())
 
-    @mock.patch("airflow.cli.commands.task_command.jobs.LocalTaskJob")
+    @mock.patch("airflow.cli.commands.task_command.LocalTaskJob")
     def test_run_naive_taskinstance(self, mock_local_job):
         """
         Test that we can run naive (non-localized) task instances

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -23,7 +23,7 @@ from unittest import mock
 import pytest
 
 from airflow.configuration import conf
-from airflow.jobs import BackfillJob
+from airflow.jobs.backfill_job import BackfillJob
 from airflow.models import DagBag
 from airflow.utils import timezone
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -36,12 +36,14 @@ from airflow.exceptions import (
 )
 from airflow.jobs.backfill_job import BackfillJob
 from airflow.jobs.scheduler_job import DagFileProcessor
-from airflow.models import DAG, DagBag, DagRun, Pool, TaskInstance as TI
+from airflow.models import DAG, DagBag, Pool, TaskInstance as TI
+from airflow.models.dagrun import DagRun
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
+from airflow.utils.types import DagRunType
 from tests.test_utils.db import clear_db_pools, clear_db_runs, set_default_pool_slots
 from tests.test_utils.mock_executor import MockExecutor
 
@@ -1294,7 +1296,7 @@ class TestBackfillJob(unittest.TestCase):
         job = BackfillJob(dag=dag)
 
         session = settings.Session()
-        dr = dag.create_dagrun(run_id=DagRun.ID_PREFIX,
+        dr = dag.create_dagrun(run_id=DagRunType.SCHEDULED.value,
                                state=State.RUNNING,
                                execution_date=DEFAULT_DATE,
                                start_date=DEFAULT_DATE,

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -23,7 +23,7 @@ import unittest
 from mock import Mock, patch
 from sqlalchemy.exc import OperationalError
 
-from airflow.jobs import BaseJob
+from airflow.jobs.base_job import BaseJob
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -27,7 +27,7 @@ from mock import patch
 from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.executors.sequential_executor import SequentialExecutor
-from airflow.jobs import LocalTaskJob
+from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.models.taskinstance import TaskInstance

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -20,13 +20,14 @@ import datetime
 import unittest
 
 from airflow import models, settings
-from airflow.jobs import BackfillJob
-from airflow.models import DAG, DagRun, TaskInstance as TI, clear_task_instances
+from airflow.models import DAG, TaskInstance as TI, clear_task_instances
+from airflow.models.dagrun import DagRun
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.types import DagRunType
 from tests.models import DEFAULT_DATE
 
 
@@ -42,7 +43,7 @@ class TestDagRun(unittest.TestCase):
         if execution_date is None:
             execution_date = now
         if is_backfill:
-            run_id = BackfillJob.ID_PREFIX + now.isoformat()
+            run_id = DagRunType.BACKFILL_JOB.value + now.isoformat()
         else:
             run_id = 'manual__' + now.isoformat()
         dag_run = dag.create_dagrun(
@@ -522,7 +523,7 @@ class TestDagRun(unittest.TestCase):
         dag = DAG(dag_id='test_is_backfill', start_date=DEFAULT_DATE)
 
         dagrun = self.create_dag_run(dag, execution_date=DEFAULT_DATE)
-        dagrun.run_id = BackfillJob.ID_PREFIX + '_sfddsffds'
+        dagrun.run_id = DagRunType.BACKFILL_JOB.value + '_sfddsffds'
 
         dagrun2 = self.create_dag_run(
             dag, execution_date=DEFAULT_DATE + datetime.timedelta(days=1))

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1034,7 +1034,7 @@ class TestTaskInstance(unittest.TestCase):
         ti = TI(
             task=task, execution_date=timezone.utcnow())
         self.assertEqual(ti._try_number, 0)
-        self.assertTrue(ti._check_and_change_state_before_execution())
+        self.assertTrue(ti.check_and_change_state_before_execution())
         # State should be running, and try_number column should be incremented
         self.assertEqual(ti.state, State.RUNNING)
         self.assertEqual(ti._try_number, 1)
@@ -1046,7 +1046,7 @@ class TestTaskInstance(unittest.TestCase):
         task >> task2
         ti = TI(
             task=task2, execution_date=timezone.utcnow())
-        self.assertFalse(ti._check_and_change_state_before_execution())
+        self.assertFalse(ti.check_and_change_state_before_execution())
 
     def test_try_number(self):
         """

--- a/tests/operators/test_latest_only_operator.py
+++ b/tests/operators/test_latest_only_operator.py
@@ -26,7 +26,8 @@ from airflow.models import DagRun, TaskInstance
 from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
-from airflow.utils import db, timezone
+from airflow.utils import timezone
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -55,7 +56,7 @@ class TestLatestOnlyOperator(unittest.TestCase):
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE},
             schedule_interval=INTERVAL)
-        with db.create_session() as session:
+        with create_session() as session:
             session.query(DagRun).delete()
             session.query(TaskInstance).delete()
         freezer = freeze_time(FROZEN_NOW)

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -25,7 +25,7 @@ from unittest import mock
 import psutil
 
 from airflow import models, settings
-from airflow.jobs import LocalTaskJob
+from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models import TaskInstance as TI
 from airflow.task.task_runner import StandardTaskRunner
 from airflow.utils import timezone

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -26,7 +26,8 @@ import unittest
 import unittest.mock
 from copy import deepcopy
 
-from airflow import jobs, models
+from airflow import models
+from airflow.jobs.backfill_job import BackfillJob
 from airflow.utils.db import add_default_pool_if_not_exists
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
@@ -129,7 +130,7 @@ class TestImpersonation(unittest.TestCase):
         dag = self.dagbag.get_dag(dag_id)
         dag.clear()
 
-        jobs.BackfillJob(
+        BackfillJob(
             dag=dag,
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE).run()
@@ -206,7 +207,7 @@ class TestImpersonationWithCustomPythonPath(unittest.TestCase):
         dag = self.dagbag.get_dag(dag_id)
         dag.clear()
 
-        jobs.BackfillJob(
+        BackfillJob(
             dag=dag,
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE).run()

--- a/tests/ti_deps/deps/test_dagrun_id_dep.py
+++ b/tests/ti_deps/deps/test_dagrun_id_dep.py
@@ -20,9 +20,9 @@ import unittest
 
 from mock import Mock
 
-from airflow.jobs import BackfillJob
-from airflow.models import DagRun
+from airflow.models.dagrun import DagRun
 from airflow.ti_deps.deps.dagrun_id_dep import DagrunIdDep
+from airflow.utils.types import DagRunType
 
 
 class TestDagrunRunningDep(unittest.TestCase):
@@ -31,7 +31,7 @@ class TestDagrunRunningDep(unittest.TestCase):
         Task instances whose dagrun ID is a backfill dagrun ID should fail this dep.
         """
         dagrun = DagRun()
-        dagrun.run_id = BackfillJob.ID_PREFIX + '_something'
+        dagrun.run_id = DagRunType.BACKFILL_JOB.value + '_something'
         ti = Mock(get_dagrun=Mock(return_value=dagrun))
         self.assertFalse(DagrunIdDep().is_met(ti=ti))
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -42,7 +42,7 @@ from airflow import models, settings, version
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.configuration import conf
 from airflow.executors.celery_executor import CeleryExecutor
-from airflow.jobs import BaseJob
+from airflow.jobs.base_job import BaseJob
 from airflow.models import DAG, Connection, DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.operators.dummy_operator import DummyOperator


### PR DESCRIPTION
This PR makes `airflow/jobs` pylint compatible and removes the cyclic dependency created by importing BackfillJob to access `BackfillJob.ID_PREFIX`

---
Issue link: [AIRFLOW-6864](https://issues.apache.org/jira/browse/AIRFLOW-6864)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
