### PR TITLE
[AIRFLOW-6574] Adding private_environment to docker operator.

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -193,8 +193,7 @@ class DockerOperator(BaseOperator):
         self.shm_size = shm_size
         self.tty = tty
         if kwargs.get('xcom_push') is not None:
-            raise AirflowException(
-                "'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
+            raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
         self.cli = None
         self.container = None
@@ -256,8 +255,7 @@ class DockerOperator(BaseOperator):
 
             result = self.cli.wait(self.container['Id'])
             if result['StatusCode'] != 0:
-                raise AirflowException(
-                    'docker container failed: ' + repr(result))
+                raise AirflowException('docker container failed: ' + repr(result))
 
             # duplicated conditional logic because of expensive operation
             if self.do_xcom_push:

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -91,8 +91,6 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True)
         client_mock.wait.assert_called_once_with('some_id')
 
-    @mock.patch('airflow.providers.docker.operators.docker.tls.TLSConfig')
-    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
     def test_private_environment_is_private(self):
         operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
                                   private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest',

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -45,7 +45,7 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.attach.return_value = ['container log']
         client_mock.logs.return_value = ['container log']
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.wait.return_value = {'StatusCode': 0}
+        client_mock.wait.return_value = {"StatusCode": 0}
 
         client_class_mock.return_value = client_mock
 
@@ -83,24 +83,18 @@ class TestDockerOperator(unittest.TestCase):
                                                                auto_remove=False,
                                                                dns=None,
                                                                dns_search=None)
-        tempdir_mock.assert_called_once_with(
-            dir='/host/airflow', prefix='airflowtmp')
+        tempdir_mock.assert_called_once_with(dir='/host/airflow', prefix='airflowtmp')
         client_mock.images.assert_called_once_with(name='ubuntu:latest')
         client_mock.attach.assert_called_once_with(container='some_id', stdout=True,
                                                    stderr=True, stream=True)
         client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True)
         client_mock.wait.assert_called_once_with('some_id')
 
-    def test_private_environment_is_private(self):
-        operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
-                                  private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest',
-                                  network_mode='bridge', owner='unittest', task_id='unittest',
-                                  volumes=['/host/path:/container/path'],
-                                  working_dir='/container/path', shm_size=1000,
-                                  host_tmp_dir='/host/airflow', container_name='test_container',
-                                  tty=True)
-        self.assertEqual(getattr(operator, '_private_environment'), {
-                         'PRIVATE': 'MESSAGE'})
+    @staticmethod
+    def test_private_environment_is_private():
+        operator = DockerOperator(private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest')
+        message = "To keep this private, it must be an underscored attribute."
+        assert operator._private_environment == {'PRIVATE': 'MESSAGE'}, message
 
     @mock.patch('airflow.providers.docker.operators.docker.tls.TLSConfig')
     @mock.patch('airflow.providers.docker.operators.docker.APIClient')
@@ -123,8 +117,7 @@ class TestDockerOperator(unittest.TestCase):
         operator.execute(None)
 
         tls_class_mock.assert_called_once_with(assert_hostname=None, ca_cert='ca.pem',
-                                               client_cert=(
-                                                   'cert.pem', 'key.pem'),
+                                               client_cert=('cert.pem', 'key.pem'),
                                                ssl_version=None, verify=True)
 
         client_class_mock.assert_called_once_with(base_url='https://127.0.0.1:2376',
@@ -145,8 +138,7 @@ class TestDockerOperator(unittest.TestCase):
         originalRaiseExceptions = logging.raiseExceptions  # pylint: disable=invalid-name
         logging.raiseExceptions = True
 
-        operator = DockerOperator(
-            image='ubuntu', owner='unittest', task_id='unittest')
+        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
 
         with mock.patch('traceback.print_exception') as print_exception_mock:
             operator.execute(None)
@@ -165,8 +157,7 @@ class TestDockerOperator(unittest.TestCase):
 
         client_class_mock.return_value = client_mock
 
-        operator = DockerOperator(
-            image='ubuntu', owner='unittest', task_id='unittest')
+        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
 
         with self.assertRaises(AirflowException):
             operator.execute(None)
@@ -175,8 +166,7 @@ class TestDockerOperator(unittest.TestCase):
     def test_on_kill():
         client_mock = mock.Mock(spec=APIClient)
 
-        operator = DockerOperator(
-            image='ubuntu', owner='unittest', task_id='unittest')
+        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
         operator.cli = client_mock
         operator.container = {'Id': 'some_id'}
 
@@ -187,8 +177,7 @@ class TestDockerOperator(unittest.TestCase):
     @mock.patch('airflow.providers.docker.operators.docker.APIClient')
     def test_execute_no_docker_conn_id_no_hook(self, operator_client_mock):
         # Mock out a Docker client, so operations don't raise errors
-        client_mock = mock.Mock(
-            name='DockerOperator.APIClient mock', spec=APIClient)
+        client_mock = mock.Mock(name='DockerOperator.APIClient mock', spec=APIClient)
         client_mock.images.return_value = []
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = []
@@ -223,8 +212,7 @@ class TestDockerOperator(unittest.TestCase):
     def test_execute_with_docker_conn_id_use_hook(self, operator_client_mock,
                                                   operator_docker_hook):
         # Mock out a Docker client, so operations don't raise errors
-        client_mock = mock.Mock(
-            name='DockerOperator.APIClient mock', spec=APIClient)
+        client_mock = mock.Mock(name='DockerOperator.APIClient mock', spec=APIClient)
         client_mock.images.return_value = []
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = []
@@ -270,7 +258,7 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = ['container log']
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.wait.return_value = {'StatusCode': 0}
+        client_mock.wait.return_value = {"StatusCode": 0}
 
         client_class_mock.return_value = client_mock
 

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -90,11 +90,14 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True)
         client_mock.wait.assert_called_once_with('some_id')
 
-    @staticmethod
-    def test_private_environment_is_private():
-        operator = DockerOperator(private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest')
-        message = "To keep this private, it must be an underscored attribute."
-        assert operator._private_environment == {'PRIVATE': 'MESSAGE'}, message
+    def test_private_environment_is_private(self):
+        operator = DockerOperator(private_environment={'PRIVATE': 'MESSAGE'},
+                                  image='ubuntu:latest',
+                                  task_id='unittest')
+        self.assertEqual(
+            operator._private_environment, {'PRIVATE': 'MESSAGE'},
+            "To keep this private, it must be an underscored attribute."
+        )
 
     @mock.patch('airflow.providers.docker.operators.docker.tls.TLSConfig')
     @mock.patch('airflow.providers.docker.operators.docker.APIClient')

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -45,13 +45,14 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.attach.return_value = ['container log']
         client_mock.logs.return_value = ['container log']
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.wait.return_value = {"StatusCode": 0}
+        client_mock.wait.return_value = {'StatusCode': 0}
 
         client_class_mock.return_value = client_mock
 
         operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
-                                  image='ubuntu:latest', network_mode='bridge', owner='unittest',
-                                  task_id='unittest', volumes=['/host/path:/container/path'],
+                                  private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest',
+                                  network_mode='bridge', owner='unittest', task_id='unittest',
+                                  volumes=['/host/path:/container/path'],
                                   working_dir='/container/path', shm_size=1000,
                                   host_tmp_dir='/host/airflow', container_name='test_container',
                                   tty=True)
@@ -64,7 +65,8 @@ class TestDockerOperator(unittest.TestCase):
                                                              name='test_container',
                                                              environment={
                                                                  'AIRFLOW_TMP_DIR': '/tmp/airflow',
-                                                                 'UNIT': 'TEST'
+                                                                 'UNIT': 'TEST',
+                                                                 'PRIVATE': 'MESSAGE'
                                                              },
                                                              host_config=host_config,
                                                              image='ubuntu:latest',
@@ -81,12 +83,26 @@ class TestDockerOperator(unittest.TestCase):
                                                                auto_remove=False,
                                                                dns=None,
                                                                dns_search=None)
-        tempdir_mock.assert_called_once_with(dir='/host/airflow', prefix='airflowtmp')
+        tempdir_mock.assert_called_once_with(
+            dir='/host/airflow', prefix='airflowtmp')
         client_mock.images.assert_called_once_with(name='ubuntu:latest')
         client_mock.attach.assert_called_once_with(container='some_id', stdout=True,
                                                    stderr=True, stream=True)
         client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True)
         client_mock.wait.assert_called_once_with('some_id')
+
+    @mock.patch('airflow.providers.docker.operators.docker.tls.TLSConfig')
+    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
+    def test_private_environment_is_private(self):
+        operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
+                                  private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest',
+                                  network_mode='bridge', owner='unittest', task_id='unittest',
+                                  volumes=['/host/path:/container/path'],
+                                  working_dir='/container/path', shm_size=1000,
+                                  host_tmp_dir='/host/airflow', container_name='test_container',
+                                  tty=True)
+        self.assertEqual(getattr(operator, '_private_environment'), {
+                         'PRIVATE': 'MESSAGE'})
 
     @mock.patch('airflow.providers.docker.operators.docker.tls.TLSConfig')
     @mock.patch('airflow.providers.docker.operators.docker.APIClient')
@@ -109,7 +125,8 @@ class TestDockerOperator(unittest.TestCase):
         operator.execute(None)
 
         tls_class_mock.assert_called_once_with(assert_hostname=None, ca_cert='ca.pem',
-                                               client_cert=('cert.pem', 'key.pem'),
+                                               client_cert=(
+                                                   'cert.pem', 'key.pem'),
                                                ssl_version=None, verify=True)
 
         client_class_mock.assert_called_once_with(base_url='https://127.0.0.1:2376',
@@ -130,7 +147,8 @@ class TestDockerOperator(unittest.TestCase):
         originalRaiseExceptions = logging.raiseExceptions  # pylint: disable=invalid-name
         logging.raiseExceptions = True
 
-        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
+        operator = DockerOperator(
+            image='ubuntu', owner='unittest', task_id='unittest')
 
         with mock.patch('traceback.print_exception') as print_exception_mock:
             operator.execute(None)
@@ -149,7 +167,8 @@ class TestDockerOperator(unittest.TestCase):
 
         client_class_mock.return_value = client_mock
 
-        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
+        operator = DockerOperator(
+            image='ubuntu', owner='unittest', task_id='unittest')
 
         with self.assertRaises(AirflowException):
             operator.execute(None)
@@ -158,7 +177,8 @@ class TestDockerOperator(unittest.TestCase):
     def test_on_kill():
         client_mock = mock.Mock(spec=APIClient)
 
-        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
+        operator = DockerOperator(
+            image='ubuntu', owner='unittest', task_id='unittest')
         operator.cli = client_mock
         operator.container = {'Id': 'some_id'}
 
@@ -169,7 +189,8 @@ class TestDockerOperator(unittest.TestCase):
     @mock.patch('airflow.providers.docker.operators.docker.APIClient')
     def test_execute_no_docker_conn_id_no_hook(self, operator_client_mock):
         # Mock out a Docker client, so operations don't raise errors
-        client_mock = mock.Mock(name='DockerOperator.APIClient mock', spec=APIClient)
+        client_mock = mock.Mock(
+            name='DockerOperator.APIClient mock', spec=APIClient)
         client_mock.images.return_value = []
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = []
@@ -204,7 +225,8 @@ class TestDockerOperator(unittest.TestCase):
     def test_execute_with_docker_conn_id_use_hook(self, operator_client_mock,
                                                   operator_docker_hook):
         # Mock out a Docker client, so operations don't raise errors
-        client_mock = mock.Mock(name='DockerOperator.APIClient mock', spec=APIClient)
+        client_mock = mock.Mock(
+            name='DockerOperator.APIClient mock', spec=APIClient)
         client_mock.images.return_value = []
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = []
@@ -250,7 +272,7 @@ class TestDockerOperator(unittest.TestCase):
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = ['container log']
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.wait.return_value = {"StatusCode": 0}
+        client_mock.wait.return_value = {'StatusCode': 0}
 
         client_class_mock.return_value = client_mock
 
@@ -258,6 +280,7 @@ class TestDockerOperator(unittest.TestCase):
             'api_version': '1.19',
             'command': 'env',
             'environment': {'UNIT': 'TEST'},
+            'private_environment': {'PRIVATE': 'MESSAGE'},
             'image': 'ubuntu:latest',
             'network_mode': 'bridge',
             'owner': 'unittest',


### PR DESCRIPTION
The docker operator currently does not have a means to pass in an environment dict that is not exposed to the frontend.

This links to issue 6574. 

---
Issue link: [AIRFLOW-6574](https://issues.apache.org/jira/browse/AIRFLOW-6574)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
