### PR TITLE
[AIRFLOW-5062]  Allow ACL Header in S3Hook

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -223,6 +223,19 @@ class TestAwsS3Hook:
         assert hook.get_wildcard_key('s3://{}/a'.format(s3_bucket)) is None
         assert hook.get_wildcard_key('s3://{}/b'.format(s3_bucket)) is None
 
+    @mock_s3
+    def test_get_object_permission(self):
+        hook = S3Hook(aws_conn_id=None)
+        conn = hook.get_conn()
+        conn.create_bucket(Bucket="mybucket")
+        with tempfile.NamedTemporaryFile() as temp_file:
+            temp_file.write(b'Content')
+            temp_file.seek(0)
+            hook.load_file(temp_file.name, "my_key", "mybucket",
+                           acl="bucket-owner-full-control")
+            permission = hook.get_object_permission("mybucket", "my_key")
+            assert permission == "FULL_CONTROL"
+
     def test_load_string(self, s3_bucket):
         hook = S3Hook()
         hook.load_string("Contént", "my_key", s3_bucket)


### PR DESCRIPTION
Allow passing in the ACL header in the AWS S3 Hook

Signed-off-by: Raymond Etornam <retornam@users.noreply.github.com>

---
Issue link: [AIRFLOW-5062](https://issues.apache.org/jira/browse/AIRFLOW-5062)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
