### PR TITLE
[AIRFLOW-1536] Inherit umask from parent process in daemon mode

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -536,6 +536,10 @@ ARG_CELERY_HOSTNAME = Arg(
     ("-H", "--celery-hostname"),
     help=("Set the hostname of celery worker "
           "if you have multiple workers on a single machine"))
+ARG_UMASK = Arg(
+    ("-u", "--umask"),
+    help="Set the umask of celery worker in daemon mode",
+    default=conf.get('celery', 'worker_umask'))
 
 # flower
 ARG_BROKER_API = Arg(("-a", "--broker-api"), help="Broker API")
@@ -1108,7 +1112,7 @@ CELERY_COMMANDS = (
         func=lazy_load_command('airflow.cli.commands.celery_command.worker'),
         args=(
             ARG_DO_PICKLE, ARG_QUEUES, ARG_CONCURRENCY, ARG_CELERY_HOSTNAME, ARG_PID, ARG_DAEMON,
-            ARG_STDOUT, ARG_STDERR, ARG_LOG_FILE, ARG_AUTOSCALE, ARG_SKIP_SERVE_LOGS
+            ARG_UMASK, ARG_STDOUT, ARG_STDERR, ARG_LOG_FILE, ARG_AUTOSCALE, ARG_SKIP_SERVE_LOGS
         ),
     ),
     ActionCommand(

--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -133,8 +133,12 @@ def worker(args):
         stdout = open(stdout, 'w+')
         stderr = open(stderr, 'w+')
 
+        if args.umask:
+            umask = args.umask
+
         ctx = daemon.DaemonContext(
             files_preserve=[handle],
+            umask=int(umask, 8),
             stdout=stdout,
             stderr=stderr,
         )

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1134,6 +1134,15 @@
       type: string
       example: ~
       default: "8793"
+    - name: worker_umask
+      description: |
+        Umask that will be used when starting workers with the ``airflow celery worker``
+        in daemon mode. This control the file-creation mode mask which determines the initial
+        value of file permission bits for newly created files.
+      version_added: ~
+      type: string
+      example: ~
+      default: "0o077"
     - name: broker_url
       description: |
         The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -553,6 +553,11 @@ worker_concurrency = 8
 # visible from the main web server to connect into the workers.
 worker_log_server_port = 8793
 
+# Umask that will be used when starting workers with the ``airflow celery worker``
+# in daemon mode. This control the file-creation mode mask which determines the initial
+# value of file permission bits for newly created files.
+worker_umask = 0o077
+
 # The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
 # a sqlalchemy database. Refer to the Celery documentation for more
 # information.

--- a/docs/executor/celery.rst
+++ b/docs/executor/celery.rst
@@ -83,6 +83,7 @@ Some caveats:
 
 - Make sure to use a database backed result backend
 - Make sure to set a visibility timeout in ``[celery_broker_transport_options]`` that exceeds the ETA of your longest running task
+- Make sure to set umask in ``[worker_umask]`` to set permissions for newly created files by workers.
 - Tasks can consume resources. Make sure your worker has enough resources to run ``worker_concurrency`` tasks
 - Queue names are limited to 256 characters, but each broker backend might have its own restrictions
 


### PR DESCRIPTION
When celery workers are run in daemon mode, umask was set to default(0)
which create dirs/files with 0777/0666 permissions.

---
Issue link: [AIRFLOW-1536](https://issues.apache.org/jira/browse/AIRFLOW-1536)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
