### PR TITLE
Fix breeze building production image not recognizing EXTRA_DOCKER_PROD_BUILD_FLAGS

### DIFF
--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -1396,14 +1396,14 @@ function prepare_prod_build() {
         )
     else
         if [[ "${INSTALL_AIRFLOW_REFERENCE:=}" != "" ]]; then
-            # When --install-airflow-version is used then the image is build from github tag
-            export EXTRA_DOCKER_PROD_BUILD_FLAGS=(
+            # When --install-airflow-reference is used then the image is build from github tag
+            EXTRA_DOCKER_PROD_BUILD_FLAGS=(
                 "--build-arg" "AIRFLOW_INSTALL_SOURCES=https://github.com/apache/airflow/archive/${INSTALL_AIRFLOW_REFERENCE}.tar.gz#egg=apache-airflow"
             )
             export AIRFLOW_VERSION="${INSTALL_AIRFLOW_REFERENCE}"
         else
-            # When --install-airflow-version is used then the image is build from github tag
-            export EXTRA_DOCKER_PROD_BUILD_FLAGS=(
+            # When --install-airflow-version is used then the image is build from pypi
+            EXTRA_DOCKER_PROD_BUILD_FLAGS=(
                 "--build-arg" "AIRFLOW_INSTALL_SOURCES=apache-airflow"
                 "--build-arg" "AIRFLOW_INSTALL_VERSION===${INSTALL_AIRFLOW_VERSION}"
             )


### PR DESCRIPTION
When building production docker image via breeze `./breeze build-image --production-image --install-airflow-version=1.10.10rc4` and entering it via `./breeze --production-image`, the `airflow version` is `2.0.0.dev0` which should be `1.10.10rc4` as specified via `--install-airflow-version`.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
