### PR TITLE
[AIRFLOW-7046] Locale-formatted datetimes (UI only)

### DIFF
--- a/airflow/www/static/js/base.js
+++ b/airflow/www/static/js/base.js
@@ -38,6 +38,25 @@ export function escapeHtml(text) {
 
 window.escapeHtml = escapeHtml;
 
+// Handle i18n localization of date + time (D MMMM YYYY HH:mm)
+export function localizedDate(date) {
+  const locale = window.navigator.userLanguage || window.navigator.language;
+  moment.locale(locale);
+  if (date) return moment(date).format('LLL');
+  return '';
+}
+
+window.localizedDate = localizedDate;
+
+// Handle i18n localization of time (HH:mm:ss)
+export function localizedTime(time) {
+  const locale = window.navigator.userLanguage || window.navigator.language;
+  moment.locale(locale);
+  if (time) return moment(time).format('LTS');
+  return '';
+}
+window.localizedTime = localizedTime;
+
 export function convertSecsToHumanReadable(seconds) {
    var oriSeconds = seconds
    var floatingPart = oriSeconds- Math.floor(oriSeconds)

--- a/airflow/www/static/js/base.js
+++ b/airflow/www/static/js/base.js
@@ -41,8 +41,7 @@ window.escapeHtml = escapeHtml;
 // Handle i18n localization of date + time (D MMMM YYYY HH:mm)
 export function localizedDate(date) {
   const locale = window.navigator.userLanguage || window.navigator.language;
-  moment.locale(locale);
-  if (date) return moment(date).format('LLL');
+  if (date) return moment(date).locale(locale).format('LLL');
   return '';
 }
 
@@ -51,10 +50,10 @@ window.localizedDate = localizedDate;
 // Handle i18n localization of time (HH:mm:ss)
 export function localizedTime(time) {
   const locale = window.navigator.userLanguage || window.navigator.language;
-  moment.locale(locale);
-  if (time) return moment(time).format('LTS');
+  if (time) return moment(time).locale(locale).format('LTS');
   return '';
 }
+
 window.localizedTime = localizedTime;
 
 export function convertSecsToHumanReadable(seconds) {

--- a/airflow/www/static/js/base.js
+++ b/airflow/www/static/js/base.js
@@ -38,10 +38,10 @@ export function escapeHtml(text) {
 
 window.escapeHtml = escapeHtml;
 
-// Handle i18n localization of date + time (D MMMM YYYY HH:mm)
+// Handle i18n localization of date + time (D MMMM YYYY HH:mm:ss)
 export function localizedDate(date) {
   const locale = window.navigator.userLanguage || window.navigator.language;
-  if (date) return moment(date).locale(locale).format('LLL');
+  if (date) return moment(date).locale(locale).format('LL LTS');
   return '';
 }
 

--- a/airflow/www/static/js/datetime-utils.js
+++ b/airflow/www/static/js/datetime-utils.js
@@ -17,7 +17,6 @@
  * under the License.
  */
 export const moment = require('moment-timezone');
-export const defaultFormat = 'YYYY-MM-DD, HH:mm:ss';
 export const defaultFormatWithTZ = 'YYYY-MM-DD, HH:mm:ss z';
 
 const makeDateTimeHTML = (start, end) => {

--- a/airflow/www/static/js/datetime-utils.js
+++ b/airflow/www/static/js/datetime-utils.js
@@ -20,10 +20,15 @@ export const moment = require('moment-timezone');
 export const defaultFormat = 'YYYY-MM-DD, HH:mm:ss';
 export const defaultFormatWithTZ = 'YYYY-MM-DD, HH:mm:ss z';
 
-
 const makeDateTimeHTML = (start, end) => {
   return (
-    `Started: ${start.format(defaultFormat)} <br> Ended: ${end.format(defaultFormat)} <br>`
+    `Started: ${start.format()} <br> Ended: ${end.format()} <br>`
+  )
+};
+
+const makei18nDateTimeHTML = (start, end) => {
+  return (
+    `Started: ${window.localizedDate(start)} <br> Ended: ${window.localizedDate(end)} <br>`
   )
 };
 
@@ -40,7 +45,7 @@ export const generateTooltipDateTime = (startDate, endDate, dagTZ) => {
 
   // Generate User's Local Start and End Date
   tooltipHTML += `<br><strong>Local: ${moment.tz(localTZ).format(tzFormat)}</strong><br>`;
-  tooltipHTML += makeDateTimeHTML(startDate.local(), endDate.local());
+  tooltipHTML += makei18nDateTimeHTML(startDate, endDate);
 
   // Generate DAG's Start and End Date
   if (dagTZ !== 'UTC' && dagTZ !== localTZ) {

--- a/airflow/www/static/js/gantt-chart-d3v2.js
+++ b/airflow/www/static/js/gantt-chart-d3v2.js
@@ -61,7 +61,7 @@ d3.gantt = function() {
   var tickFormat = "%H:%M";
 
   var keyFunction = function(d) {
-    return d.startDate + d.taskName + d.endDate;
+    return window.localizedDate(d.startDate) + d.taskName + window.localizedDate(d.endDate);
   };
 
   var rectTransform = function(d) {

--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -42,8 +42,7 @@
         Number of runs: {{ form.num_runs(class_="form-control") }}
         <input type="hidden" name="root" value="{{ root if root else '' }}">
         <input type="hidden" value="{{ dag.dag_id }}" name="dag_id">
-        <input type="submit" value="Go" class="btn btn-default"
-         action="" method="get">
+        <input type="submit" value="Go" class="btn btn-default" action="" method="get">
         <input name="_csrf_token" type="hidden" value="{{ csrf_token() }}">
     </form>
 </div>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -352,9 +352,9 @@
           g = d3.select('div#last-run-' + safe_dag_id)
           g.selectAll('a')
             .attr("href", "{{ url_for('Airflow.graph') }}?dag_id=" + encodeURIComponent(dag_id) + "&execution_date=" + last_run)
-            .text(last_run);
+            .text(window.localizedDate(last_run));
           g.selectAll('span')
-            .attr("data-original-title", "Start Date: " + last_run)
+            .attr("data-original-title", "Start Date: " + window.localizedDate(last_run))
             .style('display', null);
           g.selectAll(".loading-last-run").remove();
         }

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -65,7 +65,7 @@
       .taskStatus(data.taskStatus)
       .height(data.height)
       .selector('.gantt')
-      .tickFormat("%H:%M:%S");
+      .tickFormat('%H:%M:%S');
     gantt(data.tasks);
   });
 </script>

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -65,7 +65,7 @@
       .taskStatus(data.taskStatus)
       .height(data.height)
       .selector('.gantt')
-      .tickFormat('%H:%M:%S');
+      .tickFormat("%H:%M:%S");
     gantt(data.tasks);
   });
 </script>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -287,8 +287,8 @@ function update(source) {
           tt += "upstream: " + escapeHtml(d.num_dep) + "<br/>";
           tt += "retries: " + escapeHtml(d.retries) + "<br/>";
           tt += "owner: " + escapeHtml(d.owner) + "<br/>";
-          tt += "start_date: " + escapeHtml(d.start_date) + "<br/>";
-          tt += "end_date: " + escapeHtml(d.end_date) + "<br/>";
+          tt += "start_date: " + window.localizedDate(d.start_date) + "<br/>";
+          tt += "end_date: " + window.localizedDate(d.end_date) + "<br/>";
         }
         taskTip.direction('e')
         taskTip.show(tt, this)
@@ -351,9 +351,9 @@ function update(source) {
 
         s += "Operator: " + escapeHtml(task.operator) + "<br>"
         if(d.start_date != undefined){
-          s += "Started: " + escapeHtml(d.start_date) + "<br>";
+          s += "Started: " + window.localizedDate(d.start_date) + "<br>";
           if(d.end_date != undefined){
-            s += "Ended: " + escapeHtml(d.end_date) + "<br>";
+            s += "Ended: " + window.localizedDate(d.end_date) + "<br>";
           }
           if (d.duration != undefined) {
             s += "Duration: " + escapeHtml(convertSecsToHumanReadable(d.duration)) + "<br>";

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -297,7 +297,7 @@ def localized_f(attr_name):
     def dt(attr):
         f = attr.get(attr_name)
         if f is None:
-            return Markup('<time datetime="{}">{}</time>').format(f, f)
+            return None
         else:
             f = f.strftime(date_format)
             return Markup('<time datetime="{}">{}</time>').format(f, f)

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -24,6 +24,7 @@ import os
 import re
 import time
 import zipfile
+import datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
@@ -41,6 +42,14 @@ from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils import timezone
 from airflow.utils.json import AirflowJsonEncoder
 from airflow.utils.state import State
+
+
+# Localizing format of datetime
+import locale
+this_locale = locale.getlocale()
+locale.setlocale(locale.LC_ALL, this_locale)
+date_format = locale.nl_langinfo(locale.D_T_FMT)
+
 
 DEFAULT_SENSITIVE_VARIABLE_FIELDS = (
     'password',
@@ -282,7 +291,18 @@ def datetime_f(attr_name):
         f = f.isoformat() if f else ''
         if timezone.utcnow().isoformat()[:4] == f[:4]:
             f = f[5:]
-        return Markup("<nobr>{}</nobr>").format(f)
+        return Markup('<time datetime="{}">{}</time>').format(f, f)
+    return dt
+
+
+def localized_f(attr_name):
+    def dt(attr):
+        f = attr.get(attr_name)
+        if f is None:
+            return Markup('<time datetime="{}">{}</time>').format(f, f)
+        else:
+            f = f.strftime(date_format)
+            return Markup('<time datetime="{}">{}</time>').format(f, f)
     return dt
 
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -20,6 +20,7 @@ import functools
 import inspect
 import io
 import json
+import locale
 import os
 import re
 import time
@@ -42,9 +43,7 @@ from airflow.utils import timezone
 from airflow.utils.json import AirflowJsonEncoder
 from airflow.utils.state import State
 
-
 # Localizing format of datetime
-import locale
 this_locale = locale.getlocale()
 locale.setlocale(locale.LC_ALL, this_locale)
 date_format = locale.nl_langinfo(locale.D_T_FMT)

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -24,7 +24,6 @@ import os
 import re
 import time
 import zipfile
-import datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -293,7 +293,7 @@ def datetime_f(attr_name):
     return dt
 
 
-def localized_f(attr_name):
+def localized_dt_f(attr_name):
     def dt(attr):
         f = attr.get(attr_name)
         if f is None:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2170,8 +2170,8 @@ class SlaMissModelView(AirflowModelView):
 
     formatters_columns = {
         'task_id': wwwutils.task_instance_link,
-        'execution_date': wwwutils.datetime_f('execution_date'),
-        'timestamp': wwwutils.datetime_f('timestamp'),
+        'execution_date': wwwutils.localized_f('execution_date'),
+        'timestamp': wwwutils.localized_f('timestamp'),
         'dag_id': wwwutils.dag_link,
     }
 
@@ -2193,8 +2193,8 @@ class XComModelView(AirflowModelView):
 
     formatters_columns = {
         'task_id': wwwutils.task_instance_link,
-        'execution_date': wwwutils.datetime_f('execution_date'),
-        'timestamp': wwwutils.datetime_f('timestamp'),
+        'execution_date': wwwutils.localized_f('execution_date'),
+        'timestamp': wwwutils.localized_f('timestamp'),
         'dag_id': wwwutils.dag_link,
     }
 
@@ -2456,11 +2456,11 @@ class JobModelView(AirflowModelView):
     base_filters = [['dag_id', DagFilter, lambda: []]]
 
     formatters_columns = {
-        'start_date': wwwutils.datetime_f('start_date'),
-        'end_date': wwwutils.datetime_f('end_date'),
+        'start_date': wwwutils.localized_f('start_date'),
+        'end_date': wwwutils.localized_f('end_date'),
         'hostname': wwwutils.nobr_f('hostname'),
         'state': wwwutils.state_f,
-        'latest_heartbeat': wwwutils.datetime_f('latest_heartbeat'),
+        'latest_heartbeat': wwwutils.localized_f('latest_heartbeat'),
     }
 
 
@@ -2482,9 +2482,9 @@ class DagRunModelView(AirflowModelView):
     add_form = edit_form = DagRunForm
 
     formatters_columns = {
-        'execution_date': wwwutils.datetime_f('execution_date'),
+        'execution_date': wwwutils.localized_f('execution_date'),
         'state': wwwutils.state_f,
-        'start_date': wwwutils.datetime_f('start_date'),
+        'start_date': wwwutils.localized_f('start_date'),
         'dag_id': wwwutils.dag_link,
         'run_id': wwwutils.dag_run_link,
     }
@@ -2592,8 +2592,8 @@ class LogModelView(AirflowModelView):
     base_filters = [['dag_id', DagFilter, lambda: []]]
 
     formatters_columns = {
-        'dttm': wwwutils.datetime_f('dttm'),
-        'execution_date': wwwutils.datetime_f('execution_date'),
+        'dttm': wwwutils.localized_f('dttm'),
+        'execution_date': wwwutils.localized_f('execution_date'),
         'dag_id': wwwutils.dag_link,
     }
 
@@ -2637,10 +2637,10 @@ class TaskInstanceModelView(AirflowModelView):
         'task_id': wwwutils.task_instance_link,
         'hostname': wwwutils.nobr_f('hostname'),
         'state': wwwutils.state_f,
-        'execution_date': wwwutils.datetime_f('execution_date'),
-        'start_date': wwwutils.datetime_f('start_date'),
-        'end_date': wwwutils.datetime_f('end_date'),
-        'queued_dttm': wwwutils.datetime_f('queued_dttm'),
+        'execution_date': wwwutils.localized_f('execution_date'),
+        'start_date': wwwutils.localized_f('start_date'),
+        'end_date': wwwutils.localized_f('end_date'),
+        'queued_dttm': wwwutils.localized_f('queued_dttm'),
         'dag_id': wwwutils.dag_link,
         'duration': duration_f,
     }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2170,8 +2170,8 @@ class SlaMissModelView(AirflowModelView):
 
     formatters_columns = {
         'task_id': wwwutils.task_instance_link,
-        'execution_date': wwwutils.localized_f('execution_date'),
-        'timestamp': wwwutils.localized_f('timestamp'),
+        'execution_date': wwwutils.localized_dt_f('execution_date'),
+        'timestamp': wwwutils.localized_dt_f('timestamp'),
         'dag_id': wwwutils.dag_link,
     }
 
@@ -2193,8 +2193,8 @@ class XComModelView(AirflowModelView):
 
     formatters_columns = {
         'task_id': wwwutils.task_instance_link,
-        'execution_date': wwwutils.localized_f('execution_date'),
-        'timestamp': wwwutils.localized_f('timestamp'),
+        'execution_date': wwwutils.localized_dt_f('execution_date'),
+        'timestamp': wwwutils.localized_dt_f('timestamp'),
         'dag_id': wwwutils.dag_link,
     }
 
@@ -2456,11 +2456,11 @@ class JobModelView(AirflowModelView):
     base_filters = [['dag_id', DagFilter, lambda: []]]
 
     formatters_columns = {
-        'start_date': wwwutils.localized_f('start_date'),
-        'end_date': wwwutils.localized_f('end_date'),
+        'start_date': wwwutils.localized_dt_f('start_date'),
+        'end_date': wwwutils.localized_dt_f('end_date'),
         'hostname': wwwutils.nobr_f('hostname'),
         'state': wwwutils.state_f,
-        'latest_heartbeat': wwwutils.localized_f('latest_heartbeat'),
+        'latest_heartbeat': wwwutils.localized_dt_f('latest_heartbeat'),
     }
 
 
@@ -2482,9 +2482,9 @@ class DagRunModelView(AirflowModelView):
     add_form = edit_form = DagRunForm
 
     formatters_columns = {
-        'execution_date': wwwutils.localized_f('execution_date'),
+        'execution_date': wwwutils.localized_dt_f('execution_date'),
         'state': wwwutils.state_f,
-        'start_date': wwwutils.localized_f('start_date'),
+        'start_date': wwwutils.localized_dt_f('start_date'),
         'dag_id': wwwutils.dag_link,
         'run_id': wwwutils.dag_run_link,
     }
@@ -2592,8 +2592,8 @@ class LogModelView(AirflowModelView):
     base_filters = [['dag_id', DagFilter, lambda: []]]
 
     formatters_columns = {
-        'dttm': wwwutils.localized_f('dttm'),
-        'execution_date': wwwutils.localized_f('execution_date'),
+        'dttm': wwwutils.localized_dt_f('dttm'),
+        'execution_date': wwwutils.localized_dt_f('execution_date'),
         'dag_id': wwwutils.dag_link,
     }
 
@@ -2637,10 +2637,10 @@ class TaskInstanceModelView(AirflowModelView):
         'task_id': wwwutils.task_instance_link,
         'hostname': wwwutils.nobr_f('hostname'),
         'state': wwwutils.state_f,
-        'execution_date': wwwutils.localized_f('execution_date'),
-        'start_date': wwwutils.localized_f('start_date'),
-        'end_date': wwwutils.localized_f('end_date'),
-        'queued_dttm': wwwutils.localized_f('queued_dttm'),
+        'execution_date': wwwutils.localized_dt_f('execution_date'),
+        'start_date': wwwutils.localized_dt_f('start_date'),
+        'end_date': wwwutils.localized_dt_f('end_date'),
+        'queued_dttm': wwwutils.localized_dt_f('queued_dttm'),
         'dag_id': wwwutils.dag_link,
         'duration': duration_f,
     }

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -102,10 +102,6 @@ const config = {
     new CleanWebpackPlugin(['static/dist']),
     new MiniCssExtractPlugin({ filename: '[name].[chunkhash].css' }),
 
-    // MomentJS loads all the locale, making it a huge JS file.
-    // This will ignore the locales from momentJS
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),


### PR DESCRIPTION
In addition to Airflow being timezone aware, this PR handles formatting datetime in the UI. 

This PR **does not** modify the timestamps to that of the users current time - instead translates the servers UTC timestamps to readable format(s). 

This project is split about 50/50 between a new `wwwutils` def:
```python
def localized_f(attr_name):
    def dt(attr):
        f = attr.get(attr_name)
        if f is None:
            return Markup('<time datetime="{}">{}</time>').format(f, f)
        else:
            f = f.strftime(date_format)
            return Markup('<time datetime="{}">{}</time>').format(f, f)
    return dt
```

And 2 new global javascript funcs in `static/base.js`:
```js
export function localizedDate(date) {
  const locale = window.navigator.userLanguage || window.navigator.language;
  if (date) return moment(date).locale(locale).format('LLL');
  return '';
}

export function localizedTime(time) {
  const locale = window.navigator.userLanguage || window.navigator.language;
  if (time) return moment(time).locale(locale).format('LTS');
  return '';
}
```

Previews (with different locales; english, french, german):
<img width="351" alt="Screen Shot 2020-03-11 at 4 46 09 PM" src="https://user-images.githubusercontent.com/6862485/76462335-e2980500-63b7-11ea-87cf-4194713ff6d4.png">
<img width="207" alt="Screen Shot 2020-03-11 at 11 59 20 AM" src="https://user-images.githubusercontent.com/6862485/76462050-66052680-63b7-11ea-8d03-cb5ca267668d.png">
<img width="487" alt="Screen Shot 2020-03-11 at 4 16 46 PM" src="https://user-images.githubusercontent.com/6862485/76462056-68678080-63b7-11ea-888e-ecd1659cae1f.png">


---
Issue link: [AIRFLOW-7046](https://issues.apache.org/jira/browse/AIRFLOW-7046)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
