### PR TITLE
[AIRFLOW-6914] Add a default robots.txt

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -37,6 +37,7 @@ logs
 venv
 files
 airflow.iml
+robots.txt
 
 # Generated doc files
 .*html

--- a/airflow/www/blueprints.py
+++ b/airflow/www/blueprints.py
@@ -16,7 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from flask import Blueprint, redirect, url_for
+import os
+
+from flask import Blueprint, redirect, send_from_directory, url_for
 
 routes = Blueprint('routes', __name__)
 
@@ -24,3 +26,10 @@ routes = Blueprint('routes', __name__)
 @routes.route('/')
 def index():
     return redirect(url_for('Airflow.index'))
+
+
+@routes.route("/robots.txt", methods=["GET"])
+def robotstxt():
+    return send_from_directory(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static',
+                     'txt'), 'robots.txt')

--- a/airflow/www/static/txt/robots.txt
+++ b/airflow/www/static/txt/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -21,6 +21,10 @@
 
 {% block page_title %}{{ dag.dag_id }} - Airflow{% endblock %}
 
+{% block head_meta %}
+  <meta name="robots" content="noindex" />
+{% endblock %}
+
 {% block head_css %}
   {{ super() }}
   <link href="{{ url_for_asset('bootstrap-toggle.min.css') }}" rel="stylesheet" type="text/css">

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -98,6 +98,10 @@ const config = {
       {
         test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         loader: 'file-loader',
+      },{
+        test: /\.txt$/,
+        include: STATIC_DIR,
+        loader: 'file-loader',
       },
     ],
   },

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -319,6 +319,11 @@ class TestMountPoint(unittest.TestCase):
         resp = self.client.get('/', follow_redirects=True)
         self.assertEqual(resp.status_code, 404)
 
+    def test_robots_txt(self):
+        resp = self.client.get('/test/robots.txt', follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"Disallow: /", resp.data)
+
     def test_index(self):
         resp = self.client.get('/test/')
         self.assertEqual(resp.status_code, 302)


### PR DESCRIPTION
If an Airflow instance is public, Google, Bing,
DuckDuckGo and other search engines can index it.
If authentication has not been enabled, this can
create a serious security issue.

This fix adds a robots.txt to DENY all robot indexing,
adds the X-Robots-Tag header and also adds the
no-index meta tag
Signed-off-by: Raymond Etornam <retornam@users.noreply.github.com>

---
Issue link: [AIRFLOW-6914](https://issues.apache.org/jira/browse/AIRFLOW-6914)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
