### PR TITLE
[AIRFLOW-6562] Fix success/failed error in graph without dagrun

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1270,15 +1270,12 @@ class Airflow(AirflowBaseView):
         task = dag.get_task(task_id)
         task.dag = dag
 
+        latest_execution_date = dag.latest_execution_date
+        if not latest_execution_date:
+            flash(f"Cannot make {state}, seem that dag {dag_id} has never run", "error")
+            return redirect(origin)
+
         execution_date = timezone.parse(execution_date)
-
-        if not dag:
-            flash("Cannot find DAG: {}".format(dag_id))
-            return redirect(origin)
-
-        if not task:
-            flash("Cannot find task {} in DAG {}".format(task_id, dag.dag_id))
-            return redirect(origin)
 
         from airflow.api.common.experimental.mark_tasks import set_state
 


### PR DESCRIPTION
Graph view now will raise an error when click
make task instance success/failed, with the
init state and no dag run, we should make some
hint instead of raise error in the webserver

---
Issue link: [AIRFLOW-6562](https://issues.apache.org/jira/browse/AIRFLOW-6562)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
