### PR TITLE
updated _write_args on PythonVirtualenvOperator

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -344,7 +344,11 @@ class PythonVirtualenvOperator(PythonOperator):
                     if key not in invalid_args:
                         kwargs[key] = value
                 except Exception as e:
-                    self.log.warning(f"Exception {e} found while serializing argument object: {value} on op_kwargs key {key} ...skipping...")
+                    msg = """
+                    "Exception %s found while serializing argument
+                    object: %s on op_kwargs key %s ...skipping..."
+                    """ % (e, value, key)
+                    self.log.warning(msg)
             with open(input_filename, 'wb') as f:
                 arg_dict = ({'args': self.op_args, 'kwargs': kwargs})
                 serializer.dump(arg_dict, f)

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -330,13 +330,24 @@ class PythonVirtualenvOperator(PythonOperator):
 
     def _write_args(self, input_filename):
         # serialize args to file
+        if self.use_dill:
+            serializer = dill
+        else:
+            serializer = pickle
+        # some args from context can't be loaded in virtual env
+        invalid_args = set(['dag', 'task', 'ti'])
         if self._pass_op_args():
+            kwargs = {}
+            for key, value in self.op_kwargs.items():
+                try:
+                    serializer.loads(serializer.dumps(value))
+                    if key not in invalid_args:
+                        kwargs[key] = value
+                except Exception as e:
+                    self.log.warning(f"Exception {e} found while serializing argument object: {value} on op_kwargs key {key} ...skipping...")
             with open(input_filename, 'wb') as f:
-                arg_dict = ({'args': self.op_args, 'kwargs': self.op_kwargs})
-                if self.use_dill:
-                    dill.dump(arg_dict, f)
-                else:
-                    pickle.dump(arg_dict, f)
+                arg_dict = ({'args': self.op_args, 'kwargs': kwargs})
+                serializer.dump(arg_dict, f)
 
     def _read_result(self, output_filename):
         if os.stat(output_filename).st_size == 0:


### PR DESCRIPTION
This change will ensure that argument provide_context=True works on v1.10.10 for PythonVirtualenvOperator

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
