### PR TITLE
WIP: Fix issue #8237 — dag will never start if we set a cron string with the exact weekday (example: "52 11 * * 0")

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -716,10 +716,9 @@ class SchedulerJob(BaseJob):
 
             # this structure is necessary to avoid a TypeError from concatenating
             # NoneType
+            period_end = None
             if dag.schedule_interval == '@once':
                 period_end = next_run_date
-            elif next_run_date:
-                period_end = dag.following_schedule(next_run_date)
 
             # Don't schedule a dag beyond its end_date (as specified by the dag param)
             if next_run_date and dag.end_date and next_run_date > dag.end_date:
@@ -734,7 +733,8 @@ class SchedulerJob(BaseJob):
             if next_run_date and min_task_end_date and next_run_date > min_task_end_date:
                 return
 
-            if next_run_date and period_end and period_end <= timezone.utcnow():
+            if next_run_date or \
+               (next_run_date and period_end and period_end <= timezone.utcnow()):
                 next_run = dag.create_dagrun(
                     run_id=DagRun.ID_PREFIX + next_run_date.isoformat(),
                     execution_date=next_run_date,

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -714,12 +714,6 @@ class SchedulerJob(BaseJob):
             if not next_run_date or next_run_date > timezone.utcnow():
                 return
 
-            # this structure is necessary to avoid a TypeError from concatenating
-            # NoneType
-            period_end = None
-            if dag.schedule_interval == '@once':
-                period_end = next_run_date
-
             # Don't schedule a dag beyond its end_date (as specified by the dag param)
             if next_run_date and dag.end_date and next_run_date > dag.end_date:
                 return
@@ -730,11 +724,11 @@ class SchedulerJob(BaseJob):
             task_end_dates = [t.end_date for t in dag.tasks if t.end_date]
             if task_end_dates:
                 min_task_end_date = min(task_end_dates)
+
             if next_run_date and min_task_end_date and next_run_date > min_task_end_date:
                 return
 
-            if next_run_date or \
-               (next_run_date and period_end and period_end <= timezone.utcnow()):
+            if next_run_date:
                 next_run = dag.create_dagrun(
                     run_id=DagRun.ID_PREFIX + next_run_date.isoformat(),
                     execution_date=next_run_date,

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -33,17 +35,12 @@ DAG_NAME = 'test_dag_v1'
 default_args = {
     'owner': 'airflow',
     'depends_on_past': True,
-    'start_date': datetime(year=2020, day=11, month=4, hour=0, minute=0),
+    'start_date': utils.dates.days_ago(2),
 }
-dag = DAG(DAG_NAME, schedule_interval='52 11 * * 0', default_args=default_args)
+dag = DAG(DAG_NAME, schedule_interval='*/10 * * * *', default_args=default_args)
 
 run_this_1 = DummyOperator(task_id='run_this_1', dag=dag)
 run_this_2 = DummyOperator(task_id='run_this_2', dag=dag)
 run_this_2.set_upstream(run_this_1)
 run_this_3 = DummyOperator(task_id='run_this_3', dag=dag)
 run_this_3.set_upstream(run_this_2)
-
-
-if __name__ == "__main__":
-    dag.clear()
-    dag.run()

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -35,12 +33,17 @@ DAG_NAME = 'test_dag_v1'
 default_args = {
     'owner': 'airflow',
     'depends_on_past': True,
-    'start_date': utils.dates.days_ago(2)
+    'start_date': datetime(year=2020, day=11, month=4, hour=0, minute=0),
 }
-dag = DAG(DAG_NAME, schedule_interval='*/10 * * * *', default_args=default_args)
+dag = DAG(DAG_NAME, schedule_interval='52 11 * * 0', default_args=default_args)
 
 run_this_1 = DummyOperator(task_id='run_this_1', dag=dag)
 run_this_2 = DummyOperator(task_id='run_this_2', dag=dag)
 run_this_2.set_upstream(run_this_1)
 run_this_3 = DummyOperator(task_id='run_this_3', dag=dag)
 run_this_3.set_upstream(run_this_2)
+
+
+if __name__ == "__main__":
+    dag.clear()
+    dag.run()


### PR DESCRIPTION
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

---

For fixing issue #8237 this PR
1. Removes code:

```python 
period_end = dag.following_schedule(next_run_date)
```

I can't find any reason for variable `period_end`. As I said in comment: 
this variable always has value `next_run_date + interval` and sometimes it's greater than `timezone.utcnow()`.

2. Removes code:

```
if dag.schedule_interval == '@once':
	period_end = next_run_date
...
if next_run_date and period_end and period_end <= timezone.utcnow():
```

Because it may be modified to:

```python
if dag.schedule_interval == '@once' and next_run_date \
   and next_run_date >= timezone.utcnow():
    return
```

But this lines will not execute, because previous statement:

```python
if not next_run_date or next_run_date > timezone.utcnow():
                return
```

So if I remove this lines never changes.

Please, review this PR. May be you can find a reason for existence `period_end`
