### PR TITLE
[AIRFLOW-6869] Bulk fetch DAGRuns for _process_task_instances

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -27,6 +27,7 @@ import time
 from collections import defaultdict
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import timedelta
+from itertools import groupby
 from typing import List, Set
 
 from setproctitle import setproctitle
@@ -639,7 +640,9 @@ class DagFileProcessor(LoggingMixin):
         return None
 
     @provide_session
-    def _process_task_instances(self, dag: DAG, task_instances_list: List[TaskInstanceKeyType], session=None):
+    def _process_task_instances(
+        self, dag: DAG, dag_runs: List[DagRun], session=None
+    ) -> List[TaskInstanceKeyType]:
         """
         This method schedules the tasks for a single DAG by looking at the
         active DAG runs and adding task instances that should run to the
@@ -647,8 +650,8 @@ class DagFileProcessor(LoggingMixin):
         """
 
         # update the state of the previously active dag runs
-        dag_runs = DagRun.find(dag_id=dag.dag_id, state=State.RUNNING, session=session)
         active_dag_runs = 0
+        task_instances_list = []
         for run in dag_runs:
             self.log.info("Examining DAG run %s", run)
             # don't consider runs that are executed in the future unless
@@ -669,7 +672,7 @@ class DagFileProcessor(LoggingMixin):
                 continue
 
             # todo: run.dag is transient but needs to be set
-            run.dag = dag
+            run.dag = dag  # type: ignore
             # todo: preferably the integrity check happens at dag collection time
             run.verify_integrity(session=session)
             ready_tis = run.update_state(session=session)
@@ -679,8 +682,10 @@ class DagFileProcessor(LoggingMixin):
                 for ti in ready_tis:
                     self.log.debug('Queuing task: %s', ti)
                     task_instances_list.append(ti.key)
+        return task_instances_list
 
-    def _process_dags(self, dags: List[DAG], tis_out: List[TaskInstanceKeyType]):
+    @provide_session
+    def _process_dags(self, dags: List[DAG], session=None):
         """
         Iterates over the dags and processes them. Processing includes:
 
@@ -690,30 +695,44 @@ class DagFileProcessor(LoggingMixin):
 
         :param dags: the DAGs from the DagBag to process
         :type dags: List[airflow.models.DAG]
-        :param tis_out: A list to add generated TaskInstance objects
-        :type tis_out: list[TaskInstance]
-        :rtype: None
+        :rtype: list[TaskInstance]
+        :return: A list of generated TaskInstance objects
         """
         check_slas = conf.getboolean('core', 'CHECK_SLAS', fallback=True)
         # pylint: disable=too-many-nested-blocks
+
+        tis_out: List[TaskInstanceKeyType] = []
+        dag_ids = [dag.dag_id for dag in dags]
+        dag_runs = DagRun.find(dag_id=dag_ids, state=State.RUNNING, session=session)
+        # As per the docs of groupby (https://docs.python.org/3/library/itertools.html#itertools.groupby)
+        # we need to use `list()` otherwise the result will be wrong/incomplete
+        dag_runs_by_dag_id = {k: list(v) for k, v in groupby(dag_runs, lambda d: d.dag_id)}
+
         for dag in dags:
-            self.log.info("Processing %s", dag.dag_id)
+            dag_id = dag.dag_id
+            self.log.info("Processing %s", dag_id)
+            dag_runs_for_dag = dag_runs_by_dag_id.get(dag_id) or []
 
             # Only creates DagRun for DAGs that are not subdag since
             # DagRun of subdags are created when SubDagOperator executes.
             if not dag.is_subdag:
                 dag_run = self.create_dag_run(dag)
                 if dag_run:
+                    dag_runs_for_dag.append(dag_run)
                     expected_start_date = dag.following_schedule(dag_run.execution_date)
                     if expected_start_date:
                         schedule_delay = dag_run.start_date - expected_start_date
                         Stats.timing(
                             'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
                             schedule_delay)
-                self.log.info("Created %s", dag_run)
-            self._process_task_instances(dag, tis_out)
-            if check_slas:
-                self.manage_slas(dag)
+                    self.log.info("Created %s", dag_run)
+
+            if dag_runs_for_dag:
+                tis_out.extend(self._process_task_instances(dag, dag_runs_for_dag))
+                if check_slas:
+                    self.manage_slas(dag)
+
+        return tis_out
 
     def _find_dags_to_process(self, dags: List[DAG], paused_dag_ids: Set[str]) -> List[DAG]:
         """
@@ -824,17 +843,13 @@ class DagFileProcessor(LoggingMixin):
 
         dags = self._find_dags_to_process(dagbag.dags.values(), paused_dag_ids)
 
-        # Not using multiprocessing.Queue() since it's no longer a separate
-        # process and due to some unusual behavior. (empty() incorrectly
-        # returns true as described in https://bugs.python.org/issue23582 )
-        ti_keys_to_schedule = []
-        refreshed_tis = []
-
-        self._process_dags(dags, ti_keys_to_schedule)
+        ti_keys_to_schedule = self._process_dags(dags, session)
 
         # Refresh all task instances that will be scheduled
         TI = models.TaskInstance
         filter_for_tis = TI.filter_for_tis(ti_keys_to_schedule)
+
+        refreshed_tis = []
 
         if filter_for_tis is not None:
             refreshed_tis = session.query(TI).filter(filter_for_tis).with_for_update().all()

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -139,12 +139,11 @@ class TestBackfillJob(unittest.TestCase):
         target_dag.sync_to_db()
 
         dag_file_processor = DagFileProcessor(dag_ids=[], log=Mock())
-        task_instances_list = Mock()
-        dag_file_processor._process_task_instances(
+        task_instances_list = dag_file_processor._process_task_instances(
             target_dag,
-            task_instances_list=task_instances_list
+            dag_runs=DagRun.find(dag_id='example_trigger_target_dag')
         )
-        self.assertFalse(task_instances_list.append.called)
+        self.assertFalse(task_instances_list)
 
         job = BackfillJob(
             dag=dag,
@@ -154,12 +153,12 @@ class TestBackfillJob(unittest.TestCase):
         )
         job.run()
 
-        dag_file_processor._process_task_instances(
+        task_instances_list = dag_file_processor._process_task_instances(
             target_dag,
-            task_instances_list=task_instances_list
+            dag_runs=DagRun.find(dag_id='example_trigger_target_dag')
         )
 
-        self.assertTrue(task_instances_list.append.called)
+        self.assertTrue(task_instances_list)
 
     @pytest.mark.backend("postgres", "mysql")
     def test_backfill_multi_dates(self):


### PR DESCRIPTION
Another performance optimization.
When a DAG file contains 199 DAGs, and each DAG contains 5 tasks
```
from datetime import timedelta

from airflow.models import DAG
from airflow.operators.bash_operator import BashOperator
from airflow.operators.dummy_operator import DummyOperator
from airflow.utils.dates import days_ago

args = {
    'owner': 'airflow',
    'start_date': days_ago(3),
}


def create_dag(dag_number):
    dag = DAG(
        dag_id=f'perf_50_dag_dummy_tasks_{dag_number}_of_50', default_args=args,
        dagrun_timeout=timedelta(minutes=60),
        is_paused_upon_creation=False,
    )

    for j in range(1, 10):
        DummyOperator(
            task_id='task_{}_of_5'.format(j),
            dag=dag
        )

    return dag


for i in range(1, 200):
    globals()[f"dag_{i}"] = create_dag(i)


```
I ran the following code:
```
from airflow.jobs.scheduler_job import DagFileProcessor

processor = DagFileProcessor([], log)
processor.process_file(DAG_FILE, None, pickle_dags=False)
```
I got the following values.
**Before:**
Query count:  1792
Average time: 4568.156 ms
**After:**
Query count:  1594
Average time: 3964.916 ms
**Diff:**
Query count: -200 (-11%)
Average time: -603 ms (-13%)

If I didn't make a mistake, when we combine the following changes:
* https://github.com/apache/airflow/pull/7481
* https://github.com/apache/airflow/pull/7477
* https://github.com/apache/airflow/pull/7476

we get only... 5 queries per file instead of ....1792

Thanks for support to @evgenyshulman from Databand!

---
Issue link: [AIRFLOW-6869](https://issues.apache.org/jira/browse/AIRFLOW-6869)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
