### PR TITLE
[AIRFLOW-5705] Make AwsSsmSecretsBackend consistent with VaultBackend

### DIFF
--- a/airflow/providers/amazon/aws/secrets/ssm.py
+++ b/airflow/providers/amazon/aws/secrets/ssm.py
@@ -21,9 +21,10 @@ Objects relating to sourcing connections from AWS SSM Parameter Store
 from typing import List, Optional
 
 import boto3
+from cached_property import cached_property
 
 from airflow.models import Connection
-from airflow.secrets import CONN_ENV_PREFIX, BaseSecretsBackend
+from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 
@@ -37,34 +38,37 @@ class AwsSsmSecretsBackend(BaseSecretsBackend, LoggingMixin):
 
         [secrets]
         backend = airflow.providers.amazon.aws.secrets.ssm.AwsSsmSecretsBackend
-        backend_kwargs = {"prefix": "/airflow", "profile_name": null}
+        backend_kwargs = {"connections_prefix": "/airflow/connections", "profile_name": null}
 
-    For example, if ssm path is ``/airflow/AIRFLOW_CONN_SMTP_DEFAULT``, this would be accessible if you
-    provide ``{"prefix": "/airflow"}`` and request conn_id ``smtp_default``.
-
+    For example, if ssm path is ``/airflow/connections/smtp_default``, this would be accessible
+    if you provide ``{"connections_prefix": "/airflow"}`` and request conn_id ``smtp_default``.
     """
 
-    def __init__(self, prefix: str = '/airflow', profile_name: Optional[str] = None, **kwargs):
-        self._prefix = prefix
+    def __init__(
+        self, connections_prefix: str = '/airflow/connections',
+        profile_name: Optional[str] = None,
+        **kwargs
+    ):
+        self.connections_prefix = connections_prefix.rstrip("/")
         self.profile_name = profile_name
         super().__init__(**kwargs)
 
-    @property
-    def prefix(self) -> str:
+    @cached_property
+    def client(self):
         """
-        Ensures that there is no trailing slash.
+        Create a SSM client
         """
-        return self._prefix.rstrip("/")
+        session = boto3.Session(profile_name=self.profile_name)
+        return session.client("ssm")
 
     def build_ssm_path(self, conn_id: str):
         """
         Given conn_id, build SSM path.
-        Assumes connection params use same naming convention as env vars, but may have arbitrary prefix.
 
         :param conn_id: connection id
+        :type conn_id: str
         """
-        param_name = (CONN_ENV_PREFIX + conn_id).upper()
-        param_path = self.prefix + "/" + param_name
+        param_path = self.connections_prefix + "/" + conn_id
         return param_path
 
     def get_conn_uri(self, conn_id: str) -> Optional[str]:
@@ -74,16 +78,15 @@ class AwsSsmSecretsBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: connection id
         :type conn_id: str
         """
-        session = boto3.Session(profile_name=self.profile_name)
-        client = session.client("ssm")
+
         ssm_path = self.build_ssm_path(conn_id=conn_id)
         try:
-            response = client.get_parameter(
+            response = self.client.get_parameter(
                 Name=ssm_path, WithDecryption=False
             )
             value = response["Parameter"]["Value"]
             return value
-        except client.exceptions.ParameterNotFound:
+        except self.client.exceptions.ParameterNotFound:
             self.log.info(
                 "An error occurred (ParameterNotFound) when calling the GetParameter operation: "
                 "Parameter %s not found.", ssm_path

--- a/airflow/providers/amazon/aws/secrets/ssm.py
+++ b/airflow/providers/amazon/aws/secrets/ssm.py
@@ -41,11 +41,12 @@ class AwsSsmSecretsBackend(BaseSecretsBackend, LoggingMixin):
         backend_kwargs = {"connections_prefix": "/airflow/connections", "profile_name": null}
 
     For example, if ssm path is ``/airflow/connections/smtp_default``, this would be accessible
-    if you provide ``{"connections_prefix": "/airflow"}`` and request conn_id ``smtp_default``.
+    if you provide ``{"connections_prefix": "/airflow/connections"}`` and request conn_id ``smtp_default``.
     """
 
     def __init__(
-        self, connections_prefix: str = '/airflow/connections',
+        self,
+        connections_prefix: str = '/airflow/connections',
         profile_name: Optional[str] = None,
         **kwargs
     ):

--- a/airflow/secrets/__init__.py
+++ b/airflow/secrets/__init__.py
@@ -22,7 +22,7 @@ Secrets framework provides means of getting connection objects from various sour
     * Metatsore database
     * AWS SSM Parameter store
 """
-__all__ = ['CONN_ENV_PREFIX', 'BaseSecretsBackend', 'get_connections']
+__all__ = ['BaseSecretsBackend', 'get_connections']
 
 import json
 from abc import ABC, abstractmethod
@@ -34,7 +34,6 @@ from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.utils.module_loading import import_string
 
-CONN_ENV_PREFIX = "AIRFLOW_CONN_"
 CONFIG_SECTION = "secrets"
 DEFAULT_SECRETS_SEARCH_PATH = [
     "airflow.secrets.environment_variables.EnvironmentVariablesSecretsBackend",

--- a/airflow/secrets/environment_variables.py
+++ b/airflow/secrets/environment_variables.py
@@ -23,7 +23,9 @@ import os
 from typing import List
 
 from airflow.models import Connection
-from airflow.secrets import CONN_ENV_PREFIX, BaseSecretsBackend
+from airflow.secrets import BaseSecretsBackend
+
+CONN_ENV_PREFIX = "AIRFLOW_CONN_"
 
 
 class EnvironmentVariablesSecretsBackend(BaseSecretsBackend):

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -66,14 +66,15 @@ Here is a sample configuration:
 
     [secrets]
     backend = airflow.providers.amazon.aws.secrets.ssm.AwsSsmSecretsBackend
-    backend_kwargs = {"prefix": "/airflow", "profile_name": "default"}
+    backend_kwargs = {"connections_prefix": "/airflow/connections", "profile_name": "default"}
 
-If you have set your prefix as ``/airflow``, then for a connection id of ``smtp_default``, you would want to
-store your connection at ``/airflow/AIRFLOW_CONN_SMTP_DEFAULT``.
+If you have set ``connections_prefix`` as ``/airflow/connections``, then for a connection id of ``smtp_default``,
+you would want to store your connection at ``/airflow/connections/smtp_default``.
 
 Optionally you can supply a profile name to reference aws profile, e.g. defined in ``~/.aws/config``.
 
-The value of the SSM parameter must be the :ref:`airflow connection URI representation <generating_connection_uri>` of the connection object.
+The value of the SSM parameter must be the :ref:`connection URI representation <generating_connection_uri>`
+of the connection object.
 
 .. _hashicorp_vault_secrets:
 

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -33,7 +33,7 @@ from airflow.models.connection import Connection
 from airflow.models.dag import DAG
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook, HiveMetastoreHook, HiveServer2Hook
 from airflow.providers.apache.hive.operators.hive import HiveOperator
-from airflow.secrets import CONN_ENV_PREFIX
+from airflow.secrets.environment_variables import CONN_ENV_PREFIX
 from airflow.utils import timezone
 from airflow.utils.operator_helpers import AIRFLOW_VAR_NAME_FORMAT_MAPPING
 from tests.test_utils.asserts import assert_equal_ignore_multiple_spaces

--- a/tests/secrets/test_secrets.py
+++ b/tests/secrets/test_secrets.py
@@ -42,7 +42,7 @@ class TestSecrets(unittest.TestCase):
 
     @conf_vars({
         ("secrets", "backend"): "airflow.providers.amazon.aws.secrets.ssm.AwsSsmSecretsBackend",
-        ("secrets", "backend_kwargs"): '{"prefix": "/airflow", "profile_name": null}',
+        ("secrets", "backend_kwargs"): '{"connections_prefix": "/airflow", "profile_name": null}',
     })
     def test_initialize_secrets_backends(self):
         backends = initialize_secrets_backends()
@@ -53,7 +53,7 @@ class TestSecrets(unittest.TestCase):
 
     @conf_vars({
         ("secrets", "backend"): "airflow.providers.amazon.aws.secrets.ssm.AwsSsmSecretsBackend",
-        ("secrets", "backend_kwargs"): '{"prefix": "/airflow", "profile_name": null}',
+        ("secrets", "backend_kwargs"): '{"connections_prefix": "/airflow", "profile_name": null}',
     })
     @mock.patch.dict('os.environ', {
         'AIRFLOW_CONN_TEST_MYSQL': 'mysql://airflow:airflow@host:5432/airflow',


### PR DESCRIPTION
Make this PR consistent with https://github.com/apache/airflow/pull/7741 to remove the redundant **AIRFLOW_CONN** from secret key

and add more tests

---
Issue link: [AIRFLOW-5705](https://issues.apache.org/jira/browse/AIRFLOW-5705)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.


cc @dstandish 