### PR TITLE
Fix broken Triggering Dag from UI functionality

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1749,41 +1749,6 @@ class DagModel(Base):
         return self.dag_id.replace('.', '__dot__')
 
     @provide_session
-    def create_dagrun(self,
-                      run_id,
-                      state,
-                      execution_date,
-                      start_date=None,
-                      external_trigger=False,
-                      conf=None,
-                      session=None):
-        """
-        Creates a dag run from this dag including the tasks associated with this dag.
-        Returns the dag run.
-
-        :param run_id: defines the run id for this dag run
-        :type run_id: str
-        :param execution_date: the execution date of this dag run
-        :type execution_date: datetime.datetime
-        :param state: the state of the dag run
-        :type state: airflow.utils.state.State
-        :param start_date: the date this dag run should be evaluated
-        :type start_date: datetime.datetime
-        :param external_trigger: whether this dag run is externally triggered
-        :type external_trigger: bool
-        :param session: database session
-        :type session: sqlalchemy.orm.session.Session
-        """
-
-        return self.get_dag().create_dagrun(run_id=run_id,
-                                            state=state,
-                                            execution_date=execution_date,
-                                            start_date=start_date,
-                                            external_trigger=external_trigger,
-                                            conf=conf,
-                                            session=session)
-
-    @provide_session
     def set_is_paused(self,
                       is_paused: bool,
                       including_subdags: bool = True,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1009,8 +1009,8 @@ class Airflow(AirflowBaseView):
                 conf=''
             )
 
-        dag = session.query(models.DagModel).filter(models.DagModel.dag_id == dag_id).first()
-        if not dag:
+        dag_orm = session.query(models.DagModel).filter(models.DagModel.dag_id == dag_id).first()
+        if not dag_orm:
             flash("Cannot find dag {}".format(dag_id))
             return redirect(origin)
 
@@ -1036,6 +1036,7 @@ class Airflow(AirflowBaseView):
                     conf=conf
                 )
 
+        dag = get_dag(dag_orm, STORE_SERIALIZED_DAGS)
         dag.create_dagrun(
             run_id=run_id,
             execution_date=execution_date,

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -33,6 +33,7 @@ from unittest import mock
 from urllib.parse import quote_plus
 
 import jinja2
+import pytest
 from flask import Markup, session as flask_session, url_for
 from parameterized import parameterized
 from werkzeug.test import Client
@@ -53,6 +54,7 @@ from airflow.settings import Session
 from airflow.ti_deps.dependencies_states import QUEUEABLE_STATES, RUNNABLE_STATES
 from airflow.utils import dates, timezone
 from airflow.utils.session import create_session
+from airflow.utils.sqlalchemy import using_mysql
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
@@ -2114,6 +2116,7 @@ class TestTriggerDag(TestBase):
         self.assertIn('/trigger?dag_id=example_bash_operator', resp.data.decode('utf-8'))
         self.assertIn("return confirmDeleteDag(this, 'example_bash_operator')", resp.data.decode('utf-8'))
 
+    @pytest.mark.xfail(condition=using_mysql, reason="This test might be flaky on mysql")
     def test_trigger_dag_button(self):
 
         test_dag_id = "example_bash_operator"
@@ -2128,6 +2131,7 @@ class TestTriggerDag(TestBase):
         self.assertIsNotNone(run)
         self.assertIn("manual__", run.run_id)
 
+    @pytest.mark.xfail(condition=using_mysql, reason="This test might be flaky on mysql")
     def test_trigger_dag_conf(self):
 
         test_dag_id = "example_bash_operator"

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -33,7 +33,6 @@ from unittest import mock
 from urllib.parse import quote_plus
 
 import jinja2
-import pytest
 from flask import Markup, session as flask_session, url_for
 from parameterized import parameterized
 from werkzeug.test import Client
@@ -2115,7 +2114,6 @@ class TestTriggerDag(TestBase):
         self.assertIn('/trigger?dag_id=example_bash_operator', resp.data.decode('utf-8'))
         self.assertIn("return confirmDeleteDag(this, 'example_bash_operator')", resp.data.decode('utf-8'))
 
-    @pytest.mark.xfail(condition=True, reason="This test might be flaky on mysql")
     def test_trigger_dag_button(self):
 
         test_dag_id = "example_bash_operator"
@@ -2130,7 +2128,6 @@ class TestTriggerDag(TestBase):
         self.assertIsNotNone(run)
         self.assertIn("manual__", run.run_id)
 
-    @pytest.mark.xfail(condition=True, reason="This test might be flaky on mysql")
     def test_trigger_dag_conf(self):
 
         test_dag_id = "example_bash_operator"


### PR DESCRIPTION
https://github.com/apache/airflow/pull/7899 broke Triggering DAG from UI

```
>       return self.get_dag().create_dagrun(run_id=run_id,
                                            state=state,
                                            execution_date=execution_date,
                                            start_date=start_date,
                                            external_trigger=external_trigger,
                                            conf=conf,
                                            session=session)
E       AttributeError: 'DagModel' object has no attribute 'get_dag'

airflow/models/dag.py:1778: AttributeError
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
