### PR TITLE
[AIRFLOW-5825] SageMakerEndpointOperator is not idempotent

### DIFF
--- a/tests/providers/amazon/aws/operators/test_sagemaker_endpoint.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_endpoint.py
@@ -19,6 +19,7 @@
 import unittest
 
 import mock
+from botocore.exceptions import ClientError
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
@@ -111,6 +112,22 @@ class TestSageMakerEndpointOperator(unittest.TestCase):
                                       'ResponseMetadata':
                                       {'HTTPStatusCode': 404}}
         self.assertRaises(AirflowException, self.sagemaker.execute, None)
+
+    @mock.patch.object(SageMakerHook, 'get_conn')
+    @mock.patch.object(SageMakerHook, 'create_model')
+    @mock.patch.object(SageMakerHook, 'create_endpoint_config')
+    @mock.patch.object(SageMakerHook, 'create_endpoint')
+    @mock.patch.object(SageMakerHook, 'update_endpoint')
+    def test_execute_with_duplicate_endpoint_creation(self, mock_endpoint_update,
+                                                      mock_endpoint, mock_endpoint_config,
+                                                      mock_model, mock_client):
+        response = {"Error": {"Code": "ValidationException",
+                    "Message": "Cannot create already existing endpoint."}}
+        mock_endpoint.side_effect = ClientError(error_response=response, operation_name="CreateEndpoint")
+        mock_endpoint_update.return_value = {'EndpointArn': 'testarn',
+                                             'ResponseMetadata':
+                                             {'HTTPStatusCode': 200}}
+        self.sagemaker.execute(None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
	- Added try except statement to check for duplicate endpoint while executing a create_endpoint request  which if found the request changes to update_endpoint
	- Added test case to test mock the duplicate endpoint creation

---
Issue link: [AIRFLOW-5825](https://issues.apache.org/jira/browse/AIRFLOW-5825)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
