### PR TITLE
[AIRFLOW-XXXX] remove redundant wording

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -92,7 +92,7 @@ class DAG(BaseDag, LoggingMixin):
     added once to a DAG.
 
     :param dag_id: The id of the DAG; must consist exclusively of alphanumeric
-        characters, dashes, dots and underscores (all ASCII) exclusively
+        characters, dashes, dots and underscores (all ASCII)
     :type dag_id: str
     :param description: The description for the DAG to e.g. be shown on the webserver
     :type description: str


### PR DESCRIPTION
[AIRFLOW-XXXX]

follow-up to #7463 to remove double `exclusively`