### PR TITLE
[AIRFLOW-7044] Add ability to specify host_key in connections extras for SSH

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -274,3 +274,5 @@ class SSHHook(BaseHook):
                       category=DeprecationWarning)
 
         return self.get_tunnel(remote_port, remote_host, local_port)
+
+    # TODO - PRIVATE HELPER METHOD TO WRITE TO KNOWN HOSTS

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -120,6 +120,12 @@ class SSHHook(BaseHook):
                         and\
                         str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
+                if "host_public_key" in extra_options and self.no_host_key_check is False:
+                    self._add_host_to_known_hosts(
+                        self.remote_host,
+                        'ssh-rsa',
+                        extra_options["host_public_key"]
+                    )
 
         if self.pkey and self.key_file:
             raise AirflowException(
@@ -275,4 +281,30 @@ class SSHHook(BaseHook):
 
         return self.get_tunnel(remote_port, remote_host, local_port)
 
-    # TODO - PRIVATE HELPER METHOD TO WRITE TO KNOWN HOSTS
+    @staticmethod
+    def _add_host_to_known_hosts(host, key_type, public_key):
+        """This adds a specified remote_host public key to the known_hosts
+            in order to prevent man-in-the-middle attacks."""
+        # The .ssh hidden directory is required and not present on all airflow deployments
+        if not os.path.exists(os.path.expanduser('~/.ssh')):
+            os.mkdir(os.path.expanduser('~/.ssh'))
+
+        known_hosts_file_ref = os.path.expanduser('~/.ssh/known_hosts')
+
+        line_to_write = ' '.join([host, key_type, public_key])
+
+        if os.path.exists(known_hosts_file_ref):
+            with open(known_hosts_file_ref, 'r') as f:
+                known_hosts = f.read()
+
+            with open(known_hosts_file_ref, 'w') as f:
+                f.write(known_hosts)
+                # only add the entry if it doesn't already exist.
+                if line_to_write not in known_hosts:
+                    f.write('\n')
+                    f.write(line_to_write)
+        else:
+            # the known_hosts file doesn't exist so we create a new one with the required contents.
+            with open(known_hosts_file_ref, 'w') as f:
+                f.write(line_to_write)
+                f.write('\n')

--- a/docs/howto/connection/ssh.rst
+++ b/docs/howto/connection/ssh.rst
@@ -46,6 +46,7 @@ Extra (optional)
     * ``compress`` - ``true`` to ask the remote client/server to compress traffic; ``false`` to refuse compression. Default is ``true``.
     * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
     * ``allow_host_key_change`` - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This wont protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
+    * ``host_key`` - The base64 encoded ssh-rsa public key of the host. Specifying this, along with ``no_host_key_check=False`` allows you to only make the connection if the public key of the endpoint matches this value. If this value doesn't already exist in ``~/.ssh/known_hosts`` then it is created there when instantiating the SSHHook class.
 
     Example "extras" field:
 
@@ -56,7 +57,8 @@ Extra (optional)
           "timeout": "10",
           "compress": "false",
           "no_host_key_check": "false",
-          "allow_host_key_change": "false"
+          "allow_host_key_change": "false",
+          "host_key": "AAAHD...YDWwq=="
        }
 
     When specifying the connection as URI (in ``AIRFLOW_CONN_*`` variable) you should specify it

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -108,6 +108,7 @@ class TestSSHHook(unittest.TestCase):
                 host='localhost',
                 conn_type='ssh',
                 extra=json.dumps({
+                    "private_key": TEST_PRIVATE_KEY,
                     "host_public_key": TEST_HOST_PUBLIC_KEY
                 })
             )
@@ -118,6 +119,7 @@ class TestSSHHook(unittest.TestCase):
                 host='localhost',
                 conn_type='ssh',
                 extra=json.dumps({
+                    'private_key': TEST_PRIVATE_KEY,
                     "host_public_key": TEST_HOST_PUBLIC_KEY,
                     'no_host_key_check': True
                 })
@@ -129,6 +131,7 @@ class TestSSHHook(unittest.TestCase):
                 host='localhost',
                 conn_type='ssh',
                 extra=json.dumps({
+                    'private_key': TEST_PRIVATE_KEY,
                     "host_public_key": TEST_HOST_PUBLIC_KEY,
                     'no_host_key_check': False
                 })
@@ -296,6 +299,7 @@ class TestSSHHook(unittest.TestCase):
                 sock=None
             )
 
+    @mock.patch('airflow.providers.ssh.hooks.ssh.open', mock.mock_open(read_data=''))
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_public_key_extra(self, ssh_mock):
         hook = SSHHook(
@@ -319,6 +323,7 @@ class TestSSHHook(unittest.TestCase):
 
         # TODO - mock and check known_hosts file not touched
 
+    @mock.patch('airflow.providers.ssh.hooks.ssh.open', mock.mock_open(read_data=''))
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_public_key_and_no_host_key_check_true_extra(self, ssh_mock):
         hook = SSHHook(
@@ -342,22 +347,40 @@ class TestSSHHook(unittest.TestCase):
 
         # TODO - mock and check known_hosts file not touched
 
+    @mock.patch('airflow.providers.ssh.hooks.ssh.open', mock.mock_open(read_data=''))
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_public_key_and_no_host_key_check_false_extra(self, ssh_mock):
-        with pytest.raises(AirflowException):
-            SSHHook(
-                ssh_conn_id=self.CONN_SSH_WITH_PUBLIC_KEY_AND_NO_HOST_KEY_CHECK_FALSE_EXTRA,
-                remote_host='remote_host',
-                port='port',
+        hook = SSHHook(
+            ssh_conn_id=self.CONN_SSH_WITH_PUBLIC_KEY_AND_NO_HOST_KEY_CHECK_FALSE_EXTRA,
+            remote_host='remote_host',
+            port='port',
+            username='username',
+            timeout=10,
+        )
+
+        with hook.get_conn():
+            ssh_mock.return_value.connect.assert_called_once_with(
+                hostname='remote_host',
                 username='username',
+                pkey=TEST_PKEY,
                 timeout=10,
+                compress=True,
+                port='port',
+                sock=None
             )
 
-        # TODO - mock and check known_hosts file touched
-
     # TODO - TEST PRIVATE HELPER METHOD FOR CREATING FILE WITH MOCKS
-    def test_add_host_to_known_hosts(self):
-        SSHHook._add_host_to_known_hosts()
+    @staticmethod
+    def test_add_new_record_to_known_hosts():
+        assert False
+
+    @staticmethod
+    def test_format_known_hosts_record():
+        assert False
+
+    @staticmethod
+    def test_create_known_hosts():
+        assert False
 
 
 if __name__ == '__main__':

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -347,7 +347,7 @@ class TestSSHHook(unittest.TestCase):
 
         # TODO - mock and check known_hosts file not touched
 
-    @mock.patch('airflow.providers.ssh.hooks.ssh.open', mock.mock_open(read_data=''))
+    #@mock.patch('airflow.providers.ssh.hooks.ssh.open', mock.mock_open(read_data=''))
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_public_key_and_no_host_key_check_false_extra(self, ssh_mock):
         hook = SSHHook(
@@ -369,18 +369,10 @@ class TestSSHHook(unittest.TestCase):
                 sock=None
             )
 
-    # TODO - TEST PRIVATE HELPER METHOD FOR CREATING FILE WITH MOCKS
-    @staticmethod
-    def test_add_new_record_to_known_hosts():
-        assert False
-
     @staticmethod
     def test_format_known_hosts_record():
-        assert False
-
-    @staticmethod
-    def test_create_known_hosts():
-        assert False
+        assert f'remote_host ssh-rsa {TEST_HOST_PUBLIC_KEY}' == \
+               SSHHook._format_known_hosts_record('remote_host', 'ssh-rsa', TEST_HOST_PUBLIC_KEY)
 
 
 if __name__ == '__main__':

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -48,9 +48,12 @@ def generate_key_string(pkey: paramiko.PKey):
     key_str = key_fh.read()
     return key_str
 
+# TODO - GENERATE_PUBLIC KEY FUNCTION
+
 
 TEST_PKEY = paramiko.RSAKey.generate(4096)
 TEST_PRIVATE_KEY = generate_key_string(pkey=TEST_PKEY)
+# TODO - GENERATE PUBLIC KEY AND PUBLIC KEY TYPE VARS
 
 
 class TestSSHHook(unittest.TestCase):
@@ -88,6 +91,7 @@ class TestSSHHook(unittest.TestCase):
                 })
             )
         )
+        # TODO - MAKE CONN FOR PUBLIC KEY EXTRAS
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_password(self, ssh_mock):
@@ -249,6 +253,12 @@ class TestSSHHook(unittest.TestCase):
                 port='port',
                 sock=None
             )
+
+    # TODO - TEST THAT CONNECTION GETS CREATED WITH PUBLIC KEY EXTRAS
+
+    # TODO - CHECK THAT KNOWN_HOSTS GETS CREATED APPROPRIATELY GIVEN DIFFERENT CONFIGS OF PARAMS
+
+    # TODO - TEST PRIVATE HELPER METHOD FOR CREATING FILE
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a new option in the SSH connection extras where you can specify base64 ssh-rsa public key of a host. The SSHHook constructor will then add this key to `~/.ssh/known_hosts` if not present.

NB - this is my first time submitting to this project.
---
Issue link: [AIRFLOW-7044](https://issues.apache.org/jira/browse/AIRFLOW-7044)

Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
