### PR TITLE
Remove JIRA requirements from PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,13 +4,10 @@ Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-
 Make sure to mark the boxes below before creating PR: [x]
 
 - [ ] Description above provides context of the change
-- [ ] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
 - [ ] Unit tests coverage for changes (not needed for documentation changes)
 - [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
 - [ ] Relevant documentation is updated including usage instructions.
 - [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
-
-<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.
 
 ---
 In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -169,20 +169,6 @@ firstPRWelcomeComment: >
 firstPRMergeComment: >
   Awesome work, congrats on your first merged pull request!
 
-insertIssueLinkInPrDescription:
-  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"
-  matchers:
-    jiraIssueMatch:
-      titleIssueIdRegexp: \[(AIRFLOW-[0-9]{4})\]
-      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1})"
-    docOnlyIssueMatch:
-      titleIssueIdRegexp: \[(AIRFLOW-X{4})\]
-      descriptionIssueLink: "`Document only change, no JIRA issue`"
-
-verifyTitles:
-  titleRegexp: ^\[AIRFLOW-[0-9]{4}\].*$|^\[AIRFLOW-XXXX\].*$
-  validateEitherPrOrSingleCommitTitle: true
-
 checkUpToDate:
   - airflow/migrations/*
   - airflow/migrations/**/*

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -169,15 +169,16 @@ firstPRWelcomeComment: >
 firstPRMergeComment: >
   Awesome work, congrats on your first merged pull request!
 
-insertIssueLinkInPrDescription:	
-  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"	
-  matchers:	
-    jiraIssueMatch:	
-      titleIssueIdRegexp: \[(AIRFLOW-[0-9]{4})\]	
+insertIssueLinkInPrDescription:
+  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"
+  matchers:
+    jiraIssueMatch:
+      titleIssueIdRegexp: \[(AIRFLOW-[0-9]{4})\]
       descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1})"
-    docOnlyIssueMatch:	
-      titleIssueIdRegexp: \[(AIRFLOW-X{4})\]	
+    docOnlyIssueMatch:
+      titleIssueIdRegexp: \[(AIRFLOW-X{4})\]
       descriptionIssueLink: "`Document only change, no JIRA issue`"
+
 checkUpToDate:
   - airflow/migrations/*
   - airflow/migrations/**/*

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -169,6 +169,15 @@ firstPRWelcomeComment: >
 firstPRMergeComment: >
   Awesome work, congrats on your first merged pull request!
 
+insertIssueLinkInPrDescription:	
+  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"	
+  matchers:	
+    jiraIssueMatch:	
+      titleIssueIdRegexp: \[(AIRFLOW-[0-9]{4})\]	
+      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1})"
+    docOnlyIssueMatch:	
+      titleIssueIdRegexp: \[(AIRFLOW-X{4})\]	
+      descriptionIssueLink: "`Document only change, no JIRA issue`"
 checkUpToDate:
   - airflow/migrations/*
   - airflow/migrations/**/*

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -30,9 +30,6 @@ mergeable:
               message: Do not merge this PR yet.
         begins_with:
           match: '[AIRFLOW-'
-        must_include:
-          regex: ^(\[AIRFLOW-XXXX\]|\[AIRFLOW\-\d{1,4}\])
-          message: Must include Jira issue in title.
       - do: label
         must_exclude:
           regex: 'wip'
@@ -46,12 +43,6 @@ mergeable:
           message: There are incomplete TODO task(s) unchecked.
         no_empty:
           enabled: true
-        or:
-          - must_include:
-              regex: (\[AIRFLOW-XXXX\])
-          - must_include:
-              regex: (\https\:\/\/issues\.apache\.org\/jira\/browse\/AIRFLOW\-\d{1,4})
-              message: Link to the Jira Issue
       # If package.json is updated, so should yarn.lock
       - do: dependent
         changed:


### PR DESCRIPTION
As a part of our move from JIRA tickets to github issues, we should no
longer force users to add JIRA ticket numbers to the titles of their PRs

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
