### PR TITLE
Fix confusing "heartbeat" name on DagFileProcessor class

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1609,7 +1609,7 @@ class SchedulerJob(BaseJob):
             loop_start_time = time.time()
 
             if self.using_sqlite:
-                self.processor_agent.heartbeat()
+                self.processor_agent.run_single_parsing_loop()
                 # For the sqlite case w/ 1 thread, wait until the processor
                 # is finished to avoid concurrent access to the DB.
                 self.log.debug("Waiting for processors to finish since we're using sqlite")

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -270,7 +270,7 @@ class DagFileStat(NamedTuple):
 
 class DagParsingSignal(enum.Enum):
     """All signals sent to parser."""
-    AGENT_HEARTBEAT = 'agent_heartbeat'
+    AGENT_RUN_ONCE = 'agent_run_once'
     TERMINATE_MANAGER = 'terminate_manager'
     END_MANAGER = 'end_manager'
 
@@ -350,7 +350,7 @@ class DagFileProcessorAgent(LoggingMixin):
 
         self.log.info("Launched DagFileProcessorManager with pid: %s", self._process.pid)
 
-    def heartbeat(self):
+    def run_single_parsing_loop(self):
         """
         Should only be used when launched DAG file processor manager in sync mode.
         Send agent heartbeat signal to the manager, requesting that it runs one
@@ -363,7 +363,7 @@ class DagFileProcessorAgent(LoggingMixin):
             return
 
         try:
-            self._parent_signal_conn.send(DagParsingSignal.AGENT_HEARTBEAT)
+            self._parent_signal_conn.send(DagParsingSignal.AGENT_RUN_ONCE)
         except ConnectionError:
             # If this died cos of an error then we will noticed and restarted
             # when harvest_simple_dags calls _heartbeat_manager.
@@ -675,7 +675,7 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
                 elif agent_signal == DagParsingSignal.END_MANAGER:
                     self.end()
                     sys.exit(os.EX_OK)
-                elif agent_signal == DagParsingSignal.AGENT_HEARTBEAT:
+                elif agent_signal == DagParsingSignal.AGENT_RUN_ONCE:
                     # continue the loop to parse dags
                     pass
                 elif isinstance(agent_signal, FailureCallbackRequest):

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -295,7 +295,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
             processor_agent.start()
             parsing_result = []
             if not async_mode:
-                processor_agent.heartbeat()
+                processor_agent.run_single_parsing_loop()
             while not processor_agent.done:
                 if not async_mode:
                     processor_agent.wait_until_finished()
@@ -388,7 +388,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                     async_mode)
             processor_agent.start()
             if not async_mode:
-                processor_agent.heartbeat()
+                processor_agent.run_single_parsing_loop()
 
             processor_agent._process.join()
 
@@ -413,7 +413,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
         processor_agent.start()
         parsing_result = []
         if not async_mode:
-            processor_agent.heartbeat()
+            processor_agent.run_single_parsing_loop()
         while not processor_agent.done:
             if not async_mode:
                 processor_agent.wait_until_finished()
@@ -446,7 +446,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                 async_mode)
         processor_agent.start()
         if not async_mode:
-            processor_agent.heartbeat()
+            processor_agent.run_single_parsing_loop()
 
         processor_agent._process.join()
 


### PR DESCRIPTION
This method was called "heartbeat" and was called from within
SchedulerJob, but it does something very different to a job heartbeat --
and is also not called in "async" mode, just in sync/sqlite mode, so I
think this name provides a clearer indication of what it does

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
