### PR TITLE
[AIRFLOW-6443]Increase pool name length to 256, make cli give error if name is too long

### DIFF
--- a/airflow/api/common/experimental/pool.py
+++ b/airflow/api/common/experimental/pool.py
@@ -54,7 +54,7 @@ def create_pool(name, slots, description, session=None):
     # Get the length of the pool column
     pool_name_length = Pool.pool.property.columns[0].type.length
     if len(name) > pool_name_length:
-        raise AirflowBadRequest("Pool name shouldn't be more than %s characters" % pool_name_length)
+        raise AirflowBadRequest("Pool name can't be more than %s characters" % pool_name_length)
 
     session.expire_on_commit = False
     pool = session.query(Pool).filter_by(pool=name).first()

--- a/airflow/api/common/experimental/pool.py
+++ b/airflow/api/common/experimental/pool.py
@@ -51,6 +51,11 @@ def create_pool(name, slots, description, session=None):
     except ValueError:
         raise AirflowBadRequest("Bad value for `slots`: %s" % slots)
 
+    # Get the length of the pool column
+    pool_name_length = Pool.pool.property.columns[0].type.length
+    if len(name) > pool_name_length:
+        raise AirflowBadRequest("Pool name shouldn't be more than %s characters" % pool_name_length)
+
     session.expire_on_commit = False
     pool = session.query(Pool).filter_by(pool=name).first()
     if pool is None:

--- a/airflow/api/common/experimental/pool.py
+++ b/airflow/api/common/experimental/pool.py
@@ -54,7 +54,7 @@ def create_pool(name, slots, description, session=None):
     # Get the length of the pool column
     pool_name_length = Pool.pool.property.columns[0].type.length
     if len(name) > pool_name_length:
-        raise AirflowBadRequest("Pool name can't be more than %s characters" % pool_name_length)
+        raise AirflowBadRequest("Pool name can't be more than %d characters" % pool_name_length)
 
     session.expire_on_commit = False
     pool = session.query(Pool).filter_by(pool=name).first()

--- a/airflow/migrations/versions/b25a55525161_increase_length_of_pool_name.py
+++ b/airflow/migrations/versions/b25a55525161_increase_length_of_pool_name.py
@@ -35,7 +35,7 @@ depends_on = None
 
 
 def upgrade():
-    """Increase column length of pool name from 50 to 250 characters"""
+    """Increase column length of pool name from 50 to 256 characters"""
     # use batch_alter_table to support SQLite workaround
     with op.batch_alter_table('slot_pool', table_args=sa.UniqueConstraint('pool')) as batch_op:
         batch_op.alter_column('pool', type_=sa.String(256))

--- a/airflow/migrations/versions/b25a55525161_increase_length_of_pool_name.py
+++ b/airflow/migrations/versions/b25a55525161_increase_length_of_pool_name.py
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Increase length of pool name
+
+Revision ID: b25a55525161
+Revises: a4c2fd67d16b
+Create Date: 2020-03-09 08:48:14.534700
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'b25a55525161'
+down_revision = 'a4c2fd67d16b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Increase column length of pool name from 50 to 250 characters"""
+    # use batch_alter_table to support SQLite workaround
+    with op.batch_alter_table('slot_pool', table_args=sa.UniqueConstraint('pool')) as batch_op:
+        batch_op.alter_column('pool', type_=sa.String(256))
+
+
+def downgrade():
+    """Revert Increased length of pool name from 256 to 50 characters"""
+    # use batch_alter_table to support SQLite workaround
+    with op.batch_alter_table('slot_pool', table_args=sa.UniqueConstraint('pool')) as batch_op:
+        batch_op.alter_column('pool', type_=sa.String(50))

--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -28,7 +28,7 @@ class Pool(Base):
     __tablename__ = "slot_pool"
 
     id = Column(Integer, primary_key=True)
-    pool = Column(String(50), unique=True)
+    pool = Column(String(256), unique=True)
     # -1 for infinite
     slots = Column(Integer, default=0)
     description = Column(Text)

--- a/tests/api/common/experimental/test_pool.py
+++ b/tests/api/common/experimental/test_pool.py
@@ -103,7 +103,7 @@ class TestPool(unittest.TestCase):
         long_name = ''.join(random.choices(string.ascii_lowercase, k=300))
         column_length = models.Pool.pool.property.columns[0].type.length
         self.assertRaisesRegex(AirflowBadRequest,
-                               "^Pool name can't be more than %s characters$" % column_length,
+                               "^Pool name can't be more than %d characters$" % column_length,
                                pool_api.create_pool,
                                name=long_name,
                                slots=5,

--- a/tests/api/common/experimental/test_pool.py
+++ b/tests/api/common/experimental/test_pool.py
@@ -103,7 +103,7 @@ class TestPool(unittest.TestCase):
         long_name = ''.join(random.choices(string.ascii_lowercase, k=300))
         column_length = models.Pool.pool.property.columns[0].type.length
         self.assertRaisesRegex(AirflowBadRequest,
-                               "^Pool name shouldn't be more than %s characters$" % column_length,
+                               "^Pool name can't be more than %s characters$" % column_length,
                                pool_api.create_pool,
                                name=long_name,
                                slots=5,

--- a/tests/api/common/experimental/test_pool.py
+++ b/tests/api/common/experimental/test_pool.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import random
+import string
 import unittest
 
 from airflow import models
@@ -96,6 +98,16 @@ class TestPool(unittest.TestCase):
                                    name=name,
                                    slots=5,
                                    description='')
+
+    def test_create_pool_name_too_long(self):
+        long_name = ''.join(random.choices(string.ascii_lowercase, k=300))
+        column_length = models.Pool.pool.property.columns[0].type.length
+        self.assertRaisesRegex(AirflowBadRequest,
+                               "^Pool name shouldn't be more than %s characters$" % column_length,
+                               pool_api.create_pool,
+                               name=long_name,
+                               slots=5,
+                               description='')
 
     def test_create_pool_bad_slots(self):
         self.assertRaisesRegex(AirflowBadRequest,


### PR DESCRIPTION
Pool name can now give error in cli if the name is too large. The name has been increased to 256 characters 

---
Issue link: [AIRFLOW-6443](https://issues.apache.org/jira/browse/AIRFLOW-6443)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
