### PR TITLE
Add back-compat modules from 1.10.10 for SecretsBackends

### DIFF
--- a/airflow/contrib/secrets/__init__.py
+++ b/airflow/contrib/secrets/__init__.py
@@ -16,11 +16,3 @@
 # specific language governing permissions and limitations
 # under the License.
 """This package is deprecated. Please use `airflow.secrets` or `airflow.providers.*.secrets`."""
-
-import warnings
-
-warnings.warn(
-    "This package is deprecated. Please use `airflow.secrets` or `airflow.providers.*.secrets`.",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/airflow/contrib/secrets/__init__.py
+++ b/airflow/contrib/secrets/__init__.py
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This package is deprecated. Please use `airflow.secrets` or `airflow.providers.*.secrets`."""
+
+import warnings
+
+warnings.warn(
+    "This package is deprecated. Please use `airflow.secrets` or `airflow.providers.*.secrets`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/airflow/contrib/secrets/aws_secrets_manager.py
+++ b/airflow/contrib/secrets/aws_secrets_manager.py
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.secrets.secrets_manager`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.secrets.secrets_manager import SecretsManagerBackend  # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.secrets.secrets_manager`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/airflow/contrib/secrets/aws_systems_manager.py
+++ b/airflow/contrib/secrets/aws_systems_manager.py
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module is deprecated. Please use `airflow.providers.amazon.aws.secrets.systems_manager`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.providers.amazon.aws.secrets.systems_manager import SystemsManagerParameterStoreBackend  # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.secrets.systems_manager`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/airflow/contrib/secrets/gcp_secrets_manager.py
+++ b/airflow/contrib/secrets/gcp_secrets_manager.py
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module is deprecated. Please use `airflow.providers.google.cloud.secrets.secrets_manager`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.providers.google.cloud.secrets.secrets_manager import CloudSecretsManagerBackend  # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.google.cloud.secrets.secrets_manager`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/airflow/contrib/secrets/hashicorp_vault.py
+++ b/airflow/contrib/secrets/hashicorp_vault.py
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module is deprecated. Please use `airflow.providers.hashicorp.secrets.vault`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.providers.hashicorp.secrets.vault import VaultBackend  # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.hashicorp.secrets.vault`.",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
Add 1.10.10 SecretsBackends contrib paths with Deprecation Warning

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
