### PR TITLE
[AIRFLOW-6402] Fix SSH Operator Exception

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,11 @@
+Airflow 1.10.9, 2020-02-10
+--------------------------
+
+Bug Fixes
+"""""""""
+
+- [AIRFLOW-6751] Pin Werkzeug (dependency of a number of our dependencies) to < 1.0.0 (#7377)
+
 Airflow 1.10.8, 2020-02-07
 --------------------------
 

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -80,7 +80,10 @@ class SSHOperator(BaseOperator):
         self.timeout = timeout
         self.environment = environment
         self.do_xcom_push = do_xcom_push
-        self.get_pty = self.command.startswith('sudo') or get_pty
+        if self.command:
+            self.get_pty = self.command.startswith('sudo') or get_pty
+        else:
+            self.get_pty = get_pty
 
     def execute(self, context):
         try:

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.8'
+version = '1.10.9'

--- a/tests/contrib/operators/test_ssh_operator.py
+++ b/tests/contrib/operators/test_ssh_operator.py
@@ -70,6 +70,24 @@ class SSHOperatorTest(TestCase):
         self.assertEqual(TIMEOUT, task.ssh_hook.timeout)
         self.assertEqual(SSH_ID, task.ssh_hook.ssh_conn_id)
 
+    def test_empty_command_is_none(self):
+        from airflow.exceptions import AirflowException
+        TIMEOUT = 20
+        COMMAND = None
+        task = SSHOperator(
+            task_id="test",
+            command=COMMAND,
+            dag=self.dag,
+            timeout=TIMEOUT,
+            ssh_conn_id="ssh_default"
+        )
+        self.assertIsNone(task.command)
+        if six.PY2:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+            self.assertRaisesRegex(AirflowException,
+                                   "SSH command not specified. Aborting.$",
+                                   task.execute, None)
+
     @conf_vars({('core', 'enable_xcom_pickling'): 'False'})
     def test_json_command_execution(self):
         task = SSHOperator(


### PR DESCRIPTION
Fix bug in SSH Operator constructor's where the self.command variable
is None, and thus throws a NoneType Exception when called.

Signed-off-by: Raymond Etornam <retornam@users.noreply.github.com>

---
Issue link: [AIRFLOW-6402](https://issues.apache.org/jira/browse/AIRFLOW-6402)

Make sure to mark the boxes below before creating PR: [x]

- [x ] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x ] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
