### PR TITLE
Change from Instance attribute to variable in JdbcOperator.execute

### DIFF
--- a/airflow/providers/jdbc/operators/jdbc.py
+++ b/airflow/providers/jdbc/operators/jdbc.py
@@ -60,5 +60,5 @@ class JdbcOperator(BaseOperator):
 
     def execute(self, context):
         self.log.info('Executing: %s', self.sql)
-        self.hook = JdbcHook(jdbc_conn_id=self.jdbc_conn_id)
-        self.hook.run(self.sql, self.autocommit, parameters=self.parameters)
+        hook = JdbcHook(jdbc_conn_id=self.jdbc_conn_id)
+        hook.run(self.sql, self.autocommit, parameters=self.parameters)


### PR DESCRIPTION
Change from Instance attribute to variable in JdbcOperator.execute

The attribute does not need to be an instance attribute

---

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
