### PR TITLE
[AIRFLOW-5705] Fix bugs in AWS SSM Secrets Backend

### DIFF
--- a/airflow/providers/amazon/aws/secrets/ssm.py
+++ b/airflow/providers/amazon/aws/secrets/ssm.py
@@ -90,7 +90,7 @@ class AwsSsmSecretsBackend(BaseSecretsBackend, LoggingMixin):
             )
             return None
 
-    def get_connections(self, conn_id: str) -> Optional[List[Connection]]:
+    def get_connections(self, conn_id: str) -> List[Connection]:
         """
         Create connection object.
 
@@ -99,6 +99,6 @@ class AwsSsmSecretsBackend(BaseSecretsBackend, LoggingMixin):
         """
         conn_uri = self.get_conn_uri(conn_id=conn_id)
         if not conn_uri:
-            return None
+            return []
         conn = Connection(conn_id=conn_id, uri=conn_uri)
         return [conn]

--- a/airflow/providers/amazon/aws/secrets/ssm.py
+++ b/airflow/providers/amazon/aws/secrets/ssm.py
@@ -24,9 +24,10 @@ import boto3
 
 from airflow.models import Connection
 from airflow.secrets import CONN_ENV_PREFIX, BaseSecretsBackend
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-class AwsSsmSecretsBackend(BaseSecretsBackend):
+class AwsSsmSecretsBackend(BaseSecretsBackend, LoggingMixin):
     """
     Retrieves Connection object from AWS SSM Parameter Store
 
@@ -66,26 +67,38 @@ class AwsSsmSecretsBackend(BaseSecretsBackend):
         param_path = self.prefix + "/" + param_name
         return param_path
 
-    def get_conn_uri(self, conn_id: str):
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """
         Get param value
 
         :param conn_id: connection id
+        :type conn_id: str
         """
         session = boto3.Session(profile_name=self.profile_name)
         client = session.client("ssm")
-        response = client.get_parameter(
-            Name=self.build_ssm_path(conn_id=conn_id), WithDecryption=True
-        )
-        value = response["Parameter"]["Value"]
-        return value
+        ssm_path = self.build_ssm_path(conn_id=conn_id)
+        try:
+            response = client.get_parameter(
+                Name=ssm_path, WithDecryption=False
+            )
+            value = response["Parameter"]["Value"]
+            return value
+        except client.exceptions.ParameterNotFound:
+            self.log.info(
+                "An error occurred (ParameterNotFound) when calling the GetParameter operation: "
+                "Parameter %s not found.", ssm_path
+            )
+            return None
 
-    def get_connections(self, conn_id: str) -> List[Connection]:
+    def get_connections(self, conn_id: str) -> Optional[List[Connection]]:
         """
         Create connection object.
 
         :param conn_id: connection id
+        :type conn_id: str
         """
         conn_uri = self.get_conn_uri(conn_id=conn_id)
+        if not conn_uri:
+            return None
         conn = Connection(conn_id=conn_id, uri=conn_uri)
         return [conn]

--- a/airflow/secrets/__init__.py
+++ b/airflow/secrets/__init__.py
@@ -26,7 +26,7 @@ __all__ = ['CONN_ENV_PREFIX', 'BaseSecretsBackend', 'get_connections']
 import json
 from abc import ABC, abstractmethod
 from json import JSONDecodeError
-from typing import List
+from typing import List, Optional
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
@@ -50,7 +50,7 @@ class BaseSecretsBackend(ABC):
         pass
 
     @abstractmethod
-    def get_connections(self, conn_id) -> List[Connection]:
+    def get_connections(self, conn_id) -> Optional[List[Connection]]:
         """
         Return list of connection objects matching a given ``conn_id``.
 

--- a/tests/providers/amazon/aws/secrets/test_ssm.py
+++ b/tests/providers/amazon/aws/secrets/test_ssm.py
@@ -45,7 +45,7 @@ class TestSsmSecrets(TestCase):
         test_client = AwsSsmSecretsBackend()
 
         self.assertIsNone(test_client.get_conn_uri(conn_id=conn_id))
-        self.assertIsNone(test_client.get_connections(conn_id=conn_id))
+        self.assertEqual([], test_client.get_connections(conn_id=conn_id))
 
         # Fallback to connection defined in Environment Variable
         self.assertEqual(

--- a/tests/providers/amazon/aws/secrets/test_ssm.py
+++ b/tests/providers/amazon/aws/secrets/test_ssm.py
@@ -15,14 +15,39 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from unittest import mock
+from unittest import TestCase, mock
+
+from moto import mock_ssm
 
 from airflow.providers.amazon.aws.secrets.ssm import AwsSsmSecretsBackend
+from airflow.secrets import get_connections
 
 
-@mock.patch("airflow.providers.amazon.aws.secrets.ssm.AwsSsmSecretsBackend.get_conn_uri")
-def test_aws_ssm_get_connections(mock_get_uri):
-    mock_get_uri.side_effect = ["scheme://user:pass@host:100"]
-    conn_list = AwsSsmSecretsBackend().get_connections("fake_conn")
-    conn = conn_list[0]
-    assert conn.host == 'host'
+class TestSsmSecrets(TestCase):
+    @mock.patch("airflow.providers.amazon.aws.secrets.ssm.AwsSsmSecretsBackend.get_conn_uri")
+    def test_aws_ssm_get_connections(self, mock_get_uri):
+        mock_get_uri.return_value = "scheme://user:pass@host:100"
+        conn_list = AwsSsmSecretsBackend().get_connections("fake_conn")
+        conn = conn_list[0]
+        assert conn.host == 'host'
+
+    @mock.patch.dict('os.environ', {
+        'AIRFLOW_CONN_TEST_MYSQL': 'mysql://airflow:airflow@host:5432/airflow',
+    })
+    @mock_ssm
+    def test_get_conn_uri_non_existent_key(self):
+        """
+        Test that if the key with connection ID is not present in SSM,
+        AwsSsmSecretsBackend.get_connections should return None and fallback to the
+        environment variable if it is set
+        """
+        conn_id = "test_mysql"
+        test_client = AwsSsmSecretsBackend()
+
+        self.assertIsNone(test_client.get_conn_uri(conn_id=conn_id))
+        self.assertIsNone(test_client.get_connections(conn_id=conn_id))
+
+        # Fallback to connection defined in Environment Variable
+        self.assertEqual(
+            "mysql://airflow:airflow@host:5432/airflow",
+            get_connections(conn_id="test_mysql")[0].get_uri())


### PR DESCRIPTION
https://github.com/apache/airflow/pull/6376 had some bugs that this PR fixes

- `AwsSsmSecretsBackend.get_conn_uri` should return None if parameter does not exist
- This PR adds error handling if Parameter is not Found
- Adds tests case and fixes current tests

---
Issue link: [AIRFLOW-5705](https://issues.apache.org/jira/browse/AIRFLOW-5705)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

cc @dstandish 