### PR TITLE
Add a dedicated "free disk space" step to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
       TRAVIS_JOB_NAME: "Static"
     steps:
       - uses: actions/checkout@master
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,13 @@ jobs:
       RUN_INTEGRATION_TESTS: all
     steps:
       - uses: actions/checkout@master
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name: "Tests [Postgres9.6][Py3.6][integrations]"
         run: ./scripts/ci/ci_run_airflow_testing.sh
 
@@ -144,6 +151,13 @@ jobs:
       RUN_INTEGRATION_TESTS: all
     steps:
       - uses: actions/checkout@master
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name: "Tests [Sqlite][3.7][integrations]"
         run: ./scripts/ci/ci_run_airflow_testing.sh
 
@@ -173,6 +187,13 @@ jobs:
       RUN_INTEGRATION_TESTS: all
     steps:
       - uses: actions/checkout@master
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name: "Tests [MySQL][Py3.6][integrations]"
         run: ./scripts/ci/ci_run_airflow_testing.sh
 
@@ -203,6 +224,13 @@ jobs:
       ENABLED_INTEGRATIONS: "kerberos"
     steps:
       - uses: actions/checkout@master
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name: "Tests [MySQL5.7][Py3.7][core][kerberos]"
         run: ./scripts/ci/ci_run_airflow_testing.sh --ignore=tests/providers
 


### PR DESCRIPTION
The tests are failing on Master and PRs with:
```
failed to register layer: Error processing tar file(exit status 1): write /usr/share/doc/python2.7/README.gz: no space left on device
```

This is based on the solution mentioned in https://github.community/t5/GitHub-Actions/BUG-Strange-quot-No-space-left-on-device-quot-IOExceptions-on/m-p/47691#M6920

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
