### PR TITLE
[AIRFLOW-7084] Lazy initialize plugins for each entrypoint

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -670,6 +670,8 @@ class BaseOperator(Operator, LoggingMixin):
         op_extra_links_from_plugin: Dict[str, Any] = {}
         from airflow import plugins_manager
         plugins_manager.initialize_extra_operators_links_plugins()
+        if plugins_manager.operator_extra_links is None:
+            raise AirflowException("Can't load operators")
         for ope in plugins_manager.operator_extra_links:
             if ope.operators and self.__class__ in ope.operators:
                 op_extra_links_from_plugin.update({ope.name: ope})
@@ -685,9 +687,10 @@ class BaseOperator(Operator, LoggingMixin):
     @cached_property
     def global_operator_extra_link_dict(self) -> Dict[str, Any]:
         """Returns dictionary of all global extra links"""
-        from airflow.plugins_manager import global_operator_extra_links
         from airflow import plugins_manager
         plugins_manager.initialize_extra_operators_links_plugins()
+        if plugins_manager.global_operator_extra_links is None:
+            raise AirflowException("Can't load operators")
         return {link.name: link for link in plugins_manager.global_operator_extra_links}
 
     @prepare_lineage

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -668,8 +668,9 @@ class BaseOperator(Operator, LoggingMixin):
         """Returns dictionary of all extra links for the operator"""
 
         op_extra_links_from_plugin: Dict[str, Any] = {}
-        from airflow.plugins_manager import operator_extra_links
-        for ope in operator_extra_links:
+        from airflow import plugins_manager
+        plugins_manager.initialize_extra_operators_links_plugins()
+        for ope in plugins_manager.operator_extra_links:
             if ope.operators and self.__class__ in ope.operators:
                 op_extra_links_from_plugin.update({ope.name: ope})
 
@@ -685,7 +686,9 @@ class BaseOperator(Operator, LoggingMixin):
     def global_operator_extra_link_dict(self) -> Dict[str, Any]:
         """Returns dictionary of all global extra links"""
         from airflow.plugins_manager import global_operator_extra_links
-        return {link.name: link for link in global_operator_extra_links}
+        from airflow import plugins_manager
+        plugins_manager.initialize_extra_operators_links_plugins()
+        return {link.name: link for link in plugins_manager.global_operator_extra_links}
 
     @prepare_lineage
     def pre_execute(self, context: Any):

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -366,10 +366,10 @@ def integrate_dag_plugins() -> None:
             raise AirflowPluginException("Invalid plugin name")
         plugin_name: str = plugin.name
 
-        operators_module = make_module('airflow.operators.' + plugin_name, plugin.operators + plugin.sensors)
-        sensors_module = make_module('airflow.sensors.' + plugin_name, plugin.sensors)
-        hooks_module = make_module('airflow.hooks.' + plugin_name, plugin.hooks)
-        macros_module = make_module('airflow.macros.' + plugin_name, plugin.macros)
+        operators_module = make_module(f'airflow.operators.{plugin_name}', plugin.operators + plugin.sensors)
+        sensors_module = make_module(f'airflow.sensors.{plugin_name}', plugin.sensors)
+        hooks_module = make_module(f'airflow.hooks.{plugin_name}', plugin.hooks)
+        macros_module = make_module(f'airflow.macros.{plugin_name}', plugin.macros)
 
         operators_modules.append(operators_module)
         sensors_modules.append(sensors_module)

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -236,14 +236,17 @@ def initialize_web_ui_plugins():
     global flask_appbuilder_menu_links
     # pylint: enable=global-statement
 
-    ensure_plugins_loaded()
-
     if admin_views is not None and \
             flask_blueprints is not None and \
             menu_links is not None and \
             flask_appbuilder_views is not None and \
             flask_appbuilder_menu_links is not None:
         return
+
+    ensure_plugins_loaded()
+
+    if plugins is None:
+        raise AirflowPluginException("Can't load plugins.")
 
     log.debug("Initialize Web UI plugin")
 
@@ -276,6 +279,11 @@ def initialize_extra_operators_links_plugins():
             operator_extra_links is not None and \
             registered_operator_link_classes is not None:
         return
+
+    ensure_plugins_loaded()
+
+    if plugins is None:
+        raise AirflowPluginException("Can't load plugins.")
 
     log.debug("Initialize extra operators links plugins")
 

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -18,6 +18,8 @@
 """Manages all plugins."""
 # noinspection PyDeprecation
 import importlib
+import importlib.machinery
+import importlib.util
 import inspect
 import logging
 import os

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -38,11 +38,11 @@ import_errors = {}
 plugins = None  # type: Optional[List[AirflowPlugin]]
 
 # Plugin components to integrate as modules
-operators_modules = None
-sensors_modules = None
-hooks_modules = None
-macros_modules = None
-executors_modules = None
+operators_modules: Optional[List[Any]] = None
+sensors_modules: Optional[List[Any]] = None
+hooks_modules: Optional[List[Any]] = None
+macros_modules: Optional[List[Any]] = None
+executors_modules: Optional[List[Any]] = None
 
 # Plugin components to integrate directly
 admin_views: Optional[List[Any]] = None
@@ -306,16 +306,21 @@ def integrate_executor_plugins() -> None:
 
     ensure_plugins_loaded()
 
+    if plugins is None:
+        raise AirflowPluginException("Can't load plugins.")
+
     log.debug("Integrate executor plugins")
 
     executors_modules = []
     for plugin in plugins:
+        if plugin.name is None:
+            raise AirflowPluginException("Invalid plugin name")
         plugin_name: str = plugin.name
 
         executors_module = make_module('airflow.executors.' + plugin_name, plugin.executors)
         executors_modules.append(executors_module)
 
-        sys.modules[executors_module.__name__] = executors_module
+        sys.modules[executors_module.__name__] = executors_module  # pylint: disable=no-member
         # noinspection PyProtectedMember
         globals()[executors_module._name] = executors_module  # pylint: disable=protected-access
 
@@ -338,6 +343,9 @@ def integrate_dag_plugins() -> None:
 
     ensure_plugins_loaded()
 
+    if plugins is None:
+        raise AirflowPluginException("Can't load plugins.")
+
     log.debug("Integrate DAG plugins")
 
     operators_modules = []
@@ -346,6 +354,8 @@ def integrate_dag_plugins() -> None:
     macros_modules = []
 
     for plugin in plugins:
+        if plugin.name is None:
+            raise AirflowPluginException("Invalid plugin name")
         plugin_name: str = plugin.name
 
         operators_module = make_module('airflow.operators.' + plugin_name, plugin.operators + plugin.sensors)
@@ -358,18 +368,18 @@ def integrate_dag_plugins() -> None:
         hooks_modules.append(hooks_module)
         macros_modules.append(macros_module)
 
-        sys.modules[operators_module.__name__] = operators_module
+        sys.modules[operators_module.__name__] = operators_module  # pylint: disable=no-member
         # noinspection PyProtectedMember
         globals()[operators_module._name] = operators_module  # pylint: disable=protected-access
 
-        sys.modules[sensors_module.__name__] = sensors_module
+        sys.modules[sensors_module.__name__] = sensors_module  # pylint: disable=no-member
         # noinspection PyProtectedMember
         globals()[sensors_module._name] = sensors_module  # pylint: disable=protected-access
 
-        sys.modules[hooks_module.__name__] = hooks_module
+        sys.modules[hooks_module.__name__] = hooks_module  # pylint: disable=no-member
         # noinspection PyProtectedMember
         globals()[hooks_module._name] = hooks_module  # pylint: disable=protected-access
 
-        sys.modules[macros_module.__name__] = macros_module
+        sys.modules[macros_module.__name__] = macros_module  # pylint: disable=no-member
         # noinspection PyProtectedMember
         globals()[macros_module._name] = macros_module  # pylint: disable=protected-access

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -316,7 +316,6 @@ def integrate_executor_plugins() -> None:
         executors_modules.append(executors_module)
 
         sys.modules[executors_module.__name__] = executors_module
-
         # noinspection PyProtectedMember
         globals()[executors_module._name] = executors_module  # pylint: disable=protected-access
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -337,7 +337,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         """Deserializes an operator from a JSON object.
         """
         from airflow import plugins_manager
-        plugins_manager.ensure_plugins_loaded()
+        plugins_manager.initialize_extra_operators_links_plugins()
 
         if plugins_manager.operator_extra_links is None:
             raise AirflowException("Cnn't load plugins")
@@ -418,7 +418,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         :return: De-Serialized Operator Link
         """
         from airflow import plugins_manager
-        plugins_manager.ensure_plugins_loaded()
+        plugins_manager.initialize_extra_operators_links_plugins()
 
         if plugins_manager.registered_operator_link_classes is None:
             raise AirflowException("Can't load plugins")

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -339,6 +339,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         from airflow import plugins_manager
         plugins_manager.ensure_plugins_loaded()
 
+        if plugins_manager.operator_extra_links is None:
+            raise AirflowException("Cnn't load plugins")
         op = SerializedBaseOperator(task_id=encoded_op['task_id'])
 
         # Extra Operator Links defined in Plugins
@@ -418,6 +420,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         from airflow import plugins_manager
         plugins_manager.ensure_plugins_loaded()
 
+        if plugins_manager.registered_operator_link_classes is None:
+            raise AirflowException("Can't load plugins")
         op_predefined_extra_links = {}
 
         for _operator_links_source in encoded_op_links:

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -175,7 +175,7 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
                 """Integrate plugins to the context"""
                 from airflow import plugins_manager
 
-                plugins_manager.ensure_plugins_loaded()
+                plugins_manager.initialize_web_ui_plugins()
 
                 for v in plugins_manager.flask_appbuilder_views:
                     log.debug("Adding view %s", v["name"])


### PR DESCRIPTION
When we have custom executors and operators loaded using the `operators` property in plugins to avoid loading classes in the scheduler, operators are still loaded. After this change, the properties will be read only when needed.

---
Issue link: [AIRFLOW-7084](https://issues.apache.org/jira/browse/AIRFLOW-7084)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
