### PR TITLE
[AIRFLOW-7032] Remove airflow/gcp folder from doc build

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -89,7 +89,7 @@ mapfile -t DEPRECATED_MODULES < <(grep -R -i -l 'This module is deprecated.' ../
 
 IGNORED_MISSING_MODULES=('airflow.providers.google.cloud.hooks.base')
 
-mapfile -t ALL_MODULES < <(find ../airflow/{,gcp/,providers/*/*/,providers/*/}{operators,sensors,hooks} -name "*.py" | \
+mapfile -t ALL_MODULES < <(find ../airflow/{,providers/*/*/,providers/*/}{operators,sensors,hooks} -name "*.py" | \
     grep -v "__init__" | \
     grep -v "__pycache__" | \
     cut -d "/" -f 2- | \


### PR DESCRIPTION
Currently, our docs build have the following warning/error:

```
find: ‘../airflow/gcp/operators’: No such file or directory
find: ‘../airflow/gcp/sensors’: No such file or directory
find: ‘../airflow/gc
```

---
Issue link: [AIRFLOW-7032](https://issues.apache.org/jira/browse/AIRFLOW-7032)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
