### PR TITLE
Fix formatting of Pool docs in concepts.rst

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -541,8 +541,8 @@ reached, runnable tasks get queued and their state will show as such in the
 UI. As slots free up, queued tasks start running based on the
 ``priority_weight`` (of the task and its descendants).
 
-``Pools are not thread-safe , in case of more than one scheduler in localExecutor Mode
-you can't ensure the non-scheduling of task even if the pool is full.``
+Pools are not thread-safe , in case of more than one scheduler in localExecutor Mode
+you can't ensure the non-scheduling of task even if the pool is full.
 
 Note that if tasks are not given a pool, they are assigned to a default
 pool ``default_pool``.  ``default_pool`` is initialized with 128 slots and


### PR DESCRIPTION
**Previous**:
![image](https://user-images.githubusercontent.com/8811558/79669386-09b1d580-81b3-11ea-997e-a35805c39231.png)


**Now**:
![image](https://user-images.githubusercontent.com/8811558/79669411-2d751b80-81b3-11ea-9cad-f2d87c8bba51.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
