### PR TITLE
Use less fancy tables in CLI by default

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -161,7 +161,7 @@ ARG_OUTPUT = Arg(
         "the tabulate module (https://pypi.org/project/tabulate/). "
     ),
     choices=tabulate_formats,
-    default="fancy_grid")
+    default="plain")
 ARG_COLOR = Arg(
     ('--color',),
     help="Do emit colored output (default: auto)",

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -319,7 +319,7 @@ class TestCliDags(unittest.TestCase):
         ('core', 'load_examples'): 'true'
     })
     def test_cli_list_dags(self):
-        args = self.parser.parse_args(['dags', 'list'])
+        args = self.parser.parse_args(['dags', 'list', '--output=fancy_grid'])
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
             dag_command.dag_list_dags(args)
             out = temp_stdout.getvalue()

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -197,7 +197,7 @@ class TestCliTasks(unittest.TestCase):
                              'state',
                              'start_date',
                              'end_date'],
-                            tablefmt="fancy_grid")
+                            tablefmt="plain")
 
         # Check that prints, and log messages, are shown
         self.assertEqual(expected.replace("\n", ""), actual_out.replace("\n", ""))


### PR DESCRIPTION
Fancy grid is fancier but has the following disadvantages:
* Takes up a lot more space, which makes reading difficult
   ```bash
    AIRFLOW__CORE__DAGS_FOLDER=$(readlink -e airflow/providers/google/cloud/example_dags/) airflow dags list --output fancy_grid  | wc -l
     ```
  `152`
   ```bash
    AIRFLOW__CORE__DAGS_FOLDER=$(readlink -e airflow/providers/google/cloud/example_dags/) airflow dags list --output plain  | wc -l
    ```
    `76`
 * Does not work with AWK and other Linux tools ( e.g. `airflow dags list  | awk '{print $2}'  | sort | uniq`). 
 * Is less popular  - `gcloud` uses plain tables

On the other hand, the only advantages of a fancy grid being fancier than plain table

Before:
![Screenshot 2020-04-16 at 20 26 02](https://user-images.githubusercontent.com/12058428/79492700-a2fcb280-8020-11ea-8fe0-e1c9b910b8c4.png)

After:
![Screenshot 2020-04-16 at 20 24 41](https://user-images.githubusercontent.com/12058428/79492732-adb74780-8020-11ea-9a42-bf52e45e1e10.png)

Because fancy_grid was not able to be parsed by Linux tools, this is not a breaking change. 

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
