### PR TITLE
Fix typo in GCP credentials_provider's docstring

### DIFF
--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -180,8 +180,8 @@ def get_credentials_and_project_id(
 
     :param key_path: Path to GCP Credential JSON file
     :type key_path: str
-    :param key_dict: A dict representing GCP Credential as in the Credential JSON file
-    :type key_dict: Dict[str, str]
+    :param keyfile_dict: A dict representing GCP Credential as in the Credential JSON file
+    :type keyfile_dict: Dict[str, str]
     :param scopes:  OAuth scopes for the connection
     :type scopes: Sequence[str]
     :param delegate_to: The account to impersonate, if any.


### PR DESCRIPTION
Change to`keyfile_dict` from incorrect `key_dict`


Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
