### PR TITLE
[AIRFLOW-XXXX] Fix broken static check for BREEZE.rst

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -792,7 +792,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   -s, --kind-cluster-start
           Starts kind Kubernetes cluster after entering the environment. The cluster is started using
-          Kubernetes Mode selected and Kubernetes version specifed via --kubernetes-mode and
+          Kubernetes Mode selected and Kubernetes version specified via --kubernetes-mode and
           --kubernetes-version flags.
 
   -x, --kind-cluster-stop

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -792,7 +792,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   -s, --kind-cluster-start
           Starts kind Kubernetes cluster after entering the environment. The cluster is started using
-          Kubernetes Mode selected and Kubernetes version specified via --kubernetes-mode and
+          Kubernetes Mode selected and Kubernetes version specifed via --kubernetes-mode and
           --kubernetes-version flags.
 
   -x, --kind-cluster-stop

--- a/breeze
+++ b/breeze
@@ -1078,7 +1078,7 @@ Acion for the cluster : only one of the --kind-cluster-* flags can be used at a 
 
 -s, --kind-cluster-start
         Starts kind Kubernetes cluster after entering the environment. The cluster is started using
-        Kubernetes Mode selected and Kubernetes version specifed via --kubernetes-mode and
+        Kubernetes Mode selected and Kubernetes version specified via --kubernetes-mode and
         --kubernetes-version flags.
 
 -x, --kind-cluster-stop


### PR DESCRIPTION
Was broken in https://github.com/apache/airflow/commit/0a77f9fed1b1c3a1ebacd5db38d0ecdc8c161980

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
