### PR TITLE
[AIRFLOW-7081] Remove env variables from GCP guide

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_bigtable.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigtable.py
@@ -56,7 +56,6 @@ from airflow.providers.google.cloud.operators.bigtable import (
 from airflow.providers.google.cloud.sensors.bigtable import BigtableTableReplicationCompletedSensor
 from airflow.utils.dates import days_ago
 
-# [START howto_operator_gcp_bigtable_args]
 GCP_PROJECT_ID = getenv('GCP_PROJECT_ID', 'example-project')
 CBT_INSTANCE_ID = getenv('CBT_INSTANCE_ID', 'some-instance-id')
 CBT_INSTANCE_DISPLAY_NAME = getenv('CBT_INSTANCE_DISPLAY_NAME', 'Human-readable name')
@@ -69,7 +68,6 @@ CBT_CLUSTER_NODES_UPDATED = getenv('CBT_CLUSTER_NODES_UPDATED', '5')
 CBT_CLUSTER_STORAGE_TYPE = getenv('CBT_CLUSTER_STORAGE_TYPE', '2')
 CBT_TABLE_ID = getenv('CBT_TABLE_ID', 'some-table-id')
 CBT_POKE_INTERVAL = getenv('CBT_POKE_INTERVAL', '60')
-# [END howto_operator_gcp_bigtable_args]
 
 default_args = {
     'start_date': days_ago(1)

--- a/airflow/providers/google/cloud/example_dags/example_cloud_build.py
+++ b/airflow/providers/google/cloud/example_dags/example_cloud_build.py
@@ -37,14 +37,10 @@ from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.cloud_build import CloudBuildCreateOperator
 from airflow.utils import dates
 
-# [START howto_operator_gcp_common_variables]
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
-# [END howto_operator_gcp_common_variables]
 
-# [START howto_operator_gcp_create_build_variables]
 GCP_SOURCE_ARCHIVE_URL = os.environ.get("GCP_CLOUD_BUILD_ARCHIVE_URL", "gs://example-bucket/file")
 GCP_SOURCE_REPOSITORY_NAME = os.environ.get("GCP_CLOUD_BUILD_REPOSITORY_NAME", "")
-# [END howto_operator_gcp_create_build_variables]
 
 GCP_SOURCE_ARCHIVE_URL_PARTS = urlparse(GCP_SOURCE_ARCHIVE_URL)
 GCP_SOURCE_BUCKET_NAME = GCP_SOURCE_ARCHIVE_URL_PARTS.netloc

--- a/airflow/providers/google/cloud/example_dags/example_cloud_sql.py
+++ b/airflow/providers/google/cloud/example_dags/example_cloud_sql.py
@@ -41,25 +41,19 @@ from airflow.providers.google.cloud.operators.gcs import (
 )
 from airflow.utils.dates import days_ago
 
-# [START howto_operator_cloudsql_arguments]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 INSTANCE_NAME = os.environ.get('GCSQL_MYSQL_INSTANCE_NAME', 'test-mysql')
 INSTANCE_NAME2 = os.environ.get('GCSQL_MYSQL_INSTANCE_NAME2', 'test-mysql2')
 DB_NAME = os.environ.get('GCSQL_MYSQL_DATABASE_NAME', 'testdb')
-# [END howto_operator_cloudsql_arguments]
 
-# [START howto_operator_cloudsql_export_import_arguments]
 EXPORT_URI = os.environ.get('GCSQL_MYSQL_EXPORT_URI', 'gs://bucketName/fileName')
 IMPORT_URI = os.environ.get('GCSQL_MYSQL_IMPORT_URI', 'gs://bucketName/fileName')
-# [END howto_operator_cloudsql_export_import_arguments]
 
 # Bodies below represent Cloud SQL instance resources:
 # https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances
 
-# [START howto_operator_cloudsql_create_arguments]
 FAILOVER_REPLICA_NAME = INSTANCE_NAME + "-failover-replica"
 READ_REPLICA_NAME = INSTANCE_NAME + "-read-replica"
-# [END howto_operator_cloudsql_create_arguments]
 
 # [START howto_operator_cloudsql_create_body]
 body = {

--- a/airflow/providers/google/cloud/example_dags/example_cloud_sql_query.py
+++ b/airflow/providers/google/cloud/example_dags/example_cloud_sql_query.py
@@ -45,8 +45,6 @@ from airflow import models
 from airflow.providers.google.cloud.operators.cloud_sql import CloudSQLExecuteQueryOperator
 from airflow.utils.dates import days_ago
 
-# [START howto_operator_cloudsql_query_arguments]
-
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 GCP_REGION = os.environ.get('GCP_REGION', 'europe-west-1b')
 
@@ -89,7 +87,6 @@ SQL = [
     'DROP TABLE TABLE_TEST2',
 ]
 
-# [END howto_operator_cloudsql_query_arguments]
 default_args = {
     'start_date': days_ago(1)
 }

--- a/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
@@ -60,7 +60,6 @@ from airflow.providers.google.cloud.sensors.cloud_storage_transfer_service impor
 )
 from airflow.utils.dates import days_ago
 
-# [START howto_operator_gcp_transfer_common_variables]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 GCP_DESCRIPTION = os.environ.get('GCP_DESCRIPTION', 'description')
 GCP_TRANSFER_TARGET_BUCKET = os.environ.get('GCP_TRANSFER_TARGET_BUCKET')
@@ -73,7 +72,6 @@ GCP_TRANSFER_FIRST_TARGET_BUCKET = os.environ.get(
 GCP_TRANSFER_SECOND_TARGET_BUCKET = os.environ.get(
     'GCP_TRANSFER_SECOND_TARGET_BUCKET', 'gcp-transfer-second-target'
 )
-# [END howto_operator_gcp_transfer_common_variables]
 
 # [START howto_operator_gcp_transfer_create_job_body_aws]
 aws_to_gcs_transfer_body = {

--- a/airflow/providers/google/cloud/example_dags/example_compute.py
+++ b/airflow/providers/google/cloud/example_dags/example_compute.py
@@ -48,12 +48,7 @@ default_args = {
     'start_date': days_ago(1),
 }
 
-# [START howto_operator_gce_args_set_machine_type]
 GCE_SHORT_MACHINE_TYPE_NAME = os.environ.get('GCE_SHORT_MACHINE_TYPE_NAME', 'n1-standard-1')
-SET_MACHINE_TYPE_BODY = {
-    'machineType': 'zones/{}/machineTypes/{}'.format(GCE_ZONE, GCE_SHORT_MACHINE_TYPE_NAME)
-}
-# [END howto_operator_gce_args_set_machine_type]
 
 
 with models.DAG(
@@ -99,7 +94,9 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
-        body=SET_MACHINE_TYPE_BODY,
+        body={
+            'machineType': 'zones/{}/machineTypes/{}'.format(GCE_ZONE, GCE_SHORT_MACHINE_TYPE_NAME)
+        },
         task_id='gcp_compute_set_machine_type'
     )
     # [END howto_operator_gce_set_machine_type]
@@ -108,7 +105,9 @@ with models.DAG(
     gce_set_machine_type2 = ComputeEngineSetMachineTypeOperator(
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
-        body=SET_MACHINE_TYPE_BODY,
+        body={
+            'machineType': 'zones/{}/machineTypes/{}'.format(GCE_ZONE, GCE_SHORT_MACHINE_TYPE_NAME)
+        },
         task_id='gcp_compute_set_machine_type2'
     )
     # [END howto_operator_gce_set_machine_type_no_project_id]

--- a/airflow/providers/google/cloud/example_dags/example_compute_igm.py
+++ b/airflow/providers/google/cloud/example_dags/example_compute_igm.py
@@ -46,10 +46,8 @@ from airflow.providers.google.cloud.operators.compute import (
 )
 from airflow.utils.dates import days_ago
 
-# [START howto_operator_compute_igm_common_args]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 GCE_ZONE = os.environ.get('GCE_ZONE', 'europe-west1-b')
-# [END howto_operator_compute_igm_common_args]
 
 default_args = {
     'start_date': days_ago(1)

--- a/airflow/providers/google/cloud/example_dags/example_datastore.py
+++ b/airflow/providers/google/cloud/example_dags/example_datastore.py
@@ -48,11 +48,11 @@ with models.DAG(
         overwrite_existing=True,
     )
 
-    bucket = "{{ task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[2] }}"
-    file = "{{ '/'.join(task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[3:]) }}"
-
     import_task = CloudDatastoreImportEntitiesOperator(
-        task_id="import_task", bucket=bucket, file=file, project_id=GCP_PROJECT_ID
+        task_id="import_task",
+        bucket="{{ task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[2] }}",
+        file="{{ '/'.join(task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[3:]) }}",
+        project_id=GCP_PROJECT_ID
     )
 
     export_task >> import_task

--- a/airflow/providers/google/cloud/example_dags/example_functions.py
+++ b/airflow/providers/google/cloud/example_dags/example_functions.py
@@ -49,7 +49,6 @@ from airflow.providers.google.cloud.operators.functions import (
 )
 from airflow.utils import dates
 
-# [START howto_operator_gcf_common_variables]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 GCP_LOCATION = os.environ.get('GCP_LOCATION', 'europe-west1')
 GCF_SHORT_FUNCTION_NAME = os.environ.get('GCF_SHORT_FUNCTION_NAME', 'hello').\
@@ -57,8 +56,6 @@ GCF_SHORT_FUNCTION_NAME = os.environ.get('GCF_SHORT_FUNCTION_NAME', 'hello').\
 FUNCTION_NAME = 'projects/{}/locations/{}/functions/{}'.format(GCP_PROJECT_ID,
                                                                GCP_LOCATION,
                                                                GCF_SHORT_FUNCTION_NAME)
-# [END howto_operator_gcf_common_variables]
-# [START howto_operator_gcf_deploy_variables]
 GCF_SOURCE_ARCHIVE_URL = os.environ.get('GCF_SOURCE_ARCHIVE_URL', '')
 GCF_SOURCE_UPLOAD_URL = os.environ.get('GCF_SOURCE_UPLOAD_URL', '')
 GCF_SOURCE_REPOSITORY = os.environ.get(
@@ -69,7 +66,6 @@ GCF_ZIP_PATH = os.environ.get('GCF_ZIP_PATH', '')
 GCF_ENTRYPOINT = os.environ.get('GCF_ENTRYPOINT', 'helloWorld')
 GCF_RUNTIME = 'nodejs6'
 GCP_VALIDATE_BODY = os.environ.get('GCP_VALIDATE_BODY', True)
-# [END howto_operator_gcf_deploy_variables]
 
 # [START howto_operator_gcf_deploy_body]
 body = {

--- a/airflow/providers/google/cloud/example_dags/example_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_gcs.py
@@ -34,13 +34,11 @@ from airflow.utils.dates import days_ago
 
 default_args = {"start_date": days_ago(1)}
 
-# [START howto_operator_gcs_acl_args_common]
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-id")
 BUCKET_1 = os.environ.get("GCP_GCS_BUCKET_1", "test-gcs-example-bucket")
 GCS_ACL_ENTITY = os.environ.get("GCS_ACL_ENTITY", "allUsers")
 GCS_ACL_BUCKET_ROLE = "OWNER"
 GCS_ACL_OBJECT_ROLE = "OWNER"
-# [END howto_operator_gcs_acl_args_common]
 
 BUCKET_2 = os.environ.get("GCP_GCS_BUCKET_1", "test-gcs-example-bucket-2")
 

--- a/airflow/providers/google/cloud/example_dags/example_spanner.py
+++ b/airflow/providers/google/cloud/example_dags/example_spanner.py
@@ -42,7 +42,6 @@ from airflow.providers.google.cloud.operators.spanner import (
 )
 from airflow.utils.dates import days_ago
 
-# [START howto_operator_spanner_arguments]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 GCP_SPANNER_INSTANCE_ID = os.environ.get('GCP_SPANNER_INSTANCE_ID', 'testinstance')
 GCP_SPANNER_DATABASE_ID = os.environ.get('GCP_SPANNER_DATABASE_ID', 'testdatabase')
@@ -52,7 +51,6 @@ GCP_SPANNER_NODE_COUNT = os.environ.get('GCP_SPANNER_NODE_COUNT', '1')
 GCP_SPANNER_DISPLAY_NAME = os.environ.get('GCP_SPANNER_DISPLAY_NAME', 'Test Instance')
 # OPERATION_ID should be unique per operation
 OPERATION_ID = 'unique_operation_id'
-# [END howto_operator_spanner_arguments]
 
 default_args = {
     'start_date': days_ago(1)

--- a/airflow/providers/google/cloud/example_dags/example_speech.py
+++ b/airflow/providers/google/cloud/example_dags/example_speech.py
@@ -32,10 +32,8 @@ from airflow.providers.google.cloud.operators.text_to_speech import CloudTextToS
 from airflow.providers.google.cloud.operators.translate_speech import GcpTranslateSpeechOperator
 from airflow.utils import dates
 
-# [START howto_operator_text_to_speech_env_variables]
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
 BUCKET_NAME = os.environ.get("GCP_SPEECH_TEST_BUCKET", "gcp-speech-test-bucket")
-# [END howto_operator_text_to_speech_env_variables]
 
 # [START howto_operator_text_to_speech_gcp_filename]
 FILENAME = "gcp-speech-test-file"

--- a/airflow/providers/google/cloud/example_dags/example_video_intelligence.py
+++ b/airflow/providers/google/cloud/example_dags/example_video_intelligence.py
@@ -26,7 +26,6 @@ This DAG relies on the following OS environment variables:
 """
 import os
 
-# [START howto_operator_vision_retry_import]
 from google.api_core.retry import Retry
 
 from airflow import models
@@ -36,9 +35,6 @@ from airflow.providers.google.cloud.operators.video_intelligence import (
     CloudVideoIntelligenceDetectVideoShotsOperator,
 )
 from airflow.utils.dates import days_ago
-
-# [END howto_operator_vision_retry_import]
-
 
 default_args = {"start_date": days_ago(1)}
 

--- a/airflow/providers/google/cloud/example_dags/example_vision.py
+++ b/airflow/providers/google/cloud/example_dags/example_vision.py
@@ -65,26 +65,13 @@ from google.cloud.vision import enums  # isort:skip pylint: disable=wrong-import
 
 default_args = {'start_date': days_ago(1)}
 
-# [START howto_operator_vision_args_common]
 GCP_VISION_LOCATION = os.environ.get('GCP_VISION_LOCATION', 'europe-west1')
-# [END howto_operator_vision_args_common]
 
-# [START howto_operator_vision_product_set_explicit_id]
 GCP_VISION_PRODUCT_SET_ID = os.environ.get('GCP_VISION_PRODUCT_SET_ID', 'product_set_explicit_id')
-# [END howto_operator_vision_product_set_explicit_id]
-
-# [START howto_operator_vision_product_explicit_id]
 GCP_VISION_PRODUCT_ID = os.environ.get('GCP_VISION_PRODUCT_ID', 'product_explicit_id')
-# [END howto_operator_vision_product_explicit_id]
-
-# [START howto_operator_vision_reference_image_args]
 GCP_VISION_REFERENCE_IMAGE_ID = os.environ.get('GCP_VISION_REFERENCE_IMAGE_ID', 'reference_image_explicit_id')
 GCP_VISION_REFERENCE_IMAGE_URL = os.environ.get('GCP_VISION_REFERENCE_IMAGE_URL', 'gs://bucket/image1.jpg')
-# [END howto_operator_vision_reference_image_args]
-
-# [START howto_operator_vision_annotate_image_url]
 GCP_VISION_ANNOTATE_IMAGE_URL = os.environ.get('GCP_VISION_ANNOTATE_IMAGE_URL', 'gs://bucket/image2.jpg')
-# [END howto_operator_vision_annotate_image_url]
 
 # [START howto_operator_vision_product_set]
 product_set = ProductSet(display_name='My Product Set')

--- a/docs/howto/operator/gcp/bigtable.rst
+++ b/docs/howto/operator/gcp/bigtable.rst
@@ -30,16 +30,6 @@ Prerequisite Tasks
 .. include:: _partials/prerequisite_tasks.rst
 
 
-Environment variables
----------------------
-
-All examples below rely on the following variables, which can be passed via environment variables.
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_bigtable.py
-    :language: python
-    :start-after: [START howto_operator_gcp_bigtable_args]
-    :end-before: [END howto_operator_gcp_bigtable_args]
-
 .. _howto/operator:BigtableCreateInstanceOperator:
 
 BigtableCreateInstanceOperator

--- a/docs/howto/operator/gcp/cloud_sql.rst
+++ b/docs/howto/operator/gcp/cloud_sql.rst
@@ -39,15 +39,6 @@ Creates a new database inside a Cloud SQL instance.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_sql.CloudSqlInstanceDatabaseCreateOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_arguments]
-    :end-before: [END howto_operator_cloudsql_arguments]
 
 Using the operator
 """"""""""""""""""
@@ -93,15 +84,6 @@ Deletes a database from a Cloud SQL instance.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_sql.CloudSqlInstanceDatabaseDeleteOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_arguments]
-    :end-before: [END howto_operator_cloudsql_arguments]
 
 Using the operator
 """"""""""""""""""
@@ -142,15 +124,6 @@ See: https://cloud.google.com/sql/docs/mysql/admin-api/how-tos/performance#patch
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_sql.CloudSqlInstanceDatabasePatchOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_arguments]
-    :end-before: [END howto_operator_cloudsql_arguments]
 
 Using the operator
 """"""""""""""""""
@@ -198,15 +171,6 @@ It is also used for deleting read and failover replicas.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_sql.CloudSqlInstanceDeleteOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_arguments]
-    :end-before: [END howto_operator_cloudsql_arguments]
 
 Using the operator
 """"""""""""""""""
@@ -261,18 +225,6 @@ For parameter definition take a look at
 
 Arguments
 """""""""
-
-Some arguments in the example DAG are taken from Airflow variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_arguments]
-    :end-before: [END howto_operator_cloudsql_arguments]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_export_import_arguments]
-    :end-before: [END howto_operator_cloudsql_export_import_arguments]
 
 Example body defining the export operation:
 
@@ -359,18 +311,6 @@ For parameter definition take a look at
 Arguments
 """""""""
 
-Some arguments in the example DAG are taken from Airflow variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_arguments]
-    :end-before: [END howto_operator_cloudsql_arguments]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_export_import_arguments]
-    :end-before: [END howto_operator_cloudsql_export_import_arguments]
-
 Example body defining the import operation:
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
@@ -442,20 +382,6 @@ will succeed.
 Arguments
 """""""""
 
-Some arguments in the example DAG are taken from OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_arguments]
-    :end-before: [END howto_operator_cloudsql_arguments]
-
-Some other arguments are created based on the arguments above:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_create_arguments]
-    :end-before: [END howto_operator_cloudsql_create_arguments]
-
 Example body defining the instance with failover replica:
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
@@ -516,13 +442,6 @@ unchanged.
 
 Arguments
 """""""""
-
-Some arguments in the example DAG are taken from OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_arguments]
-    :end-before: [END howto_operator_cloudsql_arguments]
 
 Example body defining the instance:
 
@@ -607,13 +526,6 @@ Note that in case of SSL connections you need to have a mechanism to make the
 certificate/key files available in predefined locations for all the workers on
 which the operator can run. This can be provided for example by mounting
 NFS-like volumes in the same path for all the workers.
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_sql_query.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_query_arguments]
-    :end-before: [END howto_operator_cloudsql_query_arguments]
 
 Example connection definitions for all connectivity cases. Note that all the components
 of the connection URI should be URL-encoded:

--- a/docs/howto/operator/gcp/cloud_storage_transfer_service.rst
+++ b/docs/howto/operator/gcp/cloud_storage_transfer_service.rst
@@ -58,15 +58,6 @@ The selected connection for AWS can be indicated by the parameter ``aws_conn_id`
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceCreateJobOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
 
 Using the operator
 """"""""""""""""""
@@ -112,15 +103,6 @@ Deletes a transfer job.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceDeleteJobOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
 
 Using the operator
 """"""""""""""""""
@@ -156,15 +138,6 @@ Updates a transfer job.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceUpdateJobOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
 
 Using the operator
 """"""""""""""""""
@@ -205,16 +178,6 @@ Gets a transfer operation. The result is returned to XCOM.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceCancelOperationOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
-
 Using the operator
 """"""""""""""""""
 
@@ -250,15 +213,6 @@ Gets a transfer operation. The result is returned to XCOM.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceGetOperationOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
 
 Using the operator
 """"""""""""""""""
@@ -294,15 +248,6 @@ List a transfer operations. The result is returned to XCOM.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceListOperationsOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
 
 Using the operator
 """"""""""""""""""
@@ -338,16 +283,6 @@ Pauses a transfer operations.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServicePauseOperationOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
-
 Using the operator
 """"""""""""""""""
 
@@ -381,16 +316,6 @@ Resumes a transfer operations.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceResumeOperationOperator`.
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
 
 Using the operator
 """"""""""""""""""
@@ -426,15 +351,6 @@ Waits for at least one operation belonging to the job to have the expected statu
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.sensors.cloud_storage_transfer_service.CloudDataTransferServiceJobStatusSensor`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service.py
-      :language: python
-      :start-after: [START howto_operator_gcp_transfer_common_variables]
-      :end-before: [END howto_operator_gcp_transfer_common_variables]
 
 Using the operator
 """"""""""""""""""

--- a/docs/howto/operator/gcp/compute.rst
+++ b/docs/howto/operator/gcp/compute.rst
@@ -38,17 +38,6 @@ Use the
 :class:`~airflow.providers.google.cloud.operators.compute.ComputeEngineStartInstanceOperator`
 to start an existing Google Compute Engine instance.
 
-
-Arguments
-"""""""""
-
-The following examples of OS environment variables used to pass arguments to the operator:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute.py
-    :language: python
-    :start-after: [START howto_operator_gce_args_common]
-    :end-before: [END howto_operator_gce_args_common]
-
 Using the operator
 """"""""""""""""""
 
@@ -94,16 +83,6 @@ Use the operator to stop Google Compute Engine instance.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.compute.ComputeEngineStopInstanceOperator`
-
-Arguments
-"""""""""
-
-The following examples of OS environment variables used to pass arguments to the operator:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute.py
-   :language: python
-   :start-after: [START howto_operator_gce_args_common]
-   :end-before: [END howto_operator_gce_args_common]
 
 Using the operator
 """"""""""""""""""
@@ -153,18 +132,7 @@ For parameter definition, take a look at
 Arguments
 """""""""
 
-The following examples of OS environment variables used to pass arguments to the operator:
 
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute.py
-    :language: python
-    :start-after: [START howto_operator_gce_args_common]
-    :end-before: [END howto_operator_gce_args_common]
-
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute.py
-    :language: python
-    :start-after: [START howto_operator_gce_args_set_machine_type]
-    :end-before: [END howto_operator_gce_args_set_machine_type]
 
 Using the operator
 """"""""""""""""""
@@ -212,25 +180,15 @@ applying a patch to it.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.compute.ComputeEngineCopyInstanceTemplateOperator`.
 
-Arguments
-"""""""""
+Using the operator
+""""""""""""""""""
 
-The following examples of OS environment variables used to pass arguments to the operator:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute_igm.py
-    :language: python
-    :start-after: [START howto_operator_compute_igm_common_args]
-    :end-before: [END howto_operator_compute_igm_common_args]
+The code to create the operator:
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute_igm.py
     :language: python
     :start-after: [START howto_operator_compute_template_copy_args]
     :end-before: [END howto_operator_compute_template_copy_args]
-
-Using the operator
-""""""""""""""""""
-
-The code to create the operator:
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute_igm.py
     :language: python
@@ -275,22 +233,16 @@ For parameter definition, take a look at
 Arguments
 """""""""
 
-The following examples of OS environment variables used to pass arguments to the operator:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute_igm.py
-    :language: python
-    :start-after: [START howto_operator_compute_igm_common_args]
-    :end-before: [END howto_operator_compute_igm_common_args]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute_igm.py
-    :language: python
-    :start-after: [START howto_operator_compute_igm_update_template_args]
-    :end-before: [END howto_operator_compute_igm_update_template_args]
 
 Using the operator
 """"""""""""""""""
 
 The code to create the operator:
+
+.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute_igm.py
+    :language: python
+    :start-after: [START howto_operator_compute_igm_update_template_args]
+    :end-before: [END howto_operator_compute_igm_update_template_args]
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_compute_igm.py
     :language: python

--- a/docs/howto/operator/gcp/functions.rst
+++ b/docs/howto/operator/gcp/functions.rst
@@ -39,17 +39,6 @@ Use the operator to delete a function from Google Cloud Functions.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.functions.CloudFunctionDeleteFunctionOperator`.
 
-Arguments
-"""""""""
-
-The following examples of OS environment variables show how you can build function name
-to use in the operator:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_functions.py
-    :language: python
-    :start-after: [START howto_operator_gcf_common_variables]
-    :end-before: [END howto_operator_gcf_common_variables]
-
 Using the operator
 """"""""""""""""""
 
@@ -89,26 +78,6 @@ For parameter definition, take a look at
 Arguments
 """""""""
 
-In the example DAG the following environment variables are used to parameterize the
-operator's definition:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_functions.py
-    :language: python
-    :start-after: [START howto_operator_gcf_common_variables]
-    :end-before: [END howto_operator_gcf_common_variables]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_functions.py
-    :language: python
-    :start-after: [START howto_operator_gcf_deploy_variables]
-    :end-before: [END howto_operator_gcf_deploy_variables]
-
-Some of those variables are used to create the request's body:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_functions.py
-    :language: python
-    :start-after: [START howto_operator_gcf_deploy_body]
-    :end-before: [END howto_operator_gcf_deploy_body]
-
 When a DAG is created, the default_args dictionary can be used to pass
 arguments common with other tasks:
 
@@ -135,6 +104,11 @@ Using the operator
 
 Depending on the combination of parameters, the Function's source code can be obtained
 from different sources:
+
+.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_functions.py
+    :language: python
+    :start-after: [START howto_operator_gcf_deploy_body]
+    :end-before: [END howto_operator_gcf_deploy_body]
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_functions.py
     :language: python

--- a/docs/howto/operator/gcp/gcs.rst
+++ b/docs/howto/operator/gcp/gcs.rst
@@ -53,16 +53,6 @@ Creates a new ACL entry on the specified bucket.
 For parameter definition, take a look at
 :class:`~airflow.contrib.operators.gcs.GoogleCloudStorageBucketCreateAclEntryOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_gcs.py
-    :language: python
-    :start-after: [START howto_operator_gcs_acl_args_common]
-    :end-before: [END howto_operator_gcs_acl_args_common]
-
 Using the operator
 """"""""""""""""""
 
@@ -96,16 +86,6 @@ Creates a new ACL entry on the specified object.
 
 For parameter definition, take a look at
 :class:`~airflow.contrib.operators.gcs_acl_operator.GoogleCloudStorageObjectCreateAclEntryOperator`
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_gcs.py
-    :language: python
-    :start-after: [START howto_operator_gcs_acl_args_common]
-    :end-before: [END howto_operator_gcs_acl_args_common]
 
 Using the operator
 """"""""""""""""""

--- a/docs/howto/operator/gcp/search_ads.rst
+++ b/docs/howto/operator/gcp/search_ads.rst
@@ -57,8 +57,8 @@ The result is saved to :ref:`XCom <concepts:xcom>`, which allows it to be used b
 
 .. _howto/operator:GoogleSearchAdsReportSensor:
 
-A section title
-^^^^^^^^^^^^^^^
+Awaiting for a report
+^^^^^^^^^^^^^^^^^^^^^
 
 To wait for a report to be ready for download use
 :class:`~airflow.providers.google.marketing_platform.sensors.search_ads.GoogleSearchAdsReportSensor`.

--- a/docs/howto/operator/gcp/spanner.rst
+++ b/docs/howto/operator/gcp/spanner.rst
@@ -40,16 +40,6 @@ exist, no action is taken, and the operator succeeds.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.spanner.SpannerDeleteDatabaseInstanceOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from environment variables.
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_spanner.py
-    :language: python
-    :start-after: [START howto_operator_spanner_arguments]
-    :end-before: [END howto_operator_spanner_arguments]
-
 Using the operator
 """"""""""""""""""
 
@@ -89,16 +79,6 @@ with the same name.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.spanner.SpannerDeployDatabaseInstanceOperator`.
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from environment variables.
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_spanner.py
-    :language: python
-    :start-after: [START howto_operator_spanner_arguments]
-    :end-before: [END howto_operator_spanner_arguments]
 
 Using the operator
 """"""""""""""""""
@@ -144,16 +124,6 @@ a valid identifier: ``[a-z][a-z0-9_]*``. More information can be found in
 For parameter definition take a look at
 :class:`~airflow.providers.google.cloud.operators.spanner.SpannerUpdateDatabaseInstanceOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from environment variables.
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_spanner.py
-    :language: python
-    :start-after: [START howto_operator_spanner_arguments]
-    :end-before: [END howto_operator_spanner_arguments]
-
 Using the operator
 """"""""""""""""""
 
@@ -197,16 +167,6 @@ Executes an arbitrary DML query (INSERT, UPDATE, DELETE).
 For parameter definition take a look at
 :class:`~airflow.providers.google.cloud.operators.spanner.SpannerQueryDatabaseInstanceOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from environment variables.
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_spanner.py
-    :language: python
-    :start-after: [START howto_operator_spanner_arguments]
-    :end-before: [END howto_operator_spanner_arguments]
-
 Using the operator
 """"""""""""""""""
 
@@ -245,15 +205,6 @@ and the operator succeeds.
 For parameter definition take a look at
 :class:`~airflow.providers.google.cloud.operators.spanner.SpannerDeleteInstanceOperator`.
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_spanner.py
-    :language: python
-    :start-after: [START howto_operator_spanner_arguments]
-    :end-before: [END howto_operator_spanner_arguments]
 
 Using the operator
 """"""""""""""""""

--- a/docs/howto/operator/gcp/speech.rst
+++ b/docs/howto/operator/gcp/speech.rst
@@ -38,15 +38,8 @@ For parameter definition, take a look at
 Arguments
 """""""""
 
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_speech.py
-      :language: python
-      :start-after: [START howto_operator_text_to_speech_env_variables]
-      :end-before: [END howto_operator_text_to_speech_env_variables]
-
-input, voice and audio_config arguments need to be dicts or objects of corresponding classes from
-google.cloud.texttospeech_v1.types module
+The ``input``, ``voice`` and ``audio_config`` arguments need to be dicts or objects of corresponding classes from
+``google.cloud.texttospeech_v1.types`` module
 
 for more information, see: https://googleapis.github.io/google-cloud-python/latest/texttospeech/gapic/v1/api.html#google.cloud.texttospeech_v1.TextToSpeechClient.synthesize_speech
 
@@ -55,7 +48,7 @@ for more information, see: https://googleapis.github.io/google-cloud-python/late
       :start-after: [START howto_operator_text_to_speech_api_arguments]
       :end-before: [END howto_operator_text_to_speech_api_arguments]
 
-filename is a simple string argument:
+The ``filename`` argument is a simple string argument:
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_speech.py
       :language: python

--- a/docs/howto/operator/gcp/video_intelligence.rst
+++ b/docs/howto/operator/gcp/video_intelligence.rst
@@ -54,15 +54,8 @@ Performs video annotation, annotating video labels.
 For parameter definition, take a look at
 :class:`airflow.providers.google.cloud.operators.video_intelligence.CloudVideoIntelligenceDetectVideoLabelsOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_video_intelligence.py
-      :language: python
-      :start-after: [START howto_operator_video_intelligence_os_args]
-      :end-before: [END howto_operator_video_intelligence_os_args]
+Using the operator
+""""""""""""""""""
 
 Input uri is an uri to a file in Google Cloud Storage
 
@@ -70,9 +63,6 @@ Input uri is an uri to a file in Google Cloud Storage
       :language: python
       :start-after: [START howto_operator_video_intelligence_other_args]
       :end-before: [END howto_operator_video_intelligence_other_args]
-
-Using the operator
-""""""""""""""""""
 
 .. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_video_intelligence.py
       :language: python
@@ -115,13 +105,6 @@ For parameter definition, take a look at
 
 Arguments
 """""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_video_intelligence.py
-      :language: python
-      :start-after: [START howto_operator_video_intelligence_os_args]
-      :end-before: [END howto_operator_video_intelligence_os_args]
 
 Input uri is an uri to a file in Google Cloud Storage
 
@@ -174,13 +157,6 @@ For parameter definition, take a look at
 
 Arguments
 """""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_video_intelligence.py
-      :language: python
-      :start-after: [START howto_operator_video_intelligence_os_args]
-      :end-before: [END howto_operator_video_intelligence_os_args]
 
 Input uri is an uri to a file in Google Cloud Storage
 

--- a/docs/howto/operator/gcp/vision.rst
+++ b/docs/howto/operator/gcp/vision.rst
@@ -39,26 +39,6 @@ Creates a new :code:`ReferenceImage` resource.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionAddProductToProductSetOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_args_common]
-      :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_product_explicit_id]
-      :end-before: [END howto_operator_vision_product_explicit_id]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_product_set_explicit_id]
-      :end-before: [END howto_operator_vision_product_set_explicit_id]
-
 Using the operator
 """"""""""""""""""
 
@@ -125,22 +105,6 @@ Run image detection and annotation for an image.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionAnnotateImageOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_args_common]
-      :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_annotate_image_url]
-      :end-before: [END howto_operator_vision_annotate_image_url]
-
-
 Using the operator
 """"""""""""""""""
 
@@ -203,21 +167,6 @@ Possible errors regarding the :code:`Product` object provided:
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionProductCreateOperator`
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_args_common]
-    :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_product_explicit_id]
-    :end-before: [END howto_operator_vision_product_explicit_id]
 
 Using the operator
 """"""""""""""""""
@@ -289,21 +238,6 @@ Possible errors:
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionProductDeleteOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_args_common]
-    :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_product_explicit_id]
-    :end-before: [END howto_operator_vision_product_explicit_id]
-
 Using the operator
 """"""""""""""""""
 
@@ -352,21 +286,6 @@ Possible errors:
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionProductGetOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_args_common]
-    :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_product_explicit_id]
-    :end-before: [END howto_operator_vision_product_explicit_id]
-
 Using the operator
 """"""""""""""""""
 
@@ -410,21 +329,6 @@ Creates a new :code:`ProductSet` resource.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionProductSetCreateOperator`
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_args_common]
-    :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_product_set_explicit_id
-    :end-before: [END howto_operator_vision_product_set_explicit_id
 
 Using the operator
 """"""""""""""""""
@@ -490,21 +394,6 @@ Google Cloud Storage.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionProductSetDeleteOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_args_common]
-    :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_product_set_explicit_id]
-    :end-before: [END howto_operator_vision_product_set_explicit_id]
-
 Using the operator
 """"""""""""""""""
 
@@ -549,20 +438,7 @@ Gets information associated with a :code:`ProductSet`.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionProductSetGetOperator`
 
-Arguments
-"""""""""
 
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_args_common]
-    :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_product_set_explicit_id]
-    :end-before: [END howto_operator_vision_product_set_explicit_id]
 
 Using the operator
 """"""""""""""""""
@@ -619,21 +495,6 @@ having Airflow use the connection default ``project_id``.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionProductSetUpdateOperator`
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_args_common]
-    :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_product_set_explicit_id]
-    :end-before: [END howto_operator_vision_product_set_explicit_id]
 
 Using the operator
 """"""""""""""""""
@@ -716,21 +577,6 @@ Possible errors:
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionProductUpdateOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_args_common]
-    :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-    :language: python
-    :start-after: [START howto_operator_vision_product_explicit_id]
-    :end-before: [END howto_operator_vision_product_explicit_id]
-
 Using the operator
 """"""""""""""""""
 
@@ -786,21 +632,6 @@ Creates a new :code:`ReferenceImage` resource.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionReferenceImageCreateOperator`
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_args_common]
-      :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_reference_image_args]
-      :end-before: [END howto_operator_vision_reference_image_args]
 
 Using the operator
 """"""""""""""""""
@@ -863,26 +694,6 @@ Creates a new :code:`ReferenceImage` resource.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionRemoveProductFromProductSetOperator`
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_args_common]
-      :end-before: [END howto_operator_vision_args_common]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_product_explicit_id]
-      :end-before: [END howto_operator_vision_product_explicit_id]
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_product_set_explicit_id]
-      :end-before: [END howto_operator_vision_product_set_explicit_id]
 
 Using the operator
 """"""""""""""""""
@@ -950,16 +761,6 @@ Run text detection for an image.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionDetectTextOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_annotate_image_url]
-      :end-before: [END howto_operator_vision_annotate_image_url]
-
 
 Using the operator
 """"""""""""""""""
@@ -1011,16 +812,6 @@ Run document text detection for an image.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionDetectDocumentTextOperator`
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_annotate_image_url]
-      :end-before: [END howto_operator_vision_annotate_image_url]
 
 
 Using the operator
@@ -1074,15 +865,6 @@ Run image label detection for an image.
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionDetectImageLabelsOperator`
 
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_annotate_image_url]
-      :end-before: [END howto_operator_vision_annotate_image_url]
 
 
 Using the operator
@@ -1135,16 +917,6 @@ Run image label detection for an image.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.vision.CloudVisionDetectImageSafeSearchOperator`
-
-Arguments
-"""""""""
-
-Some arguments in the example DAG are taken from the OS environment variables:
-
-.. exampleinclude:: ../../../../airflow/providers/google/cloud/example_dags/example_vision.py
-      :language: python
-      :start-after: [START howto_operator_vision_annotate_image_url]
-      :end-before: [END howto_operator_vision_annotate_image_url]
 
 
 Using the operator


### PR DESCRIPTION
We have a button to show the full source code, so we don't have to include this information in the documentation. They don't have much value for users.

---
Issue link: [AIRFLOW-7081](https://issues.apache.org/jira/browse/AIRFLOW-7081)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
