### PR TITLE
[AIRFLOW-5277] Gantt chart respects per-user the Timezone UI setting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -238,6 +238,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     (MIT License) normalize.css v3.0.2 (http://necolas.github.io/normalize.css/)
     (MIT License) ElasticMock v1.3.2 (https://github.com/vrcmarcos/elasticmock)
     (MIT License) MomentJS v2.24.0 (http://momentjs.com/)
+    (MIT License) moment-strftime v0.5.0 (https://github.com/benjaminoakes/moment-strftime)
     (MIT License) python-slugify v2.0.1 (https://github.com/un33k/python-slugify)
     (MIT License) python-nvd3 v0.15.0 (https://github.com/areski/python-nvd3)
     (MIT License) eonasdan-bootstrap-datetimepicker v4.17.37 (https://github.com/eonasdan/bootstrap-datetimepicker/)

--- a/airflow/www/static/js/base.js
+++ b/airflow/www/static/js/base.js
@@ -39,6 +39,10 @@ function changDisplayedTimezone(tz) {
   localStorage.setItem('selected-timezone', tz);
   setDisplayedTimezone(tz);
   displayTime();
+  $('body').trigger({
+    type: 'airflow.timezone-change',
+    timezone: tz,
+  });
 }
 
 var el = document.createElement("span");

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -64,6 +64,9 @@
       .selector('.gantt')
       .tickFormat("%H:%M:%S");
     gantt(data.tasks);
+    $('body').on('airflow.timezone-change', (e) => {
+      gantt.redraw(data.tasks);
+    });
   });
 </script>
 

--- a/licenses/LICENSE-moment-strftime.txt
+++ b/licenses/LICENSE-moment-strftime.txt
@@ -1,0 +1,9 @@
+(The MIT License)
+
+Copyright (c) 2012 Benjamin Oakes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ license_files =
    licenses/LICENSE-hue.txt
    licenses/LICENSE-jqclock.txt
    licenses/LICENSE-jquery.txt
+   licenses/LICENSE-moment-strftime.txt
    licenses/LICENSE-moment.txt
    licenses/LICENSE-normalize.txt
    licenses/LICENSE-python-nvd3.txt


### PR DESCRIPTION

![output](https://user-images.githubusercontent.com/34150/78368532-ae30f680-75bb-11ea-88b4-ff1d76018e1c.gif)

(click for a slightly larger view)

`new Date()` in javascript was always returning user-local time, so we
switch over to using MomentJS to render the ticks.

I also had to fix a bug in the `redraw` function here (previously
unused, now used when the user selects a different timezone.)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
