### PR TITLE
Fix issue #8163 where gcp auth fails

### DIFF
--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -244,10 +244,10 @@ def get_credentials_and_project_id(
         if hasattr(credentials, 'with_subject'):
             credentials = credentials.with_subject(delegate_to)
         else:
-            log.warning(
-                "The `delegate_to` parameter has been ignored as the current "
-                "authentication method does not support account impersonate"
-                ". Please use service-account for authorization."
+            raise AirflowException(
+                "The `delegate_to` parameter cannot be used here as the current "
+                "authentication method does not support account impersonate. "
+                "Please use service-account for authorization."
             )
 
     return credentials, project_id

--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -241,7 +241,14 @@ def get_credentials_and_project_id(
         project_id = credentials.project_id
 
     if delegate_to:
-        credentials = credentials.with_subject(delegate_to)
+        if hasattr(credentials, 'with_subject'):
+            credentials = credentials.with_subject(delegate_to)
+        else:
+            log.warning(
+                "The `delegate_to` parameter has been ignored as the current "
+                "authentication method does not support account impersonate"
+                ". Please use service-account for authorization."
+            )
 
     return credentials, project_id
 

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -432,7 +432,7 @@ class TestGoogleBaseHook(unittest.TestCase):
             "The `delegate_to` parameter cannot be used here as the current authentication method does not "
             "support account impersonate. Please use service-account for authorization."
         )):
-            get_credentials_and_project_id(delegate_to="USER")
+            self.instance._get_credentials_and_project_id(delegate_to="USER")
 
     @mock.patch(  # type: ignore
         MODULE_NAME + '.get_credentials_and_project_id',

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -420,7 +420,7 @@ class TestGoogleBaseHook(unittest.TestCase):
             delegate_to="USER"
         )
         self.assertEqual((mock_credentials, "PROJECT_ID"), result)
-    
+
     @mock.patch('google.auth.default')
     def test_get_credentials_and_project_id_with_default_auth_and_unsupported_delegate(
         self, mock_auth_default

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -425,6 +425,7 @@ class TestGoogleBaseHook(unittest.TestCase):
     def test_get_credentials_and_project_id_with_default_auth_and_unsupported_delegate(
         self, mock_auth_default
     ):
+        self.instance.delegate_to = "TEST_DELLEGATE_TO"
         mock_credentials = mock.MagicMock(spec=google.auth.compute_engine.Credentials)
         mock_auth_default.return_value = (mock_credentials, "PROJECT_ID")
 

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -433,7 +433,7 @@ class TestGoogleBaseHook(unittest.TestCase):
             "The `delegate_to` parameter cannot be used here as the current authentication method does not "
             "support account impersonate. Please use service-account for authorization."
         )):
-            self.instance._get_credentials_and_project_id(delegate_to="USER")
+            self.instance._get_credentials_and_project_id()
 
     @mock.patch(  # type: ignore
         MODULE_NAME + '.get_credentials_and_project_id',

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -433,7 +433,6 @@ class TestGoogleBaseHook(unittest.TestCase):
             "support account impersonate. Please use service-account for authorization."
         )):
             get_credentials_and_project_id(delegate_to="USER")
-    
 
     @mock.patch(  # type: ignore
         MODULE_NAME + '.get_credentials_and_project_id',

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -425,7 +425,7 @@ class TestGoogleBaseHook(unittest.TestCase):
     def test_get_credentials_and_project_id_with_default_auth_and_unsupported_delegate(
         self, mock_auth_default
     ):
-        mock_credentials = mock.MagicMock(spec=compute_engine.Credentials)
+        mock_credentials = mock.MagicMock(spec=google.auth.compute_engine.Credentials)
         mock_auth_default.return_value = (mock_credentials, self.test_project_id)
 
         with self.assertRaisesRegex(AirflowException, re.escape(

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -426,7 +426,7 @@ class TestGoogleBaseHook(unittest.TestCase):
         self, mock_auth_default
     ):
         mock_credentials = mock.MagicMock(spec=google.auth.compute_engine.Credentials)
-        mock_auth_default.return_value = (mock_credentials, self.test_project_id)
+        mock_auth_default.return_value = (mock_credentials, "PROJECT_ID")
 
         with self.assertRaisesRegex(AirflowException, re.escape(
             "The `delegate_to` parameter cannot be used here as the current authentication method does not "

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -420,6 +420,20 @@ class TestGoogleBaseHook(unittest.TestCase):
             delegate_to="USER"
         )
         self.assertEqual((mock_credentials, "PROJECT_ID"), result)
+    
+    @mock.patch('google.auth.default')
+    def test_get_credentials_and_project_id_with_default_auth_and_unsupported_delegate(
+        self, mock_auth_default
+    ):
+        mock_credentials = mock.MagicMock(spec=compute_engine.Credentials)
+        mock_auth_default.return_value = (mock_credentials, self.test_project_id)
+
+        with self.assertRaisesRegex(AirflowException, re.escape(
+            "The `delegate_to` parameter cannot be used here as the current authentication method does not "
+            "support account impersonate. Please use service-account for authorization."
+        )):
+            get_credentials_and_project_id(delegate_to="USER")
+    
 
     @mock.patch(  # type: ignore
         MODULE_NAME + '.get_credentials_and_project_id',


### PR DESCRIPTION
Apache Airflow version:
master

What happened:
Whendelegate_to is supplied and no key_path or keyfile_dict is supplied (i.e. google.auth.default() is called) the Credentials object has no attribute with_subject.

This is called in get_credentials_and_project_id in https://github.com/apache/airflow/blob/master/airflow/providers/google/cloud/utils/credentials_provider.py

AttributeError: 'Credentials' object has no attribute 'with_subject'

What you expected to happen:
Correct authentication, or raise an Exception that you shouldn't be supplying a delegate_to when you haven't supplied a key_path or keyfile_dict.

How to reproduce it:
Supply a delegate_to argument in the Operator, but do not supply a key_path or keyfile_dict.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
