### PR TITLE
[AIRFLOW-7000] Allow passing in env var JSON dict in task_test

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -19,6 +19,7 @@
 """Command-line interface"""
 
 import argparse
+import json
 import os
 import textwrap
 from argparse import RawTextHelpFormatter
@@ -459,6 +460,10 @@ class CLIFactory:
             action="store_true",
             help="Open debugger on uncaught exception",
         ),
+        'env_vars': Arg(
+            ("--env-vars", ),
+            help="Set env var in both parsing time and runtime for each of entry supplied in a JSON dict",
+            type=json.loads),
         # connections
         'conn_id': Arg(
             ('conn_id',),
@@ -734,7 +739,7 @@ class CLIFactory:
                 "dependencies or recording its state in the database"),
             'args': (
                 'dag_id', 'task_id', 'execution_date', 'subdir', 'dry_run',
-                'task_params', 'post_mortem'),
+                'task_params', 'post_mortem', 'env_vars'),
         },
         {
             'func': lazy_load_command('airflow.cli.commands.task_command.task_states_for_dag_run'),

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -320,6 +320,11 @@ def task_test(args, dag=None):
     if not already_has_stream_handler:
         logging.getLogger('airflow.task').propagate = True
 
+    env_vars = {'AIRFLOW_TEST_MODE': 'True'}
+    if args.env_vars:
+        env_vars.update(args.env_vars)
+        os.environ.update(env_vars)
+
     dag = dag or get_dag(args.subdir, args.dag_id)
 
     task = dag.get_task(task_id=args.task_id)

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -18,6 +18,7 @@
 
 """Example DAG demonstrating the usage of the params arguments in templated arguments."""
 
+import os
 from datetime import timedelta
 
 from airflow import DAG
@@ -68,6 +69,24 @@ also_run_this = BashOperator(
     bash_command=my_templated_command,
     params={"miff": "agg"},
     dag=dag,
+)
+
+
+def print_env_vars(test_mode):
+    """
+    Print out the "foo" param passed in via
+    `airflow tasks test example_passing_params_via_test_command env_var_test_task <date>
+    --env-vars '{"foo":"bar"}'`
+    """
+    if test_mode:
+        print("foo={}".format(os.environ.get('foo')))
+        print("AIRFLOW_TEST_MODE={}".format(os.environ.get('AIRFLOW_TEST_MODE')))
+
+
+env_var_test_task = PythonOperator(
+    task_id='env_var_test_task',
+    python_callable=print_env_vars,
+    dag=dag
 )
 
 run_this >> also_run_this

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -119,6 +119,15 @@ class TestCliTasks(unittest.TestCase):
             'tasks', 'test', 'example_passing_params_via_test_command', 'also_run_this',
             '--task-params', '{"foo":"bar"}', DEFAULT_DATE.isoformat()]))
 
+    def test_cli_test_with_env_vars(self):
+        with redirect_stdout(io.StringIO()) as stdout:
+            task_command.task_test(self.parser.parse_args([
+                'tasks', 'test', 'example_passing_params_via_test_command', 'env_var_test_task',
+                '--env-vars', '{"foo":"bar"}', DEFAULT_DATE.isoformat()]))
+        output = stdout.getvalue()
+        self.assertIn('foo=bar', output)
+        self.assertIn('AIRFLOW_TEST_MODE=True', output)
+
     def test_cli_run(self):
         task_command.task_run(self.parser.parse_args([
             'tasks', 'run', 'example_bash_operator', 'runme_0', '--local',


### PR DESCRIPTION
---
Issue link: [AIRFLOW-7000](https://issues.apache.org/jira/browse/AIRFLOW-7000)

1. Allow batch passing in env var through JSON dict
2. Set `AIRFLOW_TEST_MODE` for all `airflow test` executions

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
