### PR TITLE
Fix minor issues with Announcements Dev Scripts

### DIFF
--- a/dev/send_email.py
+++ b/dev/send_email.py
@@ -37,14 +37,9 @@ except ModuleNotFoundError:
 
 SMTP_PORT = 587
 SMTP_SERVER = "mail-relay.apache.org"
-PROJECT_NAME = "Airflow"
-PROJECT_MODULE = "airflow"
-PROJECT_DESCRIPTION = "Apache Airflow - A platform to programmatically author, " \
-                      "schedule, and monitor workflows"
-TWITTER_HANDLE = "@ApacheAirflow"
 MAILING_LIST = {
-    "dev": f"dev@{PROJECT_MODULE}.apache.org",
-    "users": f"users@{PROJECT_MODULE}.apache.org"
+    "dev": f"dev@airflow.apache.org",
+    "users": f"users@airflow.apache.org"
 }
 
 
@@ -200,13 +195,9 @@ def cli(
     base_parameters = BaseParameters(
         name, apache_email, apache_username, apache_password, version, version_rc
     )
-    base_parameters.template_arguments["project_name"] = PROJECT_NAME
-    base_parameters.template_arguments["project_module"] = PROJECT_MODULE
-    base_parameters.template_arguments["project_description"] = PROJECT_DESCRIPTION
     base_parameters.template_arguments["version"] = base_parameters.version
     base_parameters.template_arguments["version_rc"] = base_parameters.version_rc
     base_parameters.template_arguments["sender_email"] = base_parameters.email
-    base_parameters.template_arguments["twitter_handle"] = TWITTER_HANDLE
     base_parameters.template_arguments["release_manager"] = base_parameters.name
     ctx.obj = base_parameters
 

--- a/dev/templates/announce_email.j2
+++ b/dev/templates/announce_email.j2
@@ -18,25 +18,25 @@
 -#}
 To: {{ receiver_email | list | join(', ') }}
 From: {{ sender_email }}
-Subject: [ANNOUNCE] Apache {{ project_name }} version {{ version }} Released
+Subject: [ANNOUNCE] Apache Airflow version {{ version }} Released
 
-Dear {{ project_name }} community,
+Dear Apache Airflow community,
 
-I am pleased to announce that {{ project_name }} {{ version }} has just been released.
+I am pleased to announce that Apache Airflow {{ version }} has just been released.
 
-{{ project_description }}
+Apache Airflow - A platform to programmatically author, schedule, and monitor workflows.
 
 The official source release:
-https://dist.apache.org/repos/dist/release/{{ project_module }}/{{ version }}
+https://dist.apache.org/repos/dist/release/airflow/{{ version }}
 
 The Pypi package:
-https://pypi.org/project/apache-{{ project_module }}/{{ version }}/
+https://pypi.org/project/apache-airflow/{{ version }}/
 
 The documentation is available on:
-https://{{ project_module }}.apache.org/docs/{{ version }}/
+https://airflow.apache.org/docs/{{ version }}/
 
 Find the CHANGELOG here for more details:
-https://{{ project_module }}.apache.org/docs/{{ version }}/changelog.html
+https://airflow.apache.org/docs/{{ version }}/changelog.html
 
 If you have any usage questions, or have problems when upgrading or
 find any problems about enhancements included in this release, please

--- a/dev/templates/result_email.j2
+++ b/dev/templates/result_email.j2
@@ -18,9 +18,9 @@
 -#}
 To: {{ receiver_email }}
 From: {{ sender_email }}
-Subject: [RESULT][VOTE] Release Apache {{ project_name }} {{ version }} based on {{ version_rc }}
+Subject: [RESULT][VOTE] Release Apache Apache Airflow {{ version }} based on {{ version_rc }}
 
-The vote to release Apache {{ project_name }} version {{ version }} based on {{ version_rc }} is now closed.
+The vote to release Apache Apache Airflow version {{ version }} based on {{ version_rc }} is now closed.
 
 {% if vote_negatives|length > vote_bindings|length -%}
 The vote did NOT PASS with {{vote_bindings|length}} binding "+1", {{ vote_nonbindings|length}} non-binding "+1" and {{vote_negatives|length}} "-1" votes:

--- a/dev/templates/slack.j2
+++ b/dev/templates/slack.j2
@@ -17,15 +17,15 @@
   under the License.
 -#}
 {% if slack_rc -%}
-@here We've just released {{ project_name }} {{ version }} :tada:
-:package: https://pypi.org/project/{{ project_module }}/{{ version }}/
-:books: https://{{ project_module }}.apache.org/docs/{{ version }}/
-:hammer_and_wrench: https://{{ project_module }}.apache.org/docs/{{ version }}/changelog.html
+@here We've just released Apache Airflow {{ version }} :tada:
+:package: https://pypi.org/project/apache-airflow/{{ version }}/
+:books: https://airflow.apache.org/docs/{{ version }}/
+:hammer_and_wrench: https://airflow.apache.org/docs/{{ version }}/changelog.html
 {% else -%}
-@here  Hot off the press :hotsprings: :fire: {{ project_name }} {{ version_rc }} available for testing.
+@here  Hot off the press :hotsprings: :fire: Apache Airflow {{ version_rc }} available for testing.
 
-Snapshots have been uploaded on PyPI too: `pip install {{ project_module }}=={{ version_rc }}`
-**ChangeLog:** https://github.com/apache/{{ project_module }}/blob/{{ version_rc }}/CHANGELOG.txt
+Snapshots have been uploaded on PyPI too: `pip install apache-airflow=={{ version_rc }}`
+**ChangeLog:** https://github.com/apache/airflow/blob/{{ version_rc }}/CHANGELOG.txt
 
 Please let us know if you have any issues on {{ receiver_email }}
 {%- endif %}

--- a/dev/templates/twitter.j2
+++ b/dev/templates/twitter.j2
@@ -16,8 +16,8 @@
   specific language governing permissions and limitations
   under the License.
 -#}
-We've just released {{ twitter_handle }} {{ version }} 🎉
+We've just released @ApacheAirflow {{ version }} 🎉
 
-📦 https://pypi.org/project/{{ project_module }}/{{ version }}/
-📚 https://{{ project_module }}.apache.org/docs/{{ version }}/
-🛠 https://{{ project_module }}.apache.org/docs/{{ version }}/changelog.html
+📦 https://pypi.org/project/apache-airflow/{{ version }}/
+📚 https://airflow.apache.org/docs/{{ version }}/
+🛠 https://airflow.apache.org/docs/{{ version }}/changelog.html

--- a/dev/templates/vote_email.j2
+++ b/dev/templates/vote_email.j2
@@ -18,23 +18,24 @@
 -#}
 To: {{ receiver_email }}
 From: {{ sender_email }}
-Subject: [VOTE] Release Apache {{ project_name }} {{ version }} based on {{ version_rc }}
+Subject: [VOTE] Release Apache Airflow {{ version }} based on {{ version_rc }}
 
-Hello {{ project_name }} Community,
+Hello Apache Airflow Community,
 
-This is a call for the vote to release Apache {{ project_name }} version {{ version }}.
+This is a call for the vote to release Apache Airflow version {{ version }}.
 
 The release candidate:
-https://dist.apache.org/repos/dist/dev/{{ project_module }}/{{ version_rc }}/
+https://dist.apache.org/repos/dist/dev/airflow/{{ version_rc }}/
 
 *apache-airflow-{{ version_rc }}-source.tar.gz* is a source release that comes
 with INSTALL instructions.
 *apache-airflow-{{ version_rc }}-bin.tar.gz* is the binary Python "sdist" release.
+*apache_airflow-{{ version_rc }}-py2.py3-none-any.whl* is the binary Python wheel release.
 
-Public keys are available at: https://www.apache.org/dist/{{ project_module }}/KEYS
+Public keys are available at: https://www.apache.org/dist/airflow/KEYS
 
 The Change Log for the release:
-https://github.com/apache/{{ project_module }}/blob/{{ version_rc }}/CHANGELOG.txt
+https://github.com/apache/airflow/blob/{{ version_rc }}/CHANGELOG.txt
 
 The vote will be open for at least 72 hours or until the necessary number
 of votes are reached.


### PR DESCRIPTION
Fixes following Minor issues:

- Adds **wheel** package name in Voting email
- Fixes pip package name (`apache-airflow instead of `airflow`)
- Simplifies templates by removing unnecessary Templating(hardcode Project Names, Twitter handle etc)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
