### PR TITLE
Fix airflow.www.views import

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -202,8 +202,14 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
                 log.debug("Adding blueprint %s:%s", bp["name"], bp["blueprint"].import_name)
                 app.register_blueprint(bp["blueprint"])
 
+        def init_error_handlers(app: Flask):
+            from airflow.www import views
+            app.register_error_handler(500, views.show_traceback)
+            app.register_error_handler(404, views.circles)
+
         init_views(appbuilder)
         init_plugin_blueprints(app)
+        init_error_handlers(app)
 
         if conf.getboolean('webserver', 'UPDATE_FAB_PERMS'):
             security_manager = appbuilder.sm

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -72,7 +72,7 @@ from airflow.utils.helpers import alchemy_to_dict, render_log_filename
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.www import utils as wwwutils
-from airflow.www.app import app, appbuilder
+from airflow.www.app import appbuilder
 from airflow.www.decorators import action_logging, gzipped, has_dag_access
 from airflow.www.forms import (
     ConnectionForm, DagRunForm, DateTimeForm, DateTimeWithNumRunsForm, DateTimeWithNumRunsWithDagRunsForm,
@@ -142,9 +142,9 @@ def get_date_time_num_runs_dag_runs_form_data(request, session, dag):
 
 
 ######################################################################################
-#                                    BaseViews
+#                                    Error handlers
 ######################################################################################
-@app.errorhandler(404)
+
 def circles(error):
     return render_template(
         'airflow/circles.html', hostname=socket.getfqdn() if conf.getboolean(
@@ -153,7 +153,6 @@ def circles(error):
             fallback=True) else 'redact'), 404
 
 
-@app.errorhandler(500)
 def show_traceback(error):
     from airflow.utils import asciiart as ascii_
     return render_template(
@@ -167,6 +166,10 @@ def show_traceback(error):
             'webserver',
             'EXPOSE_STACKTRACE',
             fallback=True) else 'Error! Please contact server admin'), 500
+
+######################################################################################
+#                                    BaseViews
+######################################################################################
 
 
 class AirflowBaseView(BaseView):


### PR DESCRIPTION
Before:
```
03:20 $ python -c 'import airflow.www.views'
[2020-04-02 03:20:51,157] {dagbag.py:368} INFO - Filling up the DagBag from /Users/kamilbregula/airflow/dags
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/kamilbregula/devel/google-airflow/airflow/airflow/www/views.py", line 147, in <module>
    @app.errorhandler(404)
AttributeError: 'NoneType' object has no attribute 'errorhandler'
```
After:
```
03:20 $ python -c 'import airflow.www.views'
[2020-04-02 03:24:12,793] {dagbag.py:368} INFO - Filling up the DagBag from /Users/kamilbregula/airflow/dags
```
We use factory pattern, so we should use register_error_handler.

https://flask.palletsprojects.com/en/1.1.x/patterns/errorpages/#error-handlers



---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
