### PR TITLE
Add Local Filesystem Secret Backend

### DIFF
--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from abc import ABC
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from airflow.models.connection import Connection
 
@@ -43,7 +43,7 @@ class BaseSecretsBackend(ABC):
         """
         return f"{path_prefix}{sep}{secret_id}"
 
-    def get_conn_uri(self, conn_id: str) -> Optional[Union[str, List[str]]]:
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """
         Get conn_uri from Secrets Backend
 

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from abc import ABC
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from airflow.models.connection import Connection
 
@@ -43,7 +43,7 @@ class BaseSecretsBackend(ABC):
         """
         return f"{path_prefix}{sep}{secret_id}"
 
-    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+    def get_conn_uri(self, conn_id: str) -> Optional[Union[str, List[str]]]:
         """
         Get conn_uri from Secrets Backend
 

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -1,0 +1,257 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Objects relating to retreiving connections and variables from local file
+"""
+import json
+import logging
+import os
+from collections import defaultdict
+from json import JSONDecodeError
+from typing import Any, Dict, List, Optional, Tuple
+
+from airflow.exceptions import AirflowException, AirflowFileParseException, FileSyntaxError
+from airflow.secrets.base_secrets import BaseSecretsBackend
+from airflow.utils.file import COMMENT_PATTERN
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+# constants to limit cyclical imports
+CONNECTION_PARAMETERS_NAMES = {
+    "conn_id",
+    "conn_type",
+    "host",
+    "login",
+    "password",
+    "schema",
+    "port",
+    "extra",
+    "uri",
+}
+
+log = logging.getLogger(__name__)
+
+
+def _parser_env_file(content: str) -> Tuple[Dict[str, List[str]], List[FileSyntaxError]]:
+    """
+    Parse a file in the ``.env '' format.
+
+   .. code-block:: text
+        MY_CONN_ID=my-conn-type://my-login:my-pa%2Fssword@my-host:5432/my-schema?param1=val1&param2=val2
+
+    :param content:
+    :return: Tuple with mapping of key and list of values and list of syntax errors
+    """
+    secrets: Dict[str, List[str]] = defaultdict(list)
+    errors: List[FileSyntaxError] = []
+    for line_no, line in enumerate(content.splitlines(), 1):
+        if not line:
+            # Ignore empty line
+            continue
+
+        if COMMENT_PATTERN.match(line):
+            # Ignore comments:
+            continue
+
+        var_parts: List[str] = line.split("=", 2)
+        if len(var_parts) != 2:
+            errors.append(
+                FileSyntaxError(
+                    line_no=line_no,
+                    message='Invalid line format. The line should contain at least one equal sign ("=").',
+                )
+            )
+            continue
+
+        key, value = var_parts
+        if not key:
+            errors.append(FileSyntaxError(line_no=line_no, message="Invalid line format. Key is empty.",))
+        secrets[key].append(value)
+    return secrets, errors
+
+
+def _parse_json_file(content: str) -> Tuple[Dict[str, Any], List[FileSyntaxError]]:
+    """
+    Parrse a file in the JSON format.
+
+    :param content:
+    :return: Tuple with mapping of key and list of values and list of syntax errors
+    """
+    if not content:
+        return {}, [FileSyntaxError(line_no=1, message="The file is empty.")]
+    try:
+        secrets = json.loads(content)
+    except JSONDecodeError as e:
+        return {}, [FileSyntaxError(line_no=int(e.lineno), message=e.msg)]
+    if not isinstance(secrets, dict):
+        return {}, [FileSyntaxError(line_no=1, message="The file should contain the object.")]
+
+    return secrets, []
+
+
+def _parse_secret_file(file_content: str, file_path: str) -> Tuple[Dict[str, Any], List[FileSyntaxError]]:
+    """
+    Based on the file extension format, selects a parser and parse the file.
+
+    :param file_content:
+    :param file_path:
+    :return:
+    """
+    if file_path.lower().endswith(".env"):
+        secrets, parse_errors = _parser_env_file(file_content)
+    elif file_path.lower().endswith(".json"):
+        secrets, parse_errors = _parse_json_file(file_content)
+    else:
+        raise AirflowException("Unsupported file format. The file must have the extension .env or .json")
+    return secrets, parse_errors
+
+
+def _read_secret_file(file_path: str) -> Dict[str, str]:
+    if not os.path.exists(file_path):
+        raise AirflowException(
+            f"File {file_path} was not found. Check the configuration of your secret backend."
+        )
+
+    log.debug("Reading file: %s", file_path)
+    with open(file_path) as f:
+        file_content = f.read()
+
+    log.debug("Parsing file: %s", file_path)
+    secrets, parse_errors = _parse_secret_file(file_content, file_path)
+    log.debug("Parsed file file: len(parse_errors)=%d, len(secrets)=%d", len(parse_errors), len(secrets))
+
+    if parse_errors:
+        raise AirflowFileParseException(
+            f"Failed to load the secret file.", file_path=file_path, parse_errors=parse_errors
+        )
+    return secrets or {}
+
+
+def _create_connection(conn_id: str, value: Any):
+    """
+    Creates a connection based on a URL or object.
+    """
+    from airflow.models import Connection
+
+    if isinstance(value, str):
+        return Connection(conn_id=conn_id, uri=value)
+    if isinstance(value, dict):
+        current_keys = set(value.keys())
+        if not current_keys.issubset(CONNECTION_PARAMETERS_NAMES):
+            illegal_keys = current_keys - CONNECTION_PARAMETERS_NAMES
+            illegal_keys_list = ", ".join(illegal_keys)
+            raise AirflowException(
+                f"The object have illegal keys: {illegal_keys_list}. "
+                f"The dictionary can only contain the following keys: {CONNECTION_PARAMETERS_NAMES}"
+            )
+
+        if "conn_id" in current_keys and conn_id != value["conn_id"]:
+            raise AirflowException(
+                f"Mismatch conn_id. "
+                f"The dictionary key has the value: {value['conn_id']}. "
+                f"The item has the value: {conn_id}."
+            )
+        value["conn_id"] = conn_id
+        return Connection(**value)
+    raise AirflowException(
+        f"Unexpected value type: {type(value)}. The connection can only be defined using a string or object."
+    )
+
+
+def load_variables(file_path: str) -> Dict[str, str]:
+    """
+    Load vaariable from text file.
+
+    Both ``JSON`` and ``.env`` files are supported.
+
+    :rtype: Dict[str, List[str]]
+    """
+    log.debug("Loading variables")
+
+    secrets = _read_secret_file(file_path)
+    invalid_keys = [key for key, values in secrets.items() if isinstance(values, list) and len(values) != 1]
+    if invalid_keys:
+        raise AirflowException(f'The "{file_path}" file contains multiple values for keys: {invalid_keys}')
+    variables = {key: values[0] if isinstance(values, list) else values for key, values in secrets.items()}
+    log.debug("Loaded %d variables: ", len(variables))
+    return variables
+
+
+def load_connections(file_path: str):
+    """
+    Load connection from text file.
+
+    Both ``JSON`` and ``.env`` files are supported.
+
+    :return: A dictionary where the key contains a connection ID and the value contains a list of connections.
+    :rtype: Dict[str, List[airflow.models.connection.Connection]]
+    """
+    log.debug("Loading connection")
+
+    secrets: Dict[str, Any] = _read_secret_file(file_path)
+    connections_by_conn_id = defaultdict(list)
+    for key, secret_values in list(secrets.items()):
+        if isinstance(secret_values, list):
+            for secret_value in secret_values:
+                connections_by_conn_id[key].append(_create_connection(key, secret_value))
+        else:
+            connections_by_conn_id[key].append(_create_connection(key, secret_values))
+    num_conn = sum(map(len, connections_by_conn_id.values()))
+    log.debug("Loaded %d connections", num_conn)
+
+    return connections_by_conn_id
+
+
+class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
+    """
+    Retrieves Connection objects and Variables from local files
+
+    Both ``JSON`` and ``.env`` files are supported.
+
+    :param variable_file_path: File location with variables data.
+    :type variable_file_path: str
+    :param connection_file_path: File location with connection data.
+    :type connection_file_path: str
+    """
+
+    def __init__(self, variable_file_path: Optional[str] = None, connection_file_path: Optional[str] = None):
+        super().__init__()
+        self.variable_file = variable_file_path
+        self.connection_file = connection_file_path
+
+    @property
+    def _local_variables(self) -> Dict[str, str]:
+        if not self.variable_file:
+            self.log.debug("The file for variables is not specified. Skipping")
+            # The user may not specify any file.
+            return {}
+        secrets = load_variables(self.variable_file)
+        return secrets
+
+    @property
+    def _local_connections(self) -> Dict[str, List[Any]]:
+        if not self.connection_file:
+            self.log.debug("The file for connection is not specified. Skipping")
+            # The user may not specify any file.
+            return {}
+        return load_connections(self.connection_file)
+
+    def get_connections(self, conn_id: str) -> List[Any]:
+        return self._local_connections.get(conn_id) or []
+
+    def get_variable(self, key: str) -> Optional[str]:
+        return self._local_variables.get(key)

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Objects relating to retreiving connections and variables from local file
+Objects relating to retrieving connections and variables from local file
 """
 import json
 import logging

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -41,7 +41,7 @@ def get_connection_parameter_names() -> Set[str]:
     return {k for k in signature(Connection.__init__).parameters.keys() if k != "self"}
 
 
-def _parser_env_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyntaxError]]:
+def _parse_env_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyntaxError]]:
     """
     Parse a file in the ``.env '' format.
 
@@ -64,7 +64,7 @@ def _parser_env_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyn
             continue
 
         if COMMENT_PATTERN.match(line):
-            # Ignore comments:
+            # Ignore comments
             continue
 
         var_parts: List[str] = line.split("=", 2)
@@ -108,14 +108,14 @@ def _parse_json_file(file_path: str) -> Tuple[Dict[str, Any], List[FileSyntaxErr
 
 
 FILE_PARSERS = {
-    "env": _parser_env_file,
+    "env": _parse_env_file,
     "json": _parse_json_file,
 }
 
 
 def _parse_secret_file(file_path: str) -> Dict[str, Any]:
     """
-    Based on the file extension format, selects a parser and parse the file.
+    Based on the file extension format, selects a parser, and parses the file.
 
     :param file_path: The location of the file that will be processed.
     :type file_path: str
@@ -123,7 +123,7 @@ def _parse_secret_file(file_path: str) -> Dict[str, Any]:
     """
     if not os.path.exists(file_path):
         raise AirflowException(
-            f"File {file_path} was not found. Check the configuration of your secret backend."
+            f"File {file_path} was not found. Check the configuration of your Secrets backend."
         )
 
     log.debug("Parsing file: %s", file_path)
@@ -149,7 +149,7 @@ def _create_connection(conn_id: str, value: Any):
     """
     Creates a connection based on a URL or JSON object.
     """
-    from airflow.models import Connection
+    from airflow.models.connection import Connection
 
     if isinstance(value, str):
         return Connection(conn_id=conn_id, uri=value)
@@ -179,7 +179,7 @@ def _create_connection(conn_id: str, value: Any):
 
 def load_variables(file_path: str) -> Dict[str, str]:
     """
-    Load variable from a text file.
+    Load variables from a text file.
 
     Both ``JSON`` and ``.env`` files are supported.
 

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -22,40 +22,40 @@ import json
 import logging
 import os
 from collections import defaultdict
+from inspect import signature
 from json import JSONDecodeError
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from airflow.exceptions import AirflowException, AirflowFileParseException, FileSyntaxError
 from airflow.secrets.base_secrets import BaseSecretsBackend
 from airflow.utils.file import COMMENT_PATTERN
 from airflow.utils.log.logging_mixin import LoggingMixin
 
-# constants to limit cyclical imports
-CONNECTION_PARAMETERS_NAMES = {
-    "conn_id",
-    "conn_type",
-    "host",
-    "login",
-    "password",
-    "schema",
-    "port",
-    "extra",
-    "uri",
-}
-
 log = logging.getLogger(__name__)
 
 
-def _parser_env_file(content: str) -> Tuple[Dict[str, List[str]], List[FileSyntaxError]]:
+def get_connection_parameter_names() -> Set[str]:
+    """Returns :class:`airflow.models.connection.Connection` constructor parameters."""
+    from airflow.models.connection import Connection
+
+    return {k for k in signature(Connection.__init__).parameters.keys() if k != "self"}
+
+
+def _parser_env_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyntaxError]]:
     """
     Parse a file in the ``.env '' format.
 
    .. code-block:: text
+
         MY_CONN_ID=my-conn-type://my-login:my-pa%2Fssword@my-host:5432/my-schema?param1=val1&param2=val2
 
-    :param content:
+    :param file_path: The location of the file that will be processed.
+    :type file_path: str
     :return: Tuple with mapping of key and list of values and list of syntax errors
     """
+    with open(file_path) as f:
+        content = f.read()
+
     secrets: Dict[str, List[str]] = defaultdict(list)
     errors: List[FileSyntaxError] = []
     for line_no, line in enumerate(content.splitlines(), 1):
@@ -84,13 +84,17 @@ def _parser_env_file(content: str) -> Tuple[Dict[str, List[str]], List[FileSynta
     return secrets, errors
 
 
-def _parse_json_file(content: str) -> Tuple[Dict[str, Any], List[FileSyntaxError]]:
+def _parse_json_file(file_path: str) -> Tuple[Dict[str, Any], List[FileSyntaxError]]:
     """
-    Parrse a file in the JSON format.
+    Parse a file in the JSON format.
 
-    :param content:
+    :param file_path: The location of the file that will be processed.
+    :type file_path: str
     :return: Tuple with mapping of key and list of values and list of syntax errors
     """
+    with open(file_path) as f:
+        content = f.read()
+
     if not content:
         return {}, [FileSyntaxError(line_no=1, message="The file is empty.")]
     try:
@@ -103,60 +107,61 @@ def _parse_json_file(content: str) -> Tuple[Dict[str, Any], List[FileSyntaxError
     return secrets, []
 
 
-def _parse_secret_file(file_content: str, file_path: str) -> Tuple[Dict[str, Any], List[FileSyntaxError]]:
+FILE_PARSERS = {
+    "env": _parser_env_file,
+    "json": _parse_json_file,
+}
+
+
+def _parse_secret_file(file_path: str) -> Dict[str, Any]:
     """
     Based on the file extension format, selects a parser and parse the file.
 
-    :param file_content:
-    :param file_path:
-    :return:
+    :param file_path: The location of the file that will be processed.
+    :type file_path: str
+    :return: Map of secret key (e.g. connection ID) and value.
     """
-    if file_path.lower().endswith(".env"):
-        secrets, parse_errors = _parser_env_file(file_content)
-    elif file_path.lower().endswith(".json"):
-        secrets, parse_errors = _parse_json_file(file_content)
-    else:
-        raise AirflowException("Unsupported file format. The file must have the extension .env or .json")
-    return secrets, parse_errors
-
-
-def _read_secret_file(file_path: str) -> Dict[str, str]:
     if not os.path.exists(file_path):
         raise AirflowException(
             f"File {file_path} was not found. Check the configuration of your secret backend."
         )
 
-    log.debug("Reading file: %s", file_path)
-    with open(file_path) as f:
-        file_content = f.read()
-
     log.debug("Parsing file: %s", file_path)
-    secrets, parse_errors = _parse_secret_file(file_content, file_path)
-    log.debug("Parsed file file: len(parse_errors)=%d, len(secrets)=%d", len(parse_errors), len(secrets))
+
+    ext = file_path.rsplit(".", 2)[-1].lower()
+
+    if ext not in FILE_PARSERS:
+        raise AirflowException("Unsupported file format. The file must have the extension .env or .json")
+
+    secrets, parse_errors = FILE_PARSERS[ext](file_path)
+
+    log.debug("Parsed file: len(parse_errors)=%d, len(secrets)=%d", len(parse_errors), len(secrets))
 
     if parse_errors:
         raise AirflowFileParseException(
             f"Failed to load the secret file.", file_path=file_path, parse_errors=parse_errors
         )
-    return secrets or {}
+
+    return secrets
 
 
 def _create_connection(conn_id: str, value: Any):
     """
-    Creates a connection based on a URL or object.
+    Creates a connection based on a URL or JSON object.
     """
     from airflow.models import Connection
 
     if isinstance(value, str):
         return Connection(conn_id=conn_id, uri=value)
     if isinstance(value, dict):
+        connection_parameter_names = get_connection_parameter_names()
         current_keys = set(value.keys())
-        if not current_keys.issubset(CONNECTION_PARAMETERS_NAMES):
-            illegal_keys = current_keys - CONNECTION_PARAMETERS_NAMES
+        if not current_keys.issubset(connection_parameter_names):
+            illegal_keys = current_keys - connection_parameter_names
             illegal_keys_list = ", ".join(illegal_keys)
             raise AirflowException(
                 f"The object have illegal keys: {illegal_keys_list}. "
-                f"The dictionary can only contain the following keys: {CONNECTION_PARAMETERS_NAMES}"
+                f"The dictionary can only contain the following keys: {connection_parameter_names}"
             )
 
         if "conn_id" in current_keys and conn_id != value["conn_id"]:
@@ -174,15 +179,17 @@ def _create_connection(conn_id: str, value: Any):
 
 def load_variables(file_path: str) -> Dict[str, str]:
     """
-    Load vaariable from text file.
+    Load variable from a text file.
 
     Both ``JSON`` and ``.env`` files are supported.
 
+    :param file_path: The location of the file that will be processed.
+    :type file_path: str
     :rtype: Dict[str, List[str]]
     """
-    log.debug("Loading variables")
+    log.debug("Loading variables from a text file")
 
-    secrets = _read_secret_file(file_path)
+    secrets = _parse_secret_file(file_path)
     invalid_keys = [key for key, values in secrets.items() if isinstance(values, list) and len(values) != 1]
     if invalid_keys:
         raise AirflowException(f'The "{file_path}" file contains multiple values for keys: {invalid_keys}')
@@ -202,7 +209,7 @@ def load_connections(file_path: str):
     """
     log.debug("Loading connection")
 
-    secrets: Dict[str, Any] = _read_secret_file(file_path)
+    secrets: Dict[str, Any] = _parse_secret_file(file_path)
     connections_by_conn_id = defaultdict(list)
     for key, secret_values in list(secrets.items()):
         if isinstance(secret_values, list):
@@ -222,33 +229,35 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
 
     Both ``JSON`` and ``.env`` files are supported.
 
-    :param variable_file_path: File location with variables data.
-    :type variable_file_path: str
-    :param connection_file_path: File location with connection data.
-    :type connection_file_path: str
+    :param variables_file_path: File location with variables data.
+    :type variables_file_path: str
+    :param connections_file_path: File location with connection data.
+    :type connections_file_path: str
     """
 
-    def __init__(self, variable_file_path: Optional[str] = None, connection_file_path: Optional[str] = None):
+    def __init__(
+        self, variables_file_path: Optional[str] = None, connections_file_path: Optional[str] = None
+    ):
         super().__init__()
-        self.variable_file = variable_file_path
-        self.connection_file = connection_file_path
+        self.variables_file = variables_file_path
+        self.connections_file = connections_file_path
 
     @property
     def _local_variables(self) -> Dict[str, str]:
-        if not self.variable_file:
+        if not self.variables_file:
             self.log.debug("The file for variables is not specified. Skipping")
             # The user may not specify any file.
             return {}
-        secrets = load_variables(self.variable_file)
+        secrets = load_variables(self.variables_file)
         return secrets
 
     @property
     def _local_connections(self) -> Dict[str, List[Any]]:
-        if not self.connection_file:
+        if not self.connections_file:
             self.log.debug("The file for connection is not specified. Skipping")
             # The user may not specify any file.
             return {}
-        return load_connections(self.connection_file)
+        return load_connections(self.connections_file)
 
     def get_connections(self, conn_id: str) -> List[Any]:
         return self._local_connections.get(conn_id) or []

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -38,6 +38,7 @@ from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagBag, DagModel, DagPickle, Log
 from airflow.utils import cli_action_loggers
+from airflow.utils.platform import is_terminal_support_colors
 from airflow.utils.session import provide_session
 
 
@@ -234,24 +235,6 @@ def sigquit_handler(sig, frame):  # pylint: disable=unused-argument
             if line:
                 code.append("  {}".format(line.strip()))
     print("\n".join(code))
-
-
-def is_terminal_support_colors() -> bool:
-    """"
-    Try to determine if the current terminal supports colors.
-    """
-    if sys.platform == 'win32':
-        return False
-    if not hasattr(sys.stdout, 'isatty'):
-        return False
-    if not sys.stdout.isatty():
-        return False
-    if 'COLORTERM' in os.environ:
-        return True
-    term = os.environ.get('TERM', 'dumb').lower()
-    if term in ('xterm', 'linux') or 'color' in term:
-        return True
-    return False
 
 
 class ColorMode:

--- a/airflow/utils/code_utils.py
+++ b/airflow/utils/code_utils.py
@@ -50,3 +50,30 @@ def get_python_source(x: Any) -> Optional[str]:
     if source_code is None:
         source_code = 'No source code available for {}'.format(type(x))
     return source_code
+
+
+def prepare_code_snippet(file_path: str, line_no: int, context_lines_count: int = 5) -> str:
+    """
+    Prepare code snippet with line numbers and  a specific line marked.
+
+    :param file_path: File nam
+    :param line_no: Line number
+    :param context_lines_count: The number of lines that will be cut before and after.
+    :return: str
+    """
+    with open(file_path) as text_file:
+        # Highlight code
+        code = text_file.read()
+        code_lines = code.split("\n")
+        # Prepend line number
+        code_lines = [
+            f">{lno:3} | {line}" if line_no == lno else f"{lno:4} | {line}"
+            for lno, line in enumerate(code_lines, 1)
+        ]
+        # # Cut out the snippet
+        start_line_no = max(0, line_no - context_lines_count - 1)
+        end_line_no = line_no + context_lines_count
+        code_lines = code_lines[start_line_no:end_line_no]
+        # Join lines
+        code = "\n".join(code_lines)
+    return code

--- a/airflow/utils/platform.py
+++ b/airflow/utils/platform.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Platform and system specific function.
+"""
+import os
+import sys
+
+
+def is_tty():
+    """
+    Checks if the standard output is s connected (is associated with a terminal device) to a tty(-like) device
+    """
+    if not hasattr(sys.stdout, "isatty"):
+        return False
+    return sys.stdout.isatty()
+
+
+def is_terminal_support_colors() -> bool:
+    """"
+    Try to determine if the current terminal supports colors.
+    """
+    if sys.platform == "win32":
+        return False
+    if is_tty():
+        return False
+    if "COLORTERM" in os.environ:
+        return True
+    term = os.environ.get("TERM", "dumb").lower()
+    if term in ("xterm", "linux") or "color" in term:
+        return True
+    return False

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -59,12 +59,11 @@ Local Filesystem Secrets Backend
 
 This backend is especially useful in the following use cases:
 
-* **development**: It ensures data synchronization between all terminal windows (same as databases),
+* **Development**: It ensures data synchronization between all terminal windows (same as databases),
   and at the same time the values are retained after database restart (same as environment variable)
 * **Kubernetes**: It allows you to store secrets in `Kubernetes Secrets <https://kubernetes.io/docs/concepts/configuration/secret/>`__
   or you can synchronize values using the sidecar container and
   `a shared volume <https://kubernetes.io/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/>`__
-* **JSON**: If you're tired of defining all connections using a URI - creating JSON object is easier than using URI.
 
 To use variable and connection from local file, specify :py:class:`~airflow.secrets.local_filesystem.LocalFilesystemBackend`
 as the ``backend`` in  ``[secrets]`` section of ``airflow.cfg``.
@@ -94,7 +93,7 @@ file ``/files/my_conn.json`` when it looks for connections.
 The file can be defined in ``JSON`` or ``env`` format.
 
 The JSON file must contain an object where the key contains the connection ID and the value contains
-the definitions of one or more connections. The connection can be defined as a URL (string) or object.
+the definitions of one or more connections. The connection can be defined as a URI (string) or JSON object.
 For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 The following is a sample JSON file.

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -147,7 +147,7 @@ the variable value. The following is a sample JSON file.
 You can also define variable using a ``.env`` file. Then the key is the variable key, and variable should
 describe the variable value. The following is a sample file.
 
-  .. code-block:: json
+  .. code-block:: text
 
     VAR_A=some_value
     var_B=different_value

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -52,7 +52,7 @@ Set ``backend`` to the fully qualified class name of the backend you want to ena
 You can provide ``backend_kwargs`` with json and it will be passed as kwargs to the ``__init__`` method of
 your secrets backend.
 
-.. _local_disk_secrets:
+.. _local_filesystem_secrets:
 
 Local Filesystem Secrets Backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,8 +71,8 @@ as the ``backend`` in  ``[secrets]`` section of ``airflow.cfg``.
 
 Available parameters to ``backend_kwargs``:
 
-* ``variable_file_path``: File location with variables data.
-* ``connection_file_path``: File location with connection data.
+* ``variables_file_path``: File location with variables data.
+* ``connections_file_path``: File location with connections data.
 
 Here is a sample configuration:
 
@@ -88,14 +88,14 @@ the backend returns an empty collection.
 Storing and Retrieving Connections
 """"""""""""""""""""""""""""""""""
 
-If you have set ``connection_file_path`` as ``/files/my_conn.json``, then the backend will read the
+If you have set ``connections_file_path`` as ``/files/my_conn.json``, then the backend will read the
 file ``/files/my_conn.json`` when it looks for connections.
 
 The file can be defined in ``JSON`` or ``env`` format.
 
 The JSON file must contain an object where the key contains the connection ID and the value contains
 the definitions of one or more connections. The connection can be defined as a URL (string) or object.
-For a guide about defining a connection as a URI, see:: :doc:`generating_connection_uri`.
+For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 The following is a sample JSON file.
 
@@ -123,13 +123,13 @@ be returned. The following is a sample file.
 
   .. code-block:: text
 
-    mysql_conn_id=mysql//log:password@13.1.21.1:3306/mysqldbrd
+    mysql_conn_id=mysql://log:password@13.1.21.1:3306/mysqldbrd
     google_custom_key=google-cloud-platform://?extra__google_cloud_platform__key_path=%2Fkeys%2Fkey.json
 
 Storing and Retrieving Variables
 """"""""""""""""""""""""""""""""
 
-If you have set ``variable_file_path`` as ``/files/my_var.json``, then the backend will read the
+If you have set ``variables_file_path`` as ``/files/my_var.json``, then the backend will read the
 file ``/files/my_var.json`` when it looks for variables.
 
 The file can be defined in ``JSON`` or ``env`` format.
@@ -145,7 +145,7 @@ the variable value. The following is a sample JSON file.
     }
 
 You can also define variable using a ``.env`` file. Then the key is the variable key, and variable should
-describe the variable value. The following is a sample  file.
+describe the variable value. The following is a sample file.
 
   .. code-block:: json
 

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -52,7 +52,105 @@ Set ``backend`` to the fully qualified class name of the backend you want to ena
 You can provide ``backend_kwargs`` with json and it will be passed as kwargs to the ``__init__`` method of
 your secrets backend.
 
-See :ref:`AWS SSM Parameter Store <ssm_parameter_store_secrets>` for an example configuration.
+.. _local_disk_secrets:
+
+Local Filesystem Secrets Backend
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This backend is especially useful in the following use cases:
+
+* **development**: It ensures data synchronization between all terminal windows (same as databases),
+  and at the same time the values are retained after database restart (same as environment variable)
+* **Kubernetes**: It allows you to store secrets in `Kubernetes Secrets <https://kubernetes.io/docs/concepts/configuration/secret/>`__
+  or you can synchronize values using the sidecar container and
+  `a shared volume <https://kubernetes.io/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/>`__
+* **JSON**: If you're tired of defining all connections using a URI - creating JSON object is easier than using URI.
+
+To use variable and connection from local file, specify :py:class:`~airflow.secrets.local_filesystem.LocalFilesystemBackend`
+as the ``backend`` in  ``[secrets]`` section of ``airflow.cfg``.
+
+Available parameters to ``backend_kwargs``:
+
+* ``variable_file_path``: File location with variables data.
+* ``connection_file_path``: File location with connection data.
+
+Here is a sample configuration:
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.secrets.local_filesystem.LocalFilesystemBackend
+    backend_kwargs = {"variable_file_path": "/files/var.json", "connection_file_path": "/files/conn.json"}
+
+Both ``JSON`` and ``.env`` files are supported. All parameters are optional. If the file path is not passed,
+the backend returns an empty collection.
+
+Storing and Retrieving Connections
+""""""""""""""""""""""""""""""""""
+
+If you have set ``connection_file_path`` as ``/files/my_conn.json``, then the backend will read the
+file ``/files/my_conn.json`` when it looks for connections.
+
+The file can be defined in ``JSON`` or ``env`` format.
+
+The JSON file must contain an object where the key contains the connection ID and the value contains
+the definitions of one or more connections. The connection can be defined as a URL (string) or object.
+For a guide about defining a connection as a URI, see:: :doc:`generating_connection_uri`.
+For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
+The following is a sample JSON file.
+
+.. code-block:: json
+
+    {
+        "CONN_A": "mysq://host_a",
+        "CONN_B": [
+            "mysq://host_a",
+            "mysq://host_a"
+        ],
+        "CONN_C": {
+            "conn_type": "scheme",
+            "host": "host",
+            "schema": "lschema",
+            "login": "Login",
+            "password": "None",
+            "port": "1234"
+        }
+    }
+
+You can also define connections using a ``.env`` file. Then the key is the connection ID, and
+the value should describe the connection using the URI. If the connection ID is repeated, all values will
+be returned. The following is a sample file.
+
+  .. code-block:: text
+
+    mysql_conn_id=mysql//log:password@13.1.21.1:3306/mysqldbrd
+    google_custom_key=google-cloud-platform://?extra__google_cloud_platform__key_path=%2Fkeys%2Fkey.json
+
+Storing and Retrieving Variables
+""""""""""""""""""""""""""""""""
+
+If you have set ``variable_file_path`` as ``/files/my_var.json``, then the backend will read the
+file ``/files/my_var.json`` when it looks for variables.
+
+The file can be defined in ``JSON`` or ``env`` format.
+
+The JSON file must contain an object where the key contains the variable key and the value contains
+the variable value. The following is a sample JSON file.
+
+  .. code-block:: json
+
+    {
+        "VAR_A": "some_value",
+        "var_b": "differnet_value"
+    }
+
+You can also define variable using a ``.env`` file. Then the key is the variable key, and variable should
+describe the variable value. The following is a sample  file.
+
+  .. code-block:: json
+
+    VAR_A=some_value
+    var_B=different_value
 
 .. _ssm_parameter_store_secrets:
 

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -199,7 +199,7 @@ class TestLocalFileBackend(unittest.TestCase):
         with NamedTemporaryFile(suffix="var.env") as tmp_file:
             tmp_file.write("KEY_A=VAL_A".encode())
             tmp_file.flush()
-            backend = LocalFilesystemBackend(variable_file_path=tmp_file.name)
+            backend = LocalFilesystemBackend(variables_file_path=tmp_file.name)
             self.assertEqual("VAL_A", backend.get_variable("KEY_A"))
             self.assertEqual(None, backend.get_variable("KEY_B"))
 
@@ -207,7 +207,7 @@ class TestLocalFileBackend(unittest.TestCase):
         with NamedTemporaryFile(suffix=".env") as tmp_file:
             tmp_file.write("CONN_A=mysql://host_a\nCONN_A=mysql://host_b".encode())
             tmp_file.flush()
-            backend = LocalFilesystemBackend(connection_file_path=tmp_file.name)
+            backend = LocalFilesystemBackend(connections_file_path=tmp_file.name)
             self.assertEqual(
                 ["mysql://host_a", "mysql://host_b"],
                 [conn.get_uri() for conn in backend.get_connections("CONN_A")],
@@ -216,5 +216,5 @@ class TestLocalFileBackend(unittest.TestCase):
 
     def test_files_are_optional(self):
         backend = LocalFilesystemBackend()
-        self.assertIsNone(backend.get_connections("CONN_A"))
+        self.assertEqual([], backend.get_connections("CONN_A"))
         self.assertIsNone(backend.get_variable("VAR_A"))

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -100,7 +100,7 @@ class TestLoadVariables(unittest.TestCase):
     def test_missing_file(self, mock_exists):
         with self.assertRaisesRegex(
             AirflowException,
-            re.escape("File a.json was not found. Check the configuration of your secret backend."),
+            re.escape("File a.json was not found. Check the configuration of your Secrets backend."),
         ):
             local_filesystem.load_variables("a.json")
 
@@ -189,7 +189,7 @@ class TestLoadConnection(unittest.TestCase):
     def test_missing_file(self, mock_exists):
         with self.assertRaisesRegex(
             AirflowException,
-            re.escape("File a.json was not found. Check the configuration of your secret backend."),
+            re.escape("File a.json was not found. Check the configuration of your Secrets backend."),
         ):
             local_filesystem.load_connections("a.json")
 

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -1,0 +1,220 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import re
+import unittest
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+from parameterized import parameterized
+
+from airflow.exceptions import AirflowException, AirflowFileParseException
+from airflow.secrets import local_filesystem
+from airflow.secrets.local_filesystem import LocalFilesystemBackend
+
+
+@contextmanager
+def mock_local_file(content):
+    with mock.patch(
+        "airflow.secrets.local_filesystem.open", mock.mock_open(read_data=content)
+    ) as file_mock, mock.patch("airflow.secrets.local_filesystem.os.path.exists", return_value=True):
+        yield file_mock
+
+
+class FileParsers(unittest.TestCase):
+    @parameterized.expand(
+        (
+            ("AA", 'Invalid line format. The line should contain at least one equal sign ("=")'),
+            ("=", "Invalid line format. Key is empty."),
+        )
+    )
+    def test_env_file_invalid_format(self, content, expected_message):
+        with mock_local_file(content):
+            with self.assertRaisesRegex(AirflowFileParseException, re.escape(expected_message)):
+                local_filesystem.load_variables("a.env")
+
+    @parameterized.expand(
+        (
+            ("[]", "The file should contain the object."),
+            ("{AAAAA}", "Expecting property name enclosed in double quotes"),
+            ("", "The file is empty."),
+        )
+    )
+    def test_json_file_invalid_format(self, content, expected_message):
+        with mock_local_file(content):
+            with self.assertRaisesRegex(AirflowFileParseException, re.escape(expected_message)):
+                local_filesystem.load_variables("a.json")
+
+
+class TestLoadVariables(unittest.TestCase):
+    @parameterized.expand(
+        (
+            ("", {}),
+            ("KEY=AAA", {"KEY": "AAA"}),
+            ("KEY_A=AAA\nKEY_B=BBB", {"KEY_A": "AAA", "KEY_B": "BBB"}),
+            ("KEY_A=AAA\n # AAAA\nKEY_B=BBB", {"KEY_A": "AAA", "KEY_B": "BBB"}),
+            ("\n\n\n\nKEY_A=AAA\n\n\n\n\nKEY_B=BBB\n\n\n", {"KEY_A": "AAA", "KEY_B": "BBB"}),
+        )
+    )
+    def test_env_file_should_load_variables(self, file_content, expected_variables):
+        with mock_local_file(file_content):
+            variables = local_filesystem.load_variables("a.env")
+            self.assertEqual(expected_variables, variables)
+
+    @parameterized.expand((("AA=A\nAA=B", "The \"a.env\" file contains multiple values for keys: ['AA']"),))
+    def test_env_file_invalid_logic(self, content, expected_message):
+        with mock_local_file(content):
+            with self.assertRaisesRegex(AirflowException, re.escape(expected_message)):
+                local_filesystem.load_variables("a.env")
+
+    @parameterized.expand(
+        (
+            ({}, {}),
+            ({"KEY": "AAA"}, {"KEY": "AAA"}),
+            ({"KEY_A": "AAA", "KEY_B": "BBB"}, {"KEY_A": "AAA", "KEY_B": "BBB"}),
+            ({"KEY_A": "AAA", "KEY_B": "BBB"}, {"KEY_A": "AAA", "KEY_B": "BBB"}),
+        )
+    )
+    def test_json_file_should_load_variables(self, file_content, expected_variables):
+        with mock_local_file(json.dumps(file_content)):
+            variables = local_filesystem.load_variables("a.json")
+            self.assertEqual(expected_variables, variables)
+
+    @mock.patch("airflow.secrets.local_filesystem.os.path.exists", return_value=False)
+    def test_missing_file(self, mock_exists):
+        with self.assertRaisesRegex(
+            AirflowException,
+            re.escape("File a.json was not found. Check the configuration of your secret backend."),
+        ):
+            local_filesystem.load_variables("a.json")
+
+
+class TestLoadConnection(unittest.TestCase):
+    @parameterized.expand(
+        (
+            ("CONN_ID=mysql://host_1/", {"CONN_ID": ["mysql://host_1"]}),
+            (
+                "CONN_ID=mysql://host_1/\nCONN_ID=mysql://host_2/",
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+            ),
+            (
+                "CONN_ID=mysql://host_1/\n # AAAA\nCONN_ID=mysql://host_2/",
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+            ),
+            (
+                "\n\n\n\nCONN_ID=mysql://host_1/\n\n\n\n\nCONN_ID=mysql://host_2/\n\n\n",
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+            ),
+        )
+    )
+    def test_env_file_should_load_connection(self, file_content, expected_connection_uris):
+        with mock_local_file(file_content):
+            connections_by_conn_id = local_filesystem.load_connections("a.env")
+            connection_uris_by_conn_id = {
+                conn_id: [connection.get_uri() for connection in connections]
+                for conn_id, connections in connections_by_conn_id.items()
+            }
+
+            self.assertEqual(expected_connection_uris, connection_uris_by_conn_id)
+
+    @parameterized.expand(
+        (
+            ("AA", 'Invalid line format. The line should contain at least one equal sign ("=")'),
+            ("=", "Invalid line format. Key is empty."),
+        )
+    )
+    def test_env_file_invalid_format(self, content, expected_message):
+        with mock_local_file(content):
+            with self.assertRaisesRegex(AirflowFileParseException, re.escape(expected_message)):
+                local_filesystem.load_connections("a.env")
+
+    @parameterized.expand(
+        (
+            ({"CONN_ID": "mysql://host_1"}, {"CONN_ID": ["mysql://host_1"]}),
+            ({"CONN_ID": ["mysql://host_1"]}, {"CONN_ID": ["mysql://host_1"]}),
+            (
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+            ),
+            ({"CONN_ID": {"uri": "mysql://host_1"}}, {"CONN_ID": ["mysql://host_1"]}),
+            ({"CONN_ID": [{"uri": "mysql://host_1"}]}, {"CONN_ID": ["mysql://host_1"]}),
+            (
+                {"CONN_ID": [{"uri": "mysql://host_1"}, {"uri": "mysql://host_2"}]},
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+            ),
+        )
+    )
+    def test_json_file_should_load_connection(self, file_content, expected_connection_uris):
+        with mock_local_file(json.dumps(file_content)):
+            connections_by_conn_id = local_filesystem.load_connections("a.json")
+            connection_uris_by_conn_id = {
+                conn_id: [connection.get_uri() for connection in connections]
+                for conn_id, connections in connections_by_conn_id.items()
+            }
+
+            self.assertEqual(expected_connection_uris, connection_uris_by_conn_id)
+
+    @parameterized.expand(
+        (
+            ({"CONN_ID": None}, "Unexpected value type: <class 'NoneType'>."),
+            ({"CONN_ID": 1}, "Unexpected value type: <class 'int'>."),
+            ({"CONN_ID": [2]}, "Unexpected value type: <class 'int'>."),
+            ({"CONN_ID": ["mysql://host_1", None]}, "Unexpected value type: <class 'NoneType'>."),
+            ({"CONN_ID": {"AAA": "mysql://host_1"}}, "The object have illegal keys: AAA."),
+            ({"CONN_ID": {"conn_id": "BBBB"}}, "Mismatch conn_id."),
+        )
+    )
+    def test_env_file_invalid_input(self, file_content, expected_connection_uris):
+        with mock_local_file(json.dumps(file_content)):
+            with self.assertRaisesRegex(AirflowException, re.escape(expected_connection_uris)):
+                local_filesystem.load_connections("a.json")
+
+    @mock.patch("airflow.secrets.local_filesystem.os.path.exists", return_value=False)
+    def test_missing_file(self, mock_exists):
+        with self.assertRaisesRegex(
+            AirflowException,
+            re.escape("File a.json was not found. Check the configuration of your secret backend."),
+        ):
+            local_filesystem.load_connections("a.json")
+
+
+class TestLocalFileBackend(unittest.TestCase):
+    def test_should_read_variable(self):
+        with NamedTemporaryFile(suffix="var.env") as tmp_file:
+            tmp_file.write("KEY_A=VAL_A".encode())
+            tmp_file.flush()
+            backend = LocalFilesystemBackend(variable_file_path=tmp_file.name)
+            self.assertEqual("VAL_A", backend.get_variable("KEY_A"))
+            self.assertEqual(None, backend.get_variable("KEY_B"))
+
+    def test_should_read_connection(self):
+        with NamedTemporaryFile(suffix=".env") as tmp_file:
+            tmp_file.write("CONN_A=mysql://host_a\nCONN_A=mysql://host_b".encode())
+            tmp_file.flush()
+            backend = LocalFilesystemBackend(connection_file_path=tmp_file.name)
+            self.assertEqual(
+                ["mysql://host_a", "mysql://host_b"],
+                [conn.get_uri() for conn in backend.get_connections("CONN_A")],
+            )
+            self.assertIsNone(backend.get_variable("CONN_B"))
+
+    def test_files_are_optional(self):
+        backend = LocalFilesystemBackend()
+        self.assertIsNone(backend.get_connections("CONN_A"))
+        self.assertIsNone(backend.get_variable("VAR_A"))

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -201,7 +201,7 @@ class TestLocalFileBackend(unittest.TestCase):
             tmp_file.flush()
             backend = LocalFilesystemBackend(variables_file_path=tmp_file.name)
             self.assertEqual("VAL_A", backend.get_variable("KEY_A"))
-            self.assertEqual(None, backend.get_variable("KEY_B"))
+            self.assertIsNone(backend.get_variable("KEY_B"))
 
     def test_should_read_connection(self):
         with NamedTemporaryFile(suffix=".env") as tmp_file:


### PR DESCRIPTION
This backend is especially useful in the following use cases:

* **development**: It ensures data synchronization between all terminal windows (same as databases),
  and at the same time the values are retained after database restart (same as environment variable)
* **Kubernetes**: It allows you to store secrets in [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
  or you can synchronize secrets using the sidecar container and
  [a shared volume](https://kubernetes.io/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/)
* if you're tired of defining all connections using a URI.


---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
