### PR TITLE
[AIRFLOW-6978] Add PubSubPullOperator

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_pubsub.py
+++ b/airflow/providers/google/cloud/example_dags/example_pubsub.py
@@ -25,13 +25,14 @@ from airflow import models
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.pubsub import (
     PubSubCreateSubscriptionOperator, PubSubCreateTopicOperator, PubSubDeleteSubscriptionOperator,
-    PubSubDeleteTopicOperator, PubSubPublishMessageOperator,
+    PubSubDeleteTopicOperator, PubSubPublishMessageOperator, PubSubPullOperator,
 )
 from airflow.providers.google.cloud.sensors.pubsub import PubSubPullSensor
 from airflow.utils.dates import days_ago
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
-TOPIC = "PubSubTestTopic"
+TOPIC_FOR_SENSOR_DAG = "PubSubSensorTestTopic"
+TOPIC_FOR_OPERATOR_DAG = "PubSubOperatorTestTopic"
 MESSAGE = {"data": b"Tool", "attributes": {"name": "wrench", "mass": "1.3kg", "count": "3"}}
 
 default_args = {"start_date": days_ago(1)}
@@ -45,19 +46,19 @@ echo_cmd = """
 # [END howto_operator_gcp_pubsub_pull_messages_result_cmd]
 
 with models.DAG(
-    "example_gcp_pubsub",
+    "example_gcp_pubsub_sensor",
     default_args=default_args,
     schedule_interval=None,  # Override to match your needs
-) as example_dag:
+) as example_sensor_dag:
     # [START howto_operator_gcp_pubsub_create_topic]
     create_topic = PubSubCreateTopicOperator(
-        task_id="create_topic", topic=TOPIC, project_id=GCP_PROJECT_ID
+        task_id="create_topic", topic=TOPIC_FOR_SENSOR_DAG, project_id=GCP_PROJECT_ID
     )
     # [END howto_operator_gcp_pubsub_create_topic]
 
     # [START howto_operator_gcp_pubsub_create_subscription]
     subscribe_task = PubSubCreateSubscriptionOperator(
-        task_id="subscribe_task", project_id=GCP_PROJECT_ID, topic=TOPIC
+        task_id="subscribe_task", project_id=GCP_PROJECT_ID, topic=TOPIC_FOR_SENSOR_DAG
     )
     # [END howto_operator_gcp_pubsub_create_subscription]
 
@@ -82,7 +83,7 @@ with models.DAG(
     publish_task = PubSubPublishMessageOperator(
         task_id="publish_task",
         project_id=GCP_PROJECT_ID,
-        topic=TOPIC,
+        topic=TOPIC_FOR_SENSOR_DAG,
         messages=[MESSAGE, MESSAGE, MESSAGE],
     )
     # [END howto_operator_gcp_pubsub_publish]
@@ -97,9 +98,72 @@ with models.DAG(
 
     # [START howto_operator_gcp_pubsub_delete_topic]
     delete_topic = PubSubDeleteTopicOperator(
-        task_id="delete_topic", topic=TOPIC, project_id=GCP_PROJECT_ID
+        task_id="delete_topic", topic=TOPIC_FOR_SENSOR_DAG, project_id=GCP_PROJECT_ID
     )
     # [END howto_operator_gcp_pubsub_delete_topic]
 
     create_topic >> subscribe_task >> publish_task
     subscribe_task >> pull_messages >> pull_messages_result >> unsubscribe_task >> delete_topic
+
+
+with models.DAG(
+    "example_gcp_pubsub_operator",
+    default_args=default_args,
+    schedule_interval=None,  # Override to match your needs
+) as example_operator_dag:
+    # [START howto_operator_gcp_pubsub_create_topic]
+    create_topic = PubSubCreateTopicOperator(
+        task_id="create_topic", topic=TOPIC_FOR_OPERATOR_DAG, project_id=GCP_PROJECT_ID
+    )
+    # [END howto_operator_gcp_pubsub_create_topic]
+
+    # [START howto_operator_gcp_pubsub_create_subscription]
+    subscribe_task = PubSubCreateSubscriptionOperator(
+        task_id="subscribe_task", project_id=GCP_PROJECT_ID, topic=TOPIC_FOR_OPERATOR_DAG
+    )
+    # [END howto_operator_gcp_pubsub_create_subscription]
+
+    # [START howto_operator_gcp_pubsub_pull_message]
+    subscription = "{{ task_instance.xcom_pull('subscribe_task') }}"
+
+    pull_messages = PubSubPullOperator(
+        task_id="pull_messages",
+        ack_messages=True,
+        project_id=GCP_PROJECT_ID,
+        subscription=subscription,
+    )
+    # [END howto_operator_gcp_pubsub_pull_message]
+
+    # [START howto_operator_gcp_pubsub_pull_messages_result]
+    pull_messages_result = BashOperator(
+        task_id="pull_messages_result", bash_command=echo_cmd
+    )
+    # [END howto_operator_gcp_pubsub_pull_messages_result]
+
+    # [START howto_operator_gcp_pubsub_publish]
+    publish_task = PubSubPublishMessageOperator(
+        task_id="publish_task",
+        project_id=GCP_PROJECT_ID,
+        topic=TOPIC_FOR_OPERATOR_DAG,
+        messages=[MESSAGE, MESSAGE, MESSAGE],
+    )
+    # [END howto_operator_gcp_pubsub_publish]
+
+    # [START howto_operator_gcp_pubsub_unsubscribe]
+    unsubscribe_task = PubSubDeleteSubscriptionOperator(
+        task_id="unsubscribe_task",
+        project_id=GCP_PROJECT_ID,
+        subscription="{{ task_instance.xcom_pull('subscribe_task') }}",
+    )
+    # [END howto_operator_gcp_pubsub_unsubscribe]
+
+    # [START howto_operator_gcp_pubsub_delete_topic]
+    delete_topic = PubSubDeleteTopicOperator(
+        task_id="delete_topic", topic=TOPIC_FOR_OPERATOR_DAG, project_id=GCP_PROJECT_ID
+    )
+    # [END howto_operator_gcp_pubsub_delete_topic]
+
+    (
+        create_topic >> subscribe_task >> publish_task
+        >> pull_messages >> pull_messages_result >> unsubscribe_task >> delete_topic
+    )

--- a/airflow/providers/google/cloud/example_dags/example_pubsub.py
+++ b/airflow/providers/google/cloud/example_dags/example_pubsub.py
@@ -62,7 +62,7 @@ with models.DAG(
     )
     # [END howto_operator_gcp_pubsub_create_subscription]
 
-    # [START howto_operator_gcp_pubsub_pull_message]
+    # [START howto_operator_gcp_pubsub_pull_message_with_sensor]
     subscription = "{{ task_instance.xcom_pull('subscribe_task') }}"
 
     pull_messages = PubSubPullSensor(
@@ -71,7 +71,7 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
         subscription=subscription,
     )
-    # [END howto_operator_gcp_pubsub_pull_message]
+    # [END howto_operator_gcp_pubsub_pull_message_with_sensor]
 
     # [START howto_operator_gcp_pubsub_pull_messages_result]
     pull_messages_result = BashOperator(
@@ -123,7 +123,7 @@ with models.DAG(
     )
     # [END howto_operator_gcp_pubsub_create_subscription]
 
-    # [START howto_operator_gcp_pubsub_pull_message]
+    # [START howto_operator_gcp_pubsub_pull_message_with_operator]
     subscription = "{{ task_instance.xcom_pull('subscribe_task') }}"
 
     pull_messages = PubSubPullOperator(
@@ -132,7 +132,7 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
         subscription=subscription,
     )
-    # [END howto_operator_gcp_pubsub_pull_message]
+    # [END howto_operator_gcp_pubsub_pull_message_with_operator]
 
     # [START howto_operator_gcp_pubsub_pull_messages_result]
     pull_messages_result = BashOperator(

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -553,17 +553,15 @@ class PubSubHook(CloudBaseHook):
         if not project_id:
             raise ValueError("Project ID should be set.")
 
-        if ack_ids is not None and messages is not None:
-            raise ValueError("'ack_ids' and 'messages' arguments are mutually exclusive.")
-
-        if ack_ids is None:
-            if messages is None:
-                raise ValueError("Either 'ack_ids' or 'messages' argument have to be provided.")
-            else:
-                ack_ids = [
-                    message.ack_id
-                    for message in messages
-                ]
+        if ack_ids is not None and messages is None:
+            pass
+        elif ack_ids is None and messages is not None:
+            ack_ids = [
+                message.ack_id
+                for message in messages
+            ]
+        else:
+            raise ValueError("One and only one of 'ack_ids' and 'messages' arguments have to be provided")
 
         subscriber = self.subscriber_client
         subscription_path = SubscriberClient.subscription_path(project_id, subscription)  # noqa E501 # pylint: disable=no-member,line-too-long

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -496,7 +496,7 @@ class PubSubHook(CloudBaseHook):
         subscriber = self.subscriber_client
         subscription_path = SubscriberClient.subscription_path(project_id, subscription)  # noqa E501 # pylint: disable=no-member,line-too-long
 
-        self.log.info("Pulling mex %d messages from subscription (path) %s", max_messages, subscription_path)
+        self.log.info("Pulling max %d messages from subscription (path) %s", max_messages, subscription_path)
         try:
             # pylint: disable=no-member
             response = subscriber.pull(

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -531,7 +531,7 @@ class PubSubHook(CloudBaseHook):
             include the 'projects/{project}/topics/' prefix.
         :type subscription: str
         :param ack_ids: List of ReceivedMessage ackIds from a previous pull response.
-            Mutually exclusive with `messages` argument.
+            Mutually exclusive with ``messages`` argument.
         :type ack_ids: list
         :param messages: List of ReceivedMessage objects to acknowledge.
             Mutually exclusive with ``ack_ids`` argument.

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -534,7 +534,7 @@ class PubSubHook(CloudBaseHook):
             Mutually exclusive with `messages` argument.
         :type ack_ids: list
         :param messages: List of ReceivedMessage objects to acknowledge.
-            Mutually exclusive with `messages` argument.
+            Mutually exclusive with ``ack_ids`` argument.
         :type messages: list
         :param project_id: Optional, the GCP project name or ID in which to create the topic
             If set to None or missing, the default project_id from the GCP connection is used.

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -28,7 +28,7 @@ from google.api_core.exceptions import AlreadyExists, GoogleAPICallError
 from google.api_core.retry import Retry
 from google.cloud.exceptions import NotFound
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
-from google.cloud.pubsub_v1.types import Duration, MessageStoragePolicy, PushConfig
+from google.cloud.pubsub_v1.types import Duration, MessageStoragePolicy, PushConfig, ReceivedMessage
 from googleapiclient.errors import HttpError
 
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
@@ -460,7 +460,7 @@ class PubSubHook(CloudBaseHook):
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
-    ) -> List[Dict]:
+    ) -> List[ReceivedMessage]:
         """
         Pulls up to ``max_messages`` messages from Pub/Sub subscription.
 

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -732,9 +732,9 @@ class PubSubPullOperator(BaseOperator):
             subscription: str,
             max_messages: int = 5,
             ack_messages: bool = False,
+            messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]] = None,
             gcp_conn_id: str = 'google_cloud_default',
             delegate_to: Optional[str] = None,
-            messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]] = None,
             *args,
             **kwargs
     ) -> None:

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -671,22 +671,14 @@ class PubSubPublishMessageOperator(BaseOperator):
 
 class PubSubPullOperator(BaseOperator):
     """Pulls messages from a PubSub subscription and passes them through XCom.
-    If there are no messages available, returns empty list.
-
-    This Operator always calls PubSub API with ``return_immediately`` equal True.
-    This means that the graph execution will continue regardless of
-        whether there are any messages awaiting in the topic.
-        If you need to wait for messages, please use
+    If the queue is empty, returns empty list - never waits for messages.
+        If you do need to wait, please use
         :class:`airflow.providers.google.cloud.sensors.PubSubPullSensor`
         instead.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:PubSubPullSensor`
-
-    .. seealso::
-        If you want to wait for new messages, use Sensor instead:
-        :class:`airflow.providers.google.cloud.sensors.PubSubPullSensor`
 
     This sensor operator will pull up to ``max_messages`` messages from the
     specified PubSub subscription. When the subscription returns messages,

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -673,7 +673,7 @@ class PubSubPullOperator(BaseOperator):
     """Pulls messages from a PubSub subscription and passes them through XCom.
 
     This Operator always calls PubSub API with return_immediately=True.
-        This means that the graph execution will continue regardless of
+    This means that the graph execution will continue regardless of
         whether there are any messages awaiting in the topic.
         If you need to wait for messages, please use
         :class:`airflow.providers.google.cloud.sensors.PubSubPullSensor`

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -671,6 +671,7 @@ class PubSubPublishMessageOperator(BaseOperator):
 
 class PubSubPullOperator(BaseOperator):
     """Pulls messages from a PubSub subscription and passes them through XCom.
+    If there are no messages available, returns empty list.
 
     This Operator always calls PubSub API with ``return_immediately`` equal True.
     This means that the graph execution will continue regardless of
@@ -684,6 +685,7 @@ class PubSubPullOperator(BaseOperator):
         :ref:`howto/operator:PubSubPullSensor`
 
     .. seealso::
+        If you want to wait for new messages, use Sensor instead:
         :class:`airflow.providers.google.cloud.sensors.PubSubPullSensor`
 
     This sensor operator will pull up to ``max_messages`` messages from the

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -19,7 +19,7 @@
 This module contains Google PubSub operators.
 """
 import warnings
-from typing import Dict, List, Optional, Sequence, Tuple, Union, Any, Callable
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from google.api_core.retry import Retry
 from google.cloud.pubsub_v1.types import Duration, MessageStoragePolicy, PushConfig, ReceivedMessage

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -672,9 +672,8 @@ class PubSubPublishMessageOperator(BaseOperator):
 class PubSubPullOperator(BaseOperator):
     """Pulls messages from a PubSub subscription and passes them through XCom.
     If the queue is empty, returns empty list - never waits for messages.
-        If you do need to wait, please use
-        :class:`airflow.providers.google.cloud.sensors.PubSubPullSensor`
-        instead.
+    If you do need to wait, please use :class:`airflow.providers.google.cloud.sensors.PubSubPullSensor`
+    instead.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -714,7 +713,7 @@ class PubSubPullOperator(BaseOperator):
         It's return value will be saved to XCom.
         If you are pulling large messages, you probably want to provide a custom callback.
         If not provided, the default implementation will convert `ReceivedMessage` objects
-            into JSON-serializable dicts using `google.protobuf.json_format.MessageToDict` function.
+        into JSON-serializable dicts using `google.protobuf.json_format.MessageToDict` function.
     :type messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]]
     """
     template_fields = ['project_id', 'subscription']

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -776,7 +776,7 @@ class PubSubPullOperator(BaseOperator):
     def _default_message_callback(
             self,
             pulled_messages: List[ReceivedMessage],
-            context: Dict[str, Any],
+            context: Dict[str, Any],  # pylint: disable=unused-argument
     ):
         """
         This method can be overridden by subclasses or by `messages_callback` constructor argument.

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -19,10 +19,11 @@
 This module contains Google PubSub operators.
 """
 import warnings
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union, Any, Callable
 
 from google.api_core.retry import Retry
-from google.cloud.pubsub_v1.types import Duration, MessageStoragePolicy, PushConfig
+from google.cloud.pubsub_v1.types import Duration, MessageStoragePolicy, PushConfig, ReceivedMessage
+from google.protobuf.json_format import MessageToDict
 
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.pubsub import PubSubHook
@@ -666,3 +667,130 @@ class PubSubPublishMessageOperator(BaseOperator):
         self.log.info("Publishing to topic %s", self.topic)
         hook.publish(project_id=self.project_id, topic=self.topic, messages=self.messages)
         self.log.info("Published to topic %s", self.topic)
+
+
+class PubSubPullOperator(BaseOperator):
+    """Pulls messages from a PubSub subscription and passes them through XCom.
+
+    This Operator always calls PubSub API with return_immediately=True.
+        This means that the graph execution will continue regardless of
+        whether there are any messages awaiting in the topic.
+        If you need to wait for messages, please use
+        :class:`airflow.providers.google.cloud.sensors.PubSubPullSensor`
+        instead.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:PubSubPullSensor`
+
+    .. seealso::
+        :class:`airflow.providers.google.cloud.sensors.PubSubPullSensor`
+
+    This sensor operator will pull up to ``max_messages`` messages from the
+    specified PubSub subscription. When the subscription returns messages,
+    the poke method's criteria will be fulfilled and the messages will be
+    returned from the operator and passed through XCom for downstream tasks.
+
+    If ``ack_messages`` is set to True, messages will be immediately
+    acknowledged before being returned, otherwise, downstream tasks will be
+    responsible for acknowledging them.
+
+    ``project`` and ``subscription`` are templated so you can use
+    variables in them.
+
+    :param project: the GCP project ID for the subscription (templated)
+    :type project: str
+    :param subscription: the Pub/Sub subscription name. Do not include the
+        full subscription path.
+    :type subscription: str
+    :param max_messages: The maximum number of messages to retrieve per
+        PubSub pull request
+    :type max_messages: int
+    :param ack_messages: If True, each message will be acknowledged
+        immediately rather than by any downstream tasks
+    :type ack_messages: bool
+    :param gcp_conn_id: The connection ID to use connecting to
+        Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request
+        must have domain-wide delegation enabled.
+    :type delegate_to: str
+    :param messages_callback: (Optional) Callback to process received messages.
+        It's return value will be saved to XCom.
+        If you are pulling large messages, you probably want to provide a custom callback.
+        If not provided, the default implementation will convert `ReceivedMessage` objects
+            into JSON-serializable dicts using `google.protobuf.json_format.MessageToDict` function.
+    :type messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]]
+    """
+    template_fields = ['project_id', 'subscription']
+
+    @apply_defaults
+    def __init__(
+            self,
+            project_id: str,
+            subscription: str,
+            max_messages: int = 5,
+            ack_messages: bool = False,
+            gcp_conn_id: str = 'google_cloud_default',
+            delegate_to: Optional[str] = None,
+            messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]] = None,
+            *args,
+            **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.gcp_conn_id = gcp_conn_id
+        self.delegate_to = delegate_to
+        self.project_id = project_id
+        self.subscription = subscription
+        self.max_messages = max_messages
+        self.ack_messages = ack_messages
+        self.messages_callback = messages_callback
+
+    def execute(self, context):
+        hook = PubSubHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+        )
+
+        pulled_messages = hook.pull(
+            project_id=self.project_id,
+            subscription=self.subscription,
+            max_messages=self.max_messages,
+            return_immediately=True,
+        )
+
+        handle_messages = self.messages_callback or self._default_message_callback
+
+        ret = handle_messages(pulled_messages, context)
+
+        if pulled_messages and self.ack_messages:
+            hook.acknowledge(
+                project_id=self.project_id,
+                subscription=self.subscription,
+                messages=pulled_messages,
+            )
+
+        return ret
+
+    def _default_message_callback(
+            self,
+            pulled_messages: List[ReceivedMessage],
+            context: Dict[str, Any],
+    ):
+        """
+        This method can be overridden by subclasses or by `messages_callback` constructor argument.
+        This default implementation converts `ReceivedMessage` objects into JSON-serializable dicts.
+
+        :param pulled_messages: messages received from the topic.
+        :type pulled_messages: List[ReceivedMessage]
+        :param context: same as in `execute`
+        :return: value to be saved to XCom.
+        """
+
+        messages_json = [
+            MessageToDict(m)
+            for m in pulled_messages
+        ]
+
+        return messages_json

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -672,7 +672,7 @@ class PubSubPublishMessageOperator(BaseOperator):
 class PubSubPullOperator(BaseOperator):
     """Pulls messages from a PubSub subscription and passes them through XCom.
 
-    This Operator always calls PubSub API with return_immediately=True.
+    This Operator always calls PubSub API with ``return_immediately`` equal True.
     This means that the graph execution will continue regardless of
         whether there are any messages awaiting in the topic.
         If you need to wait for messages, please use

--- a/airflow/providers/google/cloud/sensors/pubsub.py
+++ b/airflow/providers/google/cloud/sensors/pubsub.py
@@ -19,7 +19,7 @@
 This module contains a Google PubSub sensor.
 """
 import warnings
-from typing import Optional, List, Callable, Any, Dict
+from typing import Any, Callable, Dict, List, Optional
 
 from google.cloud.pubsub_v1.types import ReceivedMessage
 from google.protobuf.json_format import MessageToDict

--- a/airflow/providers/google/cloud/sensors/pubsub.py
+++ b/airflow/providers/google/cloud/sensors/pubsub.py
@@ -64,7 +64,7 @@ class PubSubPullSensor(BaseSensorOperator):
     :param return_immediately:
         (Deprecated) This is an underlying PubSub API implementation detail.
         It has no real effect on Sensor behaviour other than some internal wait time before retrying
-            on empty queue.
+        on empty queue.
         The Sensor task will (by definition) always wait for a message, regardless of this argument value.
 
         If you want a non-blocking task that does not to wait for messages, please use
@@ -85,7 +85,7 @@ class PubSubPullSensor(BaseSensorOperator):
         It's return value will be saved to XCom.
         If you are pulling large messages, you probably want to provide a custom callback.
         If not provided, the default implementation will convert `ReceivedMessage` objects
-            into JSON-serializable dicts using `google.protobuf.json_format.MessageToDict` function.
+        into JSON-serializable dicts using `google.protobuf.json_format.MessageToDict` function.
     :type messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]]
     """
     template_fields = ['project_id', 'subscription']

--- a/airflow/providers/google/cloud/sensors/pubsub.py
+++ b/airflow/providers/google/cloud/sensors/pubsub.py
@@ -99,9 +99,9 @@ class PubSubPullSensor(BaseSensorOperator):
             return_immediately: Optional[bool] = None,
             ack_messages: bool = False,
             gcp_conn_id: str = 'google_cloud_default',
+            messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]] = None,
             delegate_to: Optional[str] = None,
             project: Optional[str] = None,
-            messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]] = None,
             *args,
             **kwargs
     ) -> None:

--- a/airflow/providers/google/cloud/sensors/pubsub.py
+++ b/airflow/providers/google/cloud/sensors/pubsub.py
@@ -84,8 +84,8 @@ class PubSubPullSensor(BaseSensorOperator):
             delegate_to: Optional[str] = None,
             project: Optional[str] = None,
             *args,
-            **kwargs) -> None:
-
+            **kwargs
+    ) -> None:
         # To preserve backward compatibility
         # TODO: remove one day
         if project:
@@ -111,18 +111,24 @@ class PubSubPullSensor(BaseSensorOperator):
         return self._messages
 
     def poke(self, context):
-        hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
-                          delegate_to=self.delegate_to)
+        hook = PubSubHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+        )
+
         pulled_messages = hook.pull(
             project_id=self.project_id,
             subscription=self.subscription,
             max_messages=self.max_messages,
-            return_immediately=self.return_immediately
+            return_immediately=self.return_immediately,
         )
 
         self._messages = [MessageToDict(m) for m in pulled_messages]
 
         if self._messages and self.ack_messages:
-            ack_ids = [m['ackId'] for m in self._messages if m.get('ackId')]
+            ack_ids = [
+                m['ackId'] for m in self._messages if m.get('ackId')
+            ]
             hook.acknowledge(project_id=self.project_id, subscription=self.subscription, ack_ids=ack_ids)
+
         return self._messages

--- a/airflow/providers/google/cloud/sensors/pubsub.py
+++ b/airflow/providers/google/cloud/sensors/pubsub.py
@@ -163,7 +163,7 @@ class PubSubPullSensor(BaseSensorOperator):
     def _default_message_callback(
             self,
             pulled_messages: List[ReceivedMessage],
-            context: Dict[str, Any],
+            context: Dict[str, Any],  # pylint: disable=unused-argument
     ):
         """
         This method can be overridden by subclasses or by `messages_callback` constructor argument.

--- a/airflow/providers/google/cloud/sensors/pubsub.py
+++ b/airflow/providers/google/cloud/sensors/pubsub.py
@@ -31,12 +31,14 @@ from airflow.utils.decorators import apply_defaults
 
 class PubSubPullSensor(BaseSensorOperator):
     """Pulls messages from a PubSub subscription and passes them through XCom.
+    Always waits for at least one message to be returned from the subscription.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:PubSubPullSensor`
 
     .. seealso::
+        If you don't want to wait for at least one message to come, use Operator instead:
         :class:`airflow.providers.google.cloud.operators.PubSubPullOperator`
 
     This sensor operator will pull up to ``max_messages`` messages from the

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -19,7 +19,7 @@
 import hashlib
 from datetime import timedelta
 from time import sleep
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Any
 
 from airflow.exceptions import (
     AirflowException, AirflowRescheduleException, AirflowSensorTimeout, AirflowSkipException,
@@ -103,7 +103,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         """
         raise AirflowException('Override me.')
 
-    def execute(self, context: Dict) -> None:
+    def execute(self, context: Dict) -> Any:
         started_at = timezone.utcnow()
         try_number = 1
         if self.reschedule:

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -19,7 +19,7 @@
 import hashlib
 from datetime import timedelta
 from time import sleep
-from typing import Dict, Iterable, Any
+from typing import Any, Dict, Iterable
 
 from airflow.exceptions import (
     AirflowException, AirflowRescheduleException, AirflowSensorTimeout, AirflowSkipException,

--- a/docs/howto/operator/gcp/pubsub.rst
+++ b/docs/howto/operator/gcp/pubsub.rst
@@ -89,8 +89,13 @@ and pass them through XCom.
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_pubsub.py
     :language: python
-    :start-after: [START howto_operator_gcp_pubsub_pull_message]
-    :end-before: [END howto_operator_gcp_pubsub_pull_message]
+    :start-after: [START howto_operator_gcp_pubsub_pull_message_with_sensor]
+    :end-before: [END howto_operator_gcp_pubsub_pull_message_with_sensor]
+
+.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_pubsub.py
+    :language: python
+    :start-after: [START howto_operator_gcp_pubsub_pull_message_with_operator]
+    :end-before: [END howto_operator_gcp_pubsub_pull_message_with_operator]
 
 To pull messages from XCom use the :class:`~airflow.operators.bash.BashOperator`.
 

--- a/tests/providers/google/cloud/hooks/test_pubsub.py
+++ b/tests/providers/google/cloud/hooks/test_pubsub.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import unittest
+from typing import List
 
 import mock
 from google.api_core.exceptions import AlreadyExists, GoogleAPICallError
@@ -60,13 +61,13 @@ class TestPubSubHook(unittest.TestCase):
                         new=mock_init):
             self.pubsub_hook = PubSubHook(gcp_conn_id='test')
 
-    def _generate_messages(self, count):
+    def _generate_messages(self, count) -> List[ReceivedMessage]:
         return [
             ParseDict(
                 {
-                    "ack_id": "%s" % i,
+                    "ack_id": str(i),
                     "message": {
-                        "data": 'Message {}'.format(i).encode('utf8'),
+                        "data": f'Message {i}'.encode('utf8'),
                         "attributes": {"type": "generated message"},
                     },
                 },

--- a/tests/providers/google/cloud/operators/test_pubsub.py
+++ b/tests/providers/google/cloud/operators/test_pubsub.py
@@ -17,21 +17,16 @@
 # under the License.
 
 import unittest
-from typing import List, Any, Dict
+from typing import Any, Dict, List
 
 import mock
 from google.cloud.pubsub_v1.types import ReceivedMessage
-from google.protobuf.json_format import ParseDict, MessageToDict
+from google.protobuf.json_format import MessageToDict, ParseDict
 
 from airflow.providers.google.cloud.operators.pubsub import (
-    PubSubCreateSubscriptionOperator,
-    PubSubCreateTopicOperator,
-    PubSubDeleteSubscriptionOperator,
-    PubSubDeleteTopicOperator,
-    PubSubPublishMessageOperator,
-    PubSubPullOperator,
+    PubSubCreateSubscriptionOperator, PubSubCreateTopicOperator, PubSubDeleteSubscriptionOperator,
+    PubSubDeleteTopicOperator, PubSubPublishMessageOperator, PubSubPullOperator,
 )
-
 
 TASK_ID = 'test-task-id'
 TEST_PROJECT = 'test-project'

--- a/tests/providers/google/cloud/operators/test_pubsub.py
+++ b/tests/providers/google/cloud/operators/test_pubsub.py
@@ -36,7 +36,6 @@ TEST_MESSAGES = [
     },
     {'data': b'Knock, knock'},
     {'attributes': {'foo': ''}}]
-TEST_POKE_INTERVAl = 0
 
 
 class TestPubSubTopicCreateOperator(unittest.TestCase):

--- a/tests/providers/google/cloud/operators/test_pubsub.py
+++ b/tests/providers/google/cloud/operators/test_pubsub.py
@@ -21,8 +21,11 @@ import unittest
 import mock
 
 from airflow.providers.google.cloud.operators.pubsub import (
-    PubSubCreateSubscriptionOperator, PubSubCreateTopicOperator, PubSubDeleteSubscriptionOperator,
-    PubSubDeleteTopicOperator, PubSubPublishMessageOperator,
+    PubSubCreateSubscriptionOperator,
+    PubSubCreateTopicOperator,
+    PubSubDeleteSubscriptionOperator,
+    PubSubDeleteTopicOperator,
+    PubSubPublishMessageOperator,
 )
 
 TASK_ID = 'test-task-id'
@@ -39,7 +42,6 @@ TEST_MESSAGES = [
 
 
 class TestPubSubTopicCreateOperator(unittest.TestCase):
-
     @mock.patch('airflow.providers.google.cloud.operators.pubsub.PubSubHook')
     def test_failifexists(self, mock_hook):
         operator = PubSubCreateTopicOperator(
@@ -86,7 +88,6 @@ class TestPubSubTopicCreateOperator(unittest.TestCase):
 
 
 class TestPubSubTopicDeleteOperator(unittest.TestCase):
-
     @mock.patch('airflow.providers.google.cloud.operators.pubsub.PubSubHook')
     def test_execute(self, mock_hook):
         operator = PubSubDeleteTopicOperator(
@@ -107,7 +108,6 @@ class TestPubSubTopicDeleteOperator(unittest.TestCase):
 
 
 class TestPubSubSubscriptionCreateOperator(unittest.TestCase):
-
     @mock.patch('airflow.providers.google.cloud.operators.pubsub.PubSubHook')
     def test_execute(self, mock_hook):
         operator = PubSubCreateSubscriptionOperator(
@@ -192,7 +192,6 @@ class TestPubSubSubscriptionCreateOperator(unittest.TestCase):
 
 
 class TestPubSubSubscriptionDeleteOperator(unittest.TestCase):
-
     @mock.patch('airflow.providers.google.cloud.operators.pubsub.PubSubHook')
     def test_execute(self, mock_hook):
         operator = PubSubDeleteSubscriptionOperator(
@@ -208,18 +207,19 @@ class TestPubSubSubscriptionDeleteOperator(unittest.TestCase):
             fail_if_not_exists=False,
             retry=None,
             timeout=None,
-            metadata=None
+            metadata=None,
         )
 
 
 class TestPubSubPublishOperator(unittest.TestCase):
-
     @mock.patch('airflow.providers.google.cloud.operators.pubsub.PubSubHook')
     def test_publish(self, mock_hook):
-        operator = PubSubPublishMessageOperator(task_id=TASK_ID,
-                                                project_id=TEST_PROJECT,
-                                                topic=TEST_TOPIC,
-                                                messages=TEST_MESSAGES)
+        operator = PubSubPublishMessageOperator(
+            task_id=TASK_ID,
+            project_id=TEST_PROJECT,
+            topic=TEST_TOPIC,
+            messages=TEST_MESSAGES,
+        )
 
         operator.execute(None)
         mock_hook.return_value.publish.assert_called_once_with(

--- a/tests/providers/google/cloud/operators/test_pubsub_system.py
+++ b/tests/providers/google/cloud/operators/test_pubsub_system.py
@@ -25,5 +25,9 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 @pytest.mark.credential_file(GCP_PUBSUB_KEY)
 class PubSubSystemTest(GoogleSystemTest):
     @provide_gcp_context(GCP_PUBSUB_KEY)
-    def test_run_example_dag(self):
-        self.run_dag(dag_id="example_gcp_pubsub", dag_folder=CLOUD_DAG_FOLDER)
+    def test_run_example_sensor_dag(self):
+        self.run_dag(dag_id="example_gcp_pubsub_sensor", dag_folder=CLOUD_DAG_FOLDER)
+
+    @provide_gcp_context(GCP_PUBSUB_KEY)
+    def test_run_example_operator_dag(self):
+        self.run_dag(dag_id="example_gcp_pubsub_operator", dag_folder=CLOUD_DAG_FOLDER)

--- a/tests/providers/google/cloud/sensors/test_pubsub.py
+++ b/tests/providers/google/cloud/sensors/test_pubsub.py
@@ -48,23 +48,36 @@ class TestPubSubPullSensor(unittest.TestCase):
         ]
 
     def _generate_dicts(self, count):
-        return [MessageToDict(m) for m in self._generate_messages(count)]
+        return [
+            MessageToDict(m)
+            for m in self._generate_messages(count)
+        ]
 
     @mock.patch('airflow.providers.google.cloud.sensors.pubsub.PubSubHook')
     def test_poke_no_messages(self, mock_hook):
-        operator = PubSubPullSensor(task_id=TASK_ID, project_id=TEST_PROJECT,
-                                    subscription=TEST_SUBSCRIPTION)
+        operator = PubSubPullSensor(
+            task_id=TASK_ID,
+            project_id=TEST_PROJECT,
+            subscription=TEST_SUBSCRIPTION,
+        )
+
         mock_hook.return_value.pull.return_value = []
         self.assertEqual([], operator.poke({}))
 
     @mock.patch('airflow.providers.google.cloud.sensors.pubsub.PubSubHook')
     def test_poke_with_ack_messages(self, mock_hook):
-        operator = PubSubPullSensor(task_id=TASK_ID, project_id=TEST_PROJECT,
-                                    subscription=TEST_SUBSCRIPTION,
-                                    ack_messages=True)
+        operator = PubSubPullSensor(
+            task_id=TASK_ID,
+            project_id=TEST_PROJECT,
+            subscription=TEST_SUBSCRIPTION,
+            ack_messages=True,
+        )
+
         generated_messages = self._generate_messages(5)
         generated_dicts = self._generate_dicts(5)
+
         mock_hook.return_value.pull.return_value = generated_messages
+
         self.assertEqual(generated_dicts, operator.poke({}))
         mock_hook.return_value.acknowledge.assert_called_once_with(
             project_id=TEST_PROJECT,
@@ -78,11 +91,13 @@ class TestPubSubPullSensor(unittest.TestCase):
             task_id=TASK_ID,
             project_id=TEST_PROJECT,
             subscription=TEST_SUBSCRIPTION,
-            poke_interval=0
+            poke_interval=0,
         )
+
         generated_messages = self._generate_messages(5)
         generated_dicts = self._generate_dicts(5)
         mock_hook.return_value.pull.return_value = generated_messages
+
         response = operator.execute({})
         mock_hook.return_value.pull.assert_called_once_with(
             project_id=TEST_PROJECT,
@@ -94,10 +109,16 @@ class TestPubSubPullSensor(unittest.TestCase):
 
     @mock.patch('airflow.providers.google.cloud.sensors.pubsub.PubSubHook')
     def test_execute_timeout(self, mock_hook):
-        operator = PubSubPullSensor(task_id=TASK_ID, project_id=TEST_PROJECT,
-                                    subscription=TEST_SUBSCRIPTION,
-                                    poke_interval=0, timeout=1)
+        operator = PubSubPullSensor(
+            task_id=TASK_ID,
+            project_id=TEST_PROJECT,
+            subscription=TEST_SUBSCRIPTION,
+            poke_interval=0,
+            timeout=1,
+        )
+
         mock_hook.return_value.pull.return_value = []
+
         with self.assertRaises(AirflowSensorTimeout):
             operator.execute({})
             mock_hook.return_value.pull.assert_called_once_with(

--- a/tests/providers/google/cloud/sensors/test_pubsub.py
+++ b/tests/providers/google/cloud/sensors/test_pubsub.py
@@ -17,7 +17,7 @@
 # under the License.
 
 import unittest
-from typing import List, Any, Dict
+from typing import Any, Dict, List
 
 import mock
 from google.cloud.pubsub_v1.types import ReceivedMessage

--- a/tests/providers/google/cloud/sensors/test_pubsub.py
+++ b/tests/providers/google/cloud/sensors/test_pubsub.py
@@ -54,7 +54,7 @@ class TestPubSubPullSensor(unittest.TestCase):
         operator = PubSubPullSensor(task_id=TASK_ID, project_id=TEST_PROJECT,
                                     subscription=TEST_SUBSCRIPTION)
         mock_hook.return_value.pull.return_value = []
-        self.assertEqual([], operator.poke(None))
+        self.assertEqual([], operator.poke({}))
 
     @mock.patch('airflow.providers.google.cloud.sensors.pubsub.PubSubHook')
     def test_poke_with_ack_messages(self, mock_hook):
@@ -64,7 +64,7 @@ class TestPubSubPullSensor(unittest.TestCase):
         generated_messages = self._generate_messages(5)
         generated_dicts = self._generate_dicts(5)
         mock_hook.return_value.pull.return_value = generated_messages
-        self.assertEqual(generated_dicts, operator.poke(None))
+        self.assertEqual(generated_dicts, operator.poke({}))
         mock_hook.return_value.acknowledge.assert_called_once_with(
             project_id=TEST_PROJECT,
             subscription=TEST_SUBSCRIPTION,
@@ -82,7 +82,7 @@ class TestPubSubPullSensor(unittest.TestCase):
         generated_messages = self._generate_messages(5)
         generated_dicts = self._generate_dicts(5)
         mock_hook.return_value.pull.return_value = generated_messages
-        response = operator.execute(None)
+        response = operator.execute({})
         mock_hook.return_value.pull.assert_called_once_with(
             project_id=TEST_PROJECT,
             subscription=TEST_SUBSCRIPTION,
@@ -98,7 +98,7 @@ class TestPubSubPullSensor(unittest.TestCase):
                                     poke_interval=0, timeout=1)
         mock_hook.return_value.pull.return_value = []
         with self.assertRaises(AirflowSensorTimeout):
-            operator.execute(None)
+            operator.execute({})
             mock_hook.return_value.pull.assert_called_once_with(
                 project_id=TEST_PROJECT,
                 subscription=TEST_SUBSCRIPTION,

--- a/tests/providers/google/cloud/sensors/test_pubsub.py
+++ b/tests/providers/google/cloud/sensors/test_pubsub.py
@@ -62,7 +62,7 @@ class TestPubSubPullSensor(unittest.TestCase):
         )
 
         mock_hook.return_value.pull.return_value = []
-        self.assertEqual([], operator.poke({}))
+        self.assertEqual(False, operator.poke({}))
 
     @mock.patch('airflow.providers.google.cloud.sensors.pubsub.PubSubHook')
     def test_poke_with_ack_messages(self, mock_hook):
@@ -74,15 +74,14 @@ class TestPubSubPullSensor(unittest.TestCase):
         )
 
         generated_messages = self._generate_messages(5)
-        generated_dicts = self._generate_dicts(5)
 
         mock_hook.return_value.pull.return_value = generated_messages
 
-        self.assertEqual(generated_dicts, operator.poke({}))
+        self.assertEqual(True, operator.poke({}))
         mock_hook.return_value.acknowledge.assert_called_once_with(
             project_id=TEST_PROJECT,
             subscription=TEST_SUBSCRIPTION,
-            ack_ids=['1', '2', '3', '4', '5']
+            messages=generated_messages,
         )
 
     @mock.patch('airflow.providers.google.cloud.sensors.pubsub.PubSubHook')


### PR DESCRIPTION
Add PubSubPullOperator - a non-blocking equivalent to Add PubSubPullSensor.

These two share most of functionality but ultimately serve different purpose - while existing PubSubPullSensor will block the pipeline until it receives a message, new PubSubPullOperator can be used to check for new messages opportunistically.

---
Issue link: [AIRFLOW-6978](https://issues.apache.org/jira/browse/AIRFLOW-6978)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
