### PR TITLE
[AIRFLOW-7010] Skip in-container checks for Dockerhub builds

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -22,4 +22,7 @@
 
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Dockerhub builds are run inside Docker container
+export SKIP_IN_CONTAINER_CHECK="true"
+
 exec "${MY_DIR}/../scripts/ci/ci_build_dockerhub.sh"

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -414,6 +414,9 @@ function check_if_coreutils_installed() {
 # Asserts that we are not inside of the container
 #
 function assert_not_in_container() {
+    if [[ ${SKIP_IN_CONTAINER_CHECK:=} == "true" ]]; then
+        return
+    fi
     if [[ -f /.dockerenv ]]; then
         echo >&2
         echo >&2 "You are inside the Airflow docker container!"


### PR DESCRIPTION
---
Issue link: [AIRFLOW-7010](https://issues.apache.org/jira/browse/AIRFLOW-7010)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
