### PR TITLE
[AIRFLOW-6856] BugFix: Paused Dags still Scheduled

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -818,6 +818,8 @@ class DagFileProcessor(LoggingMixin):
             .all()
         )
 
+        paused_dag_ids = set(paused_dag_id for paused_dag_id, in paused_dag_ids)
+
         # Pickle the DAGs (if necessary) and put them into a SimpleDag
         for dag_id, dag in dagbag.dags.items():
             # Only return DAGs that are not paused


### PR DESCRIPTION
https://github.com/apache/airflow/pull/7476/ introduced a bug due to which Paused Dags where still Scheduled.

The Bug is the following query returns a list of sets:

Query:
```python
paused_dag_ids = (
            session.query(DagModel.dag_id)
            .filter(DagModel.is_paused.is_(True))
            .filter(DagModel.dag_id.in_(dagbag.dag_ids))
            .all()
        )
```

Result:
```python
[('example_bash_operator',)]
```
Hence in `_find_dags_to_process()` (below):

```python
        if len(self.dag_ids) > 0:
            dags = [dag for dag in dags
                    if dag.dag_id in self.dag_ids and
                    dag.dag_id not in paused_dag_ids]
        else:
            dags = [dag for dag in dags
                    if dag.dag_id not in paused_dag_ids]
        return dags
``` 

following happens:

```python
dags = [dag for dag in dags if "example_bash_operator" not in [('example_bash_operator',)] ] 
```
This evaluates to false. Instead `paused_dag_ids` should be `{'example_bash_operator'}` (A set) or just a list `['example_bash_operator']`

Simplified Problem and solution:

```python
In [1]: a = [('example_bash_operator',)]

In [2]: b = 'example_bash_operator'

In [3]: set(aa for aa in a)
Out[3]: {('example_bash_operator',)}

In [4]: b in a
Out[4]: False

In [5]: set(aa for aa, in a)
Out[5]: {'example_bash_operator'}

In [6]: b in set(aa for aa, in a)
Out[6]: True
```

---
Issue link: [AIRFLOW-6856](https://issues.apache.org/jira/browse/AIRFLOW-6856)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
