### PR TITLE
AIRFLOW-2644 - Allow wild-cards in the search box in the UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+import re
 import copy
 import itertools
 import json
@@ -278,6 +279,7 @@ class Airflow(AirflowBaseView):
                     DagModel.dag_id.ilike('%' + arg_search_query + '%') |
                     DagModel.owners.ilike('%' + arg_search_query + '%')
                 )
+                dags_query = re.findall('*' + arg_search_query +'*', DagModel.dag_id)
 
             if arg_tags_filter:
                 dags_query = dags_query.filter(DagModel.tags.any(DagTag.name.in_(arg_tags_filter)))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-import re
 import copy
 import itertools
 import json
@@ -25,6 +24,7 @@ import logging
 import math
 import os
 import pkgutil
+import re
 import socket
 import traceback
 from collections import defaultdict
@@ -279,7 +279,7 @@ class Airflow(AirflowBaseView):
                     DagModel.dag_id.ilike('%' + arg_search_query + '%') |
                     DagModel.owners.ilike('%' + arg_search_query + '%')
                 )
-                dags_query = re.findall('*' + arg_search_query +'*', DagModel.dag_id)
+                dags_query = re.findall('*' + arg_search_query + '*', DagModel.dag_id)
 
             if arg_tags_filter:
                 dags_query = dags_query.filter(DagModel.tags.any(DagTag.name.in_(arg_tags_filter)))


### PR DESCRIPTION
  Allow support of wildcards mainly for *. If i have a Dag name called example and i search for ex*, it should show example in the list.
  I use regular expression to allow wildcards. Regular expressions are used to identify without a pattern exist in a given sequence or not.
  I use the findall() function which returns the list containing all matches.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
