### PR TITLE
[AIRFLOW-6919] Make Breeze DAG-test friedly

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -362,8 +362,9 @@ After you run Breeze for the first time, you will have an empty directory ``file
 which will be mapped to ``/files`` in your Docker container. You can pass there any files you need to
 configure and run Docker. They will not be removed between Docker runs.
 
-If you wish to add local DAGs that can be run by Breeze, you can add the dags to ``/files/dags`` and then
-run ``export AIRFLOW__CORE__DAGS_FOLDER="/files/dags"`` once the container has started.
+By default ``/files/dags`` folder is mounted from your local ``<AIRFLOW_SOURCES>/files/dags`` and this is
+the directory used by airflow scheduler and webserver to scan dags for. You can use it to test your dags
+from local sources in Airflow. If you wish to add local DAGs that can be run by Breeze.
 
 Adding/Modifying Dependencies
 -----------------------------

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -631,6 +631,9 @@ Also, with the Airflow CLI command ``airflow dags test``, you can execute one co
     # airflow dags test [dag_id] [execution_date]
     airflow dags test example_branch_operator 2018-01-01
 
+By default ``/files/dags`` folder is mounted from your local ``<AIRFLOW_SOURCES>/files/dags`` and this is
+the directory used by airflow scheduler and webserver to scan dags for. You can place your dags there
+to test them.
 
 BASH Unit Testing (BATS)
 ========================

--- a/breeze
+++ b/breeze
@@ -213,8 +213,7 @@ function initialize_virtualenv() {
         echo
         echo "Resetting AIRFLOW sqlite unit test database"
         echo
-        export AIRFLOW__CORE__UNIT_TEST_MODE=True
-        airflow db reset -y
+        AIRFLOW__CORE__UNIT_TEST_MODE=True airflow db reset -y
         exit 0
    fi
 }

--- a/docs/howto/use-test-config.rst
+++ b/docs/howto/use-test-config.rst
@@ -21,7 +21,8 @@ Using the Test Mode Configuration
 =================================
 
 Airflow has a fixed set of "test mode" configuration options. You can load these
-at any time by calling ``airflow.configuration.load_test_config()``. Please **note** that this operation is **not reversible**.
+at any time by calling ``airflow.configuration.load_test_config()``. Please **note** that this
+operation is **not reversible**.
 
 Some options for example, ``DAG_FOLDER``, are loaded before you have a chance to call ``load_test_config()``.
 In order to eagerly load the test configuration, set ``test_mode`` in ``airflow.cfg``:
@@ -31,4 +32,5 @@ In order to eagerly load the test configuration, set ``test_mode`` in ``airflow.
   [tests]
   unit_test_mode = True
 
-Due to Airflow's automatic environment variable expansion (see :doc:`set-config`), you can also set the environment variable ``AIRFLOW__CORE__UNIT_TEST_MODE`` to temporarily overwrite ``airflow.cfg``.
+Due to Airflow's automatic environment variable expansion (see :doc:`set-config`), you can also set the
+environment variable ``AIRFLOW__CORE__UNIT_TEST_MODE`` to temporarily overwrite ``airflow.cfg``.

--- a/scripts/ci/in_container/entrypoint_ci.sh
+++ b/scripts/ci/in_container/entrypoint_ci.sh
@@ -101,6 +101,9 @@ fi
 # Added to have run-tests on path
 export PATH=${PATH}:${AIRFLOW_SOURCES}
 
+# This is now set in conftest.py - only for pytest tests
+unset AIRFLOW__CORE__UNIT_TEST_MODE
+
 # Fix codecov build path
 # TODO: Check this - this should be made travis-independent
 if [[ ! -h /home/travis/build/apache/airflow ]]; then
@@ -176,6 +179,19 @@ export FILES_DIR="/files"
 export AIRFLOW_BREEZE_CONFIG_DIR="${FILES_DIR}/airflow-breeze-config"
 VARIABLES_ENV_FILE="variables.env"
 
+if [[ -d "${FILES_DIR}" ]]; then
+    export AIRFLOW__CORE__DAGS_FOLDER="/files/dags"
+    mkdir -pv "${AIRFLOW__CORE__DAGS_FOLDER}"
+    sudo chown "${HOST_USER_ID}":"${HOST_GROUP_ID}" "${AIRFLOW__CORE__DAGS_FOLDER}"
+    echo "Your dags for webserver and scheduler are read from ${AIRFLOW__CORE__DAGS_FOLDER} directory"
+    echo "which is mounted from your <AIRFLOW_SOURCES>/files/dags folder"
+    echo
+else
+    export AIRFLOW__CORE__DAGS_FOLDER="${AIRFLOW_HOME}/dags"
+    echo "Your dags for webserver and scheduler are read from ${AIRFLOW__CORE__DAGS_FOLDER} directory"
+fi
+
+
 if [[ -d "${AIRFLOW_BREEZE_CONFIG_DIR}" && \
     -f "${AIRFLOW_BREEZE_CONFIG_DIR}/${VARIABLES_ENV_FILE}" ]]; then
     pushd "${AIRFLOW_BREEZE_CONFIG_DIR}" >/dev/null 2>&1 || exit 1
@@ -191,6 +207,7 @@ else
     echo "In it to make breeze source the variables automatically for you"
     echo
 fi
+
 
 set +u
 # If we do not want to run tests, we simply drop into bash


### PR DESCRIPTION
Originally Breeze was used to run unit and integration tests, recently system
tests and finally we make it a bit more friendly to test  your DAGs there. You
can now install any older airflow version in Breeze via
--install-airflow-version switch and "files/dags" folder is mounted to
"/files/dags" and this folder is used to read the dags from.

---
Issue link: [AIRFLOW-6919](https://issues.apache.org/jira/browse/AIRFLOW-6919)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
