### PR TITLE
Remove super().__init__() call in backported hooks

### DIFF
--- a/backport_packages/setup_backport_packages.py
+++ b/backport_packages/setup_backport_packages.py
@@ -144,7 +144,6 @@ def change_import_paths_to_deprecated():
     from bowler import LN, TOKEN, Capture, Filename, Query
     from fissix.pytree import Leaf
 
-
     def remove_tags_modifier(node: LN, capture: Capture, filename: Filename) -> None:
         for node in capture['function_arguments'][0].post_order():
             if isinstance(node, Leaf) and node.value == "tags" and node.type == TOKEN.NAME:
@@ -158,8 +157,9 @@ def change_import_paths_to_deprecated():
 
     def remove_super_init_call(node: LN, capture: Capture, filename: Filename) -> None:
         for ch in node.post_order():
-            if hasattr(ch, "value") and ch.value == "super":
-                ch.parent.remove()
+            if isinstance(ch, Leaf) and ch.value == "super":
+                if any(c.value for c in ch.parent.post_order() if isinstance(c, Leaf)):
+                    ch.parent.remove()
 
     changes = [
         ("airflow.operators.bash", "airflow.operators.bash_operator"),


### PR DESCRIPTION
---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
