### PR TITLE
[AIRFLOW-4679] Make airflow/operators Pylint compatible

### DIFF
--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -100,8 +100,6 @@ class BashOperator(BaseOperator):
                                   for k, v in airflow_context_vars.items()]))
         env.update(airflow_context_vars)
 
-        self.lineage_data = self.bash_command
-
         with TemporaryDirectory(prefix='airflowtmp') as tmp_dir:
 
             def pre_exec():
@@ -113,7 +111,7 @@ class BashOperator(BaseOperator):
 
             self.log.info('Running command: %s', self.bash_command)
 
-            self.sub_process = Popen(
+            self.sub_process = Popen(  # pylint: disable=subprocess-popen-preexec-fn
                 ['bash', "-c", self.bash_command],
                 stdout=PIPE,
                 stderr=STDOUT,

--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -90,6 +90,12 @@ class CheckOperator(BaseOperator):
         self.log.info("Success.")
 
     def get_db_hook(self):
+        """
+        Get the database hook for the connection.
+
+        :return: the database hook object.
+        :rtype: DbApiHook
+        """
         return BaseHook.get_hook(conn_id=self.conn_id)
 
 
@@ -195,6 +201,12 @@ class ValueCheckOperator(BaseOperator):
         return [record == numeric_pass_value_conv for record in numeric_records]
 
     def get_db_hook(self):
+        """
+        Get the database hook for the connection.
+
+        :return: the database hook object.
+        :rtype: DbApiHook
+        """
         return BaseHook.get_hook(conn_id=self.conn_id)
 
 
@@ -295,16 +307,16 @@ class IntervalCheckOperator(BaseOperator):
         ratios = {}
         test_results = {}
 
-        for m in self.metrics_sorted:
-            cur = current[m]
-            ref = reference[m]
-            threshold = self.metrics_thresholds[m]
+        for metric in self.metrics_sorted:
+            cur = current[metric]
+            ref = reference[metric]
+            threshold = self.metrics_thresholds[metric]
             if cur == 0 or ref == 0:
-                ratios[m] = None
-                test_results[m] = self.ignore_zero
+                ratios[metric] = None
+                test_results[metric] = self.ignore_zero
             else:
-                ratios[m] = self.ratio_formulas[self.ratio_formula](current[m], reference[m])
-                test_results[m] = ratios[m] < threshold
+                ratios[metric] = self.ratio_formulas[self.ratio_formula](current[metric], reference[metric])
+                test_results[metric] = ratios[metric] < threshold
 
             self.log.info(
                 (
@@ -312,13 +324,12 @@ class IntervalCheckOperator(BaseOperator):
                     "Past metric for %s: %s\n"
                     "Ratio for %s: %s\n"
                     "Threshold: %s\n"
-                ), m, cur, m, ref, m, ratios[m], threshold)
+                ), metric, cur, metric, ref, metric, ratios[metric], threshold)
 
         if not all(test_results.values()):
             failed_tests = [it[0] for it in test_results.items() if not it[1]]
-            j = len(failed_tests)
-            n = len(self.metrics_sorted)
-            self.log.warning("The following %s tests out of %s failed:", j, n)
+            self.log.warning("The following %s tests out of %s failed:",
+                             len(failed_tests), len(self.metrics_sorted))
             for k in failed_tests:
                 self.log.warning(
                     "'%s' check failed. %s is above %s", k, ratios[k], self.metrics_thresholds[k]
@@ -329,4 +340,10 @@ class IntervalCheckOperator(BaseOperator):
         self.log.info("All tests have passed")
 
     def get_db_hook(self):
+        """
+        Get the database hook for the connection.
+
+        :return: the database hook object.
+        :rtype: DbApiHook
+        """
         return BaseHook.get_hook(conn_id=self.conn_id)

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -136,6 +136,12 @@ class PythonOperator(BaseOperator):
         return return_value
 
     def execute_callable(self):
+        """
+        Calls the python callable with the given arguments.
+
+        :return: the return value of the call.
+        :rtype: any
+        """
         return self.python_callable(*self.op_args, **self.op_kwargs)
 
 
@@ -240,7 +246,7 @@ class PythonVirtualenvOperator(PythonOperator):
     """
 
     @apply_defaults
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         python_callable: Callable,
         requirements: Optional[Iterable[str]] = None,
@@ -278,8 +284,8 @@ class PythonVirtualenvOperator(PythonOperator):
         if (not isinstance(self.python_callable,
                            types.FunctionType) or (self.python_callable.__name__ ==
                                                    (lambda x: 0).__name__)):
-            raise AirflowException('{} only supports functions for python_callable arg',
-                                   self.__class__.__name__)
+            raise AirflowException('{} only supports functions for python_callable arg'.format(
+                self.__class__.__name__))
         # check that args are passed iff python major version matches
         if (python_version is not None and
            str(python_version)[0] != str(sys.version_info[0]) and
@@ -358,7 +364,7 @@ class PythonVirtualenvOperator(PythonOperator):
     def _write_script(self, script_filename):
         with open(script_filename, 'w') as file:
             python_code = self._generate_python_code()
-            self.log.debug('Writing code to file\n', python_code)
+            self.log.debug('Writing code to file\n %s', python_code)
             file.write(python_code)
 
     @staticmethod
@@ -373,7 +379,7 @@ class PythonVirtualenvOperator(PythonOperator):
             pickling_library = 'dill'
         else:
             pickling_library = 'pickle'
-        fn = self.python_callable
+
         # dont try to read pickle if we didnt pass anything
         if self._pass_op_args():
             load_args_line = 'with open(sys.argv[1], "rb") as file: arg_dict = {}.load(file)' \
@@ -397,6 +403,6 @@ class PythonVirtualenvOperator(PythonOperator):
         with open(sys.argv[2], 'wb') as file:
             res is not None and {pickling_library}.dump(res, file)
         """).format(load_args_code=load_args_line,
-                    python_callable_lines=dedent(inspect.getsource(fn)),
-                    python_callable_name=fn.__name__,
+                    python_callable_lines=dedent(inspect.getsource(self.python_callable)),
+                    python_callable_name=self.python_callable.__name__,
                     pickling_library=pickling_library)

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -26,13 +26,6 @@
 ./airflow/models/taskinstance.py
 ./airflow/models/variable.py
 ./airflow/models/xcom.py
-./airflow/operators/bash.py
-./airflow/operators/check_operator.py
-./airflow/operators/dagrun_operator.py
-./airflow/operators/dummy_operator.py
-./airflow/operators/generic_transfer.py
-./airflow/operators/jdbc_operator.py
-./airflow/operators/python.py
 ./airflow/providers/apache/druid/hooks/druid.py
 ./airflow/providers/apache/druid/operators/druid.py
 ./airflow/providers/apache/druid/operators/druid_check.py


### PR DESCRIPTION
- remove unused lineage_data field in BashOperator
- fix string formatting in AirflowException in PythonVirtualenvOperator

---
Issue link: [AIRFLOW-4679](https://issues.apache.org/jira/browse/AIRFLOW-4679)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
