### PR TITLE
Clarify docs for on delete_worker_pods_on_success

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1754,7 +1754,9 @@
       default: "True"
     - name: delete_worker_pods_on_success
       description: |
-        If True (default), worker pods will be deleted only on task success
+        If True (default), worker pods will be deleted only on task success.
+        Note that this feature overrides `delete_worker_pods`, so failed pods
+        will not be deleted if both are set to true.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -815,7 +815,9 @@ worker_container_image_pull_policy = IfNotPresent
 # If True, all worker pods will be deleted upon termination
 delete_worker_pods = True
 
-# If True (default), worker pods will be deleted only on task success
+# If True (default), worker pods will be deleted only on task success.
+# Note that this feature overrides `delete_worker_pods`, so failed pods
+# will not be deleted if both are set to true.
 delete_worker_pods_on_success = True
 
 # Number of Kubernetes Worker Pod creation calls per scheduler loop.


### PR DESCRIPTION
This PR adds a description of how `delete_worker_pods_on_success`
interacts with `delete_worker_pods`

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
