### PR TITLE
[AIRFLOW-6937] Inline _get_simple_dags method in SchedulerJob

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1506,9 +1506,6 @@ class SchedulerJob(BaseJob):
             self.processor_agent.end()
             self.log.info("Exited execute loop")
 
-    def _get_simple_dags(self):
-        return self.processor_agent.harvest_simple_dags()
-
     def _execute_helper(self):
         """
         The actual scheduler loop. The main steps in the loop are:
@@ -1552,7 +1549,7 @@ class SchedulerJob(BaseJob):
                 self.log.debug("Waiting for processors to finish since we're using sqlite")
                 self.processor_agent.wait_until_finished()
 
-            simple_dags = self._get_simple_dags()
+            simple_dags = self.processor_agent.harvest_simple_dags()
 
             self.log.debug("Harvested %d SimpleDAGs", len(simple_dags))
 


### PR DESCRIPTION
This method has an inaccurate name and is very short. It is only used once. I don't think it's needed.  

---
Issue link: [AIRFLOW-6937](https://issues.apache.org/jira/browse/AIRFLOW-6937)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
