### PR TITLE
RBAC ui: fix missing Y-axis labels with units in plots

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1698,10 +1698,10 @@ class Airflow(AirflowBaseView):
         # update the y Axis on both charts to have the correct time units
         chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                             label='Duration ({})'.format(y_unit))
-        chart.axislist['yAxis']['axisLabelDistance'] = '40'
+        chart.axislist['yAxis']['axisLabelDistance'] = '-15'
         cum_chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                                 label='Duration ({})'.format(cum_y_unit))
-        cum_chart.axislist['yAxis']['axisLabelDistance'] = '40'
+        cum_chart.axislist['yAxis']['axisLabelDistance'] = '-15'
 
         for task in dag.tasks:
             if x[task.task_id]:
@@ -1853,7 +1853,7 @@ class Airflow(AirflowBaseView):
         # update the y Axis to have the correct time units
         chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                             label='Landing Time ({})'.format(y_unit))
-        chart.axislist['yAxis']['axisLabelDistance'] = '40'
+        chart.axislist['yAxis']['axisLabelDistance'] = '-15'
         for task in dag.tasks:
             if x[task.task_id]:
                 chart.add_serie(name=task.task_id, x=x[task.task_id],


### PR DESCRIPTION
In RBAC ui there's a bug in the Task Duration and Landing Times plots: Y-axis label (with the time units) is not visible:

<img width="946" alt="Screenshot 2020-04-11 at 17 12 34" src="https://user-images.githubusercontent.com/2418596/79047325-92160080-7c1e-11ea-88ea-ebf18f303a7d.png">

In the legacy flask-admin UI there's no such issue (don't mind the different data on the plots, these are two different installations):

<img width="975" alt="Screenshot 2020-04-11 at 17 13 00" src="https://user-images.githubusercontent.com/2418596/79047329-96dab480-7c1e-11ea-81c5-9986f82e525f.png">

(Notice that the `y`-offset in the object inspector is different).

This PR fixes the issue by changing the offset, making it the same as it was in the legacy UI:

<img width="1011" alt="Screenshot 2020-04-11 at 17 12 48" src="https://user-images.githubusercontent.com/2418596/79047327-95a98780-7c1e-11ea-917b-27dba08c38f4.png">

I suppose the reason why this broke is that in flask-admin the `d3` js library is vendored and has not been updated since 2016: https://github.com/apache/airflow/commits/v1-10-test/airflow/www/static/d3.v3.min.js , but in RBAC a newer version of d3 is installed via package.json. Perhaps the interpretation of `axisLabelDistance` has changed in the newer versions of d3?

I have tested this patch on Airflow 1.10.10. Didn't test on master yet, but I'm going to if I manage to get along with the breeze environment.


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] ~~Unit tests coverage for changes (not needed for documentation changes)~~
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] ~~Relevant documentation is updated including usage instructions.~~
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
