### PR TITLE
BugFix: Show task_id in the Graph View tooltip

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -33,7 +33,7 @@ function update_nodes_states(task_instances) {
         const task = tasks[task_id];
         let tt = "";
         if(ti.task_id != undefined) {
-          tt +=  "Task_id: " + escapeHtml(task.task_id) + "<br>";
+          tt +=  "Task_id: " + escapeHtml(ti.task_id) + "<br>";
         }
         tt += "Run: " + converAndFormatUTC(task.execution_date) + "<br>";
         if(ti.run_id != undefined) {


### PR DESCRIPTION
I am not sure how to add a test for this as the Tooltip is generated using jQuery

**Before**:
![image](https://user-images.githubusercontent.com/8811558/77487854-755e8800-6e2b-11ea-9a8a-0d96d5537705.png)



**After**:
![image](https://user-images.githubusercontent.com/8811558/77487826-64ae1200-6e2b-11ea-916c-6cef18ecb23e.png)


Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
