### PR TITLE
[AIRFLOW-7019] Show un/pause errors in dags view.

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -563,13 +563,23 @@ function updateQueryStringParameter(uri, key, value) {
 
     $("#pause_resume").change(function() {
       var dag_id = $(this).attr('dag_id');
-      if ($(this).prop('checked')) {
+      var $input = $(this);
+      var $buttons = $input.parent('.toggle').find('.btn');
+      $buttons.removeClass('btn-danger');
+      if ($input.prop('checked')) {
         is_paused = 'true'
       } else {
         is_paused = 'false'
       }
-      url = "{{ url_for('Airflow.paused') }}" + '?is_paused=' + is_paused + '&dag_id=' + encodeURIComponent(dag_id);
-      $.post(url);
+      var url = "{{ url_for('Airflow.paused') }}" + '?is_paused=' + is_paused + '&dag_id=' + encodeURIComponent(dag_id);
+      $.post(url).fail(function() {
+        if (is_paused === 'true') {
+          $input.data('bs.toggle').off(true);
+        } else {
+          $input.data('bs.toggle').on(true);
+        }
+        $buttons.addClass('btn-danger');
+      });
     });
 
   </script>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -283,17 +283,27 @@
       var encoded_dag_ids = new URLSearchParams();
 
       $.each($("[id^=toggle]"), function(i, v) {
-        var dag_id = $(v).attr('dag_id');
+        var $input = $(v);
+        var dag_id = $input.attr('dag_id');
         encoded_dag_ids.append('dag_ids', dag_id);
 
-        $(v).change (function() {
-          if ($(v).prop('checked')) {
+        $input.change(function() {
+          var $buttons = $input.parent('.toggle').find('.btn');
+          $buttons.removeClass('btn-danger');
+          if ($input.prop('checked')) {
             is_paused = 'true'
           } else {
             is_paused = 'false'
           }
-          url = 'paused?is_paused=' + is_paused + '&dag_id=' + dag_id;
-          $.post(url);
+          var url = 'paused?is_paused=' + is_paused + '&dag_id=' + dag_id;
+          $.post(url).fail(function() {
+            if (is_paused === 'true') {
+              $input.data('bs.toggle').off(true);
+            } else {
+              $input.data('bs.toggle').on(true);
+            }
+            $buttons.addClass('btn-danger');
+          });
         });
       });
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -220,3 +220,11 @@ How do I stop the sync perms happening multiple times per webserver?
 --------------------------------------------------------------------
 
 Set the value of ``update_fab_perms`` configuration in ``airflow.cfg`` to ``False``.
+
+Why did the pause dag toggle turn red?
+--------------------------------------
+
+If pausing or unpausing a dag fails for any reason, the dag toggle will
+revert to its previous state and turn red. If you observe this behavior,
+try pausing the dag again, or check the console or server logs if the
+issue recurs.


### PR DESCRIPTION
Pausing and unpausing dags in the dags view is asynchronous, and there
is currently no indication to the user if the operation fails. This
patch updates the paused input and highlights it in red when pausing or
unpausing fails.

---
Issue link: [AIRFLOW-7019](https://issues.apache.org/jira/browse/AIRFLOW-7019)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
