### PR TITLE
[AIRFLOW-XXXX] Fix typo from upstream to downstream

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -200,7 +200,7 @@ When we enable this DAG, the scheduler creates several DAG Runs - one with ``exe
 one with ``execution_date`` of 2016-01-02, and so on up to the current date.
 
 Each DAG Run will contain a task_1 Task Instance and a task_2 Task instance. Both Task Instances will
-have ``execution_date`` equal to the DAG Run's ``execution_date``, and each task_2 will be *upstream* of
+have ``execution_date`` equal to the DAG Run's ``execution_date``, and each task_2 will be *downstream* of
 (depends on) its task_1.
 
 We can also say that task_1 for 2016-01-01 is the *previous* task instance of the task_1 for 2016-01-02.


### PR DESCRIPTION
This is how it used to be:
Each DAG Run will contain a task_1 Task Instance and a task_2 Task instance. Both Task Instances will
have ``execution_date`` equal to the DAG Run's ``execution_date``, and each task_2 will be *upstream* of
(depends on) its task_1.

if task_2 depends on task_1 this means task_2 is set downstream of tastk_1  - wondering if I am missing something here - or misreading it

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
