### PR TITLE
Enable Github issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,11 @@ github:
     - python
     - scheduler
     - workflow
+  features:
+    # Enable issues management
+    issues: true
+    # Enable projects for project management boards
+    projects: true
 
   enabled_merge_buttons:
     squash: true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Problems and issues with code or docs
+title: ''
+labels: Bug
+assignees: ''
+
+---
+
+<!--
+
+Welcome to Apache Airflow!  For a smooth issue process, try to answer the following questions.
+Don't worry if they're not all applicable; just try to include what you can :-)
+
+If you need to include code snippets or logs, please put them in fenced code
+blocks.  If they're super-long, please use the details tag like
+<details><summary>super-long log</summary> lots of stuff </details>
+
+Please delete these comment blocks before submitting the issue.
+
+-->
+
+<!--
+
+IMPORTANT!!!
+
+Please complete the next sections or the issue will be closed.
+This questions are the first thing we need to know to understand the context.
+
+-->
+
+**Apache Airflow version**:
+
+**What happened**:
+
+<!-- (please include exact error messages if you can) -->
+
+**What you expected to happen**:
+
+<!-- What do you think went wrong? -->
+
+**How to reproduce it**:
+<!---
+
+As minimally and precisely as possible. Keep in mind we do not have access to your cluster or dags.
+
+--->
+
+**Anything else we need to know**:
+
+<!-- If this is actually about documentation, add `/kind documentation` below -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -50,7 +50,7 @@ As minimally and precisely as possible. Keep in mind we do not have access to yo
 
 <!--
 
-How often does this problem occur? Once? Ever time etc?
+How often does this problem occur? Once? Every time etc?
 
 Any relevant logs to include? Put them here in side a detail tag:
 <details><summary>x.log</summary> lots of stuff </details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -50,7 +50,7 @@ As minimally and precisely as possible. Keep in mind we do not have access to yo
 
 <!--
 
-How often does this problem occurr? Once? Ever time etc?
+How often does this problem occur? Once? Ever time etc?
 
 Any relevant logs to include? Put them here in side a detail tag:
 <details><summary>x.log</summary> lots of stuff </details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,5 +47,3 @@ As minimally and precisely as possible. Keep in mind we do not have access to yo
 --->
 
 **Anything else we need to know**:
-
-<!-- If this is actually about documentation, add `/kind documentation` below -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Problems and issues with code or docs
 title: ''
-labels: Bug
+labels: 'kind:bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,3 +47,12 @@ As minimally and precisely as possible. Keep in mind we do not have access to yo
 --->
 
 **Anything else we need to know**:
+
+<!--
+
+How often does this problem occurr? Once? Ever time etc?
+
+Any relevant logs to include? Put them here in side a detail tag:
+<details><summary>x.log</summary> lots of stuff </details>
+
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,8 +20,11 @@ Please delete these comment blocks before submitting the issue.
 
 -->
 
-<!-- What do you want to happen? -->
+<!-- What do you want to happen?
+
+Rather than telling us how you might implement this solution, try to take a
+step back and describe what you are trying to achieve.
+
+-->
 
 <!-- Is there currently another issue associated with this? -->
-
-<!-- Does it require a particular kubernetes version? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project or its docs
 title: ''
-labels: kind/feature
+labels: 'kind:feature'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project or its docs
+title: ''
+labels: kind/feature
+assignees: ''
+
+---
+
+<!--
+
+Welcome to Apache Airflow!  For a smooth issue process, try to answer the following questions.
+Don't worry if they're not all applicable; just try to include what you can :-)
+
+If you need to include code snippets or logs, please put them in fenced code
+blocks.  If they're super-long, please use the details tag like
+<details><summary>super-long log</summary> lots of stuff </details>
+
+Please delete these comment blocks before submitting the issue.
+
+-->
+
+<!-- What do you want to happen? -->
+
+<!-- Is there currently another issue associated with this? -->
+
+<!-- Does it require a particular kubernetes version? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,11 +20,19 @@ Please delete these comment blocks before submitting the issue.
 
 -->
 
+** Description **
+
+<!-- A short description of your feature -->
+
+** Use case / motivation **
+
 <!-- What do you want to happen?
 
 Rather than telling us how you might implement this solution, try to take a
 step back and describe what you are trying to achieve.
 
 -->
+
+** Related Issues **
 
 <!-- Is there currently another issue associated with this? -->

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,14 @@
+---
+name: Question or Support request
+about: Any questions you might have.
+title: ''
+labels: invalid
+assignees: ''
+
+---
+
+**Do not use issues for support requests or general help queries**
+
+Please ask on one of our mailing lists, or in our Slack channel. See the "Ask a question" section of http://airflow.apache.org/community/
+
+Issues which are not bug reports or feature requests (i.e. "how do I get X working", or "How do I best do X?") will likely be closed without a response.


### PR DESCRIPTION
As we don't want people using GitHub issues for asking for help, I have
tried to make this clear in the issue template.

Lets see if it works or not...


---

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.