### PR TITLE
Add airflow info command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -678,6 +678,15 @@ ARG_SKIP_SERVE_LOGS = Arg(
     help="Don't start the serve logs process along with the workers",
     action="store_true")
 
+# info
+ARG_ANONYMIZE = Arg(
+    ('--anonymize',),
+    help=(
+        'Minimize any personal identifiable information. '
+        'Use it when sharing output with others.'
+    ),
+    action='store_true'
+)
 
 ALTERNATIVE_CONN_SPECS_ARGS = [
     ARG_CONN_TYPE, ARG_CONN_HOST, ARG_CONN_LOGIN, ARG_CONN_PASSWORD, ARG_CONN_SCHEMA, ARG_CONN_PORT
@@ -1058,6 +1067,35 @@ ROLES_COMMANDS = (
         args=(ARG_ROLES,),
     ),
 )
+
+CELERY_COMMANDS = (
+    ActionCommand(
+        name='worker',
+        help="Start a Celery worker node",
+        func=lazy_load_command('airflow.cli.commands.celery_command.worker'),
+        args=(
+            ARG_DO_PICKLE, ARG_QUEUES, ARG_CONCURRENCY, ARG_CELERY_HOSTNAME, ARG_PID, ARG_DAEMON,
+            ARG_STDOUT, ARG_STDERR, ARG_LOG_FILE, ARG_AUTOSCALE, ARG_SKIP_SERVE_LOGS
+        ),
+    ),
+    ActionCommand(
+        name='flower',
+        help="Start a Celery Flower",
+        func=lazy_load_command('airflow.cli.commands.celery_command.flower'),
+        args=(
+            ARG_FLOWER_HOSTNAME, ARG_FLOWER_PORT, ARG_FLOWER_CONF, ARG_FLOWER_URL_PREFIX,
+            ARG_FLOWER_BASIC_AUTH, ARG_BROKER_API, ARG_PID, ARG_DAEMON, ARG_STDOUT, ARG_STDERR,
+            ARG_LOG_FILE
+        ),
+    ),
+    ActionCommand(
+        name='stop',
+        help="Stop the Celery worker gracefully",
+        func=lazy_load_command('airflow.cli.commands.celery_command.stop_worker'),
+        args=(),
+    )
+)
+
 airflow_commands: List[CLICommand] = [
     GroupCommand(
         name='dags',
@@ -1152,39 +1190,19 @@ airflow_commands: List[CLICommand] = [
         func=lazy_load_command('airflow.cli.commands.config_command.show_config'),
         args=(),
     ),
+    ActionCommand(
+        name='info',
+        help='Show information about current Airflow and environment',
+        func=lazy_load_command('airflow.cli.commands.info_command.show_info'),
+        args=(ARG_ANONYMIZE, ),
+    ),
     GroupCommand(
         name="celery",
         help=(
             'Start celery components. Works only when using CeleryExecutor. For more information, see '
             'https://airflow.readthedocs.io/en/stable/executor/celery.html'
         ),
-        subcommands=(
-            ActionCommand(
-                name='worker',
-                help="Start a Celery worker node",
-                func=lazy_load_command('airflow.cli.commands.celery_command.worker'),
-                args=(
-                    ARG_DO_PICKLE, ARG_QUEUES, ARG_CONCURRENCY, ARG_CELERY_HOSTNAME, ARG_PID, ARG_DAEMON,
-                    ARG_STDOUT, ARG_STDERR, ARG_LOG_FILE, ARG_AUTOSCALE, ARG_SKIP_SERVE_LOGS
-                ),
-            ),
-            ActionCommand(
-                name='flower',
-                help="Start a Celery Flower",
-                func=lazy_load_command('airflow.cli.commands.celery_command.flower'),
-                args=(
-                    ARG_FLOWER_HOSTNAME, ARG_FLOWER_PORT, ARG_FLOWER_CONF, ARG_FLOWER_URL_PREFIX,
-                    ARG_FLOWER_BASIC_AUTH, ARG_BROKER_API, ARG_PID, ARG_DAEMON, ARG_STDOUT, ARG_STDERR,
-                    ARG_LOG_FILE
-                ),
-            ),
-            ActionCommand(
-                name='stop',
-                help="Stop the Celery worker gracefully",
-                func=lazy_load_command('airflow.cli.commands.celery_command.stop_worker'),
-                args=(),
-            )
-        )
+        subcommands=CELERY_COMMANDS
     )
 ]
 ALL_COMMANDS_DICT: Dict[str, CLICommand] = {sp.name: sp for sp in airflow_commands}

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -687,6 +687,13 @@ ARG_ANONYMIZE = Arg(
     ),
     action='store_true'
 )
+ARG_FILE_IO = Arg(
+    ('--file-io',),
+    help=(
+        'Send output to file.io service and returns link.'
+    ),
+    action='store_true'
+)
 
 ALTERNATIVE_CONN_SPECS_ARGS = [
     ARG_CONN_TYPE, ARG_CONN_HOST, ARG_CONN_LOGIN, ARG_CONN_PASSWORD, ARG_CONN_SCHEMA, ARG_CONN_PORT
@@ -1194,7 +1201,7 @@ airflow_commands: List[CLICommand] = [
         name='info',
         help='Show information about current Airflow and environment',
         func=lazy_load_command('airflow.cli.commands.info_command.show_info'),
-        args=(ARG_ANONYMIZE, ),
+        args=(ARG_ANONYMIZE, ARG_FILE_IO, ),
     ),
     GroupCommand(
         name="celery",

--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -1,0 +1,318 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Config sub-commands"""
+import getpass
+import locale
+import os
+import platform
+import subprocess
+import sys
+import textwrap
+from typing import Optional
+
+from typing_extensions import Protocol
+
+from airflow import configuration
+from airflow.version import version as airflow_version
+
+
+class Anonymizer(Protocol):
+    """Anonymizer protocol."""
+
+    def process_path(self, value):
+        """Remove pii from paths"""
+
+
+class NullAnonymizer(Anonymizer):
+    """Do nothing."""
+
+    def process_path(self, value):
+        return value
+
+
+class PiiAnonymizer(Anonymizer):
+    """Remove personally identifiable info from path."""
+
+    def __init__(self):
+        home_path = os.path.expanduser("~")
+        username = getpass.getuser()
+        self._path_replacements = {home_path: "${HOME}", username: "${USER}"}
+
+    def process_path(self, value):
+        if not value:
+            return value
+        for src, target in self._path_replacements.items():
+            value = value.replace(src, target)
+        return value
+
+
+class OperatingSystem:
+    """Operating system"""
+
+    WINDOWS = "Windows"
+    LINUX = "Linux"
+    MACOSX = "Mac OS"
+    CYGWIN = "Cygwin"
+
+    @staticmethod
+    def get_current() -> Optional[str]:
+        """Get current operating system"""
+        if os.name == "nt":
+            return OperatingSystem.WINDOWS
+        elif "linux" in sys.platform:
+            return OperatingSystem.LINUX
+        elif "darwin" in sys.platform:
+            return OperatingSystem.MACOSX
+        elif "cygwin" in sys.platform:
+            return OperatingSystem.CYGWIN
+        return None
+
+
+class Architecture:
+    """Compute architecture"""
+
+    X86_64 = "x86_64"
+    X86 = "x86"
+    PPC = "ppc"
+    ARM = "arm"
+
+    @staticmethod
+    def get_current():
+        """Get architecture"""
+        return _MACHINE_TO_ARCHITECTURE.get(platform.machine().lower())
+
+
+_MACHINE_TO_ARCHITECTURE = {
+    "amd64": Architecture.X86_64,
+    "x86_64": Architecture.X86_64,
+    "i686-64": Architecture.X86_64,
+    "i386": Architecture.X86,
+    "i686": Architecture.X86,
+    "x86": Architecture.X86,
+    "ia64": Architecture.X86,  # Itanium is different x64 arch, treat it as the common x86.
+    "powerpc": Architecture.PPC,
+    "power macintosh": Architecture.PPC,
+    "ppc64": Architecture.PPC,
+    "armv6": Architecture.ARM,
+    "armv6l": Architecture.ARM,
+    "arm64": Architecture.ARM,
+    "armv7": Architecture.ARM,
+    "armv7l": Architecture.ARM,
+}
+
+
+class AirflowInfo:
+    """All information related to Airflow, system and other."""
+
+    def __init__(self, anonymizer: Anonymizer):
+        self.airflow_version = airflow_version
+        self.system = SystemInfo(anonymizer)
+        self.tools = ToolsInfo(anonymizer)
+        self.paths = PathsInfo(anonymizer)
+        self.config = ConfigInfo(anonymizer)
+
+    def __str__(self):
+        return (
+            textwrap.dedent(
+                """\
+                Apache Airflow [{version}]
+
+                {system}
+
+                {tools}
+
+                {paths}
+
+                {config}
+                """
+            )
+            .strip()
+            .format(
+                version=airflow_version,
+                system=self.system,
+                tools=self.tools,
+                paths=self.paths,
+                config=self.config,
+            )
+        )
+
+
+class SystemInfo:
+    """Basic system and python information"""
+
+    def __init__(self, anonymizer: Anonymizer):
+        self.operating_system = OperatingSystem.get_current()
+        self.arch = Architecture.get_current()
+        self.uname = platform.uname()
+        self.locale = locale.getdefaultlocale()
+        self.python_location = anonymizer.process_path(sys.executable)
+        self.python_version = sys.version.replace("\n", " ")
+
+    def __str__(self):
+        return (
+            textwrap.dedent(
+                """\
+                Platform: [{os}, {arch}] {uname}
+                Locale: {locale}
+                Python Version: [{python_version}]
+                Python Location: [{python_location}]
+                """
+            )
+            .strip()
+            .format(
+                version=airflow_version,
+                os=self.operating_system or "NOT AVAILABLE",
+                arch=self.arch or "NOT AVAILABLE",
+                uname=self.uname,
+                locale=self.locale,
+                python_version=self.python_version,
+                python_location=self.python_location,
+            )
+        )
+
+
+class PathsInfo:
+    """Path informaation"""
+
+    def __init__(self, anonymizer: Anonymizer):
+        system_path = os.environ.get("PATH", "").split(os.pathsep)
+
+        self.airflow_home = anonymizer.process_path(configuration.get_airflow_home())
+        self.system_path = [anonymizer.process_path(p) for p in system_path]
+        self.python_path = [anonymizer.process_path(p) for p in sys.path]
+        self.airflow_on_path = any(
+            os.path.exists(os.path.join(path_elem, "airflow")) for path_elem in system_path
+        )
+
+    def __str__(self):
+        return (
+            textwrap.dedent(
+                """\
+                Airflow Home: [{airflow_home}]
+                System PATH: [{system_path}]
+                Python PATH: [{python_path}]
+                airflow on PATH: {airflow_on_path}
+                """
+            )
+            .strip()
+            .format(
+                airflow_home=self.airflow_home,
+                system_path=os.pathsep.join(self.system_path),
+                python_path=os.pathsep.join(self.python_path),
+                airflow_on_path=self.airflow_on_path,
+            )
+        )
+
+
+class ConfigInfo:
+    """"Most critical config properties"""
+
+    def __init__(self, anonymizer: Anonymizer):
+        self.dags_folder = anonymizer.process_path(
+            configuration.conf.get("core", "dags_folder", fallback="NOT AVAILABLE")
+        )
+        self.plugins_folder = anonymizer.process_path(
+            configuration.conf.get("core", "plugins_folder", fallback="NOT AVAILABLE")
+        )
+        self.base_log_folder = anonymizer.process_path(
+            configuration.conf.get("logging", "base_log_folder", fallback="NOT AVAILABLE")
+        )
+        self.executor = configuration.conf.get("core", "executor")
+
+    def __str__(self):
+        return (
+            textwrap.dedent(
+                """\
+                DAGS Folder: [{dags_folder}]
+                Plugins Folder: [{plugins_folder}]
+                Base Log Folder: [{base_log_folder}]
+                Executor: [{executor}]
+                """
+            )
+            .strip()
+            .format(
+                dags_folder=self.dags_folder,
+                plugins_folder=self.plugins_folder,
+                base_log_folder=self.base_log_folder,
+                executor=self.executor,
+            )
+        )
+
+
+class ToolsInfo:
+    """The versions of the tools that Airflow uses"""
+
+    def __init__(self, anonymize: Anonymizer):
+        del anonymize  # Nothing to anonymize here.
+        self.git_version = self._get_version(["git", "--version"])
+        self.ssh_version = self._get_version(["ssh", "-V"])
+        self.kubectl_version = self._get_version(["kubectl", "version", "--short=True", "--client=True"])
+        self.gcloud_version = self._get_version(["gcloud", "version"], grep=b"Google Cloud SDK")
+        self.cloud_sql_proxy_version = self._get_version(["cloud_sql_proxy", "--version"])
+        self.mysql_version = self._get_version(["mysql", "--version"])
+        self.sqlite3_version = self._get_version(["sqlite3", "--version"])
+        self.psql_version = self._get_version(["psql", "--version"])
+
+    def _get_version(self, cmd, grep=None):
+        """Return tools version."""
+        try:
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        except OSError:
+            return "NOT AVAILABLE"
+        stdoutdata, _ = proc.communicate()
+        data = [f for f in stdoutdata.split(b"\n") if f]
+        if grep:
+            data = [line for line in data if grep in line]
+        if len(data) != 1:
+            return "NOT AVAILABLE"
+        else:
+            return data[0].decode()
+
+    def __str__(self):
+        return (
+            textwrap.dedent(
+                """\
+                git: [{git}]
+                ssh: [{ssh}]
+                kubectl: [{kubectl}]
+                gcloud: [{gcloud}]
+                cloud_sql_proxy: [{cloud_sql_proxy}]
+                mysql: [{mysql}]
+                sqlite3: [{sqlite3}]
+                psql: [{psql}]
+                """
+            )
+            .strip()
+            .format(
+                git=self.git_version,
+                ssh=self.ssh_version,
+                kubectl=self.kubectl_version,
+                gcloud=self.gcloud_version,
+                cloud_sql_proxy=self.cloud_sql_proxy_version,
+                mysql=self.mysql_version,
+                sqlite3=self.sqlite3_version,
+                psql=self.psql_version,
+            )
+        )
+
+
+def show_info(args):
+    """
+    Show information related to Airflow, system and other.
+    """
+    anonymizer = PiiAnonymizer() if args.anonymize else NullAnonymizer()
+    print(AirflowInfo(anonymizer))

--- a/tests/cli/commands/test_info_command.py
+++ b/tests/cli/commands/test_info_command.py
@@ -1,0 +1,119 @@
+import contextlib
+import io
+import os
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from airflow.cli import cli_parser
+from airflow.cli.commands import info_command
+from airflow.version import version as airflow_version
+from tests.test_utils.config import conf_vars
+
+
+class TestPiiAnonymizer(unittest.TestCase):
+    def setUp(self) -> None:
+        self.instance = info_command.PiiAnonymizer()
+
+    def test_should_remove_pii_from_path(self):
+        home_path = os.path.expanduser("~/airflow/config")
+        self.assertEqual("${HOME}/airflow/config", self.instance.process_path(home_path))
+
+    @parameterized.expand(
+        [
+            (
+                "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                "postgresql+psycopg2://p...s:PASSWORD@postgres/airflow",
+            ),
+            (
+                "postgresql+psycopg2://postgres@postgres/airflow",
+                "postgresql+psycopg2://p...s@postgres/airflow",
+            ),
+            (
+                "postgresql+psycopg2://:airflow@postgres/airflow",
+                "postgresql+psycopg2://:PASSWORD@postgres/airflow",
+            ),
+            ("postgresql+psycopg2://postgres/airflow", "postgresql+psycopg2://postgres/airflow",),
+        ]
+    )
+    def test_should_remove_pii_from_url(self, before, after):
+        self.assertEqual(after, self.instance.process_url(before))
+
+
+class TestAirflowInfo(unittest.TestCase):
+    def test_should_be_string(self):
+        text = str(info_command.AirflowInfo(info_command.NullAnonymizer()))
+
+        self.assertIn("Apache Airflow [{}]".format(airflow_version), text)
+
+
+class TestSystemInfo(unittest.TestCase):
+    def test_should_be_string(self):
+        self.assertTrue(str(info_command.SystemInfo(info_command.NullAnonymizer())))
+
+
+class TestPathsInfo(unittest.TestCase):
+    def test_should_be_string(self):
+        self.assertTrue(str(info_command.PathsInfo(info_command.NullAnonymizer())))
+
+
+class TestConfigInfo(unittest.TestCase):
+    @conf_vars(
+        {
+            ("core", "executor"): "TEST_EXECUTOR",
+            ("core", "dags_folder"): "TEST_DAGS_FOLDER",
+            ("core", "plugins_folder"): "TEST_PLUGINS_FOLDER",
+            ("logging", "base_log_folder"): "TEST_LOG_FOLDER",
+            ("core", "SQL_ALCHEMY_CONN"): "postgresql+psycopg2://postgres:airflow@postgres/airflow",
+        }
+    )
+    def test_should_read_config(self):
+        instance = info_command.ConfigInfo(info_command.NullAnonymizer())
+        text = str(instance)
+        self.assertIn("TEST_EXECUTOR", text)
+        self.assertIn("TEST_DAGS_FOLDER", text)
+        self.assertIn("TEST_PLUGINS_FOLDER", text)
+        self.assertIn("TEST_LOG_FOLDER", text)
+        self.assertIn("postgresql+psycopg2://postgres:airflow@postgres/airflow", text)
+
+
+class TestToolsInfo(unittest.TestCase):
+    def test_should_be_string(self):
+        self.assertTrue(str(info_command.ToolsInfo(info_command.NullAnonymizer())))
+
+
+class TestShowInfo(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    def test_show_info(self):
+        with contextlib.redirect_stdout(io.StringIO()) as stdout:
+            info_command.show_info(self.parser.parse_args(["info"]))
+
+        self.assertIn("Apache Airflow [{}]".format(airflow_version), stdout.getvalue())
+
+    def test_show_info_anonymize(self):
+        with contextlib.redirect_stdout(io.StringIO()) as stdout:
+            info_command.show_info(self.parser.parse_args(["info", "--anonymize"]))
+
+        self.assertIn("Apache Airflow [{}]".format(airflow_version), stdout.getvalue())
+
+    @mock.patch(
+        "airflow.cli.commands.info_command.requests",
+        **{
+            "post.return_value.ok": True,
+            "post.return_value.json.return_value": {
+                "success": True,
+                "key": "f9U3zs3I",
+                "link": "https://file.io/TEST",
+                "expiry": "14 days",
+            },
+        }
+    )
+    def test_show_info_anonymize_fileio(self, mock_requests):
+        with contextlib.redirect_stdout(io.StringIO()) as stdout:
+            info_command.show_info(self.parser.parse_args(["info", "--anonymize", "--file-io"]))
+
+        self.assertIn("https://file.io/TEST", stdout.getvalue())

--- a/tests/cli/commands/test_info_command.py
+++ b/tests/cli/commands/test_info_command.py
@@ -76,16 +76,13 @@ class TestPathsInfo(unittest.TestCase):
 
 
 class TestConfigInfo(unittest.TestCase):
-    @mock.patch.dict(
-        "os.environ",
-        {"AIRFLOW__CORE__SQL_ALCHEMY_CONN": "postgresql+psycopg2://postgres:airflow@postgres/airflow"},
-    )
     @conf_vars(
         {
             ("core", "executor"): "TEST_EXECUTOR",
             ("core", "dags_folder"): "TEST_DAGS_FOLDER",
             ("core", "plugins_folder"): "TEST_PLUGINS_FOLDER",
             ("logging", "base_log_folder"): "TEST_LOG_FOLDER",
+            ('core', 'sql_alchemy_conn'): 'postgresql+psycopg2://postgres:airflow@postgres/airflow',
         }
     )
     def test_should_read_config(self):
@@ -108,9 +105,10 @@ class TestShowInfo(unittest.TestCase):
     def setUpClass(cls):
         cls.parser = cli_parser.get_parser()
 
-    @mock.patch.dict(
-        "os.environ",
-        {"AIRFLOW__CORE__SQL_ALCHEMY_CONN": "postgresql+psycopg2://postgres:airflow@postgres/airflow"},
+    @conf_vars(
+        {
+            ('core', 'sql_alchemy_conn'): 'postgresql+psycopg2://postgres:airflow@postgres/airflow',
+        }
     )
     def test_show_info(self):
         with contextlib.redirect_stdout(io.StringIO()) as stdout:
@@ -120,9 +118,10 @@ class TestShowInfo(unittest.TestCase):
         self.assertIn("Apache Airflow [{}]".format(airflow_version), output)
         self.assertIn("postgresql+psycopg2://postgres:airflow@postgres/airflow", output)
 
-    @mock.patch.dict(
-        "os.environ",
-        {"AIRFLOW__CORE__SQL_ALCHEMY_CONN": "postgresql+psycopg2://postgres:airflow@postgres/airflow"},
+    @conf_vars(
+        {
+            ('core', 'sql_alchemy_conn'): 'postgresql+psycopg2://postgres:airflow@postgres/airflow',
+        }
     )
     def test_show_info_anonymize(self):
         with contextlib.redirect_stdout(io.StringIO()) as stdout:
@@ -132,9 +131,10 @@ class TestShowInfo(unittest.TestCase):
         self.assertIn("Apache Airflow [{}]".format(airflow_version), output)
         self.assertIn("postgresql+psycopg2://p...s:PASSWORD@postgres/airflow", output)
 
-    @mock.patch.dict(
-        "os.environ",
-        {"AIRFLOW__CORE__SQL_ALCHEMY_CONN": "postgresql+psycopg2://postgres:airflow@postgres/airflow"},
+    @conf_vars(
+        {
+            ('core', 'sql_alchemy_conn'): 'postgresql+psycopg2://postgres:airflow@postgres/airflow',
+        }
     )
     @mock.patch(
         "airflow.cli.commands.info_command.requests",


### PR DESCRIPTION
Hi. 

Users often have problems with the runtime environment or with several basic configuration options. To make it easier to gather information, I have created an additional command that allows us to collect the necessary data also in anonymized form.

For now, I've added only a few basic keys, but I think we can easily extend based on observation. In particular, I'd like to see keys that get some data from the database (e.g. jobs). However, this can be done in the future.

I would like to cherry-pick this command to Airflow 1.10, so I didn't use the latest syntax from Python 3.

Best regards,
Kamil

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
