### PR TITLE
[AIRFLOW-7033] Change dag and task state meanwhile

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -228,7 +228,8 @@
                 <input type="checkbox" value="true" name="downstream" checked autocomplete="off">
                 Downstream
               </label>
-              <label class="btn active">
+              <label class="btn active"
+                title="Also include subdags">
                 <input type="checkbox" value="true" name="recursive" checked autocomplete="off">
                  Recursive
               </label>
@@ -240,48 +241,68 @@
             </span>
             <hr/>
             <button id="btn_failed" type="button" class="btn btn-primary"
+                title="Change task instance state to failed"
                 data-action="{{ url_for('Airflow.failed') }}">
               Mark Failed
             </button>
             <span class="btn-group" data-toggle="buttons">
-              <label class="btn">
+              <label class="btn"
+                title="Also include past task instances when clearing this one">
                 <input type="checkbox" value="true" name="failed_past" autocomplete="off">
                 Past
               </label>
-              <label class="btn">
+              <label class="btn"
+                title="Also include future task instances when clearing this one">
                 <input type="checkbox" value="true" name="failed_future" autocomplete="off">
                 Future
               </label>
-              <label class="btn">
+              <label class="btn"
+                title="Also include upstream dependencies">
                 <input type="checkbox" value="true" name="failed_upstream" autocomplete="off">
                 Upstream
               </label>
-              <label class="btn">
+              <label class="btn"
+                title="Also include downstream dependencies">
                 <input type="checkbox" value="true" name="failed_downstream" autocomplete="off">
                 Downstream
+              </label>
+              <label class="btn active"
+                title="Also include DAG run">
+                <input type="checkbox" value="true" name="failed_include_dag" checked autocomplete="off">
+                DAG
               </label>
             </span>
             <hr/>
             <button id="btn_success" type="button" class="btn btn-primary"
+                title="Change task instance state to success"
                 data-action="{{ url_for('Airflow.success') }}">
               Mark Success
             </button>
             <span class="btn-group" data-toggle="buttons">
-              <label class="btn">
+              <label class="btn"
+                title="Also include past task instances when clearing this one">
                 <input type="checkbox" value="true" name="success_past" autocomplete="off">
                 Past
               </label>
-              <label class="btn">
+              <label class="btn"
+                title="Also include future task instances when clearing this one">
                 <input type="checkbox" value="true" name="success_future" autocomplete="off">
                 Future
               </label>
-              <label class="btn">
+              <label class="btn"
+                title="Also include upstream dependencies">
                 <input type="checkbox" value="true" name="success_upstream" autocomplete="off">
                 Upstream
               </label>
-              <label class="btn">
+              <label class="btn"
+                title="Also include downstream dependencies">
                 <input type="checkbox" value="true" name="success_downstream" autocomplete="off">
                 Downstream
+              </label>
+              <label class="btn active"
+                title="Also include DAG run if all task instance success">
+                <input type="checkbox" value="true" name="success_include_dag" checked autocomplete="off">
+                DAG
               </label>
             </span>
           </form>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1205,7 +1205,7 @@ class Airflow(AirflowBaseView):
 
             response = self.render_template(
                 'airflow/confirm.html',
-                message=("Here's the list of task instances you are about to mark as failed"),
+                message="Here's the list of task instances you are about to mark as failed",
                 details=details)
 
             return response
@@ -1234,7 +1234,7 @@ class Airflow(AirflowBaseView):
 
             response = self.render_template(
                 'airflow/confirm.html',
-                message=("Here's the list of task instances you are about to mark as success"),
+                message="Here's the list of task instances you are about to mark as success",
                 details=details)
 
             return response
@@ -1265,7 +1265,7 @@ class Airflow(AirflowBaseView):
 
     def _mark_task_instance_state(self, dag_id, task_id, origin, execution_date,
                                   confirmed, upstream, downstream,
-                                  future, past, state):
+                                  future, past, include_dag, state):
         dag = dagbag.get_dag(dag_id)
         task = dag.get_task(task_id)
         task.dag = dag
@@ -1285,16 +1285,16 @@ class Airflow(AirflowBaseView):
         if confirmed:
             altered = set_state(tasks=[task], execution_date=execution_date,
                                 upstream=upstream, downstream=downstream,
-                                future=future, past=past, state=state,
-                                commit=True)
+                                future=future, past=past, include_dag=include_dag,
+                                state=state, commit=True)
 
             flash("Marked {} on {} task instances".format(state, len(altered)))
             return redirect(origin)
 
         to_be_altered = set_state(tasks=[task], execution_date=execution_date,
                                   upstream=upstream, downstream=downstream,
-                                  future=future, past=past, state=state,
-                                  commit=False)
+                                  future=future, past=past, include_dag=include_dag,
+                                  state=state, commit=False)
 
         details = "\n".join([str(t) for t in to_be_altered])
 
@@ -1320,10 +1320,11 @@ class Airflow(AirflowBaseView):
         downstream = request.form.get('failed_downstream') == "true"
         future = request.form.get('failed_future') == "true"
         past = request.form.get('failed_past') == "true"
+        include_dag = request.form.get('failed_include_dag') == "true"
 
         return self._mark_task_instance_state(dag_id, task_id, origin, execution_date,
                                               confirmed, upstream, downstream,
-                                              future, past, State.FAILED)
+                                              future, past, include_dag, State.FAILED)
 
     @expose('/success', methods=['POST'])
     @has_dag_access(can_dag_edit=True)
@@ -1340,10 +1341,11 @@ class Airflow(AirflowBaseView):
         downstream = request.form.get('success_downstream') == "true"
         future = request.form.get('success_future') == "true"
         past = request.form.get('success_past') == "true"
+        include_dag = request.form.get('success_include_dag') == "true"
 
         return self._mark_task_instance_state(dag_id, task_id, origin, execution_date,
                                               confirmed, upstream, downstream,
-                                              future, past, State.SUCCESS)
+                                              future, past, include_dag, State.SUCCESS)
 
     @expose('/tree')
     @has_dag_access(can_dag_read=True)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -646,6 +646,7 @@ class TestAirflowBaseViews(TestBase):
             downstream="false",
             future="false",
             past="false",
+            include_dag="true",
         )
         resp = self.client.post("failed", data=form)
         self.check_content_in_response('Wait a minute', resp)
@@ -659,6 +660,7 @@ class TestAirflowBaseViews(TestBase):
             downstream="false",
             future="false",
             past="false",
+            include_dag="true",
         )
         resp = self.client.post('success', data=form)
         self.check_content_in_response('Wait a minute', resp)
@@ -1760,6 +1762,7 @@ class TestDagACLView(TestBase):
             downstream="false",
             future="false",
             past="false",
+            include_dag="true",
         )
         resp = self.client.post('failed', data=form)
         self.check_content_in_response('Redirecting', resp, 302)
@@ -1841,7 +1844,7 @@ class TestDagACLView(TestBase):
         self.check_content_not_in_response('example_bash_operator', resp)
 
     def test_success_fail_for_read_only_role(self):
-        # succcess endpoint need can_dag_edit, which read only role can not access
+        # success endpoint need can_dag_edit, which read only role can not access
         self.logout()
         self.login(username='dag_read_only',
                    password='dag_read_only')
@@ -1854,6 +1857,7 @@ class TestDagACLView(TestBase):
             downstream="false",
             future="false",
             past="false",
+            include_dag="true",
         )
         resp = self.client.post('success', data=form)
         self.check_content_not_in_response('Wait a minute', resp, resp_code=302)


### PR DESCRIPTION
In dag page, have make task instance state to success
or failed bottom, when we click those bottom not only
change task instance state but also dag run state
if possible.

* When trigger make_failed bottom, the dag run state
  should change to failed
* When trigger make_success bottom, then dag run
  state should change to success if all task instance
  state are success, otherwise should keep the
  original state

---
Issue link: [AIRFLOW-7033](https://issues.apache.org/jira/browse/AIRFLOW-7033)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
