### PR TITLE
Handle DST better in Task Instance tool tips

### DIFF
--- a/airflow/www/static/js/datetime-utils.js
+++ b/airflow/www/static/js/datetime-utils.js
@@ -22,16 +22,9 @@ export const defaultFormat = 'YYYY-MM-DD, HH:mm:ss';
 export const defaultFormatWithTZ = 'YYYY-MM-DD, HH:mm:ss z';
 export const defaultTZFormat = 'z (Z)';
 
-let currentTimezone = 'UTC'
-
 export function setDisplayedTimezone(tz) {
-  currentTimezone = tz;
   moment.tz.setDefault(tz);
   updateAllDateTimes();
-}
-
-export function getCurrentTimezone() {
-  return currentTimezone;
 }
 
 export function formatTimezone(what) {

--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -20,7 +20,7 @@
 /* global window, dagTZ, moment, convertSecsToHumanReadable */
 
 // We don't re-import moment again, otherwise webpack will include it twice in the bundle!
-import { defaultFormat, formatDateTime, getCurrentTimezone } from './datetime-utils';
+import { defaultFormat, formatDateTime } from './datetime-utils';
 import { escapeHtml } from './base';
 
 function makeDateTimeHTML(start, end) {
@@ -31,7 +31,7 @@ function makeDateTimeHTML(start, end) {
 
 function generateTooltipDateTimes(startDate, endDate, dagTZ) {
   const tzFormat = 'z (Z)';
-  const localTZ = getCurrentTimezone();
+  const localTZ = moment.defaultZone.name;
   startDate = moment.utc(startDate);
   endDate = moment.utc(endDate);
   dagTZ = dagTZ.toUpperCase();
@@ -46,13 +46,15 @@ function generateTooltipDateTimes(startDate, endDate, dagTZ) {
   tooltipHTML += makeDateTimeHTML(startDate, endDate);
 
   // Generate User's Local Start and End Date
-  tooltipHTML += `<br><strong>Local: ${moment.tz(localTZ).format(tzFormat)}</strong><br>`;
-  tooltipHTML += makeDateTimeHTML(startDate.tz(localTZ), endDate.tz(localTZ));
+  startDate.tz(localTZ);
+  tooltipHTML += `<br><strong>Local: ${startDate.format(tzFormat)}</strong><br>`;
+  tooltipHTML += makeDateTimeHTML(startDate, endDate.tz(localTZ));
 
   // Generate DAG's Start and End Date
   if (dagTZ !== 'UTC' && dagTZ !== localTZ) {
-    tooltipHTML += `<br><strong>DAG's TZ: ${moment.tz(dagTZ).format(tzFormat)}</strong><br>`;
-    tooltipHTML += makeDateTimeHTML(startDate.tz(dagTZ), endDate.tz(dagTZ));
+    startDate.tz(dagTZ);
+    tooltipHTML += `<br><strong>DAG's TZ: ${startDate.format(tzFormat)}</strong><br>`;
+    tooltipHTML += makeDateTimeHTML(startDate, endDate.tz(dagTZ));
   }
 
   return tooltipHTML;


### PR DESCRIPTION
We displayed the zone "name" based on the current time, which could lead
to confusion when the date to be displayed was not in the same
daylight-savings state as "now".

![image (1)](https://user-images.githubusercontent.com/34150/78388745-6f119e00-75d9-11ea-85b3-fd34a745a6a8.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
