### PR TITLE
Remove Preparing backport package for 1.10.6 test from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,11 +148,6 @@ jobs:
         INSTALL_AIRFLOW_VERSION="1.10.9"
       stage: test
       script: ./scripts/ci/ci_prepare_and_test_backport_packages.sh
-    - name: "Prepare & test backport packages 1.10.6"
-      env: >-
-        INSTALL_AIRFLOW_VERSION="1.10.6"
-      stage: test
-      script: ./scripts/ci/ci_prepare_and_test_backport_packages.sh
 install: skip
 before_install:
   - ./scripts/ci/ci_before_install.sh


### PR DESCRIPTION
We should only test backporting to the latest release

---

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
