### PR TITLE
[AIRFLOW-XXXX] Fix tutorial that initialize the database tables for 2.0.0

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -263,7 +263,7 @@ Let's run a few commands to validate this script further.
 .. code-block:: bash
 
     # initialize the database tables
-    airflow initdb
+    airflow db init
 
     # print the list of active DAGs
     airflow dags list


### PR DESCRIPTION


The aiflow initdb part of the commit 61455c69ddb5677ce02af626fbbeaf4bc29c15d3
was added to tutorial. However, if using 'initdb' command in version 2.0.0
as current document, it doesn't work like below. Because `db init` is used
instead of `initdb` in v2.0.0, so must fix it.

```
  $ airflow initdb
  airflow command error: argument subcommand: invalid choice: 'initdb'
  (choose from 'config', 'connections', 'dags', 'db', 'kerberos', 'pools',
  'roles', 'rotate_fernet_key', 'scheduler', 'sync_perm', 'tasks', 'users',
  'variables', 'version', 'webserver'), see help above.
```

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
