### PR TITLE
Add documentation for CLI command airflow dags test

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -309,6 +309,11 @@ their log to stdout (on screen), doesn't bother with dependencies, and
 doesn't communicate state (running, success, failed, ...) to the database.
 It simply allows testing a single task instance.
 
+The same applies to ``airflow dags test [dag_id] [execution_date]``, but on a DAG level. It performs a single
+DAG run of the given DAG id. While it does take task dependencies into account, no state is registered in the
+database. It is convenient for locally testing a full run of your DAG, given that e.g. if one of your tasks
+expects data at some location, it is available.
+
 Backfill
 ''''''''
 Everything looks like it's running fine so let's run a backfill.


### PR DESCRIPTION
This PR adds a paragraph to the docs explaining `airflow dags test`, as requested https://github.com/apache/airflow/pull/7426#issuecomment-601653089. There are tests now so I believe that part is resolved.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
