### PR TITLE
[AIRFLOW-6966] Move reap_process_group to process_utils

### DIFF
--- a/airflow/task/task_runner/cgroup_task_runner.py
+++ b/airflow/task/task_runner/cgroup_task_runner.py
@@ -27,8 +27,8 @@ import psutil
 from cgroupspy import trees
 
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
-from airflow.utils.helpers import reap_process_group
 from airflow.utils.operator_resources import Resources
+from airflow.utils.process_utils import reap_process_group
 
 
 class CgroupTaskRunner(BaseTaskRunner):

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -23,7 +23,7 @@ import psutil
 from setproctitle import setproctitle  # pylint: disable=no-name-in-module
 
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
-from airflow.utils.helpers import reap_process_group
+from airflow.utils.process_utils import reap_process_group
 
 CAN_FORK = hasattr(os, 'fork')
 

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -45,8 +45,8 @@ from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.stats import Stats
 from airflow.utils import timezone
 from airflow.utils.file import list_py_file_paths
-from airflow.utils.helpers import reap_process_group
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.process_utils import reap_process_group
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
@@ -484,7 +484,7 @@ class DagFileProcessorAgent(LoggingMixin):
         if not self._process:
             self.log.warning('Ending without manager process.')
             return
-        reap_process_group(self._process.pid, log=self.log)
+        reap_process_group(self._process.pid, logger=self.log)
         self._parent_signal_conn.close()
 
 

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -16,10 +16,74 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import logging
+import multiprocessing
+import os
+import signal
+import time
 import unittest
 from subprocess import CalledProcessError
 
+import psutil
+
 from airflow.utils import process_utils
+
+
+class TestReapProcessGroup(unittest.TestCase):
+
+    @staticmethod
+    def _ignores_sigterm(child_pid, child_setup_done):
+        def signal_handler(unused_signum, unused_frame):
+            pass
+
+        signal.signal(signal.SIGTERM, signal_handler)
+        child_pid.value = os.getpid()
+        child_setup_done.release()
+        while True:
+            time.sleep(1)
+
+    @staticmethod
+    def _parent_of_ignores_sigterm(parent_pid, child_pid, setup_done):
+        def signal_handler(unused_signum, unused_frame):
+            pass
+        os.setsid()
+        signal.signal(signal.SIGTERM, signal_handler)
+        child_setup_done = multiprocessing.Semaphore(0)
+        child = multiprocessing.Process(target=TestReapProcessGroup._ignores_sigterm,
+                                        args=[child_pid, child_setup_done])
+        child.start()
+        child_setup_done.acquire(timeout=5.0)
+        parent_pid.value = os.getpid()
+        setup_done.release()
+        while True:
+            time.sleep(1)
+
+    def test_reap_process_group(self):
+        """
+        Spin up a process that can't be killed by SIGTERM and make sure
+        it gets killed anyway.
+        """
+        parent_setup_done = multiprocessing.Semaphore(0)
+        parent_pid = multiprocessing.Value('i', 0)
+        child_pid = multiprocessing.Value('i', 0)
+        args = [parent_pid, child_pid, parent_setup_done]
+        parent = multiprocessing.Process(target=TestReapProcessGroup._parent_of_ignores_sigterm, args=args)
+        try:
+            parent.start()
+            self.assertTrue(parent_setup_done.acquire(timeout=5.0))
+            self.assertTrue(psutil.pid_exists(parent_pid.value))
+            self.assertTrue(psutil.pid_exists(child_pid.value))
+
+            process_utils.reap_process_group(parent_pid.value, logging.getLogger(), timeout=1)
+
+            self.assertFalse(psutil.pid_exists(parent_pid.value))
+            self.assertFalse(psutil.pid_exists(child_pid.value))
+        finally:
+            try:
+                os.kill(parent_pid.value, signal.SIGKILL)  # terminate doesnt work here
+                os.kill(child_pid.value, signal.SIGKILL)  # terminate doesnt work here
+            except OSError:
+                pass
 
 
 class TestExecuteInSubProcess(unittest.TestCase):


### PR DESCRIPTION
---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
