### PR TITLE
Get Airflow Variables from Hashicorp Vault

### DIFF
--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Objects relating to sourcing connections from Hashicorp Vault
+Objects relating to sourcing connections & variables from Hashicorp Vault
 """
 from typing import Optional
 
@@ -31,7 +31,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 class VaultBackend(BaseSecretsBackend, LoggingMixin):
     """
-    Retrieves Connection object from Hashicorp Vault
+    Retrieves Connections and Variables from Hashicorp Vault
 
     Configurable via ``airflow.cfg`` as follows:
 
@@ -50,7 +50,11 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     conn_id ``smtp_default``.
 
     :param connections_path: Specifies the path of the secret to read to get Connections.
+        (default: 'connections')
     :type connections_path: str
+    :param variables_path: Specifies the path of the secret to read to get Variables.
+        (default: 'variables')
+    :type variables_path: str
     :param url: Base URL for the Vault instance being addressed.
     :type url: str
     :param auth_type: Authentication Type for Vault (one of 'token', 'ldap', 'userpass', 'approle',
@@ -78,7 +82,8 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     """
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        connections_path: str,
+        connections_path: str = 'connections',
+        variables_path: str = 'variables',
         url: Optional[str] = None,
         auth_type: str = 'token',
         mount_point: str = 'secret',
@@ -94,6 +99,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     ):
         super().__init__(**kwargs)
         self.connections_path = connections_path.rstrip('/')
+        self.variables_path = variables_path.rstrip('/')
         self.url = url
         self.auth_type = auth_type
         self.kwargs = kwargs
@@ -150,7 +156,29 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: connection id
         :type conn_id: str
         """
-        secret_path = self.build_path(self.connections_path, conn_id)
+        response = self._get_secret(self.connections_path, conn_id)
+        return response.get("conn_uri") if response else None
+
+    def get_variable(self, key: str) -> Optional[str]:
+        """
+        Get Airflow Variable from Environment Variable
+
+        :param key: Variable Key
+        :return: Variable Value
+        """
+        response = self._get_secret(self.variables_path, key)
+        return response.get("value") if response else None
+
+    def _get_secret(self, path_prefix: str, secret_id: str) -> Optional[dict]:
+        """
+        Get secret value from Vault.
+
+        :param path_prefix: Prefix for the Path to get Secret
+        :type path_prefix: str
+        :param secret_id: Secret Key
+        :type secret_id: str
+        """
+        secret_path = self.build_path(path_prefix, secret_id)
 
         try:
             if self.kv_engine_version == 1:
@@ -161,8 +189,8 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
                 response = self.client.secrets.kv.v2.read_secret_version(
                     path=secret_path, mount_point=self.mount_point)
         except InvalidPath:
-            self.log.info("Connection ID %s not found in Path: %s", conn_id, secret_path)
+            self.log.info("Secret %s not found in Path: %s", secret_id, secret_path)
             return None
 
         return_data = response["data"] if self.kv_engine_version == 1 else response["data"]["data"]
-        return return_data.get("conn_uri")
+        return return_data

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -19,14 +19,14 @@
 Alternative secrets backend
 ---------------------------
 
-In addition to retrieving connections from environment variables or the metastore database, you can enable
-an alternative secrets backend to retrieve connections,
+In addition to retrieving connections & variables from environment variables or the metastore database, you can enable
+an alternative secrets backend to retrieve Airflow connections or Airflow variables,
 such as :ref:`AWS SSM Parameter Store <ssm_parameter_store_secrets>`,
 :ref:`Hashicorp Vault Secrets<hashicorp_vault_secrets>` or you can :ref:`roll your own <roll_your_own_secrets_backend>`.
 
 Search path
 ^^^^^^^^^^^
-When looking up a connection, by default Airflow will search environment variables first and metastore
+When looking up a connection/variable, by default Airflow will search environment variables first and metastore
 database second.
 
 If you enable an alternative secrets backend, it will be searched first, followed by environment variables,
@@ -81,7 +81,7 @@ of the connection object.
 Hashicorp Vault Secrets Backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To enable Hashicorp vault to retrieve connection, specify :py:class:`~airflow.providers.hashicorp.secrets.vault.VaultBackend`
+To enable Hashicorp vault to retrieve Airflow connection/variable, specify :py:class:`~airflow.providers.hashicorp.secrets.vault.VaultBackend`
 as the ``backend`` in  ``[secrets]`` section of ``airflow.cfg``.
 
 Here is a sample configuration:
@@ -90,7 +90,7 @@ Here is a sample configuration:
 
     [secrets]
     backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
-    backend_kwargs = {"connections_path": "connections", "mount_point": "airflow", "url": "http://127.0.0.1:8200"}
+    backend_kwargs = {"connections_path": "connections", "variables_path": "variables", "mount_point": "airflow", "url": "http://127.0.0.1:8200"}
 
 The default KV version engine is ``2``, pass ``kv_engine_version: 1`` in ``backend_kwargs`` if you use
 KV Secrets Engine Version ``1``.
@@ -105,6 +105,10 @@ key to ``backend_kwargs``:
 
     export VAULT_ADDR="http://127.0.0.1:8200"
 
+
+Storing and Retrieving Connections
+""""""""""""""""""""""""""""""""""
+
 If you have set ``connections_path`` as ``connections`` and ``mount_point`` as ``airflow``, then for a connection id of
 ``smtp_default``, you would want to store your secret as:
 
@@ -112,7 +116,7 @@ If you have set ``connections_path`` as ``connections`` and ``mount_point`` as `
 
     vault kv put airflow/connections/smtp_default conn_uri=smtps://user:host@relay.example.com:465
 
-Note that the ``key`` is ``conn_uri``, ``value`` is ``postgresql://airflow:airflow@host:5432/airflow`` and
+Note that the ``Key`` is ``conn_uri``, ``Value`` is ``postgresql://airflow:airflow@host:5432/airflow`` and
 ``mount_point`` is ``airflow``.
 
 You can make a ``mount_point`` for ``airflow`` as follows:
@@ -140,7 +144,39 @@ Verify that you can get the secret from ``vault``:
     conn_uri    smtps://user:host@relay.example.com:465
 
 The value of the Vault key must be the :ref:`connection URI representation <generating_connection_uri>`
-of the connection object.
+of the connection object to get connection.
+
+Storing and Retrieving Variables
+""""""""""""""""""""""""""""""""
+
+If you have set ``variables_path`` as ``variables`` and ``mount_point`` as ``airflow``, then for a variable with
+``hello`` as key, you would want to store your secret as:
+
+.. code-block:: bash
+
+    vault kv put airflow/variables/hello value=world
+
+Verify that you can get the secret from ``vault``:
+
+.. code-block:: console
+
+    ❯ vault kv get airflow/variables/hello
+    ====== Metadata ======
+    Key              Value
+    ---              -----
+    created_time     2020-03-28T02:10:54.301784Z
+    deletion_time    n/a
+    destroyed        false
+    version          1
+
+    ==== Data ====
+    Key      Value
+    ---      -----
+    value    world
+
+Note that the secret ``Key`` is ``value``, and secret ``Value`` is ``world`` and
+``mount_point`` is ``airflow``.
+
 
 .. _secrets_manager_backend:
 


### PR DESCRIPTION
Depends on https://github.com/apache/airflow/pull/7948

Get Airflow Variables from Hashicorp Vault

**_Please only check the last commit_**

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
