### PR TITLE
[AIRFLOW-7079] Remove redundant code for storing template_fields

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -23,7 +23,7 @@ This module contains Google BigQuery operators.
 
 import json
 import warnings
-from typing import Any, Dict, FrozenSet, Iterable, List, Optional, SupportsAbs, Union
+from typing import Any, Dict, Iterable, List, Optional, SupportsAbs, Union
 
 import attr
 from googleapiclient.errors import HttpError
@@ -456,9 +456,6 @@ class BigQueryExecuteQueryOperator(BaseOperator):
     template_ext = ('.sql', )
     ui_color = '#e4f0e8'
 
-    # The _serialized_fields are lazily loaded when get_serialized_fields() method is called
-    __serialized_fields: Optional[FrozenSet[str]] = None
-
     @property
     def operator_extra_links(self):
         """
@@ -591,13 +588,6 @@ class BigQueryExecuteQueryOperator(BaseOperator):
         if self.hook is not None:
             self.log.info('Cancelling running query')
             self.hook.cancel_query()
-
-    @classmethod
-    def get_serialized_fields(cls):
-        """Serialized BigQueryOperator contain exactly these fields."""
-        if not cls.__serialized_fields:
-            cls.__serialized_fields = frozenset(super().get_serialized_fields() | {"sql"})
-        return cls.__serialized_fields
 
 
 class BigQueryCreateEmptyTableOperator(BaseOperator):

--- a/airflow/providers/qubole/operators/qubole.py
+++ b/airflow/providers/qubole/operators/qubole.py
@@ -17,7 +17,7 @@
 # under the License.
 """Qubole operator"""
 import re
-from typing import FrozenSet, Iterable, Optional
+from typing import Iterable
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import BaseOperator, BaseOperatorLink
@@ -181,9 +181,6 @@ class QuboleOperator(BaseOperator):
         QDSLink(),
     )
 
-    # The _serialized_fields are lazily loaded when get_serialized_fields() method is called
-    __serialized_fields: Optional[FrozenSet[str]] = None
-
     @apply_defaults
     def __init__(self, qubole_conn_id="qubole_default", *args, **kwargs):
         self.args = args
@@ -243,10 +240,3 @@ class QuboleOperator(BaseOperator):
             self.kwargs[name] = value
         else:
             object.__setattr__(self, name, value)
-
-    @classmethod
-    def get_serialized_fields(cls):
-        """Serialized QuboleOperator contain exactly these fields."""
-        if not cls.__serialized_fields:
-            cls.__serialized_fields = frozenset(super().get_serialized_fields() | {"qubole_conn_id"})
-        return cls.__serialized_fields

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -81,7 +81,7 @@ serialized_simple_dag_ground_truth = {
                 "_operator_extra_links": [{"tests.test_utils.mock_operators.CustomOpLink": {}}],
                 "ui_color": "#fff",
                 "ui_fgcolor": "#000",
-                "template_fields": [],
+                "template_fields": ['bash_command'],
                 "_task_type": "CustomOperator",
                 "_task_module": "tests.test_utils.mock_operators",
             },

--- a/tests/test_utils/mock_operators.py
+++ b/tests/test_utils/mock_operators.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import FrozenSet, NamedTuple, Optional
+from typing import NamedTuple
 
 import attr
 
@@ -103,8 +103,7 @@ class CustomOpLink(BaseOperatorLink):
 
 class CustomOperator(BaseOperator):
 
-    # The _serialized_fields are lazily loaded when get_serialized_fields() method is called
-    __serialized_fields: Optional[FrozenSet[str]] = None
+    template_fields = ['bash_command']
 
     @property
     def operator_extra_links(self):
@@ -127,13 +126,6 @@ class CustomOperator(BaseOperator):
     def execute(self, context):
         self.log.info("Hello World!")
         context['task_instance'].xcom_push(key='search_query', value="dummy_value")
-
-    @classmethod
-    def get_serialized_fields(cls):
-        """Stringified CustomOperator contain exactly these fields."""
-        if not cls.__serialized_fields:
-            cls.__serialized_fields = frozenset(super().get_serialized_fields() | {"bash_command"})
-        return cls.__serialized_fields
 
 
 class GoogleLink(BaseOperatorLink):


### PR DESCRIPTION
We don't need the logic in https://github.com/apache/airflow/pull/6715 to store fields used in Extra Operator links as now we store all the template_fields (https://github.com/apache/airflow/pull/7633)

---
Issue link: [AIRFLOW-7079](https://issues.apache.org/jira/browse/AIRFLOW-7079)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
