### PR TITLE
[AIRFLOW-6991] Allow passing arbitrary arguments to psycopg2

### DIFF
--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -35,6 +35,10 @@ class PostgresHook(DbApiHook):
     Also you can choose cursor as ``{"cursor": "dictcursor"}``. Refer to the
     psycopg2.extras for more details.
 
+    You can specify arbitrary libpq arguments as ``{"options": ...}```. Refer
+    to `https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS`
+    for more details.
+
     Note: For Redshift, use keepalives_idle in the extra connection parameters
     and set it to less than 300 seconds.
 
@@ -89,7 +93,7 @@ class PostgresHook(DbApiHook):
         for arg_name, arg_val in conn.extra_dejson.items():
             if arg_name in ['sslmode', 'sslcert', 'sslkey',
                             'sslrootcert', 'sslcrl', 'application_name',
-                            'keepalives_idle']:
+                            'keepalives_idle', 'options']:
                 conn_args[arg_name] = arg_val
 
         self.conn = psycopg2.connect(**conn_args)

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -63,6 +63,13 @@ class TestPostgresHookConn(unittest.TestCase):
                                              dbname='schema', port=None)
 
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
+    def test_get_conn_options(self, mock_connect):
+        self.connection.extra = '{"options": "-csearch_path=test"}'
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(user='login', password='password', host='host',
+                                             dbname='schema', port=None, options='-csearch_path=test')
+
+    @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
     def test_get_conn_cursor(self, mock_connect):
         self.connection.extra = '{"cursor": "dictcursor"}'
         self.db_hook.get_conn()


### PR DESCRIPTION
I specifically want to be able to pass search_path configured in the connection settings.

So `{"options":"-csearch_path=test"}` in the connection extras will pass that to the psycopg2 connect function

---
Issue link: [AIRFLOW-6991](https://issues.apache.org/jira/browse/AIRFLOW-6991)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
