### PR TITLE
[AIRFLOW-7074] Add Permissions to view SubDAGs

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -380,7 +380,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         """
         Workflow:
         1. Fetch all the existing (permissions, view-menu) from Airflow DB.
-        2. Fetch all the existing dag models that are either active or paused. Exclude the subdags.
+        2. Fetch all the existing dag models that are either active or paused.
         3. Create both read and write permission view-menus relation for every dags from step 2
         4. Find out all the dag specific roles(excluded pubic, admin, viewer, op, user)
         5. Get all the permission-vm owned by the user role.
@@ -403,8 +403,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
         # Get all the active / paused dags and insert them into a set
         all_dags_models = session.query(models.DagModel)\
-            .filter(or_(models.DagModel.is_active, models.DagModel.is_paused))\
-            .filter(~models.DagModel.is_subdag).all()
+            .filter(or_(models.DagModel.is_active, models.DagModel.is_paused)).all()
 
         # create can_dag_edit and can_dag_read permissions for every dag(vm)
         for dag in all_dags_models:


### PR DESCRIPTION
There is no granular permission for SubDags at all.
Currently the only time you would be able to view SubDAGs would be when you can view all DAGs.

So even though a user might have the permission to view a DAG, they won't be able to view SubDag

I am not sure the reason why SubDags were excluded originally. Am I missing something @feng-tao ?

**Before**:
![image](https://user-images.githubusercontent.com/8811558/76900914-24321f80-6892-11ea-9401-fdf3579b139d.png)

**After**:
![image](https://user-images.githubusercontent.com/8811558/76900926-2d22f100-6892-11ea-8317-bdf5465e13a5.png)


---
Issue link: [AIRFLOW-7074](https://issues.apache.org/jira/browse/AIRFLOW-7074)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
