### PR TITLE
[AIRFLOW-7001] Time zone removed from MySQL TIMSTAMP field inserts

### DIFF
--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -34,6 +34,8 @@ log = logging.getLogger(__name__)
 
 utc = pendulum.timezone('UTC')
 
+using_mysql = conf.get('core', 'sql_alchemy_conn').lower().startswith('mysql')
+
 
 def setup_event_handlers(engine):
     """
@@ -114,7 +116,14 @@ class UtcDateTime(TypeDecorator):
                                 repr(value))
             elif value.tzinfo is None:
                 raise ValueError('naive datetime is disallowed')
-
+            # For mysql we should store timestamps as naive values
+            # Timestamp in MYSQL is not timezone aware. In MySQL 5.6
+            # timezone added at the end is ignored but in MySQL 5.7
+            # inserting timezone value fails with 'invalid-date'
+            # See https://issues.apache.org/jira/browse/AIRFLOW-7001
+            if using_mysql:
+                from airflow.utils.timezone import make_naive
+                return make_naive(value.astimezone(utc))
             return value.astimezone(utc)
         return None
 


### PR DESCRIPTION
For mysql we should store timestamps as naive values.

Timestamp in MYSQL is not timezone aware. In MySQL 5.6
timezone added at the end is ignored but in MySQL 5.7
inserting timezone value fails with 'invalid-date'

---
Issue link: [AIRFLOW-7001](https://issues.apache.org/jira/browse/AIRFLOW-7001)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
