### PR TITLE
[AIRFLOW-7012] Swap MySql for Postgres in Python 3.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,9 @@ jobs:
         ENABLED_INTEGRATIONS="cassandra kerberos mongo openldap rabbitmq redis"
         RUN_INTEGRATION_TESTS=all
       stage: test
-    - name: "Tests [Postgres][3.6]"
+    - name: "Tests [MySql][3.6]"
       env: >-
-        BACKEND=postgres
+        BACKEND=mysql
         PYTHON_VERSION=3.6
       stage: test
     - name: "Tests [Sqlite][3.7][integrations]"
@@ -104,9 +104,9 @@ jobs:
         ENABLED_INTEGRATIONS="cassandra kerberos mongo openldap rabbitmq redis"
         RUN_INTEGRATION_TESTS=all
       stage: test
-    - name: "Tests [MySQL][3.7][kerberos]"
+    - name: "Tests [Postgres][3.7][kerberos]"
       env: >-
-        BACKEND=mysql
+        BACKEND=postgres
         PYTHON_VERSION=3.7
         ENABLED_INTEGRATIONS="kerberos"
       stage: test


### PR DESCRIPTION
Seems that on Travis where we have MySQL 5.7 + Python 3.7 we have often (but
not always) failures resulting with "Lost connection to MySQL server during
query". While investigating it swapping Postgres and MySql in 3.6 and 3.7 tests
should help

---
Issue link: [AIRFLOW-7012](https://issues.apache.org/jira/browse/AIRFLOW-7012)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
