### PR TITLE
Fix Flaky TriggerDAG UI test

### DIFF
--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2147,7 +2147,6 @@ class TestTriggerDag(TestBase):
         self.assertIn("manual__", run.run_id)
         self.assertEqual(run.conf, conf_dict)
 
-    @pytest.mark.xfail(condition=True, reason="This test might be flaky on mysql")
     def test_trigger_dag_conf_malformed(self):
         test_dag_id = "example_bash_operator"
 
@@ -2156,7 +2155,7 @@ class TestTriggerDag(TestBase):
         self.session.commit()
 
         response = self.client.post('trigger?dag_id={}'.format(test_dag_id), data={'conf': '{"a": "b"'})
-        self.assertEqual(response.status_code, 302)
+        self.check_content_in_response('Invalid JSON configuration', response)
 
         run = self.session.query(DR).filter(DR.dag_id == test_dag_id).first()
         self.assertIsNone(run)


### PR DESCRIPTION
Fixed Flaky TriggerDAG UI test

---

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
