### PR TITLE
Move DAG._schedule_interval logic out of DAG.__init__

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -626,7 +626,7 @@ class DAG(BaseDag, LoggingMixin):
         Returns Normalized Schedule Interval. This is used internally by the Scheduler to
         schedule DAGs.
 
-        1. Converts Cron Preset to a Cron Expression (e.g "@monthly" to "0 0 1 * *")
+        1. Converts Cron Preset to a Cron Expression (e.g ``@monthly`` to ``0 0 1 * *``)
         2. If Schedule Interval is "@once" return "None"
         3. If not (1) or (2) returns schedule_interval
         """

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -290,12 +290,6 @@ class DAG(BaseDag, LoggingMixin):
             )
 
         self.schedule_interval = schedule_interval
-        if isinstance(schedule_interval, str) and schedule_interval in cron_presets:
-            self._schedule_interval = cron_presets.get(schedule_interval)  # type: Optional[ScheduleInterval]
-        elif schedule_interval == '@once':
-            self._schedule_interval = None
-        else:
-            self._schedule_interval = schedule_interval
         if isinstance(template_searchpath, str):
             template_searchpath = [template_searchpath]
         self.template_searchpath = template_searchpath
@@ -378,7 +372,7 @@ class DAG(BaseDag, LoggingMixin):
             end_date = None
         return utils_date_range(
             start_date=start_date, end_date=end_date,
-            num=num, delta=self._schedule_interval)
+            num=num, delta=self.normalized_schedule_interval)
 
     def is_fixed_time_schedule(self):
         """
@@ -387,7 +381,7 @@ class DAG(BaseDag, LoggingMixin):
         :return: True if the schedule has a fixed time, False if not.
         """
         now = datetime.now()
-        cron = croniter(self._schedule_interval, now)
+        cron = croniter(self.normalized_schedule_interval, now)
 
         start = cron.get_next(datetime)
         cron_next = cron.get_next(datetime)
@@ -404,12 +398,12 @@ class DAG(BaseDag, LoggingMixin):
         :param dttm: utc datetime
         :return: utc datetime
         """
-        if isinstance(self._schedule_interval, str):
+        if isinstance(self.normalized_schedule_interval, str):
             # we don't want to rely on the transitions created by
             # croniter as they are not always correct
             dttm = pendulum.instance(dttm)
             naive = timezone.make_naive(dttm, self.timezone)
-            cron = croniter(self._schedule_interval, naive)
+            cron = croniter(self.normalized_schedule_interval, naive)
 
             # We assume that DST transitions happen on the minute/hour
             if not self.is_fixed_time_schedule():
@@ -422,8 +416,8 @@ class DAG(BaseDag, LoggingMixin):
                 tz = pendulum.timezone(self.timezone.name)
                 following = timezone.make_aware(naive, tz)
             return timezone.convert_to_utc(following)
-        elif self._schedule_interval is not None:
-            return dttm + self._schedule_interval
+        elif self.normalized_schedule_interval is not None:
+            return dttm + self.normalized_schedule_interval
 
     def previous_schedule(self, dttm):
         """
@@ -432,12 +426,12 @@ class DAG(BaseDag, LoggingMixin):
         :param dttm: utc datetime
         :return: utc datetime
         """
-        if isinstance(self._schedule_interval, str):
+        if isinstance(self.normalized_schedule_interval, str):
             # we don't want to rely on the transitions created by
             # croniter as they are not always correct
             dttm = pendulum.instance(dttm)
             naive = timezone.make_naive(dttm, self.timezone)
-            cron = croniter(self._schedule_interval, naive)
+            cron = croniter(self.normalized_schedule_interval, naive)
 
             # We assume that DST transitions happen on the minute/hour
             if not self.is_fixed_time_schedule():
@@ -450,8 +444,8 @@ class DAG(BaseDag, LoggingMixin):
                 tz = pendulum.timezone(self.timezone.name)
                 previous = timezone.make_aware(naive, tz)
             return timezone.convert_to_utc(previous)
-        elif self._schedule_interval is not None:
-            return dttm - self._schedule_interval
+        elif self.normalized_schedule_interval is not None:
+            return dttm - self.normalized_schedule_interval
 
     def get_run_dates(self, start_date, end_date=None):
         """
@@ -625,6 +619,24 @@ class DAG(BaseDag, LoggingMixin):
         Returns a boolean indicating whether this DAG is paused
         """
         return self._get_is_paused()
+
+    @property
+    def normalized_schedule_interval(self) -> Optional[ScheduleInterval]:
+        """
+        Returns Normalized Schedule Interval. This is used internally by the Scheduler to
+        schedule DAGs.
+
+        1. Converts Cron Preset to a Cron Expression (e.g "@monthly" to "0 0 1 * *")
+        2. If Schedule Interval is "@once" return "None"
+        3. If not (1) or (2) returns schedule_interval
+        """
+        if isinstance(self.schedule_interval, str) and self.schedule_interval in cron_presets:
+            _schedule_interval = cron_presets.get(self.schedule_interval)  # type: Optional[ScheduleInterval]
+        elif self.schedule_interval == '@once':
+            _schedule_interval = None
+        else:
+            _schedule_interval = self.schedule_interval
+        return _schedule_interval
 
     @provide_session
     def handle_callback(self, dagrun, success=True, reason=None, session=None):
@@ -1636,7 +1648,7 @@ class DAG(BaseDag, LoggingMixin):
             cls.__serialized_fields = frozenset(vars(DAG(dag_id='test')).keys()) - {
                 'parent_dag', '_old_context_manager_dags', 'safe_dag_id', 'last_loaded',
                 '_full_filepath', 'user_defined_filters', 'user_defined_macros',
-                '_schedule_interval', 'partial', '_old_context_manager_dags',
+                'partial', '_old_context_manager_dags',
                 '_pickle_id', '_log', 'is_subdag', 'task_dict', 'template_searchpath',
                 'sla_miss_callback', 'on_success_callback', 'on_failure_callback',
                 'template_undefined', 'jinja_environment_kwargs'

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -287,8 +287,8 @@ class DagBag(BaseDagBag, LoggingMixin):
                     try:
                         dag.is_subdag = False
                         self.bag_dag(dag, parent_dag=dag, root_dag=dag)
-                        if isinstance(dag._schedule_interval, str):
-                            croniter(dag._schedule_interval)
+                        if isinstance(dag.normalized_schedule_interval, str):
+                            croniter(dag.normalized_schedule_interval)
                         found_dags.append(dag)
                         found_dags += dag.subdags
                     except (CroniterBadCronError,

--- a/tests/sensors/test_filesystem.py
+++ b/tests/sensors/test_filesystem.py
@@ -40,7 +40,6 @@ class TestFileSensor(unittest.TestCase):
             'start_date': DEFAULT_DATE
         }
         dag = DAG(TEST_DAG_ID + 'test_schedule_dag_once', default_args=args)
-        dag.schedule_interval = '@once'
         self.hook = hook
         self.dag = dag
 

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -376,11 +376,14 @@ class TestStringifiedDAGs(unittest.TestCase):
         self.assertEqual(simple_task.end_date, expected_task_end_date)
 
     @parameterized.expand([
-        (None, None),
-        ("@weekly", "@weekly"),
-        ({"__type": "timedelta", "__var": 86400.0}, timedelta(days=1)),
+        (None, None, None),
+        ("@weekly", "@weekly", "0 0 * * 0"),
+        ("@once", "@once", None),
+        ({"__type": "timedelta", "__var": 86400.0}, timedelta(days=1), timedelta(days=1)),
     ])
-    def test_deserialization_schedule_interval(self, serialized_schedule_interval, expected):
+    def test_deserialization_schedule_interval(
+        self, serialized_schedule_interval, expected_schedule_interval, expected_n_schedule_interval
+    ):
         serialized = {
             "__version": 1,
             "dag": {
@@ -397,7 +400,8 @@ class TestStringifiedDAGs(unittest.TestCase):
 
         dag = SerializedDAG.from_dict(serialized)
 
-        self.assertEqual(dag.schedule_interval, expected)
+        self.assertEqual(dag.schedule_interval, expected_schedule_interval)
+        self.assertEqual(dag.normalized_schedule_interval, expected_n_schedule_interval)
 
     @parameterized.expand([
         (relativedelta(days=-1), {"__type": "relativedelta", "__var": {"days": -1}}),


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/8166

- Replace usage of `DAG._schedule_interval` with `DAG.normalized_schedule_interval`. This will even allow users to tests that they set correct Cron Preset in unit tests (instead of using an internal property before)
- Added tests for Schedule Interval & Normalized Schedule Interval
- Also solves the issue mentioned in https://github.com/apache/airflow/issues/8166
- Removes confusion between `schedule_interval` and `_schedule_interval`

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
