### PR TITLE
Make KubernetesPodOperator clear in docs

### DIFF
--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -23,10 +23,11 @@ Kubernetes
 Kubernetes Executor
 ^^^^^^^^^^^^^^^^^^^
 
-The :doc:`Kubernetes Executor <executor/kubernetes>` allows you to run tasks on Kubernetes as Pods.
+The :doc:`Kubernetes Executor <executor/kubernetes>` allows you to run all the Airflow tasks on
+Kubernetes as separate Pods.
 
-Kubernetes Operator
-^^^^^^^^^^^^^^^^^^^
+KubernetesPodOperator
+^^^^^^^^^^^^^^^^^^^^^
 
 The :doc:`KubernetesPodOperator <howto/operator/kubernetes>` allows you to create
 Pods on Kubernetes.


### PR DESCRIPTION
Avoid confusion with https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
and be specific about the name of the Operator

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
