### PR TITLE
[AIRFLOW-6889] Change mutable argument value in OpsgenieAlertHook

### DIFF
--- a/airflow/providers/opsgenie/hooks/opsgenie_alert.py
+++ b/airflow/providers/opsgenie/hooks/opsgenie_alert.py
@@ -72,7 +72,7 @@ class OpsgenieAlertHook(HttpHook):
             session.headers.update(headers)
         return session
 
-    def execute(self, payload={}):
+    def execute(self, payload=None):
         """
         Execute the Opsgenie Alert call
 
@@ -80,6 +80,7 @@ class OpsgenieAlertHook(HttpHook):
             See https://docs.opsgenie.com/docs/alert-api#section-create-alert
         :type payload: dict
         """
+        payload = payload or {}
         api_key = self._get_api_key()
         return self.run(endpoint='v2/alerts',
                         data=json.dumps(payload),


### PR DESCRIPTION
**OpsgenieAlertHook** contains the following code which uses a mutable argument value.

```python
def execute(self, payload={}):
```
Reference: https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

---
Issue link: [AIRFLOW-6889](https://issues.apache.org/jira/browse/AIRFLOW-6889)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
