### PR TITLE
Remove unused Scheduler "authenticate" config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1492,12 +1492,6 @@
       type: string
       example: ~
       default: "2"
-    - name: authenticate
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: "False"
     - name: use_job_schedule
       description: |
         Turn off scheduler use of cron intervals by setting this to False.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -727,7 +727,6 @@ statsd_datadog_tags =
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run.
 max_threads = 2
-authenticate = False
 
 # Turn off scheduler use of cron intervals by setting this to False.
 # DAGs submitted manually in the web UI or with trigger_dag will still run.

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -104,7 +104,6 @@ sync_parallelism = 0
 job_heartbeat_sec = 1
 scheduler_heartbeat_sec = 5
 scheduler_health_check_threshold = 30
-authenticate = true
 max_threads = 2
 catchup_by_default = True
 scheduler_zombie_task_threshold = 300

--- a/scripts/ci/in_container/airflow_ci.cfg
+++ b/scripts/ci/in_container/airflow_ci.cfg
@@ -54,5 +54,4 @@ _test_only_string = this is a test
 [scheduler]
 job_heartbeat_sec = 1
 scheduler_heartbeat_sec = 5
-authenticate = true
 max_threads = 2


### PR DESCRIPTION
I can't find any usage of this config. I checked some commits 3 years ago but couldn't find one.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
