### PR TITLE
[AIRFLOW-Date_range compatible with schedule_interval]

### DIFF
--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -71,7 +71,7 @@ def date_range(start_date, end_date=None, num=None, delta=None):  # pylint: disa
     if not end_date and not num:
         end_date = timezone.utcnow()
     if delta in cron_presets:
-        delta = cron_presets[delta]
+        delta = cron_presets.get(delta)
 
     delta_iscron = False
     time_zone = start_date.tzinfo

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -70,6 +70,8 @@ def date_range(start_date, end_date=None, num=None, delta=None):  # pylint: disa
         raise Exception("Wait. Either specify end_date OR num")
     if not end_date and not num:
         end_date = timezone.utcnow()
+    if delta in cron_presets:
+        delta = cron_presets[delta]
 
     delta_iscron = False
     time_zone = start_date.tzinfo

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -94,3 +94,12 @@ class TestUtilsDatesDateRange(unittest.TestCase):
 
             for i in range(num):
                 self.assertTrue(timezone.is_localized(result[i]))
+
+    def test_delta_cron_presets(self):
+        num = 2
+        for delta in dates.cron_presets:
+            result = dates.date_range(datetime(2016, 1, 1), num=num, delta=delta)
+               self.assertEqual(len(result), num)
+
+            for i in range(num):
+                self.assertTrue(timezone.is_localized(result[i]))

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -96,10 +96,9 @@ class TestUtilsDatesDateRange(unittest.TestCase):
                 self.assertTrue(timezone.is_localized(result[i]))
 
     def test_delta_cron_presets(self):
-        num = 2
-        for delta in dates.cron_presets:
-            result = dates.date_range(datetime(2016, 1, 1), num=num, delta=delta)
-               self.assertEqual(len(result), num)
+        preset_range = date_range(datetime(2016, 1, 1), num=2, delta="@hourly")
+        timedelta_range = date_range(datetime(2016, 1, 1), num=2, delta=timedelta(hours=1))
+        cron_range = date_range(datetime(2016, 1, 1), num=2, delta="0 * * * *")
 
-            for i in range(num):
-                self.assertTrue(timezone.is_localized(result[i]))
+        self.assertEqual(preset_range, timedelta_range)
+        self.assertEqual(preset_range, cron_range)

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -96,9 +96,9 @@ class TestUtilsDatesDateRange(unittest.TestCase):
                 self.assertTrue(timezone.is_localized(result[i]))
 
     def test_delta_cron_presets(self):
-        preset_range = date_range(datetime(2016, 1, 1), num=2, delta="@hourly")
-        timedelta_range = date_range(datetime(2016, 1, 1), num=2, delta=timedelta(hours=1))
-        cron_range = date_range(datetime(2016, 1, 1), num=2, delta="0 * * * *")
+        preset_range = dates.date_range(datetime(2016, 1, 1), num=2, delta="@hourly")
+        timedelta_range = dates.date_range(datetime(2016, 1, 1), num=2, delta=timedelta(hours=1))
+        cron_range = dates.date_range(datetime(2016, 1, 1), num=2, delta="0 * * * *")
 
         self.assertEqual(preset_range, timedelta_range)
         self.assertEqual(preset_range, cron_range)


### PR DESCRIPTION
Schedule_interval can be a timedelta, a cron expression, or a cron_preset
And this function just accepted 2 out of those 3, i dont think that's fair for cron_presets

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
