### PR TITLE
[AIRFLOW-5948] Replace SimpleDag with SerializedDag

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -827,7 +827,7 @@ class DagFileProcessor(LoggingMixin):
         self,
         file_path: str,
         failure_callback_requests: List[FailureCallbackRequest],
-        pickle_dags: bool = False,
+        pickle_dags: bool = False,  # pylint: disable=unused-argument
         session: Session = None
     ) -> Tuple[List[dict], int]:
         """
@@ -853,9 +853,11 @@ class DagFileProcessor(LoggingMixin):
         :param pickle_dags: whether serialize the DAGs found in the file and
             save them to the db
         :type pickle_dags: bool
+        :param session: Sqlalchemy ORM Session
+        :type session: Session
         :return: a tuple with list of SimpleDags made from the Dags found in the file and
             count of import errors.
-        :rtype: Tuple[List[SerializedDAG], int]
+        :rtype: Tuple[List[dict], int]
         """
         self.log.info("Processing file %s for tasks to queue", file_path)
 
@@ -882,8 +884,7 @@ class DagFileProcessor(LoggingMixin):
         dagbag.sync_to_db()
 
         paused_dag_ids = DagModel.get_paused_dag_ids(dag_ids=dagbag.dag_ids)
-        # todo: remove the below line
-        print(pickle_dags)
+
         unpaused_dags: List[DAG] = [
             dag for dag_id, dag in dagbag.dags.items() if dag_id not in paused_dag_ids
         ]

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -964,8 +964,10 @@ class DagFileProcessor(LoggingMixin):
         # commit batch
         session.commit()
 
-    @classmethod
-    def _prepare_serialized_dags(cls, dags: List[DAG]) -> List[dict]:
+    @provide_session
+    def _prepare_serialized_dags(
+        self, dags: List[DAG], pickle_dags: bool, session: Session = None
+    ) -> List[dict]:
         """
         Convert DAGS to SimpleDags. If necessary, it also Pickle the DAGs
 
@@ -975,8 +977,9 @@ class DagFileProcessor(LoggingMixin):
         """
         serialized_dags: List[dict] = []
         # Pickle the DAGs (if necessary) and put them into a SimpleDagBag
-        # TODO: add pickling again
         for dag in dags:
+            if pickle_dags:
+                dag.pickle(session)
             serialized_dags.append(SerializedDAG.to_dict(dag))
         return serialized_dags
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -889,7 +889,7 @@ class DagFileProcessor(LoggingMixin):
             dag for dag_id, dag in dagbag.dags.items() if dag_id not in paused_dag_ids
         ]
 
-        serialized_dags = self._prepare_serialized_dags(unpaused_dags)
+        serialized_dags = self._prepare_serialized_dags(unpaused_dags, pickle_dags, session)
 
         dags = self._find_dags_to_process(unpaused_dags)
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -827,7 +827,7 @@ class DagFileProcessor(LoggingMixin):
         self,
         file_path: str,
         failure_callback_requests: List[FailureCallbackRequest],
-        pickle_dags: bool = False,  # pylint: disable=unused-argument
+        pickle_dags: bool = False,
         session: Session = None
     ) -> Tuple[List[dict], int]:
         """

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -99,7 +99,7 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin, Mul
         # The process that was launched to process the given .
         self._process: Optional[multiprocessing.process.BaseProcess] = None
         # The result of Scheduler.process_file(file_path).
-        self._result: Optional[Tuple[List[SerializedDAG], int]] = None
+        self._result: Optional[Tuple[List[dict], int]] = None
         # Whether the process is done running.
         self._done = False
         # When the process started.
@@ -166,7 +166,7 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin, Mul
 
                 log.info("Started process (PID=%s) to work on %s", os.getpid(), file_path)
                 dag_file_processor = DagFileProcessor(dag_ids=dag_ids, log=log)
-                result: Tuple[List[SerializedDAG], int] = dag_file_processor.process_file(
+                result: Tuple[List[dict], int] = dag_file_processor.process_file(
                     file_path=file_path,
                     pickle_dags=pickle_dags,
                     failure_callback_requests=failure_callback_requests,
@@ -303,10 +303,10 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin, Mul
         return False
 
     @property
-    def result(self) -> Optional[Tuple[List[SerializedDAG], int]]:
+    def result(self) -> Optional[Tuple[List[dict], int]]:
         """
         :return: result of running SchedulerJob.process_file()
-        :rtype: Optional[Tuple[List[SerializedDAG], int]]
+        :rtype: Optional[Tuple[List[dict], int]]
         """
         if not self.done:
             raise AirflowException("Tried to get the result before it's done!")
@@ -827,8 +827,9 @@ class DagFileProcessor(LoggingMixin):
         self,
         file_path: str,
         failure_callback_requests: List[FailureCallbackRequest],
-        pickle_dags: bool = False, session: Session = None
-    ) -> Tuple[List[SerializedDAG], int]:
+        pickle_dags: bool = False,
+        session: Session = None
+    ) -> Tuple[List[dict], int]:
         """
         Process a Python file containing Airflow DAGs.
 
@@ -963,18 +964,18 @@ class DagFileProcessor(LoggingMixin):
         session.commit()
 
     @classmethod
-    def _prepare_simple_dags(cls, dags: List[DAG]) -> List[SerializedDAG]:
+    def _prepare_simple_dags(cls, dags: List[DAG]) -> List[dict]:
         """
         Convert DAGS to  SimpleDags. If necessary, it also Pickle the DAGs
 
         :param dags: List of DAGs
         :return: List of SimpleDag
-        :rtype: List[airflow.utils.dag_processing.SimpleDag]
+        :rtype: List[dict]
         """
-        simple_dags: List[SerializedDAG] = []
+        simple_dags: List[dict] = []
         # Pickle the DAGs (if necessary) and put them into a SimpleDag
         for dag in dags:
-            simple_dags.append(SerializedDAG.from_dict(SerializedDAG.to_dict(dag)))
+            simple_dags.append(SerializedDAG.to_dict(dag))
         return simple_dags
 
 

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -58,18 +58,19 @@ class SimpleDagBag(BaseDagBag):
     A collection of SimpleDag objects with some convenience methods.
     """
 
-    def __init__(self, simple_dags: List[SerializedDAG]):
+    def __init__(self, simple_dags: List[dict]):
         """
         Constructor.
 
         :param simple_dags: SimpleDag objects that should be in this
-        :type simple_dags: list[SerializedDAG]
+        :type simple_dags: list[dict]
         """
         self.simple_dags = simple_dags
         self.dag_id_to_simple_dag: Dict[str, SerializedDAG] = {}
 
         for simple_dag in simple_dags:
-            self.dag_id_to_simple_dag[simple_dag.dag_id] = simple_dag
+            serialized_dag = SerializedDAG.from_dict(simple_dag)
+            self.dag_id_to_simple_dag[serialized_dag.dag_id] = serialized_dag
 
     @property
     def dag_ids(self) -> KeysView[str]:
@@ -148,12 +149,12 @@ class AbstractDagFileProcessorProcess(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def result(self) -> Optional[Tuple[List[SerializedDAG], int]]:
+    def result(self) -> Optional[Tuple[List[dict], int]]:
         """
         A list of simple dags found, and the number of import errors
 
         :return: result of running SchedulerJob.process_file() if availlablle. Otherwise, none
-        :rtype: Optional[Tuple[List[SerializedDAG], int]]
+        :rtype: Optional[Tuple[List[dict], int]]
         """
         raise NotImplementedError()
 
@@ -412,7 +413,7 @@ class DagFileProcessorAgent(LoggingMixin, MultiprocessingStartMethodMixin):
 
         processor_manager.start()
 
-    def harvest_simple_dags(self) -> List[SerializedDAG]:
+    def harvest_simple_dags(self) -> List[dict]:
         """
         Harvest DAG parsing results from result queue and sync metadata from stat queue.
 
@@ -1049,7 +1050,7 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
 
         :return: a list of SimpleDags that were produced by processors that
             have finished since the last time this was called
-        :rtype: list[SerializedDAG]
+        :rtype: list[dict]
         """
         # Collect all the DAGs that were found in the processed files
         simple_dags = []

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -58,7 +58,7 @@ class SimpleDagBag(BaseDagBag):
     A collection of SimpleDag objects with some convenience methods.
     """
 
-    def __init__(self, simple_dags: List[dict]):
+    def __init__(self, simple_dags: List[SerializedDAG]):
         """
         Constructor.
 
@@ -69,8 +69,7 @@ class SimpleDagBag(BaseDagBag):
         self.dag_id_to_simple_dag: Dict[str, SerializedDAG] = {}
 
         for simple_dag in simple_dags:
-            serialized_dag = SerializedDAG.from_dict(simple_dag)
-            self.dag_id_to_simple_dag[serialized_dag.dag_id] = serialized_dag
+            self.dag_id_to_simple_dag[simple_dag.dag_id] = simple_dag
 
     @property
     def dag_ids(self) -> KeysView[str]:
@@ -413,7 +412,7 @@ class DagFileProcessorAgent(LoggingMixin, MultiprocessingStartMethodMixin):
 
         processor_manager.start()
 
-    def harvest_simple_dags(self) -> List[dict]:
+    def harvest_simple_dags(self) -> List[SerializedDAG]:
         """
         Harvest DAG parsing results from result queue and sync metadata from stat queue.
 

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -63,7 +63,7 @@ class SimpleDagBag(BaseDagBag):
         Constructor.
 
         :param simple_dags: SimpleDag objects that should be in this
-        :type simple_dags: list[airflow.models.dag.DAG]
+        :type simple_dags: list[SerializedDAG]
         """
         self.simple_dags = simple_dags
         self.dag_id_to_simple_dag: Dict[str, SerializedDAG] = {}

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -29,7 +29,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from importlib import import_module
 from multiprocessing.connection import Connection as MultiprocessingConnection
-from typing import Any, Callable, Dict, KeysView, List, NamedTuple, Optional, Tuple
+from typing import Callable, Dict, KeysView, List, NamedTuple, Optional, Tuple
 
 from setproctitle import setproctitle  # pylint: disable=no-name-in-module
 from sqlalchemy import or_
@@ -37,10 +37,11 @@ from tabulate import tabulate
 
 import airflow.models
 from airflow.configuration import conf
-from airflow.dag.base_dag import BaseDag, BaseDagBag
+from airflow.dag.base_dag import BaseDagBag
 from airflow.exceptions import AirflowException
 from airflow.models import errors
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
+from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.settings import STORE_DAG_CODE, STORE_SERIALIZED_DAGS
 from airflow.stats import Stats
 from airflow.utils import timezone
@@ -52,101 +53,24 @@ from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 
-class SimpleDag(BaseDag):
-    """
-    A simplified representation of a DAG that contains all attributes
-    required for instantiating and scheduling its associated tasks.
-
-    :param dag: the DAG
-    :type dag: airflow.models.DAG
-    :param pickle_id: ID associated with the pickled version of this DAG.
-    :type pickle_id: unicode
-    """
-
-    def __init__(self, dag, pickle_id: Optional[int] = None):
-        self._dag_id: str = dag.dag_id
-        self._task_ids: List[str] = [task.task_id for task in dag.tasks]
-        self._full_filepath: str = dag.full_filepath
-        self._concurrency: int = dag.concurrency
-        self._pickle_id: Optional[int] = pickle_id
-        self._task_special_args: Dict[str, Any] = {}
-        for task in dag.tasks:
-            special_args = {}
-            if task.task_concurrency is not None:
-                special_args['task_concurrency'] = task.task_concurrency
-            if special_args:
-                self._task_special_args[task.task_id] = special_args
-
-    @property
-    def dag_id(self) -> str:
-        """
-        :return: the DAG ID
-        :rtype: unicode
-        """
-        return self._dag_id
-
-    @property
-    def task_ids(self) -> List[str]:
-        """
-        :return: A list of task IDs that are in this DAG
-        :rtype: list[unicode]
-        """
-        return self._task_ids
-
-    @property
-    def full_filepath(self) -> str:
-        """
-        :return: The absolute path to the file that contains this DAG's definition
-        :rtype: unicode
-        """
-        return self._full_filepath
-
-    @property
-    def concurrency(self) -> int:
-        """
-        :return: maximum number of tasks that can run simultaneously from this DAG
-        :rtype: int
-        """
-        return self._concurrency
-
-    @property
-    def pickle_id(self) -> Optional[int]:    # pylint: disable=invalid-overridden-method
-        """
-        :return: The pickle ID for this DAG, if it has one. Otherwise None.
-        :rtype: unicode
-        """
-        return self._pickle_id
-
-    @property
-    def task_special_args(self) -> Dict[str, Any]:
-        """Special arguments of the task."""
-        return self._task_special_args
-
-    def get_task_special_arg(self, task_id: str, special_arg_name: str):
-        """Retrieve special arguments of the task."""
-        if task_id in self._task_special_args and special_arg_name in self._task_special_args[task_id]:
-            return self._task_special_args[task_id][special_arg_name]
-        else:
-            return None
-
-
 class SimpleDagBag(BaseDagBag):
     """
     A collection of SimpleDag objects with some convenience methods.
     """
 
-    def __init__(self, simple_dags: List[SimpleDag]):
+    def __init__(self, simple_dags: List[dict]):
         """
         Constructor.
 
         :param simple_dags: SimpleDag objects that should be in this
-        :type list(airflow.utils.dag_processing.SimpleDag)
+        :type simple_dags: list[airflow.models.dag.DAG]
         """
         self.simple_dags = simple_dags
-        self.dag_id_to_simple_dag: Dict[str, SimpleDag] = {}
+        self.dag_id_to_simple_dag: Dict[str, SerializedDAG] = {}
 
         for simple_dag in simple_dags:
-            self.dag_id_to_simple_dag[simple_dag.dag_id] = simple_dag
+            serialized_dag = SerializedDAG.from_dict(simple_dag)
+            self.dag_id_to_simple_dag[serialized_dag.dag_id] = serialized_dag
 
     @property
     def dag_ids(self) -> KeysView[str]:
@@ -156,13 +80,13 @@ class SimpleDagBag(BaseDagBag):
         """
         return self.dag_id_to_simple_dag.keys()
 
-    def get_dag(self, dag_id: str) -> SimpleDag:
+    def get_dag(self, dag_id: str) -> SerializedDAG:
         """
         :param dag_id: DAG ID
         :type dag_id: unicode
         :return: if the given DAG ID exists in the bag, return the BaseDag
         corresponding to that ID. Otherwise, throw an Exception
-        :rtype: airflow.utils.dag_processing.SimpleDag
+        :rtype: SerializedDAG
         """
         if dag_id not in self.dag_id_to_simple_dag:
             raise AirflowException("Unknown DAG ID {}".format(dag_id))
@@ -225,12 +149,12 @@ class AbstractDagFileProcessorProcess(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def result(self) -> Optional[Tuple[List[SimpleDag], int]]:
+    def result(self) -> Optional[Tuple[List[SerializedDAG], int]]:
         """
         A list of simple dags found, and the number of import errors
 
         :return: result of running SchedulerJob.process_file() if availlablle. Otherwise, none
-        :rtype: Optional[Tuple[List[SimpleDag], int]]
+        :rtype: Optional[Tuple[List[SerializedDAG], int]]
         """
         raise NotImplementedError()
 
@@ -489,7 +413,7 @@ class DagFileProcessorAgent(LoggingMixin, MultiprocessingStartMethodMixin):
 
         processor_manager.start()
 
-    def harvest_simple_dags(self) -> List[SimpleDag]:
+    def harvest_simple_dags(self) -> List[dict]:
         """
         Harvest DAG parsing results from result queue and sync metadata from stat queue.
 
@@ -1126,7 +1050,7 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
 
         :return: a list of SimpleDags that were produced by processors that
             have finished since the last time this was called
-        :rtype: list[airflow.utils.dag_processing.SimpleDag]
+        :rtype: list[SerializedDAG]
         """
         # Collect all the DAGs that were found in the processed files
         simple_dags = []

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1167,7 +1167,7 @@ class TestDagFileProcessor(unittest.TestCase):
             tis = session.query(TaskInstance).all()
 
         self.assertEqual(0, import_errors_count)
-        self.assertEqual(['test_multiple_dags__dag_2'], [dag["dag"]["_dag_id"] for dag in simple_dags])
+        self.assertEqual(['test_multiple_dags__dag_2'], [dag.dag_id for dag in simple_dags])
         self.assertEqual({'test_multiple_dags__dag_2'}, {ti.dag_id for ti in tis})
 
     def test_should_mark_dummy_task_as_success(self):
@@ -1189,7 +1189,7 @@ class TestDagFileProcessor(unittest.TestCase):
             tis = session.query(TaskInstance).all()
 
         self.assertEqual(0, import_errors_count)
-        self.assertEqual(['test_only_dummy_tasks'], [dag["dag"]["_dag_id"] for dag in simple_dags])
+        self.assertEqual(['test_only_dummy_tasks'], [dag.dag_id for dag in simple_dags])
         self.assertEqual(5, len(tis))
         self.assertEqual({
             ('test_task_a', 'success'),
@@ -1415,7 +1415,7 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler.run()
 
     def _make_simple_dag_bag(self, dags):
-        return SimpleDagBag([SerializedDAG.to_dict(dag) for dag in dags])
+        return SimpleDagBag(DagFileProcessor._prepare_simple_dags(dags))
 
     def test_no_orphan_process_will_be_left(self):
         empty_dir = mkdtemp()
@@ -1442,7 +1442,8 @@ class TestSchedulerJob(unittest.TestCase):
         dag2 = DAG(dag_id=dag_id2, start_date=DEFAULT_DATE, full_filepath="/test_path1/")
         task1 = DummyOperator(dag=dag, task_id=task_id_1)
         DummyOperator(dag=dag2, task_id=task_id_1)
-
+        dag.fileloc = "/test_path1/"
+        dag2.fileloc = "/test_path1/"
         dagbag1 = self._make_simple_dag_bag([dag])
         dagbag2 = self._make_simple_dag_bag([dag2])
 
@@ -2370,7 +2371,7 @@ class TestSchedulerJob(unittest.TestCase):
         executor.queued_tasks
         scheduler.executor = executor
         processor = mock.MagicMock()
-        processor.harvest_simple_dags.return_value = [SerializedDAG.to_dict(dag)]
+        processor.harvest_simple_dags.return_value = [SerializedDAG.from_dict(SerializedDAG.to_dict(dag))]
         processor.done = True
         scheduler.processor_agent = processor
 
@@ -3604,7 +3605,7 @@ class TestSchedulerJobQueriesCount(unittest.TestCase):
 
             mock_agent = mock.MagicMock()
             mock_agent.harvest_simple_dags.return_value = [
-                SerializedDAG.to_dict(d) for d in dagbag.dags.values()]
+                SerializedDAG.from_dict(SerializedDAG.to_dict(d)) for d in dagbag.dags.values()]
 
             job = SchedulerJob(subdir=PERF_DAGS_FOLDER)
             job.executor = MockExecutor()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1167,7 +1167,7 @@ class TestDagFileProcessor(unittest.TestCase):
             tis = session.query(TaskInstance).all()
 
         self.assertEqual(0, import_errors_count)
-        self.assertEqual(['test_multiple_dags__dag_2'], [dag.dag_id for dag in simple_dags])
+        self.assertEqual(['test_multiple_dags__dag_2'], list(SimpleDagBag(simple_dags).dag_ids))
         self.assertEqual({'test_multiple_dags__dag_2'}, {ti.dag_id for ti in tis})
 
     def test_should_mark_dummy_task_as_success(self):
@@ -1189,7 +1189,7 @@ class TestDagFileProcessor(unittest.TestCase):
             tis = session.query(TaskInstance).all()
 
         self.assertEqual(0, import_errors_count)
-        self.assertEqual(['test_only_dummy_tasks'], [dag.dag_id for dag in simple_dags])
+        self.assertEqual(['test_only_dummy_tasks'], list(SimpleDagBag(simple_dags).dag_ids))
         self.assertEqual(5, len(tis))
         self.assertEqual({
             ('test_task_a', 'success'),
@@ -2371,7 +2371,7 @@ class TestSchedulerJob(unittest.TestCase):
         executor.queued_tasks
         scheduler.executor = executor
         processor = mock.MagicMock()
-        processor.harvest_simple_dags.return_value = [SerializedDAG.from_dict(SerializedDAG.to_dict(dag))]
+        processor.harvest_simple_dags.return_value = [SerializedDAG.to_dict(dag)]
         processor.done = True
         scheduler.processor_agent = processor
 
@@ -3605,7 +3605,7 @@ class TestSchedulerJobQueriesCount(unittest.TestCase):
 
             mock_agent = mock.MagicMock()
             mock_agent.harvest_simple_dags.return_value = [
-                SerializedDAG.from_dict(SerializedDAG.to_dict(d)) for d in dagbag.dags.values()]
+                SerializedDAG.to_dict(d) for d in dagbag.dags.values()]
 
             job = SchedulerJob(subdir=PERF_DAGS_FOLDER)
             job.executor = MockExecutor()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1170,7 +1170,7 @@ class TestDagFileProcessor(unittest.TestCase):
             tis = session.query(TaskInstance).all()
 
         self.assertEqual(0, import_errors_count)
-        self.assertEqual(['test_multiple_dags__dag_2'], list(SimpleDagBag(dags).dag_ids))
+        self.assertEqual(['test_multiple_dags__dag_2'], [dag.dag_id for dag in dags])
         self.assertEqual({'test_multiple_dags__dag_2'}, {ti.dag_id for ti in tis})
 
     def test_should_mark_dummy_task_as_success(self):
@@ -1195,7 +1195,7 @@ class TestDagFileProcessor(unittest.TestCase):
             tis = session.query(TaskInstance).all()
 
         self.assertEqual(0, import_errors_count)
-        self.assertEqual(['test_only_dummy_tasks'], list(SimpleDagBag(dags).dag_ids))
+        self.assertEqual(['test_only_dummy_tasks'], [dag.dag_id for dag in dags])
         self.assertEqual(5, len(tis))
         self.assertEqual({
             ('test_task_a', 'success'),

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -401,7 +401,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                 processor_agent.wait_until_finished()
             parsing_result.extend(processor_agent.harvest_simple_dags())
 
-        dag_ids = [result.dag_id for result in parsing_result]
+        dag_ids = [result["dag"]["_dag_id"] for result in parsing_result]
         self.assertEqual(dag_ids.count('test_start_date_scheduling'), 1)
 
     def test_launch_process(self):

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -399,7 +399,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
         while not processor_agent.done:
             if not async_mode:
                 processor_agent.wait_until_finished()
-            parsing_result.extend(processor_agent.harvest_simple_dags())
+            parsing_result.extend(processor_agent.harvest_serialized_dags())
 
         dag_ids = list(SimpleDagBag(parsing_result).dag_ids)
         self.assertEqual(dag_ids.count('test_start_date_scheduling'), 1)

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -401,7 +401,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                 processor_agent.wait_until_finished()
             parsing_result.extend(processor_agent.harvest_simple_dags())
 
-        dag_ids = [result["dag"]["_dag_id"] for result in parsing_result]
+        dag_ids = [result.dag_id for result in parsing_result]
         self.assertEqual(dag_ids.count('test_start_date_scheduling'), 1)
 
     def test_launch_process(self):

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -33,7 +33,7 @@ from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.utils import timezone
 from airflow.utils.dag_processing import (
     DagFileProcessorAgent, DagFileProcessorManager, DagFileStat, DagParsingSignal, DagParsingStat,
-    FailureCallbackRequest,
+    FailureCallbackRequest, SimpleDagBag,
 )
 from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
 from airflow.utils.session import create_session
@@ -401,7 +401,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                 processor_agent.wait_until_finished()
             parsing_result.extend(processor_agent.harvest_simple_dags())
 
-        dag_ids = [result.dag_id for result in parsing_result]
+        dag_ids = list(SimpleDagBag(parsing_result).dag_ids)
         self.assertEqual(dag_ids.count('test_start_date_scheduling'), 1)
 
     def test_launch_process(self):

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -33,7 +33,7 @@ from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.utils import timezone
 from airflow.utils.dag_processing import (
     DagFileProcessorAgent, DagFileProcessorManager, DagFileStat, DagParsingSignal, DagParsingStat,
-    FailureCallbackRequest, SimpleDagBag,
+    FailureCallbackRequest,
 )
 from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
 from airflow.utils.session import create_session
@@ -401,7 +401,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                 processor_agent.wait_until_finished()
             parsing_result.extend(processor_agent.harvest_serialized_dags())
 
-        dag_ids = list(SimpleDagBag(parsing_result).dag_ids)
+        dag_ids = [result.dag_id for result in parsing_result]
         self.assertEqual(dag_ids.count('test_start_date_scheduling'), 1)
 
     def test_launch_process(self):


### PR DESCRIPTION
Replace SimpleDag with serialized version (json over multiprocessing) in SchedulerJob etc., no other change in scheduler behaviour. (This doesn't make sense long term, but does tidy up the code)


---
Issue link: [AIRFLOW-5948](https://issues.apache.org/jira/browse/AIRFLOW-5948)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
