### PR TITLE
[AIRFLOW-6014] reschedule deleted pending tasks

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -324,10 +324,14 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             )
             if event['type'] == 'ERROR':
                 return self.process_error(event)
+
+            status = task.status.phase
+            if event['type'] == 'DELETED' and status == 'Pending':
+                status = 'Canceled'
             self.process_status(
                 pod_id=task.metadata.name,
                 namespace=task.metadata.namespace,
-                status=task.status.phase,
+                status=status,
                 labels=task.metadata.labels,
                 resource_version=task.metadata.resource_version
             )
@@ -365,6 +369,9 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         elif status == 'Failed':
             self.log.info('Event: %s Failed', pod_id)
             self.watcher_queue.put((pod_id, namespace, State.FAILED, labels, resource_version))
+        elif status == 'Canceled':
+            self.log.info('Event: %s Canceled, rescheduling', pod_id)
+            self.watcher_queue.put((pod_id, namespace, State.UP_FOR_RESCHEDULE, labels, resource_version))
         elif status == 'Succeeded':
             self.log.info('Event: %s Succeeded', pod_id)
             self.watcher_queue.put((pod_id, namespace, None, labels, resource_version))


### PR DESCRIPTION
This code checks if a k8s process has been deleted and was in the
pending state, if so it will reschedule the task.

This is an alternative implementation of https://github.com/apache/airflow/pull/6606, which we have been using internally. I don't have any preference on which PR to use, wanted to show what we have been running in production for some time.

---
Issue link: [AIRFLOW-6014](https://issues.apache.org/jira/browse/AIRFLOW-6014)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [ ] Unit tests coverage for changes (not needed for documentation changes)
  - There seem to be no tests for `KubernetesJobWatchers`, and it requires a lot of k8s api knowledge it seems, I would be happy with some help on moving forward with this.
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
