### PR TITLE
[AIRFLOW-7108] Fix CloudSecretsManagerBackend invalid connections_prefix

### DIFF
--- a/airflow/providers/google/cloud/secrets/secrets_manager.py
+++ b/airflow/providers/google/cloud/secrets/secrets_manager.py
@@ -18,6 +18,7 @@
 """
 Objects relating to sourcing connections from GCP Secrets Manager
 """
+import re
 from typing import Optional
 
 from cached_property import cached_property
@@ -26,11 +27,14 @@ from google.api_core.gapic_v1.client_info import ClientInfo
 from google.cloud.secretmanager_v1 import SecretManagerServiceClient
 
 from airflow import version
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.utils.credentials_provider import (
     _get_scopes, get_credentials_and_project_id,
 )
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
 
 
 class CloudSecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
@@ -43,10 +47,11 @@ class CloudSecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         [secrets]
         backend = airflow.providers.google.cloud.secrets.secrets_manager.CloudSecretsManagerBackend
-        backend_kwargs = {"connections_prefix": "airflow/connections"}
+        backend_kwargs = {"connections_prefix": "airflow-connections", "sep": "-"}
 
-    For example, if secret id is ``airflow/connections/smtp_default``, this would be accessible
-    if you provide ``{"connections_prefix": "airflow/connections"}`` and request conn_id ``smtp_default``.
+    For example, if the Secrets Manager secret id is ``airflow-connections-smtp_default``, this would be
+    accessiblen if you provide ``{"connections_prefix": "airflow-connections", "sep": "-"}`` and request
+    conn_id ``smtp_default``. The full secret id should follow the pattern "[a-zA-Z0-9-_]".
 
     :param connections_prefix: Specifies the prefix of the secret to read to get Connections.
     :type connections_prefix: str
@@ -55,20 +60,32 @@ class CloudSecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     :type gcp_key_path: str
     :param gcp_scopes: Comma-separated string containing GCP scopes
     :type gcp_scopes: str
+    :param sep: separator used to concatenate connections_prefix and conn_id. Default: "-"
+    :type sep: str
     """
     def __init__(
         self,
-        connections_prefix: str = "airflow/connections",
+        connections_prefix: str = "airflow-connections",
         gcp_key_path: Optional[str] = None,
         gcp_scopes: Optional[str] = None,
+        sep: str = "-",
         **kwargs
     ):
-        self.connections_prefix = connections_prefix.rstrip("/")
+        super().__init__(**kwargs)
+        self.connections_prefix = connections_prefix
         self.gcp_key_path = gcp_key_path
         self.gcp_scopes = gcp_scopes
+        self.sep = sep
         self.credentials: Optional[str] = None
         self.project_id: Optional[str] = None
-        super().__init__(**kwargs)
+        if not self._is_valid_prefix_and_sep():
+            raise AirflowException(
+                f"`connections_prefix` and `sep` should follows that pattern {SECRET_ID_PATTERN}"
+            )
+
+    def _is_valid_prefix_and_sep(self) -> bool:
+        prefix = self.connections_prefix + self.sep
+        return bool(re.match(SECRET_ID_PATTERN, prefix))
 
     @cached_property
     def client(self) -> SecretManagerServiceClient:
@@ -93,7 +110,11 @@ class CloudSecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: connection id
         :type conn_id: str
         """
-        secret_id = self.build_path(connections_prefix=self.connections_prefix, conn_id=conn_id)
+        secret_id = self.build_path(
+            connections_prefix=self.connections_prefix,
+            conn_id=conn_id,
+            sep=self.sep
+        )
         # always return the latest version of the secret
         secret_version = "latest"
         name = self.client.secret_version_path(self.project_id, secret_id, secret_version)

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -30,7 +30,7 @@ class BaseSecretsBackend(ABC):
         pass
 
     @staticmethod
-    def build_path(connections_prefix: str, conn_id: str) -> str:
+    def build_path(connections_prefix: str, conn_id: str, sep: str = "/") -> str:
         """
         Given conn_id, build path for Secrets Backend
 
@@ -38,8 +38,10 @@ class BaseSecretsBackend(ABC):
         :type connections_prefix: str
         :param conn_id: connection id
         :type conn_id: str
+        :param sep: separator used to concatenate connections_prefix and conn_id. Default: "/"
+        :type sep: str
         """
-        return f"{connections_prefix}/{conn_id}"
+        return f"{connections_prefix}{sep}{conn_id}"
 
     def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -155,6 +155,9 @@ Available parameters to ``backend_kwargs``:
 * ``connections_prefix``: Specifies the prefix of the secret to read to get Connections.
 * ``gcp_key_path``: Path to GCP Credential JSON file
 * ``gcp_scopes``: Comma-separated string containing GCP scopes
+* ``sep``: separator used to concatenate connections_prefix and conn_id. Default: "-"
+
+Note: The full GCP Secrets Manager secret id should follow the pattern "[a-zA-Z0-9-_]".
 
 Here is a sample configuration:
 
@@ -162,7 +165,7 @@ Here is a sample configuration:
 
     [secrets]
     backend = airflow.providers.google.cloud.secrets.secrets_manager.CloudSecretsManagerBackend
-    backend_kwargs = {"connections_prefix": "airflow/connections"}
+    backend_kwargs = {"connections_prefix": "airflow-connections", "sep": "-"}
 
 When ``gcp_key_path`` is not provided, it will use the Application Default Credentials in the current environment. You can set up the credentials with:
 

--- a/tests/secrets/test_secrets_backends.py
+++ b/tests/secrets/test_secrets_backends.py
@@ -19,7 +19,10 @@
 import os
 import unittest
 
+from parameterized import parameterized
+
 from airflow.models import Connection
+from airflow.secrets.base_secrets import BaseSecretsBackend
 from airflow.secrets.environment_variables import EnvironmentVariablesBackend
 from airflow.secrets.metastore import MetastoreBackend
 from airflow.utils.session import create_session
@@ -37,6 +40,15 @@ class SampleConn:
 
 
 class TestBaseSecretsBackend(unittest.TestCase):
+
+    @parameterized.expand([
+        ('default', {"connections_prefix": "PREFIX", "conn_id": "ID"}, "PREFIX/ID"),
+        ('with_sep', {"connections_prefix": "PREFIX", "conn_id": "ID", "sep": "-"}, "PREFIX-ID")
+    ])
+    def test_build_path(self, _, kwargs, output):
+        build_path = BaseSecretsBackend.build_path
+        self.assertEqual(build_path(**kwargs), output)
+
     def test_env_secrets_backend(self):
         sample_conn_1 = SampleConn("sample_1", "A")
         env_secrets_backend = EnvironmentVariablesBackend()


### PR DESCRIPTION
GCP Secrets Manager only accepts [a-zA-Z0-9-_]* as its valid secret id key. This PR fixes the implementation and adds checks in the constructor.

Screenshot at GCP Console
![image](https://user-images.githubusercontent.com/27927454/77582587-da05fb00-6e9c-11ea-9486-45780ec13466.png)



---
Issue link: [AIRFLOW-7108](https://issues.apache.org/jira/browse/AIRFLOW-7108)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
