### PR TITLE
[AIRFLOW-5354] Reduce scheduler CPU usage from 100%

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -371,7 +371,7 @@ class DagFileProcessorAgent(LoggingMixin):
 
     def wait_until_finished(self):
         """Waits until DAG parsing is finished."""
-        while self._parent_signal_conn.poll():
+        while self._parent_signal_conn.poll(timeout=None):
             try:
                 result = self._parent_signal_conn.recv()
             except EOFError:
@@ -426,7 +426,7 @@ class DagFileProcessorAgent(LoggingMixin):
         :return: List of parsing result in SimpleDag format.
         """
         # Receive any pending messages before checking if the process has exited.
-        while self._parent_signal_conn.poll():
+        while self._parent_signal_conn.poll(timeout=0.01):
             try:
                 result = self._parent_signal_conn.recv()
             except (EOFError, ConnectionError):


### PR DESCRIPTION
A previous change ended up with the scheduler busily checking if the
DagFDagFileProcessorAgent had collected any dags. This simple change
takes the CPU usage of the scheduler from an entire core, to barely
anything (dropped below 5%).

Time for 10 dag runs of 9 dags with 108 total tasks: 50.3581s (±9.538s)
vs master of Time for 10 dag runs of 9 dags with 108 total tasks: 49.6910s (±7.193s)

The change is is basically no overall change, and is a quick fix for
now, and bigger changes are in store around DAG parsing anyway.


---
Issue link: [AIRFLOW-5354](https://issues.apache.org/jira/browse/AIRFLOW-5354)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.