### PR TITLE
[AIRFLOW-6962] Fix "compeleted" to "completed"

### DIFF
--- a/airflow/providers/amazon/aws/hooks/sagemaker.py
+++ b/airflow/providers/amazon/aws/hooks/sagemaker.py
@@ -655,7 +655,7 @@ class SageMakerHook(AwsBaseHook):
                 # ensure that the job gets killed if the max ingestion time is exceeded
                 raise AirflowException(f'SageMaker job took more than {max_ingestion_time} seconds')
 
-        self.log.info('SageMaker Job Compeleted')
+        self.log.info('SageMaker Job completed')
         response = describe_function(job_name)
         return response
 

--- a/tests/providers/amazon/aws/hooks/test_sagemaker.py
+++ b/tests/providers/amazon/aws/hooks/test_sagemaker.py
@@ -170,7 +170,7 @@ create_endpoint_params = {
 
 update_endpoint_params = create_endpoint_params
 
-DESCRIBE_TRAINING_COMPELETED_RETURN = {
+DESCRIBE_TRAINING_COMPLETED_RETURN = {
     'TrainingJobStatus': 'Completed',
     'ResourceConfig': {
         'InstanceCount': 1,
@@ -184,14 +184,14 @@ DESCRIBE_TRAINING_COMPELETED_RETURN = {
     }
 }
 
-DESCRIBE_TRAINING_INPROGRESS_RETURN = dict(DESCRIBE_TRAINING_COMPELETED_RETURN)
+DESCRIBE_TRAINING_INPROGRESS_RETURN = dict(DESCRIBE_TRAINING_COMPLETED_RETURN)
 DESCRIBE_TRAINING_INPROGRESS_RETURN.update({'TrainingJobStatus': 'InProgress'})
 
-DESCRIBE_TRAINING_FAILED_RETURN = dict(DESCRIBE_TRAINING_COMPELETED_RETURN)
+DESCRIBE_TRAINING_FAILED_RETURN = dict(DESCRIBE_TRAINING_COMPLETED_RETURN)
 DESCRIBE_TRAINING_FAILED_RETURN.update({'TrainingJobStatus': 'Failed',
                                         'FailureReason': 'Unknown'})
 
-DESCRIBE_TRAINING_STOPPING_RETURN = dict(DESCRIBE_TRAINING_COMPELETED_RETURN)
+DESCRIBE_TRAINING_STOPPING_RETURN = dict(DESCRIBE_TRAINING_COMPLETED_RETURN)
 DESCRIBE_TRAINING_STOPPING_RETURN.update({'TrainingJobStatus': 'Stopping'})
 
 message = 'message'
@@ -339,8 +339,8 @@ class TestSageMakerHook(unittest.TestCase):
                  'describe_training_job.side_effect':
                  [DESCRIBE_TRAINING_INPROGRESS_RETURN,
                   DESCRIBE_TRAINING_STOPPING_RETURN,
-                  DESCRIBE_TRAINING_COMPELETED_RETURN,
-                  DESCRIBE_TRAINING_COMPELETED_RETURN]
+                  DESCRIBE_TRAINING_COMPLETED_RETURN,
+                  DESCRIBE_TRAINING_COMPLETED_RETURN]
                  }
         mock_session.configure_mock(**attrs)
         mock_client.return_value = mock_session
@@ -361,7 +361,7 @@ class TestSageMakerHook(unittest.TestCase):
                  [DESCRIBE_TRAINING_INPROGRESS_RETURN,
                   DESCRIBE_TRAINING_STOPPING_RETURN,
                   DESCRIBE_TRAINING_FAILED_RETURN,
-                  DESCRIBE_TRAINING_COMPELETED_RETURN]
+                  DESCRIBE_TRAINING_COMPLETED_RETURN]
                  }
         mock_session.configure_mock(**attrs)
         mock_client.return_value = mock_session
@@ -561,7 +561,7 @@ class TestSageMakerHook(unittest.TestCase):
         mock_session = mock.Mock()
         mock_log_session = mock.Mock()
         attrs = {'describe_training_job.return_value':
-                 DESCRIBE_TRAINING_COMPELETED_RETURN
+                 DESCRIBE_TRAINING_COMPLETED_RETURN
                  }
         log_attrs = {'describe_log_streams.side_effect':
                      LIFECYCLE_LOG_STREAMS,
@@ -589,7 +589,7 @@ class TestSageMakerHook(unittest.TestCase):
         mock_session = mock.Mock()
         mock_log_session = mock.Mock()
         attrs = {'describe_training_job.return_value':
-                 DESCRIBE_TRAINING_COMPELETED_RETURN
+                 DESCRIBE_TRAINING_COMPLETED_RETURN
                  }
         log_attrs = {'describe_log_streams.side_effect':
                      LIFECYCLE_LOG_STREAMS,
@@ -616,7 +616,7 @@ class TestSageMakerHook(unittest.TestCase):
         mock_session = mock.Mock()
         mock_log_session = mock.Mock()
         attrs = {'describe_training_job.return_value':
-                 DESCRIBE_TRAINING_COMPELETED_RETURN
+                 DESCRIBE_TRAINING_COMPLETED_RETURN
                  }
         log_attrs = {'describe_log_streams.side_effect':
                      LIFECYCLE_LOG_STREAMS,
@@ -646,13 +646,13 @@ class TestSageMakerHook(unittest.TestCase):
         mock_describe.side_effect = \
             [(LogState.WAIT_IN_PROGRESS, DESCRIBE_TRAINING_INPROGRESS_RETURN, 0),
              (LogState.JOB_COMPLETE, DESCRIBE_TRAINING_STOPPING_RETURN, 0),
-             (LogState.COMPLETE, DESCRIBE_TRAINING_COMPELETED_RETURN, 0)]
+             (LogState.COMPLETE, DESCRIBE_TRAINING_COMPLETED_RETURN, 0)]
         mock_session = mock.Mock()
         mock_log_session = mock.Mock()
         attrs = {'create_training_job.return_value':
                  test_arn_return,
                  'describe_training_job.return_value':
-                     DESCRIBE_TRAINING_COMPELETED_RETURN
+                     DESCRIBE_TRAINING_COMPLETED_RETURN
                  }
         log_attrs = {'describe_log_streams.side_effect':
                      LIFECYCLE_LOG_STREAMS,

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_training.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 from airflow.providers.amazon.aws.hooks.sagemaker import LogState, SageMakerHook
 from airflow.providers.amazon.aws.sensors.sagemaker_training import SageMakerTrainingSensor
 
-DESCRIBE_TRAINING_COMPELETED_RESPONSE = {
+DESCRIBE_TRAINING_COMPLETED_RESPONSE = {
     'TrainingJobStatus': 'Completed',
     'ResourceConfig': {
         'InstanceCount': 1,
@@ -40,14 +40,14 @@ DESCRIBE_TRAINING_COMPELETED_RESPONSE = {
     }
 }
 
-DESCRIBE_TRAINING_INPROGRESS_RESPONSE = dict(DESCRIBE_TRAINING_COMPELETED_RESPONSE)
+DESCRIBE_TRAINING_INPROGRESS_RESPONSE = dict(DESCRIBE_TRAINING_COMPLETED_RESPONSE)
 DESCRIBE_TRAINING_INPROGRESS_RESPONSE.update({'TrainingJobStatus': 'InProgress'})
 
-DESCRIBE_TRAINING_FAILED_RESPONSE = dict(DESCRIBE_TRAINING_COMPELETED_RESPONSE)
+DESCRIBE_TRAINING_FAILED_RESPONSE = dict(DESCRIBE_TRAINING_COMPLETED_RESPONSE)
 DESCRIBE_TRAINING_FAILED_RESPONSE.update({'TrainingJobStatus': 'Failed',
                                           'FailureReason': 'Unknown'})
 
-DESCRIBE_TRAINING_STOPPING_RESPONSE = dict(DESCRIBE_TRAINING_COMPELETED_RESPONSE)
+DESCRIBE_TRAINING_STOPPING_RESPONSE = dict(DESCRIBE_TRAINING_COMPLETED_RESPONSE)
 DESCRIBE_TRAINING_STOPPING_RESPONSE.update({'TrainingJobStatus': 'Stopping'})
 
 
@@ -78,7 +78,7 @@ class TestSageMakerTrainingSensor(unittest.TestCase):
         mock_describe_job.side_effect = [
             DESCRIBE_TRAINING_INPROGRESS_RESPONSE,
             DESCRIBE_TRAINING_STOPPING_RESPONSE,
-            DESCRIBE_TRAINING_COMPELETED_RESPONSE
+            DESCRIBE_TRAINING_COMPLETED_RESPONSE
         ]
         sensor = SageMakerTrainingSensor(
             task_id='test_task',
@@ -90,7 +90,7 @@ class TestSageMakerTrainingSensor(unittest.TestCase):
 
         sensor.execute(None)
 
-        # make sure we called 3 times(terminated when its compeleted)
+        # make sure we called 3 times(terminated when its completed)
         self.assertEqual(mock_describe_job.call_count, 3)
 
         # make sure the hook was initialized with the specific params
@@ -110,11 +110,11 @@ class TestSageMakerTrainingSensor(unittest.TestCase):
                              hook_init, mock_log_client, mock_client):
         hook_init.return_value = None
 
-        mock_describe_job.return_value = DESCRIBE_TRAINING_COMPELETED_RESPONSE
+        mock_describe_job.return_value = DESCRIBE_TRAINING_COMPLETED_RESPONSE
         mock_describe_job_with_log.side_effect = [
             (LogState.WAIT_IN_PROGRESS, DESCRIBE_TRAINING_INPROGRESS_RESPONSE, 0),
             (LogState.JOB_COMPLETE, DESCRIBE_TRAINING_STOPPING_RESPONSE, 0),
-            (LogState.COMPLETE, DESCRIBE_TRAINING_COMPELETED_RESPONSE, 0)
+            (LogState.COMPLETE, DESCRIBE_TRAINING_COMPLETED_RESPONSE, 0)
         ]
         sensor = SageMakerTrainingSensor(
             task_id='test_task',

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_transform.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_transform.py
@@ -30,8 +30,8 @@ DESCRIBE_TRANSFORM_INPROGRESS_RESPONSE = {
         'HTTPStatusCode': 200,
     }
 }
-DESCRIBE_TRANSFORM_COMPELETED_RESPONSE = {
-    'TransformJobStatus': 'Compeleted',
+DESCRIBE_TRANSFORM_COMPLETED_RESPONSE = {
+    'TransformJobStatus': 'Completed',
     'ResponseMetadata': {
         'HTTPStatusCode': 200,
     }
@@ -74,7 +74,7 @@ class TestSageMakerTransformSensor(unittest.TestCase):
         mock_describe_job.side_effect = [
             DESCRIBE_TRANSFORM_INPROGRESS_RESPONSE,
             DESCRIBE_TRANSFORM_STOPPING_RESPONSE,
-            DESCRIBE_TRANSFORM_COMPELETED_RESPONSE
+            DESCRIBE_TRANSFORM_COMPLETED_RESPONSE
         ]
         sensor = SageMakerTransformSensor(
             task_id='test_task',
@@ -85,7 +85,7 @@ class TestSageMakerTransformSensor(unittest.TestCase):
 
         sensor.execute(None)
 
-        # make sure we called 3 times(terminated when its compeleted)
+        # make sure we called 3 times(terminated when its completed)
         self.assertEqual(mock_describe_job.call_count, 3)
 
         # make sure the hook was initialized with the specific params

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_tuning.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_tuning.py
@@ -31,8 +31,8 @@ DESCRIBE_TUNING_INPROGRESS_RESPONSE = {
     }
 }
 
-DESCRIBE_TUNING_COMPELETED_RESPONSE = {
-    'HyperParameterTuningJobStatus': 'Compeleted',
+DESCRIBE_TUNING_COMPLETED_RESPONSE = {
+    'HyperParameterTuningJobStatus': 'Completed',
     'ResponseMetadata': {
         'HTTPStatusCode': 200,
     }
@@ -77,7 +77,7 @@ class TestSageMakerTuningSensor(unittest.TestCase):
         mock_describe_job.side_effect = [
             DESCRIBE_TUNING_INPROGRESS_RESPONSE,
             DESCRIBE_TUNING_STOPPING_RESPONSE,
-            DESCRIBE_TUNING_COMPELETED_RESPONSE
+            DESCRIBE_TUNING_COMPLETED_RESPONSE
         ]
         sensor = SageMakerTuningSensor(
             task_id='test_task',
@@ -88,7 +88,7 @@ class TestSageMakerTuningSensor(unittest.TestCase):
 
         sensor.execute(None)
 
-        # make sure we called 3 times(terminated when its compeleted)
+        # make sure we called 3 times(terminated when its completed)
         self.assertEqual(mock_describe_job.call_count, 3)
 
         # make sure the hook was initialized with the specific params


### PR DESCRIPTION
"Completed" is misspelled as "compeleted" is various places in the codebase. This PR fixes all mistakes.

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
