### PR TITLE
[AIRFLOW-6880][DONT-MERGE] Do not check task instances for new DAGRuns

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1449,7 +1449,7 @@ class DAG(BaseDag, LoggingMixin):
 
         # create the associated task instances
         # state is None at the moment of creation
-        run.verify_integrity(session=session)
+        run.verify_integrity(task_instances=[], session=session)
 
         run.refresh_from_db()
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -401,15 +401,19 @@ class DagRun(Base, LoggingMixin):
             Stats.timing('dagrun.duration.failed.{}'.format(self.dag_id), duration)
 
     @provide_session
-    def verify_integrity(self, session=None):
+    def verify_integrity(self, task_instances=None, session=None):
         """
         Verifies the DagRun by checking for removed tasks or tasks that are not in the
         database yet. It will set state to removed or add the task if required.
+
+        :param task_instances: List of instances associated with the given DagRun. If
+            not transmitted, the current value will be read from the database.
+        :type task_instances: List[airflow.models.taskinstance.TaskInstance]
         """
         from airflow.models.taskinstance import TaskInstance  # Avoid circular import
 
         dag = self.get_dag()
-        tis = self.get_task_instances(session=session)
+        tis = self.get_task_instances(session=session) if task_instances is None else task_instances
 
         # check for removed or restored tasks
         task_ids = []

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -54,6 +54,7 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.www import app as application
 from tests.test_utils.config import conf_vars
+from tests.test_utils.db import clear_db_runs
 
 
 class TestBase(unittest.TestCase):
@@ -329,20 +330,8 @@ class TestAirflowBaseViews(TestBase):
         super().setUp()
         self.logout()
         self.login()
-        self.cleanup_dagruns()
+        clear_db_runs()
         self.prepare_dagruns()
-
-    def cleanup_dagruns(self):
-        DR = models.DagRun
-        dag_ids = ['example_bash_operator',
-                   'example_subdag_operator',
-                   'example_xcom']
-        (self.session
-             .query(DR)
-             .filter(DR.dag_id.in_(dag_ids))
-             .filter(DR.run_id == self.run_id)
-             .delete(synchronize_session='fetch'))
-        self.session.commit()
 
     def prepare_dagruns(self):
         dagbag = models.DagBag(include_examples=True)
@@ -1221,17 +1210,6 @@ class TestDagACLView(TestBase):
         for dag in dagbag.dags.values():
             dag.sync_to_db()
 
-    def cleanup_dagruns(self):
-        DR = models.DagRun
-        dag_ids = ['example_bash_operator',
-                   'example_subdag_operator']
-        (self.session
-             .query(DR)
-             .filter(DR.dag_id.in_(dag_ids))
-             .filter(DR.run_id == self.run_id)
-             .delete(synchronize_session='fetch'))
-        self.session.commit()
-
     def prepare_dagruns(self):
         dagbag = models.DagBag(include_examples=True)
         self.bash_dag = dagbag.dags['example_bash_operator']
@@ -1251,7 +1229,7 @@ class TestDagACLView(TestBase):
 
     def setUp(self):
         super().setUp()
-        self.cleanup_dagruns()
+        clear_db_runs()
         self.prepare_dagruns()
         self.logout()
         self.appbuilder.sm.sync_roles()
@@ -2240,20 +2218,8 @@ class TestDecorators(TestBase):
         super().setUp()
         self.logout()
         self.login()
-        self.cleanup_dagruns()
+        clear_db_runs()
         self.prepare_dagruns()
-
-    def cleanup_dagruns(self):
-        DR = models.DagRun
-        dag_ids = ['example_bash_operator',
-                   'example_subdag_operator',
-                   'example_xcom']
-        (self.session
-             .query(DR)
-             .filter(DR.dag_id.in_(dag_ids))
-             .filter(DR.run_id == self.run_id)
-             .delete(synchronize_session='fetch'))
-        self.session.commit()
 
     def prepare_dagruns(self):
         dagbag = models.DagBag(include_examples=True)


### PR DESCRIPTION
When I have the following DAG:
```python
dag = DAG(dag_id="test_dag", schedule_interval="@once", start_date=days_ago(2))
DummyOperator(task_id=f"task", dag=dag)
dag.sync_to_db()
```
and executes the following code:
```python
for i in range(1, 1000+1):
    dag.create_dagrun(
        run_id=f"dag-{i}",
        state=State.RUNNING
    )
```
I got the following results
**Before:**
Query count:  4000
Average time 13983.817 ms
**After:**
Query count:  3000
Average time: 11499.290 ms
**Diff:**
Query count: -1000 (-25%)
Average time: 2.484 (-17%)

Thanks for support to @evgenyshulman from Databand!

---
Issue link: [AIRFLOW-6880](https://issues.apache.org/jira/browse/AIRFLOW-6880)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
