### PR TITLE
[AIRFLOW-6973] Make GCSCreateBucketOperator idempotent

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_gcs.py
@@ -144,7 +144,7 @@ with models.DAG(
     list_buckets >> delete_bucket_1
     upload_file >> delete_bucket_1
     create_bucket1 >> upload_file >> delete_bucket_1
-    transform_file >> delete_bucket_1
+    upload_file >> transform_file >> delete_bucket_1
     gcs_bucket_create_acl_entry_task >> delete_bucket_1
     gcs_object_create_acl_entry_task >> delete_bucket_1
     download_file >> delete_bucket_1

--- a/tests/providers/google/cloud/operators/test_postgres_to_gcs_system.py
+++ b/tests/providers/google/cloud/operators/test_postgres_to_gcs_system.py
@@ -20,7 +20,7 @@ from psycopg2 import ProgrammingError
 
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
-from tests.test_utils.gcp_system_helpers import GoogleSystemTest, provide_gcp_context
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTest, provide_gcp_context
 
 GCS_BUCKET = "postgres_to_gcs_example"
 CREATE_QUERY = """
@@ -79,7 +79,7 @@ class PostgresToGCSSystemTest(GoogleSystemTest):
 
     @provide_gcp_context(GCP_GCS_KEY)
     def test_run_example_dag(self):
-        self.run_dag('example_postgres_to_gcs', 'airflow/example_dags')
+        self.run_dag('example_postgres_to_gcs', CLOUD_DAG_FOLDER)
 
     @provide_gcp_context(GCP_GCS_KEY)
     def tearDown(self):


### PR DESCRIPTION

---
Issue link: [AIRFLOW-6973](https://issues.apache.org/jira/browse/AIRFLOW-6973)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
