### PR TITLE
[AIRFLOW-6935] Pass the SchedulerJob configuration using the constructor

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -53,6 +53,8 @@ class LocalTaskJob(BaseJob):
             pickle_id: Optional[str] = None,
             pool: Optional[str] = None,
             *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self.task_instance = task_instance
         self.dag_id = task_instance.dag_id
         self.ignore_all_deps = ignore_all_deps
@@ -67,8 +69,6 @@ class LocalTaskJob(BaseJob):
         # terminating state is used so that a job don't try to
         # terminate multiple times
         self.terminating = False
-
-        super().__init__(*args, **kwargs)
 
     def _execute(self):
         self.task_runner = get_task_runner(self)

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1057,7 +1057,10 @@ class SchedulerJob(BaseJob):
         if grace_multiplier is not None:
             # Accept the same behaviour as superclass
             return super().is_alive(grace_multiplier=grace_multiplier)
-
+        # The object can be retrieved from the database, so it does not contain all the attributes.
+        self.scheduler_health_check_threshold = conf.getint(
+            'scheduler', 'scheduler_health_check_threshold'
+        )
         return (
             self.state == State.RUNNING and
             (timezone.utcnow() - self.latest_heartbeat).seconds < self.scheduler_health_check_threshold


### PR DESCRIPTION
It is difficult to understand the configurations of these classes if they contain hidden configuration options. All configuration parameters should be passed by the constructor. It also forces each option to be documented and prevents it from reading in the loop, which is expensive.

---
Issue link: [AIRFLOW-6935](https://issues.apache.org/jira/browse/AIRFLOW-6935)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
