### PR TITLE
[AIRFLOW-6882] Implement SageMakerHook list_training_jobs method + convenience method for iterating list_* requests

### DIFF
--- a/airflow/providers/amazon/aws/hooks/sagemaker.py
+++ b/airflow/providers/amazon/aws/hooks/sagemaker.py
@@ -21,6 +21,8 @@ import tarfile
 import tempfile
 import time
 import warnings
+from functools import partial
+from typing import List, Dict
 
 from botocore.exceptions import ClientError
 
@@ -742,3 +744,83 @@ class SageMakerHook(AwsBaseHook):
             billable_time = (last_description['TrainingEndTime'] - last_description['TrainingStartTime']) \
                 * instance_count
             self.log.info('Billable seconds: %d', int(billable_time.total_seconds()) + 1)
+
+    def list_training_jobs(self, name_contains: str = None, max_results: int = None, **kwargs) -> List[Dict]:
+        """
+        This method wraps boto3's list_training_jobs(). The training job name and max results are configurable
+        via arguments. Other arguments are not, and should be provided via kwargs. Note boto3 expects these in
+        CamelCase format, for example:
+
+        .. code-block:: python
+
+            list_training_jobs(name_contains="myjob", StatusEquals="Failed")
+
+        .. seealso::
+            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.list_training_jobs
+
+        :param name_contains: (optional) partial name to match
+        :param max_results: (optional) maximum number of results to return. None returns infinite results
+        :param kwargs: (optional) kwargs to boto3's list_training_jobs method
+        :return: results of the list_training_jobs request
+        """
+
+        config = dict()
+
+        if name_contains:
+            if "NameContains" in kwargs:
+                raise AirflowException("Either name_contains or NameContains can be provided, not both.")
+            config["NameContains"] = name_contains
+
+        if "MaxResults" in kwargs and kwargs["MaxResults"] is not None:
+            if max_results:
+                raise AirflowException("Either max_results or MaxResults can be provided, not both.")
+            # Unset MaxResults, we'll use the SageMakerHook's internal method for iteratively fetching results
+            max_results = kwargs["MaxResults"]
+            del kwargs["MaxResults"]
+
+        config.update(kwargs)
+        list_training_jobs_request = partial(self.get_conn().list_training_jobs, **config)
+        results = self._list_request(
+            list_training_jobs_request, "TrainingJobSummaries", max_results=max_results
+        )
+        return results
+
+    def _list_request(self, partial_func, result_key: str, max_results: int = None) -> List[Dict]:
+        """
+        All AWS boto3 list_* requests return results in batches (if the key "NextToken" is contained in the
+        result, there are more results to fetch). The default AWS batch size is 10, and configurable up to
+        100. This function iteratively loads all results (or up to a given maximum).
+
+        Each boto3 function returns the results in a different dict structure. The key of this structure must
+        be given to iterate over the results, e.g. "TransformJobSummaries" for list_transform_jobs().
+
+        :param partial_func: boto3 function with arguments
+        :param result_key: the result key to iterate over
+        :param max_results: maximum number of results to return (None = infinite)
+        :return: Results of the list_* request
+        """
+
+        SAGEMAKER_MAX_RESULTS = 100  # Fixed number set by AWS
+
+        results = []
+        next_token = None
+
+        while True:
+            kwargs = dict()
+            if next_token is not None:
+                kwargs["NextToken"] = next_token
+
+            if max_results is None:
+                kwargs["MaxResults"] = SAGEMAKER_MAX_RESULTS
+            else:
+                kwargs["MaxResults"] = min(max_results - len(results), SAGEMAKER_MAX_RESULTS)
+
+            response = partial_func(**kwargs)
+            self.log.debug("Fetched %s results.", len(response[result_key]))
+            results.extend(response[result_key])
+
+            if "NextToken" not in response or (max_results is not None and len(results) == max_results):
+                # Return when there are no results left (no NextToken) or when we've reached max_results.
+                return results
+            else:
+                next_token = response["NextToken"]


### PR DESCRIPTION
The SageMakerHook currently does not support any list_* operations (there are a few... https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html). This PR adds a generic method for iterating over list_* operation results and one implementation for list_training_jobs.

By default, boto3 caps the number of results to 10. This is configurable up to 100. I've implemented `_list_request` as a convenience function for making multiple requests to AWS in case more results are available. `SageMakerHook.list_training_jobs()` makes use of this convenience function.

Not sure if tests should be added because all existing SageMakerHook tests simply test the number of calls to the underlying client's methods, which doesn't really validate correct behaviour IMO?

Example usage:

```python
from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

hook = SageMakerHook()
hook.list_training_jobs(max_results=150)
```

Say there are 2000 training jobs, then `_list_request()` will select 150 training jobs in 2 batches (first 100, next 50). 

---
Issue link: [AIRFLOW-6882](https://issues.apache.org/jira/browse/AIRFLOW-6882)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
