### PR TITLE
[AIRFLOW-XXXX] Block PR Merge if it has DONT-MERGE in title

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -21,12 +21,13 @@ mergeable:
     validate:
       - do: title
         # Do not merge when it is marked work in progress (WIP)
-        must_exclude:
-          regex: ^\[WIP\]
-          message: This is work in progress. Do not merge yet.
-        must_exclude:
-          regex: ^\[DONT-MERGE\]
-          message: Do not merge this PR yet.  
+        or:
+          - must_exclude:
+              regex: ^\[WIP\]
+              message: This is work in progress. Do not merge yet.
+          - must_exclude:
+              regex: ^\[DONT-MERGE\]
+              message: Do not merge this PR yet.  
         begins_with:
           match: '[AIRFLOW-'
         must_include:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -24,6 +24,9 @@ mergeable:
         must_exclude:
           regex: ^\[WIP\]
           message: This is work in progress. Do not merge yet.
+        must_exclude:
+          regex: ^\[DONT-MERGE\]
+          message: Do not merge this PR yet.  
         begins_with:
           match: '[AIRFLOW-'
         must_include:


### PR DESCRIPTION
Block PR Merge if it has DONT-MERGE in title

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
