### PR TITLE
[AIRFLOW-XXXX] Replace conversion from list to set

### DIFF
--- a/tests/executors/test_debug_executor.py
+++ b/tests/executors/test_debug_executor.py
@@ -45,7 +45,7 @@ class TestDebugExecutor:
         task_instance_mock.job_id = job_id
 
         executor = DebugExecutor()
-        executor.running = set([ti_key])
+        executor.running = {ti_key}
         succeeded = executor._run_task(task_instance_mock)
 
         assert succeeded
@@ -86,7 +86,7 @@ class TestDebugExecutor:
 
         executor = DebugExecutor()
         executor.tasks_to_run = [ti]
-        executor.running = set([ti.key])
+        executor.running = {ti.key}
         executor.end()
 
         ti.set_state.assert_called_once_with(State.UPSTREAM_FAILED)


### PR DESCRIPTION
```python
{ti_key}
```
is same as:

```python
set([ti_key])
```
We don't need to make a list and then convert it to set.


---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
