### PR TITLE
[AIRFLOW-6932] Add restart-environment command to Breeze

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -224,6 +224,15 @@ You can always stop it via:
 
    ./breeze stop-environment
 
+Restarting Breeze
+-----------------
+
+You can also  restart the environment and enter it via:
+
+.. code-block:: bash
+
+   ./breeze restart-environment
+
 Choosing a Breeze Environment
 -----------------------------
 
@@ -260,7 +269,7 @@ to start more than one integration at a time.
 Finally you can specify ``--integration all`` to start all integrations.
 
 Once integration is started, it will continue to run until the environment is stopped with
-``breeze stop-environment`` command.
+``breeze stop-environment`` command. or restarted via ``breeze restart-environment`` command
 
 Note that running integrations uses significant resources - CPU and memory.
 
@@ -582,6 +591,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
     initialize-local-virtualenv              Initializes local virtualenv
     setup-autocomplete                       Sets up autocomplete for breeze
     stop-environment                         Stops the docker-compose evironment
+    restart-environment                      Stops the docker-compose evironment including DB cleanup
     toggle-suppress-cheatsheet               Toggles on/off cheatsheet
     toggle-suppress-asciiart                 Toggles on/off asciiart
 
@@ -660,6 +670,12 @@ This is the current syntax for  `./breeze <./breeze>`_:
         Brings down running docker compose environment. When you start the environment, the docker
         containers will continue running so that startup time is shorter. But they take quite a lot of
         memory and CPU. This command stops all running containers from the environment.
+  ****************************************************************************************************
+  breeze [FLAGS] restart-environment -- <EXTRA_ARGS>
+
+        Restarts running docker compose environment. When you restart the environment, the docker
+        containers will be restarted. That includes cleaning up the databases. This is
+        especially useful if you switch between different versions of airflow.
   ****************************************************************************************************
   breeze [FLAGS] toggle-suppress-cheatsheet -- <EXTRA_ARGS>
 
@@ -842,7 +858,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           If different than 'current' removes the source-installed airflow and installs a
           released version of Airflow instead. One of:
 
-                 current 1.10.9 1.10.8 1.10.7 1.10.6 1.10.5 1.10.4 1.10.3 1.10.2 1.10.1
+                 current 1.10.9 1.10.8 1.10.7 1.10.6 1.10.5 1.10.4 1.10.3 1.10.2
 
           Default: current.
 
@@ -940,7 +956,7 @@ If you are having problems with the Breeze environment, try the steps below. Aft
 can check whether your problem is fixed.
 
 1. If you are on macOS, check if you have enough disk space for Docker.
-2. Stop Breeze with ``./breeze stop-environment``.
+2. Restart Breeze with ``./breeze restart-environment``.
 3. Delete the ``.build`` directory and run ``./breeze build-only --force-pull-images``.
 4. `Clean up Docker images <#cleaning-up-the-images>`_.
 5. Restart your Docker Engine and try again.

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -169,8 +169,9 @@ switch when starting Breeze. You can specify multiple integrations by repeating 
 or by using the ``--integration all`` switch that enables all integrations.
 
 NOTE: Every integration requires a separate container with the corresponding integration image.
-So, they take precious resources on your PC, mainly, the memory. The started integrations are not stopped
-until you stop the Breeze environment with the ``--stop-environment`` switch.
+They take precious resources on your PC, mainly the memory. The started integrations are not stopped
+until you stop the Breeze environment with the ``stop-environment`` command  and restart it
+via ``restart-environment`` command.
 
 The following integrations are available:
 
@@ -634,6 +635,18 @@ Also, with the Airflow CLI command ``airflow dags test``, you can execute one co
 By default ``/files/dags`` folder is mounted from your local ``<AIRFLOW_SOURCES>/files/dags`` and this is
 the directory used by airflow scheduler and webserver to scan dags for. You can place your dags there
 to test them.
+
+The DAGs can be run in the master version of Airflow but they also work
+with older versions.
+
+To run the tests for Airflow 1.10.* series, you need to run Breeze with
+``--install-airflow-version==<VERSION>`` to install a different version of Airflow.
+If ``current`` is specified (default), then the current version of Airflow is used.
+Otherwise, the released version of Airflow is installed.
+
+You should also consider running it with ``restart-environment`` command when you change installed version.
+This will clean-up the database so that you start with a clean DB and not DB installed in a previous version.
+So typically you'd run it like ``breeze --install-ariflow-version=1.10.9 restart-environment``.
 
 BASH Unit Testing (BATS)
 ========================

--- a/breeze
+++ b/breeze
@@ -34,6 +34,7 @@ declare -a EXTRA_STATIC_CHECK_OPTIONS
 function setup_default_breeze_variables() {
     # Whether to actually run docker compose with the command set given
     COMMAND_TO_RUN="enter_breeze"
+    SECOND_COMMAND_TO_RUN=""
     export BREEZE=true
     export MAX_SCREEN_WIDTH=100
 
@@ -751,6 +752,14 @@ function parse_arguments() {
           DOCKER_COMPOSE_COMMAND="down"
           EXTRA_DC_OPTIONS+=("--remove-orphans")
           shift ;;
+        restart-environment)
+          LAST_SUBCOMMAND="${1}"
+          COMMAND_TO_RUN="run_docker_compose"
+          DOCKER_COMPOSE_COMMAND="down"
+          EXTRA_DC_OPTIONS+=("--remove-orphans")
+          SECOND_COMMAND_TO_RUN="enter_breeze"
+          echo "Restarts the environment. Includes emptying the databases."
+          shift ;;
         test-target)
           LAST_SUBCOMMAND="${1}"
           if [[ "${TEST_TARGET}" == "." ]]; then
@@ -846,6 +855,7 @@ prepare_usage() {
     export USAGE_INITIALIZE_LOCAL_VIRTUALENV="Initializes local virtualenv"
     export USAGE_SETUP_AUTOCOMPLETE="Sets up autocomplete for breeze"
     export USAGE_STOP_ENVIRONMENT="Stops the docker-compose evironment"
+    export USAGE_RESTART_ENVIRONMENT="Stops the docker-compose evironment including DB cleanup"
     export USAGE_STATIC_CHECK="Performs selected static check for changed files"
     export USAGE_STATIC_CHECK_ALL_FILES="Performs selected static check for all files"
     export USAGE_TOGGLE_SUPPRESS_CHEATSHEET="Toggles on/off cheatsheet"
@@ -922,6 +932,11 @@ prepare_usage() {
       Brings down running docker compose environment. When you start the environment, the docker
       containers will continue running so that startup time is shorter. But they take quite a lot of
       memory and CPU. This command stops all running containers from the environment.
+"
+    export DETAILED_USAGE_RESTART_ENVIRONMENT="
+      Restarts running docker compose environment. When you restart the environment, the docker
+      containers will be restarted. That includes cleaning up the databases. This is
+      especially useful if you switch between different versions of airflow.
 "
     export DETAILED_USAGE_STATIC_CHECK="
       Run selected static checks for currently changed files. You should specify static check that
@@ -1509,3 +1524,9 @@ print_setup_instructions
 
 set +u  # Account for an empty array
 run_breeze_command "${REMAINING_ARGS[@]}"
+
+set +u  # Account for an empty array
+if [[ -n ${SECOND_COMMAND_TO_RUN} ]]; then
+    COMMAND_TO_RUN=${SECOND_COMMAND_TO_RUN}
+    run_breeze_command "${REMAINING_ARGS[@]}"
+fi

--- a/breeze-complete
+++ b/breeze-complete
@@ -33,7 +33,6 @@ current
 1.10.4
 1.10.3
 1.10.2
-1.10.1
 EOF
 )
 
@@ -94,6 +93,7 @@ cleanup-images
 initialize-local-virtualenv
 setup-autocomplete
 stop-environment
+restart-environment
 toggle-suppress-cheatsheet
 toggle-suppress-asciiart"
 

--- a/scripts/ci/in_container/_in_container_utils.sh
+++ b/scripts/ci/in_container/_in_container_utils.sh
@@ -356,5 +356,9 @@ function install_released_airflow_version() {
     if [[ ${1} == "1.10.2" || ${1} == "1.10.1" ]]; then
         export SLUGIFY_USES_TEXT_UNIDECODE=yes
     fi
-    pip install "apache-airflow==${1}"
+    INSTALLS=("apache-airflow==${1}" "werkzeug<1.0.0")
+    if [[ ${1} == "1.10.2" || ${1} == "1.10.1" ]]; then
+        echo
+    fi
+    pip install --upgrade "${INSTALLS[@]}"
 }

--- a/scripts/ci/in_container/entrypoint_ci.sh
+++ b/scripts/ci/in_container/entrypoint_ci.sh
@@ -127,9 +127,8 @@ if [[ ${INTEGRATION_KERBEROS:="false"} == "true" ]]; then
         echo
         echo "ERROR !!!!Kerberos initialisation requested, but failed"
         echo
-        echo "I will exit now, and you need to run 'breeze --stop-environment' to kill kerberos."
-        echo
-        echo "Then you can again run 'breeze --integration kerberos' to start it again"
+        echo "I will exit now, and you need to run 'breeze --integration kerberos restart-environment'"
+        echo "to re-enter breeze and restart kerberos."
         echo
         exit 1
     fi


### PR DESCRIPTION
When you switch between versions of Aiflow installed, you want to delete the
database so that the scripts for resetdb work

---
Issue link: [AIRFLOW-6932](https://issues.apache.org/jira/browse/AIRFLOW-6932)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
