### PR TITLE
[AIRFLOW-5705] Fix bug in Secrets Backend

### DIFF
--- a/airflow/secrets/__init__.py
+++ b/airflow/secrets/__init__.py
@@ -79,10 +79,10 @@ def initialize_secrets_backends() -> List[BaseSecretsBackend]:
     * import secrets backend classes
     * instantiate them and return them in a list
     """
-    alternative_secrets_backend = conf.get(section=CONFIG_SECTION, key='class_name', fallback='')
+    alternative_secrets_backend = conf.get(section=CONFIG_SECTION, key='backend', fallback='')
     try:
         alternative_secrets_config_dict = json.loads(
-            conf.get(section=CONFIG_SECTION, key='config_json', fallback='{}')
+            conf.get(section=CONFIG_SECTION, key='backend_kwargs', fallback='{}')
         )
     except JSONDecodeError:
         alternative_secrets_config_dict = {}


### PR DESCRIPTION
Follow up of https://github.com/apache/airflow/pull/6376 . There were some bugs where the renaming of configs was not applied at all places

---
Issue link: [AIRFLOW-5705](https://issues.apache.org/jira/browse/AIRFLOW-5705)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

cc @dstandish 