### PR TITLE
Provide GCP credentials in Bash/Python operators

### DIFF
--- a/airflow/example_dags/example_google_bash_operator.py
+++ b/airflow/example_dags/example_google_bash_operator.py
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example Airflow DAG that uses Bash operator together with Google services
+"""
+import os
+
+from airflow import models
+from airflow.operators.bash import BashOperator
+from airflow.utils import dates
+
+GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
+
+with models.DAG(
+    "example_google_bash_operator",
+    default_args=dict(start_date=dates.days_ago(1)),
+    schedule_interval=None,
+    tags=['example'],
+) as dag:
+    # [START howto_operator_bash_gcloud]
+    gcloud_task = BashOperator(
+        task_id='gcloud',
+        bash_command=(
+            'curl -H "Authorization: Bearer $(gcloud auth print-access-token)" '
+            '"https://oauth2.googleapis.com/tokeninfo"'
+        ),
+        gcp_conn_id=GCP_PROJECT_ID
+    )
+    # [END howto_operator_bash_gcloud]
+
+    # [START howto_operator_bash_custom]
+    CURRENT_DAG_FOLDER = os.path.dirname(os.path.abspath(__file__))
+    SCRIPT_PATH = os.path.join(CURRENT_DAG_FOLDER, 'example_google_bash_operator_custom_script.py')
+    gcloud_custom_app = BashOperator(
+        task_id='custom_app',
+        bash_command=(
+            f'python {SCRIPT_PATH}'
+        ),
+        gcp_conn_id=GCP_PROJECT_ID
+    )
+    # [END howto_operator_bash_custom]

--- a/airflow/example_dags/example_google_bash_operator_custom_script.py
+++ b/airflow/example_dags/example_google_bash_operator_custom_script.py
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from google.cloud import storage
+
+# If you don't specify credentials when constructing the client, the
+# client library will use the ADC strategy to determine the credentials
+storage_client = storage.Client()
+
+# Make an authenticated API request
+buckets = list(storage_client.list_buckets())
+print("\n".join(bucket.name for bucket in buckets))

--- a/airflow/example_dags/example_google_python_operator.py
+++ b/airflow/example_dags/example_google_python_operator.py
@@ -1,0 +1,96 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example Airflow DAG that uses Python operator together with Google services
+"""
+import os
+
+from airflow import models
+from airflow.operators.python import PythonOperator, PythonVirtualenvOperator
+from airflow.utils import dates
+
+GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "your-project-id")
+
+with models.DAG(
+    "example_google_python_operator",
+    default_args=dict(start_date=dates.days_ago(1)),
+    schedule_interval=None,
+    tags=['example'],
+) as dag:
+    # [START howto_operator_python_custom]
+    def callable_custom_script():
+        """Example function that use Google library."""
+        from google.cloud import storage
+
+        # If you don't specify credentials when constructing the client, the
+        # client library will use the ADC strategy to determine the credentials
+        storage_client = storage.Client()
+
+        # Make an authenticated API request
+        buckets = list(storage_client.list_buckets())
+        print("\n".join(bucket.name for bucket in buckets))
+
+    custom_script = PythonOperator(
+        task_id='custom_script',
+        python_callable=callable_custom_script,
+        gcp_conn_id=GCP_PROJECT_ID
+    )
+    # [END howto_operator_python_custom]
+
+    # [START howto_operator_python_gcloud]
+    def callable_gcloud():
+        """Execute function that use ``gcloud`` from python script."""
+        from subprocess import run
+
+        run(['gcloud', 'auth', 'print-access-token'], check=True)
+
+    gcloud = PythonOperator(
+        task_id='gcloud',
+        python_callable=callable_gcloud,
+        gcp_conn_id=GCP_PROJECT_ID
+    )
+    # [END howto_operator_python_gcloud]
+
+    def callable_virtualenv():
+        """
+        Example function that will be performed in a virtual environment.
+
+        Importing at the module level ensures that it will not attempt to import the
+        library before it is installed.
+        """
+        from google.cloud import storage
+
+        # If you don't specify credentials when constructing the client, the
+        # client library will use the ADC strategy to determine the credentials
+        storage_client = storage.Client()
+
+        # Make an authenticated API request
+        buckets = list(storage_client.list_buckets())
+        print("\n".join(bucket.name for bucket in buckets))
+
+    virtualenv = PythonVirtualenvOperator(
+        task_id="virtualenv",
+        python_callable=callable_virtualenv,
+        requirements=[
+            "google-auth==1.13.1",
+            'google-cloud-storage==1.27.0',
+        ],
+        system_site_packages=False,
+        gcp_conn_id=GCP_PROJECT_ID,
+    )

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -21,6 +21,7 @@ import os
 import pickle
 import sys
 import types
+from contextlib import ExitStack
 from inspect import signature
 from itertools import islice
 from tempfile import TemporaryDirectory
@@ -32,6 +33,7 @@ import dill
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, SkipMixin
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.documentation import DOC_BASE_URL
 from airflow.utils.process_utils import execute_in_subprocess
 from airflow.utils.python_virtualenv import prepare_virtualenv
 
@@ -60,6 +62,32 @@ class PythonOperator(BaseOperator):
     :param templates_exts: a list of file extensions to resolve while
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list[str]
+    :param gcp_conn_id: The connection ID used to interact to Google Cloud Platform.
+        If passed, the credentials for
+        `Application Default Credentials <https://cloud.google.com/docs/authentication/production>`__
+        and
+        `Cloud SDK (``gcloud``) <https://cloud.google.com/sdk>`__   will be configured.
+
+        All Google Cloud Platform operators use connection ``google_cloud_default`` by default.
+        Pass this value to also use the default connection.
+
+        If the value is empty (default), nothing is done.
+
+        .. seealso::
+            For more information on how to set-up connection for GCP, take a look at:
+            :ref:`howto/connection:gcp`
+
+        .. warning::
+            For the best reliability and integration with Airflow, consider using operators for Google
+            services. For list of GCP operators, take a look at: :ref:`GCP`
+
+    :type gcp_conn_id: str
+    :param gcp_delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have domain-wide delegation enabled.
+
+        This parameters only works if the value is passed to the ``gcp_conn_id`` parameter.
+    :param gcp_delegate_to: str
+
     """
     template_fields = ('templates_dict', 'op_args', 'op_kwargs')
     ui_color = '#ffefeb'
@@ -76,6 +104,8 @@ class PythonOperator(BaseOperator):
         op_kwargs: Optional[Dict] = None,
         templates_dict: Optional[Dict] = None,
         templates_exts: Optional[List[str]] = None,
+        gcp_conn_id: Optional[str] = None,
+        gcp_delegate_to: Optional[str] = None,
         *args,
         **kwargs
     ) -> None:
@@ -88,6 +118,9 @@ class PythonOperator(BaseOperator):
         self.templates_dict = templates_dict
         if templates_exts:
             self.template_ext = templates_exts
+
+        self.gcp_conn_id = gcp_conn_id
+        self.gcp_gcp_delegate_to = gcp_delegate_to
 
     @staticmethod
     def determine_op_kwargs(python_callable: Callable,
@@ -130,10 +163,25 @@ class PythonOperator(BaseOperator):
         context['templates_dict'] = self.templates_dict
 
         self.op_kwargs = PythonOperator.determine_op_kwargs(self.python_callable, context, len(self.op_args))
-
-        return_value = self.execute_callable()
-        self.log.info("Done. Returned value was: %s", return_value)
-        return return_value
+        with ExitStack() as exit_stack:
+            if self.gcp_conn_id:
+                try:
+                    from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
+                    exit_stack.enter_context(  # pylint: disable=no-member
+                        GoogleBaseHook(
+                            gcp_conn_id=self.gcp_conn_id, delegate_to=self.gcp_gcp_delegate_to
+                        ).provide_authorized_gcloud()
+                    )
+                except ImportError:
+                    raise AirflowException(
+                        'Additional packages gcp are not installed. Please install it to use gcp_conn_id '
+                        'parameter.'
+                        'For more information, please look at: '
+                        f'{DOC_BASE_URL}/installation.html'
+                    )
+            return_value = self.execute_callable()
+            self.log.info("Done. Returned value was: %s", return_value)
+            return return_value
 
     def execute_callable(self):
         """

--- a/airflow/utils/documentation.py
+++ b/airflow/utils/documentation.py
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.version import version as airflow_version
+
+if "dev" in airflow_version:
+    DOC_BASE_URL = "https://airflow.readthedocs.io/en/latest"
+else:
+    DOC_BASE_URL = 'https://airflow.apache.org/docs/{}'.format(airflow_version)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -33,9 +33,10 @@ from flask_wtf.csrf import CSRFProtect
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from airflow import settings, version
+from airflow import settings
 from airflow.configuration import conf
 from airflow.logging_config import configure_logging
+from airflow.utils.documentation import DOC_BASE_URL
 from airflow.utils.json import AirflowJsonEncoder
 from airflow.www.static_config import configure_manifest_files
 
@@ -142,17 +143,12 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
                                 "XComs",
                                 category="Admin")
 
-            if "dev" in version.version:
-                airflow_doc_site = "https://airflow.readthedocs.io/en/latest"
-            else:
-                airflow_doc_site = 'https://airflow.apache.org/docs/{}'.format(version.version)
-
             appbuilder.add_link("Website",
                                 href='https://airflow.apache.org',
                                 category="Docs",
                                 category_icon="fa-globe")
             appbuilder.add_link("Documentation",
-                                href=airflow_doc_site,
+                                href=DOC_BASE_URL,
                                 category="Docs",
                                 category_icon="fa-cube")
             appbuilder.add_link("GitHub",

--- a/docs/howto/operator/bash.rst
+++ b/docs/howto/operator/bash.rst
@@ -41,6 +41,43 @@ You can use :ref:`Jinja templates <jinja-templating>` to parameterize the
     :start-after: [START howto_operator_bash_template]
     :end-before: [END howto_operator_bash_template]
 
+Use with Google services
+------------------------
+
+There are special ``gcp_conn_id`` parameters that facilitate the use of this operator along with
+Google services. If it is passed, the credentials for
+`Application Default Credentials (ADC) <https://cloud.google.com/docs/authentication/production>`__
+and
+`Cloud SDK <https://cloud.google.com/sdk>`__ (``gcloud``)  will be configured.
+
+All Google Cloud Platform operators use connection ``google_cloud_default`` by default.
+Pass this value to also use the default connection.
+
+.. seealso::
+    For more information on how to set-up connection for GCP, take a look at:
+    :ref:`howto/connection:gcp`
+
+You can run ``gcloud`` commands in script. For example, you can easily read the access key using
+the ``gcloud auth print-access`` command. After passing the result to ``curl``, you can send any
+requests to the Google API.
+
+.. exampleinclude:: ../../../airflow/example_dags/example_bash_operator.py
+    :language: python
+    :start-after: [START howto_operator_bash_gcloud]
+    :end-before: [END howto_operator_bash_gcloud]
+
+If you application support Application Default Credentials (ADC), you do not have to manage service-account
+for your application separately, but all credentials will be provided by Airflow.
+
+.. exampleinclude:: ../../../airflow/example_dags/example_bash_operator.py
+    :language: python
+    :start-after: [START howto_operator_bash_custom]
+    :end-before: [END howto_operator_bash_custom]
+
+.. warning::
+    For the best reliability and integration with Airflow, consider using operators for Google services.
+    For list of GCP operators, take a look at: :ref:`GCP`
+
 Troubleshooting
 ---------------
 

--- a/docs/howto/operator/python.rst
+++ b/docs/howto/operator/python.rst
@@ -50,3 +50,37 @@ argument.
 
 The ``templates_dict`` argument is templated, so each value in the dictionary
 is evaluated as a :ref:`Jinja template <jinja-templating>`.
+
+Use with Google services
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are special ``gcp_conn_id`` parameters that facilitate the use of this operator along with
+Google services. If it is passed, the credentials for
+`Application Default Credentials (ADC) <https://cloud.google.com/docs/authentication/production>`__
+and
+`Cloud SDK <https://cloud.google.com/sdk>`__ (``gcloud``) will be configured.
+
+All Google Cloud Platform operators use connection ``google_cloud_default`` by default.
+Pass this value to also use the default connection.
+
+.. seealso::
+    For more information on how to set-up connection for GCP, take a look at:
+    :ref:`howto/connection:gcp`
+
+This allows you to use Google libraries:
+
+.. exampleinclude:: ../../../airflow/example_dags/example_google_python_operator.py
+    :language: python
+    :start-after: [START howto_operator_python_custom]
+    :end-before: [END howto_operator_python_custom]
+
+You can also execute ``gcloud`` commands:
+
+.. exampleinclude:: ../../../airflow/example_dags/example_python_operator.py
+    :language: python
+    :start-after: [START howto_operator_python_gcloud]
+    :end-before: [END howto_operator_python_gcloud]
+
+.. warning::
+    For the best reliability and integration with Airflow, consider using operators for Google services.
+    For list of GCP operators, take a look at: :ref:`GCP`

--- a/tests/operators/test_bash_system.py
+++ b/tests/operators/test_bash_system.py
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
+from tests.test_utils.gcp_system_helpers import AIRFLOW_DAG_FOLDER, GoogleSystemTest, provide_gcp_context
+
+
+@pytest.mark.credential_file(GCP_GCS_KEY)
+class GoogleBashOperatorTest(GoogleSystemTest):
+
+    @provide_gcp_context(GCP_GCS_KEY)
+    def test_run_example_dag_function(self):
+        self.run_dag('example_google_bash_operator', AIRFLOW_DAG_FOLDER)

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -310,6 +310,23 @@ class TestPythonOperator(TestPythonBase):
         )
         python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    @unittest.mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook")
+    def test_provide_gcp_credentials(self, mock_google_hook):
+        python_operator = PythonOperator(
+            task_id='python_operator',
+            python_callable=unittest.mock.MagicMock(),
+            dag=self.dag,
+            gcp_conn_id='google_cloud_default'
+        )
+        python_operator.execute(unittest.mock.MagicMock())
+        mock_google_hook.assert_called_once_with(gcp_conn_id='google_cloud_default', delegate_to=None)
+        (
+            mock_google_hook.
+            return_value.provide_authorized_gcloud.
+            return_value.__enter__.
+            assert_called_once_with(unittest.mock.ANY)
+        )
+
 
 class TestBranchOperator(unittest.TestCase):
     @classmethod

--- a/tests/operators/test_python_system.py
+++ b/tests/operators/test_python_system.py
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
+from tests.test_utils.gcp_system_helpers import AIRFLOW_DAG_FOLDER, GoogleSystemTest, provide_gcp_context
+
+
+@pytest.mark.credential_file(GCP_GCS_KEY)
+class GooglePythonOperatorTest(GoogleSystemTest):
+
+    @provide_gcp_context(GCP_GCS_KEY)
+    def test_run_example_dag_function(self):
+        self.run_dag('example_google_python_operator', AIRFLOW_DAG_FOLDER)

--- a/tests/providers/google/common/operators/__init__.py
+++ b/tests/providers/google/common/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/test_utils/gcp_system_helpers.py
+++ b/tests/test_utils/gcp_system_helpers.py
@@ -31,6 +31,9 @@ from tests.test_utils import AIRFLOW_MAIN_FOLDER
 from tests.test_utils.system_tests_class import SystemTest
 from tests.utils.logging_command_executor import get_executor
 
+AIRFLOW_DAG_FOLDER = os.path.join(
+    AIRFLOW_MAIN_FOLDER, "airflow", "example_dags"
+)
 CLOUD_DAG_FOLDER = os.path.join(
     AIRFLOW_MAIN_FOLDER, "airflow", "providers", "google", "cloud", "example_dags"
 )


### PR DESCRIPTION
I wanted to provide the ability to use GCP credentials in the ``BashOperator`` and ``PythonOperator``. Unfortunately, some users must use these operators in their workflows. 

I care about two things the most.
* the gcloud commands in the bash operator 
* the gcp credentials in PythonVirtualenvOperator, when ``system_site_packages=False``.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
