### PR TITLE
Allow "falsey" default arguments in CLI Parser

### DIFF
--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import argparse
 import re
 from collections import Counter
 from unittest import TestCase
@@ -132,3 +133,14 @@ class TestCli(TestCase):
                 self.assertEqual([], conflict_short_option,
                                  f"Command group {group} function {com.name} have conflict "
                                  f"short option flags {conflict_short_option}")
+
+    def test_falsy_default_value(self):
+        arg = cli_parser.Arg(("--test",), default=0, type=int)
+        parser = argparse.ArgumentParser()
+        arg.add_to_parser(parser)
+
+        args = parser.parse_args(['--test', '10'])
+        self.assertEqual(args.test, 10)
+
+        args = parser.parse_args([])
+        self.assertEqual(args.test, 0)


### PR DESCRIPTION
In #8219 we noticed that we couldn't set a `default=0` because of the
`and v` check. The "add_argument" function in python avoid this by using
**kwargs, but we want type checking so can't directly use the same
there.

This uses the same pattern that configparser does to allow falsey (0,
False) and even `None` as valid values, distinct from not being passed.


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.