### PR TITLE
[AIRFLOW-7045] Update SQL query to delete RenderedTaskInstanceFields

### DIFF
--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -19,7 +19,7 @@
 from typing import Optional
 
 import sqlalchemy_jsonfield
-from sqlalchemy import Column, String, and_, not_
+from sqlalchemy import Column, String, and_, not_, tuple_
 from sqlalchemy.orm import Session
 
 from airflow.configuration import conf
@@ -109,21 +109,52 @@ class RenderedTaskInstanceFields(Base):
         if num_to_keep <= 0:
             return
 
-        # Fetch Top X records given dag_id & task_id ordered by Execution Date
-        tis_to_keep = (
-            session
-            .query(cls.dag_id, cls.task_id, cls.execution_date)
-            .filter(cls.dag_id == dag_id, cls.task_id == task_id)
-            .order_by(cls.execution_date.desc())
+        tis_to_keep_query = session \
+            .query(cls.dag_id, cls.task_id, cls.execution_date) \
+            .filter(cls.dag_id == dag_id, cls.task_id == task_id) \
+            .order_by(cls.execution_date.desc()) \
             .limit(num_to_keep)
-        ).all()
 
-        filter_tis = [not_(and_(
-            cls.dag_id == ti.dag_id,
-            cls.task_id == ti.task_id,
-            cls.execution_date == ti.execution_date
-        )) for ti in tis_to_keep]
+        if session.bind.dialect.name in ["postgresql", "sqlite"]:
+            # Fetch Top X records given dag_id & task_id ordered by Execution Date
+            subq1 = tis_to_keep_query.subquery('subq1')
 
-        session.query(cls) \
-            .filter(and_(*filter_tis)) \
-            .delete(synchronize_session=False)
+            session.query(cls) \
+                .filter(and_(
+                    cls.dag_id == dag_id,
+                    cls.task_id == task_id,
+                    tuple_(cls.dag_id, cls.task_id, cls.execution_date).notin_(subq1))) \
+                .delete(synchronize_session=False)
+        elif session.bind.dialect.name in ["mysql"]:
+            # Fetch Top X records given dag_id & task_id ordered by Execution Date
+            subq1 = tis_to_keep_query.subquery('subq1')
+
+            # Second Subquery
+            # Workaround for MySQL Limitation (https://stackoverflow.com/a/19344141/5691525)
+            # Limitation: This version of MySQL does not yet support
+            # LIMIT & IN/ALL/ANY/SOME subquery
+            subq2 = (
+                session
+                .query(subq1.c.dag_id, subq1.c.task_id, subq1.c.execution_date)
+                .subquery('subq2')
+            )
+
+            session.query(cls) \
+                .filter(and_(
+                    cls.dag_id == dag_id,
+                    cls.task_id == task_id,
+                    tuple_(cls.dag_id, cls.task_id, cls.execution_date).notin_(subq2))) \
+                .delete(synchronize_session=False)
+        else:
+            # Fetch Top X records given dag_id & task_id ordered by Execution Date
+            tis_to_keep = tis_to_keep_query.all()
+
+            filter_tis = [not_(and_(
+                cls.dag_id == ti.dag_id,
+                cls.task_id == ti.task_id,
+                cls.execution_date == ti.execution_date
+            )) for ti in tis_to_keep]
+
+            session.query(cls) \
+                .filter(and_(*filter_tis)) \
+                .delete(synchronize_session=False)

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -129,7 +129,15 @@ class TestRenderedTaskInstanceFields(unittest.TestCase):
         ti2 = TI(task_2, EXECUTION_DATE)
         self.assertIsNone(RTIF.get_templated_fields(ti=ti2))
 
-    def test_delete_old_records(self):
+    @parameterized.expand([
+        (0, 1, 0),
+        (1, 1, 1),
+        (1, 0, 1),
+        (3, 1, 1),
+        (4, 2, 2),
+        (5, 2, 2),
+    ])
+    def test_delete_old_records(self, rtif_num, num_to_keep, remaining_rtifs):
         """
         Test that old records are deleted from rendered_task_instance_fields table
         for a given task_id and dag_id.
@@ -139,29 +147,27 @@ class TestRenderedTaskInstanceFields(unittest.TestCase):
         with dag:
             task = BashOperator(task_id="test", bash_command="echo {{ ds }}")
 
-        rtif_1 = RTIF(TI(task=task, execution_date=EXECUTION_DATE))
-        rtif_2 = RTIF(TI(task=task, execution_date=EXECUTION_DATE + timedelta(days=1)))
-        rtif_3 = RTIF(TI(task=task, execution_date=EXECUTION_DATE + timedelta(days=2)))
+        rtif_list = [
+            RTIF(TI(task=task, execution_date=EXECUTION_DATE + timedelta(days=num)))
+            for num in range(rtif_num)
+        ]
 
-        session.add(rtif_1)
-        session.add(rtif_2)
-        session.add(rtif_3)
+        session.add_all(rtif_list)
         session.commit()
 
         result = session.query(RTIF)\
             .filter(RTIF.dag_id == dag.dag_id, RTIF.task_id == task.task_id).all()
 
-        self.assertIn(rtif_1, result)
-        self.assertIn(rtif_2, result)
-        self.assertIn(rtif_3, result)
-        self.assertEqual(3, len(result))
+        for rtif in rtif_list:
+            self.assertIn(rtif, result)
 
-        # Verify old records are deleted and only 1 record is kept
-        RTIF.delete_old_records(task_id=task.task_id, dag_id=task.dag_id, num_to_keep=1)
+        self.assertEqual(rtif_num, len(result))
+
+        # Verify old records are deleted and only 'num_to_keep' records are kept
+        RTIF.delete_old_records(task_id=task.task_id, dag_id=task.dag_id, num_to_keep=num_to_keep)
         result = session.query(RTIF) \
             .filter(RTIF.dag_id == dag.dag_id, RTIF.task_id == task.task_id).all()
-        self.assertEqual(1, len(result))
-        self.assertEqual(rtif_3.execution_date, result[0].execution_date)
+        self.assertEqual(remaining_rtifs, len(result))
 
     def test_write(self):
         """


### PR DESCRIPTION
This is because "The composite IN construct is not supported by all backends"

Based on the discussion in https://github.com/apache/airflow/pull/6788#discussion_r391268396

I can't use **JOIN** because of the following restriction:

```
sqlalchemy.exc.InvalidRequestError: Can't call Query.update() or Query.delete() when join(), outerjoin(), select_from(), or from_self() has been called
```

---
Issue link: [AIRFLOW-7045](https://issues.apache.org/jira/browse/AIRFLOW-7045)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
