### PR TITLE
[AIRFLOW-8187] Extend elastic DAG with a binary tree, grid, star

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1190,7 +1190,7 @@ class BaseOperator(Operator, LoggingMixin):
 
 def chain(*tasks: Union[BaseOperator, List[BaseOperator]]):
     r"""
-    Given a number of tasks, builds a linear dependency chain.
+    Given a number of tasks, builds a dependency chain.
     Support mix airflow.models.BaseOperator and List[airflow.models.BaseOperator].
     If you want to chain between two List[airflow.models.BaseOperator], have to
     make sure they have same length.
@@ -1237,36 +1237,6 @@ def chain(*tasks: Union[BaseOperator, List[BaseOperator]]):
                 f'but get {len(up_task_list)} and {len(down_task_list)}')
         for up_t, down_t in zip(up_task_list, down_task_list):
             up_t.set_downstream(down_t)
-
-
-def chain_as_binary_tree(*tasks: BaseOperator):
-    r'''
-    Chain tasks as a binary tree where task i is child of task (i - 1) // 2 :
-
-        t0 -> t1 -> t3 -> t7
-          |    \
-          |      -> t4 -> t8
-          |
-           -> t2 -> t5 -> t9
-               \
-                 -> t6
-    '''
-    for i in range(1, len(tasks)):
-        tasks[i].set_downstream(tasks[(i - 1) // 2])
-
-
-def chain_as_star(*tasks: BaseOperator):
-    '''
-    Chain tasks as a star (all tasks are children of task 0)
-
-     t0 -> t1
-      | -> t2
-      | -> t3
-      | -> t4
-      | -> t5
-    '''
-    for i in range(1, len(tasks)):
-        tasks[i].set_downstream(tasks[0])
 
 
 def cross_downstream(from_tasks: List[BaseOperator],

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1190,7 +1190,7 @@ class BaseOperator(Operator, LoggingMixin):
 
 def chain(*tasks: Union[BaseOperator, List[BaseOperator]]):
     r"""
-    Given a number of tasks, builds a dependency chain.
+    Given a number of tasks, builds a linear dependency chain.
     Support mix airflow.models.BaseOperator and List[airflow.models.BaseOperator].
     If you want to chain between two List[airflow.models.BaseOperator], have to
     make sure they have same length.
@@ -1237,6 +1237,36 @@ def chain(*tasks: Union[BaseOperator, List[BaseOperator]]):
                 f'but get {len(up_task_list)} and {len(down_task_list)}')
         for up_t, down_t in zip(up_task_list, down_task_list):
             up_t.set_downstream(down_t)
+
+
+def chain_as_binary_tree(*tasks: BaseOperator):
+    r'''
+    Chain tasks as a binary tree where task i is child of task (i - 1) // 2 :
+
+        t0 -> t1 -> t3 -> t7
+          |    \
+          |      -> t4 -> t8
+          |
+           -> t2 -> t5 -> t9
+               \
+                 -> t6
+    '''
+    for i in range(1, len(tasks)):
+        tasks[i].set_downstream(tasks[(i - 1) // 2])
+
+
+def chain_as_star(*tasks: BaseOperator):
+    '''
+    Chain tasks as a star (all tasks are children of task 0)
+
+     t0 -> t1
+      | -> t2
+      | -> t3
+      | -> t4
+      | -> t5
+    '''
+    for i in range(1, len(tasks)):
+        tasks[i].set_downstream(tasks[0])
 
 
 def cross_downstream(from_tasks: List[BaseOperator],

--- a/scripts/perf/dags/elastic_dag.py
+++ b/scripts/perf/dags/elastic_dag.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 
 from airflow import DAG
-from airflow.models.baseoperator import chain
+from airflow.models.baseoperator import chain, chain_as_binary_tree, chain_as_star
 from airflow.operators.bash import BashOperator
 
 # DAG File used in performance tests. Its shape can be configured by environment variables.
@@ -74,7 +74,6 @@ def safe_dag_id(s: str) -> str:
     return re.sub('[^0-9a-zA-Z_]+', '_', s)
 
 
-# TODO: We should add more shape types e.g. binary tree
 @enum.unique
 class DagShape(Enum):
     '''
@@ -82,6 +81,8 @@ class DagShape(Enum):
     '''
     NO_STRUCTURE = "no_structure"
     LINEAR = "linear"
+    BINARY_TREE = "binary_tree"
+    STAR = "star"
 
 
 DAG_PREFIX = os.environ.get("PERF_DAG_PREFIX", "perf_scheduler")
@@ -123,5 +124,9 @@ for dag_no in range(1, DAG_COUNT + 1):
         pass
     elif SHAPE == DagShape.LINEAR:
         chain(*tasks)
+    elif SHAPE == DagShape.BINARY_TREE:
+        chain_as_binary_tree(*tasks)
+    elif SHAPE == DagShape.STAR:
+        chain_as_star(*tasks)
 
     globals()[f"dag_{dag_no}"] = dag

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1155,6 +1155,8 @@ class TestDagFileProcessorQueriesCount(unittest.TestCase):
             ( 9,  1,  1, "1d", "@once",        "linear"),  # noqa
             ( 9,  1,  1, "1d",   "30m",  "no_structure"),  # noqa
             ( 9,  1,  1, "1d",   "30m",        "linear"),  # noqa
+            ( 9,  1,  1, "1d",   "30m",   "binary_tree"),  # noqa
+            ( 9,  1,  1, "1d",   "30m",          "star"),  # noqa
             # One DAG with five tasks per DAG  file
             ( 1,  1,  5, "1d",  "None",  "no_structure"),  # noqa
             ( 1,  1,  5, "1d",  "None",        "linear"),  # noqa
@@ -1162,6 +1164,8 @@ class TestDagFileProcessorQueriesCount(unittest.TestCase):
             (10,  1,  5, "1d", "@once",        "linear"),  # noqa
             ( 9,  1,  5, "1d",   "30m",  "no_structure"),  # noqa
             (10,  1,  5, "1d",   "30m",        "linear"),  # noqa
+            (10,  1,  5, "1d",   "30m",   "binary_tree"),  # noqa
+            (10,  1,  5, "1d",   "30m",          "star"),  # noqa
             # 10 DAGs with 10 tasks per DAG file
             ( 1, 10, 10, "1d",  "None",  "no_structure"),  # noqa
             ( 1, 10, 10, "1d",  "None",        "linear"),  # noqa
@@ -1169,6 +1173,8 @@ class TestDagFileProcessorQueriesCount(unittest.TestCase):
             (91, 10, 10, "1d", "@once",        "linear"),  # noqa
             (81, 10, 10, "1d",   "30m",  "no_structure"),  # noqa
             (91, 10, 10, "1d",   "30m",        "linear"),  # noqa
+            (91, 10, 10, "1d",   "30m",   "binary_tree"),  # noqa
+            (91, 10, 10, "1d",   "30m",          "star"),  # noqa
             # pylint: enable=bad-whitespace
         ]
     )

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1157,6 +1157,7 @@ class TestDagFileProcessorQueriesCount(unittest.TestCase):
             ( 9,  1,  1, "1d",   "30m",        "linear"),  # noqa
             ( 9,  1,  1, "1d",   "30m",   "binary_tree"),  # noqa
             ( 9,  1,  1, "1d",   "30m",          "star"),  # noqa
+            ( 9,  1,  1, "1d",   "30m",          "grid"),  # noqa
             # One DAG with five tasks per DAG  file
             ( 1,  1,  5, "1d",  "None",  "no_structure"),  # noqa
             ( 1,  1,  5, "1d",  "None",        "linear"),  # noqa
@@ -1166,6 +1167,7 @@ class TestDagFileProcessorQueriesCount(unittest.TestCase):
             (10,  1,  5, "1d",   "30m",        "linear"),  # noqa
             (10,  1,  5, "1d",   "30m",   "binary_tree"),  # noqa
             (10,  1,  5, "1d",   "30m",          "star"),  # noqa
+            (10,  1,  5, "1d",   "30m",          "grid"),  # noqa
             # 10 DAGs with 10 tasks per DAG file
             ( 1, 10, 10, "1d",  "None",  "no_structure"),  # noqa
             ( 1, 10, 10, "1d",  "None",        "linear"),  # noqa
@@ -1175,6 +1177,7 @@ class TestDagFileProcessorQueriesCount(unittest.TestCase):
             (91, 10, 10, "1d",   "30m",        "linear"),  # noqa
             (91, 10, 10, "1d",   "30m",   "binary_tree"),  # noqa
             (91, 10, 10, "1d",   "30m",          "star"),  # noqa
+            (91, 10, 10, "1d",   "30m",          "grid"),  # noqa
             # pylint: enable=bad-whitespace
         ]
     )


### PR DESCRIPTION
Add three shapes to the elastic DAG :

 - BINARY_TREE
```
        t0 -> t1 -> t3 -> t7
          |    \
          |      -> t4 -> t8
          |
           -> t2 -> t5 -> t9
               \ 
                 -> t6
```
 - STAR
```
     t0 -> t1
      | -> t2
      | -> t3
      | -> t4
      | -> t5
```

- GRID
```
     t0 -> t1 -> t2 -> t3
      |     |     |
      v     v     v
     t4 -> t5 -> t6
      |     |
      v     v
     t7 -> t8
      |
      v
     t9
```
and add corresponding tests in `test_scheduler_job`.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [?] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
