### PR TITLE
BugFix: Datetimepicker is visible on page load

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -248,6 +248,11 @@ label[for="timezone-other"], #timezone-other {
     overflow-x: hidden;
 }
 
+/* depending on the version of FAB in use, we may have a style conflict */
+.bootstrap-datetimepicker-widget .datepicker>div {
+  display: block;
+}
+
 .hll { background-color: #ffffcc }
 .c { color: #408080; font-style: italic } /* Comment */
 .err { border: 1px solid #FF0000 } /* Error */

--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -25,8 +25,6 @@
 {{ super() }}
 <link rel="stylesheet" type="text/css"
     href="{{ url_for('static', filename='css/tree.css') }}">
-<link rel="stylesheet" type="text/css"
-    href="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.css')}}" >
 <link href="{{ url_for_asset('dataTables.bootstrap.min.css') }}" rel="stylesheet" type="text/css" >
 <link rel="stylesheet" type="text/css"
       href="{{ url_for_asset('nv.d3.min.css') }}">
@@ -54,6 +52,4 @@
 {% block tail %}
     {{ super() }}
     <div class="container"></div>
-
-    <script src="{{url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.js')}}"></script>
 {% endblock %}

--- a/airflow/www/templates/airflow/duration_chart.html
+++ b/airflow/www/templates/airflow/duration_chart.html
@@ -24,8 +24,6 @@
 {{ super() }}
 <link rel="stylesheet" type="text/css"
     href="{{ url_for('static', filename='css/tree.css') }}">
-<link rel="stylesheet" type="text/css"
-    href="{{url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.css')}}" >
 <link href="{{ url_for_asset('dataTables.bootstrap.min.css') }}" rel="stylesheet" type="text/css" >
 <link rel="stylesheet" type="text/css"
       href="{{ url_for_asset('nv.d3.min.css') }}">
@@ -73,6 +71,5 @@
       handleCheck();
     });
   </script>
-  <script src="{{url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.js')}}"></script>
   {{ super() }}
 {% endblock %}

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -23,8 +23,6 @@
 
 {% block head_css %}
 {{ super() }}
-<link rel="stylesheet" type="text/css"
-    href="{{url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.css')}}" >
 <link type="text/css" href="{{ url_for('static', filename='css/gantt.css') }}" rel="stylesheet" />
 <link type="text/css" href="{{ url_for('static', filename='css/tree.css') }}" rel="stylesheet" />
 {% endblock %}
@@ -50,7 +48,6 @@
 
 {% block tail %}
 {{ super() }}
-<script src="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.js') }}"></script>
 <script src="{{ url_for_asset('d3.min.js') }}"></script>
 <script src="{{ url_for_asset('d3-tip.js') }}"></script>/
 <script src="{{ url_for_asset('ganttChartD3v2.js') }}"></script>

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -19,22 +19,17 @@
 
 {% extends "airflow/dag.html" %}
 
-{% block head_css %}
-{{ super() }}
-<link rel="stylesheet" type="text/css"
-    href="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.css')}}" >
-{% endblock %}
-
 {% block content %}
   {{ super() }}
   <h4>
-<form method="get" id="daform">
-    <input name="_csrf_token" type="hidden" value="{{ csrf_token() }}">
+<form method="get" id="daform" action="#">
+    <input type="hidden" name="dag_id" value="{{ dag.dag_id }}" >
+
     <div class="form-inline">
             <span style='color:#AAA;'>Task Instance: </span>
             <span>
               {{ task_id }}
-              <input type="hidden" value="{{ dag.dag_id }}" name="dag_id">
+              <input type="hidden" value="{{ task_id }}" name="task_id">
             </span>
         {{ form.execution_date(class_="form-control") | safe }}
 
@@ -59,21 +54,17 @@
 {% endblock %}
 {% block tail %}
   {{ super() }}
-  <script src="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.js')}}"></script>
   <script>
     $( document ).ready(function() {
-      function date_change(){
-          execution_date = $("input#execution_date").val().replace(' ', 'T');
-          loc = decodeURIComponent(window.location.href);
-          loc = loc.replace('{{ execution_date }}', execution_date);
-          window.location = loc;
+      function date_change(e) {
+          // We don't want to navigate away if the datetimepicker is still visible
+          if ($(".datetimepicker bootstrap-datetimepicker-widget :visible").length > 0)
+            return
+
+          $("input#execution_date").parents("form").submit();
       }
-      $("input#execution_date").on("change.daterangepicker", function(){
-          date_change();
-      });
-      $("input#execution_date").on("apply.daterangepicker", function(){
-          date_change();
-      });
+      $("input#execution_date").parents(".datetimepicker").on("dp.change", date_change);
+      $("input#execution_date").parents(".datetimepicker").on("dp.hide", date_change);
     });
   </script>
 {% endblock %}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -23,8 +23,6 @@
 {% block head_css %}
 {{ super() }}
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/tree.css') }}">
-<link rel="stylesheet" type="text/css"
-      href="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.css') }}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Datetimepicker was visible on page load on Graph view, Log View, Tree
View, and Gantt chart, this was due to a fight between the old version
shipped with FAB and the version we now use.

Closes #8083 (as it does it in a different way).

Relates to #8046 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
