### PR TITLE
ECSOperator: Make launch_type parameter optional

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -151,11 +151,12 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
             'taskDefinition': self.task_definition,
             'overrides': self.overrides,
             'startedBy': self.owner,
-            'launchType': self.launch_type,
         }
 
-        if self.launch_type == 'FARGATE':
-            run_opts['platformVersion'] = self.platform_version
+        if self.launch_type:
+            run_opts['launchType'] = self.launch_type
+            if self.launch_type == 'FARGATE':
+                run_opts['platformVersion'] = self.platform_version
         if self.group is not None:
             run_opts['group'] = self.group
         if self.placement_constraints is not None:

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -97,6 +97,7 @@ class TestECSOperator(unittest.TestCase):
         ['EC2', None],
         ['FARGATE', None],
         ['EC2', {'testTagKey': 'testTagValue'}],
+        ['', {'testTagKey': 'testTagValue'}],
     ])
     @mock.patch.object(ECSOperator, '_wait_for_task_ended')
     @mock.patch.object(ECSOperator, '_check_success_task')
@@ -111,6 +112,8 @@ class TestECSOperator(unittest.TestCase):
 
         self.aws_hook_mock.return_value.get_conn.assert_called_once()
         extend_args = {}
+        if launch_type:
+            extend_args['launchType'] = launch_type
         if launch_type == 'FARGATE':
             extend_args['platformVersion'] = 'LATEST'
         if tags:
@@ -118,7 +121,6 @@ class TestECSOperator(unittest.TestCase):
 
         client_mock.run_task.assert_called_once_with(
             cluster='c',
-            launchType=launch_type,
             overrides={},
             startedBy=mock.ANY,  # Can by 'airflow' or 'Airflow'
             taskDefinition='t',


### PR DESCRIPTION
launch_type is not a required parameter for run_task method
See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
