### PR TITLE
Fix Extra Links in Gannt View

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1961,7 +1961,6 @@ class Airflow(AirflowBaseView):
             # https://issues.apache.org/jira/browse/AIRFLOW-2143
             try_count = ti.prev_attempted_tries
             gantt_bar_items.append((ti.task_id, ti.start_date, end_date, ti.state, try_count))
-            gantt_bar_items.append((ti.task_id, ti.start_date, end_date, ti.state, try_count))
             d = alchemy_to_dict(ti)
             d['extraLinks'] = dag.get_task(ti.task_id).extra_links
             tasks.append(d)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1961,7 +1961,10 @@ class Airflow(AirflowBaseView):
             # https://issues.apache.org/jira/browse/AIRFLOW-2143
             try_count = ti.prev_attempted_tries
             gantt_bar_items.append((ti.task_id, ti.start_date, end_date, ti.state, try_count))
-            tasks.append(alchemy_to_dict(ti))
+            gantt_bar_items.append((ti.task_id, ti.start_date, end_date, ti.state, try_count))
+            d = alchemy_to_dict(ti)
+            d['extraLinks'] = dag.get_task(ti.task_id).extra_links
+            tasks.append(d)
 
         tf_count = 0
         try_count = 1
@@ -1976,10 +1979,12 @@ class Airflow(AirflowBaseView):
             prev_task_id = tf.task_id
             gantt_bar_items.append((tf.task_id, start_date, end_date, State.FAILED, try_count))
             tf_count = tf_count + 1
+            task = dag.get_task(tf.task_id)
             d = alchemy_to_dict(tf)
             d['state'] = State.FAILED
-            d['operator'] = dag.get_task(tf.task_id).task_type
+            d['operator'] = task.task_type
             d['try_number'] = try_count
+            d['extraLinks'] = task.extra_links
             tasks.append(d)
 
         data = {


### PR DESCRIPTION
Extra link didn't appear after changes in  https://github.com/apache/airflow/pull/8220 for Gantt View


**Before**:
![image](https://user-images.githubusercontent.com/8811558/79279575-3a89c600-7ea6-11ea-898b-e39130e50960.png)

**After**:
![image](https://user-images.githubusercontent.com/8811558/79279605-4b3a3c00-7ea6-11ea-8246-ed351c98d3ea.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
