### PR TITLE
Catch ProgrammingError raised by MSSQL which doesn't know JSON_VALID()

### DIFF
--- a/airflow/migrations/versions/852ae6c715af_add_rendered_task_instance_fields_table.py
+++ b/airflow/migrations/versions/852ae6c715af_add_rendered_task_instance_fields_table.py
@@ -46,7 +46,7 @@ def upgrade():
         # versions, check for the function existing.
         try:
             conn.execute("SELECT JSON_VALID(1)").fetchone()
-        except sa.exc.OperationalError:
+        except (sa.exc.OperationalError, sa.exc.ProgrammingError):
             json_type = sa.Text
 
     op.create_table(


### PR DESCRIPTION
Similar to https://github.com/apache/airflow/pull/6920, this PR catches a ProgrammingError during migration of the `rendered_task_instance_fields` table, which will be raised by MSSQL because it doesn't know `JSON_VALID()`.

Not sure if to test this, since Airflow doesn't actively support MSSQL and doesn't test it in the CI.

Note: this table was added in Airflow 1.10.10. Anybody installing Airflow 1.10.10 backed by MSSQL will encounter this error.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
