### PR TITLE
[AIRFLOW-XXXX] correct path to script in TESTING.rst

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -339,7 +339,7 @@ After the Kubernetes Cluster is started, you need to deploy Airflow to the clust
 2. Load it to the Kubernetes cluster.
 3. Deploy the Airflow application.
 
-It can be done with a single script: ``./scripts/ci/in_container/kubernetes/deploy_airflow_to_kubernetes.sh``.
+It can be done with a single script: ``./scripts/ci/in_container/deploy_airflow_to_kubernetes.sh``.
 
 You can, however, work separately on the image in Kubernetes and deploying the Airflow app in the cluster.
 


### PR DESCRIPTION
Correcting path to `deploy_airflow_to_kubernetes.sh` in `TESTING.rst`

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
