### PR TITLE
[AIRFLOW-7065] Add optional propagation of task std streams to console

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -496,6 +496,13 @@
       type: string
       example: ~
       default: "task"
+    - name: task_console_output
+      description: |
+        When true, propagates task STDOUT and STDERR output to console as well as capturing in log file.
+      version_added: ~
+      type: boolean
+      example: ~
+      default: false
 - name: secrets
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -268,6 +268,9 @@ dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/d
 # Default to use task handler.
 task_log_reader = task
 
+# When true, propagates task STDOUT and STDERR output to console as well as capturing in log file.
+task_console_output =
+
 [secrets]
 # Full class name of secrets backend to enable (will precede env vars and metastore in search path)
 backend =

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -25,6 +25,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import timedelta
 from itertools import groupby
 from typing import List, Optional, Tuple
@@ -51,7 +52,7 @@ from airflow.utils.dag_processing import (
     AbstractDagFileProcessorProcess, DagFileProcessorAgent, FailureCallbackRequest, SimpleDag, SimpleDagBag,
 )
 from airflow.utils.email import get_email_address_list, send_email
-from airflow.utils.log.logging_mixin import LoggingMixin, StderrToLog, StdoutToLog, set_context
+from airflow.utils.log.logging_mixin import LoggingMixin, StreamLogWriter, set_context
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
@@ -140,8 +141,8 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
 
         try:
             # redirect stdout/stderr to log
-            with StdoutToLog(log, logging.INFO), \
-                    StderrToLog(log, logging.WARN):
+            with redirect_stdout(StreamLogWriter(log, logging.INFO)),\
+                    redirect_stderr(StreamLogWriter(log, logging.WARN)):
 
                 # Re-configure the ORM engine as there are issues with multiple processes
                 settings.configure_orm()

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -25,7 +25,6 @@ import sys
 import threading
 import time
 from collections import defaultdict
-from contextlib import redirect_stderr, redirect_stdout
 from datetime import timedelta
 from itertools import groupby
 from typing import List, Optional, Tuple
@@ -52,7 +51,7 @@ from airflow.utils.dag_processing import (
     AbstractDagFileProcessorProcess, DagFileProcessorAgent, FailureCallbackRequest, SimpleDag, SimpleDagBag,
 )
 from airflow.utils.email import get_email_address_list, send_email
-from airflow.utils.log.logging_mixin import LoggingMixin, StreamLogWriter, set_context
+from airflow.utils.log.logging_mixin import LoggingMixin, StderrToLog, StdoutToLog, set_context
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
@@ -141,8 +140,8 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
 
         try:
             # redirect stdout/stderr to log
-            with redirect_stdout(StreamLogWriter(log, logging.INFO)),\
-                    redirect_stderr(StreamLogWriter(log, logging.WARN)):
+            with StdoutToLog(log, logging.INFO), \
+                    StderrToLog(log, logging.WARN):
 
                 # Re-configure the ORM engine as there are issues with multiple processes
                 settings.configure_orm()

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -61,6 +61,7 @@ class LoggingMixin:
             set_context(self.log, context)
 
 
+# TODO: Formally inherit from io.IOBase
 class StreamLogWriter:
     """
     Allows to redirect stdout and stderr to logger

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -72,7 +72,7 @@ class StreamLogWriter:
         """
         self.logger = logger
         self.level = level
-        self._buffer = str()
+        self._buffer = []
 
     @property
     def closed(self):
@@ -97,19 +97,20 @@ class StreamLogWriter:
         :param message: message to log
         """
         if not message.endswith("\n"):
-            self._buffer += message
+            self._buffer.append(message)
         else:
-            self._buffer += message
-            self._propagate_log(self._buffer.rstrip())
-            self._buffer = str()
+            self._buffer.append(message)
+            full_message = ''.join(self._buffer)
+            self._propagate_log(full_message.rstrip())
+            self._buffer.clear()
 
     def flush(self):
         """
         Ensure all logging output has been flushed
         """
-        if len(self._buffer) > 0:
-            self._propagate_log(self._buffer)
-            self._buffer = str()
+        if self._buffer:
+            self._propagate_log(''.join(self._buffer))
+            self._buffer.clear()
 
     def isatty(self):
         """


### PR DESCRIPTION
Both `stdout` and `stderr` are captured during Task execution to allow handling by custom log writers. While this is great, there are cases where forwarding task execution output to system streams (console) during task runtime is advantageous (ie for capture by docker logging drivers). Adding a `LogHandler` that wrote to stdout or stderr would result in an infinite loop of message forwarding `stdout > StreamLogWriter > logger > stdout > StreamLogWriter > ...`

This adds a configuration flag `['logging']['task_log_to_console']` which enables forwarding of task stream messages to the console when set. This is implemented via a new context manager that adds existing system stream targets as targets for the `StreamLogWriter`. There is some implementation of log target replacement that is essentially duplicated from the stdlib, but I could not think of a better way to do this without a subclassing death-spiral. It has decent tests, and I do not think that this will be difficult to keep unbroken.

---
Issue link: [AIRFLOW-7065](https://issues.apache.org/jira/browse/AIRFLOW-7065)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
