### PR TITLE
Fix error message in production entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,7 +81,7 @@ function verify_db_connection {
             fi
         done
         if [[ ${RES} != 0 ]]; then
-            echo "        ERROR: ${BACKEND} db could not be reached!"
+            echo "        ERROR: ${DB_URL} db could not be reached!"
             echo
             echo "${LAST_CHECK_RESULT}"
             echo


### PR DESCRIPTION
When running Airflow using the Docker production image, I ran into an (unrelated) issue where the database connection timed out. However, instead of seeing the error message telling me about the timeout, I got an error message saying the BACKEND variable didn't exist; an error with the error message. This PR fixes that, replacing it with the original connection string as I believe was intended.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
