### PR TITLE
close sftp connection without error

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -120,12 +120,11 @@ class SFTPHook(SSHHook):
 
     def close_conn(self) -> None:
         """
-        Closes the connection. An error will occur if the
-        connection wasnt ever opened.
+        Closes the connection
         """
-        conn = self.conn
-        conn.close()  # type: ignore
-        self.conn = None
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None
 
     def describe_directory(self, path: str) -> Dict[str, Dict[str, str]]:
         """


### PR DESCRIPTION
check self.conn is None and close connection without error like
SSHHook

https://github.com/apache/airflow/blob/7b288a2f7ae48e266935e61ff743378232226bc0/airflow/providers/ssh/hooks/ssh.py#L209-L212

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
