### PR TITLE
[AIRFLOW-XXXX] Add Default kwargs description in Python Operater tutorial

### DIFF
--- a/docs/howto/operator/python.rst
+++ b/docs/howto/operator/python.rst
@@ -30,6 +30,56 @@ Python callables.
     :start-after: [START howto_operator_python]
     :end-before: [END howto_operator_python]
 
+
+Default kwargs
+-----------------
+
+
+kwargs is a dictionary where the values are templates that will get templated by the Airflow engine.
+
+Default kwargs is passed to the function (the example above is 'ds'). And it can bring in multiple arguments as well as one.
+
+
+=====================================   ====================================
+kwargs                                   Description
+=====================================   ====================================
+``conf``                                  the full configuration object located at ``airflow.configuration.conf`` which represents the content of your ``airflow.cfg``
+``dag``                                   the DAG object
+``dag_run``                               a reference to the DagRun object
+``ds``                                    the execution date as ``YYYY-MM-DD``
+``ds_nodash``                             the execution date as ``YYYYMMDD``
+``execution_date``                        the execution_date (logical date)
+``inlets``                                []
+``macros``                                a reference to the macros package
+``next_ds``                               the next execution date as ``YYYY-MM-DD`` if ``ds`` is ``2018-01-01`` and ``schedule_interval`` is ``@weekly``, ``next_ds`` will be ``2018-01-08``
+``next_ds_nodash``                        the next execution date as ``YYYYMMDD`` if exists, else ``None``
+``next_execution_date``                   the next execution date (`pendulum.Pendulum`_)
+``outlets``                               []
+``params``                                a reference to the user-defined params dictionary which can be overridden by the dictionary passed through ``trigger_dag -c`` if you enabled ``dag_run_conf_overrides_params`` in ``airflow.cfg``
+``prev_ds``                               the previous execution date as ``YYYY-MM-DD`` if ``ds`` is ``2018-01-08`` and ``schedule_interval`` is ``@weekly``, ``prev_ds`` will be ``2018-01-01``
+``prev_ds_nodash``                        the previous execution date as ``YYYYMMDD`` if exists, else ``None``
+``prev_execution_date``                   the previous execution date (if available) (`pendulum.Pendulum`_)
+``prev_execution_date_success``           execution date from prior successful dag run (if available) (`pendulum.Pendulum`_)
+``prev_start_date_success``               start date from prior successful dag run (if available) (pendulum.Pendulum_)
+``run_id``                                the ``run_id`` of the current DAG run
+``task``                                  the Task object
+``task_instance``                         the task_instance object
+``task_instance_key_str``                 a unique, human-readable key to the task instance formatted ``{dag_id}_{task_id}_{ds}``
+``templates_dict``                        a dictionary where the values are templates that will get templated by the Airflow engine
+``test_mode``                             whether the task instance was called using the CLI's test subcommand
+``ti``                                    same as ``task_instance``
+``tomorrow_ds``                           the day after the execution date as ``YYYY-MM-DD``
+``tomorrow_ds_nodash``                    the day after the execution date as ``YYYYMMDD``
+``ts``                                    same as ``execution_date.isoformat()``. Example: ``2018-01-01T00:00:00+00:00``
+``ts_nodash``                             same as ``ts`` without ``-``, ``:`` and TimeZone info. Example: ``20180101T000000``
+``ts_nodash_with_tz``                     same as ``ts`` without ``-`` and ``:``. Example: ``20180101T000000+0000``
+``var``                                   global defined variables represented as a dictionary (json, value)
+``yesterday_ds``                          the day before the execution date as ``YYYY-MM-DD``
+``yesterday_ds_nodash``                   the day before the execution date as ``YYYYMMDD``
+=====================================   ====================================
+
+
+
 Passing in arguments
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
PythonOperator Tutorial contains `ds` in the print_context function argument, which in Default kwargs that can be used as a function argument.

In this tutorial, users can write a variety of assuagements as well as ds.
Right now, we don't know what arguments we can use if we don't see kwargs.

So, add a description table for Default kwargs for detail tutorial.

I didn't understand the `inlets` and `outlets` in detail. Can you explain how it is used?

---
Issue link: `Document only change, no JIRA issue`

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
