### PR TITLE
[AIRFLOW-7105] Unify Secrets Backend method interfaces

### DIFF
--- a/airflow/secrets/__init__.py
+++ b/airflow/secrets/__init__.py
@@ -25,13 +25,13 @@ Secrets framework provides means of getting connection objects from various sour
 __all__ = ['BaseSecretsBackend', 'get_connections']
 
 import json
-from abc import ABC, abstractmethod
 from json import JSONDecodeError
 from typing import List
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
+from airflow.secrets.base_secrets import BaseSecretsBackend
 from airflow.utils.module_loading import import_string
 
 CONFIG_SECTION = "secrets"
@@ -39,24 +39,6 @@ DEFAULT_SECRETS_SEARCH_PATH = [
     "airflow.secrets.environment_variables.EnvironmentVariablesSecretsBackend",
     "airflow.secrets.metastore.MetastoreSecretsBackend",
 ]
-
-
-class BaseSecretsBackend(ABC):
-    """
-    Abstract base class to retrieve secrets given a conn_id and construct a Connection object
-    """
-
-    def __init__(self, **kwargs):
-        pass
-
-    @abstractmethod
-    def get_connections(self, conn_id) -> List[Connection]:
-        """
-        Return list of connection objects matching a given ``conn_id``.
-
-        :param conn_id: connection id to search for
-        :return:
-        """
 
 
 def get_connections(conn_id: str) -> List[Connection]:

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC
+from typing import List, Optional
+
+from airflow.models import Connection
+
+
+class BaseSecretsBackend(ABC):
+    """
+    Abstract base class to retrieve secrets given a conn_id and construct a Connection object
+    """
+
+    def __init__(self, **kwargs):
+        pass
+
+    @staticmethod
+    def build_path(connections_prefix: str, conn_id: str) -> str:
+        """
+        Given conn_id, build path for Secrets Backend
+
+        :param connections_prefix: prefix of the secret to read to get Connections
+        :type connections_prefix: str
+        :param conn_id: connection id
+        :type conn_id: str
+        """
+        return f"{connections_prefix}/{conn_id}"
+
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+        """
+        Get conn_uri from Secrets Backend
+
+        :param conn_id: connection id
+        :type conn_id: str
+        """
+        raise NotImplementedError()
+
+    def get_connections(self, conn_id: str) -> List[Connection]:
+        """
+        Return connection object with a given ``conn_id``.
+
+        :param conn_id: connection id
+        :type conn_id: str
+        """
+        conn_uri = self.get_conn_uri(conn_id=conn_id)
+        if not conn_uri:
+            return []
+        conn = Connection(conn_id=conn_id, uri=conn_uri)
+        return [conn]

--- a/airflow/secrets/environment_variables.py
+++ b/airflow/secrets/environment_variables.py
@@ -20,9 +20,8 @@ Objects relating to sourcing connections from environment variables
 """
 
 import os
-from typing import List
+from typing import Optional
 
-from airflow.models import Connection
 from airflow.secrets import BaseSecretsBackend
 
 CONN_ENV_PREFIX = "AIRFLOW_CONN_"
@@ -34,10 +33,6 @@ class EnvironmentVariablesSecretsBackend(BaseSecretsBackend):
     """
 
     # pylint: disable=missing-docstring
-    def get_connections(self, conn_id) -> List[Connection]:
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
         environment_uri = os.environ.get(CONN_ENV_PREFIX + conn_id.upper())
-        if environment_uri:
-            conn = Connection(conn_id=conn_id, uri=environment_uri)
-            return [conn]
-        else:
-            return []
+        return environment_uri

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -189,7 +189,7 @@ A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend
 
 There are two options:
 
-* Option 1: a base implmentation of the ``.get_connections`` is provided, you just need to implement the
+* Option 1: a base implmentation of the :py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` is provided, you just need to implement the
   :py:meth:`~airflow.secrets.BaseSecretsBackend.get_conn_uri` method to make it functional.
 * Option 2: simply override the :py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` method.
 

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -187,6 +187,12 @@ Roll your own secrets backend
 A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend`, and just has to implement the
 :py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` method.
 
+There are two options:
+
+* Option 1: a base implmentation of the ``.get_connections`` is provided, you just need to implement the
+  :py:meth:`~airflow.secrets.BaseSecretsBackend.get_conn_uri` method to make it functional.
+* Option 2: simply override the :py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` method.
+
 Just create your class, and put the fully qualified class name in ``backend`` key in the ``[secrets]``
 section of ``airflow.cfg``.  You can you can also pass kwargs to ``__init__`` by supplying json to the
 ``backend_kwargs`` config param.  See :ref:`Configuration <secrets_backend_configuration>` for more details,

--- a/tests/providers/google/cloud/secrets/test_secrets_manager.py
+++ b/tests/providers/google/cloud/secrets/test_secrets_manager.py
@@ -33,7 +33,7 @@ CONN_URI = 'postgresql://airflow:airflow@host:5432/airflow'
 MODULE_NAME = "airflow.providers.google.cloud.secrets.secrets_manager"
 
 
-class TestGcpSecretsManagerBackend(TestCase):
+class TestCloudSecretsManagerBackend(TestCase):
     @parameterized.expand([
         "airflow/connections",
         "connections",


### PR DESCRIPTION
Unify Secrets Backend method interfaces

- Move `BaseSecretsBackend` into a separate file `base_secrets.py`
- Move `get_connections` & `build_path` methods to BaseSecretsBackend to avoid code duplicate
- Standardize ways to implement secrets backend
  - option 1: override `get_connections` method
  - option 2: implement `get_conn_uri` method

---
Issue link: [AIRFLOW-7105](https://issues.apache.org/jira/browse/AIRFLOW-7105)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
