### PR TITLE
[AIRFLOW-6987] Avoid creating default connections

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -174,10 +174,19 @@
       default: "16"
     - name: load_examples
       description: |
-        Whether to load the examples that ship with Airflow. It's good to
+        Whether to load the DAG examples that ship with Airflow. It's good to
         get started, but you probably want to set this to False in a production
         environment
       version_added: ~
+      type: string
+      example: ~
+      default: "True"
+    - name: load_default_connections
+      description: |
+        Whether to load the default connections that ship with Airflow. It's good to
+        get started, but you probably want to set this to False in a production
+        environment
+      version_added: 1.10.10
       type: string
       example: ~
       default: "True"

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -113,10 +113,15 @@ dags_are_paused_at_creation = True
 # The maximum number of active DAG runs per DAG
 max_active_runs_per_dag = 16
 
-# Whether to load the examples that ship with Airflow. It's good to
+# Whether to load the DAG examples that ship with Airflow. It's good to
 # get started, but you probably want to set this to False in a production
 # environment
 load_examples = True
+
+# Whether to load the default connections that ship with Airflow. It's good to
+# get started, but you probably want to set this to False in a production
+# environment
+load_default_connections = True
 
 # Where your Airflow plugins are stored
 plugins_folder = {AIRFLOW_HOME}/plugins

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -35,6 +35,7 @@ plugins_folder = {TEST_PLUGINS_FOLDER}
 executor = SequentialExecutor
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db
 load_examples = True
+load_default_connections = True
 donot_pickle = True
 dag_concurrency = 16
 dags_are_paused_at_creation = False

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -503,7 +503,8 @@ def initdb():
     """
     upgradedb()
 
-    create_default_connections()
+    if conf.getboolean('core', 'LOAD_DEFAULT_CONNECTIONS'):
+        create_default_connections()
 
     dagbag = DagBag()
     # Save DAGs in the ORM

--- a/scripts/ci/in_container/airflow_ci.cfg
+++ b/scripts/ci/in_container/airflow_ci.cfg
@@ -22,6 +22,7 @@ executor = LocalExecutor
 sql_alchemy_conn = # overridden by the startup scripts
 unit_test_mode = True
 load_examples = True
+load_default_connections = True
 donot_pickle = False
 dags_are_paused_at_creation = False
 default_impersonation =

--- a/scripts/ci/in_container/kubernetes/app/templates/configmaps.template.yaml
+++ b/scripts/ci/in_container/kubernetes/app/templates/configmaps.template.yaml
@@ -27,6 +27,7 @@ data:
     executor = KubernetesExecutor
     parallelism = 32
     load_examples = False
+    load_default_connections = True
     plugins_folder = /root/airflow/plugins
     sql_alchemy_conn = $SQL_ALCHEMY_CONN
 

--- a/scripts/perf/sql_queries.py
+++ b/scripts/perf/sql_queries.py
@@ -27,6 +27,7 @@ DAG_FOLDER = os.path.join(os.path.dirname(__file__), "dags")
 os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = DAG_FOLDER
 os.environ["AIRFLOW__DEBUG__SQLALCHEMY_STATS"] = "True"
 os.environ["AIRFLOW__CORE__LOAD_EXAMPLES"] = "False"
+os.environ["AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS"] = "True"
 
 # Here we setup simpler logger to avoid any code changes in
 # Airflow core code base

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -119,6 +119,8 @@ class TestConf(unittest.TestCase):
         self.assertEqual(
             cfg_dict['core']['load_examples'][1], 'airflow.cfg')
         self.assertEqual(
+            cfg_dict['core']['load_default_connections'][1], 'airflow.cfg')
+        self.assertEqual(
             cfg_dict['testsection']['testkey'], ('< hidden >', 'env var'))
 
     def test_conf_as_dict_sensitive(self):


### PR DESCRIPTION
[AIRFLOW-6987](https://issues.apache.org/jira/browse/AIRFLOW-6987)

Adds a new `load_default_connections` in the Core configuration of Airflow, similar to `load_examples` but aimed at avoiding the creation of default Connections in `airflow/utils/db.py`.

By default it is retrocompatible: 

  * the default behaviour is the old behaviour (`True`)
  * the old behaviour is also kept in the CI tests and other places were configuration is used

The config is documented as being new in 1.10.10 (the current version being built using `master`).

See also in the Helm charts project, concerning the stable/airflow chart:

> [stable/airflow] allow default connections to be removed 
https://github.com/helm/charts/issues/20568 (by @javamonkey79)
https://github.com/helm/charts/pull/21018#issuecomment-591723861 (by @javamonkey79)

> [stable/airflow] Add a feature to run extra init scripts in the scheduler after initdb
https://github.com/helm/charts/pull/21047