### PR TITLE
[AIRFLOW-6888] Replace List creation in experimental/trigger_dag.py

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -85,8 +85,7 @@ def _trigger_dag(
             run_conf = json.loads(conf)
 
     triggers = []
-    dags_to_trigger = []
-    dags_to_trigger.append(dag)
+    dags_to_trigger = [dag]
     while dags_to_trigger:
         dag = dags_to_trigger.pop()
         trigger = dag.create_dagrun(


### PR DESCRIPTION
List creation and assignment can be combined to a single command:

Before:
```python
dags_to_trigger = []
dags_to_trigger.append(dag)
```

After:
```python
dags_to_trigger = [dag]
```
---
Issue link: [AIRFLOW-6888](https://issues.apache.org/jira/browse/AIRFLOW-6888)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
