### PR TITLE
Fix Viewing Dag Code for Stateless Webserver

### DIFF
--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -85,6 +85,14 @@ class DagCode(Base):
             .with_for_update(of=DagCode)
             .all()
         )
+
+        if existing_orm_dag_codes:
+            existing_orm_dag_codes_map = {
+                orm_dag_code.fileloc: orm_dag_code for orm_dag_code in existing_orm_dag_codes
+            }
+        else:
+            existing_orm_dag_codes_map = dict()
+
         existing_orm_dag_codes_by_fileloc_hashes = {
             orm.fileloc_hash: orm for orm in existing_orm_dag_codes
         }
@@ -122,7 +130,7 @@ class DagCode(Base):
                 os.path.getmtime(correct_maybe_zipped(fileloc)), tz=timezone.utc)
 
             if (file_modified - timedelta(seconds=120)) > old_version.last_updated:
-                orm_dag_code = DagCode(fileloc, cls._get_code_from_db(fileloc))
+                orm_dag_code = existing_orm_dag_codes_map[fileloc]
                 orm_dag_code.last_updated = timezone.utcnow()
                 orm_dag_code.source_code = cls._get_code_from_file(orm_dag_code.fileloc)
                 session.merge(orm_dag_code)

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -52,17 +52,11 @@ class DagCode(Base):
     last_updated = Column(UtcDateTime, nullable=False)
     source_code = Column(UnicodeText, nullable=False)
 
-    def __init__(self, full_filepath):
+    def __init__(self, full_filepath, source_code=None):
         self.fileloc = full_filepath
         self.fileloc_hash = DagCode.dag_fileloc_hash(self.fileloc)
         self.last_updated = timezone.utcnow()
-        self.source_code = DagCode._read_code(self.fileloc)
-
-    @classmethod
-    def _read_code(cls, fileloc):
-        with open_maybe_zipped(fileloc, 'r') as source:
-            source_code = source.read()
-        return source_code
+        self.source_code = source_code or DagCode.code(self.fileloc)
 
     @provide_session
     def sync_to_db(self, session=None):
@@ -117,7 +111,7 @@ class DagCode(Base):
         missing_filelocs = filelocs.difference(existing_filelocs)
 
         for fileloc in missing_filelocs:
-            orm_dag_code = DagCode(fileloc)
+            orm_dag_code = DagCode(fileloc, cls._get_code_from_file(fileloc))
             session.add(orm_dag_code)
 
         for fileloc in existing_filelocs:
@@ -128,9 +122,9 @@ class DagCode(Base):
                 os.path.getmtime(correct_maybe_zipped(fileloc)), tz=timezone.utc)
 
             if (file_modified - timedelta(seconds=120)) > old_version.last_updated:
-                orm_dag_code = DagCode(fileloc)
+                orm_dag_code = DagCode(fileloc, cls._get_code_from_db(fileloc))
                 orm_dag_code.last_updated = timezone.utcnow()
-                orm_dag_code.source_code = DagCode._read_code(orm_dag_code.fileloc)
+                orm_dag_code.source_code = cls._get_code_from_file(orm_dag_code.fileloc)
                 session.merge(orm_dag_code)
 
     @classmethod
@@ -169,27 +163,30 @@ class DagCode(Base):
         :param fileloc: file path of a DAG
         :return: source code as string
         """
-        return DagCode(fileloc).code()
+        return cls.code(fileloc)
 
-    def code(self):
+    @classmethod
+    def code(cls, fileloc):
         """Returns source code for this DagCode object.
 
         :return: source code as string
         """
         if conf.getboolean('core', 'store_dag_code', fallback=False):
-            return self._get_code_from_db()
+            return cls._get_code_from_db(fileloc)
         else:
-            return self._get_code_from_file()
+            return cls._get_code_from_file(fileloc)
 
-    def _get_code_from_file(self):
-        with open_maybe_zipped(self.fileloc, 'r') as f:
+    @staticmethod
+    def _get_code_from_file(fileloc):
+        with open_maybe_zipped(fileloc, 'r') as f:
             code = f.read()
         return code
 
+    @classmethod
     @provide_session
-    def _get_code_from_db(self, session=None):
-        dag_code = session.query(DagCode) \
-            .filter(DagCode.fileloc_hash == self.fileloc_hash) \
+    def _get_code_from_db(cls, fileloc, session=None):
+        dag_code = session.query(cls) \
+            .filter(cls.fileloc_hash == cls.dag_fileloc_hash(fileloc)) \
             .first()
         if not dag_code:
             raise DagCodeNotFound()

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -137,7 +137,7 @@ class TestDagCode(unittest.TestCase):
     @conf_vars({('core', 'store_dag_code'): 'True'})
     def test_db_code_updated_on_dag_file_change(self):
         """
-        Test Source Code is updated in DB when DAG File is changes
+        Test Source Code is updated in DB when DAG File is changed
         """
         example_dag = make_example_dags(example_dags_module).get('example_bash_operator')
         example_dag.sync_to_db()

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from datetime import timedelta
 
 from mock import patch
 
@@ -114,3 +115,53 @@ class TestDagCode(unittest.TestCase):
                 with open_maybe_zipped(dag.fileloc, 'r') as source:
                     source_code = source.read()
                 self.assertEqual(result.source_code, source_code)
+
+    @conf_vars({('core', 'store_dag_code'): 'True'})
+    def test_code_can_be_read_when_no_access_to_file(self):
+        """
+        Test that code can be retrieved from DB when you do not have access to Code file.
+
+        Source Code should atleast exist in one of DB or File.
+        """
+        example_dag = make_example_dags(example_dags_module).get('example_bash_operator')
+        example_dag.sync_to_db()
+
+        # Mock that there is no access to the Dag File
+        with patch('airflow.models.dagcode.open_maybe_zipped') as mock_open:
+            mock_open.side_effect = FileNotFoundError
+            dag_code = DagCode.get_code_by_fileloc(example_dag.fileloc)
+
+            for test_string in ['example_bash_operator', 'also_run_this', 'run_this_last']:
+                self.assertIn(test_string, dag_code)
+
+    @conf_vars({('core', 'store_dag_code'): 'True'})
+    def test_db_code_updated_on_dag_file_change(self):
+        """
+        Test Source Code is updated in DB when DAG File is changes
+        """
+        example_dag = make_example_dags(example_dags_module).get('example_bash_operator')
+        example_dag.sync_to_db()
+
+        with create_session() as session:
+            result = session.query(DagCode) \
+                .filter(DagCode.fileloc == example_dag.fileloc) \
+                .one()
+
+            self.assertEqual(result.fileloc, example_dag.fileloc)
+            self.assertIsNotNone(result.source_code)
+
+        with patch('airflow.models.dagcode.os.path.getmtime') as mock_mtime:
+            mock_mtime.return_value = (result.last_updated + timedelta(seconds=121)).timestamp()
+
+            with patch('airflow.models.dagcode.DagCode._get_code_from_file') as mock_code:
+                mock_code.return_value = "# dummy code"
+                example_dag.sync_to_db()
+
+                with create_session() as session:
+                    new_result = session.query(DagCode) \
+                        .filter(DagCode.fileloc == example_dag.fileloc) \
+                        .one()
+
+                    self.assertEqual(new_result.fileloc, example_dag.fileloc)
+                    self.assertEqual(new_result.source_code, "# dummy code")
+                    self.assertGreater(new_result.last_updated, result.last_updated)


### PR DESCRIPTION
This bug was found by @KostyaEsmukov 

Details in https://github.com/apache/airflow/pull/8151#issuecomment-609439815

Basically when DagCode was instantiated it read the source code from Dag File, hence when the Webserver does not have access to the Dag File, it used to fail with FileNotFoundError:

```python
>>> DagCode(dag_orm.fileloc)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 4, in __init__
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/state.py", line 433, in _initialize_instance
    manager.dispatch.init_failure(self, args, kwargs)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py", line 69, in __exit__
    exc_value, with_traceback=exc_tb,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 178, in raise_
    raise exception
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/state.py", line 430, in _initialize_instance
    return manager.original_init(*mixed[1:], **kwargs)
  File "/usr/local/lib/python3.7/site-packages/airflow/models/dagcode.py", line 59, in __init__
    self.source_code = DagCode._read_code(self.fileloc)
  File "/usr/local/lib/python3.7/site-packages/airflow/models/dagcode.py", line 63, in _read_code
    with open_maybe_zipped(fileloc, 'r') as source:
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/file.py", line 102, in open_maybe_zipped
    return io.open(fileloc, mode=mode)
FileNotFoundError: [Errno 2] No such file or directory: '<...my_dag...>'
```

This PR fixes this and adds additional tests to validate this behavior

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
