### PR TITLE
[Airflow-5565] Add extra_args param to s3hook

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -522,7 +522,8 @@ class S3Hook(AwsBaseHook):
                    bucket_name=None,
                    replace=False,
                    encrypt=False,
-                   acl_policy=None):
+                   acl_policy=None,
+                   extra_args=None):
         """
         Loads bytes to S3
 
@@ -546,7 +547,7 @@ class S3Hook(AwsBaseHook):
         :type acl_policy: str
         """
         file_obj = io.BytesIO(bytes_data)
-        self._upload_file_obj(file_obj, key, bucket_name, replace, encrypt, acl_policy)
+        self._upload_file_obj(file_obj, key, bucket_name, replace, encrypt, acl_policy, extra_args)
 
     @provide_bucket_name
     @unify_bucket_name_and_key
@@ -556,7 +557,8 @@ class S3Hook(AwsBaseHook):
                       bucket_name=None,
                       replace=False,
                       encrypt=False,
-                      acl_policy=None):
+                      acl_policy=None,
+                      extra_args=None):
         """
         Loads a file object to S3
 
@@ -576,7 +578,7 @@ class S3Hook(AwsBaseHook):
             object to be uploaded
         :type acl_policy: str
         """
-        self._upload_file_obj(file_obj, key, bucket_name, replace, encrypt, acl_policy)
+        self._upload_file_obj(file_obj, key, bucket_name, replace, encrypt, acl_policy, extra_args)
 
     def _upload_file_obj(self,
                          file_obj,
@@ -584,11 +586,13 @@ class S3Hook(AwsBaseHook):
                          bucket_name=None,
                          replace=False,
                          encrypt=False,
-                         acl_policy=None):
+                         acl_policy=None,
+                         extra_args=None):
         if not replace and self.check_for_key(key, bucket_name):
             raise ValueError("The key {key} already exists.".format(key=key))
 
-        extra_args = {}
+        if not extra_args:
+            extra_args = {}
         if encrypt:
             extra_args['ServerSideEncryption'] = "AES256"
         if acl_policy:

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -253,6 +253,14 @@ class TestAwsS3Hook:
         assert ((response['Grants'][1]['Permission'] == 'READ') and
                 (response['Grants'][0]['Permission'] == 'FULL_CONTROL'))
 
+    def test_load_bytes_extra_args(self, s3_bucket):
+        hook = S3Hook()
+        metadata = {'Metadata': {'mykey': 'myvalue'}}
+        hook.load_bytes(b"Content", "my_key", s3_bucket,
+                        extra_args=metadata)
+        response = boto3.client('s3').head_object(Bucket=s3_bucket, Key="my_key")
+        assert response["Metadata"] == metadata["Metadata"]
+
     def test_load_fileobj(self, s3_bucket):
         hook = S3Hook()
         with tempfile.TemporaryFile() as temp_file:
@@ -274,6 +282,16 @@ class TestAwsS3Hook:
                                                          RequestPayer='requester')  # pylint: disable=no-member # noqa: E501 # pylint: disable=C0301
             assert ((response['Grants'][1]['Permission'] == 'READ') and
                     (response['Grants'][0]['Permission'] == 'FULL_CONTROL'))
+
+    def test_load_fileobj_extra_args(self, s3_bucket):
+        hook = S3Hook()
+        metadata = {'Metadata': {'mykey': 'myvalue'}}
+        with tempfile.TemporaryFile() as temp_file:
+            temp_file.write(b"Content")
+            temp_file.seek(0)
+            hook.load_file_obj(temp_file, "my_key", s3_bucket, extra_args=metadata)
+            response = boto3.client('s3').head_object(Bucket=s3_bucket, Key="my_key")
+            assert response["Metadata"] == metadata["Metadata"]
 
     def test_load_file_gzip(self, s3_bucket):
         hook = S3Hook()


### PR DESCRIPTION
Optional extra_args param was added to the load_bytes and load_file_object functions. test_load_fileobj_extra_args and test_load_bytes_extra_args unit tests added to test_s3.py.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
