### PR TITLE
[AIRFLOW-7082] Remove catch_http_exception decorator in GCP hooks

### DIFF
--- a/airflow/providers/google/cloud/hooks/automl.py
+++ b/airflow/providers/google/cloud/hooks/automl.py
@@ -78,7 +78,6 @@ class CloudAutoMLHook(CloudBaseHook):
             credentials=self._get_credentials(), client_info=self.client_info
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def create_model(
         self,
@@ -122,7 +121,6 @@ class CloudAutoMLHook(CloudBaseHook):
             parent=parent, model=model, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def batch_predict(
         self,
@@ -185,7 +183,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def predict(
         self,
@@ -240,7 +237,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def create_dataset(
         self,
@@ -286,7 +282,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def import_data(
         self,
@@ -337,7 +332,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def list_column_specs(  # pylint: disable=too-many-arguments
         self,
@@ -406,7 +400,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def get_model(
         self,
@@ -447,7 +440,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def delete_model(
         self,
@@ -488,7 +480,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def update_dataset(
         self,
@@ -534,7 +525,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def deploy_model(
         self,
@@ -650,7 +640,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def list_datasets(
         self,
@@ -691,7 +680,6 @@ class CloudAutoMLHook(CloudBaseHook):
         )
         return result
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def delete_dataset(
         self,

--- a/airflow/providers/google/cloud/hooks/base.py
+++ b/airflow/providers/google/cloud/hooks/base.py
@@ -35,13 +35,10 @@ import google.oauth2.service_account
 import google_auth_httplib2
 import httplib2
 import tenacity
-from google.api_core.exceptions import (
-    AlreadyExists, Forbidden, GoogleAPICallError, ResourceExhausted, RetryError, TooManyRequests,
-)
+from google.api_core.exceptions import Forbidden, ResourceExhausted, TooManyRequests
 from google.api_core.gapic_v1.client_info import ClientInfo
 from google.auth import _cloud_sdk
 from google.auth.environment_vars import CREDENTIALS
-from googleapiclient.errors import HttpError
 from googleapiclient.http import set_user_agent
 
 from airflow import version
@@ -305,38 +302,6 @@ class CloudBaseHook(BaseHook):
                 *args, **default_kwargs
             )(fun)
         return decorator
-
-    @staticmethod
-    def catch_http_exception(func: Callable[..., RT]) -> Callable[..., RT]:
-        """
-        Function decorator that intercepts HTTP Errors and raises AirflowException
-        with more informative message.
-        """
-
-        @functools.wraps(func)
-        def wrapper_decorator(self: CloudBaseHook, *args, **kwargs) -> RT:
-            try:
-                return func(self, *args, **kwargs)
-            except GoogleAPICallError as e:
-                if isinstance(e, AlreadyExists):
-                    raise e
-                else:
-                    self.log.error('The request failed:\n%s', str(e))
-                    raise AirflowException(e)
-            except RetryError as e:
-                self.log.error('The request failed due to a retryable error and retry attempts failed.')
-                raise AirflowException(e)
-            except ValueError as e:
-                self.log.error('The request failed, the parameters are invalid.')
-                raise AirflowException(e)
-            except HttpError as e:
-                if hasattr(e, "content"):
-                    self.log.error('The request failed:\n%s', e.content.decode(encoding="utf-8"))
-                else:
-                    self.log.error('The request failed:\n%s', str(e))
-                raise AirflowException(e)
-
-        return wrapper_decorator
 
     @staticmethod
     def fallback_to_default_project_id(func: Callable[..., RT]) -> Callable[..., RT]:

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2285,7 +2285,7 @@ class BigQueryBaseCursor(LoggingMixin):
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_query`",
             DeprecationWarning, stacklevel=3)
-        return self.hook.cancel_query()
+        return self.hook.cancel_query(*args, **kwargs)  # type: ignore  # noqa
 
     def run_with_configuration(self, *args, **kwargs) -> str:
         """

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -161,7 +161,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
                 return False
             raise
 
-    @CloudBaseHook.catch_http_exception
     def create_empty_table(self,  # pylint: disable=too-many-arguments
                            project_id: str,
                            dataset_id: str,
@@ -266,7 +265,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
             datasetId=dataset_id,
             body=table_resource).execute(num_retries=num_retries)
 
-    @CloudBaseHook.catch_http_exception
     def create_empty_dataset(self,
                              dataset_id: str = "",
                              project_id: str = "",
@@ -341,7 +339,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
             projectId=dataset_project_id,
             body=dataset_reference).execute(num_retries=self.num_retries)
 
-    @CloudBaseHook.catch_http_exception
     def get_dataset_tables(self, dataset_id: str, project_id: Optional[str] = None,
                            max_results: Optional[int] = None,
                            page_token: Optional[str] = None) -> Dict[str, Union[str, int, List]]:
@@ -377,7 +374,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
             datasetId=dataset_id,
             **optional_params).execute(num_retries=self.num_retries))
 
-    @CloudBaseHook.catch_http_exception
     def delete_dataset(self, project_id: str, dataset_id: str, delete_contents: bool = False) -> None:
         """
         Delete a dataset of Big query in your project.
@@ -411,7 +407,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
                 'BigQuery job failed. Error was: {}'.format(err.content)
             )
 
-    @CloudBaseHook.catch_http_exception
     def create_external_table(self,  # pylint: disable=too-many-locals,too-many-arguments
                               external_project_dataset_table: str,
                               schema_fields: List,
@@ -618,7 +613,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
         self.log.info('External table created successfully: %s',
                       external_project_dataset_table)
 
-    @CloudBaseHook.catch_http_exception
     def patch_table(self,  # pylint: disable=too-many-arguments
                     dataset_id: str,
                     table_id: str,
@@ -731,7 +725,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
         self.log.info('Table patched successfully: %s:%s.%s',
                       project_id, dataset_id, table_id)
 
-    @CloudBaseHook.catch_http_exception
     def insert_all(self, project_id: str, dataset_id: str, table_id: str,
                    rows: List, ignore_unknown_values: bool = False,
                    skip_invalid_rows: bool = False, fail_on_error: bool = False) -> None:
@@ -803,7 +796,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
                 )
             self.log.info(error_msg)
 
-    @CloudBaseHook.catch_http_exception
     def update_dataset(self, dataset_id: str,
                        dataset_resource: Dict, project_id: Optional[str] = None) -> Dict:
         """
@@ -846,7 +838,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
 
         return dataset
 
-    @CloudBaseHook.catch_http_exception
     def patch_dataset(self, dataset_id: str, dataset_resource: str, project_id: Optional[str] = None) -> Dict:
         """
         Patches information in an existing dataset.
@@ -888,7 +879,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
 
         return dataset
 
-    @CloudBaseHook.catch_http_exception
     def get_dataset_tables_list(self, dataset_id, project_id=None, table_prefix=None, max_results=None):
         """
         Method returns tables list of a BigQuery dataset. If table prefix is specified,
@@ -951,7 +941,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
 
         return dataset_tables_list
 
-    @CloudBaseHook.catch_http_exception
     def get_datasets_list(self, project_id: Optional[str] = None) -> List:
         """
         Method returns full list of BigQuery datasets in the current project
@@ -996,7 +985,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
 
         return datasets_list
 
-    @CloudBaseHook.catch_http_exception
     def get_dataset(self, dataset_id: str, project_id: Optional[str] = None) -> Dict:
         """
         Method returns dataset_resource if dataset exist
@@ -1025,7 +1013,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
 
         return dataset_resource
 
-    @CloudBaseHook.catch_http_exception
     def run_grant_dataset_view_access(self,
                                       source_dataset: str,
                                       view_dataset: str,
@@ -1090,7 +1077,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
                 view_project, view_dataset, view_table, source_project, source_dataset)
             return source_dataset_resource
 
-    @CloudBaseHook.catch_http_exception
     def run_table_upsert(self, dataset_id: str, table_resource: Dict,
                          project_id: Optional[str] = None) -> Dict:
         """
@@ -1142,7 +1128,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
                     datasetId=dataset_id,
                     body=table_resource).execute(num_retries=self.num_retries)
 
-    @CloudBaseHook.catch_http_exception
     def run_table_delete(self, deletion_dataset_table: str,
                          ignore_if_missing: bool = False) -> None:
         """
@@ -1180,7 +1165,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
             else:
                 raise e
 
-    @CloudBaseHook.catch_http_exception
     def get_tabledata(self, dataset_id: str, table_id: str,
                       max_results: Optional[int] = None, selected_fields: Optional[str] = None,
                       page_token: Optional[str] = None, start_index: Optional[int] = None) -> Dict:
@@ -1216,7 +1200,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
             tableId=table_id,
             **optional_params).execute(num_retries=self.num_retries))
 
-    @CloudBaseHook.catch_http_exception
     def get_schema(self, dataset_id: str, table_id: str, project_id: Optional[str] = None) -> Dict:
         """
         Get the schema for a given datset.table.
@@ -1238,7 +1221,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
         )
         return tables_resource['schema']
 
-    @CloudBaseHook.catch_http_exception
     def poll_job_complete(self, job_id: str) -> bool:
         """
         Check if jobs completed.
@@ -1268,7 +1250,6 @@ class BigQueryHook(CloudBaseHook, DbApiHook):
                 raise err
         return False
 
-    @CloudBaseHook.catch_http_exception
     def cancel_query(self) -> None:
         """
         Cancel all started queries that have not yet completed
@@ -2304,7 +2285,7 @@ class BigQueryBaseCursor(LoggingMixin):
             "This method is deprecated. "
             "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_query`",
             DeprecationWarning, stacklevel=3)
-        return self.hook.cancel_query(*args, **kwargs)
+        return self.hook.cancel_query()
 
     def run_with_configuration(self, *args, **kwargs) -> str:
         """

--- a/airflow/providers/google/cloud/hooks/bigquery_dts.py
+++ b/airflow/providers/google/cloud/hooks/bigquery_dts.py
@@ -93,7 +93,6 @@ class BiqQueryDataTransferServiceHook(CloudBaseHook):
             )
         return self._conn
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def create_transfer_config(
         self,
@@ -139,7 +138,6 @@ class BiqQueryDataTransferServiceHook(CloudBaseHook):
             metadata=metadata,
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def delete_transfer_config(
         self,
@@ -178,7 +176,6 @@ class BiqQueryDataTransferServiceHook(CloudBaseHook):
             name=name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def start_manual_transfer_runs(
         self,
@@ -236,7 +233,6 @@ class BiqQueryDataTransferServiceHook(CloudBaseHook):
             metadata=metadata,
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def get_transfer_run(
         self,

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -130,7 +130,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
             )
         return self._conn
 
-    @CloudBaseHook.catch_http_exception
     def create_transfer_job(self, body: Dict) -> Dict:
         """
         Creates a transfer job that runs periodically.
@@ -148,7 +147,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
             num_retries=self.num_retries)
 
     @CloudBaseHook.fallback_to_default_project_id
-    @CloudBaseHook.catch_http_exception
     def get_transfer_job(self, job_name: str, project_id: Optional[str] = None) -> Dict:
         """
         Gets the latest state of a long-running operation in Google Storage
@@ -208,7 +206,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
 
         return jobs
 
-    @CloudBaseHook.catch_http_exception
     def update_transfer_job(self, job_name: str, body: Dict) -> Dict:
         """
         Updates a transfer job that runs periodically.
@@ -230,7 +227,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
         )
 
     @CloudBaseHook.fallback_to_default_project_id
-    @CloudBaseHook.catch_http_exception
     def delete_transfer_job(self, job_name: str, project_id: Optional[str] = None) -> None:
         """
         Deletes a transfer job. This is a soft delete. After a transfer job is
@@ -262,7 +258,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
             .execute(num_retries=self.num_retries)
         )
 
-    @CloudBaseHook.catch_http_exception
     def cancel_transfer_operation(self, operation_name: str) -> None:
         """
         Cancels an transfer operation in Google Storage Transfer Service.
@@ -275,7 +270,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
         self.get_conn().transferOperations().cancel(  # pylint: disable=no-member
             name=operation_name).execute(num_retries=self.num_retries)
 
-    @CloudBaseHook.catch_http_exception
     def get_transfer_operation(self, operation_name: str) -> Dict:
         """
         Gets an transfer operation in Google Storage Transfer Service.
@@ -294,7 +288,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
             .execute(num_retries=self.num_retries)
         )
 
-    @CloudBaseHook.catch_http_exception
     def list_transfer_operations(self, request_filter: Optional[Dict] = None, **kwargs) -> List[Dict]:
         """
         Gets an transfer operation in Google Storage Transfer Service.
@@ -344,7 +337,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
 
         return operations
 
-    @CloudBaseHook.catch_http_exception
     def pause_transfer_operation(self, operation_name: str) -> None:
         """
         Pauses an transfer operation in Google Storage Transfer Service.
@@ -356,7 +348,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
         self.get_conn().transferOperations().pause(  # pylint: disable=no-member
             name=operation_name).execute(num_retries=self.num_retries)
 
-    @CloudBaseHook.catch_http_exception
     def resume_transfer_operation(self, operation_name: str) -> None:
         """
         Resumes an transfer operation in Google Storage Transfer Service.
@@ -368,7 +359,6 @@ class CloudDataTransferServiceHook(CloudBaseHook):
         self.get_conn().transferOperations().resume(  # pylint: disable=no-member
             name=operation_name).execute(num_retries=self.num_retries)
 
-    @CloudBaseHook.catch_http_exception
     def wait_for_transfer_job(
         self,
         job: Dict,

--- a/airflow/providers/google/cloud/hooks/natural_language.py
+++ b/airflow/providers/google/cloud/hooks/natural_language.py
@@ -61,7 +61,6 @@ class CloudNaturalLanguageHook(CloudBaseHook):
             )
         return self._conn
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def analyze_entities(
         self,
@@ -96,7 +95,6 @@ class CloudNaturalLanguageHook(CloudBaseHook):
             document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def analyze_entity_sentiment(
         self,
@@ -131,7 +129,6 @@ class CloudNaturalLanguageHook(CloudBaseHook):
             document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def analyze_sentiment(
         self,
@@ -165,7 +162,6 @@ class CloudNaturalLanguageHook(CloudBaseHook):
             document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def analyze_syntax(
         self,
@@ -200,7 +196,6 @@ class CloudNaturalLanguageHook(CloudBaseHook):
             document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def annotate_text(
         self,
@@ -244,7 +239,6 @@ class CloudNaturalLanguageHook(CloudBaseHook):
             metadata=metadata,
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def classify_text(
         self,

--- a/airflow/providers/google/cloud/hooks/tasks.py
+++ b/airflow/providers/google/cloud/hooks/tasks.py
@@ -65,7 +65,6 @@ class CloudTasksHook(CloudBaseHook):
             )
         return self._client
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def create_queue(
         self,
@@ -123,7 +122,6 @@ class CloudTasksHook(CloudBaseHook):
             metadata=metadata,
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def update_queue(
         self,
@@ -186,7 +184,6 @@ class CloudTasksHook(CloudBaseHook):
             metadata=metadata,
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def get_queue(
         self,
@@ -226,7 +223,6 @@ class CloudTasksHook(CloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def list_queues(
         self,
@@ -276,7 +272,6 @@ class CloudTasksHook(CloudBaseHook):
         )
         return list(queues)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def delete_queue(
         self,
@@ -315,7 +310,6 @@ class CloudTasksHook(CloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def purge_queue(
         self,
@@ -355,7 +349,6 @@ class CloudTasksHook(CloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def pause_queue(
         self,
@@ -395,7 +388,6 @@ class CloudTasksHook(CloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def resume_queue(
         self,
@@ -435,7 +427,6 @@ class CloudTasksHook(CloudBaseHook):
             name=full_queue_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def create_task(
         self,
@@ -502,7 +493,6 @@ class CloudTasksHook(CloudBaseHook):
             metadata=metadata,
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def get_task(
         self,
@@ -553,7 +543,6 @@ class CloudTasksHook(CloudBaseHook):
             metadata=metadata,
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def list_tasks(
         self,
@@ -606,7 +595,6 @@ class CloudTasksHook(CloudBaseHook):
         )
         return list(tasks)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def delete_task(
         self,
@@ -648,7 +636,6 @@ class CloudTasksHook(CloudBaseHook):
             name=full_task_name, retry=retry, timeout=timeout, metadata=metadata
         )
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def run_task(
         self,

--- a/airflow/providers/google/cloud/hooks/vision.py
+++ b/airflow/providers/google/cloud/hooks/vision.py
@@ -162,7 +162,6 @@ class CloudVisionHook(CloudBaseHook):
         if "error" in response:
             raise AirflowException(response)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def create_product_set(
         self,
@@ -201,7 +200,6 @@ class CloudVisionHook(CloudBaseHook):
 
         return product_set_id
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def get_product_set(
         self,
@@ -225,7 +223,6 @@ class CloudVisionHook(CloudBaseHook):
         self.log.debug('ProductSet retrieved:\n%s', response)
         return MessageToDict(response)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def update_product_set(
         self,
@@ -256,7 +253,6 @@ class CloudVisionHook(CloudBaseHook):
         self.log.debug('ProductSet updated:\n%s', response)
         return MessageToDict(response)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def delete_product_set(
         self,
@@ -279,7 +275,6 @@ class CloudVisionHook(CloudBaseHook):
         client.delete_product_set(name=name, retry=retry, timeout=timeout, metadata=metadata)
         self.log.info('ProductSet with the name [%s] deleted.', name)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def create_product(
         self,
@@ -318,7 +313,6 @@ class CloudVisionHook(CloudBaseHook):
 
         return product_id
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def get_product(
         self,
@@ -343,7 +337,6 @@ class CloudVisionHook(CloudBaseHook):
         self.log.debug('Product retrieved:\n%s', response)
         return MessageToDict(response)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def update_product(
         self,
@@ -372,7 +365,6 @@ class CloudVisionHook(CloudBaseHook):
         self.log.debug('Product updated:\n%s', response)
         return MessageToDict(response)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def delete_product(
         self,
@@ -395,7 +387,6 @@ class CloudVisionHook(CloudBaseHook):
         client.delete_product(name=name, retry=retry, timeout=timeout, metadata=metadata)
         self.log.info('Product with the name [%s] deleted:', name)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def create_reference_image(
         self,
@@ -439,7 +430,6 @@ class CloudVisionHook(CloudBaseHook):
 
         return reference_image_id
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def delete_reference_image(
         self,
@@ -470,7 +460,6 @@ class CloudVisionHook(CloudBaseHook):
         self.log.info('ReferenceImage with the name [%s] deleted.', name)
         return MessageToDict(response)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def add_product_to_product_set(
         self,
@@ -501,7 +490,6 @@ class CloudVisionHook(CloudBaseHook):
 
         self.log.info('Product added to Product Set')
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.fallback_to_default_project_id
     def remove_product_from_product_set(
         self,
@@ -532,7 +520,6 @@ class CloudVisionHook(CloudBaseHook):
 
         self.log.info('Product removed from Product Set')
 
-    @CloudBaseHook.catch_http_exception
     def annotate_image(
         self,
         request: Union[dict, AnnotateImageRequest],
@@ -554,7 +541,6 @@ class CloudVisionHook(CloudBaseHook):
 
         return MessageToDict(response)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def batch_annotate_images(
         self,
@@ -578,7 +564,6 @@ class CloudVisionHook(CloudBaseHook):
 
         return MessageToDict(response)
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def text_detection(
         self,
@@ -609,7 +594,6 @@ class CloudVisionHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def document_text_detection(
         self,
@@ -640,7 +624,6 @@ class CloudVisionHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def label_detection(
         self,
@@ -671,7 +654,6 @@ class CloudVisionHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     @CloudBaseHook.quota_retry()
     def safe_search_detection(
         self,

--- a/airflow/providers/google/marketing_platform/hooks/campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/hooks/campaign_manager.py
@@ -250,7 +250,6 @@ class GoogleCampaignManagerHook(CloudBaseHook):
             },
         }
 
-    @CloudBaseHook.catch_http_exception
     def conversions_batch_insert(
         self,
         profile_id: str,
@@ -301,7 +300,6 @@ class GoogleCampaignManagerHook(CloudBaseHook):
                 raise AirflowException(errored_conversions)
         return response
 
-    @CloudBaseHook.catch_http_exception
     def conversions_batch_update(
         self,
         profile_id: str,

--- a/airflow/providers/google/suite/hooks/sheets.py
+++ b/airflow/providers/google/suite/hooks/sheets.py
@@ -73,7 +73,6 @@ class GSheetsHook(CloudBaseHook):
 
         return self._conn
 
-    @CloudBaseHook.catch_http_exception
     def get_values(
         self,
         range_: str,
@@ -110,7 +109,6 @@ class GSheetsHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     def batch_get_values(
         self,
         ranges: List,
@@ -147,7 +145,6 @@ class GSheetsHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     def update_values(
         self,
         range_: str,
@@ -202,7 +199,6 @@ class GSheetsHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     def batch_update_values(
         self,
         ranges: List,
@@ -267,7 +263,6 @@ class GSheetsHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     def append_values(
         self,
         range_: str,
@@ -327,7 +322,6 @@ class GSheetsHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     def clear(self, range_: str) -> Dict:
         """
         Clear values from Google Sheet from a single range
@@ -346,7 +340,6 @@ class GSheetsHook(CloudBaseHook):
 
         return response
 
-    @CloudBaseHook.catch_http_exception
     def batch_clear(self, ranges: List) -> Dict:
         """
         Clear values from Google Sheet from a list of ranges

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -22,7 +22,6 @@ from unittest import mock
 from googleapiclient.errors import HttpError
 from parameterized import parameterized
 
-from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks import bigquery as hook
 from airflow.providers.google.cloud.hooks.bigquery import (
     _api_resource_configs_duplication_check, _cleanse_time_partitioning, _validate_src_fmt_configs,

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -568,7 +568,7 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Address not found')
         bq_hook = hook.BigQueryHook()
-        with self.assertRaisesRegex(AirflowException, r"Address not found"):
+        with self.assertRaisesRegex(HttpError, r"Address not found"):
             bq_hook.run_table_delete(source_project_dataset_table)
         method.assert_called_once_with(datasetId=DATASET_ID, projectId=PROJECT_ID, tableId=TABLE_ID)
 
@@ -799,7 +799,7 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method_execute.side_effect = HttpError(resp=resp, content=b'Not Found')
 
         bq_hook = hook.BigQueryHook()
-        with self.assertRaisesRegex(AirflowException, "HttpError 404 \"Not Found\""):
+        with self.assertRaisesRegex(HttpError, "HttpError 404 \"Not Found\""):
             bq_hook.poll_job_complete(JOB_ID)
 
     @mock.patch(
@@ -1166,7 +1166,7 @@ class TestTableOperations(unittest.TestCase):
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Bad request')
         bq_hook = hook.BigQueryHook()
-        with self.assertRaisesRegex(AirflowException, "Bad request"):
+        with self.assertRaisesRegex(HttpError, "Bad request"):
             bq_hook.patch_table(DATASET_ID, TABLE_ID)
 
     @mock.patch(
@@ -1724,7 +1724,7 @@ class TestDatasetsOperations(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_create_empty_dataset_no_dataset_id_err(self, mock_get_service, mock_get_creds_and_proj_id):
         with self.assertRaisesRegex(
-            AirflowException,
+            ValueError,
             r"dataset_id not provided and datasetId not exist in the "
             r"datasetReference\. Impossible to create dataset"
         ):
@@ -1738,7 +1738,7 @@ class TestDatasetsOperations(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_create_empty_dataset_duplicates_call_err(self, mock_get_service, mock_get_creds_and_proj_id):
         with self.assertRaisesRegex(
-            AirflowException,
+            ValueError,
             r"Values of projectId param are duplicated\. dataset_reference contained projectId param in "
             r"`query` config and projectId was also provided with arg to run_query\(\) method\. "
             r"Please remove duplicates\."
@@ -1760,7 +1760,7 @@ class TestDatasetsOperations(unittest.TestCase):
         self, mock_get_service, mock_get_creds_and_proj_id
     ):
         with self.assertRaisesRegex(
-            AirflowException,
+            ValueError,
             r"Values of location param are duplicated\. dataset_reference contained location param in "
             r"`query` config and location was also provided with arg to run_query\(\) method\. "
             r"Please remove duplicates\."
@@ -1829,7 +1829,7 @@ class TestDatasetsOperations(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_get_dataset_without_dataset_id(self, mock_get_service, mock_get_creds_and_proj_id):
         with self.assertRaisesRegex(
-            AirflowException,
+            ValueError,
             r"ataset_id argument must be provided and has a type 'str'\. You provided: "
         ):
             bq_hook = hook.BigQueryHook()


### PR DESCRIPTION
This decorator unables to catch 409 or similar HTTP error from Google APIs.

---
Issue link: [AIRFLOW-7082](https://issues.apache.org/jira/browse/AIRFLOW-7082)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
