### PR TITLE
[AIRFLOW-7024] Add the verbose parameter support to SparkSqlOperator

### DIFF
--- a/airflow/providers/apache/spark/operators/spark_sql.py
+++ b/airflow/providers/apache/spark/operators/spark_sql.py
@@ -69,6 +69,7 @@ class SparkSqlOperator(BaseOperator):
                  master='yarn',
                  name='default-name',
                  num_executors=None,
+                 verbose=True,
                  yarn_queue='default',
                  *args,
                  **kwargs):
@@ -84,6 +85,7 @@ class SparkSqlOperator(BaseOperator):
         self._master = master
         self._name = name
         self._num_executors = num_executors
+        self._verbose = verbose
         self._yarn_queue = yarn_queue
         self._hook = None
 
@@ -102,6 +104,7 @@ class SparkSqlOperator(BaseOperator):
                                   name=self._name,
                                   num_executors=self._num_executors,
                                   master=self._master,
+                                  verbose=self._verbose,
                                   yarn_queue=self._yarn_queue
                                   )
         self._hook.run_query()

--- a/tests/providers/apache/spark/operators/test_spark_sql.py
+++ b/tests/providers/apache/spark/operators/test_spark_sql.py
@@ -38,6 +38,7 @@ class TestSparkSqlOperator(unittest.TestCase):
         'master': 'yarn-client',
         'name': 'special-application-name',
         'num_executors': 8,
+        'verbose': False,
         'yarn_queue': 'special-queue'
     }
 
@@ -69,6 +70,7 @@ class TestSparkSqlOperator(unittest.TestCase):
         self.assertEqual(self._config['master'], operator._master)
         self.assertEqual(self._config['name'], operator._name)
         self.assertEqual(self._config['num_executors'], operator._num_executors)
+        self.assertEqual(self._config['verbose'], operator._verbose)
         self.assertEqual(self._config['yarn_queue'], operator._yarn_queue)
 
 


### PR DESCRIPTION
---
Issue link: [AIRFLOW-7024](https://issues.apache.org/jira/browse/AIRFLOW-7024)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
