### PR TITLE
[AIRFLOW-6885] Delete worker on success

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1733,7 +1733,14 @@
       default: "IfNotPresent"
     - name: delete_worker_pods
       description: |
-        If True (default), worker pods will be deleted upon termination
+        If True, all worker pods will be deleted upon termination
+      version_added: ~
+      type: string
+      example: ~
+      default: "True"
+    - name: delete_worker_pods_on_success
+      description: |
+        If True (default), worker pods will be deleted only on task success
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -801,8 +801,11 @@ worker_container_tag =
 # The imagePullPolicy of the Kubernetes Image for the Worker to Run
 worker_container_image_pull_policy = IfNotPresent
 
-# If True (default), worker pods will be deleted upon termination
+# If True, all worker pods will be deleted upon termination
 delete_worker_pods = True
+
+# If True (default), worker pods will be deleted only on task success
+delete_worker_pods_on_success = True
 
 # Number of Kubernetes Worker Pod creation calls per scheduler loop.
 # Note that the current default of "1" will only launch a single pod

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -98,6 +98,8 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
         self.kube_labels = configuration_dict.get('kubernetes_labels', {})
         self.delete_worker_pods = conf.getboolean(
             self.kubernetes_section, 'delete_worker_pods')
+        self.delete_worker_pods_on_success = conf.getboolean(
+            self.kubernetes_section, 'delete_worker_pods_on_success')
         self.worker_pods_creation_batch_size = conf.getint(
             self.kubernetes_section, 'worker_pods_creation_batch_size')
         self.worker_service_account_name = conf.get(
@@ -879,7 +881,11 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                       pod_id: str,
                       namespace: str) -> None:
         if state != State.RUNNING:
-            if self.kube_config.delete_worker_pods:
+            if self.kube_config.delete_worker_pods_on_success and state is State.SUCCESS:
+                if not self.kube_scheduler:
+                    raise AirflowException(NOT_STARTED_MESSAGE)
+                self.kube_scheduler.delete_pod(pod_id, namespace)
+            elif self.kube_config.delete_worker_pods:
                 if not self.kube_scheduler:
                     raise AirflowException(NOT_STARTED_MESSAGE)
                 self.kube_scheduler.delete_pod(pod_id, namespace)

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -256,14 +256,21 @@ class TestKubernetesExecutor(unittest.TestCase):
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
     @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
     @mock.patch('airflow.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod')
-    def test_change_state_failed(self, mock_delete_pod, mock_get_kube_client, mock_kubernetes_job_watcher):
+    def test_change_state_failed_no_deletion(
+        self,
+        mock_delete_pod,
+        mock_get_kube_client,
+        mock_kubernetes_job_watcher
+    ):
         executor = KubernetesExecutor()
+        executor.kube_config.delete_worker_pods = False
+        executor.kube_config.delete_worker_pods_on_success = True
         executor.start()
         test_time = timezone.utcnow()
         key = ('dag_id', 'task_id', test_time, 'try_number3')
         executor._change_state(key, State.FAILED, 'pod_id', 'default')
         self.assertTrue(executor.event_buffer[key] == State.FAILED)
-        mock_delete_pod.assert_called_once_with('pod_id', 'default')
+        mock_delete_pod.assert_not_called()
 # pylint: enable=unused-argument
 
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
@@ -274,11 +281,27 @@ class TestKubernetesExecutor(unittest.TestCase):
         test_time = timezone.utcnow()
         executor = KubernetesExecutor()
         executor.kube_config.delete_worker_pods = False
+        executor.kube_config.delete_worker_pods_on_success = False
+
         executor.start()
         key = ('dag_id', 'task_id', test_time, 'try_number2')
         executor._change_state(key, State.SUCCESS, 'pod_id', 'default')
         self.assertTrue(executor.event_buffer[key] == State.SUCCESS)
         mock_delete_pod.assert_not_called()
+
+    @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
+    @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
+    @mock.patch('airflow.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod')
+    def test_change_state_failed_pod_deletion(self, mock_delete_pod, mock_get_kube_client,
+                                              mock_kubernetes_job_watcher):
+        executor = KubernetesExecutor()
+        executor.kube_config.delete_worker_pods_on_success = True
+
+        executor.start()
+        key = ('dag_id', 'task_id', 'ex_time', 'try_number2')
+        executor._change_state(key, State.FAILED, 'pod_id', 'test-namespace')
+        self.assertTrue(executor.event_buffer[key] == State.FAILED)
+        mock_delete_pod.assert_called_once_with('pod_id', 'test-namespace')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Users now have the option to only delete worker pods when they are successful

---
Issue link: [AIRFLOW-6885](https://issues.apache.org/jira/browse/AIRFLOW-6885)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
