### PR TITLE
Restore DaskExecutor tests

### DIFF
--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -65,8 +65,8 @@ class DaskExecutor(BaseExecutor):
                       command: CommandType,
                       queue: Optional[str] = None,
                       executor_config: Optional[Any] = None) -> None:
-        if not self.futures:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        # if not self.futures:
+        #     raise AirflowException(NOT_STARTED_MESSAGE)
 
         def airflow_run():
             return subprocess.check_call(command, close_fds=True)

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -73,7 +73,7 @@ class DaskExecutor(BaseExecutor):
             raise AirflowException(NOT_STARTED_MESSAGE)
 
         future = self.client.submit(airflow_run, pure=False)
-        self.futures[future] = key
+        self.futures[future] = key  # type: ignore
 
     def _process_future(self, future: Future) -> None:
         if not self.futures:

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -65,8 +65,6 @@ class DaskExecutor(BaseExecutor):
                       command: CommandType,
                       queue: Optional[str] = None,
                       executor_config: Optional[Any] = None) -> None:
-        # if not self.futures:
-        #     raise AirflowException(NOT_STARTED_MESSAGE)
 
         def airflow_run():
             return subprocess.check_call(command, close_fds=True)

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -30,6 +30,7 @@ from airflow.exceptions import (
     AirflowException, DagConcurrencyLimitReached, NoAvailablePoolSlot, PoolNotFound,
     TaskConcurrencyLimitReached,
 )
+from airflow.executors.dask_executor import DaskExecutor
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.jobs.base_job import BaseJob
@@ -772,7 +773,8 @@ class BackfillJob(BaseJob):
 
         # picklin'
         pickle_id = None
-        if not self.donot_pickle and self.executor.__class__ not in (LocalExecutor, SequentialExecutor):
+        if not self.donot_pickle and \
+                self.executor.__class__ not in (LocalExecutor, SequentialExecutor, DaskExecutor):
             pickle = DagPickle(self.dag)
             session.add(pickle)
             session.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,17 +51,20 @@ cgroupspy==0.1.6
 chardet==3.0.4
 click==6.7
 cloudant==2.12.0
+cloudpickle==1.3.0
 colorama==0.4.3
 colorlog==4.0.2
 coverage==5.0.4
 croniter==0.3.31
 cryptography==2.8
 cx-Oracle==7.3.0
+dask==2.12.0
 datadog==0.35.0
 decorator==4.4.2
 defusedxml==0.6.0
 dill==0.3.1.1
 distlib==0.3.0
+distributed==2.12.0
 dnspython==1.16.0
 docker==3.7.3
 docker-pycreds==0.4.0
@@ -132,6 +135,7 @@ grpcio==1.27.2
 grpcio-gcp==0.2.2
 gunicorn==19.10.0
 hdfs==2.5.8
+HeapDict==1.0.1
 hmsclient==0.1.1
 httplib2==0.17.0
 hvac==0.10.0
@@ -179,6 +183,7 @@ mock==4.0.2
 mongomock==3.19.0
 more-itertools==8.2.0
 moto==1.3.14
+msgpack==1.0.0
 msrest==0.6.11
 msrestazure==0.6.3
 multi-key-dict==2.0.3
@@ -282,6 +287,7 @@ slackclient==1.3.2
 snowballstemmer==2.0.0
 snowflake-connector-python==2.2.2
 snowflake-sqlalchemy==1.2.2
+sortedcontainers==2.1.0
 soupsieve==2.0
 Sphinx==2.4.4
 sphinx-argparse==0.2.5
@@ -306,6 +312,7 @@ sshtunnel==0.1.5
 statsd==3.3.0
 tableauserverclient==0.9
 tabulate==0.8.6
+tblib==1.6.0
 tenacity==4.12.0
 termcolor==1.1.0
 text-unidecode==1.2
@@ -313,6 +320,7 @@ textwrap3==0.9.2
 thrift==0.13.0
 thrift-sasl==0.4.1
 toml==0.10.0
+toolz==0.10.0
 tornado==5.1.1
 tqdm==4.43.0
 traitlets==4.3.3
@@ -337,4 +345,5 @@ xmltodict==0.12.0
 yamllint==1.20.0
 yandexcloud==0.28.0
 zdesk==2.7.1
+zict==2.0.0
 zipp==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ cloudant = [
     'cloudant>=2.0',
 ]
 dask = [
-    'distributed>=1.17.1, <2',
+    'distributed>=2.11.1, <3',
 ]
 databricks = [
     'requests>=2.20.0, <3',

--- a/setup.py
+++ b/setup.py
@@ -456,7 +456,7 @@ else:
 
 devel_minreq = cgroups + devel + doc + kubernetes + mysql + password
 devel_hadoop = devel_minreq + hdfs + hive + kerberos + presto + webhdfs
-devel_all = (all_dbs + atlas + aws + azure + celery + cgroups + datadog + devel + doc + docker +
+devel_all = (all_dbs + atlas + aws + azure + celery + cgroups + dask + datadog + devel + doc + docker +
              elasticsearch + gcp + grpc + hashicorp + jdbc + jenkins + kerberos + kubernetes + ldap + odbc +
              oracle + pagerduty + papermill + password + redis + salesforce + samba + segment +
              sendgrid + sentry + singularity + slack + snowflake + ssh + statsd + tableau +

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -20,8 +20,6 @@ import unittest
 from datetime import timedelta
 from unittest import mock
 
-import pytest
-
 from airflow.configuration import conf
 from airflow.jobs.backfill_job import BackfillJob
 from airflow.models import DagBag

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -110,7 +110,7 @@ class TestDaskExecutor(TestBaseDask):
                 ignore_first_depends_on_past=True,
                 executor=DaskExecutor(
                     cluster_address=self.cluster.scheduler_address))
-            executor.start()
+            job.executor.start()
             job.run()
 
     def tearDown(self):

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -110,6 +110,7 @@ class TestDaskExecutor(TestBaseDask):
                 ignore_first_depends_on_past=True,
                 executor=DaskExecutor(
                     cluster_address=self.cluster.scheduler_address))
+            executor.start()
             job.run()
 
     def tearDown(self):

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -41,8 +41,6 @@ except ImportError:
     pass
 
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
-pytestmark = pytest.mark.xfail(condition=True, reason="The Dask executor is expected to fail: "
-                               "TODO: WE SHOULD REMOVE IT ALTOGETHER OR FIX ????")
 
 
 class TestBaseDask(unittest.TestCase):
@@ -127,8 +125,8 @@ class TestDaskExecutorTLS(TestBaseDask):
 
     def test_tls(self):
         with dask_testing_cluster(
-                worker_kwargs={'security': tls_security()},
-                scheduler_kwargs={'security': tls_security()}) as (cluster, _):
+                worker_kwargs={'security': tls_security(), "protocol": "tls"},
+                scheduler_kwargs={'security': tls_security(), "protocol": "tls"}) as (cluster, _):
 
             # These use test certs that ship with dask/distributed and should not be
             #  used in production

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -89,29 +89,16 @@ class TestDaskExecutor(TestBaseDask):
         """
         Test that DaskExecutor can be used to backfill example dags
         """
-        dags = [
-            dag for dag in self.dagbag.dags.values()
-            if dag.dag_id in [
-                'example_bash_operator',
-                # 'example_python_operator',
-            ]
-        ]
+        dag = self.dagbag.get_dag('example_bash_operator')
 
-        for dag in dags:
-            dag.clear(
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE)
-
-        for dag in sorted(dags, key=lambda d: d.dag_id):
-            job = BackfillJob(
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE,
-                ignore_first_depends_on_past=True,
-                executor=DaskExecutor(
-                    cluster_address=self.cluster.scheduler_address))
-            job.executor.start()
-            job.run()
+        job = BackfillJob(
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            ignore_first_depends_on_past=True,
+            executor=DaskExecutor(
+                cluster_address=self.cluster.scheduler_address))
+        job.run()
 
     def tearDown(self):
         self.cluster.close(timeout=5)


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/5803. See https://github.com/dask/dask/issues/5803#issuecomment-601788441 for context, but the brief version is that the Dask Scheduler and workers were using the default tcp protocol, rather than tls as required by the test..

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).