### PR TITLE
[AIRFLOW-6896] AzureCosmosDBHook: Move DB call out of __init__

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -25,7 +25,7 @@ the default database and collection to use (see connection `azure_cosmos_default
 """
 import uuid
 
-import azure.cosmos.cosmos_client as cosmos_client
+from azure.cosmos.cosmos_client import CosmosClient
 from azure.cosmos.errors import HTTPFailure
 
 from airflow.exceptions import AirflowBadRequest
@@ -65,7 +65,7 @@ class AzureCosmosDBHook(BaseHook):
             self.default_collection_name = extras.get('collection_name')
 
             # Initialize the Python Azure Cosmos DB client
-            self._conn = cosmos_client.CosmosClient(endpoint_uri, {'masterKey': master_key})
+            self._conn = CosmosClient(endpoint_uri, {'masterKey': master_key})
         return self._conn
 
     def __get_database_name(self, database_name=None):

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -46,28 +46,30 @@ class AzureCosmosDBHook(BaseHook):
 
     def __init__(self, azure_cosmos_conn_id='azure_cosmos_default'):
         self.conn_id = azure_cosmos_conn_id
-        self.connection = self.get_connection(self.conn_id)
-        self.extras = self.connection.extra_dejson
+        self._conn = None
 
-        self.endpoint_uri = self.connection.login
-        self.master_key = self.connection.password
-        self.default_database_name = self.extras.get('database_name')
-        self.default_collection_name = self.extras.get('collection_name')
-        self.cosmos_client = None
+        self.default_database_name = None
+        self.default_collection_name = None
 
     def get_conn(self):
         """
         Return a cosmos db client.
         """
-        if self.cosmos_client is not None:
-            return self.cosmos_client
+        if not self._conn:
+            conn = self.get_connection(self.conn_id)
+            extras = conn.extra_dejson
+            endpoint_uri = conn.login
+            master_key = conn.password
 
-        # Initialize the Python Azure Cosmos DB client
-        self.cosmos_client = cosmos_client.CosmosClient(self.endpoint_uri, {'masterKey': self.master_key})
+            self.default_database_name = extras.get('database_name')
+            self.default_collection_name = extras.get('collection_name')
 
-        return self.cosmos_client
+            # Initialize the Python Azure Cosmos DB client
+            self._conn = cosmos_client.CosmosClient(endpoint_uri, {'masterKey': master_key})
+        return self._conn
 
     def __get_database_name(self, database_name=None):
+        self.get_conn()
         db_name = database_name
         if db_name is None:
             db_name = self.default_database_name
@@ -78,6 +80,7 @@ class AzureCosmosDBHook(BaseHook):
         return db_name
 
     def __get_collection_name(self, collection_name=None):
+        self.get_conn()
         coll_name = collection_name
         if coll_name is None:
             coll_name = self.default_collection_name

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -24,6 +24,7 @@ import unittest
 import uuid
 
 import mock
+from azure.cosmos.cosmos_client import CosmosClient
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
@@ -53,15 +54,14 @@ class TestAzureCosmosDbHook(unittest.TestCase):
             )
         )
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
-    def test_client(self):
-        import azure.cosmos.cosmos_client as cosmos_client
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient', autospec=True)
+    def test_client(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         self.assertIsNone(hook._conn)
         hook.get_conn()
-        self.assertIsInstance(hook._conn, cosmos_client.CosmosClient)
+        self.assertIsInstance(hook.get_conn(), CosmosClient)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_create_database(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.create_database(self.test_database_name)
@@ -69,17 +69,17 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
         mock_cosmos.assert_has_calls(expected_calls)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_create_database_exception(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         self.assertRaises(AirflowException, hook.create_database, None)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_create_container_exception(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         self.assertRaises(AirflowException, hook.create_collection, None)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_create_container(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.create_collection(self.test_collection_name, self.test_database_name)
@@ -89,7 +89,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
         mock_cosmos.assert_has_calls(expected_calls)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_create_container_default(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.create_collection(self.test_collection_name)
@@ -99,7 +99,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
         mock_cosmos.assert_has_calls(expected_calls)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_upsert_document_default(self, mock_cosmos):
         test_id = str(uuid.uuid4())
         mock_cosmos.return_value.CreateItem.return_value = {'id': test_id}
@@ -113,7 +113,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         logging.getLogger().info(returned_item)
         self.assertEqual(returned_item['id'], test_id)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_upsert_document(self, mock_cosmos):
         test_id = str(uuid.uuid4())
         mock_cosmos.return_value.CreateItem.return_value = {'id': test_id}
@@ -133,7 +133,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         logging.getLogger().info(returned_item)
         self.assertEqual(returned_item['id'], test_id)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_insert_documents(self, mock_cosmos):
         test_id1 = str(uuid.uuid4())
         test_id2 = str(uuid.uuid4())
@@ -157,9 +157,9 @@ class TestAzureCosmosDbHook(unittest.TestCase):
                 {'data': 'data3', 'id': test_id3})]
         logging.getLogger().info(returned_item)
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
-        mock_cosmos.assert_has_calls(expected_calls)
+        mock_cosmos.assert_has_calls(expected_calls, any_order=True)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_delete_database(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.delete_database(self.test_database_name)
@@ -167,7 +167,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
         mock_cosmos.assert_has_calls(expected_calls)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_delete_database_exception(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         self.assertRaises(AirflowException, hook.delete_database, None)
@@ -177,7 +177,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         self.assertRaises(AirflowException, hook.delete_collection, None)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_delete_container(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.delete_collection(self.test_collection_name, self.test_database_name)
@@ -185,7 +185,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
         mock_cosmos.assert_has_calls(expected_calls)
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_delete_container_default(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.delete_collection(self.test_collection_name)

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -58,7 +58,6 @@ class TestAzureCosmosDbHook(unittest.TestCase):
     def test_client(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         self.assertIsNone(hook._conn)
-        hook.get_conn()
         self.assertIsInstance(hook.get_conn(), CosmosClient)
 
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -54,6 +54,14 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         )
 
     @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    def test_client(self):
+        import azure.cosmos.cosmos_client as cosmos_client
+        hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        self.assertIsNone(hook._conn)
+        hook.get_conn()
+        self.assertIsInstance(hook._conn, cosmos_client.CosmosClient)
+
+    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
     def test_create_database(self, mock_cosmos):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.create_database(self.test_database_name)

--- a/tests/providers/microsoft/azure/operators/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_cosmos.py
@@ -49,7 +49,7 @@ class TestAzureCosmosDbHook(unittest.TestCase):
             )
         )
 
-    @mock.patch('azure.cosmos.cosmos_client.CosmosClient')
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_cosmos.CosmosClient')
     def test_insert_document(self, cosmos_mock):
         test_id = str(uuid.uuid4())
         cosmos_mock.return_value.CreateItem.return_value = {'id': test_id}


### PR DESCRIPTION
Currently, the Azure client is created in AzureCosmosDBHook.__init__ . This gets connection data from DB.



---
Issue link: [AIRFLOW-6896](https://issues.apache.org/jira/browse/AIRFLOW-6896)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
