### PR TITLE
GCP SparkR operator

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -24,7 +24,7 @@ from airflow.providers.google.cloud.operators.dataproc import (
     DataprocInstantiateInlineWorkflowTemplateOperator, DataprocInstantiateWorkflowTemplateOperator,
     DataprocJobBaseOperator, DataprocScaleClusterOperator, DataprocSubmitHadoopJobOperator,
     DataprocSubmitHiveJobOperator, DataprocSubmitPigJobOperator, DataprocSubmitPySparkJobOperator,
-    DataprocSubmitSparkJobOperator, DataprocSubmitSparkRJobOperator, DataprocSubmitSparkSqlJobOperator,
+    DataprocSubmitSparkJobOperator, DataprocSubmitSparkSqlJobOperator,
 )
 
 warnings.warn(
@@ -152,22 +152,6 @@ class DataProcPySparkOperator(DataprocSubmitPySparkJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitPySparkJobOperator`.""",
-            DeprecationWarning, stacklevel=2
-        )
-        super().__init__(*args, **kwargs)
-
-
-class DataProcSparkROperator(DataprocSubmitSparkRJobOperator):
-    """
-        This class is deprecated.
-        Please use `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitSparkRJobOperator`.
-        """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            """This class is deprecated.
-            Please use
-            `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitSparkRJobOperator`.""",
             DeprecationWarning, stacklevel=2
         )
         super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -156,6 +156,7 @@ class DataProcPySparkOperator(DataprocSubmitPySparkJobOperator):
         )
         super().__init__(*args, **kwargs)
 
+
 class DataProcSparkROperator(DataprocSubmitSparkRJobOperator):
     """
         This class is deprecated.

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -24,7 +24,7 @@ from airflow.providers.google.cloud.operators.dataproc import (
     DataprocInstantiateInlineWorkflowTemplateOperator, DataprocInstantiateWorkflowTemplateOperator,
     DataprocJobBaseOperator, DataprocScaleClusterOperator, DataprocSubmitHadoopJobOperator,
     DataprocSubmitHiveJobOperator, DataprocSubmitPigJobOperator, DataprocSubmitPySparkJobOperator,
-    DataprocSubmitSparkJobOperator, DataprocSubmitSparkSqlJobOperator, DataprocSubmitSparkRJobOperator
+    DataprocSubmitSparkJobOperator, DataprocSubmitSparkRJobOperator, DataprocSubmitSparkSqlJobOperator,
 )
 
 warnings.warn(

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -24,7 +24,7 @@ from airflow.providers.google.cloud.operators.dataproc import (
     DataprocInstantiateInlineWorkflowTemplateOperator, DataprocInstantiateWorkflowTemplateOperator,
     DataprocJobBaseOperator, DataprocScaleClusterOperator, DataprocSubmitHadoopJobOperator,
     DataprocSubmitHiveJobOperator, DataprocSubmitPigJobOperator, DataprocSubmitPySparkJobOperator,
-    DataprocSubmitSparkJobOperator, DataprocSubmitSparkSqlJobOperator,
+    DataprocSubmitSparkJobOperator, DataprocSubmitSparkSqlJobOperator, DataprocSubmitSparkRJobOperator
 )
 
 warnings.warn(
@@ -152,6 +152,21 @@ class DataProcPySparkOperator(DataprocSubmitPySparkJobOperator):
             """This class is deprecated.
             Please use
             `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitPySparkJobOperator`.""",
+            DeprecationWarning, stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+class DataProcSparkROperator(DataprocSubmitSparkRJobOperator):
+    """
+        This class is deprecated.
+        Please use `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitSparkRJobOperator`.
+        """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use
+            `airflow.providers.google.cloud.operators.dataproc.DataprocSubmitSparkRJobOperator`.""",
             DeprecationWarning, stacklevel=2
         )
         super().__init__(*args, **kwargs)

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -37,7 +37,7 @@ BUCKET = os.environ.get("GCP_DATAPROC_BUCKET", "dataproc-system-tests")
 OUTPUT_FOLDER = "wordcount"
 OUTPUT_PATH = "gs://{}/{}/".format(BUCKET, OUTPUT_FOLDER)
 PYSPARK_MAIN = os.environ.get("PYSPARK_MAIN", "hello_world.py")
-SPARKR_MAIN = os.environ.get("PYSPARK_MAIN", "hello_world.py")
+SPARKR_MAIN = os.environ.get("SPARKR_MAIN", "hello_world.R")
 PYSPARK_URI = "gs://{}/{}".format(BUCKET, PYSPARK_MAIN)
 SPARKR_URI = "gs://{}/{}".format(BUCKET, SPARKR_MAIN)
 

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -37,8 +37,9 @@ BUCKET = os.environ.get("GCP_DATAPROC_BUCKET", "dataproc-system-tests")
 OUTPUT_FOLDER = "wordcount"
 OUTPUT_PATH = "gs://{}/{}/".format(BUCKET, OUTPUT_FOLDER)
 PYSPARK_MAIN = os.environ.get("PYSPARK_MAIN", "hello_world.py")
+SPARKR_MAIN = os.environ.get("PYSPARK_MAIN", "hello_world.py")
 PYSPARK_URI = "gs://{}/{}".format(BUCKET, PYSPARK_MAIN)
-
+SPARKR_URI = "gs://{}/{}".format(BUCKET, SPARKR_MAIN)
 
 # Cluster definition
 CLUSTER = {
@@ -104,6 +105,12 @@ PYSPARK_JOB = {
     "pyspark_job": {"main_python_file_uri": PYSPARK_URI},
 }
 
+SPARKR_JOB = {
+    "reference": {"project_id": PROJECT_ID},
+    "placement": {"cluster_name": CLUSTER_NAME},
+    "sparkr_job": {"main_r_file_uri": SPARKR_URI},
+}
+
 HIVE_JOB = {
     "reference": {"project_id": PROJECT_ID},
     "placement": {"cluster_name": CLUSTER_NAME},
@@ -155,6 +162,10 @@ with models.DAG(
 
     pyspark_task = DataprocSubmitJobOperator(
         task_id="pyspark_task", job=PYSPARK_JOB, location=REGION, project_id=PROJECT_ID
+    )
+
+    sparkr_task = DataprocSubmitJobOperator(
+        task_id="sparkr_task", job=SPARKR_JOB, location=REGION, project_id=PROJECT_ID
     )
 
     hive_task = DataprocSubmitJobOperator(

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -158,6 +158,16 @@ class DataProcJobBuilder:
         if pyfiles is not None:
             self.job["job"][self.job_type]["python_file_uris"] = pyfiles
 
+    def add_r_file_uris(self, rfiles: List[str]) -> None:
+        """
+        Set python file uris for Dataproc job.
+
+        :param rfiles: List of python files URIs
+        :type rfiles: List[str]
+        """
+        if rfiles is not None:
+            self.job["job"][self.job_type]["r_file_uris"] = rfiles
+
     def set_main(self, main_jar: Optional[str], main_class: Optional[str]) -> None:
         """
         Set Dataproc main class.
@@ -183,6 +193,15 @@ class DataProcJobBuilder:
         :type main: str
         """
         self.job["job"][self.job_type]["main_python_file_uri"] = main
+
+    def set_r_main(self, main: str) -> None:
+        """
+        Set Dataproc main R file uri.
+
+        :param main: URI for the R main file.
+        :type main: str
+        """
+        self.job["job"][self.job_type]["main_r_file_uri"] = main
 
     def set_job_name(self, name: str) -> None:
         """

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -1405,7 +1405,7 @@ class DataprocSubmitSparkRJobOperator(DataprocJobBaseOperator):
         ).upload(
             bucket_name=bucket,
             object_name=temp_filename,
-            mime_type='application/x-python',
+            mime_type='application/x-r',
             filename=local_file
         )
         return "gs://{}/{}".format(bucket, temp_filename)


### PR DESCRIPTION
This PR adds a spark_R operator which will allow you to schedule R, and sparkR jobs on a dataproc cluster. The functionality to run that kind of job is already in dataproc, but for some reason there is no operator in Airflow.

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
