### PR TITLE
Make BaseSecretsBackend.build_path generic

### DIFF
--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -69,7 +69,7 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         :type conn_id: str
         """
 
-        ssm_path = self.build_path(connections_prefix=self.connections_prefix, conn_id=conn_id)
+        ssm_path = self.build_path(self.connections_prefix, conn_id)
         try:
             response = self.client.get_parameter(
                 Name=ssm_path, WithDecryption=False

--- a/airflow/providers/google/cloud/secrets/secrets_manager.py
+++ b/airflow/providers/google/cloud/secrets/secrets_manager.py
@@ -110,11 +110,7 @@ class CloudSecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: connection id
         :type conn_id: str
         """
-        secret_id = self.build_path(
-            connections_prefix=self.connections_prefix,
-            conn_id=conn_id,
-            sep=self.sep
-        )
+        secret_id = self.build_path(self.connections_prefix, conn_id, self.sep)
         # always return the latest version of the secret
         secret_version = "latest"
         name = self.client.secret_version_path(self.project_id, secret_id, secret_version)

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -150,7 +150,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: connection id
         :type conn_id: str
         """
-        secret_path = self.build_path(connections_prefix=self.connections_path, conn_id=conn_id)
+        secret_path = self.build_path(self.connections_path, conn_id)
 
         try:
             if self.kv_engine_version == 1:

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -30,18 +30,18 @@ class BaseSecretsBackend(ABC):
         pass
 
     @staticmethod
-    def build_path(connections_prefix: str, conn_id: str, sep: str = "/") -> str:
+    def build_path(path_prefix: str, secret_id: str, sep: str = "/") -> str:
         """
         Given conn_id, build path for Secrets Backend
 
-        :param connections_prefix: prefix of the secret to read to get Connections
-        :type connections_prefix: str
-        :param conn_id: connection id
-        :type conn_id: str
+        :param path_prefix: Prefix of the path to get secret
+        :type path_prefix: str
+        :param secret_id: Secret id
+        :type secret_id: str
         :param sep: separator used to concatenate connections_prefix and conn_id. Default: "/"
         :type sep: str
         """
-        return f"{connections_prefix}{sep}{conn_id}"
+        return f"{path_prefix}{sep}{secret_id}"
 
     def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """

--- a/tests/secrets/test_secrets_backends.py
+++ b/tests/secrets/test_secrets_backends.py
@@ -52,8 +52,8 @@ class TestBaseSecretsBackend(unittest.TestCase):
         clear_db_variables()
 
     @parameterized.expand([
-        ('default', {"connections_prefix": "PREFIX", "conn_id": "ID"}, "PREFIX/ID"),
-        ('with_sep', {"connections_prefix": "PREFIX", "conn_id": "ID", "sep": "-"}, "PREFIX-ID")
+        ('default', {"path_prefix": "PREFIX", "secret_id": "ID"}, "PREFIX/ID"),
+        ('with_sep', {"path_prefix": "PREFIX", "secret_id": "ID", "sep": "-"}, "PREFIX-ID")
     ])
     def test_build_path(self, _, kwargs, output):
         build_path = BaseSecretsBackend.build_path


### PR DESCRIPTION
Currently the arguments required for it are `connections_prefix` and `conn_id` . Changing this to `path_prefix` and `secret_id` allows using that method for retrieving variables too

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
