### PR TITLE
[AIRFLOW-6890] AzureDataLakeHook: Move DB call out of __init__

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -43,21 +43,22 @@ class AzureDataLakeHook(BaseHook):
 
     def __init__(self, azure_data_lake_conn_id='azure_data_lake_default'):
         self.conn_id = azure_data_lake_conn_id
-        self.connection = self.get_conn()
+        self._conn = None
+        self.account_name = None
 
     def get_conn(self):
         """Return a AzureDLFileSystem object."""
-        conn = self.get_connection(self.conn_id)
-        service_options = conn.extra_dejson
-        self.account_name = service_options.get('account_name')
+        if not self._conn:
+            conn = self.get_connection(self.conn_id)
+            service_options = conn.extra_dejson
+            self.account_name = service_options.get('account_name')
 
-        adlCreds = lib.auth(tenant_id=service_options.get('tenant'),
-                            client_secret=conn.password,
-                            client_id=conn.login)
-        adlsFileSystemClient = core.AzureDLFileSystem(adlCreds,
-                                                      store_name=self.account_name)
-        adlsFileSystemClient.connect()
-        return adlsFileSystemClient
+            adl_creds = lib.auth(tenant_id=service_options.get('tenant'),
+                                 client_secret=conn.password,
+                                 client_id=conn.login)
+            self._conn = core.AzureDLFileSystem(adl_creds, store_name=self.account_name)
+            self._conn.connect()
+        return self._conn
 
     def check_for_file(self, file_path):
         """
@@ -69,7 +70,7 @@ class AzureDataLakeHook(BaseHook):
         :rtype: bool
         """
         try:
-            files = self.connection.glob(file_path, details=False, invalidate_cache=True)
+            files = self.get_conn().glob(file_path, details=False, invalidate_cache=True)
             return len(files) == 1
         except FileNotFoundError:
             return False
@@ -102,7 +103,7 @@ class AzureDataLakeHook(BaseHook):
             block for each API call. This block cannot be bigger than a chunk.
         :type blocksize: int
         """
-        multithread.ADLUploader(self.connection,
+        multithread.ADLUploader(self.get_conn(),
                                 lpath=local_path,
                                 rpath=remote_path,
                                 nthreads=nthreads,
@@ -139,7 +140,7 @@ class AzureDataLakeHook(BaseHook):
             block for each API call. This block cannot be bigger than a chunk.
         :type blocksize: int
         """
-        multithread.ADLDownloader(self.connection,
+        multithread.ADLDownloader(self.get_conn(),
                                   lpath=local_path,
                                   rpath=remote_path,
                                   nthreads=nthreads,
@@ -155,6 +156,6 @@ class AzureDataLakeHook(BaseHook):
         :type path: str
         """
         if "*" in path:
-            return self.connection.glob(path)
+            return self.get_conn().glob(path)
         else:
-            return self.connection.walk(path)
+            return self.get_conn().walk(path)

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
@@ -46,8 +46,9 @@ class TestAzureDataLakeHook(unittest.TestCase):
         from airflow.providers.microsoft.azure.hooks.azure_data_lake import AzureDataLakeHook
         from azure.datalake.store import core
         hook = AzureDataLakeHook(azure_data_lake_conn_id='adl_test_key')
+        self.assertIsNone(hook._conn)
         self.assertEqual(hook.conn_id, 'adl_test_key')
-        self.assertIsInstance(hook.connection, core.AzureDLFileSystem)
+        self.assertIsInstance(hook.get_conn(), core.AzureDLFileSystem)
         assert mock_lib.auth.called
 
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_data_lake.core.AzureDLFileSystem',
@@ -69,7 +70,7 @@ class TestAzureDataLakeHook(unittest.TestCase):
                          remote_path='/test_adl_hook.py',
                          nthreads=64, overwrite=True,
                          buffersize=4194304, blocksize=4194304)
-        mock_uploader.assert_called_once_with(hook.connection,
+        mock_uploader.assert_called_once_with(hook.get_conn(),
                                               lpath='tests/hooks/test_adl_hook.py',
                                               rpath='/test_adl_hook.py',
                                               nthreads=64, overwrite=True,
@@ -85,7 +86,7 @@ class TestAzureDataLakeHook(unittest.TestCase):
                            remote_path='/test_adl_hook.py',
                            nthreads=64, overwrite=True,
                            buffersize=4194304, blocksize=4194304)
-        mock_downloader.assert_called_once_with(hook.connection,
+        mock_downloader.assert_called_once_with(hook.get_conn(),
                                                 lpath='test_adl_hook.py',
                                                 rpath='/test_adl_hook.py',
                                                 nthreads=64, overwrite=True,


### PR DESCRIPTION
Currently, the Azure client is created in AzureDataLakeHook._init_ . This gets connection data from DB.



---
Issue link: [AIRFLOW-6890](https://issues.apache.org/jira/browse/AIRFLOW-6890)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
