### PR TITLE
fixed typo in confirm script

### DIFF
--- a/confirm
+++ b/confirm
@@ -37,7 +37,7 @@ fi
 
 case "${RESPONSE}" in
     [yY][eE][sS]|[yY])
-        echo "The answer is 'yes'. ${1}. This can take some time !"
+        echo "The answer is 'yes'. ${1}. This can take some time!"
         exit 0
         ;;
     [qQ][uU][iI][tT]|[qQ])


### PR DESCRIPTION
Very small typo, but I had to fix it. :)
```
-  "The answer is 'yes'. ${1}. This can take some time !"
+  "The answer is 'yes'. ${1}. This can take some time!"
```
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
