### PR TITLE
Add Option for BashOperator to Set State to SKIPPED

### DIFF
--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -24,7 +24,7 @@ from tempfile import NamedTemporaryFile
 
 import mock
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils import timezone
@@ -110,6 +110,19 @@ class TestBashOperator(unittest.TestCase):
         with self.assertRaisesRegex(
             AirflowException,
             "Bash command failed\\. The command returned a non-zero exit code\\."
+        ):
+            bash_operator.execute(context={})
+
+    def test_raise_skip_exception_on_skip_exit_code(self):
+        bash_operator = BashOperator(
+            bash_command='exit 86',
+            skip_on_code=86,
+            task_id='test_return_value',
+            dag=None
+        )
+        with self.assertRaisesRegex(
+            AirflowSkipException,
+            "Bash command failed\\. The command returned the skip_on_code exit code\\."
         ):
             bash_operator.execute(context={})
 


### PR DESCRIPTION
Currently the BashOperator will raise an `AirflowException` on any non-zero exit code which will cause the task state to be set to `State.FAILED`. This PR adds a new param, `skip_on_code` which when set will allow the task state to be set to `State.SKIPPED` if the exit code of the bash command matches the given code.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
