### PR TITLE
[AIRFLOW-7085] Cache credentials, project_id in GCP Base Hook

### DIFF
--- a/airflow/providers/google/cloud/hooks/base.py
+++ b/airflow/providers/google/cloud/hooks/base.py
@@ -141,11 +141,16 @@ class CloudBaseHook(BaseHook):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.extras = self.get_connection(self.gcp_conn_id).extra_dejson  # type: Dict
+        self._cached_credentials: Optional[google.auth.credentials.Credentials] = None
+        self._cached_project_id: Optional[str] = None
 
     def _get_credentials_and_project_id(self) -> Tuple[google.auth.credentials.Credentials, Optional[str]]:
         """
         Returns the Credentials object for Google API and the associated project_id
         """
+        if self._cached_credentials is not None:
+            return self._cached_credentials, self._cached_project_id
+
         key_path = self._get_field('key_path', None)  # type: Optional[str]
         keyfile_dict = self._get_field('keyfile_dict', None)  # type: Optional[str]
         if key_path and keyfile_dict:
@@ -199,6 +204,9 @@ class CloudBaseHook(BaseHook):
         overridden_project_id = self._get_field('project')
         if overridden_project_id:
             project_id = overridden_project_id
+
+        self._cached_credentials = credentials
+        self._cached_project_id = project_id
 
         return credentials, project_id
 


### PR DESCRIPTION
Obtaining credentials is expensive because it requires sending at least one HTTP request. On the other hand, for a given hook, the credentials do not change. This is particularly problematic because the `project_id` property also uses this method.

---
Issue link: [AIRFLOW-7085](https://issues.apache.org/jira/browse/AIRFLOW-7085)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
