### PR TITLE
Fix Example in config_templates for Secrets Backend

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -511,16 +511,17 @@
     - name: backend
       description: |
         Full class name of secrets backend to enable (will precede env vars and metastore in search path)
-      version_added: ~
+      version_added: 1.10.10
       type: string
-      example: ~
+      example: "airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend"
       default: ""
     - name: backend_kwargs
       description: |
         The backend_kwargs param is loaded into a dictionary and passed to __init__ of secrets backend class.
         See documentation for the secrets backend you are using. JSON is expected.
-        Example for AWS SSM: {{"prefix": "/airflow", "profile_name": "my_aws_profile"}}
-      version_added: ~
+        Example for AWS Systems Manager ParameterStore:
+        ``{{"connections_prefix": "/airflow/connections", "profile_name": "default"}}``
+      version_added: 1.10.10
       type: string
       example: ~
       default: ""

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -275,11 +275,13 @@ task_log_reader = task
 
 [secrets]
 # Full class name of secrets backend to enable (will precede env vars and metastore in search path)
+# Example: backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
 backend =
 
 # The backend_kwargs param is loaded into a dictionary and passed to __init__ of secrets backend class.
 # See documentation for the secrets backend you are using. JSON is expected.
-# Example for AWS SSM: {{"prefix": "/airflow", "profile_name": "my_aws_profile"}}
+# Example for AWS Systems Manager ParameterStore:
+# ``{{"connections_prefix": "/airflow/connections", "profile_name": "default"}}``
 backend_kwargs =
 
 [cli]


### PR DESCRIPTION
Fix Example in config_templates for Secrets Backend. The example is outdated

---


Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
