### PR TITLE
[AIRFLOW-6892] Fix broken non-wheel releases

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,6 +27,7 @@ graft airflow/www/templates
 graft airflow/_vendor/
 include airflow/alembic.ini
 include airflow/git_version
+include airflow/serialization/schema.json
 graft scripts/systemd
 graft scripts/upstart
 graft airflow/config_templates


### PR DESCRIPTION
Our non-wheel releases on pypi are broken

```
pip install --no-binary apache-airflow apache-airflow
```
will install a version that does this:
```
FileNotFoundError: [Errno 2] No such file or directory: '/home/ash/.virtualenvs/clean/lib/python3.7/site-packages/airflow/serialization/schema.json'
```
There are no issues with wheel package. Pip install wheel package if available and unless you use "--no-binary"specifically

---
Issue link: [AIRFLOW-6892](https://issues.apache.org/jira/browse/AIRFLOW-6892)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
