### PR TITLE
[AIRFLOW-6956] Extract kill_child_processes_by_pids from DagFileProcessorManager

### DIFF
--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -20,9 +20,11 @@ import logging
 import multiprocessing
 import os
 import signal
+import subprocess
 import time
 import unittest
 from subprocess import CalledProcessError
+from time import sleep
 
 import psutil
 
@@ -104,3 +106,47 @@ class TestExecuteInSubProcess(unittest.TestCase):
     def test_should_raise_exception(self):
         with self.assertRaises(CalledProcessError):
             process_utils.execute_in_subprocess(["bash", "-c", "exit 1"])
+
+
+def my_sleep_subprocess():
+    sleep(100)
+
+
+def my_sleep_subprocess_with_signals():
+    signal.signal(signal.SIGINT, lambda signum, frame: None)
+    signal.signal(signal.SIGTERM, lambda signum, frame: None)
+    sleep(100)
+
+
+class TestKillChildProcessesByPids(unittest.TestCase):
+    def test_should_kill_process(self):
+        before_num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+
+        process = multiprocessing.Process(target=my_sleep_subprocess, args=())
+        process.start()
+        sleep(0)
+
+        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        self.assertEqual(before_num_process + 1, num_process)
+
+        process_utils.kill_child_processes_by_pids([process.pid])
+
+        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        self.assertEqual(before_num_process, num_process)
+
+    def test_should_force_kill_process(self):
+        before_num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+
+        process = multiprocessing.Process(target=my_sleep_subprocess_with_signals, args=())
+        process.start()
+        sleep(0)
+
+        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        self.assertEqual(before_num_process + 1, num_process)
+
+        with self.assertLogs(process_utils.log) as cm:
+            process_utils.kill_child_processes_by_pids([process.pid], timeout=0)
+        self.assertTrue(any("Killing child PID" in line for line in cm.output))
+
+        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        self.assertEqual(before_num_process, num_process)


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6956](https://issues.apache.org/jira/browse/AIRFLOW-6956)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
