### PR TITLE
[AIRFLOW-7034] Remove feature: Assigning Dag to task using Bitshift Op

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -61,6 +61,27 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
+
+**Previous Behaviour**:
+You could assign a task to a DAG was previously possible as following:
+
+```python
+dag = DAG('my_dag')
+dummy = DummyOperator(task_id='dummy')
+
+dag >> dummy
+```
+
+This is no longer supported. Instead, we recommend using the DAG as context manager:
+
+**Recommended Behaviour**:
+
+```python
+with DAG('my_dag):
+    dummy = DummyOperator(task_id='dummy')
+```
+
 ### Deprecating ignore_first_depends_on_past on backfill command and default it to True
 
 When doing backfill with `depends_on_past` dags, users will need to pass `ignore_first_depends_on_past`.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -63,8 +63,7 @@ https://developers.google.com/style/inclusive-documentation
 
 ### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
 
-**Previous Behaviour**:
-You could assign a task to a DAG was previously possible as following:
+Previously, you could assign a task to a DAG as follows:
 
 ```python
 dag = DAG('my_dag')
@@ -74,8 +73,6 @@ dag >> dummy
 ```
 
 This is no longer supported. Instead, we recommend using the DAG as context manager:
-
-**Recommended Behaviour**:
 
 ```python
 with DAG('my_dag):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -482,6 +482,22 @@ class BaseOperator(Operator, LoggingMixin):
         self.set_upstream(other)
         return other
 
+    def __rrshift__(self, other):
+        """
+        Called for Operator >> [Operator] because list don't have
+        __rshift__ operators.
+        """
+        self.__lshift__(other)
+        return self
+
+    def __rlshift__(self, other):
+        """
+        Called for Operator << [Operator] because list don't have
+        __lshift__ operators.
+        """
+        self.__rshift__(other)
+        return self
+
     # including lineage information
     def __or__(self, other):
         """

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -471,50 +471,16 @@ class BaseOperator(Operator, LoggingMixin):
     def __rshift__(self, other):
         """
         Implements Self >> Other == self.set_downstream(other)
-
-        If "Other" is a DAG, the DAG is assigned to the Operator.
         """
-        from airflow.models.dag import DAG
-        if isinstance(other, DAG):
-            # if this dag is already assigned, do nothing
-            # otherwise, do normal dag assignment
-            if not (self.has_dag() and self.dag is other):
-                self.dag = other
-        else:
-            self.set_downstream(other)
+        self.set_downstream(other)
         return other
 
     def __lshift__(self, other):
         """
         Implements Self << Other == self.set_upstream(other)
-
-        If "Other" is a DAG, the DAG is assigned to the Operator.
         """
-        from airflow.models.dag import DAG
-        if isinstance(other, DAG):
-            # if this dag is already assigned, do nothing
-            # otherwise, do normal dag assignment
-            if not (self.has_dag() and self.dag is other):
-                self.dag = other
-        else:
-            self.set_upstream(other)
+        self.set_upstream(other)
         return other
-
-    def __rrshift__(self, other):
-        """
-        Called for [DAG] >> [Operator] because DAGs don't have
-        __rshift__ operators.
-        """
-        self.__lshift__(other)
-        return self
-
-    def __rlshift__(self, other):
-        """
-        Called for [DAG] << [Operator] because DAGs don't have
-        __lshift__ operators.
-        """
-        self.__rshift__(other)
-        return self
 
     # including lineage information
     def __or__(self, other):

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -41,8 +41,7 @@ class PubSubCreateTopicOperator(BaseOperator):
 
         with DAG('successful DAG') as dag:
             (
-                dag
-                >> PubSubTopicCreateOperator(project='my-project',
+                PubSubTopicCreateOperator(project='my-project',
                                              topic='my_new_topic')
                 >> PubSubTopicCreateOperator(project='my-project',
                                              topic='my_new_topic')
@@ -52,8 +51,7 @@ class PubSubCreateTopicOperator(BaseOperator):
 
         with DAG('failing DAG') as dag:
             (
-                dag
-                >> PubSubTopicCreateOperator(project='my-project',
+                PubSubTopicCreateOperator(project='my-project',
                                              topic='my_new_topic')
                 >> PubSubTopicCreateOperator(project='my-project',
                                              topic='my_new_topic',
@@ -182,8 +180,7 @@ class PubSubCreateSubscriptionOperator(BaseOperator):
 
         with DAG('successful DAG') as dag:
             (
-                dag
-                >> PubSubSubscriptionCreateOperator(
+                PubSubSubscriptionCreateOperator(
                     topic_project='my-project', topic='my-topic',
                     subscription='my-subscription')
                 >> PubSubSubscriptionCreateOperator(
@@ -369,8 +366,7 @@ class PubSubDeleteTopicOperator(BaseOperator):
 
         with DAG('successful DAG') as dag:
             (
-                dag
-                >> PubSubTopicDeleteOperator(project='my-project',
+                PubSubTopicDeleteOperator(project='my-project',
                                              topic='non_existing_topic')
             )
 
@@ -378,8 +374,7 @@ class PubSubDeleteTopicOperator(BaseOperator):
 
         with DAG('failing DAG') as dag:
             (
-                dag
-                >> PubSubTopicCreateOperator(project='my-project',
+                PubSubTopicCreateOperator(project='my-project',
                                              topic='non_existing_topic',
                                              fail_if_not_exists=True)
             )
@@ -481,8 +476,7 @@ class PubSubDeleteSubscriptionOperator(BaseOperator):
 
         with DAG('successful DAG') as dag:
             (
-                dag
-                >> PubSubSubscriptionDeleteOperator(project='my-project',
+                PubSubSubscriptionDeleteOperator(project='my-project',
                                                     subscription='non-existing')
             )
 
@@ -492,8 +486,7 @@ class PubSubDeleteSubscriptionOperator(BaseOperator):
 
         with DAG('failing DAG') as dag:
             (
-                dag
-                >> PubSubSubscriptionDeleteOperator(
+                PubSubSubscriptionDeleteOperator(
                      project='my-project', subscription='non-existing',
                      fail_if_not_exists=True)
             )

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -196,8 +196,7 @@ class PubSubCreateSubscriptionOperator(BaseOperator):
 
         with DAG('failing DAG') as dag:
             (
-                dag
-                >> PubSubSubscriptionCreateOperator(
+                PubSubSubscriptionCreateOperator(
                     topic_project='my-project', topic='my-topic',
                     subscription='my-subscription')
                 >> PubSubSubscriptionCreateOperator(
@@ -210,7 +209,7 @@ class PubSubCreateSubscriptionOperator(BaseOperator):
 
         with DAG('DAG') as dag:
             (
-                dag >> PubSubSubscriptionCreateOperator(
+                PubSubSubscriptionCreateOperator(
                     topic_project='my-project', topic='my-topic')
             )
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -353,19 +353,6 @@ is equivalent to:
     op2.set_downstream(op3)
     op3.set_upstream(op4)
 
-For convenience, the bitshift operators can also be used with DAGs. For example:
-
-.. code:: python
-
-    dag >> op1 >> op2
-
-is equivalent to:
-
-.. code:: python
-
-    op1.dag = dag
-    op1.set_downstream(op2)
-
 We can put this all together to build a simple pipeline:
 
 .. code:: python

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -219,35 +219,16 @@ class TestTaskInstance(unittest.TestCase):
 
     def test_bitshift_compose_operators(self):
         dag = DAG('dag', start_date=DEFAULT_DATE)
-        op1 = DummyOperator(task_id='test_op_1', owner='test')
-        op2 = DummyOperator(task_id='test_op_2', owner='test')
-        op3 = DummyOperator(task_id='test_op_3', owner='test')
-        op4 = DummyOperator(task_id='test_op_4', owner='test')
-        op5 = DummyOperator(task_id='test_op_5', owner='test')
+        with dag:
+            op1 = DummyOperator(task_id='test_op_1', owner='test')
+            op2 = DummyOperator(task_id='test_op_2', owner='test')
+            op3 = DummyOperator(task_id='test_op_3', owner='test')
 
-        # can't compose operators without dags
-        with self.assertRaises(AirflowException):
-            op1 >> op2
-
-        dag >> op1 >> op2 << op3
-
-        # make sure dag assignment carries through
-        # using __rrshift__
-        self.assertIs(op1.dag, dag)
-        self.assertIs(op2.dag, dag)
-        self.assertIs(op3.dag, dag)
+            op1 >> op2 << op3
 
         # op2 should be downstream of both
         self.assertIn(op2, op1.downstream_list)
         self.assertIn(op2, op3.downstream_list)
-
-        # test dag assignment with __rlshift__
-        dag << op4
-        self.assertIs(op4.dag, dag)
-
-        # dag assignment with __rrshift__
-        dag >> op5
-        self.assertIs(op5.dag, dag)
 
     @patch.object(DAG, 'concurrency_reached')
     def test_requeue_over_dag_concurrency(self, mock_concurrency_reached):


### PR DESCRIPTION
It is possible to assign a task to the dag using the bitshift operators, however it doesn't pick up default_args when done this way <https://issues.apache.org/jira/browse/AIRFLOW-883>:

```python
dag = DAG('my_dag', default_args=default_args)
dummy = DummyOperator(task_id='dummy')

dag >> dummy
```

---
Issue link: [AIRFLOW-7034](https://issues.apache.org/jira/browse/AIRFLOW-7034)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
