### PR TITLE
Fixes unclean installation of Airflow 1.10

### DIFF
--- a/scripts/ci/in_container/_in_container_utils.sh
+++ b/scripts/ci/in_container/_in_container_utils.sh
@@ -310,14 +310,12 @@ function send_kubernetes_logs_to_file_io() {
 }
 
 function install_released_airflow_version() {
-    pip uninstall apache-airflow -y || true
+    pip uninstall -y apache-airflow || true
     find /root/airflow/ -type f -print0 | xargs rm -f --
     if [[ ${1} == "1.10.2" || ${1} == "1.10.1" ]]; then
         export SLUGIFY_USES_TEXT_UNIDECODE=yes
     fi
+    rm -rf "${AIRFLOW_SOURCES}"/*.egg-info
     INSTALLS=("apache-airflow==${1}" "werkzeug<1.0.0")
-    if [[ ${1} == "1.10.2" || ${1} == "1.10.1" ]]; then
-        echo
-    fi
     pip install --upgrade "${INSTALLS[@]}"
 }


### PR DESCRIPTION
Removal of airrflow installed via -e . leaves .egg-info folder
that makes subsequent airflow installation not clean.

This folder should be removed before install

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
