### PR TITLE
[AIRFLOW-4363] Fix JSON encoding error

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -275,7 +275,7 @@ class DockerOperator(BaseOperator):
         # Pull the docker image if `force_pull` is set or image does not exist locally
         if self.force_pull or not self.cli.images(name=self.image):
             self.log.info('Pulling docker image %s', self.image)
-            for line in self.cli.pull(self.image, stream=True):
+            for line in self.cli.pull(self.image, stream=True, decode=True):
                 output = json.loads(line.decode('utf-8').strip())
                 if 'status' in output:
                     self.log.info("%s", output['status'])

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -85,7 +85,8 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.images.assert_called_once_with(name='ubuntu:latest')
         client_mock.attach.assert_called_once_with(container='some_id', stdout=True,
                                                    stderr=True, stream=True)
-        client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True)
+        client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True,
+                                                 decode=True)
         client_mock.wait.assert_called_once_with('some_id')
 
     @mock.patch('airflow.providers.docker.operators.docker.tls.TLSConfig')


### PR DESCRIPTION
From the docker-py code comments for APIClient pull,
the decode parameter should be set to True, when the
stream parameter is also set to True. This will allow
decoding JSON data returned from the docker registry
server into dicts

Signed-off-by: Raymond Etornam <retornam@users.noreply.github.com>

---
Issue link: [AIRFLOW-4363](https://issues.apache.org/jira/browse/AIRFLOW-4363)

Make sure to mark the boxes below before creating PR: [x]

- [x ] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
