### PR TITLE
[AIRFLOW-XXXX] Fix outdated doc on settings.policy

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -79,28 +79,26 @@ Session: Optional[SASession] = None
 json = json
 
 
-def policy(task_instance):
+def policy(task):
     """
-    This policy setting allows altering task instances right before they
+    This policy setting allows altering tasks right before they
     are executed. It allows administrator to rewire some task parameters.
 
-    Note that the ``TaskInstance`` object has an attribute ``task`` pointing
-    to its related task object, that in turns has a reference to the DAG
+    Note that the ``Task`` object has a reference to the DAG
     object. So you can use the attributes of all of these to define your
     policy.
 
     To define policy, add a ``airflow_local_settings`` module
     to your PYTHONPATH that defines this ``policy`` function. It receives
-    a ``TaskInstance`` object and can alter it where needed.
+    a ``Task`` object and can alter it where needed.
 
     Here are a few examples of how this can be useful:
 
     * You could enforce a specific queue (say the ``spark`` queue)
         for tasks using the ``SparkOperator`` to make sure that these
-        task instances get wired to the right workers
-    * You could force all task instances running on an
-        ``execution_date`` older than a week old to run in a ``backfill``
-        pool.
+        tasks get wired to the right workers
+    * You could enforce a task timeout policy, making sure that no tasks run
+        for more than 48 hours
     * ...
     """
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -21,7 +21,7 @@ import json
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import pendulum
 from sqlalchemy import create_engine, exc
@@ -35,9 +35,6 @@ from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # NOQA F
 from airflow.logging_config import configure_logging
 from airflow.utils.module_loading import import_string
 from airflow.utils.sqlalchemy import setup_event_handlers
-
-if TYPE_CHECKING:
-    from airflow.models.baseoperator import BaseOperator
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +79,7 @@ Session: Optional[SASession] = None
 json = json
 
 
-def policy(task: 'BaseOperator'):
+def policy(task):
     """
     This policy setting allows altering tasks right before they
     are executed. It allows administrator to rewire some task parameters.

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -21,7 +21,7 @@ import json
 import logging
 import os
 import sys
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import pendulum
 from sqlalchemy import create_engine, exc
@@ -33,9 +33,11 @@ from sqlalchemy.pool import NullPool
 # noinspection PyUnresolvedReferences
 from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # NOQA F401
 from airflow.logging_config import configure_logging
-from airflow.models.baseoperator import BaseOperator
 from airflow.utils.module_loading import import_string
 from airflow.utils.sqlalchemy import setup_event_handlers
+
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
 
 log = logging.getLogger(__name__)
 
@@ -80,7 +82,7 @@ Session: Optional[SASession] = None
 json = json
 
 
-def policy(task: BaseOperator):
+def policy(task: 'BaseOperator'):
     """
     This policy setting allows altering tasks right before they
     are executed. It allows administrator to rewire some task parameters.

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -21,7 +21,7 @@ import json
 import logging
 import os
 import sys
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import pendulum
 from sqlalchemy import create_engine, exc
@@ -35,6 +35,9 @@ from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # NOQA F
 from airflow.logging_config import configure_logging
 from airflow.utils.module_loading import import_string
 from airflow.utils.sqlalchemy import setup_event_handlers
+
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +82,7 @@ Session: Optional[SASession] = None
 json = json
 
 
-def policy(task):
+def policy(task: 'BaseOperator'):
     """
     This policy setting allows altering tasks right before they
     are executed. It allows administrator to rewire some task parameters.

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -21,7 +21,7 @@ import json
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import pendulum
 from sqlalchemy import create_engine, exc
@@ -33,11 +33,9 @@ from sqlalchemy.pool import NullPool
 # noinspection PyUnresolvedReferences
 from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # NOQA F401
 from airflow.logging_config import configure_logging
+from airflow.models.baseoperator import BaseOperator
 from airflow.utils.module_loading import import_string
 from airflow.utils.sqlalchemy import setup_event_handlers
-
-if TYPE_CHECKING:
-    from airflow.models.baseoperator import BaseOperator
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +80,7 @@ Session: Optional[SASession] = None
 json = json
 
 
-def policy(task: 'BaseOperator'):
+def policy(task: BaseOperator):
     """
     This policy setting allows altering tasks right before they
     are executed. It allows administrator to rewire some task parameters.


### PR DESCRIPTION
The policy is for **task** and not **task_instance**.

Original commit that introduced this feature: https://github.com/apache/airflow/commit/9368c719fccb246dfaa396fea2c592d57aeacf7f

Then it was updated in https://github.com/apache/airflow/commit/1c322b007ec24aeaf9889be44f057d38af3f6c49

We already have documentation on it:
- https://airflow.readthedocs.io/en/1.10.9/concepts.html#cluster-policy
- https://airflow.apache.org/docs/1.10.9/concepts.html#cluster-policy

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
