### PR TITLE
[AIRFLOW-7044] Add host_key option to SSH connection extras

### DIFF
--- a/airflow/migrations/versions/449b4072c2da_increase_size_of_connection_extra_field_.py
+++ b/airflow/migrations/versions/449b4072c2da_increase_size_of_connection_extra_field_.py
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Increase size of connection.extra field to handle multiple RSA keys
+
+Revision ID: 449b4072c2da
+Revises: 952da73b5eff
+Create Date: 2020-03-16 19:02:55.337710
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '449b4072c2da'
+down_revision = '952da73b5eff'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply increase_length_for_connection_password"""
+    with op.batch_alter_table('connection', schema=None) as batch_op:
+        batch_op.alter_column('extra',
+                              existing_type=sa.VARCHAR(length=5000),
+                              type_=sa.String(length=10000),
+                              existing_nullable=True)
+
+
+def downgrade():
+    """Unapply increase_length_for_connection_password"""
+    with op.batch_alter_table('connection', schema=None) as batch_op:
+        batch_op.alter_column('extra',
+                              existing_type=sa.String(length=10000),
+                              type_=sa.VARCHAR(length=5000),
+                              existing_nullable=True)

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -117,7 +117,7 @@ class Connection(Base, LoggingMixin):
     port = Column(Integer())
     is_encrypted = Column(Boolean, unique=False, default=False)
     is_extra_encrypted = Column(Boolean, unique=False, default=False)
-    _extra = Column('extra', String(5000))
+    _extra = Column('extra', String(10000))
 
     _types = [
         ('docker', 'Docker Registry'),

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -309,7 +309,7 @@ class SSHHook(BaseHook):
         :param host_key: The base64-ecoded public key of the remote host.
         :type host_key: str
         """
-        # The .ssh hidden directory is required and not present on all airflow deployments
+        # The .ssh hidden directory is required and not present on all airflow deployments.
         try:
             known_hosts_file_ref = SSHHook._create_known_hosts()
         except PermissionError:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -289,7 +289,7 @@ class SSHHook(BaseHook):
     @staticmethod
     def add_host_to_known_hosts(host: str, key_type: str, host_key: str) -> None:
         """
-        Adds a specified remote_host public key to the known_hosts file  
+        Adds a specified remote_host public key to the known_hosts file
             in order to prevent man-in-the-middle attacks.
 
         The format of the new line in known_hosts will be:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -110,16 +110,16 @@ class SSHHook(BaseHook):
                 if "timeout" in extra_options:
                     self.timeout = int(extra_options["timeout"], 10)
 
-                if "compress" in extra_options\
-                        and str(extra_options["compress"]).lower() == 'false':
+                if "compress" in extra_options \
+                    and str(extra_options["compress"]).lower() == 'false':
                     self.compress = False
-                if "no_host_key_check" in extra_options\
-                        and\
-                        str(extra_options["no_host_key_check"]).lower() == 'false':
+                if "no_host_key_check" in extra_options \
+                    and \
+                    str(extra_options["no_host_key_check"]).lower() == 'false':
                     self.no_host_key_check = False
-                if "allow_host_key_change" in extra_options\
-                        and\
-                        str(extra_options["allow_host_key_change"]).lower() == 'true':
+                if "allow_host_key_change" in extra_options \
+                    and \
+                    str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:
                     self.add_host_to_known_hosts(
@@ -291,7 +291,11 @@ class SSHHook(BaseHook):
         """This adds a specified remote_host public key to the known_hosts
             in order to prevent man-in-the-middle attacks."""
         # The .ssh hidden directory is required and not present on all airflow deployments
-        known_hosts_file_ref = SSHHook._create_known_hosts()
+        try:
+            known_hosts_file_ref = SSHHook._create_known_hosts()
+        except PermissionError:
+            raise AirflowException("The user running airflow on this system does not have the neccesary permissions "
+                                   "to make changes to the ~/.ssh directory and its contents.")
         record = SSHHook._format_known_hosts_record(host, key_type, host_key)
         with open(known_hosts_file_ref, 'r') as known_hosts:
             file_content = known_hosts.read()

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -338,19 +338,11 @@ class SSHHook(BaseHook):
             # the host may be in the file with a different (possibly old) key
             # in this case, we should replace the existing record
             with open(known_hosts_file_ref, 'w+') as f:
-                SSHHook._update_record_in_known_hosts(
-                    host,
-                    record,
-                    file_content,
-                    f
-                )
+                SSHHook._update_record_in_known_hosts(host, record, file_content, f)
         else:
             # in this case the file is empty or the record doesn't exist in the file so add it
             with open(known_hosts_file_ref, 'a') as f:
-                SSHHook._add_new_record_to_known_hosts(
-                    record,
-                    f
-                )
+                SSHHook._add_new_record_to_known_hosts(record, f)
 
     @staticmethod
     def _format_known_hosts_record(host: str, key_type: str, public_key: str) -> str:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -289,7 +289,7 @@ class SSHHook(BaseHook):
     @staticmethod
     def add_host_to_known_hosts(host: str, key_type: str, host_key: str) -> None:
         """
-        Adds a specified remote_host public key to the known_hosts file
+        Adds a specified remote_host public key to the known_hosts file 
             in order to prevent man-in-the-middle attacks.
 
         The format of the new line in known_hosts will be:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -122,7 +122,7 @@ class SSHHook(BaseHook):
                         str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:
-                    self.add_host_to_known_hosts(
+                    self.update_host_in_known_hosts(
                         self.remote_host,
                         'ssh-rsa',
                         extra_options["host_key"]
@@ -297,7 +297,7 @@ class SSHHook(BaseHook):
         file.write(new_file_contents)
 
     @staticmethod
-    def add_host_to_known_hosts(host: str, key_type: str, host_key: str) -> None:
+    def update_host_in_known_hosts(host: str, key_type: str, host_key: str) -> None:
         """
         Adds a specified remote_host public key to the known_hosts file
             in order to prevent man-in-the-middle attacks.

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -289,7 +289,7 @@ class SSHHook(BaseHook):
     @staticmethod
     def add_host_to_known_hosts(host: str, key_type: str, host_key: str) -> None:
         """
-        Adds a specified remote_host public key to the known_hosts file 
+        Adds a specified remote_host public key to the known_hosts file  
             in order to prevent man-in-the-middle attacks.
 
         The format of the new line in known_hosts will be:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -304,7 +304,7 @@ class SSHHook(BaseHook):
 
         :param host: FQDN of the remote host.
         :type host: str
-        :param key_type: The algorithm format of the public key.
+        :param key_type: The algorithm format of the provided public key.
         :type key_type: str
         :param host_key: The base64-ecoded public key of the remote host.
         :type host_key: str

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -110,15 +110,15 @@ class SSHHook(BaseHook):
                 if "timeout" in extra_options:
                     self.timeout = int(extra_options["timeout"], 10)
 
-                if "compress" in extra_options \
+                if "compress" in extra_options\
                         and str(extra_options["compress"]).lower() == 'false':
                     self.compress = False
-                if "no_host_key_check" in extra_options \
-                        and \
+                if "no_host_key_check" in extra_options\
+                        and\
                         str(extra_options["no_host_key_check"]).lower() == 'false':
                     self.no_host_key_check = False
-                if "allow_host_key_change" in extra_options \
-                        and \
+                if "allow_host_key_change" in extra_options\
+                        and\
                         str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -332,7 +332,9 @@ class SSHHook(BaseHook):
         with open(known_hosts_file_ref, 'r') as f:
             file_content = f.read()
 
-        if host in file_content:
+        if record in file_content:
+            pass
+        elif host in file_content:
             # the host may be in the file with a different (possibly old) key
             # in this case, we should replace the existing record
             with open(known_hosts_file_ref, 'w+') as f:
@@ -342,8 +344,8 @@ class SSHHook(BaseHook):
                     file_content,
                     f
                 )
-        elif len(file_content) == 0 or record not in file_content:
-            # if file is empty or the record doesn't exist in the file, add it
+        else:
+            # in this case the file is empty or the record doesn't exist in the file so add it
             with open(known_hosts_file_ref, 'a') as f:
                 SSHHook._add_new_record_to_known_hosts(
                     record,

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -111,15 +111,15 @@ class SSHHook(BaseHook):
                     self.timeout = int(extra_options["timeout"], 10)
 
                 if "compress" in extra_options \
-                    and str(extra_options["compress"]).lower() == 'false':
+                        and str(extra_options["compress"]).lower() == 'false':
                     self.compress = False
                 if "no_host_key_check" in extra_options \
-                    and \
-                    str(extra_options["no_host_key_check"]).lower() == 'false':
+                        and \
+                        str(extra_options["no_host_key_check"]).lower() == 'false':
                     self.no_host_key_check = False
                 if "allow_host_key_change" in extra_options \
-                    and \
-                    str(extra_options["allow_host_key_change"]).lower() == 'true':
+                        and \
+                        str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:
                     self.add_host_to_known_hosts(
@@ -294,8 +294,8 @@ class SSHHook(BaseHook):
         try:
             known_hosts_file_ref = SSHHook._create_known_hosts()
         except PermissionError:
-            raise AirflowException("The user running airflow on this system does not have the neccesary permissions "
-                                   "to make changes to the ~/.ssh directory and its contents.")
+            raise AirflowException("The user running airflow on this system does not have the necessary "
+                                   "permissions to make changes to the ~/.ssh directory and its contents.")
         record = SSHHook._format_known_hosts_record(host, key_type, host_key)
         with open(known_hosts_file_ref, 'r') as known_hosts:
             file_content = known_hosts.read()

--- a/docs/howto/connection/ssh.rst
+++ b/docs/howto/connection/ssh.rst
@@ -46,6 +46,7 @@ Extra (optional)
     * ``compress`` - ``true`` to ask the remote client/server to compress traffic; ``false`` to refuse compression. Default is ``true``.
     * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
     * ``allow_host_key_change`` - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This wont protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
+    * ``host_key`` - The base64 encoded ssh-rsa public key of the host. Specifying this, along with ``no_host_key_check=False`` allows you to only make the connection if the public key of the endpoint matches this value. If this value doesn't already exist in ``~/.ssh/known_hosts`` then it is created there when instantiating the SSHHook class.
 
     Example "extras" field:
 
@@ -56,7 +57,8 @@ Extra (optional)
           "timeout": "10",
           "compress": "false",
           "no_host_key_check": "false",
-          "allow_host_key_change": "false"
+          "allow_host_key_change": "false",
+          "host_key": "AAAHD...YDWwq=="
        }
 
     When specifying the connection as URI (in ``AIRFLOW_CONN_*`` variable) you should specify it


### PR DESCRIPTION
This PR adds a new option in the SSH connection extras where you can specify base64 ssh-rsa public key of a host. The SSHHook constructor will then add this key to ~/.ssh/known_hosts if not present.

---
Issue link: [AIRFLOW-7044](https://issues.apache.org/jira/browse/AIRFLOW-7044)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
