### PR TITLE
[AIRFLOW-6971] Fix return type in CloudSpeechToTextRecognizeSpeechOp

### DIFF
--- a/airflow/providers/google/cloud/operators/speech_to_text.py
+++ b/airflow/providers/google/cloud/operators/speech_to_text.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from google.api_core.retry import Retry
 from google.cloud.speech_v1.types import RecognitionConfig
+from google.protobuf.json_format import MessageToDict
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -90,6 +91,7 @@ class CloudSpeechToTextRecognizeSpeechOperator(BaseOperator):
 
     def execute(self, context):
         hook = CloudSpeechToTextHook(gcp_conn_id=self.gcp_conn_id)
-        return hook.recognize_speech(
+        respones = hook.recognize_speech(
             config=self.config, audio=self.audio, retry=self.retry, timeout=self.timeout
         )
+        return MessageToDict(respones)

--- a/tests/providers/google/cloud/operators/test_speech_to_text.py
+++ b/tests/providers/google/cloud/operators/test_speech_to_text.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from mock import Mock, patch
+from mock import MagicMock, Mock, patch
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.speech_to_text import CloudSpeechToTextRecognizeSpeechOperator
@@ -32,7 +32,7 @@ AUDIO = {"uri": "gs://bucket/object"}
 class TestCloudSql(unittest.TestCase):
     @patch("airflow.providers.google.cloud.operators.speech_to_text.CloudSpeechToTextHook")
     def test_recognize_speech_green_path(self, mock_hook):
-        mock_hook.return_value.recognize_speech.return_value = True
+        mock_hook.return_value.recognize_speech.return_value = MagicMock()
 
         CloudSpeechToTextRecognizeSpeechOperator(  # pylint: disable=no-value-for-parameter
             project_id=PROJECT_ID, gcp_conn_id=GCP_CONN_ID, config=CONFIG, audio=AUDIO, task_id="id"


### PR DESCRIPTION


---
Issue link: [AIRFLOW-6971](https://issues.apache.org/jira/browse/AIRFLOW-6971)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides the context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
