### PR TITLE
[AIRFLOW-6497] Avoid loading DAGs in the main scheduler loop

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -770,19 +770,20 @@ class DagFileProcessor(LoggingMixin):
         TI = models.TaskInstance
 
         for request in failure_callback_requests:
-            if request.simple_task_instance.dag_id in dagbag.dags:
-                dag = dagbag.dags[request.simple_task_instance.dag_id]
-                if request.simple_task_instance.task_id in dag.task_ids:
-                    task = dag.get_task(request.simple_task_instance.task_id)
-                    ti = TI(task, request.simple_task_instance.execution_date)
+            simple_ti = request.simple_task_instance
+            if simple_ti.dag_id in dagbag.dags:
+                dag = dagbag.dags[simple_ti.dag_id]
+                if simple_ti.task_id in dag.task_ids:
+                    task = dag.get_task(simple_ti.task_id)
+                    ti = TI(task, simple_ti.execution_date)
                     # Get properties needed for failure handling from SimpleTaskInstance.
-                    ti.start_date = request.simple_task_instance.start_date
-                    ti.end_date = request.simple_task_instance.end_date
-                    ti.try_number = request.simple_task_instance.try_number
-                    ti.state = request.simple_task_instance.state
+                    ti.start_date = simple_ti.start_date
+                    ti.end_date = simple_ti.end_date
+                    ti.try_number = simple_ti.try_number
+                    ti.state = simple_ti.state
                     ti.test_mode = self.UNIT_TEST_MODE
                     ti.handle_failure(request.msg, ti.test_mode, ti.get_template_context())
-                    self.log.info('Exeuted failure callback for %s in state %s', ti, ti.state)
+                    self.log.info('Executed failure callback for %s in state %s', ti, ti.state)
         session.commit()
 
     @provide_session

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import timedelta
 from itertools import groupby
-from typing import List, Set
+from typing import List, Optional, Set
 
 from setproctitle import setproctitle
 from sqlalchemy import and_, func, not_, or_
@@ -49,7 +49,7 @@ from airflow.ti_deps.dependencies import SCHEDULED_DEPS
 from airflow.ti_deps.deps.pool_slots_available_dep import STATES_TO_COUNT_AS_RUNNING
 from airflow.utils import asciiart, helpers, timezone
 from airflow.utils.dag_processing import (
-    AbstractDagFileProcessorProcess, DagFileProcessorAgent, SimpleDag, SimpleDagBag,
+    AbstractDagFileProcessorProcess, DagFileProcessorAgent, FailureCallbackRequest, SimpleDag, SimpleDagBag,
 )
 from airflow.utils.email import get_email_address_list, send_email
 from airflow.utils.log.logging_mixin import LoggingMixin, StreamLogWriter, set_context
@@ -67,21 +67,27 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
     :type pickle_dags: bool
     :param dag_id_white_list: If specified, only look at these DAG ID's
     :type dag_id_white_list: List[str]
-    :param zombies: zombie task instances to kill
-    :type zombies: List[airflow.models.taskinstance.SimpleTaskInstance]
+    :param failure_callback_requests: failure callback to execute
+    :type failure_callback_requests: List[airflow.utils.dag_processing.FailureCallbackRequest]
     """
 
     # Counter that increments every time an instance of this class is created
     class_creation_counter = 0
 
-    def __init__(self, file_path, pickle_dags, dag_id_white_list, zombies):
+    def __init__(
+        self,
+        file_path: str,
+        pickle_dags: bool,
+        dag_id_white_list: Optional[List[str]],
+        failure_callback_requests: List[FailureCallbackRequest]
+    ):
         self._file_path = file_path
+        self._pickle_dags = pickle_dags
+        self._dag_id_white_list = dag_id_white_list
+        self._failure_callback_requests = failure_callback_requests
 
         # The process that was launched to process the given .
         self._process = None
-        self._dag_id_white_list = dag_id_white_list
-        self._pickle_dags = pickle_dags
-        self._zombies = zombies
         # The result of Scheduler.process_file(file_path).
         self._result = None
         # Whether the process is done running.
@@ -106,7 +112,7 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
                             pickle_dags,
                             dag_id_white_list,
                             thread_name,
-                            zombies):
+                            failure_callback_requests):
         """
         Process the given file.
 
@@ -122,8 +128,8 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
         :type dag_id_white_list: list[str]
         :param thread_name: the name to use for the process that is launched
         :type thread_name: str
-        :param zombies: zombie task instances to kill
-        :type zombies: list[airflow.models.taskinstance.SimpleTaskInstance]
+        :param failure_callback_requests: failure callback to execute
+        :type failure_callback_requests: list[airflow.utils.dag_processing.FailureCallbackRequest]
         :return: the process that was launched
         :rtype: multiprocessing.Process
         """
@@ -151,8 +157,8 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
                 dag_file_processor = DagFileProcessor(dag_ids=dag_id_white_list, log=log)
                 result = dag_file_processor.process_file(
                     file_path=file_path,
-                    zombies=zombies,
-                    pickle_dags=pickle_dags
+                    pickle_dags=pickle_dags,
+                    failure_callback_requests=failure_callback_requests,
                 )
                 result_channel.send(result)
                 end_time = time.time()
@@ -182,7 +188,7 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
                 self._pickle_dags,
                 self._dag_id_white_list,
                 "DagFileProcessor{}".format(self._instance_id),
-                self._zombies
+                self._failure_callback_requests
             ),
             name="DagFileProcessor{}-Process".format(self._instance_id)
         )
@@ -752,37 +758,35 @@ class DagFileProcessor(LoggingMixin):
         return dags
 
     @provide_session
-    def kill_zombies(self, dagbag, zombies, session=None):
+    def execute_on_failure_callbacks(self, dagbag, failure_callback_requests, session=None):
         """
-        Fail given zombie tasks, which are tasks that haven't
-        had a heartbeat for too long, in the current DagBag.
+        Execute on failure callbacks. These objects can come from SchedulerJob or from
+        DagFileProcessorManager.
 
-        :param zombies: zombie task instances to kill.
-        :type zombies: List[airflow.models.taskinstance.SimpleTaskInstance]
+        :param failure_callback_requests: failure callbacks to execute
+        :type failure_callback_requests: List[airflow.utils.dag_processing.FailureCallbackRequest]
         :param session: DB session.
         """
         TI = models.TaskInstance
 
-        for zombie in zombies:
-            if zombie.dag_id in dagbag.dags:
-                dag = dagbag.dags[zombie.dag_id]
-                if zombie.task_id in dag.task_ids:
-                    task = dag.get_task(zombie.task_id)
-                    ti = TI(task, zombie.execution_date)
+        for request in failure_callback_requests:
+            if request.simple_task_instance.dag_id in dagbag.dags:
+                dag = dagbag.dags[request.simple_task_instance.dag_id]
+                if request.simple_task_instance.task_id in dag.task_ids:
+                    task = dag.get_task(request.simple_task_instance.task_id)
+                    ti = TI(task, request.simple_task_instance.execution_date)
                     # Get properties needed for failure handling from SimpleTaskInstance.
-                    ti.start_date = zombie.start_date
-                    ti.end_date = zombie.end_date
-                    ti.try_number = zombie.try_number
-                    ti.state = zombie.state
+                    ti.start_date = request.simple_task_instance.start_date
+                    ti.end_date = request.simple_task_instance.end_date
+                    ti.try_number = request.simple_task_instance.try_number
+                    ti.state = request.simple_task_instance.state
                     ti.test_mode = self.UNIT_TEST_MODE
-                    ti.handle_failure("{} detected as zombie".format(ti),
-                                      ti.test_mode, ti.get_template_context())
-                    self.log.info('Marked zombie job %s as %s', ti, ti.state)
-                    Stats.incr('zombies_killed')
+                    ti.handle_failure(request.msg, ti.test_mode, ti.get_template_context())
+                    self.log.info('Exeuted failure callback for %s in state %s', ti, ti.state)
         session.commit()
 
     @provide_session
-    def process_file(self, file_path, zombies, pickle_dags=False, session=None):
+    def process_file(self, file_path, failure_callback_requests, pickle_dags=False, session=None):
         """
         Process a Python file containing Airflow DAGs.
 
@@ -801,8 +805,8 @@ class DagFileProcessor(LoggingMixin):
 
         :param file_path: the path to the Python file that should be executed
         :type file_path: str
-        :param zombies: zombie task instances to kill.
-        :type zombies: List[airflow.models.taskinstance.SimpleTaskInstance]
+        :param failure_callback_requests: failure callback to execute
+        :type failure_callback_requests: List[airflow.utils.dag_processing.FailureCallbackRequest]
         :param pickle_dags: whether serialize the DAGs found in the file and
             save them to the db
         :type pickle_dags: bool
@@ -826,6 +830,11 @@ class DagFileProcessor(LoggingMixin):
             self.log.warning("No viable dags retrieved from %s", file_path)
             self.update_import_errors(session, dagbag)
             return [], len(dagbag.import_errors)
+
+        try:
+            self.execute_on_failure_callbacks(dagbag, failure_callback_requests)
+        except Exception:  # pylint: disable=broad-except
+            self.log.exception("Error executing failure callback!")
 
         # Save individual DAGs in the ORM and update DagModel.last_scheduled_time
         dagbag.sync_to_db()
@@ -887,10 +896,6 @@ class DagFileProcessor(LoggingMixin):
             self.update_import_errors(session, dagbag)
         except Exception:  # pylint: disable=broad-except
             self.log.exception("Error logging import errors!")
-        try:
-            self.kill_zombies(dagbag, zombies)
-        except Exception:  # pylint: disable=broad-except
-            self.log.exception("Error killing zombies!")
 
         return simple_dags, len(dagbag.import_errors)
 
@@ -1448,24 +1453,19 @@ class SchedulerJob(BaseJob):
 
                 # TODO: should we fail RUNNING as well, as we do in Backfills?
                 if ti.try_number == try_number and ti.state == State.QUEUED:
-                    msg = ("Executor reports task instance {} finished ({}) "
-                           "although the task says its {}. Was the task "
-                           "killed externally?".format(ti, state, ti.state))
                     Stats.incr('scheduler.tasks.killed_externally')
-                    self.log.error(msg)
-                    try:
-                        simple_dag = simple_dag_bag.get_dag(dag_id)
-                        dagbag = models.DagBag(simple_dag.full_filepath)
-                        dag = dagbag.get_dag(dag_id)
-                        ti.task = dag.get_task(task_id)
-                        ti.handle_failure(msg)
-                    except Exception:  # pylint: disable=broad-except
-                        self.log.error("Cannot load the dag bag to handle failure for %s"
-                                       ". Setting task to FAILED without callbacks or "
-                                       "retries. Do you have enough resources?", ti)
-                        ti.state = State.FAILED
-                        session.merge(ti)
-                        session.commit()
+                    self.log.error(
+                        "Executor reports task instance %s finished (%s) although the task says its %s. "
+                        "Was the task killed externally?",
+                        ti, state, ti.state
+                    )
+                    simple_dag = simple_dag_bag.get_dag(dag_id)
+                    self.processor_agent.send_callback_to_execute(
+                        full_filepath=simple_dag.full_filepath,
+                        task_instance=ti,
+                        msg="Executor reports task instance finished ({}) although the task says its {}. "
+                            "Was the task killed externally?".format(state, ti.state)
+                    )
 
     def _execute(self):
         self.log.info("Starting the scheduler")
@@ -1477,12 +1477,12 @@ class SchedulerJob(BaseJob):
 
         self.log.info("Processing each file at most %s times", self.num_runs)
 
-        def processor_factory(file_path, zombies):
+        def processor_factory(file_path, failure_callback_requests):
             return DagFileProcessorProcess(
                 file_path=file_path,
                 pickle_dags=pickle_dags,
                 dag_id_white_list=self.dag_ids,
-                zombies=zombies
+                failure_callback_requests=failure_callback_requests
             )
 
         # When using sqlite, we do not use async_mode
@@ -1600,7 +1600,24 @@ class SchedulerJob(BaseJob):
     def _validate_and_run_task_instances(self, simple_dag_bag: SimpleDagBag) -> bool:
         if len(simple_dag_bag.simple_dags) > 0:
             try:
-                self._process_and_execute_tasks(simple_dag_bag)
+                # Handle cases where a DAG run state is set (perhaps manually) to
+                # a non-running state. Handle task instances that belong to
+                # DAG runs in those states
+                # If a task instance is up for retry but the corresponding DAG run
+                # isn't running, mark the task instance as FAILED so we don't try
+                # to re-run it.
+                self._change_state_for_tis_without_dagrun(simple_dag_bag,
+                                                          [State.UP_FOR_RETRY],
+                                                          State.FAILED)
+                # If a task instance is scheduled or queued or up for reschedule,
+                # but the corresponding DAG run isn't running, set the state to
+                # NONE so we don't try to re-run it.
+                self._change_state_for_tis_without_dagrun(simple_dag_bag,
+                                                          [State.QUEUED,
+                                                           State.SCHEDULED,
+                                                           State.UP_FOR_RESCHEDULE],
+                                                          State.NONE)
+                self._execute_task_instances(simple_dag_bag)
             except Exception as e:  # pylint: disable=broad-except
                 self.log.error("Error queuing tasks")
                 self.log.exception(e)
@@ -1615,26 +1632,6 @@ class SchedulerJob(BaseJob):
         # Process events from the executor
         self._process_executor_events(simple_dag_bag)
         return True
-
-    def _process_and_execute_tasks(self, simple_dag_bag):
-        # Handle cases where a DAG run state is set (perhaps manually) to
-        # a non-running state. Handle task instances that belong to
-        # DAG runs in those states
-        # If a task instance is up for retry but the corresponding DAG run
-        # isn't running, mark the task instance as FAILED so we don't try
-        # to re-run it.
-        self._change_state_for_tis_without_dagrun(simple_dag_bag,
-                                                  [State.UP_FOR_RETRY],
-                                                  State.FAILED)
-        # If a task instance is scheduled or queued or up for reschedule,
-        # but the corresponding DAG run isn't running, set the state to
-        # NONE so we don't try to re-run it.
-        self._change_state_for_tis_without_dagrun(simple_dag_bag,
-                                                  [State.QUEUED,
-                                                   State.SCHEDULED,
-                                                   State.UP_FOR_RESCHEDULE],
-                                                  State.NONE)
-        self._execute_task_instances(simple_dag_bag)
 
     @provide_session
     def heartbeat_callback(self, session=None):

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -25,6 +25,7 @@ import signal
 import sys
 import time
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 from datetime import datetime, timedelta
 from importlib import import_module
 from typing import Any, Callable, Dict, KeysView, List, NamedTuple, Optional, Tuple
@@ -40,7 +41,7 @@ from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.exceptions import AirflowException
 from airflow.jobs.local_task_job import LocalTaskJob as LJ
 from airflow.models import Connection, errors
-from airflow.models.taskinstance import SimpleTaskInstance
+from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
 from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.stats import Stats
 from airflow.utils import timezone
@@ -268,6 +269,13 @@ class DagParsingSignal(enum.Enum):
     END_MANAGER = 'end_manager'
 
 
+class FailureCallbackRequest(NamedTuple):
+    """A message with information about the callback to be executed."""
+    full_filepath: str
+    simple_task_instance: SimpleTaskInstance
+    msg: str
+
+
 class DagFileProcessorAgent(LoggingMixin):
     """
     Agent for DAG file processing. It is responsible for all DAG parsing
@@ -349,6 +357,29 @@ class DagFileProcessorAgent(LoggingMixin):
 
         try:
             self._parent_signal_conn.send(DagParsingSignal.AGENT_HEARTBEAT)
+        except ConnectionError:
+            # If this died cos of an error then we will noticed and restarted
+            # when harvest_simple_dags calls _heartbeat_manager.
+            pass
+
+    def send_callback_to_execute(self, full_filepath: str, task_instance: TaskInstance, msg: str):
+        """
+        Sends information about the callback to be executed by DagFileProcessor.
+
+        :param full_filepath: DAG File path
+        :type full_filepath: str
+        :param task_instance: Task Instance for which the callback is to be executed.
+        :type task_instance: airflow.models.taskinstance.TaskInstance
+        :param msg: Message sent in callback.
+        :type msg: str
+        """
+        try:
+            request = FailureCallbackRequest(
+                full_filepath=full_filepath,
+                simple_task_instance=SimpleTaskInstance(task_instance),
+                msg=msg
+            )
+            self._parent_signal_conn.send(request)
         except ConnectionError:
             # If this died cos of an error then we will noticed and restarted
             # when harvest_simple_dags calls _heartbeat_manager.
@@ -516,7 +547,10 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
     def __init__(self,
                  dag_directory: str,
                  max_runs: int,
-                 processor_factory: Callable[[str, List[Any]], AbstractDagFileProcessorProcess],
+                 processor_factory: Callable[
+                     [str, List[FailureCallbackRequest]],
+                     AbstractDagFileProcessorProcess
+                 ],
                  processor_timeout: timedelta,
                  signal_conn: Connection,
                  async_mode: bool = True):
@@ -562,13 +596,14 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         self.last_stat_print_time = timezone.datetime(2000, 1, 1)
         # TODO: Remove magic number
         self._zombie_query_interval = 10
-        self._zombies: List[SimpleTaskInstance] = []
         # How long to wait before timing out a process to parse a DAG file
         self._processor_timeout = processor_timeout
 
         # How often to scan the DAGs directory for new files. Default to 5 minutes.
-        self.dag_dir_list_interval = conf.getint('scheduler',
-                                                 'dag_dir_list_interval')
+        self.dag_dir_list_interval = conf.getint('scheduler', 'dag_dir_list_interval')
+
+        # Mapping file name and callbacks requests
+        self._callback_to_execute: Dict[str, List[FailureCallbackRequest]] = defaultdict(list)
 
         self._log = logging.getLogger('airflow.processor_manager')
 
@@ -632,6 +667,10 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
                 elif agent_signal == DagParsingSignal.AGENT_HEARTBEAT:
                     # continue the loop to parse dags
                     pass
+                elif isinstance(agent_signal, FailureCallbackRequest):
+                    self._add_callback_to_queue(agent_signal)
+                else:
+                    raise AirflowException("Invalid message")
             elif not self._async_mode:
                 # In "sync" mode we don't want to parse the DAGs until we
                 # are told to (as that would open another connection to the
@@ -642,7 +681,6 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
             self._find_zombies()  # pylint: disable=no-value-for-parameter
 
             self._kill_timed_out_processors()
-            simple_dags = self.collect_results()
 
             # Generate more file paths to process if we processed all the files
             # already.
@@ -655,6 +693,7 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
             # Update number of loop iteration.
             self._num_run += 1
 
+            simple_dags = self.collect_results()
             for simple_dag in simple_dags:
                 self._signal_conn.send(simple_dag)
 
@@ -694,6 +733,13 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
                     poll_time = 1 - loop_duration
                 else:
                     poll_time = 0.0
+
+    def _add_callback_to_queue(self, request: FailureCallbackRequest):
+        self._callback_to_execute[request.full_filepath].append(request)
+        # Callback has a higher priority over DAG Run scheduling
+        if request.full_filepath in self._file_path_queue:
+            self._file_path_queue.remove(request.full_filepath)
+        self._file_path_queue.insert(0, request.full_filepath)
 
     def _refresh_dag_dir(self):
         """
@@ -998,7 +1044,9 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         """
         while self._parallelism - len(self._processors) > 0 and self._file_path_queue:
             file_path = self._file_path_queue.pop(0)
-            processor = self._processor_factory(file_path, self._zombies)
+            callback_to_execute_for_file = self._callback_to_execute[file_path]
+            processor = self._processor_factory(file_path, callback_to_execute_for_file)
+            del self._callback_to_execute[file_path]
             Stats.incr('dag_processing.processes')
 
             processor.start()
@@ -1058,19 +1106,19 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         and update the current zombie list.
         """
         now = timezone.utcnow()
-        zombies: List[SimpleTaskInstance] = []
         if not self._last_zombie_query_time or \
                 (now - self._last_zombie_query_time).total_seconds() > self._zombie_query_interval:
             # to avoid circular imports
             self.log.info("Finding 'running' jobs without a recent heartbeat")
             TI = airflow.models.TaskInstance
-            limit_dttm = timezone.utcnow() - timedelta(
-                seconds=self._zombie_threshold_secs)
+            DM = airflow.models.DagModel
+            limit_dttm = timezone.utcnow() - timedelta(seconds=self._zombie_threshold_secs)
             self.log.info("Failing jobs without heartbeat after %s", limit_dttm)
 
-            tis = (
-                session.query(TI)
+            zombies = (
+                session.query(TI, DM.fileloc)
                 .join(LJ, TI.job_id == LJ.id)
+                .join(DM, TI.dag_id == DM.dag_id)
                 .filter(TI.state == State.RUNNING)
                 .filter(
                     or_(
@@ -1079,15 +1127,17 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
                     )
                 ).all()
             )
-            self._last_zombie_query_time = timezone.utcnow()
-            for ti in tis:
-                sti = SimpleTaskInstance(ti)
-                self.log.info(
-                    "Detected zombie job with dag_id %s, task_id %s, and execution date %s",
-                    sti.dag_id, sti.task_id, sti.execution_date.isoformat())
-                zombies.append(sti)
 
-            self._zombies = zombies
+            self._last_zombie_query_time = timezone.utcnow()
+            for ti, file_loc in zombies:
+                request = FailureCallbackRequest(
+                    full_filepath=file_loc,
+                    simple_task_instance=SimpleTaskInstance(ti),
+                    msg="Detected as zombie",
+                )
+                self.log.info("Detected zombie job: %s", request)
+                self._add_callback_to_queue(request)
+                Stats.incr('zombies_killed')
 
     def _kill_timed_out_processors(self):
         """

--- a/tests/dags/test_on_failure_callback.py
+++ b/tests/dags/test_on_failure_callback.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+
+args = {
+    'owner': 'airflow',
+    'start_date': DEFAULT_DATE,
+}
+
+dag = DAG(dag_id='test_om_failure_callback_dag', default_args=args)
+
+
+def write_data_to_callback(*arg, **kwargs):  # pylint: disable=unused-argument
+    with open(os.environ.get('AIRFLOW_CALLBACK_FILE'), "w+") as f:
+        f.write("Callback fired")
+
+
+task = DummyOperator(
+    task_id='test_om_failure_callback_task',
+    dag=dag,
+    on_failure_callback=write_data_to_callback
+)


### PR DESCRIPTION
This change should speed up the main scheduler loop, because it will not load the DAG file. This should also drastically reduce the amount of memory used because modules with external operators and libraries will not be loaded.

Thanks for support to @evgenyshulman from Databand!



---
Issue link: [AIRFLOW-6497](https://issues.apache.org/jira/browse/AIRFLOW-6497)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
