### PR TITLE
[AIRFLOW-6867] Decouple DagBag and TaskInstance

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -314,6 +314,9 @@ class DagFileProcessor(LoggingMixin):
     :param log: Logger to save the processing process
     :type log: logging.Logger
     """
+
+    UNIT_TEST_MODE = conf.getboolean('core', 'UNIT_TEST_MODE')
+
     def __init__(self, dag_ids, log):
         self.dag_ids = dag_ids
         self._log = log
@@ -731,6 +734,36 @@ class DagFileProcessor(LoggingMixin):
         return dags
 
     @provide_session
+    def kill_zombies(self, dagbag, zombies, session=None):
+        """
+        Fail given zombie tasks, which are tasks that haven't
+        had a heartbeat for too long, in the current DagBag.
+
+        :param zombies: zombie task instances to kill.
+        :type zombies: List[airflow.models.taskinstance.SimpleyTaskInstance]
+        :param session: DB session.
+        """
+        TI = models.TaskInstance
+
+        for zombie in zombies:
+            if zombie.dag_id in dagbag.dags:
+                dag = dagbag.dags[zombie.dag_id]
+                if zombie.task_id in dag.task_ids:
+                    task = dag.get_task(zombie.task_id)
+                    ti = TI(task, zombie.execution_date)
+                    # Get properties needed for failure handling from SimpleTaskInstance.
+                    ti.start_date = zombie.start_date
+                    ti.end_date = zombie.end_date
+                    ti.try_number = zombie.try_number
+                    ti.state = zombie.state
+                    ti.test_mode = self.UNIT_TEST_MODE
+                    ti.handle_failure("{} detected as zombie".format(ti),
+                                      ti.test_mode, ti.get_template_context())
+                    self.log.info('Marked zombie job %s as %s', ti, ti.state)
+                    Stats.incr('zombies_killed')
+        session.commit()
+
+    @provide_session
     def process_file(self, file_path, zombies, pickle_dags=False, session=None):
         """
         Process a Python file containing Airflow DAGs.
@@ -843,7 +876,7 @@ class DagFileProcessor(LoggingMixin):
         except Exception:
             self.log.exception("Error logging import errors!")
         try:
-            dagbag.kill_zombies(zombies)
+            self.kill_zombies(zombies)
         except Exception:
             self.log.exception("Error killing zombies!")
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -37,7 +37,6 @@ from airflow.utils import timezone
 from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.helpers import pprinttable
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.session import provide_session
 from airflow.utils.timeout import timeout
 
 
@@ -83,7 +82,6 @@ class DagBag(BaseDagBag, LoggingMixin):
     CYCLE_IN_PROGRESS = 1
     CYCLE_DONE = 2
     DAGBAG_IMPORT_TIMEOUT = conf.getint('core', 'DAGBAG_IMPORT_TIMEOUT')
-    UNIT_TEST_MODE = conf.getboolean('core', 'UNIT_TEST_MODE')
     SCHEDULER_ZOMBIE_TASK_THRESHOLD = conf.getint('scheduler', 'scheduler_zombie_task_threshold')
 
     def __init__(
@@ -323,36 +321,6 @@ class DagBag(BaseDagBag, LoggingMixin):
 
         self.file_last_changed[filepath] = file_last_changed_on_disk
         return found_dags
-
-    @provide_session
-    def kill_zombies(self, zombies, session=None):
-        """
-        Fail given zombie tasks, which are tasks that haven't
-        had a heartbeat for too long, in the current DagBag.
-
-        :param zombies: zombie task instances to kill.
-        :type zombies: List[airflow.models.taskinstance.SimpleTaskInstance]
-        :param session: DB session.
-        """
-        from airflow.models.taskinstance import TaskInstance  # Avoid circular import
-
-        for zombie in zombies:
-            if zombie.dag_id in self.dags:
-                dag = self.dags[zombie.dag_id]
-                if zombie.task_id in dag.task_ids:
-                    task = dag.get_task(zombie.task_id)
-                    ti = TaskInstance(task, zombie.execution_date)
-                    # Get properties needed for failure handling from SimpleTaskInstance.
-                    ti.start_date = zombie.start_date
-                    ti.end_date = zombie.end_date
-                    ti.try_number = zombie.try_number
-                    ti.state = zombie.state
-                    ti.test_mode = self.UNIT_TEST_MODE
-                    ti.handle_failure("{} detected as zombie".format(ti),
-                                      ti.test_mode, ti.get_template_context())
-                    self.log.info('Marked zombie job %s as %s', ti, ti.state)
-                    Stats.incr('zombies_killed')
-        session.commit()
 
     def bag_dag(self, dag, parent_dag, root_dag):
         """

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -38,6 +38,7 @@ from airflow.executors.base_executor import BaseExecutor
 from airflow.jobs import BackfillJob, SchedulerJob
 from airflow.jobs.scheduler_job import DagFileProcessor
 from airflow.models import DAG, DagBag, DagModel, DagRun, Pool, SlaMiss, TaskInstance as TI, errors
+from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
@@ -1030,6 +1031,31 @@ class TestDagFileProcessor(unittest.TestCase):
             )
 
             self.assertGreater(parent_dagruns, 0)
+
+    @patch.object(TI, 'handle_failure')
+    def test_kill_zombies(self, mock_ti_handle_failure):
+        """
+        Test that kill zombies call TIs failure handler with proper context
+        """
+        dagbag = models.DagBag(dag_folder="/dev/null", include_examples=True)
+        dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
+        with create_session() as session:
+            session.query(TI).delete()
+            dag = dagbag.get_dag('example_branch_operator')
+            task = dag.get_task(task_id='run_this_first')
+
+            ti = TI(task, DEFAULT_DATE, State.RUNNING)
+
+            session.add(ti)
+            session.commit()
+
+            zombies = [SimpleTaskInstance(ti)]
+            dag_file_processor.kill_zombies(dagbag, zombies)
+            mock_ti_handle_failure.assert_called_once_with(
+                mock.ANY,
+                conf.getboolean('core', 'unit_test_mode'),
+                mock.ANY
+            )
 
 
 class TestSchedulerJob(unittest.TestCase):


### PR DESCRIPTION
DagBag should be responsible for loading DAGs. The Scheduler should be responsible for managing task instance.

---
Issue link: [AIRFLOW-6867](https://issues.apache.org/jira/browse/AIRFLOW-6867)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
