### PR TITLE
[AIRFLOW-7016] Sort dag tags in the UI

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -105,7 +105,7 @@
                     </span>
 
                     <div style="float: right; max-width: 70%; text-align: right; line-height: 160%;">
-                    {% for tag in dag.tags %}
+                    {% for tag in dag.tags | sort(attribute='name') %}
                       <span class="label label-success" style="margin: 3px;">{{ tag.name }}</span>
                     {% endfor %}
                     </div>


### PR DESCRIPTION
A bit OCD, but two dags with the same tags can show it in a diff order and it's a bit annoying.
![image](https://user-images.githubusercontent.com/5796188/76200560-86d44d00-61fa-11ea-93be-705afcf2e6a7.png)

---
Issue link: [AIRFLOW-7016](https://issues.apache.org/jira/browse/AIRFLOW-7016)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
