### PR TITLE
[AIRFLOW-XXXX] Fix typo in bigquery_dts.rst

### DIFF
--- a/docs/howto/operator/gcp/bigquery_dts.rst
+++ b/docs/howto/operator/gcp/bigquery_dts.rst
@@ -70,7 +70,7 @@ it will be retrieved from the GCP connection used. Basic usage of the operator:
 You can use :ref:`Jinja templating <jinja-templating>` with
 :template-fields:`airflow.providers.google.cloud.operators.bigquery_dts.BigQueryCreateDataTransferOperator`
 parameters which allows you to dynamically determine values. The result is saved to :ref:`XCom <concepts:xcom>`,
-which allows it to be used by other operators. Additionaly, id of the new config is accessible in
+which allows it to be used by other operators. Additionally, id of the new config is accessible in
 :ref:`XCom <concepts:xcom>` under ``transfer_config_id`` key.
 
 


### PR DESCRIPTION
Fix typo in bigquery_dts.rst

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
