### PR TITLE
[AIRFLOW-6516] Allow different configmaps for airflow.cfg & airflow_l…

### DIFF
--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -726,7 +726,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         """
         Test that airflow_local_settings.py can be set via configmap by
         checking volume & volume-mounts are set correctly when using a different
-        configmap then airflow_configmap (airflow.cfg)
+        configmap than airflow_configmap (airflow.cfg)
         """
         self.kube_config.airflow_home = '/usr/local/airflow'
         self.kube_config.airflow_configmap = 'airflow-configmap'

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -108,7 +108,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         volumes = worker_config._get_volumes()
         volume_mounts = worker_config._get_volume_mounts()
         for volume_or_mount in volumes + volume_mounts:
-            if volume_or_mount.name != 'airflow-config':
+            if volume_or_mount.name not in ['airflow-config', 'airflow-local-settings']:
                 self.assertNotIn(
                     'subPath', self.api_client.sanitize_for_serialization(volume_or_mount),
                     "subPath shouldn't be defined"
@@ -720,6 +720,77 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                 }
             ],
             volume_mounts
+        )
+
+    def test_set_airflow_configmap_different_for_local_setting(self):
+        """
+        Test that airflow_local_settings.py can be set via configmap by
+        checking volume & volume-mounts are set correctly when using a different
+        configmap then airflow_configmap (airflow.cfg)
+        """
+        self.kube_config.airflow_home = '/usr/local/airflow'
+        self.kube_config.airflow_configmap = 'airflow-configmap'
+        self.kube_config.airflow_local_settings_configmap = 'airflow-ls-configmap'
+        self.kube_config.dags_folder = '/workers/path/to/dags'
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        pod = worker_config.as_pod()
+
+        pod_spec_dict = pod.spec.to_dict()
+
+        airflow_local_settings_volume = [
+            volume for volume in pod_spec_dict['volumes'] if volume["name"] == 'airflow-local-settings'
+        ]
+        # Test that volume_name is found
+        self.assertEqual(1, len(airflow_local_settings_volume))
+
+        # Test that config map exists
+        self.assertEqual(
+            {'default_mode': None, 'items': None, 'name': 'airflow-ls-configmap', 'optional': None},
+            airflow_local_settings_volume[0]['config_map']
+        )
+
+        # Test that 2 Volume Mounts exists and has 2 different mount-paths
+        # One for airflow.cfg
+        # Second for airflow_local_settings.py
+        airflow_cfg_volume_mount = [
+            volume_mount for volume_mount in pod_spec_dict['containers'][0]['volume_mounts']
+            if volume_mount['name'] == 'airflow-config'
+        ]
+
+        local_setting_volume_mount = [
+            volume_mount for volume_mount in pod_spec_dict['containers'][0]['volume_mounts']
+            if volume_mount['name'] == 'airflow-local-settings'
+        ]
+        self.assertEqual(1, len(airflow_cfg_volume_mount))
+        self.assertEqual(1, len(local_setting_volume_mount))
+
+        self.assertEqual(
+            [
+                {
+                    'mount_path': '/usr/local/airflow/config/airflow_local_settings.py',
+                    'mount_propagation': None,
+                    'name': 'airflow-local-settings',
+                    'read_only': True,
+                    'sub_path': 'airflow_local_settings.py',
+                    'sub_path_expr': None
+                }
+            ],
+            local_setting_volume_mount
+        )
+
+        self.assertEqual(
+            [
+                {
+                    'mount_path': '/usr/local/airflow/airflow.cfg',
+                    'mount_propagation': None,
+                    'name': 'airflow-config',
+                    'read_only': True,
+                    'sub_path': 'airflow.cfg',
+                    'sub_path_expr': None
+                }
+            ],
+            airflow_cfg_volume_mount
         )
 
     def test_kubernetes_environment_variables(self):


### PR DESCRIPTION
…ocal_settings.py (#7109)

https://github.com/apache/airflow/pull/7109 fixed a bug to allow airflow.cfg and airflow_local_settings.py to be specified in a configmap. However if someone wanted to use a different configmap for them, it would have resulted in an error **(Note I had already fixed this in the backport - https://github.com/apache/airflow/commit/adb409fd713d5c80c595d681d6a16f3ed892d5c2 and is already fixed in 1.10.8 and 1.10.9)**. This fix is for Airflow 2.0 and master


---
Issue link: [AIRFLOW-6516](https://issues.apache.org/jira/browse/AIRFLOW-6516)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
