### PR TITLE
[AIRFLOW-6515] Change Log Levels from Info/Warn to Error

### DIFF
--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -123,4 +123,4 @@ def _post_sendgrid_mail(mail_data):
                  mail_data['subject'], mail_data['personalizations'])
     else:
         log.error('Failed to send out email with subject %s, status code: %s',
-                 mail_data['subject'], response.status_code)
+                  mail_data['subject'], response.status_code)

--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -123,4 +123,4 @@ def _post_sendgrid_mail(mail_data):
                  mail_data['subject'], mail_data['personalizations'])
     else:
         log.error('Failed to send out email with subject %s, status code: %s',
-                    mail_data['subject'], response.status_code)
+                 mail_data['subject'], response.status_code)

--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -122,5 +122,5 @@ def _post_sendgrid_mail(mail_data):
         log.info('Email with subject %s is successfully sent to recipients: %s',
                  mail_data['subject'], mail_data['personalizations'])
     else:
-        log.warning('Failed to send out email with subject %s, status code: %s',
+        log.error('Failed to send out email with subject %s, status code: %s',
                     mail_data['subject'], response.status_code)

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -75,7 +75,7 @@ class BaseExecutor(LoggingMixin):
             self.log.info("Adding to queue: %s", command)
             self.queued_tasks[simple_task_instance.key] = (command, priority, queue, simple_task_instance)
         else:
-            self.log.info("could not queue task %s", simple_task_instance.key)
+            self.log.error("could not queue task %s", simple_task_instance.key)
 
     def queue_task_instance(
             self,

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -383,7 +383,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             else:
                 self.log.info('Event: %s Pending', pod_id)
         elif status == 'Failed':
-            self.log.info('Event: %s Failed', pod_id)
+            self.log.error('Event: %s Failed', pod_id)
             self.watcher_queue.put((pod_id, namespace, State.FAILED, labels, resource_version))
         elif status == 'Succeeded':
             self.log.info('Event: %s Succeeded', pod_id)

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -250,7 +250,7 @@ class PodLauncher(LoggingMixin):
         if status == PodStatus.PENDING:
             return State.QUEUED
         elif status == PodStatus.FAILED:
-            self.log.info('Event with job id %s Failed', job_id)
+            self.log.error('Event with job id %s Failed', job_id)
             return State.FAILED
         elif status == PodStatus.SUCCEEDED:
             self.log.info('Event with job id %s Succeeded', job_id)
@@ -258,5 +258,5 @@ class PodLauncher(LoggingMixin):
         elif status == PodStatus.RUNNING:
             return State.RUNNING
         else:
-            self.log.info('Event: Invalid state %s on job %s', status, job_id)
+            self.log.error('Event: Invalid state %s on job %s', status, job_id)
             return State.FAILED

--- a/airflow/logging_config.py
+++ b/airflow/logging_config.py
@@ -61,7 +61,7 @@ def configure_logging():
         # Try to init logging
         dictConfig(logging_config)
     except ValueError as e:
-        log.warning('Unable to load the config, contains a configuration error.')
+        log.error('Unable to load the config, contains a configuration error.')
         # When there is an error in the config, escalate the exception
         # otherwise Airflow would silently fall back on the default config
         raise e

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -339,7 +339,7 @@ class DagRun(Base, LoggingMixin):
         # if *all tasks* are deadlocked, the run failed
         elif (unfinished_tasks and none_depends_on_past and
               none_task_concurrency and not are_runnable_tasks):
-            self.log.info('Deadlock; marking run %s failed', self)
+            self.log.error('Deadlock; marking run %s failed', self)
             self.set_state(State.FAILED)
             dag.handle_callback(self, success=False, reason='all_tasks_deadlocked',
                                 session=session)

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -323,7 +323,7 @@ class DagRun(Base, LoggingMixin):
         if not unfinished_tasks and any(
             leaf_ti.state in {State.FAILED, State.UPSTREAM_FAILED} for leaf_ti in leaf_tis
         ):
-            self.log.info('Marking run %s failed', self)
+            self.log.error('Marking run %s failed', self)
             self.set_state(State.FAILED)
             dag.handle_callback(self, success=False, reason='task_failure',
                                 session=session)

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -139,7 +139,7 @@ class S3Hook(AwsBaseHook):
             self.get_conn().head_bucket(Bucket=bucket_name)
             return True
         except ClientError as e:
-            self.log.info(e.response["Error"]["Message"])
+            self.log.error(e.response["Error"]["Message"])
             return False
 
     @provide_bucket_name
@@ -297,7 +297,7 @@ class S3Hook(AwsBaseHook):
             self.get_conn().head_object(Bucket=bucket_name, Key=key)
             return True
         except ClientError as e:
-            self.log.info(e.response["Error"]["Message"])
+            self.log.error(e.response["Error"]["Message"])
             return False
 
     @provide_bucket_name

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -175,7 +175,7 @@ class AwsBatchOperator(BaseOperator, AwsBatchClient):
             self.log.info("AWS Batch job (%s) started: %s", self.job_id, response)
 
         except Exception as e:
-            self.log.info("AWS Batch job (%s) failed submission", self.job_id)
+            self.log.error("AWS Batch job (%s) failed submission", self.job_id)
             raise AirflowException(e)
 
     def monitor_job(self, context: Dict):  # pylint: disable=unused-argument
@@ -194,5 +194,5 @@ class AwsBatchOperator(BaseOperator, AwsBatchClient):
             self.log.info("AWS Batch job (%s) succeeded", self.job_id)
 
         except Exception as e:
-            self.log.info("AWS Batch job (%s) failed monitoring", self.job_id)
+            self.log.error("AWS Batch job (%s) failed monitoring", self.job_id)
             raise AirflowException(e)

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -85,7 +85,7 @@ class WebHDFSHook(BaseHook):
                 host_socket.close()
             except HdfsError as hdfs_error:
                 self.log.error('Read operation on namenode %s failed with error: %s',
-                              connection.host, hdfs_error)
+                               connection.host, hdfs_error)
         return None
 
     def _get_client(self, connection):

--- a/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -81,10 +81,10 @@ class WebHDFSHook(BaseHook):
                     host_socket.close()
                     return client
                 else:
-                    self.log.info("Could not connect to %s:%s", connection.host, connection.port)
+                    self.log.error("Could not connect to %s:%s", connection.host, connection.port)
                 host_socket.close()
             except HdfsError as hdfs_error:
-                self.log.info('Read operation on namenode %s failed with error: %s',
+                self.log.error('Read operation on namenode %s failed with error: %s',
                               connection.host, hdfs_error)
         return None
 

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -555,7 +555,7 @@ class HiveMetastoreHook(BaseHook):
                 host_socket.close()
                 return conn
             else:
-                self.log.info("Could not connect to %s:%s", conn.host, conn.port)
+                self.log.error("Could not connect to %s:%s", conn.host, conn.port)
         return None
 
     def get_conn(self):

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -643,5 +643,5 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     self.log.info("Spark on K8s killed with response: %s", api_response)
 
                 except kube_client.ApiException as e:
-                    self.log.info("Exception when attempting to kill Spark on K8s:")
+                    self.log.error("Exception when attempting to kill Spark on K8s:")
                     self.log.exception(e)

--- a/airflow/providers/ftp/sensors/ftp.py
+++ b/airflow/providers/ftp/sensors/ftp.py
@@ -76,7 +76,7 @@ class FTPSensor(BaseSensorOperator):
             try:
                 hook.get_mod_time(self.path)
             except ftplib.error_perm as e:
-                self.log.info('Ftp error encountered: %s', str(e))
+                self.log.error('Ftp error encountered: %s', str(e))
                 error_code = self._get_error_code(e)
                 if ((error_code != 550) and
                         (self.fail_on_transient_errors or

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -796,7 +796,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                 raise AirflowException(
                     'BigQuery job failed. Error was: {}'.format(error_msg)
                 )
-            self.log.info(error_msg)
+            self.log.error(error_msg)
 
     def update_dataset(self, dataset_id: str,
                        dataset_resource: Dict, project_id: Optional[str] = None) -> Dict:

--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -94,7 +94,7 @@ class BigtableHook(GoogleBaseHook):
         if instance:
             instance.delete()
         else:
-            self.log.info("The instance '%s' does not exist in project '%s'. Exiting", instance_id,
+            self.log.warn("The instance '%s' does not exist in project '%s'. Exiting", instance_id,
                           project_id)
 
     @GoogleBaseHook.fallback_to_default_project_id

--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -94,8 +94,8 @@ class BigtableHook(GoogleBaseHook):
         if instance:
             instance.delete()
         else:
-            self.log.warn("The instance '%s' does not exist in project '%s'. Exiting", instance_id,
-                          project_id)
+            self.log.warning("The instance '%s' does not exist in project '%s'. Exiting",
+                             instance_id, project_id)
 
     @GoogleBaseHook.fallback_to_default_project_id
     def create_instance(

--- a/airflow/providers/google/cloud/operators/dlp.py
+++ b/airflow/providers/google/cloud/operators/dlp.py
@@ -663,7 +663,7 @@ class CloudDLPDeleteDeidentifyTemplateOperator(BaseOperator):
                 metadata=self.metadata,
             )
         except NotFound:
-            self.log.info("Template %s not found.", self.template_id)
+            self.log.error("Template %s not found.", self.template_id)
 
 
 class CloudDLPDeleteDLPJobOperator(BaseOperator):
@@ -723,7 +723,7 @@ class CloudDLPDeleteDLPJobOperator(BaseOperator):
                 metadata=self.metadata,
             )
         except NotFound:
-            self.log.info("Job %s id not found.", self.dlp_job_id)
+            self.log.error("Job %s id not found.", self.dlp_job_id)
 
 
 class CloudDLPDeleteInspectTemplateOperator(BaseOperator):
@@ -788,7 +788,7 @@ class CloudDLPDeleteInspectTemplateOperator(BaseOperator):
                 metadata=self.metadata,
             )
         except NotFound:
-            self.log.info("Template %s not found", self.template_id)
+            self.log.error("Template %s not found", self.template_id)
 
 
 class CloudDLPDeleteJobTriggerOperator(BaseOperator):
@@ -847,7 +847,7 @@ class CloudDLPDeleteJobTriggerOperator(BaseOperator):
                 metadata=self.metadata,
             )
         except NotFound:
-            self.log.info("Trigger %s not found", self.job_trigger_id)
+            self.log.error("Trigger %s not found", self.job_trigger_id)
 
 
 class CloudDLPDeleteStoredInfoTypeOperator(BaseOperator):
@@ -917,7 +917,7 @@ class CloudDLPDeleteStoredInfoTypeOperator(BaseOperator):
                 metadata=self.metadata,
             )
         except NotFound:
-            self.log.info("Stored info %s not found", self.stored_info_type_id)
+            self.log.error("Stored info %s not found", self.stored_info_type_id)
 
 
 class CloudDLPGetDeidentifyTemplateOperator(BaseOperator):

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -308,7 +308,7 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
                     """, current_num_objects, path, self.inactivity_period)
                 return True
 
-            self.log.warning("FAILURE: Inactivity Period passed, not enough objects found in %s", path)
+            self.log.error("FAILURE: Inactivity Period passed, not enough objects found in %s", path)
 
             return False
         return False

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -189,7 +189,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
                 response = self.client.secrets.kv.v2.read_secret_version(
                     path=secret_path, mount_point=self.mount_point)
         except InvalidPath:
-            self.log.info("Secret %s not found in Path: %s", secret_id, secret_path)
+            self.log.error("Secret %s not found in Path: %s", secret_id, secret_path)
             return None
 
         return_data = response["data"] if self.kv_engine_version == 1 else response["data"]["data"]

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -189,7 +189,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
                 response = self.client.secrets.kv.v2.read_secret_version(
                     path=secret_path, mount_point=self.mount_point)
         except InvalidPath:
-            self.log.error("Secret %s not found in Path: %s", secret_id, secret_path)
+            self.log.debug("Secret %s not found in Path: %s", secret_id, secret_path)
             return None
 
         return_data = response["data"] if self.kv_engine_version == 1 else response["data"]["data"]

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -296,11 +296,11 @@ class AzureContainerInstancesOperator(BaseOperator):
                                            "container instance, retrying...")
 
                 if state == "Terminated":
-                    self.log.info("Container exited with detail_status %s", detail_status)
+                    self.log.error("Container exited with detail_status %s", detail_status)
                     return exit_code
 
                 if state == "Failed":
-                    self.log.info("Azure provision failure")
+                    self.log.error("Azure provision failure")
                     return 1
 
             except AirflowTaskTimeout:

--- a/airflow/providers/qubole/hooks/qubole_check.py
+++ b/airflow/providers/qubole/hooks/qubole_check.py
@@ -130,5 +130,5 @@ class QuboleCheckHook(QuboleHook):
             query_result_buffer.close()
             return query_result
         else:
-            self.log.info("Qubole command not found")
+            self.log.error("Qubole command not found")
             return None

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -173,7 +173,7 @@ class SalesforceHook(BaseHook):
         try:
             column = pd.to_datetime(column)
         except ValueError:
-            log.warning("Could not convert field to timestamps: %s", column.name)
+            log.error("Could not convert field to timestamps: %s", column.name)
             return column
 
         # now convert the newly created datetimes into timestamps

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -205,7 +205,7 @@ class BaseSerialization:
                 log.debug('Cast type %s to str in serialization.', type(var))
                 return str(var)
         except Exception:  # pylint: disable=broad-except
-            log.warning('Failed to stringify.', exc_info=True)
+            log.error('Failed to stringify.', exc_info=True)
             return FAILED
     # pylint: enable=too-many-return-statements
 

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -199,7 +199,7 @@ class _Stats(type):
                 else:
                     self.__class__.instance = DummyStatsLogger()
             except (socket.gaierror, ImportError) as e:
-                log.warning("Could not configure StatsClient: %s, using DummyStatsLogger instead.", e)
+                log.error("Could not configure StatsClient: %s, using DummyStatsLogger instead.", e)
                 self.__class__.instance = DummyStatsLogger()
 
     def get_statsd_logger(self):

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -102,7 +102,7 @@ def validate_stat(fn):
             stat_name = handle_stat_name_func(stat)
             return fn(_self, stat_name, *args, **kwargs)
         except InvalidStatsNameException:
-            log.warning('Invalid stat name: %s.', stat, exc_info=True)
+            log.error('Invalid stat name: %s.', stat, exc_info=True)
             return
 
     return wrapper

--- a/airflow/task/task_runner/cgroup_task_runner.py
+++ b/airflow/task/task_runner/cgroup_task_runner.py
@@ -186,7 +186,7 @@ class CgroupTaskRunner(BaseTaskRunner):
         # I wasn't able to track down the root cause of the package install failures, but
         # we might want to revisit that approach at some other point.
         if return_code == 137:
-            self.log.warning("Task failed with return code of 137. This may indicate "
+            self.log.error("Task failed with return code of 137. This may indicate "
                              "that it was killed due to excessive memory usage. "
                              "Please consider optimizing your task or using the "
                              "resources argument to reserve more memory for your task")

--- a/airflow/task/task_runner/cgroup_task_runner.py
+++ b/airflow/task/task_runner/cgroup_task_runner.py
@@ -187,9 +187,9 @@ class CgroupTaskRunner(BaseTaskRunner):
         # we might want to revisit that approach at some other point.
         if return_code == 137:
             self.log.error("Task failed with return code of 137. This may indicate "
-                             "that it was killed due to excessive memory usage. "
-                             "Please consider optimizing your task or using the "
-                             "resources argument to reserve more memory for your task")
+                           "that it was killed due to excessive memory usage. "
+                           "Please consider optimizing your task or using the "
+                           "resources argument to reserve more memory for your task")
         return return_code
 
     def terminate(self):

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -71,7 +71,7 @@ def trigger_dag(dag_id):
                 'Given execution date, {}, could not be identified '
                 'as a date. Example date format: 2015-11-16T14:34:15+00:00'
                 .format(execution_date))
-            log.info(error_message)
+            log.error(error_message)
             response = jsonify({'error': error_message})
             response.status_code = 400
 
@@ -229,7 +229,7 @@ def task_instance_info(dag_id, execution_date, task_id):
             'Given execution date, {}, could not be identified '
             'as a date. Example date format: 2015-11-16T14:34:15+00:00'
             .format(execution_date))
-        log.info(error_message)
+        log.error(error_message)
         response = jsonify({'error': error_message})
         response.status_code = 400
 
@@ -270,7 +270,7 @@ def dag_run_status(dag_id, execution_date):
             'Given execution date, {}, could not be identified '
             'as a date. Example date format: 2015-11-16T14:34:15+00:00'.format(
                 execution_date))
-        log.info(error_message)
+        log.error(error_message)
         response = jsonify({'error': error_message})
         response.status_code = 400
 
@@ -383,7 +383,7 @@ def get_lineage(dag_id: str, execution_date: str):
             'Given execution date, {}, could not be identified '
             'as a date. Example date format: 2015-11-16T14:34:15+00:00'.format(
                 execution_date))
-        log.info(error_message)
+        log.error(error_message)
         response = jsonify({'error': error_message})
         response.status_code = 400
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,11 @@ license_files =
    LICENSE
    NOTICE
 # Start of licenses generated automatically
-   licenses/LICENSE-bootstrap3-typeahead.txt
    licenses/LICENSE-bootstrap-toggle.txt
    licenses/LICENSE-bootstrap.txt
-   licenses/LICENSE-d3js.txt
+   licenses/LICENSE-bootstrap3-typeahead.txt
    licenses/LICENSE-d3-tip.txt
+   licenses/LICENSE-d3js.txt
    licenses/LICENSE-dagre-d3.txt
    licenses/LICENSE-datatables.txt
    licenses/LICENSE-elasticmock.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,9 @@ license_files =
    LICENSE
    NOTICE
 # Start of licenses generated automatically
+   licenses/LICENSE-bootstrap3-typeahead.txt
    licenses/LICENSE-bootstrap-toggle.txt
    licenses/LICENSE-bootstrap.txt
-   licenses/LICENSE-bootstrap3-typeahead.txt
    licenses/LICENSE-d3js.txt
    licenses/LICENSE-d3-tip.txt
    licenses/LICENSE-dagre-d3.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ license_files =
    licenses/LICENSE-bootstrap-toggle.txt
    licenses/LICENSE-bootstrap.txt
    licenses/LICENSE-bootstrap3-typeahead.txt
-   licenses/LICENSE-d3-tip.txt
    licenses/LICENSE-d3js.txt
+   licenses/LICENSE-d3-tip.txt
    licenses/LICENSE-dagre-d3.txt
    licenses/LICENSE-datatables.txt
    licenses/LICENSE-elasticmock.txt

--- a/tests/providers/google/cloud/operators/test_cloud_sql_system_helper.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql_system_helper.py
@@ -375,7 +375,7 @@ class CloudSqlQueryTestHelper(LoggingCommandExecutor):
             try:
                 os.makedirs(os.path.dirname(filepath))
             except OSError as exc:  # Guard against race condition
-                self.log.info("Error while creating dir.")
+                self.log.error("Error while creating dir.")
                 if exc.errno != errno.EEXIST:
                     raise
         self.log.info("... Done. Dir created.")

--- a/tests/providers/google/cloud/utils/gcp_authenticator.py
+++ b/tests/providers/google/cloud/utils/gcp_authenticator.py
@@ -96,7 +96,7 @@ class GcpAuthenticator(LoggingCommandExecutor):
             conn.extra = json.dumps(extras)
             session.commit()
         except BaseException as ex:
-            self.log.info('Airflow DB Session error: %s', str(ex))
+            self.log.error('Airflow DB Session error: %s', str(ex))
             session.rollback()
             raise
         finally:
@@ -122,7 +122,7 @@ class GcpAuthenticator(LoggingCommandExecutor):
             conn.extra = json.dumps(extras)
             session.commit()
         except BaseException as ex:
-            self.log.info('Airflow DB Session error: %s', str(ex))
+            self.log.error('Airflow DB Session error: %s', str(ex))
             session.rollback()
             raise
         finally:
@@ -146,11 +146,11 @@ class GcpAuthenticator(LoggingCommandExecutor):
             self.log.info("The %s is not a directory", gcp_config_dir)
         key_dir = os.path.join(gcp_config_dir, "keys")
         if not os.path.isdir(key_dir):
-            self.log.info("The %s is not a directory", key_dir)
+            self.log.error("The %s is not a directory", key_dir)
             return
         key_path = os.path.join(key_dir, self.gcp_key)
         if not os.path.isfile(key_path):
-            self.log.info("The %s file is missing", key_path)
+            self.log.error("The %s file is missing", key_path)
         self.full_key_path = key_path
 
     def _validate_key_set(self):

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -171,7 +171,7 @@ class TestLoggingSettings(unittest.TestCase):
     def test_loading_invalid_local_settings(self):
         from airflow.logging_config import configure_logging, log
         with settings_context(SETTINGS_FILE_INVALID):
-            with patch.object(log, 'warning') as mock_info:
+            with patch.object(log, 'error') as mock_info:
                 # Load config
                 with self.assertRaises(ValueError):
                     configure_logging()

--- a/tests/utils/logging_command_executor.py
+++ b/tests/utils/logging_command_executor.py
@@ -40,7 +40,7 @@ class LoggingCommandExecutor(LoggingMixin):
             self.log.info("Stdout: %s", output)
             self.log.info("Stderr: %s", err)
             if retcode:
-                self.log.warning("Error when executing %s", " ".join(cmd))
+                self.log.error("Error when executing %s", " ".join(cmd))
             return retcode
 
     def check_output(self, cmd):
@@ -50,7 +50,7 @@ class LoggingCommandExecutor(LoggingMixin):
         output, err = process.communicate()
         retcode = process.poll()
         if retcode:
-            self.log.info("Error when executing '%s'", " ".join(cmd))
+            self.log.error("Error when executing '%s'", " ".join(cmd))
             self.log.info("Stdout: %s", output)
             self.log.info("Stderr: %s", err)
             raise AirflowException("Retcode {} on {} with stdout: {}, stderr: {}".


### PR DESCRIPTION
Per [AIRFLOW-6515](https://issues.apache.org/jira/browse/AIRFLOW-6515), I executed the following to get a list of potential errors logged with the info or warn level:

```
grep -iE 'log\.(info|warn).*(error|exceptio|fail|unab|couldn|lost|gone|missing|not fou|abort|exit|could not)' -R *
```

In addition to the above, I also ran the following
```
grep -iE 'log\.(info|warn).*(unav)' -R *
grep -iE 'log\.(info|warn).*(not p)' -R *
grep -iE 'log\.(info|warn).*(invalid)' -R *
```

I changed what I thought were errors to use the error log level. I also changed one or two info entries to warn log level.

The above GREP commands still return some matches but I believe those are likely false positives.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
