### PR TITLE
[AIRFLOW-5801] Get GCP credentials from file instead of JSON blob

### DIFF
--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -520,12 +520,12 @@ class CloudSqlProxyRunner(LoggingMixin):
         connection = session.query(Connection). \
             filter(Connection.conn_id == self.gcp_conn_id).first()
         session.expunge_all()
-        if GCP_CREDENTIALS_KEY_PATH in connection.extra_dejson:
+        if connection.extra_dejson.get(GCP_CREDENTIALS_KEY_PATH):
             credential_params = [
                 '-credential_file',
                 connection.extra_dejson[GCP_CREDENTIALS_KEY_PATH]
             ]
-        elif GCP_CREDENTIALS_KEYFILE_DICT in connection.extra_dejson:
+        elif connection.extra_dejson.get(GCP_CREDENTIALS_KEYFILE_DICT):
             credential_file_content = json.loads(
                 connection.extra_dejson[GCP_CREDENTIALS_KEYFILE_DICT])
             self.log.info("Saving credentials to %s", self.credentials_path)

--- a/tests/providers/google/cloud/hooks/test_cloud_sql.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_sql.py
@@ -1143,7 +1143,7 @@ class TestCloudsqlDatabaseHook(unittest.TestCase):
 
 class TestCloudSqlDatabaseHook(unittest.TestCase):
 
-    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSQLDatabaseHook.get_connection')
+    @mock.patch('airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection')
     def setUp(self, m):
         super().setUp()
 


### PR DESCRIPTION
---
This PR fixes 'CloudSqlProxyRunner always assumes GCP credentials are passed via file instead of JSON blob'
https://issues.apache.org/jira/browse/AIRFLOW-5801

Issue link: [AIRFLOW-5801](https://issues.apache.org/jira/browse/AIRFLOW-5801)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
