### PR TITLE
[AIRFLOW-7073] GKEStartPodOperator always use connection credentials

### DIFF
--- a/airflow/providers/google/cloud/hooks/base.py
+++ b/airflow/providers/google/cloud/hooks/base.py
@@ -432,10 +432,11 @@ class CloudBaseHook(BaseHook):
                 tempfile.TemporaryDirectory() as gcloud_config_tmp, \
                 patch_environ({'CLOUDSDK_CONFIG': gcloud_config_tmp}):
 
-            # Don't display stdout/stderr for security reason
-            check_output([
-                "gcloud", "config", "set", "core/project", project_id
-            ])
+            if project_id:
+                # Don't display stdout/stderr for security reason
+                check_output([
+                    "gcloud", "config", "set", "core/project", project_id
+                ])
             if CREDENTIALS in os.environ:
                 # This solves most cases when we are logged in using the service key in Airflow.
                 # Don't display stdout/stderr for security reason

--- a/airflow/providers/google/cloud/hooks/base.py
+++ b/airflow/providers/google/cloud/hooks/base.py
@@ -26,6 +26,7 @@ import logging
 import os
 import tempfile
 from contextlib import contextmanager
+from subprocess import check_output
 from typing import Any, Callable, Dict, Optional, Sequence, TypeVar
 
 import google.auth
@@ -37,6 +38,7 @@ from google.api_core.exceptions import (
     AlreadyExists, Forbidden, GoogleAPICallError, ResourceExhausted, RetryError, TooManyRequests,
 )
 from google.api_core.gapic_v1.client_info import ClientInfo
+from google.auth import _cloud_sdk
 from google.auth.environment_vars import CREDENTIALS
 from googleapiclient.errors import HttpError
 from googleapiclient.http import set_user_agent
@@ -44,6 +46,7 @@ from googleapiclient.http import set_user_agent
 from airflow import version
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
+from airflow.utils.process_utils import patch_environ
 
 log = logging.getLogger(__name__)
 
@@ -387,28 +390,71 @@ class CloudBaseHook(BaseHook):
         It can be used to provide credentials for external programs (e.g. gcloud) that expect authorization
         file in ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable.
         """
-        with tempfile.NamedTemporaryFile(mode='w+t') as conf_file:
-            key_path = self._get_field('key_path', None)  # type: Optional[str]  # noqa: E501  #  pylint: disable=protected-access
-            keyfile_dict = self._get_field('keyfile_dict', None)  # type: Optional[Dict]  # noqa: E501  # pylint: disable=protected-access
-            current_env_state = os.environ.get(CREDENTIALS)
-            try:
-                if key_path:
-                    if key_path.endswith('.p12'):
-                        raise AirflowException(
-                            'Legacy P12 key file are not supported, use a JSON key file.'
-                        )
-                    os.environ[CREDENTIALS] = key_path
-                elif keyfile_dict:
-                    conf_file.write(keyfile_dict)
-                    conf_file.flush()
-                    os.environ[CREDENTIALS] = conf_file.name
-                else:
-                    # We will use the default service account credentials.
-                    pass
-                yield conf_file
-            finally:
-                if current_env_state is None:
-                    if CREDENTIALS in os.environ:
-                        del os.environ[CREDENTIALS]
-                else:
-                    os.environ[CREDENTIALS] = current_env_state
+        key_path = self._get_field('key_path', None)  # type: Optional[str]  # noqa: E501  #  pylint: disable=protected-access
+        keyfile_dict = self._get_field('keyfile_dict', None)  # type: Optional[Dict]  # noqa: E501  # pylint: disable=protected-access
+        if key_path and keyfile_dict:
+            raise AirflowException(
+                "The `keyfile_dict` and `key_path` fields are mutually exclusive. "
+                "Please provide only one value."
+            )
+        elif key_path:
+            if key_path.endswith('.p12'):
+                raise AirflowException(
+                    'Legacy P12 key file are not supported, use a JSON key file.'
+                )
+            with patch_environ({CREDENTIALS: key_path}):
+                yield key_path
+        elif keyfile_dict:
+            with tempfile.NamedTemporaryFile(mode='w+t') as conf_file:
+                conf_file.write(keyfile_dict)
+                conf_file.flush()
+                with patch_environ({CREDENTIALS: conf_file.name}):
+                    yield conf_file.name
+        else:
+            # We will use the default service account credentials.
+            yield None
+
+    @contextmanager
+    def provide_authorized_gcloud(self):
+        """
+        Provides a separate gcloud configuration with current credentials.
+
+        The gcloud allows you to login to GCP only - ``gcloud auth login`` and
+        for the needs of Application Default Credentials ``gcloud auth application-default login``.
+        In our case, we want all commands to use only the credentials from ADCm so
+        we need to configure the credentials in gcloud manually.
+        """
+        with self.provide_gcp_credential_file_as_context(), \
+                tempfile.TemporaryDirectory() as gcloud_config_tmp, \
+                patch_environ({'CLOUDSDK_CONFIG': gcloud_config_tmp}):
+
+            credentials_path = _cloud_sdk.get_application_default_credentials_path()
+
+            if CREDENTIALS in os.environ:
+                # This solves most cases when we are logged in using the service key in Airflow.
+                # Don't display stdout/stderr for security reason
+                check_output([
+                    "gcloud", "auth", "activate-service-account", f"--key-file={os.environ[CREDENTIALS]}",
+                ])
+            elif os.path.exists(credentials_path):
+                # If we are logged in by `gcloud auth application-default` then we need to log in manually.
+                # This will make the `gcloud auth application-default` and `gcloud auth` credentials equals.
+                with open(credentials_path) as creds_file:
+                    creds_content = json.loads(creds_file.read())
+                    # Don't display stdout/stderr for security reason
+                    check_output([
+                        "gcloud", "config", "set", "auth/client_id", creds_content["client_id"]
+                    ])
+                    # Don't display stdout/stderr for security reason
+                    check_output([
+                        "gcloud", "config", "set", "auth/client_secret", creds_content["client_secret"]
+                    ])
+                    # Don't display stdout/stderr for security reason
+                    check_output([
+                        "gcloud",
+                        "auth",
+                        "activate-refresh-token",
+                        creds_content["client_id"],
+                        creds_content["refresh_token"],
+                    ])
+            yield

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -33,6 +33,7 @@ from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import Kubernete
 from airflow.providers.google.cloud.hooks.base import CloudBaseHook
 from airflow.providers.google.cloud.hooks.kubernetes_engine import GKEHook
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.process_utils import execute_in_subprocess, patch_environ
 
 
 class GKEDeleteClusterOperator(BaseOperator):
@@ -254,22 +255,21 @@ class GKEStartPodOperator(KubernetesPodOperator):
 
         # Write config to a temp file and set the environment variable to point to it.
         # This is to avoid race conditions of reading/writing a single file
-        with tempfile.NamedTemporaryFile() as conf_file:
-            os.environ[KUBE_CONFIG_ENV_VAR] = conf_file.name
+        with tempfile.NamedTemporaryFile() as conf_file,\
+                patch_environ({KUBE_CONFIG_ENV_VAR: conf_file.name}), \
+                hook.provide_authorized_gcloud():
+            # Attempt to get/update credentials
+            # We call gcloud directly instead of using google-cloud-python api
+            # because there is no way to write kubernetes config to a file, which is
+            # required by KubernetesPodOperator.
+            # The gcloud command looks at the env variable `KUBECONFIG` for where to save
+            # the kubernetes config file.
+            execute_in_subprocess(
+                ["gcloud", "container", "clusters", "get-credentials",
+                 self.cluster_name,
+                 "--zone", self.location,
+                 "--project", self.project_id])
 
-            with hook.provide_gcp_credential_file_as_context():
-                # Attempt to get/update credentials
-                # We call gcloud directly instead of using google-cloud-python api
-                # because there is no way to write kubernetes config to a file, which is
-                # required by KubernetesPodOperator.
-                # The gcloud command looks at the env variable `KUBECONFIG` for where to save
-                # the kubernetes config file.
-                subprocess.check_call(
-                    ["gcloud", "container", "clusters", "get-credentials",
-                     self.cluster_name,
-                     "--zone", self.location,
-                     "--project", self.project_id])
-
-                # Tell `KubernetesPodOperator` where the config file is located
-                self.config_file = os.environ[KUBE_CONFIG_ENV_VAR]
-                return super().execute(context)
+            # Tell `KubernetesPodOperator` where the config file is located
+            self.config_file = os.environ[KUBE_CONFIG_ENV_VAR]
+            return super().execute(context)

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -21,7 +21,6 @@ This module contains Google Kubernetes Engine operators.
 """
 
 import os
-import subprocess
 import tempfile
 from typing import Dict, Optional, Union
 

--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -130,7 +130,7 @@ def provide_gcp_connection(
         scopes=scopes, key_file_path=key_file_path, project_id=project_id
     )
 
-    with patch_environ({"AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT": conn}):
+    with patch_environ({AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: conn}):
         yield
 
 

--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -20,7 +20,6 @@ This module contains a mechanism for providing temporary
 Google Cloud Platform authentication.
 """
 import json
-import os
 import tempfile
 from contextlib import contextmanager
 from typing import Dict, Optional, Sequence
@@ -29,6 +28,7 @@ from urllib.parse import urlencode
 from google.auth.environment_vars import CREDENTIALS
 
 from airflow.exceptions import AirflowException
+from airflow.utils.process_utils import patch_environ
 
 AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT = "AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT"
 
@@ -67,31 +67,6 @@ def build_gcp_conn(
 
 
 @contextmanager
-def temporary_environment_variable(variable_name: str, value: str):
-    """
-    Context manager that set up temporary value for a given environment
-    variable and the restore initial state.
-
-    :param variable_name: Name of the environment variable
-    :type variable_name: str
-    :param value: The temporary value
-    :type value: str
-    """
-    # Save initial value
-    init_value = os.environ.get(variable_name)
-    try:
-        # set temporary value
-        os.environ[variable_name] = value
-        yield
-    finally:
-        # Restore initial state (remove or restore)
-        if variable_name in os.environ:
-            del os.environ[variable_name]
-        if init_value:
-            os.environ[variable_name] = init_value
-
-
-@contextmanager
 def provide_gcp_credentials(
     key_file_path: Optional[str] = None, key_file_dict: Optional[Dict] = None
 ):
@@ -121,7 +96,7 @@ def provide_gcp_credentials(
             conf_file.flush()
             key_file_path = conf_file.name
         if key_file_path:
-            with temporary_environment_variable(CREDENTIALS, key_file_path):
+            with patch_environ({CREDENTIALS: key_file_path}):
                 yield
         else:
             # We will use the default service account credentials.
@@ -155,7 +130,7 @@ def provide_gcp_connection(
         scopes=scopes, key_file_path=key_file_path, project_id=project_id
     )
 
-    with temporary_environment_variable(AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT, conn):
+    with patch_environ({"AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT": conn}):
         yield
 
 

--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -25,7 +25,8 @@ import os
 import shlex
 import signal
 import subprocess
-from typing import List
+from contextlib import contextmanager
+from typing import Dict, List
 
 import psutil
 
@@ -184,3 +185,26 @@ def kill_child_processes_by_pids(pids_to_kill: List[int], timeout: int = 5) -> N
             log.info("Killing child PID: %s", child.pid)
             child.kill()
             child.wait()
+
+
+@contextmanager
+def patch_environ(new_env_variables: Dict[str, str]):
+    """
+    Sets environment variables in context. After leaving the context, it restores its original state.
+
+    :param new_env_variables: Environment variables to set
+    """
+    current_env_state = {
+        key: os.environ.get(key)
+        for key in new_env_variables.keys()
+    }
+    os.environ.update(new_env_variables)
+    try:
+        yield
+    finally:
+        for key, old_value in current_env_state.items():
+            if old_value is None:
+                if key in os.environ:
+                    del os.environ[key]
+            else:
+                os.environ[key] = old_value

--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -199,7 +199,7 @@ def patch_environ(new_env_variables: Dict[str, str]):
         for key in new_env_variables.keys()
     }
     os.environ.update(new_env_variables)
-    try:
+    try:  # pylint: disable=too-many-nested-blocks
         yield
     finally:
         for key, old_value in current_env_state.items():

--- a/tests/providers/google/cloud/hooks/test_base.py
+++ b/tests/providers/google/cloud/hooks/test_base.py
@@ -212,7 +212,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         def assert_gcp_credential_file_in_env(_):
             self.assertEqual(os.environ[CREDENTIALS], key_path)
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             AirflowException,
             'The `keyfile_dict` and `key_path` fields are mutually exclusive. '
             'Please provide only one value.'
@@ -624,7 +624,7 @@ class TestProvideAuthorizedGcloud(unittest.TestCase):
             'extra__google_cloud_platform__keyfile_dict': '{"foo": "bar"}'
         }
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             AirflowException,
             'The `keyfile_dict` and `key_path` fields are mutually exclusive. '
             'Please provide only one value.'
@@ -677,7 +677,7 @@ class TestProvideAuthorizedGcloud(unittest.TestCase):
             "refresh_token": "REFRESH_TOKEN",
             "type": "authorized_user"
         })
-        with mock.patch(MODULE_NAME + '.open', mock.mock_open(read_data=file_content)) as m:
+        with mock.patch(MODULE_NAME + '.open', mock.mock_open(read_data=file_content)):
             with self.instance.provide_authorized_gcloud():
                 # Do nothing
                 pass

--- a/tests/providers/google/cloud/hooks/test_base.py
+++ b/tests/providers/google/cloud/hooks/test_base.py
@@ -201,6 +201,24 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         ):
             self.instance = hook.CloudBaseHook(gcp_conn_id="google-cloud-default")
 
+    def test_provide_gcp_credential_file_decorator_key_path_and_keyfile_dict(self):
+        key_path = '/test/key-path'
+        self.instance.extras = {
+            'extra__google_cloud_platform__key_path': key_path,
+            'extra__google_cloud_platform__keyfile_dict': '{"foo": "bar"}'
+        }
+
+        @hook.CloudBaseHook.provide_gcp_credential_file
+        def assert_gcp_credential_file_in_env(_):
+            self.assertEqual(os.environ[CREDENTIALS], key_path)
+
+        with self.assertRaisesRegexp(
+            AirflowException,
+            'The `keyfile_dict` and `key_path` fields are mutually exclusive. '
+            'Please provide only one value.'
+        ):
+            assert_gcp_credential_file_in_env(self.instance)
+
     def test_provide_gcp_credential_file_decorator_key_path(self):
         key_path = '/test/key-path'
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}

--- a/tests/providers/google/cloud/hooks/test_base.py
+++ b/tests/providers/google/cloud/hooks/test_base.py
@@ -642,7 +642,7 @@ class TestProvideAuthorizedGcloud(unittest.TestCase):
     @mock.patch(
         'airflow.providers.google.cloud.hooks.base.CloudBaseHook.project_id',
         new_callable=mock.PropertyMock,
-        return_value=None
+        return_value="PROJECT_ID"
     )
     @mock.patch(MODULE_NAME + '.check_output')
     def test_provide_authorized_gcloud_key_path(self, mock_check_output, mock_project_id):
@@ -652,14 +652,15 @@ class TestProvideAuthorizedGcloud(unittest.TestCase):
         with self.instance.provide_authorized_gcloud():
             self.assertEqual(os.environ[CREDENTIALS], key_path)
 
-        mock_check_output.assert_called_once_with(
-            ['gcloud', 'auth', 'activate-service-account', '--key-file=/test/key-path']
+        mock_check_output.has_calls(
+            mock.call(['gcloud', 'config', 'set', 'core/project', 'PROJECT_ID']),
+            mock.call(['gcloud', 'auth', 'activate-service-account', '--key-file=/test/key-path'])
         )
 
     @mock.patch(
         'airflow.providers.google.cloud.hooks.base.CloudBaseHook.project_id',
         new_callable=mock.PropertyMock,
-        return_value=None
+        return_value="PROJECT_ID"
     )
     @mock.patch(MODULE_NAME + '.check_output')
     @mock.patch('tempfile.NamedTemporaryFile')
@@ -675,14 +676,15 @@ class TestProvideAuthorizedGcloud(unittest.TestCase):
         with self.instance.provide_authorized_gcloud():
             self.assertEqual(os.environ[CREDENTIALS], file_name)
 
-        mock_check_output.assert_called_once_with(
-            ['gcloud', 'auth', 'activate-service-account', '--key-file=/test/mock-file']
-        )
+        mock_check_output.has_calls([
+            mock.call(['gcloud', 'config', 'set', 'core/project', 'PROJECT_ID']),
+            mock.call(['gcloud', 'auth', 'activate-service-account', '--key-file=/test/mock-file'])
+        ])
 
     @mock.patch(
         'airflow.providers.google.cloud.hooks.base.CloudBaseHook.project_id',
         new_callable=mock.PropertyMock,
-        return_value=None
+        return_value="PROJECT_ID"
     )
     @mock.patch(MODULE_NAME + '._cloud_sdk')
     @mock.patch(MODULE_NAME + '.check_output')

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -20,7 +20,6 @@ import os
 import unittest
 
 import mock
-from google.auth.environment_vars import CREDENTIALS
 from mock import PropertyMock
 from parameterized import parameterized
 
@@ -151,79 +150,6 @@ class TestGKEPodOperator(unittest.TestCase):
             GKEStartPodOperator.template_fields))
 
     # pylint: disable=unused-argument
-    @mock.patch(
-        "airflow.hooks.base_hook.BaseHook.get_connections",
-        return_value=[Connection(
-            extra=json.dumps({})
-        )]
-    )
-    @mock.patch(
-        'airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.execute')
-    @mock.patch('tempfile.NamedTemporaryFile')
-    @mock.patch("subprocess.check_call")
-    @mock.patch.dict(os.environ, {CREDENTIALS: '/tmp/local-creds'})
-    def test_execute_conn_id_none(self, proc_mock, file_mock, exec_mock, get_conn):
-        type(file_mock.return_value.__enter__.return_value).name = PropertyMock(side_effect=[
-            FILE_NAME
-        ])
-
-        def assert_credentials(*args, **kwargs):
-            # since we passed in keyfile_path we should get a file
-            self.assertIn(CREDENTIALS, os.environ)
-            self.assertEqual(os.environ[CREDENTIALS], '/tmp/local-creds')
-
-        proc_mock.side_effect = assert_credentials
-
-        self.gke_op.execute(None)
-
-        # Assert Environment Variable is being set correctly
-        self.assertIn(KUBE_ENV_VAR, os.environ)
-        self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
-
-        # Assert the gcloud command being called correctly
-        proc_mock.assert_called_once_with(
-            GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, TEST_GCP_PROJECT_ID).split())
-
-        self.assertEqual(self.gke_op.config_file, FILE_NAME)
-
-    # pylint: disable=unused-argument
-    @mock.patch(
-        "airflow.hooks.base_hook.BaseHook.get_connections",
-        return_value=[Connection(
-            extra=json.dumps({
-                'extra__google_cloud_platform__key_path': '/path/to/file'
-            })
-        )]
-    )
-    @mock.patch(
-        'airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.execute')
-    @mock.patch('tempfile.NamedTemporaryFile')
-    @mock.patch("subprocess.check_call")
-    @mock.patch.dict(os.environ, {})
-    def test_execute_conn_id_path(self, proc_mock, file_mock, exec_mock, get_con_mock):
-        type(file_mock.return_value.__enter__.return_value).name = PropertyMock(side_effect=[
-            FILE_NAME
-        ])
-
-        def assert_credentials(*args, **kwargs):
-            # since we passed in keyfile_path we should get a file
-            self.assertIn(CREDENTIALS, os.environ)
-            self.assertEqual(os.environ[CREDENTIALS], '/path/to/file')
-
-        proc_mock.side_effect = assert_credentials
-        self.gke_op.execute(None)
-
-        # Assert Environment Variable is being set correctly
-        self.assertIn(KUBE_ENV_VAR, os.environ)
-        self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
-
-        # Assert the gcloud command being called correctly
-        proc_mock.assert_called_once_with(
-            GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, TEST_GCP_PROJECT_ID).split())
-
-        self.assertEqual(self.gke_op.config_file, FILE_NAME)
-
-    # pylint: disable=unused-argument
     @mock.patch.dict(os.environ, {})
     @mock.patch(
         "airflow.hooks.base_hook.BaseHook.get_connections",
@@ -235,28 +161,23 @@ class TestGKEPodOperator(unittest.TestCase):
     )
     @mock.patch(
         'airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.execute')
+    @mock.patch(
+        'airflow.providers.google.cloud.operators.kubernetes_engine.CloudBaseHook')
+    @mock.patch(
+        'airflow.providers.google.cloud.operators.kubernetes_engine.execute_in_subprocess')
     @mock.patch('tempfile.NamedTemporaryFile')
-    @mock.patch("subprocess.check_call")
-    def test_execute_conn_id_dict(self, proc_mock, file_mock, exec_mock, get_con_mock):
+    def test_execute(
+        self, file_mock, mock_execute_in_subprocess, mock_gcp_hook, exec_mock, get_con_mock
+    ):
         type(file_mock.return_value.__enter__.return_value).name = PropertyMock(side_effect=[
             FILE_NAME, '/path/to/new-file'
         ])
 
-        def assert_credentials(*args, **kwargs):
-            # since we passed in keyfile_dict we should get a new file
-            self.assertIn(CREDENTIALS, os.environ)
-            self.assertEqual(os.environ[CREDENTIALS], '/path/to/new-file')
-
-        proc_mock.side_effect = assert_credentials
-
         self.gke_op.execute(None)
 
-        # Assert Environment Variable is being set correctly
-        self.assertIn(KUBE_ENV_VAR, os.environ)
-        self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
+        mock_gcp_hook.return_value.provide_authorized_gcloud.assert_called_once()
 
-        # Assert the gcloud command being called correctly
-        proc_mock.assert_called_once_with(
+        mock_execute_in_subprocess.assert_called_once_with(
             GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, TEST_GCP_PROJECT_ID).split())
 
         self.assertEqual(self.gke_op.config_file, FILE_NAME)

--- a/tests/providers/google/cloud/utils/test_credentials_provider.py
+++ b/tests/providers/google/cloud/utils/test_credentials_provider.py
@@ -26,7 +26,7 @@ from google.auth.environment_vars import CREDENTIALS
 
 from airflow.providers.google.cloud.utils.credentials_provider import (
     AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT, build_gcp_conn, provide_gcp_conn_and_credentials,
-    provide_gcp_connection, provide_gcp_credentials, temporary_environment_variable,
+    provide_gcp_connection, provide_gcp_credentials,
 )
 
 ENV_VALUE = "test_env"
@@ -57,28 +57,6 @@ class TestHelper(unittest.TestCase):
         self.assertEqual(
             "google-cloud-platform://?extra__google_cloud_platform__projects=test", conn
         )
-
-
-class TestTemporaryEnvironmentVariable(unittest.TestCase):
-    @mock.patch.dict(os.environ, clear=True)
-    def test_temporary_environment_variable_delete(self):
-        with temporary_environment_variable(KEY, ENV_VALUE):
-            self.assertEqual(os.environ.get(KEY), ENV_VALUE)
-        self.assertNotIn(KEY, os.environ)
-
-    @mock.patch.dict(os.environ, {KEY: ENV_VALUE})
-    def test_temporary_environment_variable_restore(self):
-        with temporary_environment_variable(KEY, TEMP_VARIABLE):
-            self.assertEqual(os.environ.get(KEY), TEMP_VARIABLE)
-        self.assertEqual(os.environ.get(KEY), ENV_VALUE)
-
-    @mock.patch.dict(os.environ, clear=True)
-    def test_temporary_environment_variable_error(self):
-        with self.assertRaises(Exception):
-            with temporary_environment_variable(KEY, ENV_VALUE):
-                self.assertEqual(os.environ.get(KEY), ENV_VALUE)
-                raise Exception("test")
-            self.assertNotIn(KEY, os.environ)
 
 
 class TestProvideGcpCredentials(unittest.TestCase):


### PR DESCRIPTION
The gcloud allows you to login to GCP only - ``gcloud auth login`` and for the needs of Application Default Credentials ``gcloud auth application-default login``.
In our case, we want all commands to use only the credentials from ADC. so we need to configure the credentials in gcloud manually.

---
Issue link: [AIRFLOW-7073](https://issues.apache.org/jira/browse/AIRFLOW-7073)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
