### PR TITLE
[AIRFLOW-7025] Fix SparkSqlHook.run_query to handle its parameter properly

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -93,7 +93,7 @@ class SparkSqlHook(BaseHook):
         as default.
 
         :param cmd: command to append to the spark-sql command
-        :type cmd: str
+        :type cmd: str or list[str]
         :return: full command to be executed
         """
         connection_cmd = ["spark-sql"]
@@ -127,7 +127,13 @@ class SparkSqlHook(BaseHook):
         if self._yarn_queue:
             connection_cmd += ["--queue", self._yarn_queue]
 
-        connection_cmd += cmd
+        if isinstance(cmd, str):
+            connection_cmd += cmd.split()
+        elif isinstance(cmd, list):
+            connection_cmd += cmd
+        else:
+            raise AirflowException("Invalid additional command: {}".format(cmd))
+
         self.log.debug("Spark-Sql cmd: %s", connection_cmd)
 
         return connection_cmd
@@ -136,8 +142,10 @@ class SparkSqlHook(BaseHook):
         """
         Remote Popen (actually execute the Spark-sql query)
 
-        :param cmd: command to remotely execute
+        :param cmd: command to append to the spark-sql command
+        :type cmd: str or list[str]
         :param kwargs: extra arguments to Popen (see subprocess.Popen)
+        :type kwargs: dict
         """
         spark_sql_cmd = self._prepare_command(cmd)
         self._sp = subprocess.Popen(spark_sql_cmd,

--- a/tests/providers/apache/spark/hooks/test_spark_sql.py
+++ b/tests/providers/apache/spark/hooks/test_spark_sql.py
@@ -108,6 +108,44 @@ class TestSparkSqlHook(unittest.TestCase):
                   '--queue', 'default'], stderr=-2, stdout=-1)
         )
 
+    @patch('airflow.providers.apache.spark.hooks.spark_sql.subprocess.Popen')
+    def test_spark_process_runcmd_with_str(self, mock_popen):
+        # Given
+        mock_popen.return_value.wait.return_value = 0
+
+        # When
+        hook = SparkSqlHook(
+            conn_id='spark_default',
+            sql='SELECT 1'
+        )
+        hook.run_query('--deploy-mode cluster')
+
+        # Then
+        self.assertEqual(
+            mock_popen.mock_calls[0],
+            call(['spark-sql', '-e', 'SELECT 1', '--master', 'yarn', '--name', 'default-name', '--verbose',
+                  '--queue', 'default', '--deploy-mode', 'cluster'], stderr=-2, stdout=-1)
+        )
+
+    @patch('airflow.providers.apache.spark.hooks.spark_sql.subprocess.Popen')
+    def test_spark_process_runcmd_with_list(self, mock_popen):
+        # Given
+        mock_popen.return_value.wait.return_value = 0
+
+        # When
+        hook = SparkSqlHook(
+            conn_id='spark_default',
+            sql='SELECT 1'
+        )
+        hook.run_query(['--deploy-mode', 'cluster'])
+
+        # Then
+        self.assertEqual(
+            mock_popen.mock_calls[0],
+            call(['spark-sql', '-e', 'SELECT 1', '--master', 'yarn', '--name', 'default-name', '--verbose',
+                  '--queue', 'default', '--deploy-mode', 'cluster'], stderr=-2, stdout=-1)
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
---
Issue link: [AIRFLOW-7025](https://issues.apache.org/jira/browse/AIRFLOW-7025)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
