### PR TITLE
[AIRFLOW-6989] Display Rendered template_fields without accessing Dagfiles

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -31,6 +31,7 @@ from urllib.parse import quote
 import dill
 import lazy_object_proxy
 import pendulum
+from jinja2 import TemplateAssertionError, UndefinedError
 from sqlalchemy import Column, Float, Index, Integer, PickleType, String, and_, func, or_
 from sqlalchemy.orm import reconstructor
 from sqlalchemy.orm.session import Session
@@ -1375,8 +1376,15 @@ class TaskInstance(Base, LoggingMixin):
                 for field_name, rendered_value in rtif.items():
                     setattr(self.task, field_name, rendered_value)
             else:
-                # TODO: Fetch Unrendered strings
-                ...
+                try:
+                    self.render_templates()
+                except (TemplateAssertionError, UndefinedError):
+                    raise AirflowException(
+                        "Webserver does not have access to User-defined Macros or Filters "
+                        "when Dag Serialization is enabled. Hence for the task that have not yet "
+                        "started running, please use 'airflow tasks render' for debugging the "
+                        "rendering of template_fields."
+                    )
         else:
             self.render_templates()
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1378,13 +1378,13 @@ class TaskInstance(Base, LoggingMixin):
             else:
                 try:
                     self.render_templates()
-                except (TemplateAssertionError, UndefinedError):
+                except (TemplateAssertionError, UndefinedError) as e:
                     raise AirflowException(
                         "Webserver does not have access to User-defined Macros or Filters "
                         "when Dag Serialization is enabled. Hence for the task that have not yet "
                         "started running, please use 'airflow tasks render' for debugging the "
                         "rendering of template_fields."
-                    )
+                    ) from e
         else:
             self.render_templates()
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -56,6 +56,7 @@ from airflow.api.common.experimental.mark_tasks import (
     set_dag_run_state_to_failed, set_dag_run_state_to_success,
 )
 from airflow.configuration import AIRFLOW_CONFIG, conf
+from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job import BaseJob
 from airflow.jobs.scheduler_job import SchedulerJob
@@ -587,6 +588,11 @@ class Airflow(AirflowBaseView):
         ti = models.TaskInstance(task=task, execution_date=dttm)
         try:
             ti.get_rendered_template_fields()
+        except AirflowException as e:
+            msg = "Error rendering template: " + escape(e)
+            if e.__cause__:
+                msg += Markup("<br/><br/>OriginalError: ") + escape(e.__cause__)
+            flash(msg, "error")
         except Exception as e:
             flash("Error rendering template: " + str(e), "error")
         title = "Rendered Template"

--- a/docs/dag-serialization.rst
+++ b/docs/dag-serialization.rst
@@ -21,7 +21,7 @@
 DAG Serialization
 =================
 
-In order to make Airflow Webserver stateless (almost!), Airflow >=1.10.7 supports
+In order to make Airflow Webserver stateless, Airflow >=1.10.7 supports
 DAG Serialization and DB Persistence.
 
 .. image:: img/dag_serialization.png
@@ -69,13 +69,19 @@ If you are updating Airflow from <1.10.7, please do not forget to run ``airflow 
 
 Limitations
 -----------
-The Webserver will still need access to DAG files in the following cases,
-which is why we said "almost" stateless.
 
-*   **Rendered Template** tab will still have to parse Python file as it needs all the details like
-    the execution date and even the data passed by the upstream task using Xcom.
+*   When using user-defined filters and macros, the Rendered View in the Webserver might show incorrect results
+    for TIs that have not yet executed as it might be using external modules that Webserver wont have access to.
+    Use ``airflow tasks render`` cli command in such situation to debug or test rendering of you template_fields.
+    Once the tasks execution starts the Rendered Template Fields will be stored in the DB in a separate table and
+    after which the correct values would be showed in the Webserver (Rendered View tab).
 *   **Code View** will read the DAG File & show it using Pygments.
     However, it does not need to Parse the Python file so it is still a small operation.
+
+.. note::
+    You need Airflow >= 1.10.10 for completely stateless Webserver.
+    Airflow 1.10.7 to 1.10.9 needed access to Dag files in some cases.
+    More Information: http://airflow.apache.org/docs/stable/dag-serialization.html#limitations
 
 Using a different JSON Library
 ------------------------------

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -57,18 +57,19 @@ serialized_simple_dag_ground_truth = {
         "fileloc": None,
         "tasks": [
             {
-                "task_id": "simple_task",
+                "task_id": "bash_task",
                 "owner": "airflow",
                 "retries": 1,
                 "retry_delay": 300.0,
                 "_downstream_task_ids": [],
                 "_inlets": [],
                 "_outlets": [],
-                "ui_color": "#fff",
+                "ui_color": "#f0ede4",
                 "ui_fgcolor": "#000",
-                "template_fields": [],
-                "_task_type": "BaseOperator",
-                "_task_module": "airflow.models.baseoperator",
+                "template_fields": ['bash_command', 'env'],
+                "bash_command": "echo {{ task.task_id }}",
+                "_task_type": "BashOperator",
+                "_task_module": "airflow.operators.bash",
             },
             {
                 "task_id": "custom_task",
@@ -102,7 +103,7 @@ def make_example_dags(module_path):
 
 def make_simple_dag():
     """Make very simple DAG to verify serialization result."""
-    dag = DAG(
+    with DAG(
         dag_id='simple_dag',
         default_args={
             "retries": 1,
@@ -111,9 +112,9 @@ def make_simple_dag():
         },
         start_date=datetime(2019, 8, 1),
         is_paused_upon_creation=False,
-    )
-    BaseOperator(task_id='simple_task', dag=dag, owner='airflow')
-    CustomOperator(task_id='custom_task', dag=dag)
+    ) as dag:
+        CustomOperator(task_id='custom_task')
+        BashOperator(task_id='bash_task', bash_command='echo {{ task.task_id }}', owner='airflow')
     return {'simple_dag': dag}
 
 
@@ -537,6 +538,77 @@ class TestStringifiedDAGs(unittest.TestCase):
         # Test Deserialized link registered via Airflow Plugin
         google_link_from_plugin = simple_task.get_extra_links(test_date, GoogleLink.name)
         self.assertEqual("https://www.google.com", google_link_from_plugin)
+
+    class ClassWithCustomAttributes:
+        """
+        Class for testing purpose: allows to create objects with custom attributes in one single statement.
+        """
+
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+        def __str__(self):
+            return "{}({})".format(self.__class__.__name__, str(self.__dict__))
+
+        def __repr__(self):
+            return self.__str__()
+
+        def __eq__(self, other):
+            return self.__dict__ == other.__dict__
+
+        def __ne__(self, other):
+            return not self.__eq__(other)
+
+    @parameterized.expand([
+        (None, None),
+        ([], []),
+        ({}, {}),
+        ("{{ task.task_id }}", "{{ task.task_id }}"),
+        (["{{ task.task_id }}", "{{ task.task_id }}"]),
+        ({"foo": "{{ task.task_id }}"}, {"foo": "{{ task.task_id }}"}),
+        ({"foo": {"bar": "{{ task.task_id }}"}}, {"foo": {"bar": "{{ task.task_id }}"}}),
+        (
+            [{"foo1": {"bar": "{{ task.task_id }}"}}, {"foo2": {"bar": "{{ task.task_id }}"}}],
+            [{"foo1": {"bar": "{{ task.task_id }}"}}, {"foo2": {"bar": "{{ task.task_id }}"}}],
+        ),
+        (
+            {"foo": {"bar": {"{{ task.task_id }}": ["sar"]}}},
+            {"foo": {"bar": {"{{ task.task_id }}": ["sar"]}}}),
+        (
+            ClassWithCustomAttributes(
+                att1="{{ task.task_id }}", att2="{{ task.task_id }}", template_fields=["att1"]),
+            "ClassWithCustomAttributes("
+            "{'att1': '{{ task.task_id }}', 'att2': '{{ task.task_id }}', 'template_fields': ['att1']})",
+        ),
+        (
+            ClassWithCustomAttributes(nested1=ClassWithCustomAttributes(att1="{{ task.task_id }}",
+                                                                        att2="{{ task.task_id }}",
+                                                                        template_fields=["att1"]),
+                                      nested2=ClassWithCustomAttributes(att3="{{ task.task_id }}",
+                                                                        att4="{{ task.task_id }}",
+                                                                        template_fields=["att3"]),
+                                      template_fields=["nested1"]),
+            "ClassWithCustomAttributes("
+            "{'nested1': ClassWithCustomAttributes({'att1': '{{ task.task_id }}', "
+            "'att2': '{{ task.task_id }}', 'template_fields': ['att1']}), "
+            "'nested2': ClassWithCustomAttributes({'att3': '{{ task.task_id }}', "
+            "'att4': '{{ task.task_id }}', 'template_fields': ['att3']}), 'template_fields': ['nested1']})",
+        ),
+    ])
+    def test_templated_fields_exist_in_serialized_dag(self, templated_field, expected_field):
+        """
+        Test that templated_fields exists for all Operators in Serialized DAG
+        """
+
+        dag = DAG("test_serialized_template_fields", start_date=datetime(2019, 8, 1))
+        with dag:
+            BashOperator(task_id="test", bash_command=templated_field)
+
+        serialized_dag = SerializedDAG.to_dict(dag)
+        deserialized_dag = SerializedDAG.from_dict(serialized_dag)
+        deserialized_test_task = deserialized_dag.task_dict["test"]
+        self.assertEqual(expected_field, getattr(deserialized_test_task, "bash_command"))
 
     def test_dag_serialized_fields_with_schema(self):
         """

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -599,6 +599,9 @@ class TestStringifiedDAGs(unittest.TestCase):
     def test_templated_fields_exist_in_serialized_dag(self, templated_field, expected_field):
         """
         Test that templated_fields exists for all Operators in Serialized DAG
+
+        Since we don't want to inflate arbitrary python objects (it poses a RCE/security risk etc.)
+        we want check that non-"basic" objects are turned in to strings after deserializing.
         """
 
         dag = DAG("test_serialized_template_fields", start_date=datetime(2019, 8, 1))

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1914,10 +1914,20 @@ class TestRenderedView(TestBase):
     def setUp(self):
         super().setUp()
         self.default_date = datetime(2020, 3, 1)
-        self.dag = DAG("testdag", start_date=self.default_date)
-        self.task = BashOperator(
-            task_id='testtask',
+        self.dag = DAG(
+            "testdag",
+            start_date=self.default_date,
+            user_defined_filters={"hello": lambda name: f'Hello {name}'},
+            user_defined_macros={"fullname": lambda fname, lname: f'{fname} {lname}'}
+        )
+        self.task1 = BashOperator(
+            task_id='task1',
             bash_command='{{ task_instance_key_str }}',
+            dag=self.dag
+        )
+        self.task2 = BashOperator(
+            task_id='task2',
+            bash_command='echo {{ fullname("Apache", "Airflow") | hello }}',
             dag=self.dag
         )
         SerializedDagModel.write_dag(self.dag)
@@ -1938,17 +1948,61 @@ class TestRenderedView(TestBase):
         """
         get_dag_function.return_value = SerializedDagModel.get(self.dag.dag_id).dag
 
-        self.assertEqual(self.task.bash_command, '{{ task_instance_key_str }}')
-        ti = TaskInstance(self.task, self.default_date)
+        self.assertEqual(self.task1.bash_command, '{{ task_instance_key_str }}')
+        ti = TaskInstance(self.task1, self.default_date)
 
         with create_session() as session:
             session.add(RTIF(ti))
 
-        url = ('rendered?task_id=testtask&dag_id=testdag&execution_date={}'
+        url = ('rendered?task_id=task1&dag_id=testdag&execution_date={}'
                .format(self.percent_encode(self.default_date)))
 
         resp = self.client.get(url, follow_redirects=True)
-        self.check_content_in_response("testdag__testtask__20200301", resp)
+        self.check_content_in_response("testdag__task1__20200301", resp)
+
+    @mock.patch('airflow.www.views.STORE_SERIALIZED_DAGS', True)
+    @mock.patch('airflow.models.taskinstance.STORE_SERIALIZED_DAGS', True)
+    @mock.patch('airflow.www.views.dagbag.get_dag')
+    def test_rendered_view_for_unexecuted_tis(self, get_dag_function):
+        """
+        Test that the Rendered View is able to show rendered values
+        even for TIs that have not yet executed
+        """
+        get_dag_function.return_value = SerializedDagModel.get(self.dag.dag_id).dag
+
+        self.assertEqual(self.task1.bash_command, '{{ task_instance_key_str }}')
+
+        url = ('rendered?task_id=task1&dag_id=task1&execution_date={}'
+               .format(self.percent_encode(self.default_date)))
+
+        resp = self.client.get(url, follow_redirects=True)
+        self.check_content_in_response("testdag__task1__20200301", resp)
+
+    @mock.patch('airflow.www.views.STORE_SERIALIZED_DAGS', True)
+    @mock.patch('airflow.models.taskinstance.STORE_SERIALIZED_DAGS', True)
+    @mock.patch('airflow.www.views.dagbag.get_dag')
+    def test_user_defined_filter_and_macros_raise_error(self, get_dag_function):
+        """
+        Test that the Rendered View is able to show rendered values
+        even for TIs that have not yet executed
+        """
+        get_dag_function.return_value = SerializedDagModel.get(self.dag.dag_id).dag
+
+        self.assertEqual(self.task2.bash_command,
+                         'echo {{ fullname("Apache", "Airflow") | hello }}')
+
+        url = ('rendered?task_id=task2&dag_id=testdag&execution_date={}'
+               .format(self.percent_encode(self.default_date)))
+
+        resp = self.client.get(url, follow_redirects=True)
+        self.check_content_not_in_response("echo Hello Apache Airflow", resp)
+        self.check_content_in_response(
+            "Webserver does not have access to User-defined Macros or Filters "
+            "when Dag Serialization is enabled. Hence for the task that have not yet "
+            "started running, please use &#39;airflow tasks render&#39; for debugging the "
+            "rendering of template_fields.",
+            resp
+        )
 
 
 class TestTriggerDag(TestBase):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2000,7 +2000,7 @@ class TestRenderedView(TestBase):
             "Webserver does not have access to User-defined Macros or Filters "
             "when Dag Serialization is enabled. Hence for the task that have not yet "
             "started running, please use &#39;airflow tasks render&#39; for debugging the "
-            "rendering of template_fields.",
+            "rendering of template_fields.<br/><br/>OriginalError: no filter named &#39;hello&#39",
             resp
         )
 


### PR DESCRIPTION

Continuation of https://issues.apache.org/jira/browse/AIRFLOW-5944 (https://github.com/apache/airflow/pull/6788)

Store unrendered Task Instance Template Fields in the DAG serialization table. 



---
Issue link: [AIRFLOW-6989](https://issues.apache.org/jira/browse/AIRFLOW-6989)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
