### PR TITLE
[Issue-8388] Handle no dagrun in DagrunIdDep

### DIFF
--- a/airflow/ti_deps/deps/dagrun_id_dep.py
+++ b/airflow/ti_deps/deps/dagrun_id_dep.py
@@ -47,9 +47,9 @@ class DagrunIdDep(BaseTIDep):
         """
         dagrun = ti.get_dagrun(session)
 
-        if not dagrun.run_id or not match(f"{DagRunType.BACKFILL_JOB.value}.*", dagrun.run_id):
+        if not dagrun or not dagrun.run_id or not match(f"{DagRunType.BACKFILL_JOB.value}.*", dagrun.run_id):
             yield self._passing_status(
-                reason=f"Task's DagRun run_id is either NULL "
+                reason=f"Task's DagRun doesn't exist or the run_id is either NULL "
                        f"or doesn't start with {DagRunType.BACKFILL_JOB.value}")
         else:
             yield self._failing_status(

--- a/tests/ti_deps/deps/test_dagrun_id_dep.py
+++ b/tests/ti_deps/deps/test_dagrun_id_dep.py
@@ -48,3 +48,10 @@ class TestDagrunRunningDep(unittest.TestCase):
         dagrun.run_id = None
         ti = Mock(get_dagrun=Mock(return_value=dagrun))
         self.assertTrue(DagrunIdDep().is_met(ti=ti))
+
+    def test_dagrun_is_none(self):
+        """
+        Task instances which don't yet have an associated dagrun.
+        """
+        ti = Mock(get_dagrun=Mock(return_value=None))
+        self.assertTrue(DagrunIdDep().is_met(ti=ti))


### PR DESCRIPTION
Issue: https://github.com/apache/airflow/issues/8388
Summary: 
If a dag has not been turned on and/or never been run (i.e. no dagruns associated with this DAG) and you click on that DAG in the admin page, click on a task in the DAG graph, and then click on `Task Instance Details` you get the "Ooops" explosion error page.  The reason is `DagrunIdDep` expects a dagrun to exist.  This PR adds a check to make sure a dagrun exists.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
