### PR TITLE
[AIRFLOW-6949] Respect explicit `spark.kubernetes.namespace` conf to SparkSubmitOperator

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -125,7 +125,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                  env_vars=None,
                  verbose=False,
                  spark_binary=None):
-        self._conf = conf
+        self._conf = conf or {}
         self._conn_id = conn_id
         self._files = files
         self._py_files = py_files
@@ -208,6 +208,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 self._conn_id, conn_data['master']
             )
 
+        if 'spark.kubernetes.namespace' in self._conf:
+            conn_data['namespace'] = self._conf['spark.kubernetes.namespace']
+
         return conn_data
 
     def get_conn(self):
@@ -247,9 +250,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         # The url of the spark master
         connection_cmd += ["--master", self._connection['master']]
 
-        if self._conf:
-            for key in self._conf:
-                connection_cmd += ["--conf", "{}={}".format(key, str(self._conf[key]))]
+        for key in self._conf:
+            connection_cmd += ["--conf", "{}={}".format(key, str(self._conf[key]))]
         if self._env_vars and (self._is_kubernetes or self._is_yarn):
             if self._is_yarn:
                 tmpl = "spark.yarn.appMasterEnv.{}={}"

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -356,6 +356,30 @@ class TestSparkSubmitHook(unittest.TestCase):
         self.assertEqual(dict_cmd["--master"], "k8s://https://k8s-master")
         self.assertEqual(dict_cmd["--deploy-mode"], "cluster")
 
+    def test_resolve_connection_spark_k8s_cluster_ns_conf(self):
+        # Given we specify the config option directly
+        conf = {
+            'spark.kubernetes.namespace': 'airflow',
+        }
+        hook = SparkSubmitHook(conn_id='spark_k8s_cluster', conf=conf)
+
+        # When
+        connection = hook._resolve_connection()
+        cmd = hook._build_spark_submit_command(self._spark_job_file)
+
+        # Then
+        dict_cmd = self.cmd_args_to_dict(cmd)
+        expected_spark_connection = {"spark_home": "/opt/spark",
+                                     "queue": None,
+                                     "spark_binary": "spark-submit",
+                                     "master": "k8s://https://k8s-master",
+                                     "deploy_mode": "cluster",
+                                     "namespace": "airflow"}
+        self.assertEqual(connection, expected_spark_connection)
+        self.assertEqual(dict_cmd["--master"], "k8s://https://k8s-master")
+        self.assertEqual(dict_cmd["--deploy-mode"], "cluster")
+        self.assertEqual(dict_cmd["--conf"], "spark.kubernetes.namespace=airflow")
+
     def test_resolve_connection_spark_home_set_connection(self):
         # Given
         hook = SparkSubmitHook(conn_id='spark_home_set')


### PR DESCRIPTION
This means the value from the Operator/dag file takes precedence over
the connection

The previous behaviour was to emit one line from the conf arg, but then
a later one from the connection:


Example operator from original reporter:

```
   worker_events_job = SparkSubmitOperator(
        task_id="worker_events_job",
        application="s3a://spark-jobs/twilio/worker_events.py",
        conn_id="spark-default",
        driver_memory="2g",
        executor_cores="4",
        executor_memory="4g",
        conf={
            "spark.kubernetes.authenticate.driver.serviceAccountName": "spark",
            "spark.kubernetes.container.image": "1234.dkr.ecr.us-east-1.amazonaws.com/spark:0.0.1",
            "spark.kubernetes.container.image.pullPolicy": "Always",
            "spark.kubernetes.namespace": "airflow",
            "spark.driver.cores": "2"
        }
    )
```

and it produced this (wrong) spark-submit command:
```
--conf spark.kubernetes.namespace=airflow \
--conf spark.kubernetes.namespace=default \
```



---
Issue link: [AIRFLOW-6949](https://issues.apache.org/jira/browse/AIRFLOW-6949)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.