### PR TITLE
Improve process terminating in scheduler_job

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -25,7 +25,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout, suppress
 from datetime import timedelta
 from itertools import groupby
 from typing import List, Optional, Tuple
@@ -219,7 +219,8 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
 
         self._process.terminate()
         # Arbitrarily wait 5s for the process to die
-        self._process.join(5)
+        with suppress(TimeoutError):
+            self._process.wait(5)
         if sigkill:
             self._kill_process()
         self._parent_channel.close()

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -220,7 +220,7 @@ class DagFileProcessorProcess(AbstractDagFileProcessorProcess, LoggingMixin):
         self._process.terminate()
         # Arbitrarily wait 5s for the process to die
         with suppress(TimeoutError):
-            self._process.wait(5)
+            self._process._popen.wait(5)  # pylint: disable=protected-access
         if sigkill:
             self._kill_process()
         self._parent_channel.close()


### PR DESCRIPTION
We cannot perform operation `join` because the process may already be terminated. To wait for the process to complete is the `wait` method.

This occurs when I send ctrl-c to the scheduler (running with MySQL backend)
```
File "/opt/airflow/airflow/utils/dag_processing.py", line 633, in _exit_gracefully
    self.terminate()
  File "/opt/airflow/airflow/utils/dag_processing.py", line 1206, in terminate
    processor.terminate()
  File "/opt/airflow/airflow/jobs/scheduler_job.py", line 222, in terminate
    self._process.join(5)
  File "/usr/local/lib/python3.6/multiprocessing/process.py", line 122, in join
    assert self._parent_pid == os.getpid(), 'can only join a child process'
AssertionError: can only join a child process
```

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
