### PR TITLE
Enable celery command in any environment

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -22,7 +22,7 @@ import argparse
 import json
 import os
 import textwrap
-from argparse import RawTextHelpFormatter
+from argparse import ArgumentError, RawTextHelpFormatter
 from typing import Callable, Dict, Iterable, List, NamedTuple, Set, Union
 
 from tabulate import tabulate_formats
@@ -53,6 +53,24 @@ def lazy_load_command(import_path: str) -> Callable:
     command.__name__ = name  # type: ignore
 
     return command
+
+
+class DefaultHelpParser(argparse.ArgumentParser):
+    """CustomParser to display help message"""
+
+    def _check_value(self, action, value):
+        """Override _check_value and check conditionally added command"""
+        executor = conf.get('core', 'EXECUTOR')
+        if value == 'celery' and executor != ExecutorLoader.CELERY_EXECUTOR:
+            message = f'celery subcommand works only with CeleryExecutor, your current executor: {executor}'
+            raise ArgumentError(action, message)
+
+        super()._check_value(action, value)
+
+    def error(self, message):
+        """Override error and use print_instead of print_usage"""
+        self.print_help()
+        self.exit(2, f'\n{self.prog} command error: {message}, see help above.\n')
 
 
 class Arg:
@@ -1102,11 +1120,12 @@ airflow_commands: List[CLICommand] = [
         func=lazy_load_command('airflow.cli.commands.config_command.show_config'),
         args=(),
     ),
-]
-if conf.get("core", "EXECUTOR") == ExecutorLoader.CELERY_EXECUTOR or BUILD_DOCS:
-    airflow_commands.append(GroupCommand(
+    GroupCommand(
         name="celery",
-        help="Start celery components",
+        help=(
+            'Start celery components. Works only when using CeleryExecutor. For more information, see '
+            'https://airflow.readthedocs.io/en/stable/executor/celery.html'
+        ),
         subcommands=(
             ActionCommand(
                 name='worker',
@@ -1134,7 +1153,8 @@ if conf.get("core", "EXECUTOR") == ExecutorLoader.CELERY_EXECUTOR or BUILD_DOCS:
                 args=(),
             )
         )
-    ))
+    )
+]
 ALL_COMMANDS_DICT: Dict[str, CLICommand] = {sp.name: sp for sp in airflow_commands}
 DAG_CLI_COMMANDS: Set[str] = {
     'list_tasks', 'backfill', 'test', 'run', 'pause', 'unpause', 'list_dag_runs'
@@ -1143,11 +1163,6 @@ DAG_CLI_COMMANDS: Set[str] = {
 
 def get_parser(dag_parser: bool = False) -> argparse.ArgumentParser:
     """Creates and returns command line argument parser"""
-    class DefaultHelpParser(argparse.ArgumentParser):
-        """Override argparse.ArgumentParser.error and use print_help instead of print_usage"""
-        def error(self, message):
-            self.print_help()
-            self.exit(2, '\n{} command error: {}, see help above.\n'.format(self.prog, message))
     parser = DefaultHelpParser(prog="airflow")
     subparsers = parser.add_subparsers(
         help='sub-command help', dest='subcommand')

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import importlib
 import unittest
 from argparse import Namespace
 from tempfile import NamedTemporaryFile
@@ -69,15 +68,11 @@ class TestWorkerPrecheck(unittest.TestCase):
 class TestWorkerServeLogs(unittest.TestCase):
 
     @classmethod
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def setUpClass(cls):
-        importlib.reload(cli_parser)
         cls.parser = cli_parser.get_parser()
 
-    def tearDown(self):
-        importlib.reload(cli_parser)
-
     @mock.patch('airflow.cli.commands.celery_command.worker_bin')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_serve_logs_on_worker_start(self, mock_worker):
         with mock.patch('airflow.cli.commands.celery_command.Process') as mock_process:
             args = self.parser.parse_args(['celery', 'worker', '--concurrency', '1'])
@@ -88,6 +83,7 @@ class TestWorkerServeLogs(unittest.TestCase):
                 mock_process.assert_called()
 
     @mock.patch('airflow.cli.commands.celery_command.worker_bin')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_skip_serve_logs_on_worker_start(self, mock_worker):
         with mock.patch('airflow.cli.commands.celery_command.Process') as mock_popen:
             args = self.parser.parse_args(['celery', 'worker', '--concurrency', '1', '--skip-serve-logs'])
@@ -100,16 +96,12 @@ class TestWorkerServeLogs(unittest.TestCase):
 
 class TestCeleryStopCommand(unittest.TestCase):
     @classmethod
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def setUpClass(cls):
-        importlib.reload(cli_parser)
         cls.parser = cli_parser.get_parser()
-
-    def tearDown(self):
-        importlib.reload(cli_parser)
 
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
     @mock.patch("airflow.cli.commands.celery_command.psutil.Process")
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_if_right_pid_is_read(self, mock_process, mock_setup_locations):
         args = self.parser.parse_args(['celery', 'stop'])
         pid = "123"
@@ -130,6 +122,7 @@ class TestCeleryStopCommand(unittest.TestCase):
     @mock.patch("airflow.cli.commands.celery_command.read_pid_from_pidfile")
     @mock.patch("airflow.cli.commands.celery_command.worker_bin.worker")
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_same_pid_file_is_used_in_start_and_stop(
         self,
         mock_setup_locations,
@@ -156,17 +149,13 @@ class TestCeleryStopCommand(unittest.TestCase):
 
 class TestWorkerStart(unittest.TestCase):
     @classmethod
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def setUpClass(cls):
-        importlib.reload(cli_parser)
         cls.parser = cli_parser.get_parser()
-
-    def tearDown(self):
-        importlib.reload(cli_parser)
 
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
     @mock.patch('airflow.cli.commands.celery_command.Process')
     @mock.patch('airflow.cli.commands.celery_command.worker_bin')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_worker_started_with_required_arguments(self, mock_worker, mock_popen, mock_locations):
         pid_file = "pid_file"
         mock_locations.return_value = (pid_file, None, None, None)


### PR DESCRIPTION
Set celery command visible even if the executor is not CeleryExecutor
Instead, raise ArgumentError and display help message when the executor is
not CeleryExecutor

`airflow` command
Before:
![image](https://user-images.githubusercontent.com/41822575/77749493-767af980-7065-11ea-986c-7b0b4caf8d23.png)

After:
![image](https://user-images.githubusercontent.com/41822575/77821817-6b40d000-7130-11ea-93c1-d9083384f93e.png)


`airflow celery` command
After (executor is SequentialExecutor):
![image](https://user-images.githubusercontent.com/41822575/77821826-785dbf00-7130-11ea-8ab0-a56c95e6db02.png)


reference from: #7873, #7070
reviewed from: @mik-laj, @turbaszek 

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
