### PR TITLE
[AIRFLOW-6860] Default ignore_first_depends_on_past to True

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -63,7 +63,7 @@ https://developers.google.com/style/inclusive-documentation
 
 ### Deprecating ignore_first_depends_on_past on backfill command and default it to True
 
-When doing backfill with `--depends-on-past` dags, users will need to pass `--ignore-first-depends-on-past`.
+When doing backfill with `depends_on_past` dags, users will need to pass `--ignore-first-depends-on-past`.
 We should default it as `true` to avoid confusion
 
 ### Custom executors is loaded using full import path

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -63,7 +63,7 @@ https://developers.google.com/style/inclusive-documentation
 
 ### Deprecating ignore_first_depends_on_past on backfill command and default it to True
 
-When doing backfill with `depends_on_past` dags, users will need to pass `ignore_first_depends_on_past`.
+When doing backfill with `--depends-on-past` dags, users will need to pass `--ignore-first-depends-on-past`.
 We should default it as `true` to avoid confusion
 
 ### Custom executors is loaded using full import path

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -68,7 +68,7 @@ def dag_backfill(args, dag=None):
     signal.signal(signal.SIGTERM, sigint_handler)
 
     import warnings
-    warnings.warn('--ignore_first_depends_on_past is deprecated as the value is always set to True',
+    warnings.warn('--ignore-first-depends-on-past is deprecated as the value is always set to True',
                   category=PendingDeprecationWarning)
 
     if args.ignore_first_depends_on_past is False:


### PR DESCRIPTION
---
Issue link: [AIRFLOW-6860](https://issues.apache.org/jira/browse/AIRFLOW-6860)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
