### PR TITLE
[AIRFLOW-6895] AzureFileShareHook: Move DB call out of __init__

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
@@ -35,14 +35,16 @@ class AzureFileShareHook(BaseHook):
 
     def __init__(self, wasb_conn_id='wasb_default'):
         self.conn_id = wasb_conn_id
-        self.connection = self.get_conn()
+        self._conn = None
 
     def get_conn(self):
         """Return the FileService object."""
-        conn = self.get_connection(self.conn_id)
-        service_options = conn.extra_dejson
-        return FileService(account_name=conn.login,
-                           account_key=conn.password, **service_options)
+        if not self._conn:
+            conn = self.get_connection(self.conn_id)
+            service_options = conn.extra_dejson
+            self._conn = FileService(account_name=conn.login,
+                                     account_key=conn.password, **service_options)
+        return self._conn
 
     def check_for_directory(self, share_name, directory_name, **kwargs):
         """
@@ -58,7 +60,7 @@ class AzureFileShareHook(BaseHook):
         :return: True if the file exists, False otherwise.
         :rtype: bool
         """
-        return self.connection.exists(share_name, directory_name,
+        return self.get_conn().exists(share_name, directory_name,
                                       **kwargs)
 
     def check_for_file(self, share_name, directory_name, file_name, **kwargs):
@@ -77,7 +79,7 @@ class AzureFileShareHook(BaseHook):
         :return: True if the file exists, False otherwise.
         :rtype: bool
         """
-        return self.connection.exists(share_name, directory_name,
+        return self.get_conn().exists(share_name, directory_name,
                                       file_name, **kwargs)
 
     def list_directories_and_files(self, share_name, directory_name=None, **kwargs):
@@ -94,7 +96,7 @@ class AzureFileShareHook(BaseHook):
         :return: A list of files and directories
         :rtype: list
         """
-        return self.connection.list_directories_and_files(share_name,
+        return self.get_conn().list_directories_and_files(share_name,
                                                           directory_name,
                                                           **kwargs)
 
@@ -112,7 +114,7 @@ class AzureFileShareHook(BaseHook):
         :return: A list of files and directories
         :rtype: list
         """
-        return self.connection.create_directory(share_name, directory_name, **kwargs)
+        return self.get_conn().create_directory(share_name, directory_name, **kwargs)
 
     def get_file(self, file_path, share_name, directory_name, file_name, **kwargs):
         """
@@ -130,7 +132,7 @@ class AzureFileShareHook(BaseHook):
             `FileService.get_file_to_path()` takes.
         :type kwargs: object
         """
-        self.connection.get_file_to_path(share_name, directory_name,
+        self.get_conn().get_file_to_path(share_name, directory_name,
                                          file_name, file_path, **kwargs)
 
     def get_file_to_stream(self, stream, share_name, directory_name, file_name, **kwargs):
@@ -149,7 +151,7 @@ class AzureFileShareHook(BaseHook):
             `FileService.get_file_to_stream()` takes.
         :type kwargs: object
         """
-        self.connection.get_file_to_stream(share_name, directory_name,
+        self.get_conn().get_file_to_stream(share_name, directory_name,
                                            file_name, stream, **kwargs)
 
     def load_file(self, file_path, share_name, directory_name, file_name, **kwargs):
@@ -168,7 +170,7 @@ class AzureFileShareHook(BaseHook):
             `FileService.create_file_from_path()` takes.
         :type kwargs: object
         """
-        self.connection.create_file_from_path(share_name, directory_name,
+        self.get_conn().create_file_from_path(share_name, directory_name,
                                               file_name, file_path, **kwargs)
 
     def load_string(self, string_data, share_name, directory_name, file_name, **kwargs):
@@ -187,7 +189,7 @@ class AzureFileShareHook(BaseHook):
             `FileService.create_file_from_text()` takes.
         :type kwargs: object
         """
-        self.connection.create_file_from_text(share_name, directory_name,
+        self.get_conn().create_file_from_text(share_name, directory_name,
                                               file_name, string_data, **kwargs)
 
     def load_stream(self, stream, share_name, directory_name, file_name, count, **kwargs):
@@ -208,5 +210,5 @@ class AzureFileShareHook(BaseHook):
             `FileService.create_file_from_stream()` takes.
         :type kwargs: object
         """
-        self.connection.create_file_from_stream(share_name, directory_name,
+        self.get_conn().create_file_from_stream(share_name, directory_name,
                                                 file_name, stream, count, **kwargs)

--- a/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
@@ -51,6 +51,7 @@ class TestAzureFileshareHook(unittest.TestCase):
             )
         )
 
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_conn(self):
         from azure.storage.file import FileService
         hook = AzureFileShareHook(wasb_conn_id='wasb_test_key')

--- a/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
@@ -51,19 +51,11 @@ class TestAzureFileshareHook(unittest.TestCase):
             )
         )
 
-    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
-    def test_conn(self):
+    def test_key_and_connection(self):
         from azure.storage.file import FileService
         hook = AzureFileShareHook(wasb_conn_id='wasb_test_key')
+        self.assertEqual(hook.conn_id, 'wasb_test_key')
         self.assertIsNone(hook._conn)
-        self.assertEqual(hook.conn_id, 'wasb_test_key')
-        hook.get_conn()
-        self.assertIsInstance(hook._conn, FileService)
-
-    def test_key(self):
-        from azure.storage.file import FileService
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_key')
-        self.assertEqual(hook.conn_id, 'wasb_test_key')
         self.assertIsInstance(hook.get_conn(), FileService)
 
     def test_sas_token(self):

--- a/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
@@ -51,17 +51,25 @@ class TestAzureFileshareHook(unittest.TestCase):
             )
         )
 
+    def test_conn(self):
+        from azure.storage.file import FileService
+        hook = AzureFileShareHook(wasb_conn_id='wasb_test_key')
+        self.assertIsNone(hook._conn)
+        self.assertEqual(hook.conn_id, 'wasb_test_key')
+        hook.get_conn()
+        self.assertIsInstance(hook._conn, FileService)
+
     def test_key(self):
         from azure.storage.file import FileService
         hook = AzureFileShareHook(wasb_conn_id='wasb_test_key')
         self.assertEqual(hook.conn_id, 'wasb_test_key')
-        self.assertIsInstance(hook.connection, FileService)
+        self.assertIsInstance(hook.get_conn(), FileService)
 
     def test_sas_token(self):
         from azure.storage.file import FileService
         hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
         self.assertEqual(hook.conn_id, 'wasb_test_sas_token')
-        self.assertIsInstance(hook.connection, FileService)
+        self.assertIsInstance(hook.get_conn(), FileService)
 
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService',
                 autospec=True)


### PR DESCRIPTION
Currently, the Azure client is created in AzureFileShareHook.__init__ . This gets connection data from DB.



---
Issue link: [AIRFLOW-6895](https://issues.apache.org/jira/browse/AIRFLOW-6895)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
