### PR TITLE
Fix non updating DAG code by checking against last modification time

### DIFF
--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -124,15 +124,14 @@ class DagCode(Base):
             session.add(orm_dag_code)
 
         for fileloc in existing_filelocs:
-            old_version = existing_orm_dag_codes_by_fileloc_hashes[
-                filelocs_to_hashes[fileloc]
-            ]
-            file_modified = datetime.fromtimestamp(
-                os.path.getmtime(correct_maybe_zipped(fileloc)), tz=timezone.utc)
+            current_version = existing_orm_dag_codes_by_fileloc_hashes[filelocs_to_hashes[fileloc]]
+            file_mod_time = datetime.fromtimestamp(
+                os.path.getmtime(correct_maybe_zipped(fileloc)), tz=timezone.utc
+            )
 
-            if (file_modified - timedelta(seconds=120)) > old_version.last_updated:
+            if file_mod_time > current_version.last_updated:
                 orm_dag_code = existing_orm_dag_codes_map[fileloc]
-                orm_dag_code.last_updated = timezone.utcnow()
+                orm_dag_code.last_updated = file_mod_time
                 orm_dag_code.source_code = cls._get_code_from_file(orm_dag_code.fileloc)
                 session.merge(orm_dag_code)
 

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -17,7 +17,7 @@
 import logging
 import os
 import struct
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Iterable, List, Optional
 
 from sqlalchemy import BigInteger, Column, String, UnicodeText, and_, exists

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -135,9 +135,7 @@ class TestDagCode(unittest.TestCase):
 
     @conf_vars({('core', 'store_dag_code'): 'True'})
     def test_db_code_updated_on_dag_file_change(self):
-        """
-        Test Source Code is updated in DB when DAG File is changed
-        """
+        """Test if DagCode is updated in DB when DAG file is changed"""
         example_dag = make_example_dags(example_dags_module).get('example_bash_operator')
         example_dag.sync_to_db()
 
@@ -150,7 +148,7 @@ class TestDagCode(unittest.TestCase):
             self.assertIsNotNone(result.source_code)
 
         with patch('airflow.models.dagcode.os.path.getmtime') as mock_mtime:
-            mock_mtime.return_value = (result.last_updated + timedelta(seconds=121)).timestamp()
+            mock_mtime.return_value = (result.last_updated + timedelta(seconds=1)).timestamp()
 
             with patch('airflow.models.dagcode.DagCode._get_code_from_file') as mock_code:
                 mock_code.return_value = "# dummy code"
@@ -163,4 +161,4 @@ class TestDagCode(unittest.TestCase):
 
                     self.assertEqual(new_result.fileloc, example_dag.fileloc)
                     self.assertEqual(new_result.source_code, "# dummy code")
-                    self.assertGreaterEqual(new_result.last_updated, result.last_updated)
+                    self.assertGreater(new_result.last_updated, result.last_updated)


### PR DESCRIPTION
The DAG code only seemed to update in certain conditions. After closer inspection, it turns out we save utcnow() in the last_updated column. With a threshold of 120 seconds, the result was that a file updated within two minutes from the last utcnow(), will never be updated.

This change simply checks if the last updated time is larger than the last updated time registered in the DB. If so, that means a change and the file is updated.

Draft for now, because I don't understand the reasoning for a 120 second threshold yet, plus want to check tests. @kaxil why was the 120 second threshold in there? Simply checking for a different modification time makes more sense to me, with this change I instantly see the updated code in the webserver, and I don't think people update DAG code every second.

Lastly, I noticed the other views seem to suffer from a similar bug when using `AIRFLOW__CORE__STORE_SERIALIZED_DAGS=True`. Clicking Refresh in the UI doesn't update the DAG structure if I add a new task. Will cover in a separate issue.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
