### PR TITLE
[AIRFLOW-5822] Updated CSRF_ENABLED to WTF_CSRF_ENABLED in default we…

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -652,6 +652,12 @@
       type: string
       example: ~
       default: ""
+    - name: wtf_csrf_enabled
+      description: |
+        This enables and disables csrf token on the flask webserver.
+      type: boolean
+      example: ~
+      default: "True"
     - name: web_server_master_timeout
       description: |
         Number of seconds the webserver waits before killing gunicorn master that doesn't respond

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -320,6 +320,9 @@ web_server_ssl_cert =
 # provided SSL will be enabled. This does not change the web server port.
 web_server_ssl_key =
 
+# This enables and disables csrf token on the flask webserver.
+wtf_csrf_enabled = True
+
 # Number of seconds the webserver waits before killing gunicorn master that doesn't respond
 web_server_master_timeout = 120
 

--- a/airflow/config_templates/default_webserver_config.py
+++ b/airflow/config_templates/default_webserver_config.py
@@ -34,7 +34,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
 
 # Flask-WTF flag for CSRF
-CSRF_ENABLED = True
+WTF_CSRF_ENABLED = conf.getboolean('webserver', 'WTF_CSRF_ENABLED')
 
 # ----------------------------------------------------
 # AUTHENTICATION CONFIG

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -77,7 +77,8 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     # Configure the JSON encoder used by `|tojson` filter from Flask
     app.json_encoder = AirflowJsonEncoder
 
-    csrf.init_app(app)
+    if conf.getboolean('webserver', 'WTF_CSRF_ENABLED'):
+        csrf.init_app(app)
 
     db = SQLA(app)
 


### PR DESCRIPTION
WTF_CSRF_ENABLED flag was introduced but never used. The unit test cases are already there but not used.
---
Issue link: [AIRFLOW-5822](https://issues.apache.org/jira/browse/AIRFLOW-5822)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
