### PR TITLE
Don't use DagBag in set_is_paused method

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -39,7 +39,7 @@ from sqlalchemy.orm.session import Session
 from airflow import settings, utils
 from airflow.configuration import conf
 from airflow.dag.base_dag import BaseDag
-from airflow.exceptions import AirflowException, DuplicateTaskIdFound, TaskNotFound,
+from airflow.exceptions import AirflowException, DuplicateTaskIdFound, TaskNotFound
 from airflow.models.base import ID_LEN, Base
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -39,7 +39,7 @@ from sqlalchemy.orm.session import Session
 from airflow import settings, utils
 from airflow.configuration import conf
 from airflow.dag.base_dag import BaseDag
-from airflow.exceptions import AirflowException, DagNotFound, DuplicateTaskIdFound, TaskNotFound
+from airflow.exceptions import AirflowException, DuplicateTaskIdFound, TaskNotFound,
 from airflow.models.base import ID_LEN, Base
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag
@@ -1801,31 +1801,27 @@ class DagModel(Base):
     def set_is_paused(self,
                       is_paused: bool,
                       including_subdags: bool = True,
-                      store_serialized_dags: bool = False,
                       session=None) -> None:
         """
         Pause/Un-pause a DAG.
 
         :param is_paused: Is the DAG paused
         :param including_subdags: whether to include the DAG's subdags
-        :param store_serialized_dags: whether to serialize DAGs & store it in DB
         :param session: session
         """
-        dag_ids = [self.dag_id]  # type: List[str]
+        filter_query = [
+            DagModel.dag_id == self.dag_id,
+        ]
         if including_subdags:
-            dag = self.get_dag(store_serialized_dags)
-            if dag is None:
-                raise DagNotFound("Dag id {} not found".format(self.dag_id))
-            subdags = dag.subdags
-            dag_ids.extend([subdag.dag_id for subdag in subdags])
-        dag_models = session.query(DagModel).filter(DagModel.dag_id.in_(dag_ids)).all()
-        try:
-            for dag_model in dag_models:
-                dag_model.is_paused = is_paused
-            session.commit()
-        except Exception:
-            session.rollback()
-            raise
+            filter_query.append(
+                DagModel.root_dag_id == self.dag_id
+            )
+        session.query(DagModel).filter(or_(
+            *filter_query
+        )).update(
+            {DagModel.is_paused: is_paused}, synchronize_session='fetch'
+        )
+        session.commit()
 
     @classmethod
     @provide_session

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1861,8 +1861,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.args.get('dag_id')
         is_paused = True if request.args.get('is_paused') == 'false' else False
         models.DagModel.get_dagmodel(dag_id).set_is_paused(
-            is_paused=is_paused,
-            store_serialized_dags=STORE_SERIALIZED_DAGS)
+            is_paused=is_paused)
         return "OK"
 
     @expose('/refresh', methods=['POST'])


### PR DESCRIPTION
I decided to split PR to make it easier to fix errors.

Part of https://github.com/apache/airflow/pull/7806

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
