### PR TITLE
Update Security doc for 1.10.* (in which we have two Web UIs)

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -84,6 +84,12 @@ attack. Creating a new user has to be done via a Python REPL on the same machine
 LDAP
 ''''
 
+.. note::
+
+   This is for flask-admin based web UI only. If you are using FAB-based web UI with RBAC feature,
+   check the `Security section of FAB docs <https://flask-appbuilder.readthedocs.io/en/latest/security.html>`_
+   for how to configure in ``webserver_config.py`` file.
+
 To turn on LDAP authentication configure your ``airflow.cfg`` as follows. Please note that the example uses
 an encrypted connection to the ldap server as we do not want passwords be readable on the network level.
 
@@ -268,6 +274,12 @@ To use kerberos authentication, you must install Airflow with the ``kerberos`` e
 
 OAuth Authentication
 --------------------
+
+.. note::
+
+   This is for flask-admin based web UI only. If you are using FAB-based web UI with RBAC feature,
+   check the `Security section of FAB docs <https://flask-appbuilder.readthedocs.io/en/latest/security.html>`_
+   for how to configure in ``webserver_config.py`` file.
 
 GitHub Enterprise (GHE) Authentication
 ''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
This PR is to address out-dated documentation issue in 1.10.*, in which we still have two sets of web UI supported. The stable doc of 1.10.* is not reflecting the authentication feature of FAB-based UI properly.

Note this PR is raised against V1-1-stable

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
