### PR TITLE
[AIRFLOW-6886] Cleanup the SageMakerTrainingOperator result

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -61,6 +61,11 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Return the raw boto3 JSON response in SageMakerTrainingOperator
+
+The SageMakerTrainingOperator used to return the JSON response of `describe_training_job()` wrapped in a dict
+with key "Training". For simplicity, with now returns only the JSON response itself.
+
 ### Removed sub-package imports from `airflow/__init__.py`
 
 The imports `LoggingMixin`, `conf`, `AirflowException`, and `DAG` have been removed from `airflow/__init__.py`.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -64,7 +64,7 @@ https://developers.google.com/style/inclusive-documentation
 ### Return the raw boto3 JSON response in SageMakerTrainingOperator
 
 The SageMakerTrainingOperator used to return the JSON response of `describe_training_job()` wrapped in a dict
-with key "Training". For simplicity, with now returns only the JSON response itself.
+with key "Training". For simplicity, it now returns only the JSON response itself.
 
 ### Removed sub-package imports from `airflow/__init__.py`
 

--- a/airflow/providers/amazon/aws/operators/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_training.py
@@ -90,8 +90,4 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
         if response['ResponseMetadata']['HTTPStatusCode'] != 200:
             raise AirflowException('Sagemaker Training Job creation failed: %s' % response)
         else:
-            return {
-                'Training': self.hook.describe_training_job(
-                    self.config['TrainingJobName']
-                )
-            }
+            return self.hook.describe_training_job(self.config['TrainingJobName'])

--- a/airflow/providers/amazon/aws/operators/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_training.py
@@ -26,7 +26,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
     """
     Initiate a SageMaker training job.
 
-    This operator returns The ARN of the training job created in Amazon SageMaker.
+    This operator returns the config of the training job created in Amazon SageMaker.
 
     :param config: The configuration necessary to start a training job (templated).
 


### PR DESCRIPTION
The SageMakerTrainingOperator returns the response of `hook.describe_training_job()` wrapped in a dict with key `Training`. I don't see it used anywhere in the codebase, nor anywhere on the internet, so I suggest to simplify the result and return the JSON returned by `hook.describe_training_job()`.

Before:

```python
{
    'Training': {... SageMaker result here ...}
}
```

After:
```python
{... SageMaker result here ...}
```

This way, you avoid one useless step processing the results:

```python
# before
jobname = result["Training"]["TrainingJobName"]
# after
jobname = result["TrainingJobName"]
```

---
Issue link: [AIRFLOW-6886](https://issues.apache.org/jira/browse/AIRFLOW-6886)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
