### PR TITLE
[AIRFLOW-6938] Don't read dag_directory in SchedulerJob

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -51,7 +51,6 @@ from airflow.utils.dag_processing import (
     AbstractDagFileProcessorProcess, DagFileProcessorAgent, SimpleDag, SimpleDagBag,
 )
 from airflow.utils.email import get_email_address_list, send_email
-from airflow.utils.file import list_py_file_paths
 from airflow.utils.log.logging_mixin import LoggingMixin, StreamLogWriter, set_context
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
@@ -1472,11 +1471,6 @@ class SchedulerJob(BaseJob):
 
         self.log.info("Processing each file at most %s times", self.num_runs)
 
-        # Build up a list of Python files that could contain DAGs
-        self.log.info("Searching for files in %s", self.subdir)
-        known_file_paths = list_py_file_paths(self.subdir)
-        self.log.info("There are %s files in %s", len(known_file_paths), self.subdir)
-
         def processor_factory(file_path, zombies):
             return DagFileProcessorProcess(
                 file_path=file_path,
@@ -1492,7 +1486,6 @@ class SchedulerJob(BaseJob):
         processor_timeout_seconds = conf.getint('core', 'dag_file_processor_timeout')
         processor_timeout = timedelta(seconds=processor_timeout_seconds)
         self.processor_agent = DagFileProcessorAgent(self.subdir,
-                                                     known_file_paths,
                                                      self.num_runs,
                                                      processor_factory,
                                                      processor_timeout,

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -141,7 +141,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
     def test_set_file_paths_when_processor_file_path_not_in_new_file_paths(self):
         manager = DagFileProcessorManager(
             dag_directory='directory',
-            file_paths=['abc.txt'],
             max_runs=1,
             processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
@@ -162,7 +161,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
     def test_set_file_paths_when_processor_file_path_is_in_new_file_paths(self):
         manager = DagFileProcessorManager(
             dag_directory='directory',
-            file_paths=['abc.txt'],
             max_runs=1,
             processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
@@ -182,7 +180,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
     def test_find_zombies(self):
         manager = DagFileProcessorManager(
             dag_directory='directory',
-            file_paths=['abc.txt'],
             max_runs=1,
             processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
@@ -281,7 +278,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
                                          'test_example_bash_operator.py')
             async_mode = 'sqlite' not in conf.get('core', 'sql_alchemy_conn')
             processor_agent = DagFileProcessorAgent(test_dag_path,
-                                                    [],
                                                     1,
                                                     processor_factory,
                                                     timedelta.max,
@@ -305,7 +301,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         mock_pid.return_value = 1234
         manager = DagFileProcessorManager(
             dag_directory='directory',
-            file_paths=['abc.txt'],
             max_runs=1,
             processor_factory=MagicMock().return_value,
             processor_timeout=timedelta(seconds=5),
@@ -324,7 +319,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         mock_pid.return_value = 1234
         manager = DagFileProcessorManager(
             dag_directory='directory',
-            file_paths=['abc.txt'],
             max_runs=1,
             processor_factory=MagicMock().return_value,
             processor_timeout=timedelta(seconds=5),
@@ -376,7 +370,6 @@ class TestDagFileProcessorAgent(unittest.TestCase):
 
             # Starting dag processing with 0 max_runs to avoid redundant operations.
             processor_agent = DagFileProcessorAgent(test_dag_path,
-                                                    [],
                                                     0,
                                                     processor_factory,
                                                     timedelta.max,
@@ -401,7 +394,6 @@ class TestDagFileProcessorAgent(unittest.TestCase):
         test_dag_path = os.path.join(TEST_DAG_FOLDER, 'test_scheduler_dags.py')
         async_mode = 'sqlite' not in conf.get('core', 'sql_alchemy_conn')
         processor_agent = DagFileProcessorAgent(test_dag_path,
-                                                [test_dag_path],
                                                 1,
                                                 processor_factory,
                                                 timedelta.max,
@@ -436,7 +428,6 @@ class TestDagFileProcessorAgent(unittest.TestCase):
 
         # Starting dag processing with 0 max_runs to avoid redundant operations.
         processor_agent = DagFileProcessorAgent(test_dag_path,
-                                                [],
                                                 0,
                                                 processor_factory,
                                                 timedelta.max,


### PR DESCRIPTION
This change separates two SchedulerJob from files. I want to sort out the code.

---
Issue link: [AIRFLOW-6938](https://issues.apache.org/jira/browse/AIRFLOW-6938)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
