### PR TITLE
[AIRFLOW-7080] Simple API endpoint to return a DAG's paused state

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -199,6 +199,16 @@ def dag_paused(dag_id, paused):
     return jsonify({'response': 'ok'})
 
 
+@api_experimental.route('/dags/<string:dag_id>/paused', methods=['GET'])
+@requires_authentication
+def dag_is_paused(dag_id):
+    """Get paused state of a dag"""
+
+    is_paused = models.DagModel.get_dagmodel(dag_id).is_paused
+
+    return jsonify({'is_paused': is_paused})
+
+
 @api_experimental.route(
     '/dags/<string:dag_id>/dag_runs/<string:execution_date>/tasks/<string:task_id>',
     methods=['GET'])

--- a/docs/rest-api-ref.rst
+++ b/docs/rest-api-ref.rst
@@ -75,6 +75,11 @@ Endpoints
   '<string:paused>' must be a 'true' to pause a DAG and 'false' to unpause.
 
 
+.. http:get:: /api/experimental/dags/<DAG_ID>/paused
+
+  Returns the paused state of a DAG
+
+
 .. http:get:: /api/experimental/latest_runs
 
   Returns the latest DagRun for each DAG formatted for the UI.

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -131,25 +131,35 @@ class TestApiExperimental(TestBase):
             )
             self.assertEqual(404, response.status_code)
 
-    def test_task_paused(self):
+    def test_dag_paused(self):
         with conf_vars(
             {("core", "store_serialized_dags"): self.dag_serialization}
         ):
-            url_template = '/api/experimental/dags/{}/paused/{}'
+            pause_url_template = '/api/experimental/dags/{}/paused/{}'
+            paused_url_template = '/api/experimental/dags/{}/paused'
+            paused_url = paused_url_template.format('example_bash_operator')
 
             response = self.client.get(
-                url_template.format('example_bash_operator', 'true')
+                pause_url_template.format('example_bash_operator', 'true')
             )
             self.assertIn('ok', response.data.decode('utf-8'))
             self.assertEqual(200, response.status_code)
 
-            url_template = '/api/experimental/dags/{}/paused/{}'
+            paused_response = self.client.get(paused_url)
+
+            self.assertEqual(200, paused_response.status_code)
+            self.assertEqual({"is_paused": True}, paused_response.json)
 
             response = self.client.get(
-                url_template.format('example_bash_operator', 'false')
+                pause_url_template.format('example_bash_operator', 'false')
             )
             self.assertIn('ok', response.data.decode('utf-8'))
             self.assertEqual(200, response.status_code)
+
+            paused_response = self.client.get(paused_url)
+
+            self.assertEqual(200, paused_response.status_code)
+            self.assertEqual({"is_paused": False}, paused_response.json)
 
     def test_trigger_dag(self):
         with conf_vars(


### PR DESCRIPTION
So far it is possible to set the paused state of a DAG via the experimental API. It would be nice to be also able to query the current paused state of a DAG. 


---
Issue link: [AIRFLOW-7080](https://issues.apache.org/jira/browse/AIRFLOW-7080)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
