### PR TITLE
Fix indentation in GitHub bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -41,6 +41,7 @@ This questions are the first thing we need to know to understand the context.
 - **Kernel** (e.g. `uname -a`):
 - **Install tools**:
 - **Others**:
+
 **What happened**:
 
 <!-- (please include exact error messages if you can) -->


### PR DESCRIPTION
This fixes a small nit in the GitHub bug report template.

Before:
![image](https://user-images.githubusercontent.com/6249654/79042544-0047cc80-7bf9-11ea-8037-7253f573e499.png)

After:
![image](https://user-images.githubusercontent.com/6249654/79042555-0d64bb80-7bf9-11ea-8f7c-9d6bb5f6abb6.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
