### PR TITLE
GCP SparkR Example

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -108,7 +108,7 @@ PYSPARK_JOB = {
 SPARKR_JOB = {
     "reference": {"project_id": PROJECT_ID},
     "placement": {"cluster_name": CLUSTER_NAME},
-    "sparkRJob": {"mainRFileUri": SPARKR_URI},
+    "spark_r_job": {"main_r_file_uri": SPARKR_URI},
 }
 
 HIVE_JOB = {

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -38,7 +38,8 @@ OUTPUT_FOLDER = "wordcount"
 OUTPUT_PATH = "gs://{}/{}/".format(BUCKET, OUTPUT_FOLDER)
 PYSPARK_MAIN = os.environ.get("PYSPARK_MAIN", "hello_world.py")
 PYSPARK_URI = "gs://{}/{}".format(BUCKET, PYSPARK_MAIN)
-
+SPARKR_MAIN = os.environ.get("SPARKR_MAIN", "hello_world.R")
+SPARKR_URI = "gs://{}/{}".format(BUCKET, SPARKR_MAIN)
 
 # Cluster definition
 CLUSTER = {
@@ -104,6 +105,12 @@ PYSPARK_JOB = {
     "pyspark_job": {"main_python_file_uri": PYSPARK_URI},
 }
 
+SPARKR_JOB = {
+    "reference": {"project_id": PROJECT_ID},
+    "placement": {"cluster_name": CLUSTER_NAME},
+    "sparkRJob": {"mainRFileUri": SPARKR_URI},
+}
+
 HIVE_JOB = {
     "reference": {"project_id": PROJECT_ID},
     "placement": {"cluster_name": CLUSTER_NAME},
@@ -157,6 +164,10 @@ with models.DAG(
         task_id="pyspark_task", job=PYSPARK_JOB, location=REGION, project_id=PROJECT_ID
     )
 
+    sparkr_task = DataprocSubmitJobOperator(
+        task_id="sparkr_task", job=SPARKR_JOB, location=REGION, project_id=PROJECT_ID
+    )
+
     hive_task = DataprocSubmitJobOperator(
         task_id="hive_task", job=HIVE_JOB, location=REGION, project_id=PROJECT_ID
     )
@@ -178,4 +189,5 @@ with models.DAG(
     scale_cluster >> spark_sql_task >> delete_cluster
     scale_cluster >> spark_task >> delete_cluster
     scale_cluster >> pyspark_task >> delete_cluster
+    scale_cluster >> sparkr_task >> delete_cluster
     scale_cluster >> hadoop_task >> delete_cluster

--- a/tests/providers/google/cloud/operators/test_dataproc_system.py
+++ b/tests/providers/google/cloud/operators/test_dataproc_system.py
@@ -39,6 +39,10 @@ print(words)
 
 sparkr_file = """
 #!/usr/bin/r
+if (nchar(Sys.getenv("SPARK_HOME")) < 1) {
+Sys.setenv(SPARK_HOME = "/home/spark")
+}
+library(SparkR, lib.loc = c(file.path(Sys.getenv("SPARK_HOME"), "R", "lib")))
 sparkR.session()
 # Create the SparkDataFrame
 df <- as.DataFrame(faithful)

--- a/tests/providers/google/cloud/operators/test_dataproc_system.py
+++ b/tests/providers/google/cloud/operators/test_dataproc_system.py
@@ -25,6 +25,8 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 BUCKET = os.environ.get("GCP_DATAPROC_BUCKET", "dataproc-system-tests")
 PYSPARK_MAIN = os.environ.get("PYSPARK_MAIN", "hello_world.py")
 PYSPARK_URI = "gs://{}/{}".format(BUCKET, PYSPARK_MAIN)
+SPARKR_MAIN = os.environ.get("SPARKR_MAIN", "hello_world.R")
+SPARKR_URI = "gs://{}/{}".format(BUCKET, SPARKR_MAIN)
 
 pyspark_file = """
 #!/usr/bin/python
@@ -35,16 +37,28 @@ words = sorted(rdd.collect())
 print(words)
 """
 
+sparkr_file = """
+#!/usr/bin/r
+sparkR.session()
+# Create the SparkDataFrame
+df <- as.DataFrame(faithful)
+head(summarize(groupBy(df, df$waiting), count = n(df$waiting)))
+"""
+
 
 @pytest.mark.backend("mysql", "postgres")
 @pytest.mark.credential_file(GCP_DATAPROC_KEY)
 class DataprocExampleDagsTest(GoogleSystemTest):
-
     @provide_gcp_context(GCP_DATAPROC_KEY)
     def setUp(self):
         super().setUp()
         self.create_gcs_bucket(BUCKET)
-        self.upload_content_to_gcs(lines=pyspark_file, bucket=PYSPARK_URI, filename=PYSPARK_MAIN)
+        self.upload_content_to_gcs(
+            lines=pyspark_file, bucket=PYSPARK_URI, filename=PYSPARK_MAIN
+        )
+        self.upload_content_to_gcs(
+            lines=sparkr_file, bucket=SPARKR_URI, filename=SPARKR_MAIN
+        )
 
     @provide_gcp_context(GCP_DATAPROC_KEY)
     def tearDown(self):


### PR DESCRIPTION
Show how to schedule R, and sparkR jobs on a dataproc cluster.
The functionality to run that kind of job is already in dataproc,
but it was not so clear how to do that from Airflow.

This is a replacement for https://github.com/apache/airflow/pull/7864

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
