### PR TITLE
Allow setting Airflow Variable values to empty string ('')

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -61,6 +61,20 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Setting Empty string to a Airflow Variable will return an empty string
+
+Previously when you set an Airflow Variable with an empty string (`''`), the value you used to get
+back was ``None``. This will now return an empty string (`'''`)
+
+Example:
+
+```python
+>> Variable.set('test_key', '')
+>> Variable.get('test_key')
+```
+
+The above code returned `None` previously, now it will return `''`.
+
 ### Remove SQL support in base_hook
 
 Remove ``get_records`` and ``get_pandas_df`` and ``run`` from base_hook, which only apply for sql like hook,

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -45,7 +45,7 @@ class Variable(Base, LoggingMixin):
         return '{} : {}'.format(self.key, self._val)
 
     def get_val(self):
-        if self._val and self.is_encrypted:
+        if self._val is not None and self.is_encrypted:
             try:
                 fernet = get_fernet()
                 return fernet.decrypt(bytes(self._val, 'utf-8')).decode()
@@ -59,7 +59,7 @@ class Variable(Base, LoggingMixin):
             return self._val
 
     def set_val(self, value):
-        if value:
+        if value is not None:
             fernet = get_fernet()
             self._val = fernet.encrypt(bytes(value, 'utf-8')).decode()
             self.is_encrypted = fernet.is_encrypted

--- a/airflow/secrets/__init__.py
+++ b/airflow/secrets/__init__.py
@@ -65,7 +65,7 @@ def get_variable(key: str) -> Optional[str]:
     """
     for secrets_backend in ensure_secrets_loaded():
         var_val = secrets_backend.get_variable(key=key)
-        if var_val:
+        if var_val is not None:
             return var_val
 
     return None

--- a/tests/secrets/test_secrets_backends.py
+++ b/tests/secrets/test_secrets_backends.py
@@ -86,19 +86,23 @@ class TestBaseSecretsBackend(unittest.TestCase):
 
     @mock.patch.dict('os.environ', {
         'AIRFLOW_VAR_HELLO': 'World',
+        'AIRFLOW_VAR_EMPTY_STR': '',
     })
     def test_variable_env_secrets_backend(self):
         env_secrets_backend = EnvironmentVariablesBackend()
         variable_value = env_secrets_backend.get_variable(key="hello")
         self.assertEqual('World', variable_value)
         self.assertIsNone(env_secrets_backend.get_variable(key="non_existent_key"))
+        self.assertEqual('', env_secrets_backend.get_variable(key="empty_str"))
 
     def test_variable_metastore_secrets_backend(self):
         Variable.set(key="hello", value="World")
+        Variable.set(key="empty_str", value="")
         metastore_backend = MetastoreBackend()
         variable_value = metastore_backend.get_variable(key="hello")
         self.assertEqual("World", variable_value)
         self.assertIsNone(metastore_backend.get_variable(key="non_existent_key"))
+        self.assertEqual('', metastore_backend.get_variable(key="empty_str"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This will allow users to set a Variable with empty string.

It is related to https://github.com/apache/airflow/pull/6084 which was only included in 1.10.5 but not in master

---

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
