### PR TITLE
Improve idempodency in CloudDataTransferServiceCreateJobOperator

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.py
+++ b/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.py
@@ -43,8 +43,8 @@ from airflow import models
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     ALREADY_EXISTING_IN_SINK, AWS_S3_DATA_SOURCE, BUCKET_NAME, DESCRIPTION, FILTER_JOB_NAMES,
     FILTER_PROJECT_ID, GCS_DATA_SINK, PROJECT_ID, SCHEDULE, SCHEDULE_END_DATE, SCHEDULE_START_DATE,
-    START_TIME_OF_DAY, STATUS, TRANSFER_OPTIONS, TRANSFER_SPEC, GcpTransferJobsStatus,
-    GcpTransferOperationStatus,
+    START_TIME_OF_DAY, STATUS, TRANSFER_OPTIONS, TRANSFER_SPEC, JOB_NAME,
+    GcpTransferJobsStatus, GcpTransferOperationStatus
 )
 from airflow.providers.google.cloud.operators.cloud_storage_transfer_service import (
     CloudDataTransferServiceCancelOperationOperator, CloudDataTransferServiceCreateJobOperator,
@@ -67,11 +67,16 @@ GCP_TRANSFER_FIRST_TARGET_BUCKET = os.environ.get(
     'GCP_TRANSFER_FIRST_TARGET_BUCKET', 'gcp-transfer-first-target'
 )
 
+GCP_TRANSFER_JOB_NAME = os.environ.get(
+    'GCP_TRANSFER_JOB_NAME', 'transferJobs/sampleJob'
+)
+
 # [START howto_operator_gcp_transfer_create_job_body_aws]
 aws_to_gcs_transfer_body = {
     DESCRIPTION: GCP_DESCRIPTION,
     STATUS: GcpTransferJobsStatus.ENABLED,
     PROJECT_ID: GCP_PROJECT_ID,
+    JOB_NAME: GCP_TRANSFER_JOB_NAME,
     SCHEDULE: {
         SCHEDULE_START_DATE: datetime(2015, 1, 1).date(),
         SCHEDULE_END_DATE: datetime(2030, 1, 1).date(),

--- a/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.py
+++ b/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.py
@@ -42,9 +42,9 @@ from datetime import datetime, timedelta
 from airflow import models
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     ALREADY_EXISTING_IN_SINK, AWS_S3_DATA_SOURCE, BUCKET_NAME, DESCRIPTION, FILTER_JOB_NAMES,
-    FILTER_PROJECT_ID, GCS_DATA_SINK, PROJECT_ID, SCHEDULE, SCHEDULE_END_DATE, SCHEDULE_START_DATE,
-    START_TIME_OF_DAY, STATUS, TRANSFER_OPTIONS, TRANSFER_SPEC, JOB_NAME,
-    GcpTransferJobsStatus, GcpTransferOperationStatus
+    FILTER_PROJECT_ID, GCS_DATA_SINK, JOB_NAME, PROJECT_ID, SCHEDULE, SCHEDULE_END_DATE, SCHEDULE_START_DATE,
+    START_TIME_OF_DAY, STATUS, TRANSFER_OPTIONS, TRANSFER_SPEC, GcpTransferJobsStatus,
+    GcpTransferOperationStatus,
 )
 from airflow.providers.google.cloud.operators.cloud_storage_transfer_service import (
     CloudDataTransferServiceCancelOperationOperator, CloudDataTransferServiceCreateJobOperator,

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -114,8 +114,8 @@ def gen_job_name(job_name: str) -> str:
     :return: job_name with suffix
     :rtype: str
     """
-    uniq = str(int(time.time()))
-    return "_".join([job_name, uniq])
+    uniq = int(time.time())
+    return f"{job_name}_{uniq}"
 
 
 # noinspection PyAbstractClass

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -20,9 +20,11 @@ This module contains a Google Storage Transfer Service Hook.
 """
 
 import json
-import logging
 import time
 import warnings
+import re
+import logging
+
 from copy import deepcopy
 from datetime import timedelta
 from typing import Dict, List, Optional, Set, Union
@@ -108,14 +110,12 @@ def gen_job_name(job_name: str) -> str:
     """
     Adds unique suffix to job name. If suffix already exists, updates it.
     Suffix — current timestamp
-
     :param job_name:
     :rtype job_name: str
-    :return: job_name with suffix
-    :rtype: str
+    :return:
     """
-    uniq = int(time.time())
-    return f"{job_name}_{uniq}"
+    uniq = str(int(time.time()))
+    return "_".join([job_name, uniq])
 
 
 # noinspection PyAbstractClass
@@ -164,7 +164,7 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
         """
         body = self._inject_project_id(body, BODY, PROJECT_ID)
         try:
-            transfer_job = self.get_conn().transferJobs() \
+            transfer_job = self.get_conn().transferJobs()\
                 .create(body=body).execute(  # pylint: disable=no-member
                 num_retries=self.num_retries)
         except HttpError as e:
@@ -182,11 +182,9 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                     self.log.info(
                         "Job `%s` has been soft deleted. Creating job with "
                         "new name `%s`", job_name, {body[JOB_NAME]})
-                    # pylint: disable=no-member
-                    return self.get_conn() \
-                        .transferJobs() \
-                        .create(body=body) \
-                        .execute(num_retries=self.num_retries)
+                    return self.get_conn().transferJobs()\
+                        .create(body=body).execute(  # pylint: disable=no-member
+                                num_retries=self.num_retries)
                 elif transfer_job.get(STATUS) == GcpTransferJobsStatus.DISABLED:
                     return self.enable_transfer_job(
                         job_name=job_name, project_id=body.get(PROJECT_ID))
@@ -211,9 +209,9 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
         """
         return (
             self.get_conn()  # pylint: disable=no-member
-                .transferJobs()
-                .get(jobName=job_name, projectId=project_id)
-                .execute(num_retries=self.num_retries)
+            .transferJobs()
+            .get(jobName=job_name, projectId=project_id)
+            .execute(num_retries=self.num_retries)
         )
 
     def list_transfer_job(self, request_filter: Optional[Dict] = None, **kwargs) -> List[Dict]:
@@ -256,7 +254,6 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
     def enable_transfer_job(self, job_name: str, project_id: str) -> Dict:
         """
         New transfers will be performed based on the schedule.
-
         :param job_name: (Required) Name of the job to be updated
         :type job_name: str
         :param project_id: (Optional) the ID of the project that owns the Transfer
@@ -277,7 +274,7 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                     TRANSFER_JOB_FIELD_MASK: STATUS1,
                 },
             )
-                .execute(num_retries=self.num_retries)
+            .execute(num_retries=self.num_retries)
         )
 
     def update_transfer_job(self, job_name: str, body: Dict) -> Dict:
@@ -295,9 +292,9 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
         body = self._inject_project_id(body, BODY, PROJECT_ID)
         return (
             self.get_conn()  # pylint: disable=no-member
-                .transferJobs()
-                .patch(jobName=job_name, body=body)
-                .execute(num_retries=self.num_retries)
+            .transferJobs()
+            .patch(jobName=job_name, body=body)
+            .execute(num_retries=self.num_retries)
         )
 
     @GoogleBaseHook.fallback_to_default_project_id
@@ -318,8 +315,8 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
         """
         (
             self.get_conn()  # pylint: disable=no-member
-                .transferJobs()
-                .patch(
+            .transferJobs()
+            .patch(
                 jobName=job_name,
                 body={
                     PROJECT_ID: project_id,
@@ -327,7 +324,7 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                     TRANSFER_JOB_FIELD_MASK: STATUS1,
                 },
             )
-                .execute(num_retries=self.num_retries)
+            .execute(num_retries=self.num_retries)
         )
 
     def cancel_transfer_operation(self, operation_name: str) -> None:
@@ -355,9 +352,9 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
         """
         return (
             self.get_conn()  # pylint: disable=no-member
-                .transferOperations()
-                .get(name=operation_name)
-                .execute(num_retries=self.num_retries)
+            .transferOperations()
+            .get(name=operation_name)
+            .execute(num_retries=self.num_retries)
         )
 
     def list_transfer_operations(self, request_filter: Optional[Dict] = None, **kwargs) -> List[Dict]:
@@ -467,8 +464,8 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                 request_filter={FILTER_PROJECT_ID: job[PROJECT_ID], FILTER_JOB_NAMES: [job[NAME]]}
             )
 
-            if CloudDataTransferServiceHook. \
-                operations_contain_expected_statuses(operations, expected_statuses):
+            if CloudDataTransferServiceHook.\
+                    operations_contain_expected_statuses(operations, expected_statuses):
                 return
             time.sleep(TIME_TO_SLEEP_IN_SECONDS)
         raise AirflowException("Timeout. The operation could not be completed within the allotted time.")

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -20,10 +20,9 @@ This module contains a Google Storage Transfer Service Hook.
 """
 
 import json
+import logging
 import time
 import warnings
-import logging
-
 from copy import deepcopy
 from datetime import timedelta
 from typing import Dict, List, Optional, Set, Union

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -110,9 +110,11 @@ def gen_job_name(job_name: str) -> str:
     """
     Adds unique suffix to job name. If suffix already exists, updates it.
     Suffix — current timestamp
+
     :param job_name:
     :rtype job_name: str
-    :return:
+    :return: job_name with suffix
+    :rtype: str
     """
     uniq = str(int(time.time()))
     return "_".join([job_name, uniq])
@@ -254,6 +256,7 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
     def enable_transfer_job(self, job_name: str, project_id: str) -> Dict:
         """
         New transfers will be performed based on the schedule.
+
         :param job_name: (Required) Name of the job to be updated
         :type job_name: str
         :param project_id: (Optional) the ID of the project that owns the Transfer

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -22,11 +22,14 @@ This module contains a Google Storage Transfer Service Hook.
 import json
 import time
 import warnings
+import re
+
 from copy import deepcopy
 from datetime import timedelta
 from typing import Dict, List, Optional, Set, Union
 
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
@@ -62,6 +65,7 @@ AWS_ACCESS_KEY = "awsAccessKey"
 AWS_S3_DATA_SOURCE = 'awsS3DataSource'
 BODY = 'body'
 BUCKET_NAME = 'bucketName'
+JOB_NAME = 'name'
 DAY = 'day'
 DESCRIPTION = "description"
 FILTER = 'filter'
@@ -96,6 +100,22 @@ TRANSFER_SPEC = 'transferSpec'
 YEAR = 'year'
 
 NEGATIVE_STATUSES = {GcpTransferOperationStatus.FAILED, GcpTransferOperationStatus.ABORTED}
+
+
+def gen_job_name(job_name: str) -> str:
+    """
+    Adds unique suffix to job name. If suffix already exists, updates it
+        suffix — current timestamp
+    :param job_name:
+    :rtype job_name: str
+    :return:
+    """
+    split = job_name.split("_")
+    uniq = str(int(time.time()))
+    if len(split) > 1 and re.compile("^[0-9]{10}$").match(split[-1]):
+        split[-1] = uniq
+        return "_".join(split)
+    return "_".join([job_name, uniq])
 
 
 # noinspection PyAbstractClass
@@ -143,8 +163,29 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
         :rtype: dict
         """
         body = self._inject_project_id(body, BODY, PROJECT_ID)
-        return self.get_conn().transferJobs().create(body=body).execute(  # pylint: disable=no-member
-            num_retries=self.num_retries)
+        try:
+            transfer_job = self.get_conn().transferJobs()\
+                .create(body=body).execute(  # pylint: disable=no-member
+                num_retries=self.num_retries)
+        except HttpError as e:
+            # If status code "Conflict"
+            # https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferOperations#Code.ENUM_VALUES.ALREADY_EXISTS
+            # we should try to find this job
+            job_name = body.get(JOB_NAME, "")
+            if 409 == int(e.resp.status) and job_name:
+                transfer_job = self.get_transfer_job(
+                    job_name=job_name, project_id=body.get(PROJECT_ID))
+                # Generate new job_name, if jobs status is deleted
+                # and try to create this job again
+                if transfer_job.get(STATUS) == GcpTransferJobsStatus.DELETED:
+                    raise e
+                    # body[JOB_NAME] = gen_job_name(job_name)
+                    # return self.create_transfer_job(body)
+                elif transfer_job.get(STATUS) == GcpTransferJobsStatus.DISABLED:
+                    return self.enable_transfer_job(job_name=job_name)
+            else:
+                raise e
+        return transfer_job
 
     @GoogleBaseHook.fallback_to_default_project_id
     def get_transfer_job(self, job_name: str, project_id: str) -> Dict:
@@ -203,6 +244,33 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                                                     previous_response=response)
 
         return jobs
+
+    @GoogleBaseHook.fallback_to_default_project_id
+    def enable_transfer_job(self, job_name: str, project_id: str) -> Dict:
+        """
+        New transfers will be performed based on the schedule.
+        :param job_name: (Required) Name of the job to be updated
+        :type job_name: str
+        :param project_id: (Optional) the ID of the project that owns the Transfer
+            Job. If set to None or missing, the default project_id from the GCP
+            connection is used.
+        :type project_id: str
+        :return: If successful, TransferJob.
+        :rtype: dict
+        """
+        return (
+            self.get_conn()  # pylint: disable=no-member
+                .transferJobs()
+                .patch(
+                jobName=job_name,
+                body={
+                    PROJECT_ID: project_id,
+                    TRANSFER_JOB: {STATUS1: GcpTransferJobsStatus.ENABLED},
+                    TRANSFER_JOB_FIELD_MASK: STATUS1,
+                },
+            )
+            .execute(num_retries=self.num_retries)
+        )
 
     def update_transfer_job(self, job_name: str, body: Dict) -> Dict:
         """

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -22,7 +22,6 @@ This module contains a Google Storage Transfer Service Hook.
 import json
 import time
 import warnings
-import re
 import logging
 
 from copy import deepcopy
@@ -184,9 +183,11 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
                     self.log.info(
                         "Job `%s` has been soft deleted. Creating job with "
                         "new name `%s`", job_name, {body[JOB_NAME]})
-                    return self.get_conn().transferJobs()\
-                        .create(body=body).execute(  # pylint: disable=no-member
-                                num_retries=self.num_retries)
+                    # pylint: disable=no-member
+                    return self.get_conn()\
+                        .transferJobs()\
+                        .create(body=body)\
+                        .execute(num_retries=self.num_retries)
                 elif transfer_job.get(STATUS) == GcpTransferJobsStatus.DISABLED:
                     return self.enable_transfer_job(
                         job_name=job_name, project_id=body.get(PROJECT_ID))

--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -47,7 +47,7 @@ class TransferJobPreprocessor:
 
     def _inject_aws_credentials(self):
         if TRANSFER_SPEC in self.body and AWS_S3_DATA_SOURCE in self.body[TRANSFER_SPEC]:
-            aws_hook = AwsBaseHook(self.aws_conn_id)
+            aws_hook = AwsBaseHook(self.aws_conn_id, resource_type="s3")
             aws_credentials = aws_hook.get_credentials()
             aws_access_key_id = aws_credentials.access_key
             aws_secret_access_key = aws_credentials.secret_key
@@ -160,15 +160,20 @@ class CloudDataTransferServiceCreateJobOperator(BaseOperator):
 
     .. warning::
 
-        This operator is NOT idempotent. If you run it many times, many transfer
-        jobs will be created in the Google Cloud Platform.
+        This operator is NOT idempotent in the following cases:
+
+        * `name` is not passed in body param
+        * transfer job `name` has been soft deleted. In this case,
+          each new task will receive a unique suffix
+
+        If you run it many times, many transfer jobs will be created in the Google Cloud Platform.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:CloudDataTransferServiceCreateJobOperator`
 
     :param body: (Required) The request body, as described in
-        https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/create#request-body
+        https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs#TransferJob
         With three additional improvements:
 
         * dates can be given in the form :class:`datetime.date`

--- a/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
@@ -17,28 +17,23 @@
 # under the License.
 #
 import json
-import unittest
 import re
-
-from typing import Dict
-from copy import deepcopy
+import unittest
 from collections import namedtuple
+from copy import deepcopy
+from typing import Dict
 
 import mock
-
 from googleapiclient.errors import HttpError
-from mock import PropertyMock, MagicMock
+from mock import MagicMock, PropertyMock
 from parameterized import parameterized
-
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
-    DESCRIPTION, FILTER_JOB_NAMES, FILTER_PROJECT_ID, METADATA, OPERATIONS, PROJECT_ID, STATUS,
+    DESCRIPTION, FILTER_JOB_NAMES, FILTER_PROJECT_ID, JOB_NAME, METADATA, OPERATIONS, PROJECT_ID, STATUS,
     TIME_TO_SLEEP_IN_SECONDS, TRANSFER_JOB, TRANSFER_JOB_FIELD_MASK, TRANSFER_JOBS,
-    CloudDataTransferServiceHook, GcpTransferJobsStatus, GcpTransferOperationStatus,
-    gen_job_name, JOB_NAME,
+    CloudDataTransferServiceHook, GcpTransferJobsStatus, GcpTransferOperationStatus, gen_job_name,
 )
-
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,
     mock_base_gcp_hook_no_default_project_id,
@@ -199,7 +194,6 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         self.assertEqual(res, TEST_TRANSFER_JOB)
         create_method.assert_called_once_with(body=TEST_BODY)
         execute_method.assert_called_once_with(num_retries=5)
-
 
     @mock.patch(
         'airflow.providers.google.cloud.hooks.cloud_storage_transfer_service'

--- a/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
@@ -18,10 +18,13 @@
 #
 import json
 import unittest
-from copy import deepcopy
-
 import mock
-from mock import PropertyMock
+import re
+
+from copy import deepcopy
+from collections import namedtuple
+from googleapiclient.errors import HttpError
+from mock import PropertyMock, MagicMock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
@@ -29,7 +32,9 @@ from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import 
     DESCRIPTION, FILTER_JOB_NAMES, FILTER_PROJECT_ID, METADATA, OPERATIONS, PROJECT_ID, STATUS,
     TIME_TO_SLEEP_IN_SECONDS, TRANSFER_JOB, TRANSFER_JOB_FIELD_MASK, TRANSFER_JOBS,
     CloudDataTransferServiceHook, GcpTransferJobsStatus, GcpTransferOperationStatus,
+    gen_job_name
 )
+
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,
     mock_base_gcp_hook_no_default_project_id,
@@ -38,9 +43,10 @@ from tests.providers.google.cloud.utils.base_gcp_mock import (
 NAME = "name"
 
 TEST_PROJECT_ID = 'project-id'
+TEST_TRANSFER_JOB_NAME = "transfer-job"
+
 TEST_BODY = {DESCRIPTION: 'AAA', PROJECT_ID: TEST_PROJECT_ID}
 
-TEST_TRANSFER_JOB_NAME = "transfer-job"
 TEST_TRANSFER_OPERATION_NAME = "transfer-operation"
 
 TEST_TRANSFER_JOB = {NAME: TEST_TRANSFER_JOB_NAME}
@@ -57,11 +63,93 @@ TEST_UPDATE_TRANSFER_JOB_BODY = {
     TRANSFER_JOB_FIELD_MASK: 'description',
 }
 
+TEST_HTTP_ERR_CODE = 409
+TEST_HTTP_ERR_CONTENT = b'Conflict'
+
+TEST_RESULT_STATUS_ENABLED = {STATUS: GcpTransferJobsStatus.ENABLED}
+TEST_RESULT_STATUS_DISABLED = {STATUS: GcpTransferJobsStatus.DISABLED}
+TEST_RESULT_STATUS_DELETED = {STATUS: GcpTransferJobsStatus.DELETED}
+
 
 def _without_key(body, key):
     obj = deepcopy(body)
     del obj[key]
     return obj
+
+
+def _with_name(body):
+    obj = deepcopy(body)
+    obj[NAME] = TEST_TRANSFER_JOB_NAME
+    return obj
+
+
+class TestGCPTransferServiceHookWithPassedName(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch(
+            'airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__',
+            new=mock_base_gcp_hook_no_default_project_id,
+        ):
+            self.gct_hook = CloudDataTransferServiceHook(gcp_conn_id='test')
+
+    @mock.patch(
+        'airflow.providers.google.cloud.hooks.cloud_storage_transfer_service'
+        '.CloudDataTransferServiceHook.enable_transfer_job'
+    )
+    @mock.patch(
+        'airflow.providers.google.cloud.hooks.cloud_storage_transfer_service'
+        '.CloudDataTransferServiceHook.get_transfer_job'
+    )
+    @mock.patch(
+        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
+    @mock.patch(
+        'airflow.providers.google.cloud.hooks.cloud_storage_transfer_service'
+        '.CloudDataTransferServiceHook.get_conn'
+    )
+    def test_pass_name_on_create_job(self,
+                                     get_conn: MagicMock,
+                                     project_id: PropertyMock,
+                                     get_transfer_job: MagicMock,
+                                     enable_transfer_job: MagicMock
+                                     ):
+        body = _with_name(TEST_BODY)
+        nt = namedtuple('resp', ['status'])(409)
+        get_conn.return_value.transferJobs.return_value.create.side_effect \
+            = HttpError(nt, b'Conflict', "/")
+
+        # check status DELETED raises HttpError
+        get_transfer_job.return_value = TEST_RESULT_STATUS_DELETED
+        with self.assertRaises(HttpError):
+            self.gct_hook.create_transfer_job(body=body)
+
+        # check status DISABLED changes to status ENABLED
+        get_transfer_job.return_value = TEST_RESULT_STATUS_DISABLED
+        enable_transfer_job.return_value = TEST_RESULT_STATUS_ENABLED
+        res = self.gct_hook.create_transfer_job(body=body)
+        self.assertEqual(res, TEST_RESULT_STATUS_ENABLED)
+
+
+class TestJobNames(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.re = re.compile("^[0-9]{10}$")
+
+    def test_new_suffix(self):
+        for job_name in ["jobNames/new_job", "jobNames/new_job_h",
+                         "jobNames/newJob"]:
+            self.assertIsNotNone(
+                self.re.match(gen_job_name(job_name).split("_")[-1])
+            )
+
+    def test_update_suffix(self):
+        current_suffix = "123"
+        new_job_name = gen_job_name(
+            "jobNames/new_job_{}".format(current_suffix))
+        self.assertEqual(current_suffix, new_job_name.split("_")[-2])
+        self.assertNotEqual(current_suffix, new_job_name.split("_")[-1])
 
 
 class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
@@ -102,6 +190,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         self.assertEqual(res, TEST_TRANSFER_JOB)
         create_method.assert_called_once_with(body=TEST_BODY)
         execute_method.assert_called_once_with(num_retries=5)
+
 
     @mock.patch(
         'airflow.providers.google.cloud.hooks.cloud_storage_transfer_service'
@@ -652,7 +741,8 @@ class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
             self.gct_hook.create_transfer_job(body=_without_key(TEST_BODY, PROJECT_ID))
 
         self.assertEqual(
-            'The project id must be passed either as `projectId` key in `body` parameter or as project_id '
+            'The project id must be passed either as `projectId` key in `body` '
+            'parameter or as project_id '
             'extra in GCP connection definition. Both are not set!',
             str(e.exception),
         )

--- a/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
@@ -17,26 +17,21 @@
 # under the License.
 #
 import json
-import unittest
-import mock
 import re
-
+import unittest
 from copy import deepcopy
-from collections import namedtuple
-from googleapiclient.errors import HttpError
-from mock import PropertyMock, MagicMock
-from parameterized import parameterized
 
-from typing import Dict
+import mock
+from googleapiclient.errors import HttpError
+from mock import MagicMock, PropertyMock
+from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
     DESCRIPTION, FILTER_JOB_NAMES, FILTER_PROJECT_ID, METADATA, OPERATIONS, PROJECT_ID, STATUS,
     TIME_TO_SLEEP_IN_SECONDS, TRANSFER_JOB, TRANSFER_JOB_FIELD_MASK, TRANSFER_JOBS,
-    CloudDataTransferServiceHook, GcpTransferJobsStatus, GcpTransferOperationStatus,
-    gen_job_name, JOB_NAME,
+    CloudDataTransferServiceHook, GcpTransferJobsStatus, GcpTransferOperationStatus, gen_job_name,
 )
-
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id,
     mock_base_gcp_hook_no_default_project_id,
@@ -86,21 +81,14 @@ def _with_name(body, job_name):
     return obj
 
 
+class GCPRequestMock:
+
+    status = TEST_HTTP_ERR_CODE
+
+
 class TestGCPTransferServiceHookWithPassedName(unittest.TestCase):
 
-    def __create_job_se(self, body: Dict):
-        if body.get(JOB_NAME) == TEST_CLEAR_JOB_NAME:
-            nt = namedtuple('resp', ['status'])(409)
-            raise HttpError(nt, b'Conflict')
-
-        class __Create:
-            def execute(*args, **kwargs):
-                return TEST_RESULT_STATUS_ENABLED
-
-        return __Create
-
     def setUp(self):
-        self.re = re.compile("^[0-9]{10}$")
         with mock.patch(
             'airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__',
             new=mock_base_gcp_hook_no_default_project_id,
@@ -124,6 +112,7 @@ class TestGCPTransferServiceHookWithPassedName(unittest.TestCase):
         'airflow.providers.google.cloud.hooks.cloud_storage_transfer_service'
         '.CloudDataTransferServiceHook.get_conn'
     )
+    # pylint: disable=unused-argument
     def test_pass_name_on_create_job(self,
                                      get_conn: MagicMock,
                                      project_id: PropertyMock,
@@ -131,17 +120,19 @@ class TestGCPTransferServiceHookWithPassedName(unittest.TestCase):
                                      enable_transfer_job: MagicMock
                                      ):
         body = _with_name(TEST_BODY, TEST_CLEAR_JOB_NAME)
-        nt = namedtuple('resp', ['status'])(409)
-        get_conn.return_value.transferJobs.return_value.create.side_effect \
-            = self.__create_job_se
+        get_conn.side_effect \
+            = HttpError(GCPRequestMock(), TEST_HTTP_ERR_CONTENT)
 
-        # check status DELETED generates new job name
-        get_transfer_job.return_value = TEST_RESULT_STATUS_DELETED
-        self.gct_hook.create_transfer_job(body=body)
+        with self.assertRaises(HttpError):
+
+            # check status DELETED generates new job name
+            get_transfer_job.return_value = TEST_RESULT_STATUS_DELETED
+            self.gct_hook.create_transfer_job(body=body)
 
         # check status DISABLED changes to status ENABLED
         get_transfer_job.return_value = TEST_RESULT_STATUS_DISABLED
         enable_transfer_job.return_value = TEST_RESULT_STATUS_ENABLED
+
         res = self.gct_hook.create_transfer_job(body=body)
         self.assertEqual(res, TEST_RESULT_STATUS_ENABLED)
 
@@ -149,21 +140,15 @@ class TestGCPTransferServiceHookWithPassedName(unittest.TestCase):
 class TestJobNames(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.re = re.compile("^[0-9]{10}$")
+        self.re_suffix = re.compile("^[0-9]{10}$")
 
     def test_new_suffix(self):
-        for job_name in ["jobNames/new_job", "jobNames/new_job_h",
+        for job_name in ["jobNames/new_job",
+                         "jobNames/new_job_h",
                          "jobNames/newJob"]:
             self.assertIsNotNone(
-                self.re.match(gen_job_name(job_name).split("_")[-1])
+                self.re_suffix.match(gen_job_name(job_name).split("_")[-1])
             )
-
-    def test_update_suffix(self):
-        current_suffix = "123"
-        new_job_name = gen_job_name(
-            "jobNames/new_job_{}".format(current_suffix))
-        self.assertEqual(current_suffix, new_job_name.split("_")[-2])
-        self.assertNotEqual(current_suffix, new_job_name.split("_")[-1])
 
 
 class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
@@ -204,7 +189,6 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         self.assertEqual(res, TEST_TRANSFER_JOB)
         create_method.assert_called_once_with(body=TEST_BODY)
         execute_method.assert_called_once_with(num_retries=5)
-
 
     @mock.patch(
         'airflow.providers.google.cloud.hooks.cloud_storage_transfer_service'


### PR DESCRIPTION
This PR Resolves #8285 

1. If `body.name` is passed `CloudDataTransferServiceCreateJobOperator` became idempotent
2. If transfer `body.name` has been soft deleted, operator became *not idempotent*. Every run name will have unique suffix (`name_{unix_time_stamp}`)
DRAFT PR: https://github.com/apache/airflow/pull/8399 (sorry, i've deleted branch, my mistake :( )

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
