### PR TITLE
Add colors to airflow config command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -153,6 +153,12 @@ ARG_OUTPUT = Arg(
     ),
     choices=tabulate_formats,
     default="fancy_grid")
+ARG_COLOR = Arg(
+    ('--color',),
+    help="do emit colored output (default: auto-detect)")
+ARG_NO_COLOR = Arg(
+    ('--no-color',),
+    help="do not emit colored output (default: auto-detect)")
 
 # list_dag_runs
 ARG_NO_BACKFILL = Arg(
@@ -1207,7 +1213,7 @@ airflow_commands: List[CLICommand] = [
         name='config',
         help='Show current application configuration',
         func=lazy_load_command('airflow.cli.commands.config_command.show_config'),
-        args=(),
+        args=(ARG_COLOR, ARG_NO_COLOR),
     ),
     ActionCommand(
         name='info',

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -31,6 +31,7 @@ from airflow import settings
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
+from airflow.utils.cli import ColorMode
 from airflow.utils.helpers import partition
 from airflow.utils.module_loading import import_string
 from airflow.utils.timezone import parse as parsedate
@@ -155,10 +156,9 @@ ARG_OUTPUT = Arg(
     default="fancy_grid")
 ARG_COLOR = Arg(
     ('--color',),
-    help="do emit colored output (default: auto-detect)")
-ARG_NO_COLOR = Arg(
-    ('--no-color',),
-    help="do not emit colored output (default: auto-detect)")
+    help="Do emit colored output (default: auto)",
+    choices={ColorMode.ON, ColorMode.OFF, ColorMode.AUTO},
+    default=ColorMode.AUTO)
 
 # list_dag_runs
 ARG_NO_BACKFILL = Arg(
@@ -1213,7 +1213,7 @@ airflow_commands: List[CLICommand] = [
         name='config',
         help='Show current application configuration',
         func=lazy_load_command('airflow.cli.commands.config_command.show_config'),
-        args=(ARG_COLOR, ARG_NO_COLOR),
+        args=(ARG_COLOR, ),
     ),
     ActionCommand(
         name='info',

--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -17,11 +17,21 @@
 """Config sub-commands"""
 import io
 
+import pygments
+from pygments.formatters.terminal import TerminalFormatter
+from pygments.lexers.configs import IniLexer
+
 from airflow.configuration import conf
+from airflow.utils.cli import should_use_colors
 
 
 def show_config(args):
     """Show current application configuration"""
     with io.StringIO() as output:
         conf.write(output)
-        print(output.getvalue())
+        code = output.getvalue()
+        if should_use_colors(args):
+            code = pygments.highlight(
+                code=code, formatter=TerminalFormatter(), lexer=IniLexer()
+            )
+        print(code)

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -234,3 +234,39 @@ def sigquit_handler(sig, frame):  # pylint: disable=unused-argument
             if line:
                 code.append("  {}".format(line.strip()))
     print("\n".join(code))
+
+
+def is_terminal_support_colors() -> bool:
+    """"
+    Try to determine if the current terminal supports colors.
+    """
+    if sys.platform == 'win32':
+        return False
+    if not hasattr(sys.stdout, 'isatty'):
+        return False
+    if not sys.stdout.isatty():
+        return False
+    if 'COLORTERM' in os.environ:
+        return True
+    term = os.environ.get('TERM', 'dumb').lower()
+    if term in ('xterm', 'linux') or 'color' in term:
+        return True
+    return False
+
+
+def should_use_colors(args) -> bool:
+    """
+    Processes arguments and decides whether to enable color in output
+    """
+    if args.color and args.no_color:
+        print(
+            "Option --color and --no-color are mutually exclusive. "
+            "Please remove one option to execute the command.",
+            file=sys.stderr
+        )
+        sys.exit(1)
+    if args.color:
+        return True
+    if args.no_color:
+        return False
+    return is_terminal_support_colors()

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -254,19 +254,21 @@ def is_terminal_support_colors() -> bool:
     return False
 
 
+class ColorMode:
+    """
+    Coloring modes. If `auto` is then automatically detected.
+    """
+    ON = "on"
+    OFF = "off"
+    AUTO = "auto"
+
+
 def should_use_colors(args) -> bool:
     """
     Processes arguments and decides whether to enable color in output
     """
-    if args.color and args.no_color:
-        print(
-            "Option --color and --no-color are mutually exclusive. "
-            "Please remove one option to execute the command.",
-            file=sys.stderr
-        )
-        sys.exit(1)
-    if args.color:
+    if args.color == ColorMode.ON:
         return True
-    if args.no_color:
+    if args.color == ColorMode.OFF:
         return False
     return is_terminal_support_colors()


### PR DESCRIPTION
I didn't write automatic tests because it is a system-specific thing and we can't write reliable automated tests. Argument parsing is covered by current tests.

I did manual tests.
When I run the `airflow config` command, I see the screen below.
<img width="549" alt="Screenshot 2020-04-16 at 15 19 46" src="https://user-images.githubusercontent.com/12058428/79461334-51d7c900-7ff6-11ea-8170-40cfe549ce99.png">
When I run the `airflow config | cat` command, I see the scrceen below.
<img width="543" alt="Screenshot 2020-04-16 at 15 27 45" src="https://user-images.githubusercontent.com/12058428/79461745-dd515a00-7ff6-11ea-8baa-9a297c86d041.png">

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
