### PR TITLE
Fix performance degradation when updating dagrun state

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -317,7 +317,8 @@ class DagRun(Base, LoggingMixin):
         duration = (timezone.utcnow() - start_dttm)
         Stats.timing("dagrun.dependency-check.{}".format(self.dag_id), duration)
 
-        leaf_tis = [ti for ti in tis if ti.task_id in {t.task_id for t in dag.leaves}]
+        leaf_task_ids = {t.task_id for t in dag.leaves}
+        leaf_tis = [ti for ti in tis if ti.task_id in leaf_task_ids]
 
         # if all roots finished and at least one failed, the run failed
         if not unfinished_tasks and any(


### PR DESCRIPTION
The set comprehension `{t.task_id for t in dag.leaves}` in the conditional is re-evaluated every for each loop in the outer list comprehension resulting in an O(n^2) computation and significant slowdowns on large dags. 

Introduced here: https://github.com/apache/airflow/commit/8f6ca5305d8f1ae068903972bc6ad8893693514c#diff-32aa8dbb910719ef24a39cab5d0f2a97R302 

Diagnosed and discovered by @cmlad


---
Make sure to mark the boxes below before creating PR: [x]

- [x ] Description above provides context of the change
- [not sure - please advise ] Unit tests coverage for changes (not needed for documentation changes)
- [x ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [not sure - please advise ] Relevant documentation is updated including usage instructions.
- [x ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
