### PR TITLE
[AIRFLOW-4175] S3Hook load_file should support ACL policy parameter

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -231,11 +231,27 @@ class TestAwsS3Hook:
         resource = boto3.resource('s3').Object(s3_bucket, 'my_key')  # pylint: disable=no-member
         assert resource.get()['Body'].read() == b'Cont\xC3\xA9nt'
 
+    def test_load_string_acl(self, s3_bucket):
+        hook = S3Hook()
+        hook.load_string("Contént", "my_key", s3_bucket,
+                         acl_policy='public-read')
+        response = boto3.client('s3').get_object_acl(Bucket=s3_bucket, Key="my_key", RequestPayer='requester')
+        assert ((response['Grants'][1]['Permission'] == 'READ') and
+                (response['Grants'][0]['Permission'] == 'FULL_CONTROL'))
+
     def test_load_bytes(self, s3_bucket):
         hook = S3Hook()
         hook.load_bytes(b"Content", "my_key", s3_bucket)
         resource = boto3.resource('s3').Object(s3_bucket, 'my_key')  # pylint: disable=no-member
         assert resource.get()['Body'].read() == b'Content'
+
+    def test_load_bytes_acl(self, s3_bucket):
+        hook = S3Hook()
+        hook.load_bytes(b"Content", "my_key", s3_bucket,
+                        acl_policy='public-read')
+        response = boto3.client('s3').get_object_acl(Bucket=s3_bucket, Key="my_key", RequestPayer='requester')
+        assert ((response['Grants'][1]['Permission'] == 'READ') and
+                (response['Grants'][0]['Permission'] == 'FULL_CONTROL'))
 
     def test_load_fileobj(self, s3_bucket):
         hook = S3Hook()
@@ -246,6 +262,19 @@ class TestAwsS3Hook:
             resource = boto3.resource('s3').Object(s3_bucket, 'my_key')  # pylint: disable=no-member
             assert resource.get()['Body'].read() == b'Content'
 
+    def test_load_fileobj_acl(self, s3_bucket):
+        hook = S3Hook()
+        with tempfile.TemporaryFile() as temp_file:
+            temp_file.write(b"Content")
+            temp_file.seek(0)
+            hook.load_file_obj(temp_file, "my_key", s3_bucket,
+                               acl_policy='public-read')
+            response = boto3.client('s3').get_object_acl(Bucket=s3_bucket,
+                                                         Key="my_key",
+                                                         RequestPayer='requester')  # pylint: disable=no-member # noqa: E501 # pylint: disable=C0301
+            assert ((response['Grants'][1]['Permission'] == 'READ') and
+                    (response['Grants'][0]['Permission'] == 'FULL_CONTROL'))
+
     def test_load_file_gzip(self, s3_bucket):
         hook = S3Hook()
         with tempfile.NamedTemporaryFile() as temp_file:
@@ -254,6 +283,19 @@ class TestAwsS3Hook:
             hook.load_file(temp_file, "my_key", s3_bucket, gzip=True)
             resource = boto3.resource('s3').Object(s3_bucket, 'my_key')  # pylint: disable=no-member
             assert gz.decompress(resource.get()['Body'].read()) == b'Content'
+
+    def test_load_file_acl(self, s3_bucket):
+        hook = S3Hook()
+        with tempfile.NamedTemporaryFile() as temp_file:
+            temp_file.write(b"Content")
+            temp_file.seek(0)
+            hook.load_file(temp_file, "my_key", s3_bucket, gzip=True,
+                           acl_policy='public-read')
+            response = boto3.client('s3').get_object_acl(Bucket=s3_bucket,
+                                                         Key="my_key",
+                                                         RequestPayer='requester')  # pylint: disable=no-member # noqa: E501 # pylint: disable=C0301
+            assert ((response['Grants'][1]['Permission'] == 'READ') and
+                    (response['Grants'][0]['Permission'] == 'FULL_CONTROL'))
 
     @mock.patch.object(S3Hook, 'get_connection', return_value=Connection(schema='test_bucket'))
     def test_provide_bucket_name(self, mock_get_connection):


### PR DESCRIPTION
	- Added acl_policy parameter to all the S3Hook.load_*() and S3Hook.copy_object() functions
	- Added unittest to test the response permissions when the policy is passed
	- Updated the docstring of the function

---
Issue link: [AIRFLOW-4175](https://issues.apache.org/jira/browse/AIRFLOW-4175)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
