### PR TITLE
[AIRFLOW-6872] Fix: Show Git Version in UI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,7 @@ graft airflow/www/static
 graft airflow/www/templates
 graft airflow/_vendor/
 include airflow/alembic.ini
+include airflow/git_version
 graft scripts/systemd
 graft scripts/upstart
 graft airflow/config_templates

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -23,6 +23,7 @@ import json
 import logging
 import math
 import os
+import pkgutil
 import socket
 import traceback
 from collections import defaultdict
@@ -2056,9 +2057,7 @@ class VersionView(AirflowBaseView):
         # Get the Git repo and git hash
         git_version = None
         try:
-            with open(os.path.join(*[settings.AIRFLOW_HOME,
-                                   'airflow', 'git_version'])) as f:
-                git_version = f.readline()
+            git_version = str(pkgutil.get_data('airflow', 'git_version'), encoding="UTF-8")
         except Exception as e:
             logging.error(e)
 


### PR DESCRIPTION
Currently git_version is always "Not Available" in Webserver. This is because the file (git_version) is missing from the final built package


**After Fix: (on dev commit)**
![image](https://user-images.githubusercontent.com/8811558/75078440-80a55780-54fd-11ea-8f8b-e540f54ce829.png)


---
Issue link: [AIRFLOW-6872](https://issues.apache.org/jira/browse/AIRFLOW-6872)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
