### PR TITLE
[AIRFLOW-7072] Task instance email_alert render only if need

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1425,15 +1425,6 @@ class TaskInstance(Base, LoggingMixin):
             'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
         )
 
-        default_html_content_err = (
-            'Try {{try_number}} out of {{max_tries + 1}}<br>'
-            'Exception:<br>Failed attempt to attach error logs<br>'
-            'Log: <a href="{{ti.log_url}}">Link</a><br>'
-            'Host: {{ti.hostname}}<br>'
-            'Log file: {{ti.log_filepath}}<br>'
-            'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
-        )
-
         def render(key, content):
             if conf.has_option('email', key):
                 path = conf.get('email', key)
@@ -1444,10 +1435,18 @@ class TaskInstance(Base, LoggingMixin):
 
         subject = render('subject_template', default_subject)
         html_content = render('html_content_template', default_html_content)
-        html_content_err = render('html_content_template', default_html_content_err)
         try:
             send_email(self.task.email, subject, html_content)
         except Exception:
+            default_html_content_err = (
+                'Try {{try_number}} out of {{max_tries + 1}}<br>'
+                'Exception:<br>Failed attempt to attach error logs<br>'
+                'Log: <a href="{{ti.log_url}}">Link</a><br>'
+                'Host: {{ti.hostname}}<br>'
+                'Log file: {{ti.log_filepath}}<br>'
+                'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
+            )
+            html_content_err = render('html_content_template', default_html_content_err)
             send_email(self.task.email, subject, html_content_err)
 
     def set_duration(self) -> None:


### PR DESCRIPTION
Task instance email_alert render html_content_err template
only if need

---
Issue link: [AIRFLOW-7072](https://issues.apache.org/jira/browse/AIRFLOW-7072)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
