### PR TITLE
Make get_user_roles staticmethod

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -224,7 +224,8 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             raise AirflowException("Role named '{}' does not exist".format(
                 role_name))
 
-    def get_user_roles(self, user=None):
+    @staticmethod
+    def get_user_roles(user=None):
         """
         Get all the roles associated with the user.
 


### PR DESCRIPTION
Make get_user_roles staticmethod


Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
