### PR TITLE
[AIRFLOW-7047] Fix build providers dependencies pre-commit on Mac

### DIFF
--- a/scripts/ci/pre_commit_build_providers_dependencies.sh
+++ b/scripts/ci/pre_commit_build_providers_dependencies.sh
@@ -28,7 +28,6 @@ cd "${MY_DIR}/../../" || exit;
 PYTHONPATH="$(pwd)"
 export PYTHONPATH
 find airflow/providers -name '*.py' -print0 | \
-    xargs --null \
-        python3 tests/build_provider_packages_dependencies.py \
-            --provider-dependencies-file "airflow/providers/dependencies.json" \
-            --documentation-file CONTRIBUTING.rst
+    xargs -0 python3 tests/build_provider_packages_dependencies.py \
+        --provider-dependencies-file "airflow/providers/dependencies.json" \
+        --documentation-file CONTRIBUTING.rst


### PR DESCRIPTION
---
Issue link: [AIRFLOW-7047](https://issues.apache.org/jira/browse/AIRFLOW-7047)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
