### PR TITLE
Pinning max pandas version to 2.0 (lesser than) to allow pandas 1.0.

### DIFF
--- a/requirements/requirements-python3.6.txt
+++ b/requirements/requirements-python3.6.txt
@@ -93,7 +93,7 @@ flask-swagger==0.2.13
 Flask-WTF==0.14.3
 flower==0.9.4
 freezegun==0.3.15
-fsspec==0.7.0
+fsspec==0.7.1
 funcsigs==1.0.2
 future==0.18.2
 future-fstrings==1.2.0
@@ -203,7 +203,7 @@ numpy==1.18.2
 oauthlib==3.1.0
 oscrypto==1.2.0
 packaging==20.3
-pandas==0.25.3
+pandas==1.0.3
 pandas-gbq==0.13.1
 papermill==2.0.0
 parameterized==0.7.1
@@ -334,7 +334,7 @@ unicodecsv==0.14.1
 Unidecode==1.1.1
 uritemplate==3.0.1
 urllib3==1.25.8
-vertica-python==0.10.2
+vertica-python==0.10.3
 vine==1.3.0
 virtualenv==20.0.15
 watchtower==0.7.3

--- a/requirements/requirements-python3.7.txt
+++ b/requirements/requirements-python3.7.txt
@@ -93,7 +93,7 @@ flask-swagger==0.2.13
 Flask-WTF==0.14.3
 flower==0.9.4
 freezegun==0.3.15
-fsspec==0.7.0
+fsspec==0.7.1
 funcsigs==1.0.2
 future==0.18.2
 future-fstrings==1.2.0
@@ -202,7 +202,7 @@ numpy==1.18.2
 oauthlib==3.1.0
 oscrypto==1.2.0
 packaging==20.3
-pandas==0.25.3
+pandas==1.0.3
 pandas-gbq==0.13.1
 papermill==2.0.0
 parameterized==0.7.1
@@ -331,7 +331,7 @@ unicodecsv==0.14.1
 Unidecode==1.1.1
 uritemplate==3.0.1
 urllib3==1.25.8
-vertica-python==0.10.2
+vertica-python==0.10.3
 vine==1.3.0
 virtualenv==20.0.15
 watchtower==0.7.3

--- a/setup.py
+++ b/setup.py
@@ -566,7 +566,7 @@ INSTALL_REQUIREMENTS = [
     'lazy_object_proxy~=1.3',
     'lockfile>=0.12.2',
     'markdown>=2.5.2, <3.0',
-    'pandas>=0.17.1, <1.0.0',
+    'pandas>=0.17.1, <2.0',
     'pendulum==1.4.4',
     'pep562~=1.0;python_version<"3.7"',
     'psutil>=4.2.0, <6.0.0',


### PR DESCRIPTION
Issue link: https://github.com/apache/airflow/issues/7905

Currently on master, pandas is pinned to < 1.0.0 in Airflow's dependencies. Version 1.0 was released in October 31, 2019. Lots of projects are starting to migrate to pandas 1.0 and it will gradually become more and more difficult to solve conflicts between their dependencies and Airflow's dependencies.

This PR increases the max version of pandas to `2.0`, which will allow installing pandas 1.0. The minimum pandas version stays unchanged so all existing projects with pandas version pinned to `1.0` shouldn't be impacted.

My commit passed the pre-commits. I installed (or tried to) installed as much dependencies as possible in the `all` extra (in a local virtualenv), and ran as much unit tests as possible before upgrading pandas. This was my baseline. I then upgraded pandas to 1.0.3 and ran the same tests again and the number of failed tests didn't decrease.

I'm sorry I can't give a clearer answer on whether pandas' version will break something, but testing has proven to be difficult: the integration tests are tangled with the unit tests and it's unclear to me which tests should pass or not. Help is appreciated.


- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
