### PR TITLE
[AIRFLOW-7087] Rename _execute_helper to _run_scheduler_loop

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2105,7 +2105,6 @@ class TestSchedulerJob(unittest.TestCase):
         processor = mock.MagicMock()
 
         scheduler = SchedulerJob(num_runs=0)
-        executor = MockExecutor(do_update=False)
         scheduler.processor_agent = processor
 
         scheduler.reset_state_for_orphaned_tasks()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2109,7 +2109,11 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler.executor = executor
         scheduler.processor_agent = processor
 
+        scheduler.executor.start()
+        scheduler.processor_agent.start()
         scheduler._run_scheduler_loop()
+        scheduler.processor_agent.terminate()
+        scheduler.executor.end()
 
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         self.assertEqual(ti.state, State.NONE)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2109,7 +2109,7 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler.executor = executor
         scheduler.processor_agent = processor
 
-        scheduler._execute_helper()
+        scheduler._run_scheduler_loop()
 
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         self.assertEqual(ti.state, State.NONE)
@@ -2158,7 +2158,7 @@ class TestSchedulerJob(unittest.TestCase):
         processor.done = True
         scheduler.processor_agent = processor
 
-        scheduler._execute_helper()
+        scheduler._run_scheduler_loop()
 
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         self.assertEqual(ti.state, expected_task_state)


### PR DESCRIPTION
This name is very misleading. I changed the name and moved some elements to other places. I am happy because now the _run_scheduler_loop method calls only harvest_simple_dags for processor_agent in happy path.  The processor_agent and executor starts and stops in one method. This makes it easier to understand the code.

---
Issue link: [AIRFLOW-7087](https://issues.apache.org/jira/browse/AIRFLOW-7087)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
