### PR TITLE
Return non-zero error code when variable is missing

### DIFF
--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -18,6 +18,7 @@
 """Variable subcommands"""
 import json
 import os
+import sys
 
 from airflow.models import Variable
 from airflow.utils import cli as cli_utils
@@ -34,12 +35,21 @@ def variables_list(args):
 def variables_get(args):
     """Displays variable by a given name"""
     try:
-        var = Variable.get(args.key,
-                           deserialize_json=args.json,
-                           default_var=args.default)
-        print(var)
-    except ValueError as e:
-        print(e)
+        if args.default is None:
+            Variable.get(
+                args.key,
+                deserialize_json=args.json
+            )
+        else:
+            var = Variable.get(
+                args.key,
+                deserialize_json=args.json,
+                default_var=args.default
+            )
+            print(var)
+    except (ValueError, KeyError) as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
 
 
 @cli_utils.action_logging

--- a/tests/cli/commands/test_variable_command.py
+++ b/tests/cli/commands/test_variable_command.py
@@ -127,3 +127,7 @@ class TestCliVariables(unittest.TestCase):
         os.remove('variables1.json')
         os.remove('variables2.json')
         os.remove('variables3.json')
+
+    def test_get_missing_variable(self):
+        with self.assertRaises(SystemExit):
+            variable_command.variables_get(self.parser.parse_args(['variables', 'get', 'no-existing-VAR']))


### PR DESCRIPTION
A non-zero exit status indicates failure. If the variable did not exist, it means that the command to retrieve the content could not be successful.  This is especially needed when writing scripts that run Airflow commands. 

Similar behavior can be seen with the `cat` command
```
22:30 $ cat /tmp/a.txt
cat: /tmp/a.txt: No such file or directory
22:30 $ echo $?
1
22:30 $ touch /tmp/a.txt
22:30 $ cat /tmp/a.txt
22:30 $ echo $?
0
```

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
