### PR TITLE
RBAC ui: fix missing task runs being rendered as circles instead of squares

### DIFF
--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -89,7 +89,7 @@ function ts_to_dtstr(ts) {
 }
 
 function is_dag_run(d) {
-  return d.operator === undefined;
+  return d.run_id != undefined;
 }
 
 var now_ts = Date.now()/1000;


### PR DESCRIPTION
In RBAC ui there's a bug: when an existing DAG is expanded with new tasks, the missing taskinstances for previous DAG runs are being rendered as circles (like dagruns) instead of squares:

<img width="771" alt="Screenshot 2020-04-11 at 17 32 20" src="https://user-images.githubusercontent.com/2418596/79048074-35691480-7c23-11ea-85c5-3886b24426f6.png">

This PR fixes that, making it look like this (as it was in the legacy flask-admin UI):

<img width="797" alt="Screenshot 2020-04-11 at 17 42 20" src="https://user-images.githubusercontent.com/2418596/79048086-4154d680-7c23-11ea-9075-dd0cc76689a7.png">

The check now looks exactly as it is in the flask-admin UI: https://github.com/apache/airflow/blob/1.10.10/airflow/www/templates/airflow/tree.html#L249

In RBAC for some reason it is different: https://github.com/apache/airflow/blob/1.10.10/airflow/www_rbac/templates/airflow/tree.html#L91

I'm not sure if the change was intentional, and also I'm not sure if the fix is proper, but it seems to work that way.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] ~~Unit tests coverage for changes (not needed for documentation changes)~~
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] ~~Relevant documentation is updated including usage instructions.~~
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
