### PR TITLE
BigQueryCheckOperator location fix

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2445,6 +2445,7 @@ class BigQueryCursor(BigQueryBaseCursor):
             query_results = (self.service.jobs().getQueryResults(
                 projectId=self.project_id,
                 jobId=self.job_id,
+                location=self.location,
                 pageToken=self.page_token).execute(num_retries=self.num_retries))
 
             if 'rows' in query_results and query_results['rows']:

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -77,6 +77,10 @@ class BigQueryCheckOperator(CheckOperator):
     :param use_legacy_sql: Whether to use legacy SQL (true)
         or standard SQL (false).
     :type use_legacy_sql: bool
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
 
     template_fields = ('sql', 'gcp_conn_id',)
@@ -88,6 +92,7 @@ class BigQueryCheckOperator(CheckOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  bigquery_conn_id: Optional[str] = None,
                  use_legacy_sql: bool = True,
+                 location=None,
                  *args, **kwargs) -> None:
         super().__init__(sql=sql, *args, **kwargs)
         if bigquery_conn_id:
@@ -99,10 +104,12 @@ class BigQueryCheckOperator(CheckOperator):
         self.gcp_conn_id = gcp_conn_id
         self.sql = sql
         self.use_legacy_sql = use_legacy_sql
+        self.location = location
 
     def get_db_hook(self):
         return BigQueryHook(bigquery_conn_id=self.gcp_conn_id,
-                            use_legacy_sql=self.use_legacy_sql)
+                            use_legacy_sql=self.use_legacy_sql,
+                            location=self.location)
 
 
 class BigQueryValueCheckOperator(ValueCheckOperator):

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -34,6 +34,7 @@ DATASET_ID = "bq_dataset"
 TABLE_ID = "bq_table"
 VIEW_ID = 'bq_view'
 JOB_ID = 1234
+LOCATION = 'europe-north1'
 
 
 class TestBigQueryHookMethods(unittest.TestCase):
@@ -1612,6 +1613,7 @@ class TestBigQueryCursor(unittest.TestCase):
         bq_hook = hook.BigQueryHook()
         bq_cursor = bq_hook.get_cursor()
         bq_cursor.job_id = JOB_ID
+        bq_cursor.location = LOCATION
 
         result = bq_cursor.next()
         self.assertEqual(['one', 1], result)
@@ -1619,7 +1621,8 @@ class TestBigQueryCursor(unittest.TestCase):
         result = bq_cursor.next()
         self.assertEqual(['two', 2], result)
 
-        mock_get_query_results.assert_called_once_with(jobId=JOB_ID, pageToken=None, projectId='bq-project')
+        mock_get_query_results.assert_called_once_with(jobId=JOB_ID, location=LOCATION, pageToken=None,
+                                                       projectId='bq-project')
         mock_execute.assert_called_once_with(num_retries=bq_cursor.num_retries)
 
     @mock.patch(
@@ -1640,7 +1643,8 @@ class TestBigQueryCursor(unittest.TestCase):
         result = bq_cursor.next()
 
         self.assertIsNone(result)
-        mock_get_query_results.assert_called_once_with(jobId=JOB_ID, pageToken=None, projectId='bq-project')
+        mock_get_query_results.assert_called_once_with(jobId=JOB_ID, location=None, pageToken=None,
+                                                       projectId='bq-project')
         mock_execute.assert_called_once_with(num_retries=bq_cursor.num_retries)
         assert mock_flush_results.call_count == 1
 


### PR DESCRIPTION
There is currently an issue with BigQueryCheckOperator when the BigQuery dataset is not in US or EU, resulting in DAG failure with a 404 No Found issue. This is because the location parameter is currently not passed to the `jobs.getQueryResults` BigQuery API endpoint.

This PR fixes the issue, though I have not yet had time to add any unit tests. I could not find many for these classes as is.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
