### PR TITLE
Reorder middleware - ProxyFix and BaseUrl

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -49,15 +49,6 @@ log = logging.getLogger(__name__)
 def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     global app, appbuilder
     app = Flask(__name__)
-    if conf.getboolean('webserver', 'ENABLE_PROXY_FIX'):
-        app.wsgi_app = ProxyFix(
-            app.wsgi_app,
-            x_for=conf.getint("webserver", "PROXY_FIX_X_FOR", fallback=1),
-            x_proto=conf.getint("webserver", "PROXY_FIX_X_PROTO", fallback=1),
-            x_host=conf.getint("webserver", "PROXY_FIX_X_HOST", fallback=1),
-            x_port=conf.getint("webserver", "PROXY_FIX_X_PORT", fallback=1),
-            x_prefix=conf.getint("webserver", "PROXY_FIX_X_PREFIX", fallback=1)
-        )
     app.secret_key = conf.get('webserver', 'SECRET_KEY')
 
     session_lifetime_days = conf.getint('webserver', 'SESSION_LIFETIME_DAYS', fallback=30)
@@ -306,6 +297,15 @@ def cached_app(config=None, session=None, testing=False):
 
         app, _ = create_app(config, session, testing)
         app = DispatcherMiddleware(root_app, {base_url: app})
+        if conf.getboolean('webserver', 'ENABLE_PROXY_FIX'):
+            app = ProxyFix(
+                app,
+                x_for=conf.getint("webserver", "PROXY_FIX_X_FOR", fallback=1),
+                x_proto=conf.getint("webserver", "PROXY_FIX_X_PROTO", fallback=1),
+                x_host=conf.getint("webserver", "PROXY_FIX_X_HOST", fallback=1),
+                x_port=conf.getint("webserver", "PROXY_FIX_X_PORT", fallback=1),
+                x_prefix=conf.getint("webserver", "PROXY_FIX_X_PREFIX", fallback=1)
+            )
     return app
 
 

--- a/tests/www/test_app.py
+++ b/tests/www/test_app.py
@@ -17,41 +17,185 @@
 # under the License.
 
 import unittest
+from unittest import mock
 
-from werkzeug.middleware.proxy_fix import ProxyFix
+from werkzeug.routing import Rule
+from werkzeug.test import create_environ
+from werkzeug.wrappers import Response
 
-from airflow.settings import Session
 from airflow.www import app as application
 from tests.test_utils.config import conf_vars
 
 
 class TestApp(unittest.TestCase):
-    @conf_vars({('webserver', 'enable_proxy_fix'): 'False'})
-    def test_constructor_no_proxyfix(self):
-        app, _ = application.create_app(session=Session, testing=True)
-        self.assertFalse(isinstance(app.wsgi_app, ProxyFix))
 
-    @conf_vars({('webserver', 'enable_proxy_fix'): 'True'})
-    def test_constructor_proxyfix(self):
-        app, _ = application.create_app(session=Session, testing=True)
-        self.assertTrue(isinstance(app.wsgi_app, ProxyFix))
-        self.assertEqual(app.wsgi_app.x_for, 1)
-        self.assertEqual(app.wsgi_app.x_proto, 1)
-        self.assertEqual(app.wsgi_app.x_host, 1)
-        self.assertEqual(app.wsgi_app.x_port, 1)
-        self.assertEqual(app.wsgi_app.x_prefix, 1)
+    @conf_vars({
+        ('webserver', 'enable_proxy_fix'): 'True',
+        ('webserver', 'proxy_fix_x_for'): '1',
+        ('webserver', 'proxy_fix_x_proto'): '1',
+        ('webserver', 'proxy_fix_x_host'): '1',
+        ('webserver', 'proxy_fix_x_port'): '1',
+        ('webserver', 'proxy_fix_x_prefix'): '1'
+    })
+    @mock.patch("airflow.www.app.app", None)
+    @mock.patch("airflow.www.app.appbuilder", None)
+    def test_should_respect_proxy_fix(self):
+        app = application.cached_app(testing=True)
+        flask_app = next(iter(app.app.mounts.values()))
+        flask_app.url_map.add(Rule("/debug", endpoint="debug"))
 
-    @conf_vars({('webserver', 'enable_proxy_fix'): 'True',
-                ('webserver', 'proxy_fix_x_for'): '3',
-                ('webserver', 'proxy_fix_x_proto'): '4',
-                ('webserver', 'proxy_fix_x_host'): '5',
-                ('webserver', 'proxy_fix_x_port'): '6',
-                ('webserver', 'proxy_fix_x_prefix'): '7'})
-    def test_constructor_proxyfix_args(self):
-        app, _ = application.create_app(session=Session, testing=True)
-        self.assertTrue(isinstance(app.wsgi_app, ProxyFix))
-        self.assertEqual(app.wsgi_app.x_for, 3)
-        self.assertEqual(app.wsgi_app.x_proto, 4)
-        self.assertEqual(app.wsgi_app.x_host, 5)
-        self.assertEqual(app.wsgi_app.x_port, 6)
-        self.assertEqual(app.wsgi_app.x_prefix, 7)
+        def debug_view():
+            from flask import request
+
+            # Should respect HTTP_X_FORWARDED_FOR
+            self.assertEqual(request.remote_addr, '192.168.0.1')
+            # Should respect HTTP_X_FORWARDED_PROTO, HTTP_X_FORWARDED_HOST, HTTP_X_FORWARDED_PORT,
+            # HTTP_X_FORWARDED_PREFIX
+            self.assertEqual(request.url, 'https://valid:445/proxy-prefix/debug')
+
+            return Response("success")
+
+        flask_app.view_functions['debug'] = debug_view
+
+        new_environ = {
+            "PATH_INFO": "/debug",
+            "REMOTE_ADDR": "192.168.0.2",
+            "HTTP_HOST": "invalid:9000",
+            "HTTP_X_FORWARDED_FOR": "192.168.0.1",
+            "HTTP_X_FORWARDED_PROTO": "https",
+            "HTTP_X_FORWARDED_HOST": "valid",
+            "HTTP_X_FORWARDED_PORT": "445",
+            "HTTP_X_FORWARDED_PREFIX": "/proxy-prefix",
+        }
+        environ = create_environ(environ_overrides=new_environ)
+
+        response = Response.from_app(app, environ)
+
+        self.assertEqual(b"success", response.get_data())
+        self.assertEqual(response.status_code, 200)
+
+    @conf_vars({
+        ('webserver', 'base_url'): 'http://localhost:8080/internal-client',
+    })
+    @mock.patch("airflow.www.app.app", None)
+    @mock.patch("airflow.www.app.appbuilder", None)
+    def test_should_respect_base_url_ignore_proxy_headers(self):
+        app = application.cached_app(testing=True)
+        flask_app = next(iter(app.mounts.values()))
+        flask_app.url_map.add(Rule("/debug", endpoint="debug"))
+
+        def debug_view():
+            from flask import request
+
+            # Should respect HTTP_X_FORWARDED_FOR
+            self.assertEqual(request.remote_addr, '192.168.0.2')
+            # Should respect HTTP_X_FORWARDED_PROTO, HTTP_X_FORWARDED_HOST, HTTP_X_FORWARDED_PORT,
+            # HTTP_X_FORWARDED_PREFIX
+            self.assertEqual(request.url, 'http://invalid:9000/internal-client/debug')
+
+            return Response("success")
+
+        flask_app.view_functions['debug'] = debug_view
+
+        new_environ = {
+            "PATH_INFO": "/internal-client/debug",
+            "REMOTE_ADDR": "192.168.0.2",
+            "HTTP_HOST": "invalid:9000",
+            "HTTP_X_FORWARDED_FOR": "192.168.0.1",
+            "HTTP_X_FORWARDED_PROTO": "https",
+            "HTTP_X_FORWARDED_HOST": "valid",
+            "HTTP_X_FORWARDED_PORT": "445",
+            "HTTP_X_FORWARDED_PREFIX": "/proxy-prefix",
+        }
+        environ = create_environ(environ_overrides=new_environ)
+
+        response = Response.from_app(app, environ)
+
+        self.assertEqual(b"success", response.get_data())
+        self.assertEqual(response.status_code, 200)
+
+    @conf_vars({
+        ('webserver', 'base_url'): 'http://localhost:8080/internal-client',
+        ('webserver', 'enable_proxy_fix'): 'True',
+        ('webserver', 'proxy_fix_x_for'): '1',
+        ('webserver', 'proxy_fix_x_proto'): '1',
+        ('webserver', 'proxy_fix_x_host'): '1',
+        ('webserver', 'proxy_fix_x_port'): '1',
+        ('webserver', 'proxy_fix_x_prefix'): '1'
+    })
+    @mock.patch("airflow.www.app.app", None)
+    @mock.patch("airflow.www.app.appbuilder", None)
+    def test_should_respect_base_url_when_proxy_fix_and_base_url_is_set_up_but_headers_missing(self):
+        app = application.cached_app(testing=True)
+        flask_app = next(iter(app.app.mounts.values()))
+        flask_app.url_map.add(Rule("/debug", endpoint="debug"))
+
+        def debug_view():
+            from flask import request
+
+            # Should use original REMOTE_ADDR
+            self.assertEqual(request.remote_addr, '192.168.0.1')
+            # Should respect base_url
+            self.assertEqual(request.url, "http://invalid:9000/internal-client/debug")
+
+            return Response("success")
+
+        flask_app.view_functions['debug'] = debug_view
+
+        new_environ = {
+            "PATH_INFO": "/internal-client/debug",
+            "REMOTE_ADDR": "192.168.0.1",
+            "HTTP_HOST": "invalid:9000",
+        }
+        environ = create_environ(environ_overrides=new_environ)
+
+        response = Response.from_app(app, environ)
+
+        self.assertEqual(b"success", response.get_data())
+        self.assertEqual(response.status_code, 200)
+
+    @conf_vars({
+        ('webserver', 'base_url'): 'http://localhost:8080/internal-client',
+        ('webserver', 'enable_proxy_fix'): 'True',
+        ('webserver', 'proxy_fix_x_for'): '1',
+        ('webserver', 'proxy_fix_x_proto'): '1',
+        ('webserver', 'proxy_fix_x_host'): '1',
+        ('webserver', 'proxy_fix_x_port'): '1',
+        ('webserver', 'proxy_fix_x_prefix'): '1'
+    })
+    @mock.patch("airflow.www.app.app", None)
+    @mock.patch("airflow.www.app.appbuilder", None)
+    def test_should_respect_base_url_and_proxy_when_proxy_fix_and_base_url_is_set_up(self):
+        app = application.cached_app(testing=True)
+        flask_app = next(iter(app.app.mounts.values()))
+        flask_app.url_map.add(Rule("/debug", endpoint="debug"))
+
+        def debug_view():
+            from flask import request
+
+            # Should respect HTTP_X_FORWARDED_FOR
+            self.assertEqual(request.remote_addr, '192.168.0.1')
+            # Should respect HTTP_X_FORWARDED_PROTO, HTTP_X_FORWARDED_HOST, HTTP_X_FORWARDED_PORT,
+            # HTTP_X_FORWARDED_PREFIX and use base_url
+            self.assertEqual(request.url, "https://valid:445/proxy-prefix/internal-client/debug")
+
+            return Response("success")
+
+        flask_app.view_functions['debug'] = debug_view
+
+        new_environ = {
+            "PATH_INFO": "/internal-client/debug",
+            "REMOTE_ADDR": "192.168.0.2",
+            "HTTP_HOST": "invalid:9000",
+            "HTTP_X_FORWARDED_FOR": "192.168.0.1",
+            "HTTP_X_FORWARDED_PROTO": "https",
+            "HTTP_X_FORWARDED_HOST": "valid",
+            "HTTP_X_FORWARDED_PORT": "445",
+            "HTTP_X_FORWARDED_PREFIX": "/proxy-prefix",
+        }
+        environ = create_environ(environ_overrides=new_environ)
+
+        response = Response.from_app(app, environ)
+
+        self.assertEqual(b"success", response.get_data())
+        self.assertEqual(response.status_code, 200)

--- a/tests/www/test_app.py
+++ b/tests/www/test_app.py
@@ -87,7 +87,7 @@ class TestApp(unittest.TestCase):
         def debug_view():
             from flask import request
 
-            # Should respect HTTP_X_FORWARDED_FOR
+            # Should ignore HTTP_X_FORWARDED_FOR
             self.assertEqual(request.remote_addr, '192.168.0.2')
             # Should ignore HTTP_X_FORWARDED_PROTO, HTTP_X_FORWARDED_HOST, HTTP_X_FORWARDED_PORT,
             # HTTP_X_FORWARDED_PREFIX

--- a/tests/www/test_app.py
+++ b/tests/www/test_app.py
@@ -89,7 +89,7 @@ class TestApp(unittest.TestCase):
 
             # Should respect HTTP_X_FORWARDED_FOR
             self.assertEqual(request.remote_addr, '192.168.0.2')
-            # Should respect HTTP_X_FORWARDED_PROTO, HTTP_X_FORWARDED_HOST, HTTP_X_FORWARDED_PORT,
+            # Should ignore HTTP_X_FORWARDED_PROTO, HTTP_X_FORWARDED_HOST, HTTP_X_FORWARDED_PORT,
             # HTTP_X_FORWARDED_PREFIX
             self.assertEqual(request.url, 'http://invalid:9000/internal-client/debug')
 


### PR DESCRIPTION
ProxyFix overrides the value of `environ["SCRIPT_NAME"]` variable, so it must be the first middleware.

When I have setup proxy fix , setup base url (`internal-client`) and I send proxy headers (``"HTTP_X_FORWARDED_PREFIX": "/proxy-prefix"``). The application expects to be available at: ``https://valid:445/proxy-prefix/debug``
Now the application is building the URL correctly:``https://valid:445/proxy-prefix/internal-client/debug``

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
