### PR TITLE
[AIRFLOW-7026] Improve SparkSqlHook's error message

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -160,8 +160,8 @@ class SparkSqlHook(BaseHook):
 
         if returncode:
             raise AirflowException(
-                "Cannot execute {} on {}. Process exit code: {}.".format(
-                    cmd, self._conn.host, returncode
+                "Cannot execute '{}' on {} (additional parameters: '{}'). Process exit code: {}.".format(
+                    self._sql, self._master, cmd, returncode
                 )
             )
 


### PR DESCRIPTION
* Replace self._conn.host in the error message with
  self._master, because the former is unused in
  SparkSqlHook actually.

* Add self._sql into the error message, because it's
  the executed query or a file that contains it.

---
Issue link: [AIRFLOW-7026](https://issues.apache.org/jira/browse/AIRFLOW-7026)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
