### PR TITLE
Expose Airflow Webserver Port in Production Docker Image

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -263,6 +263,8 @@ Set up local development environment:
 Note that the below environment interaction is by default with the CI image. If you want to use production
 image for those commands you need to add ``--production-image`` flag.
 
+Note that you also should not run both (CI and production) environments simultaneously, as they are using
+the same docker-compose configuration which for example contain the link to the database, port mapping, etc.
 
 Entering Breeze CI environment
 ------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -328,5 +328,7 @@ WORKDIR ${AIRFLOW_HOME}
 
 ENV AIRFLOW__CORE__LOAD_EXAMPLES="false"
 
+EXPOSE 8080
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]
 CMD ["airflow", "--help"]

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -34,10 +34,10 @@ The images are named as follows:
 
 where:
 
-* ``BRANCH_OR_TAG`` - branch or tag used when creating the image. Examples: master, v1-10-test, 1.10.10
-  The ``master`` and ``v1-10-test`` labels are built from branches so they change over time. the 1.10.* and in
+* ``BRANCH_OR_TAG`` - branch or tag used when creating the image. Examples: ``master``, ``v1-10-test``, ``1.10.10``
+  The ``master`` and ``v1-10-test`` labels are built from branches so they change over time. The ``1.10.*`` and in
   the future ``2.*`` labels are build from git tags and they are "fixed" once built.
-* PYTHON_MAJOR_MINOR_VERSION - version of python used to build the image. Examples: 3.5, 3.7
+* ``PYTHON_MAJOR_MINOR_VERSION`` - version of python used to build the image. Examples: ``3.5``, ``3.7``
 * The ``-ci`` suffix is added for CI images
 * The ``-manifest`` is added for manifest images (see below for explanation of manifest images)
 
@@ -49,7 +49,7 @@ The easiest way to build those images is to use `<BREEZE.rst>`_.
 Note! Breeze by default builds production image from local sources. You can change it's behaviour by
 providing ``--install-airflow-version`` parameter, where you can specify the
 tag/branch used to download Airflow package from in github repository. You can
-also change the repository itself by adding --dockerhub-user and --dockerhub-repo flag values.
+also change the repository itself by adding ``--dockerhub-user`` and ``--dockerhub-repo`` flag values.
 
 You can build the CI image using this command:
 
@@ -123,7 +123,7 @@ Technical details of Airflow images
 
 The CI image is used by Breeze as shell image but it is also used during CI builds on Travis.
 The image is single segment image that contains Airflow installation with "all" dependencies installed.
-It is optimised for rebuild speed (AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD flag set to "true").
+It is optimised for rebuild speed (``AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD`` flag set to "true").
 It installs PIP dependencies from the current branch first - so that any changes in setup.py do not trigger
 reinstalling of all dependencies. There is a second step of installation that re-installs the dependencies
 from the latest sources so that we are sure that latest dependencies are installed.
@@ -350,18 +350,17 @@ the 1.10.10 tag.
     --build-arg AIRFLOW_SOURCES_FROM="entrypoint.sh" \
     --build-arg AIRFLOW_SOURCES_TO="/entrypoint"
 
-This builds the production image in version 3.6 with default extras from current sources.
+This builds the production image in version 3.7 with default extras from 1.10.10 Pypi package and
+requirements taken from v1-10-test branch in Github.
 
 .. code-block::
 
-  docker build . --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
-    --build-arg PYTHON_MAJOR_MINOR_VERSION=3.7 --build-arg COPY_SOURCE=. \
-    --build-arg COPY_TARGET=/opt/airflow --build-arg AIRFLOW_SOURCES=/opt/airflow \
-    --build-arg CONSTRAINT_REQUIREMENTS=requirements/requirements-python3.7.txt" \
-    --build-arg ENTRYPOINT_FILE=entrypoint.sh \
+  docker build . \
+    --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
+    --build-arg PYTHON_MAJOR_MINOR_VERSION=3.7 \
     --build-arg AIRFLOW_INSTALL_SOURCES="apache-airflow" \
     --build-arg AIRFLOW_INSTALL_VERSION="==1.10.10" \
-    --build-arg CONSTRAINT_REQUIREMENTS="https://raw.githubusercontent.com/apache/airflow/1.10.10/requirements/requirements-python3.7.txt"
+    --build-arg CONSTRAINT_REQUIREMENTS="https://raw.githubusercontent.com/apache/airflow/1.10.10/requirements/requirements-python3.7.txt" \
     --build-arg ENTRYPOINT_FILE="https://raw.githubusercontent.com/apache/airflow/1.10.10/entrypoint.sh" \
     --build-arg AIRFLOW_SOURCES_FROM="entrypoint.sh" \
     --build-arg AIRFLOW_SOURCES_TO="/entrypoint"

--- a/breeze
+++ b/breeze
@@ -467,6 +467,7 @@ function prepare_command_files() {
     MAIN_PROD_DOCKER_COMPOSE_FILE=${SCRIPTS_CI_DIR}/docker-compose/base.yml
     BACKEND_DOCKER_COMPOSE_FILE=${SCRIPTS_CI_DIR}/docker-compose/backend-${BACKEND}.yml
     LOCAL_DOCKER_COMPOSE_FILE=${SCRIPTS_CI_DIR}/docker-compose/local.yml
+    LOCAL_PROD_DOCKER_COMPOSE_FILE=${SCRIPTS_CI_DIR}/docker-compose/local-prod.yml
     KUBERNETES_DOCKER_COMPOSE_FILE=${SCRIPTS_CI_DIR}/docker-compose/runtime-kubernetes.yml
     REMOVE_SOURCES_DOCKER_COMPOSE_FILE=${SCRIPTS_CI_DIR}/docker-compose/remove-sources.yml
     FORWARD_CREDENTIALS_DOCKER_COMPOSE_FILE=${SCRIPTS_CI_DIR}/docker-compose/forward-credentials.yml
@@ -476,6 +477,7 @@ function prepare_command_files() {
 
     if [[ "${MOUNT_LOCAL_SOURCES}" != "false" ]]; then
         COMPOSE_CI_FILE=${COMPOSE_CI_FILE}:${LOCAL_DOCKER_COMPOSE_FILE}
+        COMPOSE_PROD_FILE=${COMPOSE_PROD_FILE}:${LOCAL_PROD_DOCKER_COMPOSE_FILE}
     fi
 
     if [[ ${FORWARD_CREDENTIALS} == "true" ]]; then

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -64,3 +64,5 @@ services:
       # Pass docker to inside of the container so that Kind and Moto tests can use it.
       - /var/run/docker.sock:/var/run/docker.sock
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
+    ports:
+      - "${WEBSERVER_HOST_PORT}:8080"

--- a/scripts/ci/docker-compose/local-prod.yml
+++ b/scripts/ci/docker-compose/local-prod.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+version: "2.2"
+services:
+  airflow:
+    # We need to mount files an directories individually because some files
+    # such apache_airflow.egg-info should not be mounted from host
+    # we only mount those files that it makes sense to edit while developing
+    # or those that might be useful to see in the host as output of the
+    # tests (such as logs)
+    volumes:
+      - ../../../.bash_aliases:/root/.bash_aliases:cached
+      - ../../../.bash_history:/root/.bash_history:cached
+      - ../../../.github:/opt/airflow/.github:cached
+      - ../../../.inputrc:/root/.inputrc:cached
+      - ../../../.kube:/root/.kube:cached
+      - ../../../files:/files:cached
+      - ../../../dist:/dist:cached
+      - ../../../scripts/ci/in_container/entrypoint_ci.sh:/entrypoint_ci.sh:cached
+      - ../../../setup.cfg:/opt/airflow/setup.cfg:cached
+      - ../../../setup.py:/opt/airflow/setup.py:cached
+      - ../../../tests:/opt/airflow/tests:cached
+      - ../../../tmp:/opt/airflow/tmp:cached
+    environment:
+      - HOST_USER_ID
+      - HOST_GROUP_ID
+      - PYTHONDONTWRITEBYTECODE


### PR DESCRIPTION
The production docker image currently does not expose a port which is needed for Airflow's webserver to be accessible from the host. This PR exposes a port and the breeze script will pass the port configured in breeze env.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
