### PR TITLE
Fix static check failure: end-of-file-fixer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -81,4 +81,3 @@ Any relevant logs to include? Put them here in side a detail tag:
 <details><summary>x.log</summary> lots of stuff </details>
 
 -->
-


### PR DESCRIPTION
https://github.com/apache/airflow/pull/7789 introduced this bug by adding a new line at the end of the file

```
Fix End of Files..................................................................................................................Failed
- hook id: end-of-file-fixer
- duration: 0.23s
- exit code: 1
- files were modified by this hook
Fixing .github/ISSUE_TEMPLATE/bug_report.md
```

Travis Link: https://travis-ci.org/github/apache/airflow/jobs/666843713#L1852-L1858

---

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
