### PR TITLE
[docs-only] Simplify language re roll-your-own secrets backend

### DIFF
--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -314,7 +314,7 @@ A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend
 After writing your backend class, provide the fully qualified class name in the ``backend`` key in the ``[secrets]``
 section of ``airflow.cfg``.
 
-You can you can also pass kwargs to ``__init__`` by supplying json to the ``backend_kwargs`` config param.
+Additional arguments to your SecretsBackend can be configured in ``airflow.cfg`` by supplying a JSON to ``backend_kwargs``, which will be passed to the ``__init__`` of your SecretsBackend.
 See :ref:`Configuration <secrets_backend_configuration>` for more details, and :ref:`SSM Parameter Store <ssm_parameter_store_secrets>` for an example.
 
 .. note::

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -314,7 +314,7 @@ A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend
 After writing your backend class, provide the fully qualified class name in the ``backend`` key in the ``[secrets]``
 section of ``airflow.cfg``.
 
-Additional arguments to your SecretsBackend can be configured in ``airflow.cfg`` by supplying a JSON to ``backend_kwargs``, which will be passed to the ``__init__`` of your SecretsBackend.
+Additional arguments to your SecretsBackend can be configured in ``airflow.cfg`` by supplying a JSON string to ``backend_kwargs``, which will be passed to the ``__init__`` of your SecretsBackend.
 See :ref:`Configuration <secrets_backend_configuration>` for more details, and :ref:`SSM Parameter Store <ssm_parameter_store_secrets>` for an example.
 
 .. note::

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -308,19 +308,14 @@ of the connection object.
 Roll your own secrets backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend`, and just has to implement the
-:py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` method.
+A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend` and must implement either
+:py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` or :py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections`.
 
-There are two options:
+After writing your backend class, provide the fully qualified class name in the ``backend`` key in the ``[secrets]``
+section of ``airflow.cfg``.
 
-* Option 1: a base implmentation of the :py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` is provided, you just need to implement the
-  :py:meth:`~airflow.secrets.BaseSecretsBackend.get_conn_uri` method to make it functional.
-* Option 2: simply override the :py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` method.
-
-Just create your class, and put the fully qualified class name in ``backend`` key in the ``[secrets]``
-section of ``airflow.cfg``.  You can you can also pass kwargs to ``__init__`` by supplying json to the
-``backend_kwargs`` config param.  See :ref:`Configuration <secrets_backend_configuration>` for more details,
-and :ref:`SSM Parameter Store <ssm_parameter_store_secrets>` for an example.
+You can you can also pass kwargs to ``__init__`` by supplying json to the ``backend_kwargs`` config param.
+See :ref:`Configuration <secrets_backend_configuration>` for more details, and :ref:`SSM Parameter Store <ssm_parameter_store_secrets>` for an example.
 
 .. note::
 

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -309,7 +309,7 @@ Roll your own secrets backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend` and must implement either
-:py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` or :py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections`.
+:py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` or :py:meth:`~airflow.secrets.BaseSecretsBackend.get_conn_uri`.
 
 After writing your backend class, provide the fully qualified class name in the ``backend`` key in the ``[secrets]``
 section of ``airflow.cfg``.


### PR DESCRIPTION
* remove the "simply" and "just" modifiers -- too infomercialey
* simplify language surrounding "options" -- i.e. whether to implement get_conn_uri or get_connections

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
