### PR TITLE
[AIRFLOW-3126] Add option to specify additional K8s volumes

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1898,6 +1898,20 @@
       type: string
       example: ~
       default: ""
+    - name: extra_volume_mounts
+      description: |
+        Extra volumes to be mounted in worker pods.  Volumes are specified as
+        keys in a JSON object with nested JSON values specifying each volume's
+        options.  Recognized options are `claim_name` or `secret_name`
+        (required), `mount_path` (required), `read_only` (boolean, default
+        null), `sub_path` (default null), `secret_key` (string, default null),
+        `secret_mode` (string, default null).
+      version_added: ~
+      type: string
+      example: >-
+        {{"secret_vol": {{"secret_name": "some-secret", "mount_path": "/dir1", "sub_path": "subpath1",
+        "secret_mode": "440"}}, "pvc": {{"claim_name": "some-pvc", "mount_path": "/dir2"}}}}
+      default: ""
     - name: dags_volume_host
       description: |
         For DAGs mounted via a hostPath volume (mutually exclusive with volume claim and git-sync)

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -914,6 +914,15 @@ logs_volume_subpath =
 # A shared volume claim for the logs
 logs_volume_claim =
 
+# Extra volumes to be mounted in worker pods.  Volumes are specified as
+# keys in a JSON object with nested JSON values specifying each volume's
+# options.  Recognized options are `claim_name` or `secret_name`
+# (required), `mount_path` (required), `read_only` (boolean, default
+# null), `sub_path` (default null), `secret_key` (string, default null),
+# `secret_mode` (string, default null).
+# Example: extra_volume_mounts = {{{{"secret_vol": {{{{"secret_name": "some-secret", "mount_path": "/dir1", "sub_path": "subpath1", "secret_mode": "440"}}}}, "pvc": {{{{"claim_name": "some-pvc", "mount_path": "/dir2"}}}}}}}}
+extra_volume_mounts =
+
 # For DAGs mounted via a hostPath volume (mutually exclusive with volume claim and git-sync)
 # Useful in local environment, discouraged in production
 dags_volume_host =

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -35,6 +35,7 @@ try:
     from airflow.executors.kubernetes_executor import KubeConfig
     from airflow.kubernetes import pod_generator
     from airflow.kubernetes.pod_generator import PodGenerator
+    from airflow.exceptions import AirflowConfigException
     from airflow.utils.state import State
 except ImportError:
     AirflowKubernetesScheduler = None  # type: ignore
@@ -167,6 +168,125 @@ class TestKubeConfig(unittest.TestCase):
     })
     def test_kube_config_git_sync_run_as_user_empty_string(self):
         self.assertEqual(KubeConfig().git_sync_run_as_user, '')
+
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'):
+        '{"pvc1": {"secret_name": "secret1", "mount_path": "/volume1",'
+        ' "sub_path": "subpath1", "secret_mode": "440"}}',
+    })
+    def test_worker_extra_volume_mounts_single(self):
+        kube_config = KubeConfig()
+
+        assert len(kube_config.extra_volume_mounts) == 1
+        assert kube_config.extra_volume_mounts['pvc1'] == {
+            'claim_name': None,
+            'mount_path': '/volume1',
+            'sub_path': 'subpath1',
+            'read_only': None,
+            'secret_name': 'secret1',
+            'secret': True,
+            'secret_key': None,
+            'secret_mode': 0o440,
+        }
+
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'): '{[]}',
+    })
+    def test_worker_extra_volume_mounts_invalid_json(self):
+        with self.assertRaisesRegex(AirflowConfigException,
+                                    'Error parsing.*`extra_volume_mounts`.*'):
+            KubeConfig()
+
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'):
+        '{"pvc1": {"mount_path": "/volume1", "secret_mode": 1}}',
+    })
+    def test_worker_extra_volume_mounts_invalid_mode(self):
+        with self.assertRaisesRegex(AirflowConfigException,
+                                    'Error converting.*`extra_volume_mounts`.*'):
+            KubeConfig()
+
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'):
+        '{"pvc1": {"mount_path": "/volume1", "read_only": "no"}}',
+    })
+    def test_worker_extra_volume_mounts_invalid_read_only(self):
+        with self.assertRaisesRegex(
+                AirflowConfigException,
+                'Value of `read_only` is not boolean.*`extra_volume_mounts`.*'):
+            KubeConfig()
+
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'):
+        '{"pvc1": {"mount_path": "/volume1", "secret_key": "key"}}',
+    })
+    def test_worker_extra_volume_mounts_missing_key_path(self):
+        with self.assertRaisesRegex(
+                AirflowConfigException,
+                'Missing `secret_key_path`.*`extra_volume_mounts`.*'):
+            KubeConfig()
+
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'):
+        '{"pvc1": {"read_only": true}}',
+    })
+    def test_worker_extra_volume_mounts_missing_mount_path(self):
+        with self.assertRaisesRegex(
+                AirflowConfigException,
+                'Missing `mount_path`.*`extra_volume_mounts`.*'):
+            KubeConfig()
+
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'):
+        '{"pvc1": {"mount_path": "/volume1", "secret_mode": "443"}}',
+    })
+    def test_worker_extra_volume_mounts_missing_secret_name(self):
+        with self.assertRaisesRegex(
+                AirflowConfigException,
+                'Missing `secret_name`.*`extra_volume_mounts`.*'):
+            KubeConfig()
+
+    @conf_vars({
+        ('kubernetes', 'dags_volume_subpath'): 'dags',
+        ('kubernetes', 'logs_volume_subpath'): 'logs',
+        ('kubernetes', 'dags_volume_claim'): 'dags',
+        ('kubernetes', 'dags_folder'): 'dags',
+        ('kubernetes', 'extra_volume_mounts'):
+        '{"pvc1": {"mount_path": "/volume1"}}',
+    })
+    def test_worker_extra_volume_mounts_missing_name(self):
+        with self.assertRaisesRegex(
+                AirflowConfigException,
+                'Missing `claim_name` or `secret_name`.*`extra_volume_mounts`.*'):
+            KubeConfig()
 
 
 class TestKubernetesExecutor(unittest.TestCase):


### PR DESCRIPTION
This PR introduces a new config option, `kubernetes.extra_volume_mounts`, that allows users to specify multiple Kubernetes volumes to be mounted in each generated worker pod.

This PR replaces #7423 (moved to my personal fork).

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
