### PR TITLE
[AIRFLOW-6883] Speed up import of airflow.utils.log.file_task_hanlder

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -18,14 +18,16 @@
 """File logging handler for tasks."""
 import logging
 import os
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import requests
 
 from airflow.configuration import AirflowConfigException, conf
-from airflow.models import TaskInstance
 from airflow.utils.file import mkdirs
 from airflow.utils.helpers import parse_template_string
+
+if TYPE_CHECKING:
+    from airflow.models import TaskInstance
 
 
 class FileTaskHandler(logging.Handler):
@@ -45,7 +47,7 @@ class FileTaskHandler(logging.Handler):
         self.filename_template, self.filename_jinja_template = \
             parse_template_string(filename_template)
 
-    def set_context(self, ti: TaskInstance):
+    def set_context(self, ti: 'TaskInstance'):
         """
         Provide task_instance context to airflow task handler.
 


### PR DESCRIPTION
This module imports form airflow.models, which in turn means we impor
all the other modules (which we can fix in a later issue) -- but there
is still no need to import that module here as it is only used for type
checking.

So lets use the already existing guard built in to the typing module.

On my machine this speeds up `import airflow` from 0.74s to 0.44s


---
Issue link: [AIRFLOW-6883](https://issues.apache.org/jira/browse/AIRFLOW-6883)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.