### PR TITLE
[AIRFLOW-6941] Add queries count test for create_dagrun

### DIFF
--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1346,7 +1346,7 @@ class TestDag(unittest.TestCase):
         self.assertNotEqual(hash(dag_subclass), hash(dag))
 
 
-class TestPerformance(unittest.TestCase):
+class TestQueries(unittest.TestCase):
 
     def setUp(self) -> None:
         clear_db_runs()

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -30,6 +30,7 @@ from unittest.mock import patch
 
 import pendulum
 from dateutil.relativedelta import relativedelta
+from parameterized import parameterized
 from pendulum import utcnow
 
 from airflow import models, settings
@@ -48,6 +49,8 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime as datetime_tz
 from airflow.utils.weight_rule import WeightRule
 from tests.models import DEFAULT_DATE
+from tests.test_utils.asserts import assert_queries_count
+from tests.test_utils.db import clear_db_runs
 
 
 class TestDag(unittest.TestCase):
@@ -1341,3 +1344,26 @@ class TestDag(unittest.TestCase):
         self.assertEqual(hash(dag_eq), hash(dag))
         self.assertNotEqual(hash(dag_diff_name), hash(dag))
         self.assertNotEqual(hash(dag_subclass), hash(dag))
+
+
+class TestPerformance(unittest.TestCase):
+
+    def setUp(self) -> None:
+        clear_db_runs()
+
+    def tearDown(self) -> None:
+        clear_db_runs()
+
+    @parameterized.expand([
+        (3, ),
+        (12, ),
+    ])
+    def test_count_number_queries(self, tasks_count):
+        dag = DAG('test_dagrun_query_count', start_date=DEFAULT_DATE)
+        for i in range(tasks_count):
+            DummyOperator(task_id=f'dummy_task_{i}', owner='test', dag=dag)
+        with assert_queries_count(3):
+            dag.create_dagrun(
+                run_id="test_dagrun_query_count",
+                state=State.RUNNING
+            )

--- a/tests/test_utils/asserts.py
+++ b/tests/test_utils/asserts.py
@@ -20,7 +20,8 @@ from contextlib import contextmanager
 
 from sqlalchemy import event
 
-from airflow.settings import engine
+# Long import to not create a copy of the reference, but to refer to one place.
+import airflow.settings
 
 
 def assert_equal_ignore_multiple_spaces(case, first, second, msg=None):
@@ -45,11 +46,11 @@ class CountQueries:
         self.result = CountQueriesResult()
 
     def __enter__(self):
-        event.listen(engine, "after_cursor_execute", self.after_cursor_execute)
+        event.listen(airflow.settings.engine, "after_cursor_execute", self.after_cursor_execute)
         return self.result
 
     def __exit__(self, type_, value, traceback):
-        event.remove(engine, "after_cursor_execute", self.after_cursor_execute)
+        event.remove(airflow.settings.engine, "after_cursor_execute", self.after_cursor_execute)
 
     def after_cursor_execute(self, *args, **kwargs):
         self.result.count += 1


### PR DESCRIPTION
This test prevents regression for https://github.com/apache/airflow/pull/7510

---
Issue link: [AIRFLOW-6941](https://issues.apache.org/jira/browse/AIRFLOW-6941)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
