### PR TITLE
Decouple DAG from DagBag and DAG from SerializedDagModel - remove cyclic imports

### DIFF
--- a/airflow/api/common/experimental/__init__.py
+++ b/airflow/api/common/experimental/__init__.py
@@ -21,7 +21,8 @@ from typing import Optional
 
 from airflow.configuration import conf
 from airflow.exceptions import DagNotFound, DagRunNotFound, TaskNotFound
-from airflow.models import DagBag, DagModel, DagRun
+from airflow.models import DagModel, DagRun
+from airflow.models.dagbag import DagBag
 
 
 def check_and_get_dag(dag_id: str, task_id: Optional[str] = None) -> DagModel:

--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -21,7 +21,8 @@ from datetime import datetime
 from typing import List, Optional, Union
 
 from airflow.exceptions import DagNotFound, DagRunAlreadyExists
-from airflow.models import DagBag, DagModel, DagRun
+from airflow.models import DagModel, DagRun
+from airflow.models.dagbag import DagBag
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -32,9 +32,9 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.debug_executor import DebugExecutor
 from airflow.jobs.base_job import BaseJob
-from airflow.models import DagBag, DagModel, DagRun, TaskInstance
-from airflow.models.dag import DAG
-from airflow.utils import cli as cli_utils
+from airflow.models import DagModel, DagRun, TaskInstance
+from airflow.models.dagbag import DagBag
+from airflow.utils import cli as cli_utils, dag_cleaner
 from airflow.utils.cli import get_dag, get_dag_by_file_location, process_subdir, sigint_handler
 from airflow.utils.dot_renderer import render_dag
 from airflow.utils.session import create_session
@@ -101,7 +101,7 @@ def dag_backfill(args, dag=None):
             ti.dry_run()
     else:
         if args.reset_dagruns:
-            DAG.clear_dags(
+            dag_cleaner.clear_dags(
                 [dag],
                 start_date=args.start_date,
                 end_date=args.end_date,
@@ -341,5 +341,5 @@ def dag_list_dag_runs(args, dag=None):
 def dag_test(args):
     """Execute one single DagRun for a given DAG and execution date, using the DebugExecutor."""
     dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)
-    dag.clear(start_date=args.execution_date, end_date=args.execution_date, reset_dag_runs=True)
+    dag_cleaner.clear(dag, start_date=args.execution_date, end_date=args.execution_date, reset_dag_runs=True)
     dag.run(executor=DebugExecutor(), start_date=args.execution_date, end_date=args.execution_date)

--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Sync permission command"""
-from airflow.models import DagBag
+from airflow.models.dagbag import DagBag
 from airflow.utils import cli as cli_utils
 from airflow.www.app import cached_appbuilder
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -32,10 +32,9 @@ from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models import DagPickle, TaskInstance
-from airflow.models.dag import DAG
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies import SCHEDULER_QUEUED_DEPS
-from airflow.utils import cli as cli_utils
+from airflow.utils import cli as cli_utils, dag_cleaner
 from airflow.utils.cli import get_dag, get_dag_by_file_location, get_dag_by_pickle, get_dags
 from airflow.utils.log.logging_mixin import StreamLogWriter
 from airflow.utils.net import get_hostname
@@ -388,7 +387,7 @@ def task_clear(args):
                     include_downstream=args.downstream,
                     include_upstream=args.upstream)
 
-    DAG.clear_dags(
+    dag_cleaner.clear_dags(
         dags,
         start_date=args.start_date,
         end_date=args.end_date,

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -41,6 +41,7 @@ from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.jobs.base_job import BaseJob
 from airflow.models import DAG, DagModel, SlaMiss, errors
+from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKeyType
 from airflow.stats import Stats
@@ -492,7 +493,7 @@ class DagFileProcessor(LoggingMixin):
         :param session: session for ORM operations
         :type session: sqlalchemy.orm.session.Session
         :param dagbag: DagBag containing DAGs with import errors
-        :type dagbag: airflow.models.DagBag
+        :type dagbag: airflow.models.dagbag.DagBag
         """
         # Clear the errors of the processed files
         for dagbag_file in dagbag.file_last_changed:
@@ -825,7 +826,7 @@ class DagFileProcessor(LoggingMixin):
         self.log.info("Processing file %s for tasks to queue", file_path)
 
         try:
-            dagbag = models.DagBag(file_path, include_examples=False)
+            dagbag = DagBag(file_path, include_examples=False)
         except Exception:  # pylint: disable=broad-except
             self.log.exception("Failed at reloading the DAG file %s", file_path)
             Stats.incr('dag_file_refresh_error', 1, 1)
@@ -869,7 +870,7 @@ class DagFileProcessor(LoggingMixin):
     @provide_session
     def _schedule_task_instances(
         self,
-        dagbag: models.DagBag,
+        dagbag: DagBag,
         ti_keys_to_schedule: List[TaskInstanceKeyType],
         session=None
     ) -> None:
@@ -878,7 +879,7 @@ class DagFileProcessor(LoggingMixin):
         updates the information in the database,
 
         :param dagbag: DagBag
-        :type dagbag: models.DagBag
+        :type dagbag: airflow.models.dagbag.DagBag
         :param ti_keys_to_schedule:  List of task instnace keys which can be scheduled.
         :param ti_keys_to_schedule:
         """

--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -30,9 +30,9 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.ext.declarative import declarative_base
 
 from airflow import settings
-from airflow.models import DagBag
 # revision identifiers, used by Alembic.
 from airflow.models.base import COLLATION_ARGS
+from airflow.models.dagbag import DagBag
 
 revision = 'cc1e65623dc7'
 down_revision = '127d2bf2dfa7'

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Airflow models"""
+from airflow.jobs.backfill_job import BackfillJob
 from airflow.models.base import ID_LEN, Base
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.connection import Connection

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -20,7 +20,6 @@ from airflow.models.base import ID_LEN, Base
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG, DagModel, DagTag
-from airflow.models.dagbag import DagBag
 from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.errors import ImportError  # pylint: disable=redefined-builtin

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Airflow models"""
-from airflow.jobs.backfill_job import BackfillJob
 from airflow.models.base import ID_LEN, Base
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.connection import Connection

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1271,7 +1271,7 @@ class DAG(BaseDag, LoggingMixin):
             if dag.is_paused_upon_creation is not None:
                 orm_dag.is_paused = dag.is_paused_upon_creation
             orm_dag.tags = []
-            log.info("Creating ORM DAG for %s", dag.dag_id)
+            log.info("Creating ORM DAG for %s %s", dag.dag_id, orm_dag.is_paused)
             session.add(orm_dag)
             orm_dags.append(orm_dag)
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1571,16 +1571,16 @@ class DagModel(Base):
         :param session: session
         """
         filter_query = [
-            DagModel.dag_id.in_(self.dag_id),
+            DagModel.dag_id == self.dag_id,
         ]
         if including_subdags:
             filter_query.append(
-                DagModel.root_dag_id.in_(self.dag_id)
+                DagModel.root_dag_id == self.dag_id
             )
         session.query(DagModel).filter(or_(
             *filter_query
         )).update(
-            {DagModel.is_paused: is_paused}
+            {DagModel.is_paused: is_paused}, synchronize_session='fetch'
         )
         session.commit()
 

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -27,7 +27,7 @@ from sqlalchemy import BigInteger, Column, Index, String, and_
 from sqlalchemy.sql import exists
 
 from airflow.models.base import ID_LEN, Base
-from airflow.models.dag import DAG
+from airflow.models.dag import DAG, DagModel
 from airflow.models.dagcode import DagCode
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.settings import MIN_SERIALIZED_DAG_UPDATE_INTERVAL, STORE_SERIALIZED_DAGS, json
@@ -182,7 +182,6 @@ class SerializedDagModel(Base):
         :param dag_id: the DAG to fetch
         :param session: ORM Session
         """
-        from airflow.models.dag import DagModel
         row = session.query(cls).filter(cls.dag_id == dag_id).one_or_none()
         if row:
             return row
@@ -194,8 +193,9 @@ class SerializedDagModel(Base):
 
         return session.query(cls).filter(cls.dag_id == root_dag_id).one_or_none()
 
+    @staticmethod
     @provide_session
-    def bulk_sync_to_db(self, dags: List[DAG], session=None):
+    def bulk_sync_to_db(dags: List[DAG], session=None):
         """Stores list of dags in DB as SerializedDagModel"""
         if not STORE_SERIALIZED_DAGS:
             return

--- a/airflow/providers/google/cloud/example_dags/example_datafusion.py
+++ b/airflow/providers/google/cloud/example_dags/example_datafusion.py
@@ -28,7 +28,7 @@ from airflow.providers.google.cloud.operators.datafusion import (
     CloudDataFusionRestartInstanceOperator, CloudDataFusionStartPipelineOperator,
     CloudDataFusionStopPipelineOperator, CloudDataFusionUpdateInstanceOperator,
 )
-from airflow.utils import dates
+from airflow.utils import dag_cleaner, dates
 
 # [START howto_data_fusion_env_variables]
 LOCATION = "europe-north1"
@@ -220,5 +220,5 @@ with models.DAG(
     delete_pipeline >> delete_instance
 
 if __name__ == "__main__":
-    dag.clear(reset_dag_runs=True)
+    dag_cleaner.clear(dag, reset_dag_runs=True)
     dag.run()

--- a/airflow/providers/google/cloud/example_dags/example_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_gcs.py
@@ -30,6 +30,7 @@ from airflow.providers.google.cloud.operators.gcs import (
 )
 from airflow.providers.google.cloud.operators.gcs_to_gcs import GCSToGCSOperator
 from airflow.providers.google.cloud.operators.local_to_gcs import LocalFilesystemToGCSOperator
+from airflow.utils import dag_cleaner
 from airflow.utils.dates import days_ago
 
 default_args = {"start_date": days_ago(1)}
@@ -152,5 +153,5 @@ with models.DAG(
 
 
 if __name__ == '__main__':
-    dag.clear(reset_dag_runs=True)
+    dag_cleaner.clear(dag, reset_dag_runs=True)
     dag.run()

--- a/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py
@@ -30,7 +30,7 @@ from airflow.providers.google.marketing_platform.operators.campaign_manager impo
 from airflow.providers.google.marketing_platform.sensors.campaign_manager import (
     GoogleCampaignManagerReportSensor,
 )
-from airflow.utils import dates
+from airflow.utils import dag_cleaner, dates
 
 PROFILE_ID = os.environ.get("MARKETING_PROFILE_ID", "123456789")
 FLOODLIGHT_ACTIVITY_ID = os.environ.get("FLOODLIGHT_ACTIVITY_ID", 12345)
@@ -157,5 +157,5 @@ with models.DAG(
     insert_conversion >> update_conversion
 
 if __name__ == "__main__":
-    dag.clear(reset_dag_runs=True)
+    dag_cleaner.clear(dag, reset_dag_runs=True)
     dag.run()

--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -23,7 +23,8 @@ from typing import Optional, Union
 from sqlalchemy import func
 
 from airflow.exceptions import AirflowException
-from airflow.models import DagBag, DagModel, DagRun, TaskInstance
+from airflow.models import DagModel, DagRun, TaskInstance
+from airflow.models.dagbag import DagBag
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -35,7 +35,7 @@ from airflow.serialization.helpers import serialize_template_field
 from airflow.serialization.json_schema import Validator, load_dag_schema
 from airflow.settings import json
 from airflow.utils.module_loading import import_string
-from airflow.www.utils import get_python_source
+from airflow.utils.source_utils import get_python_source
 
 log = logging.getLogger(__name__)
 FAILED = 'serialization_failed'

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -36,7 +36,8 @@ from typing import Optional
 
 from airflow import settings
 from airflow.exceptions import AirflowException
-from airflow.models import DAG, DagBag, DagModel, DagPickle, Log
+from airflow.models import DAG, DagModel, DagPickle, Log
+from airflow.models.dagbag import DagBag
 from airflow.utils import cli_action_loggers
 from airflow.utils.session import provide_session
 

--- a/airflow/utils/cycle_tester.py
+++ b/airflow/utils/cycle_tester.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections import defaultdict
+
+from airflow.exceptions import AirflowDagCycleException
+
+CYCLE_NEW = 0
+CYCLE_IN_PROGRESS = 1
+CYCLE_DONE = 2
+
+
+def test_cycle(dag):
+    """
+    Check to see if there are any cycles in the DAG. Returns False if no cycle found,
+    otherwise raises exception.
+    """
+    def _test_cycle_helper(visit_map, task_id):
+        """
+        Checks if a cycle exists from the input task using DFS traversal
+        """
+        # print('Inspecting %s' % task_id)
+        if visit_map[task_id] == CYCLE_DONE:
+            return
+
+        visit_map[task_id] = CYCLE_IN_PROGRESS
+
+        task = dag.task_dict[task_id]
+        for descendant_id in task.get_direct_relative_ids():
+            if visit_map[descendant_id] == CYCLE_IN_PROGRESS:
+                msg = "Cycle detected in DAG. Faulty task: {0} to {1}".format(
+                    task_id, descendant_id)
+                raise AirflowDagCycleException(msg)
+            else:
+                _test_cycle_helper(visit_map, descendant_id)
+
+        visit_map[task_id] = CYCLE_DONE
+
+    # default of int is 0 which corresponds to CYCLE_NEW
+    visit_map = defaultdict(int)
+    for task_id in dag.task_dict.keys():
+        # print('starting %s' % task_id)
+        if visit_map[task_id] == CYCLE_NEW:
+            _test_cycle_helper(visit_map, task_id)
+    return False

--- a/airflow/utils/dag_cleaner.py
+++ b/airflow/utils/dag_cleaner.py
@@ -1,0 +1,288 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from operator import or_
+
+from pendulum import pendulum
+
+from airflow import AirflowException
+from airflow.models import TaskInstance, clear_task_instances
+from airflow.models.dagbag import DagBag
+from airflow.utils.helpers import ask_yesno
+from airflow.utils.session import provide_session
+from airflow.utils.state import State
+
+# pylint: disable=too-many-locals,too-many-nested-blocks,too-many-branches
+
+
+@provide_session
+def clear(  # pylint: disable=too-many-arguments
+    dag,
+    start_date=None, end_date=None,
+    only_failed=False,
+    only_running=False,
+    confirm_prompt=False,
+    include_subdags=True,
+    include_parentdag=True,
+    reset_dag_runs=True,
+    dry_run=False,
+    session=None,
+    get_tis=False,
+    recursion_depth=0,
+    max_recursion_depth=None,
+    dag_bag=None,
+):
+    """
+    Clears a set of task instances associated with the dag for
+    a specified date range.
+
+    :param start_date: The minimum execution_date to clear
+    :type start_date: datetime.datetime or None
+    :param end_date: The maximum exeuction_date to clear
+    :type end_date: datetime.datetime or None
+    :param only_failed: Only clear failed tasks
+    :type only_failed: bool
+    :param only_running: Only clear running tasks.
+    :type only_running: bool
+    :param confirm_prompt: Ask for confirmation
+    :type confirm_prompt: bool
+    :param include_subdags: Clear tasks in subdags and clear external tasks
+        indicated by ExternalTaskMarker
+    :type include_subdags: bool
+    :param include_parentdag: Clear tasks in the parent dag of the subdag.
+    :type include_parentdag: bool
+    :param reset_dag_runs: Set state of dag to RUNNING
+    :type reset_dag_runs: bool
+    :param dry_run: Find the tasks to clear but don't clear them.
+    :type dry_run: bool
+    :param session: The sqlalchemy session to use
+    :type session: sqlalchemy.orm.session.Session
+    :param get_tis: Return the sqlachemy query for finding the TaskInstance without clearing the tasks
+    :type get_tis: bool
+    :param recursion_depth: The recursion depth of nested calls to DAG.clear().
+    :type recursion_depth: int
+    :param max_recursion_depth: The maximum recusion depth allowed. This is determined by the
+        first encountered ExternalTaskMarker. Default is None indicating no ExternalTaskMarker
+        has been encountered.
+    :type max_recursion_depth: int
+    :param dag_bag: The DagBag used to find the dags
+    :type dag_bag: airflow.models.dagbag.DagBag
+    """
+    TI = TaskInstance
+    tis = session.query(TI)
+    if include_subdags:
+        # Crafting the right filter for dag_id and task_ids combo
+        conditions = []
+        for current_dag in dag.subdags + [dag]:
+            conditions.append(
+                TI.dag_id.like(current_dag.dag_id) &
+                TI.task_id.in_(current_dag.task_ids)
+            )
+        tis = tis.filter(or_(*conditions))
+    else:
+        tis = session.query(TI).filter(TI.dag_id == dag.dag_id)
+        tis = tis.filter(TI.task_id.in_(dag.task_ids))
+
+    if include_parentdag and dag.is_subdag:
+
+        p_dag = dag.parent_dag.sub_dag(
+            task_regex=r"^{}$".format(dag.dag_id.split('.')[1]),
+            include_upstream=False,
+            include_downstream=True)
+
+        tis = tis.union(p_dag.clear(
+            start_date=start_date, end_date=end_date,
+            only_failed=only_failed,
+            only_running=only_running,
+            confirm_prompt=confirm_prompt,
+            include_subdags=include_subdags,
+            include_parentdag=False,
+            reset_dag_runs=reset_dag_runs,
+            get_tis=True,
+            session=session,
+            recursion_depth=recursion_depth,
+            max_recursion_depth=max_recursion_depth,
+            dag_bag=dag_bag
+        ))
+
+    if start_date:
+        tis = tis.filter(TI.execution_date >= start_date)
+    if end_date:
+        tis = tis.filter(TI.execution_date <= end_date)
+    if only_failed:
+        tis = tis.filter(or_(
+            TI.state == State.FAILED,
+            TI.state == State.UPSTREAM_FAILED))
+    if only_running:
+        tis = tis.filter(TI.state == State.RUNNING)
+
+    if include_subdags:
+        from airflow.sensors.external_task_sensor import ExternalTaskMarker
+
+        # Recursively find external tasks indicated by ExternalTaskMarker
+        instances = tis.all()
+        for ti in instances:
+            if ti.operator == ExternalTaskMarker.__name__:
+                ti.task = dag.get_task(ti.task_id)
+
+                if recursion_depth == 0:
+                    # Maximum recursion depth allowed is the recursion_depth of the first
+                    # ExternalTaskMarker in the tasks to be cleared.
+                    max_recursion_depth = ti.task.recursion_depth
+
+                if recursion_depth + 1 > max_recursion_depth:
+                    # Prevent cycles or accidents.
+                    raise AirflowException("Maximum recursion depth {} reached for {} {}. "
+                                           "Attempted to clear too many tasks "
+                                           "or there may be a cyclic dependency."
+                                           .format(max_recursion_depth,
+                                                   ExternalTaskMarker.__name__, ti.task_id))
+                ti.render_templates()
+                external_tis = session.query(TI).filter(TI.dag_id == ti.task.external_dag_id,
+                                                        TI.task_id == ti.task.external_task_id,
+                                                        TI.execution_date ==
+                                                        pendulum.parse(ti.task.execution_date))
+
+                for tii in external_tis:
+                    if not dag_bag:
+                        dag_bag = DagBag()
+                    external_dag = dag_bag.get_dag(tii.dag_id)
+                    if not external_dag:
+                        raise AirflowException("Could not find dag {}".format(tii.dag_id))
+                    downstream = external_dag.sub_dag(
+                        task_regex=r"^{}$".format(tii.task_id),
+                        include_upstream=False,
+                        include_downstream=True
+                    )
+                    tis = tis.union(downstream.clear(start_date=tii.execution_date,
+                                                     end_date=tii.execution_date,
+                                                     only_failed=only_failed,
+                                                     only_running=only_running,
+                                                     confirm_prompt=confirm_prompt,
+                                                     include_subdags=include_subdags,
+                                                     include_parentdag=False,
+                                                     reset_dag_runs=reset_dag_runs,
+                                                     get_tis=True,
+                                                     session=session,
+                                                     recursion_depth=recursion_depth + 1,
+                                                     max_recursion_depth=max_recursion_depth,
+                                                     dag_bag=dag_bag))
+
+    if get_tis:
+        return tis
+
+    tis = tis.all()
+
+    if dry_run:
+        session.expunge_all()
+        return tis
+
+    # Do not use count() here, it's actually much slower than just retrieving all the rows when
+    # tis has multiple UNION statements.
+    count = len(tis)
+    do_it = True
+    if count == 0:
+        return 0
+    if confirm_prompt:
+        ti_list = "\n".join([str(t) for t in tis])
+        question = (
+            "You are about to delete these {count} tasks:\n"
+            "{ti_list}\n\n"
+            "Are you sure? (yes/no): ").format(count=count, ti_list=ti_list)
+        do_it = ask_yesno(question)
+
+    if do_it:
+        clear_task_instances(tis,
+                             session,
+                             dag=dag,
+                             )
+        if reset_dag_runs:
+            dag.set_dag_runs_state(session=session,
+                                   start_date=start_date,
+                                   end_date=end_date,
+                                   )
+    else:
+        count = 0
+        print("Bail. Nothing was cleared.")
+
+    session.commit()
+    return count
+
+
+def clear_dags(
+    dags,
+    start_date=None,
+    end_date=None,
+    only_failed=False,
+    only_running=False,
+    confirm_prompt=False,
+    include_subdags=True,
+    include_parentdag=False,
+    reset_dag_runs=True,
+    dry_run=False,
+):
+    """
+    Clears a set of task instances associated with the list of dag for
+    a specified date range.
+
+    For more information look; `clear_dag`
+    """
+    all_tis = []
+    for dag in dags:
+        tis = dag.clear(
+            start_date=start_date,
+            end_date=end_date,
+            only_failed=only_failed,
+            only_running=only_running,
+            confirm_prompt=False,
+            include_subdags=include_subdags,
+            include_parentdag=include_parentdag,
+            reset_dag_runs=reset_dag_runs,
+            dry_run=True)
+        all_tis.extend(tis)
+
+    if dry_run:
+        return all_tis
+
+    count = len(all_tis)
+    do_it = True
+    if count == 0:
+        print("Nothing to clear.")
+        return 0
+    if confirm_prompt:
+        ti_list = "\n".join([str(t) for t in all_tis])
+        question = (
+            "You are about to delete these {} tasks:\n"
+            "{}\n\n"
+            "Are you sure? (yes/no): ").format(count, ti_list)
+        do_it = ask_yesno(question)
+
+    if do_it:
+        for dag in dags:
+            dag.clear(start_date=start_date,
+                      end_date=end_date,
+                      only_failed=only_failed,
+                      only_running=only_running,
+                      confirm_prompt=False,
+                      include_subdags=include_subdags,
+                      reset_dag_runs=reset_dag_runs,
+                      dry_run=False,
+                      )
+    else:
+        count = 0
+        print("Bail. Nothing was cleared.")
+    return count

--- a/airflow/utils/dag_cleaner.py
+++ b/airflow/utils/dag_cleaner.py
@@ -15,9 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from operator import or_
-
 from pendulum import pendulum
+from sqlalchemy import or_
 
 from airflow import AirflowException
 from airflow.models import TaskInstance, clear_task_instances
@@ -104,7 +103,8 @@ def clear(  # pylint: disable=too-many-arguments
             include_upstream=False,
             include_downstream=True)
 
-        tis = tis.union(p_dag.clear(
+        tis = tis.union(clear(
+            p_dag,
             start_date=start_date, end_date=end_date,
             only_failed=only_failed,
             only_running=only_running,

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -39,7 +39,10 @@ from airflow.configuration import conf
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.exceptions import AirflowException
 from airflow.jobs.local_task_job import LocalTaskJob as LJ
-from airflow.models import errors
+from airflow.models import errors, DagModel
+from airflow.models.dag import DagModel
+from airflow.models.dagcode import DagCode
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
 from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.stats import Stats
@@ -772,13 +775,10 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
                 self.log.exception("Error removing old import errors")
 
             if STORE_SERIALIZED_DAGS:
-                from airflow.models.serialized_dag import SerializedDagModel
-                from airflow.models.dag import DagModel
                 SerializedDagModel.remove_deleted_dags(self._file_paths)
                 DagModel.deactivate_deleted_dags(self._file_paths)
 
             if self.store_dag_code:
-                from airflow.models.dagcode import DagCode
                 DagCode.remove_deleted_code(self._file_paths)
 
     def _print_stat(self):

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -39,7 +39,7 @@ from airflow.configuration import conf
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.exceptions import AirflowException
 from airflow.jobs.local_task_job import LocalTaskJob as LJ
-from airflow.models import errors, DagModel
+from airflow.models import errors
 from airflow.models.dag import DagModel
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -26,9 +26,10 @@ from airflow.configuration import conf
 from airflow.jobs.base_job import BaseJob  # noqa: F401 # pylint: disable=unused-import
 # noinspection PyUnresolvedReferences
 from airflow.models import (  # noqa: F401 # pylint: disable=unused-import
-    DAG, XCOM_RETURN_KEY, BaseOperator, BaseOperatorLink, Connection, DagBag, DagModel, DagPickle, DagRun,
-    DagTag, Log, Pool, SkipMixin, SlaMiss, TaskFail, TaskInstance, TaskReschedule, Variable, XCom,
+    DAG, XCOM_RETURN_KEY, BaseOperator, BaseOperatorLink, Connection, DagModel, DagPickle, DagRun, DagTag,
+    Log, Pool, SkipMixin, SlaMiss, TaskFail, TaskInstance, TaskReschedule, Variable, XCom,
 )
+from airflow.models.dagbag import DagBag
 # We need to add this model manually to get reset working well
 # noinspection PyUnresolvedReferences
 from airflow.models.serialized_dag import SerializedDagModel  # noqa: F401  # pylint: disable=unused-import

--- a/airflow/utils/source_utils.py
+++ b/airflow/utils/source_utils.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import functools
+import inspect
+from typing import Any, Optional
+
+
+def get_python_source(x: Any) -> Optional[str]:
+    """
+    Helper function to get Python source (or not), preventing exceptions
+    """
+    if isinstance(x, str):
+        return x
+
+    if x is None:
+        return None
+
+    source_code = None
+
+    if isinstance(x, functools.partial):
+        source_code = inspect.getsource(x.func)
+
+    if source_code is None:
+        try:
+            source_code = inspect.getsource(x)
+        except TypeError:
+            pass
+
+    if source_code is None:
+        try:
+            source_code = inspect.getsource(x.__call__)
+        except (TypeError, AttributeError):
+            pass
+
+    if source_code is None:
+        source_code = 'No source code available for {}'.format(type(x))
+    return source_code

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -16,11 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import functools
-import inspect
 import json
 import time
-from typing import Any, Optional
 from urllib.parse import urlencode
 
 import flask_appbuilder.models.sqla.filters as fab_sqlafilters
@@ -33,9 +30,11 @@ from pygments.formatters import HtmlFormatter
 
 from airflow.configuration import conf
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.dagbag import DagBag
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils import timezone
 from airflow.utils.json import AirflowJsonEncoder
+from airflow.utils.source_utils import get_python_source
 from airflow.utils.state import State
 
 DEFAULT_SENSITIVE_VARIABLE_FIELDS = (
@@ -360,38 +359,6 @@ def get_chart_height(dag):
     return 600 + len(dag.tasks) * 10
 
 
-def get_python_source(x: Any) -> Optional[str]:
-    """
-    Helper function to get Python source (or not), preventing exceptions
-    """
-    if isinstance(x, str):
-        return x
-
-    if x is None:
-        return None
-
-    source_code = None
-
-    if isinstance(x, functools.partial):
-        source_code = inspect.getsource(x.func)
-
-    if source_code is None:
-        try:
-            source_code = inspect.getsource(x)
-        except TypeError:
-            pass
-
-    if source_code is None:
-        try:
-            source_code = inspect.getsource(x.__call__)
-        except (TypeError, AttributeError):
-            pass
-
-    if source_code is None:
-        source_code = 'No source code available for {}'.format(type(x))
-    return source_code
-
-
 class UtcAwareFilterMixin:
     def apply(self, query, value):
         value = timezone.parse(value, timezone=timezone.utc)
@@ -457,3 +424,18 @@ class CustomSQLAInterface(SQLAInterface):
         return False
 
     filter_converter_class = UtcAwareFilterConverter
+
+
+def get_dag(dag, store_serialized_dags=False):
+    """Creates a dagbag to load and return a DAG.
+
+    Calling it from UI should set store_serialized_dags = STORE_SERIALIZED_DAGS.
+    There may be a delay for scheduler to write serialized DAG into database,
+    loads from file in this case.
+    FIXME: remove it when webserver does not access to DAG folder in future.
+    """
+    dag = DagBag(
+        dag_folder=dag.fileloc, store_serialized_dags=store_serialized_dags).get_dag(dag.dag_id)
+    if store_serialized_dags and dag is None:
+        dag = DagBag(dag_folder=dag.fileloc, store_serialized_dags=False).get_dag(dag.dag_id)
+    return dag

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -551,9 +551,8 @@ class Airflow(AirflowBaseView):
     @provide_session
     def dag_details(self, session=None):
         dag_id = request.args.get('dag_id')
-        dag_orm = DagModel.get_dagmodel(dag_id, session=session)
         # FIXME: items needed for this view should move to the database
-        dag = dag_orm.get_dag(STORE_SERIALIZED_DAGS)
+        dag = dagbag.get_dag(dag_id)
         title = "DAG details"
         root = request.args.get('root', '')
 

--- a/scripts/perf/scheduler_ops_metrics.py
+++ b/scripts/perf/scheduler_ops_metrics.py
@@ -24,7 +24,8 @@ import pandas as pd
 from airflow import settings
 from airflow.configuration import conf
 from airflow.jobs.scheduler_job import SchedulerJob
-from airflow.models import DagBag, DagModel, DagRun, TaskInstance
+from airflow.models import DagModel, DagRun, TaskInstance
+from airflow.models.dagbag import DagBag
 from airflow.utils import timezone
 from airflow.utils.state import State
 

--- a/tests/api/client/test_local_client.py
+++ b/tests/api/client/test_local_client.py
@@ -25,7 +25,8 @@ from freezegun import freeze_time
 from airflow.api.client.local_client import Client
 from airflow.example_dags import example_bash_operator
 from airflow.exceptions import AirflowException
-from airflow.models import DAG, DagBag, DagModel, Pool
+from airflow.models import DAG, DagModel, Pool
+from airflow.models.dagbag import DagBag
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State

--- a/tests/api/common/experimental/test_delete_dag.py
+++ b/tests/api/common/experimental/test_delete_dag.py
@@ -21,7 +21,9 @@ import unittest
 from airflow import models
 from airflow.api.common.experimental.delete_dag import delete_dag
 from airflow.exceptions import DagNotFound
+from airflow.models.dagbag import DagBag
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils import dag_cleaner
 from airflow.utils.dates import days_ago
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -38,12 +40,12 @@ IE = models.ImportError
 class TestDeleteDAGCatchError(unittest.TestCase):
 
     def setUp(self):
-        self.dagbag = models.DagBag(include_examples=True)
+        self.dagbag = DagBag(include_examples=True)
         self.dag_id = 'example_bash_operator'
         self.dag = self.dagbag.dags[self.dag_id]
 
     def tearDown(self):
-        self.dag.clear()
+        dag_cleaner.clear(self.dag)
 
     def test_delete_dag_non_existent_dag(self):
         with self.assertRaises(DagNotFound):

--- a/tests/api/common/experimental/test_mark_tasks.py
+++ b/tests/api/common/experimental/test_mark_tasks.py
@@ -28,7 +28,8 @@ from airflow.api.common.experimental.mark_tasks import (
     set_state,
 )
 from airflow.models import DagRun
-from airflow.utils import timezone
+from airflow.models.dagbag import DagBag
+from airflow.utils import dag_cleaner, timezone
 from airflow.utils.dates import days_ago
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
@@ -42,7 +43,7 @@ class TestMarkTasks(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        dagbag = models.DagBag(include_examples=True)
+        dagbag = DagBag(include_examples=True)
         cls.dag1 = dagbag.dags['example_bash_operator']
         cls.dag1.sync_to_db()
         cls.dag2 = dagbag.dags['example_subdag_operator']
@@ -281,7 +282,7 @@ class TestMarkDAGRun(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        dagbag = models.DagBag(include_examples=True)
+        dagbag = DagBag(include_examples=True)
         cls.dag1 = dagbag.dags['example_bash_operator']
         cls.dag1.sync_to_db()
         cls.dag2 = dagbag.dags['example_subdag_operator']
@@ -587,8 +588,8 @@ class TestMarkDAGRun(unittest.TestCase):
         set_dag_run_state_to_failed(self.dag1, date)
 
     def tearDown(self):
-        self.dag1.clear()
-        self.dag2.clear()
+        dag_cleaner.clear(self.dag1)
+        dag_cleaner.clear(self.dag2)
 
         with create_session() as session:
             session.query(models.DagRun).delete()

--- a/tests/api/common/experimental/test_trigger_dag.py
+++ b/tests/api/common/experimental/test_trigger_dag.py
@@ -29,7 +29,7 @@ from airflow.utils import timezone
 class TestTriggerDag(unittest.TestCase):
 
     @mock.patch('airflow.models.DagRun')
-    @mock.patch('airflow.models.DagBag')
+    @mock.patch('airflow.models.dagbag.DagBag')
     def test_trigger_dag_dag_not_found(self, dag_bag_mock, dag_run_mock):
         dag_bag_mock.dags = []
         self.assertRaises(
@@ -45,7 +45,7 @@ class TestTriggerDag(unittest.TestCase):
         )
 
     @mock.patch('airflow.models.DagRun')
-    @mock.patch('airflow.models.DagBag')
+    @mock.patch('airflow.models.dagbag.DagBag')
     def test_trigger_dag_dag_run_exist(self, dag_bag_mock, dag_run_mock):
         dag_id = "dag_run_exist"
         dag = DAG(dag_id)
@@ -66,7 +66,7 @@ class TestTriggerDag(unittest.TestCase):
 
     @mock.patch('airflow.models.DAG')
     @mock.patch('airflow.models.DagRun')
-    @mock.patch('airflow.models.DagBag')
+    @mock.patch('airflow.models.dagbag.DagBag')
     def test_trigger_dag_include_subdags(self, dag_bag_mock, dag_run_mock, dag_mock):
         dag_id = "trigger_dag"
         dag_bag_mock.dags = [dag_id]
@@ -89,7 +89,7 @@ class TestTriggerDag(unittest.TestCase):
 
         self.assertEqual(3, len(triggers))
 
-    @mock.patch('airflow.models.DagBag')
+    @mock.patch('airflow.models.dagbag.DagBag')
     def test_trigger_dag_with_str_conf(self, dag_bag_mock):
         dag_id = "trigger_dag_with_str_conf"
         dag = DAG(dag_id)
@@ -108,7 +108,7 @@ class TestTriggerDag(unittest.TestCase):
 
         self.assertEqual(triggers[0].conf, json.loads(conf))
 
-    @mock.patch('airflow.models.DagBag')
+    @mock.patch('airflow.models.dagbag.DagBag')
     def test_trigger_dag_with_too_early_start_date(self, dag_bag_mock):
         dag_id = "trigger_dag_with_too_early_start_date"
         dag = DAG(dag_id, default_args={'start_date': timezone.datetime(2016, 9, 5, 10, 10, 0)})
@@ -128,7 +128,7 @@ class TestTriggerDag(unittest.TestCase):
             replace_microseconds=True,
         )
 
-    @mock.patch('airflow.models.DagBag')
+    @mock.patch('airflow.models.dagbag.DagBag')
     def test_trigger_dag_with_valid_start_date(self, dag_bag_mock):
         dag_id = "trigger_dag_with_valid_start_date"
         dag = DAG(dag_id, default_args={'start_date': timezone.datetime(2016, 9, 5, 10, 10, 0)})
@@ -148,7 +148,7 @@ class TestTriggerDag(unittest.TestCase):
 
         assert len(triggers) == 1
 
-    @mock.patch('airflow.models.DagBag')
+    @mock.patch('airflow.models.dagbag.DagBag')
     def test_trigger_dag_with_dict_conf(self, dag_bag_mock):
         dag_id = "trigger_dag_with_dict_conf"
         dag = DAG(dag_id)

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -30,7 +30,8 @@ from airflow import settings
 from airflow.cli import cli_parser
 from airflow.cli.commands import dag_command
 from airflow.exceptions import AirflowException
-from airflow.models import DagBag, DagModel, DagRun
+from airflow.models import DagModel, DagRun
+from airflow.models.dagbag import DagBag
 from airflow.settings import Session
 from airflow.utils import timezone
 from airflow.utils.state import State

--- a/tests/cli/commands/test_pool_command.py
+++ b/tests/cli/commands/test_pool_command.py
@@ -35,7 +35,7 @@ class TestCliPools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.dagbag = DagBag(include_examples=True)
-        cls.parser = cli_parser.CLIFactory.get_parser()
+        cls.parser = cli_parser.get_parser()
 
     def setUp(self):
         super().setUp()

--- a/tests/cli/commands/test_pool_command.py
+++ b/tests/cli/commands/test_pool_command.py
@@ -22,10 +22,11 @@ import os
 import unittest
 from contextlib import redirect_stdout
 
-from airflow import models, settings
+from airflow import settings
 from airflow.cli import cli_parser
 from airflow.cli.commands import pool_command
 from airflow.models import Pool
+from airflow.models.dagbag import DagBag
 from airflow.settings import Session
 from airflow.utils.db import add_default_pool_if_not_exists
 
@@ -33,8 +34,8 @@ from airflow.utils.db import add_default_pool_if_not_exists
 class TestCliPools(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
-        cls.parser = cli_parser.get_parser()
+        cls.dagbag = DagBag(include_examples=True)
+        cls.parser = cli_parser.CLIFactory.get_parser()
 
     def setUp(self):
         super().setUp()

--- a/tests/cli/commands/test_role_command.py
+++ b/tests/cli/commands/test_role_command.py
@@ -20,9 +20,9 @@ import io
 import unittest
 from contextlib import redirect_stdout
 
-from airflow import models
 from airflow.cli import cli_parser
 from airflow.cli.commands import role_command
+from airflow.models.dagbag import DagBag
 from airflow.settings import Session
 
 TEST_USER1_EMAIL = 'test-user1@example.com'
@@ -32,7 +32,7 @@ TEST_USER2_EMAIL = 'test-user2@example.com'
 class TestCliRoles(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
+        cls.dagbag = DagBag(include_examples=True)
         cls.parser = cli_parser.get_parser()
 
     def setUp(self):

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -28,9 +28,10 @@ from tabulate import tabulate
 from airflow.cli import cli_parser
 from airflow.cli.commands import task_command
 from airflow.exceptions import AirflowException
-from airflow.models import DagBag, TaskInstance
+from airflow.models import TaskInstance
+from airflow.models.dagbag import DagBag
 from airflow.settings import Session
-from airflow.utils import timezone
+from airflow.utils import dag_cleaner, timezone
 from airflow.utils.cli import get_dag
 from airflow.utils.state import State
 from tests.test_utils.db import clear_db_pools, clear_db_runs
@@ -260,7 +261,7 @@ class TestCliTaskBackfill(unittest.TestCase):
         dag_id = 'test_run_ignores_all_dependencies'
 
         dag = self.dagbag.get_dag('test_run_ignores_all_dependencies')
-        dag.clear()
+        dag_cleaner.clear(dag)
 
         task0_id = 'test_run_dependent_task'
         args0 = ['tasks',

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -22,9 +22,9 @@ import tempfile
 import unittest
 from contextlib import redirect_stdout
 
-from airflow import models
 from airflow.cli import cli_parser
 from airflow.cli.commands import user_command
+from airflow.models.dagbag import DagBag
 from airflow.settings import Session
 
 TEST_USER1_EMAIL = 'test-user1@example.com'
@@ -43,7 +43,7 @@ def _does_user_belong_to_role(appbuilder, email, rolename):
 class TestCliUsers(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
+        cls.dagbag = DagBag(include_examples=True)
         cls.parser = cli_parser.get_parser()
 
     def setUp(self):

--- a/tests/cli/commands/test_variable_command.py
+++ b/tests/cli/commands/test_variable_command.py
@@ -19,16 +19,16 @@
 import os
 import unittest
 
-from airflow import models
 from airflow.cli import cli_parser
 from airflow.cli.commands import variable_command
 from airflow.models import Variable
+from airflow.models.dagbag import DagBag
 
 
 class TestCliVariables(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
+        cls.dagbag = DagBag(include_examples=True)
         cls.parser = cli_parser.get_parser()
 
     def test_variables(self):

--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -28,7 +28,7 @@ from airflow import settings
 from airflow.cli import cli_parser
 from airflow.cli.commands import webserver_command
 from airflow.cli.commands.webserver_command import get_num_ready_workers_running
-from airflow.models import DagBag
+from airflow.models.dagbag import DagBag
 from airflow.utils.cli import setup_locations
 from tests.test_utils.config import conf_vars
 

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 from airflow.configuration import conf
 from airflow.jobs.backfill_job import BackfillJob
-from airflow.models import DagBag
+from airflow.models.dagbag import DagBag
 from airflow.utils import timezone
 
 try:

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -36,10 +36,11 @@ from airflow.exceptions import (
 )
 from airflow.jobs.backfill_job import BackfillJob
 from airflow.jobs.scheduler_job import DagFileProcessor
-from airflow.models import DAG, DagBag, Pool, TaskInstance as TI
+from airflow.models import DAG, Pool, TaskInstance as TI
+from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.utils import timezone
+from airflow.utils import dag_cleaner, timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
@@ -67,7 +68,7 @@ class TestBackfillJob(unittest.TestCase):
                 task_concurrency=task_concurrency,
                 dag=dag)
 
-        dag.clear()
+        dag_cleaner.clear(dag)
         return dag
 
     def _times_called_with(self, method, class_):
@@ -208,7 +209,7 @@ class TestBackfillJob(unittest.TestCase):
                         DEFAULT_DATE + datetime.timedelta(days=1))
         self.assertTrue(drs[1].state == State.SUCCESS)
 
-        dag.clear()
+        dag_cleaner.clear(dag)
         session.close()
 
     @pytest.mark.backend("postgres", "mysql")
@@ -550,7 +551,7 @@ class TestBackfillJob(unittest.TestCase):
                 dag=dag,
             )
 
-        dag.clear()
+        dag_cleaner.clear(dag)
 
         executor = MockExecutor()
 
@@ -589,7 +590,7 @@ class TestBackfillJob(unittest.TestCase):
                 task_id='test_backfill_rerun_failed_task-1',
                 dag=dag)
 
-        dag.clear()
+        dag_cleaner.clear(dag)
 
         executor = MockExecutor()
 
@@ -668,7 +669,7 @@ class TestBackfillJob(unittest.TestCase):
                 task_id='test_backfill_rerun_failed_task-1',
                 dag=dag)
 
-        dag.clear()
+        dag_cleaner.clear(dag)
 
         executor = MockExecutor()
 
@@ -761,7 +762,7 @@ class TestBackfillJob(unittest.TestCase):
         session.close()
 
         dag = self.dagbag.get_dag('test_backfill_pooled_task_dag')
-        dag.clear()
+        dag_cleaner.clear(dag)
 
         executor = MockExecutor(do_update=True)
         job = BackfillJob(
@@ -821,7 +822,7 @@ class TestBackfillJob(unittest.TestCase):
             end_date=end_date,
         )
         dag = self.dagbag.get_dag(dag_id)
-        dag.clear()
+        dag_cleaner.clear(dag)
 
         executor = MockExecutor()
         job = BackfillJob(dag=dag,

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -38,7 +38,8 @@ from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
 from airflow.jobs.backfill_job import BackfillJob
 from airflow.jobs.scheduler_job import DagFileProcessor, SchedulerJob
-from airflow.models import DAG, DagBag, DagModel, Pool, SlaMiss, TaskInstance, errors
+from airflow.models import DAG, DagModel, Pool, SlaMiss, TaskInstance, errors
+from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.operators.bash import BashOperator
@@ -202,8 +203,8 @@ class TestDagFileProcessor(unittest.TestCase):
                 session.merge(ti)
 
             # scheduler._process_dags(simple_dag_bag)
-            @mock.patch('airflow.models.DagBag', return_value=dagbag)
-            @mock.patch('airflow.models.DagBag.collect_dags')
+            @mock.patch('airflow.models.dagbag.DagBag', return_value=dagbag)
+            @mock.patch('airflow.models.dagbag.DagBag.collect_dags')
             @mock.patch('airflow.jobs.scheduler_job.SchedulerJob._change_state_for_tis_without_dagrun')
             def do_schedule(mock_dagbag, mock_collect_dags, mock_change_state):
                 # Use a empty file since the above mock will return the
@@ -2508,8 +2509,8 @@ class TestSchedulerJob(unittest.TestCase):
 
         dagbag.bag_dag(dag=dag, root_dag=dag, parent_dag=dag)
 
-        @mock.patch('airflow.models.DagBag', return_value=dagbag)
-        @mock.patch('airflow.models.DagBag.collect_dags')
+        @mock.patch('airflow.models.dagbag.DagBag', return_value=dagbag)
+        @mock.patch('airflow.models.dagbag.DagBag.collect_dags')
         def do_schedule(mock_dagbag, mock_collect_dags):
             # Use a empty file since the above mock will return the
             # expected DAGs. Also specify only a single file so that it doesn't
@@ -2564,8 +2565,8 @@ class TestSchedulerJob(unittest.TestCase):
 
         dagbag.bag_dag(dag=dag, root_dag=dag, parent_dag=dag)
 
-        @mock.patch('airflow.models.DagBag', return_value=dagbag)
-        @mock.patch('airflow.models.DagBag.collect_dags')
+        @mock.patch('airflow.models.dagbag.DagBag', return_value=dagbag)
+        @mock.patch('airflow.models.dagbag.DagBag.collect_dags')
         def do_schedule(mock_dagbag, mock_collect_dags):
             # Use a empty file since the above mock will return the
             # expected DAGs. Also specify only a single file so that it doesn't

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -44,7 +44,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils import timezone
 from airflow.utils.file import list_py_file_paths
-from airflow.utils.session import create_session
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime as datetime_tz
 from airflow.utils.types import DagRunType
@@ -783,8 +783,8 @@ class TestDag(unittest.TestCase):
         self.assertEqual(orm_dag.default_view, "graph")
         session.close()
 
-    @patch('airflow.models.dag.DagBag')
-    def test_is_paused_subdag(self, mock_dag_bag):
+    @provide_session
+    def test_is_paused_subdag(self, session):
         subdag_id = 'dag.subdag'
         subdag = DAG(
             subdag_id,
@@ -807,33 +807,39 @@ class TestDag(unittest.TestCase):
                 subdag=subdag
             )
 
-        mock_dag_bag.return_value.get_dag.return_value = dag
+        # parent_dag and is_subdag was set by DagBag. We don't use DagBag, so this value is not set.
+        subdag.parent_dag = dag
+        subdag.is_subdag = True
 
-        session = settings.Session()
+        session.query(DagModel).filter(DagModel.dag_id.in_([subdag_id, dag_id])).delete(
+            synchronize_session=False
+        )
+
         dag.sync_to_db(session=session)
 
         unpaused_dags = session.query(
-            DagModel
+            DagModel.dag_id, DagModel.is_paused
         ).filter(
             DagModel.dag_id.in_([subdag_id, dag_id]),
-        ).filter(
-            DagModel.is_paused.is_(False)
-        ).count()
+        ).all()
 
-        self.assertEqual(2, unpaused_dags)
+        self.assertEqual({
+            (subdag_id, False),
+            (dag_id, False),
+        }, set(unpaused_dags))
 
         DagModel.get_dagmodel(dag.dag_id).set_is_paused(is_paused=True)
 
         paused_dags = session.query(
-            DagModel
+            DagModel.dag_id, DagModel.is_paused
         ).filter(
             DagModel.dag_id.in_([subdag_id, dag_id]),
-        ).filter(
-            DagModel.is_paused.is_(True)
-        ).count()
+        ).all()
 
-        self.assertEqual(2, paused_dags)
-        session.close()
+        self.assertEqual({
+            (subdag_id, True),
+            (dag_id, True),
+        }, set(paused_dags))
 
     def test_existing_dag_is_paused_upon_creation(self):
         dag = DAG(

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -27,7 +27,8 @@ from unittest.mock import patch
 
 import airflow.example_dags
 from airflow import models
-from airflow.models import DagBag, DagModel
+from airflow.models import DagModel
+from airflow.models.dagbag import DagBag
 from airflow.utils.session import create_session
 from tests.models import TEST_DAGS_FOLDER
 from tests.test_utils.config import conf_vars
@@ -46,7 +47,7 @@ class TestDagBag(unittest.TestCase):
         """
         Test that we're able to parse some example DAGs and retrieve them
         """
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=True)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=True)
 
         some_expected_dag_ids = ["example_bash_operator",
                                  "example_branch_operator"]
@@ -63,7 +64,7 @@ class TestDagBag(unittest.TestCase):
         """
         test that retrieving a non existing dag id returns None without crashing
         """
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
 
         non_existing_dag_id = "non_existing_dag_id"
         self.assertIsNone(dagbag.get_dag(non_existing_dag_id))
@@ -72,7 +73,7 @@ class TestDagBag(unittest.TestCase):
         """
         test that the example are not loaded
         """
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
 
         self.assertEqual(dagbag.size(), 0)
 
@@ -86,7 +87,7 @@ class TestDagBag(unittest.TestCase):
             f.flush()
 
             with conf_vars({('core', 'dags_folder'): self.empty_dir}):
-                dagbag = models.DagBag(include_examples=False, safe_mode=True)
+                dagbag = DagBag(include_examples=False, safe_mode=True)
 
             self.assertEqual(len(dagbag.dagbag_stats), 1)
             self.assertEqual(
@@ -99,7 +100,7 @@ class TestDagBag(unittest.TestCase):
         """
         with NamedTemporaryFile(dir=self.empty_dir, suffix=".py"):
             with conf_vars({('core', 'dags_folder'): self.empty_dir}):
-                dagbag = models.DagBag(include_examples=False, safe_mode=True)
+                dagbag = DagBag(include_examples=False, safe_mode=True)
             self.assertEqual(len(dagbag.dagbag_stats), 0)
 
     def test_safe_mode_disabled(self):
@@ -107,7 +108,7 @@ class TestDagBag(unittest.TestCase):
         """
         with NamedTemporaryFile(dir=self.empty_dir, suffix=".py") as f:
             with conf_vars({('core', 'dags_folder'): self.empty_dir}):
-                dagbag = models.DagBag(include_examples=False, safe_mode=False)
+                dagbag = DagBag(include_examples=False, safe_mode=False)
             self.assertEqual(len(dagbag.dagbag_stats), 1)
             self.assertEqual(
                 dagbag.dagbag_stats[0].file,
@@ -121,7 +122,7 @@ class TestDagBag(unittest.TestCase):
         f.write('\u3042'.encode())  # write multi-byte char (hiragana)
         f.flush()
 
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
         self.assertEqual([], dagbag.process_file(f.name))
 
     def test_zip_skip_log(self):
@@ -130,10 +131,10 @@ class TestDagBag(unittest.TestCase):
         it doesn't have "airflow" and "DAG"
         """
         from unittest.mock import Mock
-        with patch('airflow.models.DagBag.log') as log_mock:
+        with patch('airflow.models.dagbag.DagBag.log') as log_mock:
             log_mock.info = Mock()
             test_zip_path = os.path.join(TEST_DAGS_FOLDER, "test_zip.zip")
-            dagbag = models.DagBag(dag_folder=test_zip_path, include_examples=False)
+            dagbag = DagBag(dag_folder=test_zip_path, include_examples=False)
 
             self.assertTrue(dagbag.has_logged)
             log_mock.info.assert_any_call("File %s assumed to contain no DAGs. Skipping.",
@@ -143,7 +144,7 @@ class TestDagBag(unittest.TestCase):
         """
         test the loading of a DAG within a zip file that includes dependencies
         """
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
         dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, "test_zip.zip"))
         self.assertTrue(dagbag.get_dag("test_zip_dag"))
 
@@ -153,7 +154,7 @@ class TestDagBag(unittest.TestCase):
         as schedule interval can be identified
         """
         invalid_dag_files = ["test_invalid_cron.py", "test_zip_invalid_cron.zip"]
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
 
         self.assertEqual(len(dagbag.import_errors), 0)
         for file in invalid_dag_files:
@@ -172,7 +173,7 @@ class TestDagBag(unittest.TestCase):
         mock_dagmodel.return_value.last_expired = None
         mock_dagmodel.return_value.fileloc = 'foo'
 
-        class _TestDagBag(models.DagBag):
+        class _TestDagBag(DagBag):
             process_file_calls = 0
 
             def process_file(self, filepath, only_if_updated=True, safe_mode=True):
@@ -193,7 +194,7 @@ class TestDagBag(unittest.TestCase):
         Test that fileloc is correctly set when we load example DAGs,
         specifically SubDAGs and packaged DAGs.
         """
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=True)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=True)
         dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, "test_zip.zip"))
 
         expected = {
@@ -284,7 +285,7 @@ class TestDagBag(unittest.TestCase):
         f.write(source.encode('utf8'))
         f.flush()
 
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
         found_dags = dagbag.process_file(f.name)
         return dagbag, found_dags, f.name
 
@@ -595,7 +596,7 @@ class TestDagBag(unittest.TestCase):
         """
         test that process_file can handle Nones
         """
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+        dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
 
         self.assertEqual([], dagbag.process_file(None))
 

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -20,7 +20,7 @@ import unittest
 from mock import patch
 
 from airflow import AirflowException, example_dags as example_dags_module
-from airflow.models import DagBag
+from airflow.models.dagbag import DagBag
 from airflow.models.dagcode import DagCode
 # To move it to a shared module.
 from airflow.utils.file import open_maybe_zipped

--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -21,7 +21,7 @@
 import unittest
 
 from airflow import example_dags as example_dags_module
-from airflow.models import DagBag
+from airflow.models.dagbag import DagBag
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel as SDM
 from airflow.serialization.serialized_objects import SerializedDAG

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -26,6 +26,7 @@ from parameterized import parameterized
 from airflow import models
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, TaskFail, TaskInstance, XCom
+from airflow.models.dagbag import DagBag
 from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryCheckOperator, BigQueryConsoleIndexableLink, BigQueryConsoleLink,
     BigQueryCreateEmptyDatasetOperator, BigQueryCreateEmptyTableOperator, BigQueryCreateExternalTableOperator,
@@ -300,7 +301,7 @@ class TestBigQueryUpdateDatasetOperator(unittest.TestCase):
 
 class TestBigQueryOperator(unittest.TestCase):
     def setUp(self):
-        self.dagbag = models.DagBag(
+        self.dagbag = DagBag(
             dag_folder='/dev/null', include_examples=True)
         self.args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         self.dag = DAG(TEST_DAG_ID, default_args=self.args)

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -22,8 +22,9 @@ import pytest
 
 from airflow import exceptions, settings
 from airflow.exceptions import AirflowException, AirflowSensorTimeout
-from airflow.models import DagBag, TaskInstance
+from airflow.models import TaskInstance
 from airflow.models.dag import DAG
+from airflow.models.dagbag import DagBag
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.sensors.external_task_sensor import ExternalTaskMarker, ExternalTaskSensor

--- a/tests/sensors/test_timedelta_sensor.py
+++ b/tests/sensors/test_timedelta_sensor.py
@@ -18,8 +18,8 @@
 import unittest
 from datetime import timedelta
 
-from airflow.models import DagBag
 from airflow.models.dag import DAG
+from airflow.models.dagbag import DagBag
 from airflow.sensors.time_delta_sensor import TimeDeltaSensor
 from airflow.utils.timezone import datetime
 

--- a/tests/sensors/test_weekday_sensor.py
+++ b/tests/sensors/test_weekday_sensor.py
@@ -23,8 +23,9 @@ from parameterized import parameterized
 
 from airflow.contrib.utils.weekday import WeekDay
 from airflow.exceptions import AirflowSensorTimeout
-from airflow.models import DagBag, TaskFail, TaskInstance
+from airflow.models import TaskFail, TaskInstance
 from airflow.models.dag import DAG
+from airflow.models.dagbag import DagBag
 from airflow.sensors.weekday_sensor import DayOfWeekSensor
 from airflow.settings import Session
 from airflow.utils.timezone import datetime

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -29,8 +29,9 @@ from dateutil.relativedelta import FR, relativedelta
 from parameterized import parameterized
 
 from airflow.hooks.base_hook import BaseHook
-from airflow.models import DAG, Connection, DagBag, TaskInstance
+from airflow.models import DAG, Connection, TaskInstance
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.dagbag import DagBag
 from airflow.operators.bash import BashOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.serialization.json_schema import load_dag_schema_dict

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -24,9 +24,10 @@ from unittest import mock
 
 import psutil
 
-from airflow import models, settings
+from airflow import settings
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models import TaskInstance as TI
+from airflow.models.dagbag import DagBag
 from airflow.task.task_runner import StandardTaskRunner
 from airflow.utils import timezone
 from airflow.utils.state import State
@@ -132,7 +133,7 @@ class TestStandardTaskRunner(unittest.TestCase):
         except OSError:
             pass
 
-        dagbag = models.DagBag(
+        dagbag = DagBag(
             dag_folder=TEST_DAG_FOLDER,
             include_examples=False,
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,9 +30,10 @@ from airflow import settings
 from airflow.exceptions import AirflowException, AirflowTaskTimeout
 from airflow.hooks.base_hook import BaseHook
 from airflow.jobs.local_task_job import LocalTaskJob
-from airflow.models import DagBag, DagRun, TaskFail, TaskInstance
+from airflow.models import DagRun, TaskFail, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
+from airflow.models.dagbag import DagBag
 from airflow.operators.bash import BashOperator
 from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
 from airflow.operators.dummy_operator import DummyOperator

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -19,7 +19,7 @@ import os
 import unittest
 from glob import glob
 
-from airflow.models import DagBag
+from airflow.models.dagbag import DagBag
 from tests.test_utils.asserts import assert_queries_count
 
 ROOT_FOLDER = os.path.realpath(

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -28,6 +28,7 @@ from copy import deepcopy
 
 from airflow import models
 from airflow.jobs.backfill_job import BackfillJob
+from airflow.models.dagbag import DagBag
 from airflow.utils.db import add_default_pool_if_not_exists
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
@@ -113,7 +114,7 @@ class TestImpersonation(unittest.TestCase):
         check_original_docker_image()
         grant_permissions()
         add_default_pool_if_not_exists()
-        self.dagbag = models.DagBag(
+        self.dagbag = DagBag(
             dag_folder=TEST_DAG_FOLDER,
             include_examples=False,
         )
@@ -190,7 +191,7 @@ class TestImpersonationWithCustomPythonPath(unittest.TestCase):
         check_original_docker_image()
         grant_permissions()
         add_default_pool_if_not_exists()
-        self.dagbag = models.DagBag(
+        self.dagbag = DagBag(
             dag_folder=TEST_DAG_CORRUPTED_FOLDER,
             include_examples=False,
         )

--- a/tests/utils/cycle_tester.py
+++ b/tests/utils/cycle_tester.py
@@ -1,0 +1,158 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import DAG
+from airflow.exceptions import AirflowDagCycleException
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils import cycle_tester
+from tests.models import DEFAULT_DATE
+
+
+class TestCycleTester(unittest.TestCase):
+
+    def test_cycle_empty(self):
+        # test empty
+        dag = DAG(
+            'dag',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        self.assertFalse(cycle_tester.test_cycle(dag))
+
+    def test_cycle_single_task(self):
+        # test single task
+        dag = DAG(
+            'dag',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        with dag:
+            DummyOperator(task_id='A')
+
+        self.assertFalse(cycle_tester.test_cycle(dag))
+
+    def test_cycle_no_cycle(self):
+        # test no cycle
+        dag = DAG(
+            'dag',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        # A -> B -> C
+        #      B -> D
+        # E -> F
+        with dag:
+            op1 = DummyOperator(task_id='A')
+            op2 = DummyOperator(task_id='B')
+            op3 = DummyOperator(task_id='C')
+            op4 = DummyOperator(task_id='D')
+            op5 = DummyOperator(task_id='E')
+            op6 = DummyOperator(task_id='F')
+            op1.set_downstream(op2)
+            op2.set_downstream(op3)
+            op2.set_downstream(op4)
+            op5.set_downstream(op6)
+
+        self.assertFalse(cycle_tester.test_cycle(dag))
+
+    def test_cycle_loop(self):
+        # test self loop
+        dag = DAG(
+            'dag',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        # A -> A
+        with dag:
+            op1 = DummyOperator(task_id='A')
+            op1.set_downstream(op1)
+
+        with self.assertRaises(AirflowDagCycleException):
+            cycle_tester.test_cycle(dag)
+
+    def test_cycle_downstream_loop(self):
+        # test downstream self loop
+        dag = DAG(
+            'dag',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        # A -> B -> C -> D -> E -> E
+        with dag:
+            op1 = DummyOperator(task_id='A')
+            op2 = DummyOperator(task_id='B')
+            op3 = DummyOperator(task_id='C')
+            op4 = DummyOperator(task_id='D')
+            op5 = DummyOperator(task_id='E')
+            op1.set_downstream(op2)
+            op2.set_downstream(op3)
+            op3.set_downstream(op4)
+            op4.set_downstream(op5)
+            op5.set_downstream(op5)
+
+        with self.assertRaises(AirflowDagCycleException):
+            cycle_tester.test_cycle(dag)
+
+    def test_cycle_large_loop(self):
+        # large loop
+        dag = DAG(
+            'dag',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        # A -> B -> C -> D -> E -> A
+        with dag:
+            op1 = DummyOperator(task_id='A')
+            op2 = DummyOperator(task_id='B')
+            op3 = DummyOperator(task_id='C')
+            op4 = DummyOperator(task_id='D')
+            op5 = DummyOperator(task_id='E')
+            op1.set_downstream(op2)
+            op2.set_downstream(op3)
+            op3.set_downstream(op4)
+            op4.set_downstream(op5)
+            op5.set_downstream(op1)
+
+        with self.assertRaises(AirflowDagCycleException):
+            cycle_tester.test_cycle(dag)
+
+    def test_cycle_arbitrary_loop(self):
+        # test arbitrary loop
+        dag = DAG(
+            'dag',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        # E-> A -> B -> F -> A
+        #       -> C -> F
+        with dag:
+            op1 = DummyOperator(task_id='A')
+            op2 = DummyOperator(task_id='B')
+            op3 = DummyOperator(task_id='C')
+            op4 = DummyOperator(task_id='E')
+            op5 = DummyOperator(task_id='F')
+            op1.set_downstream(op2)
+            op1.set_downstream(op3)
+            op4.set_downstream(op1)
+            op3.set_downstream(op5)
+            op2.set_downstream(op5)
+            op5.set_downstream(op1)
+
+        with self.assertRaises(AirflowDagCycleException):
+            cycle_tester.test_cycle(dag)

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -28,7 +28,8 @@ from unittest.mock import MagicMock, PropertyMock
 from airflow.configuration import conf
 from airflow.jobs.local_task_job import LocalTaskJob as LJ
 from airflow.jobs.scheduler_job import DagFileProcessorProcess
-from airflow.models import DagBag, TaskInstance as TI
+from airflow.models import TaskInstance as TI
+from airflow.models.dagbag import DagBag
 from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.utils import timezone
 from airflow.utils.dag_processing import (

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -21,7 +21,8 @@ import unittest
 from parameterized import parameterized_class
 
 from airflow.api.common.experimental.trigger_dag import trigger_dag
-from airflow.models import DagBag, DagRun
+from airflow.models import DagRun
+from airflow.models.dagbag import DagBag
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.settings import Session
 from airflow.www import app as application

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -26,7 +26,8 @@ from parameterized import parameterized_class
 
 from airflow import settings
 from airflow.api.common.experimental.trigger_dag import trigger_dag
-from airflow.models import DagBag, DagRun, Pool, TaskInstance
+from airflow.models import DagRun, Pool, TaskInstance
+from airflow.models.dagbag import DagBag
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.settings import Session
 from airflow.utils.timezone import datetime, parse as parse_datetime, utcnow

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -46,6 +46,7 @@ from airflow.executors.celery_executor import CeleryExecutor
 from airflow.jobs.base_job import BaseJob
 from airflow.models import DAG, Connection, DagRun, TaskInstance
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+from airflow.models.dagbag import DagBag
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.bash import BashOperator
@@ -331,7 +332,7 @@ class TestAirflowBaseViews(TestBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.dagbag = models.DagBag(include_examples=True)
+        cls.dagbag = DagBag(include_examples=True)
         DAG.bulk_sync_to_db(cls.dagbag.dags.values())
 
     def setUp(self):
@@ -610,7 +611,7 @@ class TestAirflowBaseViews(TestBase):
             }
         ):
             from airflow.models.dagcode import DagCode
-            dag = models.DagBag(include_examples=True).get_dag("example_bash_operator")
+            dag = DagBag(include_examples=True).get_dag("example_bash_operator")
             DagCode(dag.fileloc).sync_to_db()
             url = 'code?dag_id=example_bash_operator'
             resp = self.client.get(url)
@@ -624,7 +625,7 @@ class TestAirflowBaseViews(TestBase):
             }
         ):
             from airflow.models.dagcode import DagCode
-            dagbag = models.DagBag(include_examples=True)
+            dagbag = DagBag(include_examples=True)
             for dag in dagbag.dags.values():
                 DagCode(dag.fileloc).sync_to_db()
             url = 'code?dag_id=example_bash_operator'
@@ -1346,11 +1347,11 @@ class TestDagACLView(TestBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        dagbag = models.DagBag(include_examples=True)
+        dagbag = DagBag(include_examples=True)
         DAG.bulk_sync_to_db(dagbag.dags.values())
 
     def prepare_dagruns(self):
-        dagbag = models.DagBag(include_examples=True)
+        dagbag = DagBag(include_examples=True)
         self.bash_dag = dagbag.dags['example_bash_operator']
         self.sub_dag = dagbag.dags['example_subdag_operator']
 
@@ -2108,7 +2109,7 @@ class TestTriggerDag(TestBase):
     def setUp(self):
         super().setUp()
         self.session = Session()
-        models.DagBag().get_dag("example_bash_operator").sync_to_db(session=self.session)
+        DagBag().get_dag("example_bash_operator").sync_to_db(session=self.session)
 
     def test_trigger_dag_button_normal_exist(self):
         resp = self.client.get('/', follow_redirects=True)
@@ -2391,7 +2392,7 @@ class TestDagRunModelView(TestBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        models.DagBag().get_dag("example_bash_operator").sync_to_db(session=cls.session)
+        DagBag().get_dag("example_bash_operator").sync_to_db(session=cls.session)
         cls.clear_table(models.DagRun)
 
     def tearDown(self):
@@ -2454,7 +2455,7 @@ class TestDecorators(TestBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        dagbag = models.DagBag(include_examples=True)
+        dagbag = DagBag(include_examples=True)
         DAG.bulk_sync_to_db(dagbag.dags.values())
 
     def setUp(self):
@@ -2465,7 +2466,7 @@ class TestDecorators(TestBase):
         self.prepare_dagruns()
 
     def prepare_dagruns(self):
-        dagbag = models.DagBag(include_examples=True)
+        dagbag = DagBag(include_examples=True)
         self.bash_dag = dagbag.dags['example_bash_operator']
         self.sub_dag = dagbag.dags['example_subdag_operator']
         self.xcom_dag = dagbag.dags['example_xcom']


### PR DESCRIPTION
DAG objects is created by DagBag object. DAG object creates a DAGBag instance to load DAGs objects.

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
