### PR TITLE
[AIRFLOW-6817] Lazy-load `airflow.DAG` to keep user-facing API untouched

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -63,7 +63,7 @@ https://developers.google.com/style/inclusive-documentation
 
 ### Removed sub-package imports from `airflow/__init__.py`
 
-The imports `LoggingMixin`, `conf`, `AirflowException`, and `DAG` have been removed from `airflow/__init__.py`.
+The imports `LoggingMixin`, `conf`, and `AirflowException` have been removed from `airflow/__init__.py`.
 All implicit references of these objects will no longer be valid. To migrate, all usages of each old path must be
 replaced with its corresponding new path.
 
@@ -72,7 +72,6 @@ replaced with its corresponding new path.
 | ``airflow.LoggingMixin``     | ``airflow.utils.log.logging_mixin.LoggingMixin`` |
 | ``airflow.conf``             | ``airflow.configuration.conf``                   |
 | ``airflow.AirflowException`` | ``airflow.exceptions.AirflowException``          |
-| ``airflow.DAG``              | ``airflow.models.dag.DAG``                  |
 
 ### Success Callback will be called when a task in marked as success from UI
 

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -28,12 +28,15 @@ isort:skip_file
 
 # flake8: noqa: F401
 # pylint: disable=wrong-import-position
+import sys
 from typing import Callable, Optional
 
 from airflow import settings
 from airflow import version
 
 __version__ = version.version
+
+__all__ = ['__version__', 'login', 'DAG']
 
 settings.initialize()
 
@@ -43,7 +46,8 @@ login: Optional[Callable] = None
 
 integrate_plugins()
 
-__all__ = ['__version__', 'login', 'DAG']
+
+PY37 = sys.version_info >= (3, 7)
 
 
 def __getattr__(name):
@@ -61,3 +65,9 @@ STATICA_HACK = True
 globals()['kcah_acitats'[::-1].upper()] = False
 if STATICA_HACK:  # pragma: no cover
     from airflow.models.dag import DAG
+
+
+if not PY37:
+    from pep562 import Pep562
+
+    Pep562(__name__)

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -42,3 +42,22 @@ from airflow.plugins_manager import integrate_plugins
 login: Optional[Callable] = None
 
 integrate_plugins()
+
+__all__ = ['__version__', 'login', 'DAG']
+
+
+def __getattr__(name):
+    # PEP-562: Lazy loaded attributes on python modules
+    if name == "DAG":
+        from airflow.models.dag import DAG # pylint: disable=redefined-outer-name
+        return DAG
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+# This is never executed, but tricks static analyzers (PyDev, PyCharm,
+# pylint, etc.) into knowing the types of these symbols, and what
+# they contain.
+STATICA_HACK = True
+globals()['kcah_acitats'[::-1].upper()] = False
+if STATICA_HACK:  # pragma: no cover
+    from airflow.models.dag import DAG

--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -20,7 +20,7 @@
 
 from datetime import timedelta
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -20,7 +20,7 @@
 
 import random
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_branch_python_dop_operator_3.py
+++ b/airflow/example_dags/example_branch_python_dop_operator_3.py
@@ -21,7 +21,7 @@ Example DAG demonstrating the usage of BranchPythonOperator with depends_on_past
 or skipped on alternating runs.
 """
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_external_task_marker_dag.py
+++ b/airflow/example_dags/example_external_task_marker_dag.py
@@ -28,7 +28,7 @@ downstream tasks.
 
 import datetime
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.sensors.external_task_sensor import ExternalTaskMarker, ExternalTaskSensor
 

--- a/airflow/example_dags/example_kubernetes_executor.py
+++ b/airflow/example_dags/example_kubernetes_executor.py
@@ -20,8 +20,8 @@ This is an example dag for using the Kubernetes Executor.
 """
 import os
 
+from airflow import DAG
 from airflow.example_dags.libs.helper import print_stuff
-from airflow.models import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/example_dags/example_kubernetes_executor_config.py
@@ -20,8 +20,8 @@ This is an example dag for using a Kubernetes Executor Configuration.
 """
 import os
 
+from airflow import DAG
 from airflow.example_dags.libs.helper import print_stuff
-from airflow.models import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/example_latest_only.py
+++ b/airflow/example_dags/example_latest_only.py
@@ -20,7 +20,7 @@
 
 import datetime as dt
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_latest_only_with_trigger.py
+++ b/airflow/example_dags/example_latest_only_with_trigger.py
@@ -20,7 +20,7 @@ Example LatestOnlyOperator and TriggerRule interactions
 """
 import datetime as dt
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -20,7 +20,7 @@
 
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -21,7 +21,7 @@
 import time
 from pprint import pprint
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.python import PythonOperator, PythonVirtualenvOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/example_short_circuit_operator.py
+++ b/airflow/example_dags/example_short_circuit_operator.py
@@ -17,7 +17,7 @@
 # under the License.
 
 """Example DAG demonstrating the usage of the ShortCircuitOperator."""
-from airflow.models import DAG
+from airflow import DAG
 from airflow.models.baseoperator import chain
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import ShortCircuitOperator

--- a/airflow/example_dags/example_skip_dag.py
+++ b/airflow/example_dags/example_skip_dag.py
@@ -18,8 +18,8 @@
 
 """Example DAG demonstrating the DummyOperator and a custom DummySkipOperator which skips by default."""
 
+from airflow import DAG
 from airflow.exceptions import AirflowSkipException
-from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/example_subdag_operator.py
+++ b/airflow/example_dags/example_subdag_operator.py
@@ -18,8 +18,8 @@
 
 """Example DAG demonstrating the usage of the SubDagOperator."""
 
+from airflow import DAG
 from airflow.example_dags.subdags.subdag import subdag
-from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_trigger_controller_dag.py
+++ b/airflow/example_dags/example_trigger_controller_dag.py
@@ -21,7 +21,7 @@ Example usage of the TriggerDagRunOperator. This example holds 2 DAGs:
 1. 1st DAG (example_trigger_controller_dag) holds a TriggerDagRunOperator, which will trigger the 2nd DAG
 2. 2nd DAG (example_trigger_target_dag) which will be triggered by the TriggerDagRunOperator in the 1st DAG
 """
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -22,7 +22,7 @@ Example usage of the TriggerDagRunOperator. This example holds 2 DAGs:
 2. 2nd DAG (example_trigger_target_dag) which will be triggered by the TriggerDagRunOperator in the 1st DAG
 """
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -17,7 +17,7 @@
 # under the License.
 
 """Example DAG demonstrating the usage of XComs."""
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/subdags/subdag.py
+++ b/airflow/example_dags/subdags/subdag.py
@@ -18,7 +18,7 @@
 
 """Helper function to generate a DAG and operators given some arguments."""
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 
 

--- a/airflow/example_dags/test_utils.py
+++ b/airflow/example_dags/test_utils.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Used for unit tests"""
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -26,7 +26,7 @@ from datetime import timedelta
 
 # [START import_module]
 # The DAG object; we'll need this to instantiate a DAG
-from airflow.models.dag import DAG
+from airflow import DAG
 # Operators; we need this to operate!
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago

--- a/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_automatic_steps.py
+++ b/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_automatic_steps.py
@@ -20,7 +20,7 @@ This is an example dag for a AWS EMR Pipeline with auto steps.
 """
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.amazon.aws.operators.emr_create_job_flow import EmrCreateJobFlowOperator
 from airflow.providers.amazon.aws.sensors.emr_job_flow import EmrJobFlowSensor
 from airflow.utils.dates import days_ago

--- a/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.py
+++ b/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.py
@@ -23,7 +23,7 @@ terminating the cluster.
 """
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.amazon.aws.operators.emr_add_steps import EmrAddStepsOperator
 from airflow.providers.amazon.aws.operators.emr_create_job_flow import EmrCreateJobFlowOperator
 from airflow.providers.amazon.aws.operators.emr_terminate_job_flow import EmrTerminateJobFlowOperator

--- a/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
+++ b/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
@@ -30,7 +30,7 @@ This is an example dag for managing twitter data.
 """
 from datetime import date, timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.providers.apache.hive.operators.hive import HiveOperator

--- a/airflow/providers/apache/livy/example_dags/example_livy.py
+++ b/airflow/providers/apache/livy/example_dags/example_livy.py
@@ -21,7 +21,7 @@ The tasks below trigger the computation of pi on the Spark instance
 using the Java and Python executables provided in the example library.
 """
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.apache.livy.operators.livy import LivyOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/apache/pig/example_dags/example_pig.py
+++ b/airflow/providers/apache/pig/example_dags/example_pig.py
@@ -18,7 +18,7 @@
 
 """Example DAG demonstrating the usage of the PigOperator."""
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.providers.apache.pig.operators.pig import PigOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
@@ -20,7 +20,7 @@ This is an example dag for using the KubernetesPodOperator.
 """
 import logging
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.utils.dates import days_ago
 
 log = logging.getLogger(__name__)

--- a/airflow/providers/databricks/example_dags/example_databricks.py
+++ b/airflow/providers/databricks/example_dags/example_databricks.py
@@ -31,7 +31,7 @@ For more information about the state of a run refer to
 https://docs.databricks.com/api/latest/jobs.html#runstate
 """
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.databricks.operators.databricks import DatabricksSubmitRunOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/dingding/example_dags/example_dingding.py
+++ b/airflow/providers/dingding/example_dags/example_dingding.py
@@ -20,7 +20,7 @@ This is an example dag for using the DingdingOperator.
 """
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.dingding.operators.dingding import DingdingOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/docker/example_dags/example_docker.py
+++ b/airflow/providers/docker/example_dags/example_docker.py
@@ -17,7 +17,7 @@
 # under the License.
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.utils.dates import days_ago

--- a/airflow/providers/docker/example_dags/example_docker_copy_data.py
+++ b/airflow/providers/docker/example_dags/example_docker_copy_data.py
@@ -27,7 +27,7 @@ TODO: Review the workflow, change it accordingly to
 
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.providers.docker.operators.docker import DockerOperator

--- a/airflow/providers/docker/example_dags/example_docker_swarm.py
+++ b/airflow/providers/docker/example_dags/example_docker_swarm.py
@@ -17,7 +17,7 @@
 # under the License.
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/providers/google/cloud/example_dags/example_dlp.py
+++ b/airflow/providers/google/cloud/example_dags/example_dlp.py
@@ -28,7 +28,7 @@ import os
 
 from google.cloud.dlp_v2.types import ContentItem, InspectConfig, InspectTemplate
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.providers.google.cloud.operators.dlp import (
     CloudDLPCreateInspectTemplateOperator, CloudDLPDeleteInspectTemplateOperator,
     CloudDLPInspectContentOperator,

--- a/airflow/providers/google/cloud/example_dags/example_tasks.py
+++ b/airflow/providers/google/cloud/example_dags/example_tasks.py
@@ -29,7 +29,7 @@ from google.api_core.retry import Retry
 from google.cloud.tasks_v2.types import Queue
 from google.protobuf import timestamp_pb2
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.providers.google.cloud.operators.tasks import (
     CloudTasksQueueCreateOperator, CloudTasksTaskCreateOperator, CloudTasksTaskRunOperator,
 )

--- a/airflow/providers/http/example_dags/example_http.py
+++ b/airflow/providers/http/example_dags/example_http.py
@@ -21,7 +21,7 @@
 import json
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.http.operators.http import SimpleHttpOperator
 from airflow.providers.http.sensors.http import HttpSensor
 from airflow.utils.dates import days_ago

--- a/airflow/providers/jenkins/example_dags/example_jenkins_job_trigger.py
+++ b/airflow/providers/jenkins/example_dags/example_jenkins_job_trigger.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 
 from six.moves.urllib.request import Request
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.providers.jenkins.hooks.jenkins import JenkinsHook
 from airflow.providers.jenkins.operators.jenkins_job_trigger import JenkinsJobTriggerOperator

--- a/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
@@ -20,7 +20,7 @@ This is an example dag for using the AzureContainerInstancesOperator.
 """
 from datetime import datetime, timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.microsoft.azure.operators.azure_container_instances import (
     AzureContainerInstancesOperator,
 )

--- a/airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py
@@ -26,7 +26,7 @@ You can trigger this manually with `airflow dags trigger example_cosmosdb_sensor
 this example.*
 """
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.microsoft.azure.operators.azure_cosmos import AzureCosmosInsertDocumentOperator
 from airflow.providers.microsoft.azure.sensors.azure_cosmos import AzureCosmosDocumentSensor
 from airflow.utils import dates

--- a/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
+++ b/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
@@ -30,7 +30,7 @@ This is an example dag for using the WinRMOperator.
 """
 from datetime import timedelta
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 from airflow.providers.microsoft.winrm.operators.winrm import WinRMOperator

--- a/airflow/providers/papermill/example_dags/example_papermill.py
+++ b/airflow/providers/papermill/example_dags/example_papermill.py
@@ -25,8 +25,8 @@ from datetime import timedelta
 
 import scrapbook as sb
 
+from airflow import DAG
 from airflow.lineage import AUTO
-from airflow.models import DAG
 from airflow.operators.python import PythonOperator
 from airflow.providers.papermill.operators.papermill import PapermillOperator
 from airflow.utils.dates import days_ago

--- a/airflow/providers/qubole/example_dags/example_qubole.py
+++ b/airflow/providers/qubole/example_dags/example_qubole.py
@@ -20,7 +20,7 @@ import filecmp
 import random
 import textwrap
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.providers.qubole.operators.qubole import QuboleOperator

--- a/airflow/providers/salesforce/example_dags/example_tableau_refresh_workbook.py
+++ b/airflow/providers/salesforce/example_dags/example_tableau_refresh_workbook.py
@@ -22,7 +22,7 @@ when the operation actually finishes. That's why we have another task that check
 """
 from datetime import timedelta
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.salesforce.operators.tableau_refresh_workbook import TableauRefreshWorkbookOperator
 from airflow.providers.salesforce.sensors.tableau_job_status import TableauJobStatusSensor
 from airflow.utils.dates import days_ago

--- a/airflow/providers/singularity/example_dags/example_singularity_operator.py
+++ b/airflow/providers/singularity/example_dags/example_singularity_operator.py
@@ -18,7 +18,7 @@
 
 from datetime import datetime, timedelta
 
-from airflow.models import DAG
+from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.providers.singularity.operators.singularity import SingularityOperator
 

--- a/airflow/providers/yandex/example_dags/example_yandexcloud_dataproc.py
+++ b/airflow/providers/yandex/example_dags/example_yandexcloud_dataproc.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.models.dag import DAG
+from airflow import DAG
 from airflow.providers.yandex.operators.yandexcloud_dataproc import (
     DataprocCreateClusterOperator, DataprocCreateHiveJobOperator, DataprocCreateMapReduceJobOperator,
     DataprocCreatePysparkJobOperator, DataprocCreateSparkJobOperator, DataprocDeleteClusterOperator,

--- a/setup.py
+++ b/setup.py
@@ -487,6 +487,7 @@ def do_setup():
             'markdown>=2.5.2, <3.0',
             'pandas>=0.17.1, <1.0.0',
             'pendulum==1.4.4',
+            'pep562~=1.0>=3.7.4;python_version<"3.7"',
             'psutil>=4.2.0, <6.0.0',
             'pygments>=2.0.1, <3.0',
             'python-daemon>=2.1.1, <2.2',

--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,7 @@ def do_setup():
             'markdown>=2.5.2, <3.0',
             'pandas>=0.17.1, <1.0.0',
             'pendulum==1.4.4',
-            'pep562~=1.0>=3.7.4;python_version<"3.7"',
+            'pep562~=1.0;python_version<"3.7"',
             'psutil>=4.2.0, <6.0.0',
             'pygments>=2.0.1, <3.0',
             'python-daemon>=2.1.1, <2.2',


### PR DESCRIPTION
`from airflow import DAG` is _such_ a common pattern that it's worth
making sure this stays working.

Since we are now on Python 3 we can use PEP-562 to have officially
supported lazy-loading of attributes on a module.

Since the example_dags will be referred to/copied by users I have
updated them all back to import from the airflow module, but have left
any internal uses untouched.

This approach taken from Celery: https://github.com/celery/celery/blob/f2ddd894c32f642a20f03b805b97e460f4fb3b4f/celery/__init__.py#L63-L78

---
Issue link: [AIRFLOW-6817](https://issues.apache.org/jira/browse/AIRFLOW-6817)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
