### PR TITLE
[AIRFLOW-6952] Use property for dag default_view

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1512,7 +1512,7 @@ class DAG(BaseDag, LoggingMixin):
                 orm_dag.owners = dag.owner
             orm_dag.is_active = True
             orm_dag.last_scheduler_run = sync_time
-            orm_dag.default_view = dag._default_view
+            orm_dag.default_view = dag.default_view
             orm_dag.description = dag.description
             orm_dag.schedule_interval = dag.schedule_interval
             orm_dag.tags = dag.get_dagtags(session=session)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -128,7 +128,7 @@ class TestDag(unittest.TestCase):
             dag_id='test-default_default_view'
         )
         self.assertEqual(conf.get('webserver', 'dag_default_view').lower(),
-                         dag._default_view)
+                         dag.default_view)
 
     def test_dag_invalid_orientation(self):
         """


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6952](https://issues.apache.org/jira/browse/AIRFLOW-6952)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
