### PR TITLE
[AIRFLOW-7111] Add generate_presigned_url method to S3Hook

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -730,7 +730,7 @@ class S3Hook(AwsBaseHook):
 
         return local_tmp_file.name
 
-    def generate_presigned_url(self, client_method, params=None, expires_in=3600, http_method=None) -> str:
+    def generate_presigned_url(self, client_method, params=None, expires_in=3600, http_method=None):
         """
             Generate a presigned url given a client, its method, and arguments
 
@@ -738,9 +738,11 @@ class S3Hook(AwsBaseHook):
             :type client_method: str
             :param params: The parameters normally passed to ClientMethod.
             :type params: dict
-            :param expires_in: The number of seconds the presigned url is valid for. By default it expires in an hour (3600 seconds).
+            :param expires_in: The number of seconds the presigned url is valid for.
+                By default it expires in an hour (3600 seconds).
             :type expires_in: int
-            :param http_method: The http method to use on the generated url. By default, the http method is whatever is used in the method's model.
+            :param http_method: The http method to use on the generated url.
+                By default, the http method is whatever is used in the method's model.
             :type http_method: str
             :return: The presigned url.
             :rtype: str

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -729,3 +729,30 @@ class S3Hook(AwsBaseHook):
             s3_obj.download_fileobj(local_tmp_file)
 
         return local_tmp_file.name
+
+    def generate_presigned_url(self, client_method, params=None, expires_in=3600, http_method=None) -> str:
+        """
+            Generate a presigned url given a client, its method, and arguments
+
+            :param client_method: The client method to presign for.
+            :type client_method: str
+            :param params: The parameters normally passed to ClientMethod.
+            :type params: dict
+            :param expires_in: The number of seconds the presigned url is valid for. By default it expires in an hour (3600 seconds).
+            :type expires_in: int
+            :param http_method: The http method to use on the generated url. By default, the http method is whatever is used in the method's model.
+            :type http_method: str
+            :return: The presigned url.
+            :rtype: str
+            """
+
+        s3_client = self.get_conn()
+        try:
+            return s3_client.generate_presigned_url(ClientMethod=client_method,
+                                                    Params=params,
+                                                    ExpiresIn=expires_in,
+                                                    HttpMethod=http_method)
+
+        except ClientError as e:
+            self.log.error(e.response["Error"]["Message"])
+            return None

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -732,21 +732,21 @@ class S3Hook(AwsBaseHook):
 
     def generate_presigned_url(self, client_method, params=None, expires_in=3600, http_method=None):
         """
-            Generate a presigned url given a client, its method, and arguments
+        Generate a presigned url given a client, its method, and arguments
 
-            :param client_method: The client method to presign for.
-            :type client_method: str
-            :param params: The parameters normally passed to ClientMethod.
-            :type params: dict
-            :param expires_in: The number of seconds the presigned url is valid for.
-                By default it expires in an hour (3600 seconds).
-            :type expires_in: int
-            :param http_method: The http method to use on the generated url.
-                By default, the http method is whatever is used in the method's model.
-            :type http_method: str
-            :return: The presigned url.
-            :rtype: str
-            """
+        :param client_method: The client method to presign for.
+        :type client_method: str
+        :param params: The parameters normally passed to ClientMethod.
+        :type params: dict
+        :param expires_in: The number of seconds the presigned url is valid for.
+            By default it expires in an hour (3600 seconds).
+        :type expires_in: int
+        :param http_method: The http method to use on the generated url.
+            By default, the http method is whatever is used in the method's model.
+        :type http_method: str
+        :return: The presigned url.
+        :rtype: str
+        """
 
         s3_client = self.get_conn()
         try:

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -399,3 +399,15 @@ class TestAwsS3Hook:
         s3_hook.check_for_key.assert_called_once_with(key, bucket)
         s3_hook.get_key.assert_called_once_with(key, bucket)
         s3_obj.download_fileobj.assert_called_once_with(mock_temp_file)
+
+    def test_generate_presigned_url(self, s3_bucket):
+        hook = S3Hook()
+        presigned_url = hook.generate_presigned_url(client_method="get_object",
+                                                    params={'Bucket': s3_bucket,
+                                                            'Key': "my_key"})
+
+        url = presigned_url.split("?")[1]
+        params = {x[0]: x[1]
+                  for x in [x.split("=") for x in url[0:].split("&")]}
+
+        assert {"AWSAccessKeyId", "Signature", "Expires"}.issubset(set(params.keys()))


### PR DESCRIPTION
Boto3 generate_presigned_url exposed to S3Hook.

Jira: https://issues.apache.org/jira/browse/AIRFLOW-7111

---

- [ x ] Description above provides context of the change
- [ x ] Unit tests coverage for changes (not needed for documentation changes)
- [ x ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ x ] Relevant documentation is updated including usage instructions.
- [ x ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---

