### PR TITLE
[AIRFLOW-6983] Use SingletonThreadPool for database communication

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -155,11 +155,7 @@ def task_run(args, dag=None):
         conf.read_dict(conf_dict, source=args.cfg_path)
         settings.configure_vars()
 
-    # IMPORTANT, have to use the NullPool, otherwise, each "run" command may leave
-    # behind multiple open sleeping connections while heartbeating, which could
-    # easily exceed the database connection limit when
-    # processing hundreds of simultaneous tasks.
-    settings.configure_orm(disable_connection_pool=True)
+    settings.configure_orm()
 
     if dag and args.pickle:
         raise AirflowException("You cannot use the --pickle option when using DAG.cli() method.")

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -100,21 +100,6 @@
       type: string
       example: ~
       default: "5"
-    - name: sql_alchemy_max_overflow
-      description: |
-        The maximum overflow size of the pool.
-        When the number of checked-out connections reaches the size set in pool_size,
-        additional connections will be returned up to this limit.
-        When those additional connections are returned to the pool, they are disconnected and discarded.
-        It follows then that the total number of simultaneous connections the pool will allow
-        is pool_size + max_overflow,
-        and the total number of "sleeping" connections the pool will allow is pool_size.
-        max_overflow can be set to -1 to indicate no overflow limit;
-        no limit will be placed on the total number of concurrent connections. Defaults to 10.
-      version_added: 1.10.4
-      type: string
-      example: ~
-      default: "10"
     - name: sql_alchemy_pool_recycle
       description: |
         The SqlAlchemy pool recycle is the number of seconds a connection

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -73,17 +73,6 @@ sql_alchemy_pool_enabled = True
 # in the pool. 0 indicates no limit.
 sql_alchemy_pool_size = 5
 
-# The maximum overflow size of the pool.
-# When the number of checked-out connections reaches the size set in pool_size,
-# additional connections will be returned up to this limit.
-# When those additional connections are returned to the pool, they are disconnected and discarded.
-# It follows then that the total number of simultaneous connections the pool will allow
-# is pool_size + max_overflow,
-# and the total number of "sleeping" connections the pool will allow is pool_size.
-# max_overflow can be set to -1 to indicate no overflow limit;
-# no limit will be placed on the total number of concurrent connections. Defaults to 10.
-sql_alchemy_max_overflow = 10
-
 # The SqlAlchemy pool recycle is the number of seconds a connection
 # can be idle in the pool before it is invalidated. This config does
 # not apply to sqlite. If the number of DB connections is ever exceeded,

--- a/tests/test_sqlalchemy_config.py
+++ b/tests/test_sqlalchemy_config.py
@@ -19,7 +19,7 @@
 import unittest
 
 from mock import patch
-from sqlalchemy.pool import NullPool
+from sqlalchemy.pool import NullPool, SingletonThreadPool
 
 from airflow import settings
 from airflow.exceptions import AirflowConfigException
@@ -58,9 +58,9 @@ class TestSqlAlchemySettings(unittest.TestCase):
         settings.configure_orm()
         mock_create_engine.assert_called_once_with(
             settings.SQL_ALCHEMY_CONN,
+            poolclass=SingletonThreadPool,
             connect_args={},
             encoding='utf-8',
-            max_overflow=10,
             pool_pre_ping=True,
             pool_recycle=1800,
             pool_size=5


### PR DESCRIPTION
Tasks are executed in CLI mode when connection pool to the database is disabled.
`settings.configure_orm(disable_connection_pool=True)`

While one task is run, multiple DB communications are happening while a separate connection is allocated for each of them. It results in DB failures.

Having SingletonThreadPool allows us to reuse the same connection. Also SingletonThreadPool is useful for other places (WebServer, Scheduler) because they are single-threaded.

---
Issue link: [AIRFLOW-6983](https://issues.apache.org/jira/browse/AIRFLOW-6983)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] ~Unit tests coverage for changes (not needed for documentation changes)~ Not sure if this is relevant for such configuration udpates
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
