### PR TITLE
Simplify mocking in BigQueryHook tests

### DIFF
--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -22,10 +22,9 @@ from unittest import mock
 from googleapiclient.errors import HttpError
 from parameterized import parameterized
 
-from airflow.providers.google.cloud.hooks import bigquery as hook
 from airflow.providers.google.cloud.hooks.bigquery import (
-    _api_resource_configs_duplication_check, _cleanse_time_partitioning, _validate_src_fmt_configs,
-    _validate_value,
+    BigQueryCursor, BigQueryHook, _api_resource_configs_duplication_check, _cleanse_time_partitioning,
+    _split_tablename, _validate_src_fmt_configs, _validate_value,
 )
 
 PROJECT_ID = "bq-project"
@@ -37,77 +36,73 @@ JOB_ID = 1234
 LOCATION = 'europe-north1'
 
 
-class TestBigQueryHookMethods(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
+class _BigQueryBaseTestClass(unittest.TestCase):
+    def setUp(self) -> None:
+        class MockedBigQueryHook(BigQueryHook):
+            def _get_credentials_and_project_id(self):
+                return CREDENTIALS, PROJECT_ID
+
+        self.hook = MockedBigQueryHook()
+
+
+class TestBigQueryHookMethods(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryConnection")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook._authorize")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.build")
     def test_bigquery_client_creation(
-        self, mock_build, mock_authorize, mock_bigquery_connection, mock_get_creds_and_proj_id
+        self, mock_build, mock_authorize, mock_bigquery_connection
     ):
-        bq_hook = hook.BigQueryHook()
-        result = bq_hook.get_conn()
+        result = self.hook.get_conn()
         mock_build.assert_called_once_with(
             'bigquery', 'v2', http=mock_authorize.return_value, cache_discovery=False
         )
         mock_bigquery_connection.assert_called_once_with(
             service=mock_build.return_value,
             project_id=PROJECT_ID,
-            hook=bq_hook,
-            use_legacy_sql=bq_hook.use_legacy_sql,
-            location=bq_hook.location,
-            num_retries=bq_hook.num_retries
+            hook=self.hook,
+            use_legacy_sql=self.hook.use_legacy_sql,
+            location=self.hook.location,
+            num_retries=self.hook.num_retries
         )
         self.assertEqual(mock_bigquery_connection.return_value, result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__")
     def test_bigquery_bigquery_conn_id_deprecation_warning(
-        self, mock_base_hook_init, mock_get_creds_and_proj_id
+        self, mock_base_hook_init,
     ):
         bigquery_conn_id = "bigquery conn id"
         warning_message = "The bigquery_conn_id parameter has been deprecated. " \
                           "You should pass the gcp_conn_id parameter."
         with self.assertWarns(DeprecationWarning) as warn:
-            hook.BigQueryHook(bigquery_conn_id=bigquery_conn_id)
+            BigQueryHook(bigquery_conn_id=bigquery_conn_id)
             mock_base_hook_init.assert_called_once_with(delegate_to=None, gcp_conn_id='bigquery conn id')
         self.assertEqual(warning_message, str(warn.warning))
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
-    def test_bigquery_insert_rows_not_implemented(self, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        with self.assertRaises(NotImplementedError):
-            bq_hook.insert_rows(table="table", rows=[1, 2])
-
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_bigquery_table_exists_true(self, mock_get_service, mock_get_creds_and_proj_id):
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
+    def test_location_propagates_properly(
+        self, run_with_config, mock_get_service
+    ):
+        self.assertIsNone(self.hook.location)
+        self.hook.run_query(sql='select 1', location='US')
+        assert run_with_config.call_count == 1
+        self.assertEqual(self.hook.location, 'US')
+
+    def test_bigquery_insert_rows_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self.hook.insert_rows(table="table", rows=[1, 2])
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
+    def test_bigquery_table_exists_true(self, mock_get_service):
         method = mock_get_service.return_value.tables.return_value.get
 
-        bq_hook = hook.BigQueryHook()
-        result = bq_hook.table_exists(project_id=PROJECT_ID, dataset_id=DATASET_ID, table_id=TABLE_ID)
+        result = self.hook.table_exists(project_id=PROJECT_ID, dataset_id=DATASET_ID, table_id=TABLE_ID)
 
         method.assert_called_once_with(datasetId=DATASET_ID, projectId=PROJECT_ID, tableId=TABLE_ID)
         self.assertTrue(result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_bigquery_table_exists_false(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_bigquery_table_exists_false(self, mock_get_service):
         resp_getitem = mock.MagicMock()
         resp_getitem.return_value = '404'
         resp = type('', (object,), {"status": 404, "__getitem__": resp_getitem})()
@@ -115,18 +110,13 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Address not found')
 
-        bq_hook = hook.BigQueryHook()
-        result = bq_hook.table_exists(project_id=PROJECT_ID, dataset_id=DATASET_ID, table_id=TABLE_ID)
+        result = self.hook.table_exists(project_id=PROJECT_ID, dataset_id=DATASET_ID, table_id=TABLE_ID)
 
         resp_getitem.assert_called_once_with('status')
         self.assertFalse(result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_bigquery_table_exists_raise_exception(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_bigquery_table_exists_raise_exception(self, mock_get_service):
         resp_getitem = mock.MagicMock()
         resp_getitem.return_value = '500'
         resp = type('', (object,), {"status": 500, "__getitem__": resp_getitem})()
@@ -134,55 +124,40 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Internal server error')
 
-        bq_hook = hook.BigQueryHook()
-
         with self.assertRaises(HttpError):
-            bq_hook.table_exists(project_id=PROJECT_ID, dataset_id=DATASET_ID, table_id=TABLE_ID)
+            self.hook.table_exists(project_id=PROJECT_ID, dataset_id=DATASET_ID, table_id=TABLE_ID)
 
         resp_getitem.assert_called_once_with('status')
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch('airflow.providers.google.cloud.hooks.bigquery.read_gbq')
-    def test_get_pandas_df(self, mock_read_gbq, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_hook.get_pandas_df('select 1')
+    def test_get_pandas_df(self, mock_read_gbq):
+        self.hook.get_pandas_df('select 1')
 
         mock_read_gbq.assert_called_once_with(
             'select 1', credentials=CREDENTIALS, dialect='legacy', project_id=PROJECT_ID, verbose=False
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=("CREDENTIALS", "PROJECT_ID",)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_invalid_schema_update_options(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_invalid_schema_update_options(self, mock_get_service):
         with self.assertRaisesRegex(
             Exception,
             r"\['THIS IS NOT VALID'\] contains invalid schema update options.Please only use one or more of "
             r"the following options: \['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'\]"
         ):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.run_load(
+
+            self.hook.run_load(
                 "test.test",
                 "test_schema.json",
                 ["test_data.json"],
                 schema_update_options=["THIS IS NOT VALID"]
             )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_invalid_schema_update_and_write_disposition(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_invalid_schema_update_and_write_disposition(self, mock_get_service):
         with self.assertRaisesRegex(Exception, "schema_update_options is only allowed if"
                                                " write_disposition is 'WRITE_APPEND' or 'WRITE_TRUNCATE'."):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.run_load(
+
+            self.hook.run_load(
                 "test.test",
                 "test_schema.json",
                 ["test_data.json"],
@@ -194,102 +169,72 @@ class TestBigQueryHookMethods(unittest.TestCase):
         "airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete",
         side_effect=[False, True]
     )
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_cancel_queries(self, mock_get_service, mock_get_creds_and_proj_id, mock_poll_job_complete):
+    def test_cancel_queries(self, mock_get_service, mock_poll_job_complete):
         running_job_id = 3
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.running_job_id = running_job_id
-        bq_hook.cancel_query()
+        self.hook.running_job_id = running_job_id
+        self.hook.cancel_query()
 
         mock_poll_job_complete.has_calls(mock.call(running_job_id), mock.call(running_job_id))
         mock_get_service.return_value.jobs.return_value.cancel.assert_called_once_with(
             projectId=PROJECT_ID, jobId=running_job_id
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_query_sql_dialect_default(
-        self, run_with_config, mock_get_service, mock_get_creds_and_proj_id
+        self, run_with_config, mock_get_service,
     ):
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query('query')
+        self.hook.run_query('query')
         args, kwargs = run_with_config.call_args
         self.assertIs(args[0]['query']['useLegacySql'], True)
 
     @parameterized.expand([(None, True), (True, True), (False, False)])
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_query_sql_dialect(
-        self, bool_val, expected, run_with_config, mock_get_service, mock_get_creds_and_proj_id
+        self, bool_val, expected, run_with_config, mock_get_service,
     ):
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query('query', use_legacy_sql=bool_val)
+        self.hook.run_query('query', use_legacy_sql=bool_val)
         args, kwargs = run_with_config.call_args
         self.assertIs(args[0]['query']['useLegacySql'], expected)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_query_sql_dialect_legacy_with_query_params(
-        self, run_with_config, mock_get_service, mock_get_creds_and_proj_id
+        self, run_with_config, mock_get_service
     ):
-        bq_hook = hook.BigQueryHook()
         params = [{
             'name': "param_name",
             'parameterType': {'type': "STRING"},
             'parameterValue': {'value': "param_value"}
         }]
-        bq_hook.run_query('query', use_legacy_sql=False, query_params=params)
+        self.hook.run_query('query', use_legacy_sql=False, query_params=params)
         args, kwargs = run_with_config.call_args
         self.assertIs(args[0]['query']['useLegacySql'], False)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_run_query_sql_dialect_legacy_with_query_params_fails(
-        self, mock_get_service, mock_get_creds_and_proj_id
+        self, mock_get_service,
     ):
-        bq_hook = hook.BigQueryHook()
         params = [{
             'name': "param_name",
             'parameterType': {'type': "STRING"},
             'parameterValue': {'value': "param_value"}
         }]
         with self.assertRaisesRegex(ValueError, "Query parameters are not allowed when using legacy SQL"):
-            bq_hook.run_query('query', use_legacy_sql=True, query_params=params)
+            self.hook.run_query('query', use_legacy_sql=True, query_params=params)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_run_query_without_sql_fails(
-        self, mock_get_service, mock_get_creds_and_proj_id
+        self, mock_get_service,
     ):
-        bq_hook = hook.BigQueryHook()
         with self.assertRaisesRegex(
             TypeError,
             r"`BigQueryBaseCursor.run_query` missing 1 required positional argument: `sql`"
         ):
-            bq_hook.run_query(sql=None)
+            self.hook.run_query(sql=None)
 
     @parameterized.expand([
         (['ALLOW_FIELD_ADDITION'], 'WRITE_APPEND'),
@@ -299,10 +244,6 @@ class TestBigQueryHookMethods(unittest.TestCase):
         (['ALLOW_FIELD_RELAXATION'], 'WRITE_TRUNCATE'),
         (['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'], 'WRITE_TRUNCATE'),
     ])
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_run_query_schema_update_options(
@@ -311,10 +252,8 @@ class TestBigQueryHookMethods(unittest.TestCase):
         write_disposition,
         run_with_config,
         mock_get_service,
-        mock_get_creds_and_proj_id
     ):
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query(
+        self.hook.run_query(
             sql='query',
             destination_dataset_table='my_dataset.my_table',
             schema_update_options=schema_update_options,
@@ -351,10 +290,6 @@ class TestBigQueryHookMethods(unittest.TestCase):
             r"schema_update_options is only allowed if write_disposition is "
             r"'WRITE_APPEND' or 'WRITE_TRUNCATE'"),
     ])
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_run_query_schema_update_options_incorrect(
         self,
@@ -362,11 +297,9 @@ class TestBigQueryHookMethods(unittest.TestCase):
         write_disposition,
         expected_regex,
         mock_get_service,
-        mock_get_creds_and_proj_id
     ):
-        bq_hook = hook.BigQueryHook()
         with self.assertRaisesRegex(ValueError, expected_regex):
-            bq_hook.run_query(
+            self.hook.run_query(
                 sql='query',
                 destination_dataset_table='my_dataset.my_table',
                 schema_update_options=schema_update_options,
@@ -374,40 +307,28 @@ class TestBigQueryHookMethods(unittest.TestCase):
             )
 
     @parameterized.expand([(True,), (False,)])
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_api_resource_configs(
-        self, bool_val, run_with_config, mock_get_service, mock_get_creds_and_proj_id
+        self, bool_val, run_with_config, mock_get_service,
     ):
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query('query',
-                          api_resource_configs={
-                              'query': {'useQueryCache': bool_val}})
+        self.hook.run_query('query', api_resource_configs={'query': {'useQueryCache': bool_val}})
         args, kwargs = run_with_config.call_args
         self.assertIs(args[0]['query']['useQueryCache'], bool_val)
         self.assertIs(args[0]['query']['useLegacySql'], True)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_api_resource_configs_duplication_warning(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_api_resource_configs_duplication_warning(self, mock_get_service):
         with self.assertRaisesRegex(
             ValueError,
             r"Values of useLegacySql param are duplicated\. api_resource_configs contained useLegacySql "
             r"param in `query` config and useLegacySql was also provided with arg to run_query\(\) method\. "
             r"Please remove duplicates\."
         ):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.run_query('query',
-                              use_legacy_sql=True,
-                              api_resource_configs={
-                                  'query': {'useLegacySql': False}})
+            self.hook.run_query('query',
+                                use_legacy_sql=True,
+                                api_resource_configs={'query': {'useLegacySql': False}}
+                                )
 
     def test_validate_value(self):
         with self.assertRaisesRegex(
@@ -455,17 +376,12 @@ class TestBigQueryHookMethods(unittest.TestCase):
     @parameterized.expand(
         [("AVRO",), ("PARQUET",), ("NEWLINE_DELIMITED_JSON",), ("DATASTORE_BACKUP",)]
     )
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_load_with_non_csv_as_src_fmt(self, fmt, mock_get_service, mock_project_id, mock_rwc):
-        bq_hook = hook.BigQueryHook()
+    def test_run_load_with_non_csv_as_src_fmt(self, fmt, mock_get_service, mock_rwc):
 
         try:
-            bq_hook.run_load(
+            self.hook.run_load(
                 destination_project_dataset_table='my_dataset.my_table',
                 source_uris=[],
                 source_format=fmt,
@@ -474,13 +390,9 @@ class TestBigQueryHookMethods(unittest.TestCase):
         except ValueError:
             self.fail("run_load() raised ValueError unexpectedly!")
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_extract(self, run_with_config, mock_get_service, mock_project_id):
+    def test_run_extract(self, run_with_config, mock_get_service):
         source_project_dataset_table = "{}.{}.{}".format(PROJECT_ID, DATASET_ID, TABLE_ID)
         destination_cloud_storage_uris = ["gs://bucket/file.csv"]
         expected_configuration = {
@@ -498,34 +410,23 @@ class TestBigQueryHookMethods(unittest.TestCase):
             }
         }
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_extract(
+        self.hook.run_extract(
             source_project_dataset_table=source_project_dataset_table,
             destination_cloud_storage_uris=destination_cloud_storage_uris
         )
         run_with_config.assert_called_once_with(expected_configuration)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_tabledata_default_parameters(self, mock_get_service, mock_project_id):
+    def test_get_tabledata_default_parameters(self, mock_get_service):
         method = mock_get_service.return_value.tabledata.return_value.list
-        bq_hook = hook.BigQueryHook()
-        cursor = bq_hook.get_cursor()
+        cursor = self.hook.get_cursor()
         cursor.get_tabledata(DATASET_ID, TABLE_ID)
         method.assert_called_once_with(datasetId=DATASET_ID, projectId=PROJECT_ID, tableId=TABLE_ID)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_tabledata_optional_parameters(self, mock_get_service, mock_project_id):
+    def test_get_tabledata_optional_parameters(self, mock_get_service):
         method = mock_get_service.return_value.tabledata.return_value.list
-        bq_hook = hook.BigQueryHook()
-        cursor = bq_hook.get_cursor()
+        cursor = self.hook.get_cursor()
         cursor.get_tabledata(
             DATASET_ID,
             TABLE_ID,
@@ -544,55 +445,36 @@ class TestBigQueryHookMethods(unittest.TestCase):
             startIndex=5
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_run_table_delete(self, mock_get_service, mock_project_id):
+    def test_run_table_delete(self, mock_get_service,):
         source_project_dataset_table = "{}.{}.{}".format(PROJECT_ID, DATASET_ID, TABLE_ID)
         method = mock_get_service.return_value.tables.return_value.delete
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_table_delete(source_project_dataset_table)
+        self.hook.run_table_delete(source_project_dataset_table)
         method.assert_called_once_with(datasetId=DATASET_ID, projectId=PROJECT_ID, tableId=TABLE_ID)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_run_table_delete_ignore_if_missing_fails(self, mock_get_service, mock_project_id):
+    def test_run_table_delete_ignore_if_missing_fails(self, mock_get_service):
         source_project_dataset_table = "{}.{}.{}".format(PROJECT_ID, DATASET_ID, TABLE_ID)
         method = mock_get_service.return_value.tables.return_value.delete
         resp = type('', (object,), {"status": 404, "reason": "Address not found"})()
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Address not found')
-        bq_hook = hook.BigQueryHook()
         with self.assertRaisesRegex(HttpError, r"Address not found"):
-            bq_hook.run_table_delete(source_project_dataset_table)
+            self.hook.run_table_delete(source_project_dataset_table)
         method.assert_called_once_with(datasetId=DATASET_ID, projectId=PROJECT_ID, tableId=TABLE_ID)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_run_table_delete_ignore_if_missing_pass(self, mock_get_service, mock_project_id):
+    def test_run_table_delete_ignore_if_missing_pass(self, mock_get_service):
         source_project_dataset_table = "{}.{}.{}".format(PROJECT_ID, DATASET_ID, TABLE_ID)
         method = mock_get_service.return_value.tables.return_value.delete
         resp = type('', (object,), {"status": 404, "reason": "Address not found"})()
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Address not found')
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_table_delete(source_project_dataset_table, ignore_if_missing=True)
+        self.hook.run_table_delete(source_project_dataset_table, ignore_if_missing=True)
         method.assert_called_once_with(datasetId=DATASET_ID, projectId=PROJECT_ID, tableId=TABLE_ID)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_table_upsert_create_new_table(self, mock_get_service, mock_project_id):
+    def test_table_upsert_create_new_table(self, mock_get_service):
         table_resource = {
             "tableReference": {
                 "tableId": TABLE_ID
@@ -604,8 +486,7 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method_tables_insert = mock_get_service.return_value.tables.return_value.insert
         method_tables_insert_execute = method_tables_insert.return_value.execute
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_table_upsert(dataset_id=DATASET_ID, table_resource=table_resource)
+        self.hook.run_table_upsert(dataset_id=DATASET_ID, table_resource=table_resource)
 
         method_tables_list.assert_called_once_with(datasetId=DATASET_ID, projectId=PROJECT_ID)
         method_tables_insert.assert_called_once_with(
@@ -614,12 +495,8 @@ class TestBigQueryHookMethods(unittest.TestCase):
         assert method_tables_list_execute.call_count == 1
         assert method_tables_insert_execute.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_table_upsert_already_exists(self, mock_get_service, mock_project_id):
+    def test_table_upsert_already_exists(self, mock_get_service):
         page_token = "token"
         table_resource = {
             "tableReference": {
@@ -641,8 +518,7 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method_tables_update = mock_get_service.return_value.tables.return_value.update
         method_tables_update_execute = method_tables_update.return_value.execute
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_table_upsert(dataset_id=DATASET_ID, table_resource=table_resource)
+        self.hook.run_table_upsert(dataset_id=DATASET_ID, table_resource=table_resource)
 
         method_tables_list.has_calls(
             mock.call(datasetId=DATASET_ID, projectId=PROJECT_ID),
@@ -653,12 +529,8 @@ class TestBigQueryHookMethods(unittest.TestCase):
         assert method_tables_list_execute.call_count == 2
         assert method_tables_update_execute.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_run_grant_dataset_view_access_granting(self, mock_get_service, mock_project_id):
+    def test_run_grant_dataset_view_access_granting(self, mock_get_service):
         source_dataset = "source_dataset_{}".format(DATASET_ID)
         view_dataset = "view_dataset_{}".format(DATASET_ID)
         view = {"projectId": PROJECT_ID, "datasetId": view_dataset, "tableId": TABLE_ID}
@@ -671,9 +543,7 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method_patch = mock_get_service.return_value.datasets.return_value.patch
         method_patch_execute = method_patch.return_value.execute
 
-        bq_hook = hook.BigQueryHook()
-
-        bq_hook.run_grant_dataset_view_access(
+        self.hook.run_grant_dataset_view_access(
             source_dataset=source_dataset,
             view_dataset=view_dataset,
             view_table=TABLE_ID
@@ -686,12 +556,8 @@ class TestBigQueryHookMethods(unittest.TestCase):
         assert method_patch.call_count == 1
         assert method_patch_execute.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_run_grant_dataset_view_access_already_granted(self, mock_get_service, mock_project_id):
+    def test_run_grant_dataset_view_access_already_granted(self, mock_get_service):
         source_dataset = "source_dataset_{}".format(DATASET_ID)
         view_dataset = "view_dataset_{}".format(DATASET_ID)
         view = {"projectId": PROJECT_ID, "datasetId": view_dataset, "tableId": TABLE_ID}
@@ -703,9 +569,7 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method_get_execute.return_value = body
         method_patch = mock_get_service.return_value.datasets.return_value.patch
 
-        bq_hook = hook.BigQueryHook()
-
-        bq_hook.run_grant_dataset_view_access(
+        self.hook.run_grant_dataset_view_access(
             source_dataset=source_dataset,
             view_dataset=view_dataset,
             view_table=TABLE_ID
@@ -716,12 +580,8 @@ class TestBigQueryHookMethods(unittest.TestCase):
         assert method_get_execute.call_count == 1
         method_patch.assert_not_called()
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_dataset_tables_list(self, mock_get_service, mock_project_id):
+    def test_get_dataset_tables_list(self, mock_get_service):
         table_list = [
             {"projectId": PROJECT_ID, "datasetId": DATASET_ID, "tableId": "a-1"},
             {"projectId": PROJECT_ID, "datasetId": DATASET_ID, "tableId": "b-1"},
@@ -743,8 +603,7 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method_list_next = mock_get_service.return_value.tables.return_value.list_next
         method_list_next.side_effect = method_list_next_mocks
 
-        bq_hook = hook.BigQueryHook()
-        result = bq_hook.get_dataset_tables_list(dataset_id=DATASET_ID, project_id=PROJECT_ID)
+        result = self.hook.get_dataset_tables_list(dataset_id=DATASET_ID, project_id=PROJECT_ID)
 
         self.assertEqual(table_list, result)
 
@@ -777,7 +636,7 @@ class TestBigQueryHookMethods(unittest.TestCase):
         method_execute.side_effect = exception
 
         hook_params = {"location": location} if location else {}
-        bq_hook = hook.BigQueryHook(**hook_params)
+        bq_hook = BigQueryHook(**hook_params)
 
         result = bq_hook.poll_job_complete(JOB_ID)
         self.assertEqual(expected_result, result)
@@ -786,60 +645,45 @@ class TestBigQueryHookMethods(unittest.TestCase):
         assert method_get.call_count == 1
         assert method_execute.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_pull_job_complete_on_fails(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_pull_job_complete_on_fails(self, mock_get_service):
         method_jobs = mock_get_service.return_value.jobs
         method_get = method_jobs.return_value.get
         method_execute = method_get.return_value.execute
         resp = type('', (object,), {"status": 404, "reason": "Not Found"})()
         method_execute.side_effect = HttpError(resp=resp, content=b'Not Found')
 
-        bq_hook = hook.BigQueryHook()
         with self.assertRaisesRegex(HttpError, "HttpError 404 \"Not Found\""):
-            bq_hook.poll_job_complete(JOB_ID)
+            self.hook.poll_job_complete(JOB_ID)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete")
     @mock.patch("logging.Logger.info")
     def test_cancel_query_np_jobs_to_cancel(
-        self, mock_logger_info, poll_job_complete, mock_get_service, mock_get_creds_and_proj_id
+        self, mock_logger_info, poll_job_complete, mock_get_service,
     ):
         method_jobs = mock_get_service.return_value.jobs
         poll_job_complete.return_value = True
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.running_job_id = JOB_ID
-        bq_hook.cancel_query()
+        self.hook.running_job_id = JOB_ID
+        self.hook.cancel_query()
         assert method_jobs.call_count == 1
         assert poll_job_complete.call_count == 1
         mock_logger_info.has_call(mock.call("No running BigQuery jobs to cancel."))
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete")
     @mock.patch("time.sleep")
     @mock.patch("logging.Logger.info")
     def test_cancel_query_np_cancel_timeout(
-        self, mock_logger_info, mock_sleep, poll_job_complete, mock_get_service, mock_get_creds_and_proj_id
+        self, mock_logger_info, mock_sleep, poll_job_complete, mock_get_service,
     ):
         method_jobs = mock_get_service.return_value.jobs
         method_jobs_cancel = method_jobs.return_value.cancel
         poll_job_complete.side_effect = [False] * 13
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.running_job_id = JOB_ID
-        bq_hook.cancel_query()
+        self.hook.running_job_id = JOB_ID
+        self.hook.cancel_query()
         assert method_jobs.call_count == 1
         assert method_jobs_cancel.call_count == 1
         assert poll_job_complete.call_count == 13
@@ -849,73 +693,150 @@ class TestBigQueryHookMethods(unittest.TestCase):
                       "has not completed cancel and may or may not finish.".format(JOB_ID))
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete")
     @mock.patch("time.sleep")
     @mock.patch("logging.Logger.info")
     def test_cancel_query_np_cancel_completed(
-        self, mock_logger_info, mock_sleep, poll_job_complete, mock_get_service, mock_get_creds_and_proj_id
+        self, mock_logger_info, mock_sleep, poll_job_complete, mock_get_service,
     ):
         method_jobs = mock_get_service.return_value.jobs
         method_jobs_cancel = method_jobs.return_value.cancel
         poll_job_complete.side_effect = [False] * 12 + [True]
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.running_job_id = JOB_ID
-        bq_hook.cancel_query()
+        self.hook.running_job_id = JOB_ID
+        self.hook.cancel_query()
         assert method_jobs.call_count == 1
         assert method_jobs_cancel.call_count == 1
         assert poll_job_complete.call_count == 13
         assert mock_sleep.call_count == 11
         mock_logger_info.has_call(mock.call("Job successfully canceled: {}, {}".format(PROJECT_ID, JOB_ID)))
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_schema(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_get_schema(self, mock_get_service):
         schema = "SCHEMA"
         method_get = mock_get_service.return_value.tables.return_value.get
         method_execute = method_get.return_value.execute
         method_execute.return_value = {"schema": schema}
 
-        bq_hook = hook.BigQueryHook()
-        result = bq_hook.get_schema(dataset_id=DATASET_ID, table_id=TABLE_ID)
+        result = self.hook.get_schema(dataset_id=DATASET_ID, table_id=TABLE_ID)
 
         method_get.assert_called_once_with(projectId=PROJECT_ID, datasetId=DATASET_ID, tableId=TABLE_ID)
         assert method_execute.call_count == 1
         self.assertEqual(schema, result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_schema_other_project(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_get_schema_other_project(self, mock_get_service,):
         other_project = "another-project"
         schema = "SCHEMA"
         method_get = mock_get_service.return_value.tables.return_value.get
         method_execute = method_get.return_value.execute
         method_execute.return_value = {"schema": schema}
 
-        bq_hook = hook.BigQueryHook()
-        cursor = bq_hook.get_cursor()
+        cursor = self.hook.get_cursor()
         result = cursor.get_schema(dataset_id=DATASET_ID, table_id=TABLE_ID, project_id=other_project)
 
         method_get.assert_called_once_with(projectId=other_project, datasetId=DATASET_ID, tableId=TABLE_ID)
         assert method_execute.call_count == 1
         self.assertEqual(schema, result)
 
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
+    def test_invalid_source_format(self, mock_get_service):
+        with self.assertRaisesRegex(
+            Exception,
+            r"JSON is not a valid source format. Please use one of the following types: \['CSV', "
+            r"'NEWLINE_DELIMITED_JSON', 'AVRO', 'GOOGLE_SHEETS', 'DATASTORE_BACKUP', 'PARQUET'\]"
+        ):
+            self.hook.run_load(
+                "test.test", "test_schema.json", ["test_data.json"], source_format="json"
+            )
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
+    def test_external_table_invalid_source_format(self, mock_get_service):
+        with self.assertRaisesRegex(
+            Exception,
+            r"JSON is not a valid source format. Please use one of the following types: \['CSV', "
+            r"'NEWLINE_DELIMITED_JSON', 'AVRO', 'GOOGLE_SHEETS', 'DATASTORE_BACKUP', 'PARQUET'\]"
+        ):
+            self.hook.create_external_table(
+                external_project_dataset_table='test.test',
+                schema_fields='test_schema.json',
+                source_uris=['test_data.json'],
+                source_format='json'
+            )
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
+    def test_insert_all_succeed(self, mock_get_service):
+        rows = [
+            {"json": {"a_key": "a_value_0"}}
+        ]
+        body = {
+            "rows": rows,
+            "ignoreUnknownValues": False,
+            "kind": "bigquery#tableDataInsertAllRequest",
+            "skipInvalidRows": False,
+        }
+
+        mock_service = mock_get_service.return_value
+        method = mock_service.tabledata.return_value.insertAll
+        method.return_value.execute.return_value = {
+            "kind": "bigquery#tableDataInsertAllResponse"
+        }
+
+        self.hook.insert_all(PROJECT_ID, DATASET_ID, TABLE_ID, rows)
+        method.assert_called_once_with(
+            projectId=PROJECT_ID,
+            datasetId=DATASET_ID,
+            tableId=TABLE_ID,
+            body=body
+        )
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
+    def test_insert_all_fail(self, mock_get_service):
+        rows = [
+            {"json": {"a_key": "a_value_0"}}
+        ]
+
+        mock_service = mock_get_service.return_value
+        method = mock_service.tabledata.return_value.insertAll
+        method.return_value.execute.return_value = {
+            "kind": "bigquery#tableDataInsertAllResponse",
+            "insertErrors": [
+                {
+                    "index": 1,
+                    "errors": []
+                }
+            ]
+        }
+        with self.assertRaisesRegex(
+            Exception,
+            r"BigQuery job failed\. Error was: 1 insert error\(s\) occurred: "
+            r"bq-project:bq_dataset\.bq_table\. Details: \[{'index': 1, 'errors': \[\]}\]"
+        ):
+            self.hook.insert_all(PROJECT_ID, DATASET_ID, TABLE_ID, rows, fail_on_error=True)
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
+    def test_run_query_with_arg(self, mocked_rwc, mock_get_service):
+        def run_with_config(config):
+            self.assertEqual(
+                config['labels'], {'label1': 'test1', 'label2': 'test2'}
+            )
+        mocked_rwc.side_effect = run_with_config
+
+        self.hook.run_query(
+            sql='select 1',
+            destination_dataset_table='my_dataset.my_table',
+            labels={'label1': 'test1', 'label2': 'test2'}
+        )
+
+        assert mocked_rwc.call_count == 1
+
 
 class TestBigQueryTableSplitter(unittest.TestCase):
     def test_internal_need_default_project(self):
         with self.assertRaisesRegex(Exception, "INTERNAL: No default project is specified"):
-            hook._split_tablename("dataset.table", None)
+            _split_tablename("dataset.table", None)
 
     @parameterized.expand([
         ("project", "dataset", "table", "dataset.table"),
@@ -926,7 +847,7 @@ class TestBigQueryTableSplitter(unittest.TestCase):
     ])
     def test_split_tablename(self, project_expected, dataset_expected, table_expected, table_input):
         default_project_id = "project"
-        project, dataset, table = hook._split_tablename(table_input, default_project_id)
+        project, dataset, table = _split_tablename(table_input, default_project_id)
         self.assertEqual(project_expected, project)
         self.assertEqual(dataset_expected, dataset)
         self.assertEqual(table_expected, table)
@@ -954,117 +875,12 @@ class TestBigQueryTableSplitter(unittest.TestCase):
     def test_invalid_syntax(self, table_input, var_name, exception_message):
         default_project_id = "project"
         with self.assertRaisesRegex(Exception, exception_message.format(table_input)):
-            hook._split_tablename(table_input, default_project_id, var_name)
+            _split_tablename(table_input, default_project_id, var_name)
 
 
-class TestBigQueryHookSourceFormat(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
+class TestTableOperations(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_invalid_source_format(self, mock_get_service, mock_get_creds_and_proj_id):
-        with self.assertRaisesRegex(
-            Exception,
-            r"JSON is not a valid source format. Please use one of the following types: \['CSV', "
-            r"'NEWLINE_DELIMITED_JSON', 'AVRO', 'GOOGLE_SHEETS', 'DATASTORE_BACKUP', 'PARQUET'\]"
-        ):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.run_load(
-                "test.test", "test_schema.json", ["test_data.json"], source_format="json"
-            )
-
-
-class TestBigQueryExternalTableSourceFormat(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_invalid_source_format(self, mock_get_service, mock_get_creds_and_proj_id):
-        with self.assertRaisesRegex(
-            Exception,
-            r"JSON is not a valid source format. Please use one of the following types: \['CSV', "
-            r"'NEWLINE_DELIMITED_JSON', 'AVRO', 'GOOGLE_SHEETS', 'DATASTORE_BACKUP', 'PARQUET'\]"
-        ):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.create_external_table(
-                external_project_dataset_table='test.test',
-                schema_fields='test_schema.json',
-                source_uris=['test_data.json'],
-                source_format='json'
-            )
-
-
-class TestTableDataOperations(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_insert_all_succeed(self, mock_get_service, mock_get_creds_and_proj_id):
-        rows = [
-            {"json": {"a_key": "a_value_0"}}
-        ]
-        body = {
-            "rows": rows,
-            "ignoreUnknownValues": False,
-            "kind": "bigquery#tableDataInsertAllRequest",
-            "skipInvalidRows": False,
-        }
-
-        mock_service = mock_get_service.return_value
-        method = mock_service.tabledata.return_value.insertAll
-        method.return_value.execute.return_value = {
-            "kind": "bigquery#tableDataInsertAllResponse"
-        }
-
-        bq_hook = hook.BigQueryHook()
-        bq_hook.insert_all(PROJECT_ID, DATASET_ID, TABLE_ID, rows)
-        method.assert_called_once_with(
-            projectId=PROJECT_ID,
-            datasetId=DATASET_ID,
-            tableId=TABLE_ID,
-            body=body
-        )
-
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_insert_all_fail(self, mock_get_service, mock_get_creds_and_proj_id):
-        rows = [
-            {"json": {"a_key": "a_value_0"}}
-        ]
-
-        mock_service = mock_get_service.return_value
-        method = mock_service.tabledata.return_value.insertAll
-        method.return_value.execute.return_value = {
-            "kind": "bigquery#tableDataInsertAllResponse",
-            "insertErrors": [
-                {
-                    "index": 1,
-                    "errors": []
-                }
-            ]
-        }
-        bq_hook = hook.BigQueryHook()
-        with self.assertRaisesRegex(
-            Exception,
-            r"BigQuery job failed\. Error was: 1 insert error\(s\) occurred: "
-            r"bq-project:bq_dataset\.bq_table\. Details: \[{'index': 1, 'errors': \[\]}\]"
-        ):
-            bq_hook.insert_all(PROJECT_ID, DATASET_ID, TABLE_ID, rows, fail_on_error=True)
-
-
-class TestTableOperations(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_view_fails_on_exception(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_view_fails_on_exception(self, mock_get_service):
         view = {
             'incorrect_key': 'SELECT * FROM `test-project-id.test_dataset_id.test_table_prefix*`',
             "useLegacySql": False
@@ -1075,16 +891,11 @@ class TestTableOperations(unittest.TestCase):
         resp = type('', (object,), {"status": 500, "reason": "Query is required for views"})()
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Query is required for views')
-        bq_hook = hook.BigQueryHook()
         with self.assertRaisesRegex(Exception, "HttpError 500 \"Query is required for views\""):
-            bq_hook.create_empty_table(PROJECT_ID, DATASET_ID, TABLE_ID, view=view)
+            self.hook.create_empty_table(PROJECT_ID, DATASET_ID, TABLE_ID, view=view)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_view(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_view(self, mock_get_service):
         view = {
             'query': 'SELECT * FROM `test-project-id.test_dataset_id.test_table_prefix*`',
             "useLegacySql": False
@@ -1092,8 +903,7 @@ class TestTableOperations(unittest.TestCase):
 
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.insert
-        bq_hook = hook.BigQueryHook()
-        bq_hook.create_empty_table(PROJECT_ID, DATASET_ID, TABLE_ID, view=view)
+        self.hook.create_empty_table(PROJECT_ID, DATASET_ID, TABLE_ID, view=view)
         body = {
             'tableReference': {
                 'tableId': TABLE_ID
@@ -1102,12 +912,8 @@ class TestTableOperations(unittest.TestCase):
         }
         method.assert_called_once_with(projectId=PROJECT_ID, datasetId=DATASET_ID, body=body)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_patch_table(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_patch_table(self, mock_get_service):
         description_patched = 'Test description.'
         expiration_time_patched = 2524608000000
         friendly_name_patched = 'Test friendly name.'
@@ -1125,8 +931,7 @@ class TestTableOperations(unittest.TestCase):
 
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.patch
-        bq_hook = hook.BigQueryHook()
-        bq_hook.patch_table(
+        self.hook.patch_table(
             DATASET_ID, TABLE_ID, PROJECT_ID,
             description=description_patched,
             expiration_time=expiration_time_patched,
@@ -1154,27 +959,18 @@ class TestTableOperations(unittest.TestCase):
             body=body
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_patch_table_on_exception(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_patch_table_on_exception(self, mock_get_service):
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.patch
         resp = type('', (object,), {"status": 500, "reason": "Bad request"})()
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Bad request')
-        bq_hook = hook.BigQueryHook()
         with self.assertRaisesRegex(HttpError, "Bad request"):
-            bq_hook.patch_table(DATASET_ID, TABLE_ID)
+            self.hook.patch_table(DATASET_ID, TABLE_ID)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=("CREDENTIALS", "PROJECT_ID",)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_patch_view(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_patch_view(self, mock_get_service):
         view_patched = {
             'query': "SELECT * FROM `test-project-id.test_dataset_id.test_table_prefix*` LIMIT 500",
             'useLegacySql': False
@@ -1182,8 +978,7 @@ class TestTableOperations(unittest.TestCase):
 
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.patch
-        bq_hook = hook.BigQueryHook()
-        bq_hook.patch_table(DATASET_ID, VIEW_ID, PROJECT_ID, view=view_patched)
+        self.hook.patch_table(DATASET_ID, VIEW_ID, PROJECT_ID, view=view_patched)
 
         body = {
             'view': view_patched
@@ -1195,16 +990,11 @@ class TestTableOperations(unittest.TestCase):
             body=body
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_empty_table_succeed(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_empty_table_succeed(self, mock_get_service):
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.insert
-        bq_hook = hook.BigQueryHook()
-        bq_hook.create_empty_table(
+        self.hook.create_empty_table(
             project_id=PROJECT_ID,
             dataset_id=DATASET_ID,
             table_id=TABLE_ID)
@@ -1220,12 +1010,8 @@ class TestTableOperations(unittest.TestCase):
             body=body
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_empty_table_with_extras_succeed(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_empty_table_with_extras_succeed(self, mock_get_service):
         schema_fields = [
             {'name': 'id', 'type': 'STRING', 'mode': 'REQUIRED'},
             {'name': 'name', 'type': 'STRING', 'mode': 'NULLABLE'},
@@ -1236,9 +1022,8 @@ class TestTableOperations(unittest.TestCase):
 
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.insert
-        bq_hook = hook.BigQueryHook()
 
-        bq_hook.create_empty_table(
+        self.hook.create_empty_table(
             project_id=PROJECT_ID,
             dataset_id=DATASET_ID,
             table_id=TABLE_ID,
@@ -1265,27 +1050,18 @@ class TestTableOperations(unittest.TestCase):
             body=body
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_empty_table_on_exception(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_empty_table_on_exception(self, mock_get_service):
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.insert
         resp = type('', (object,), {"status": 500, "reason": "Bad request"})()
         method.return_value.execute.side_effect = HttpError(
             resp=resp, content=b'Bad request')
-        bq_hook = hook.BigQueryHook()
         with self.assertRaisesRegex(Exception, "Bad request"):
-            bq_hook.create_empty_table(PROJECT_ID, DATASET_ID, TABLE_ID)
+            self.hook.create_empty_table(PROJECT_ID, DATASET_ID, TABLE_ID)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_tables_list(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_get_tables_list(self, mock_get_service):
         expected_result = {
             "kind": "bigquery#tableList",
             "etag": "N/b12GSqMasEfwBOXofGQ==",
@@ -1319,19 +1095,14 @@ class TestTableOperations(unittest.TestCase):
         mock_service = mock_get_service.return_value
         mock_service.tables.return_value.list.return_value.execute.return_value = expected_result
 
-        bq_hook = hook.BigQueryHook()
-        result = bq_hook.get_dataset_tables(dataset_id=DATASET_ID)
+        result = self.hook.get_dataset_tables(dataset_id=DATASET_ID)
         mock_service.tables.return_value.list.assert_called_once_with(
             datasetId=DATASET_ID, projectId=PROJECT_ID
         )
         self.assertEqual(result, expected_result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_table_upsert_on_insert(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_table_upsert_on_insert(self, mock_get_service):
         table_resource = {
             "tableReference": {
                 "tableId": "test-table-id"
@@ -1340,8 +1111,7 @@ class TestTableOperations(unittest.TestCase):
         }
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.insert
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_table_upsert(
+        self.hook.run_table_upsert(
             dataset_id=DATASET_ID,
             table_resource=table_resource,
             project_id=PROJECT_ID
@@ -1353,12 +1123,8 @@ class TestTableOperations(unittest.TestCase):
             projectId=PROJECT_ID
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID),
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_table_upsert_on_update(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_table_upsert_on_update(self, mock_get_service):
         table_resource = {
             "tableReference": {
                 "tableId": "table1"
@@ -1400,8 +1166,7 @@ class TestTableOperations(unittest.TestCase):
         mock_service = mock_get_service.return_value
         mock_service.tables.return_value.list.return_value.execute.return_value = expected_tables_list
         method = mock_service.tables.return_value.update
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_table_upsert(
+        self.hook.run_table_upsert(
             dataset_id=DATASET_ID,
             table_resource=table_resource,
             project_id=PROJECT_ID
@@ -1415,17 +1180,11 @@ class TestTableOperations(unittest.TestCase):
         )
 
 
-class TestBigQueryCursor(unittest.TestCase):
-
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
+class TestBigQueryCursor(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_execute_with_parameters(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_execute_with_parameters(self, mocked_rwc, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         bq_cursor.execute("SELECT %(foo)s", {"foo": "bar"})
         assert mocked_rwc.call_count == 1
         assert mocked_rwc.has_calls(
@@ -1441,15 +1200,10 @@ class TestBigQueryCursor(unittest.TestCase):
             )
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_execute_many(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_execute_many(self, mocked_rwc, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         bq_cursor.executemany("SELECT %(foo)s", [{"foo": "bar"}, {"foo": "baz"}])
         assert mocked_rwc.call_count == 2
         assert mocked_rwc.has_calls(
@@ -1475,77 +1229,47 @@ class TestBigQueryCursor(unittest.TestCase):
             )
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_description(self, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_description(self, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         with self.assertRaises(NotImplementedError):
             bq_cursor.description
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_close(self, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_close(self, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         result = bq_cursor.close()  # pylint: disable=assignment-from-no-return
         self.assertIsNone(result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_rowcunt(self, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_rowcunt(self, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         result = bq_cursor.rowcount
         self.assertEqual(-1, result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryCursor.next")
-    def test_fetchone(self, mock_next, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_fetchone(self, mock_next, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         result = bq_cursor.fetchone()
         mock_next.call_count == 1
         self.assertEqual(mock_next.return_value, result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch(
         "airflow.providers.google.cloud.hooks.bigquery.BigQueryCursor.fetchone",
         side_effect=[1, 2, 3, None]
     )
-    def test_fetchall(self, mock_fetchone, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_fetchall(self, mock_fetchone, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         result = bq_cursor.fetchall()
         self.assertEqual([1, 2, 3], result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryCursor.fetchone")
-    def test_fetchmany(self, mock_fetchone, mock_get_service, mock_get_creds_and_proj_id):
+    def test_fetchmany(self, mock_fetchone, mock_get_service):
         side_effect_values = [1, 2, 3, None]
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+        bq_cursor = self.hook.get_cursor()
         mock_fetchone.side_effect = side_effect_values
         result = bq_cursor.fetchmany()
         self.assertEqual([1], result)
@@ -1558,26 +1282,16 @@ class TestBigQueryCursor(unittest.TestCase):
         result = bq_cursor.fetchmany(5)
         self.assertEqual([1, 2, 3], result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_next_no_jobid(self, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_next_no_jobid(self, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         bq_cursor.job_id = None
         result = bq_cursor.next()
         self.assertIsNone(result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_next_buffer(self, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_next_buffer(self, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         bq_cursor.job_id = JOB_ID
         bq_cursor.buffer = [1, 2]
         result = bq_cursor.next()
@@ -1588,12 +1302,8 @@ class TestBigQueryCursor(unittest.TestCase):
         result = bq_cursor.next()
         self.assertIsNone(result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_next(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_next(self, mock_get_service):
         mock_get_query_results = mock_get_service.return_value.jobs.return_value.getQueryResults
         mock_execute = mock_get_query_results.return_value.execute
         mock_execute.return_value = {
@@ -1610,8 +1320,7 @@ class TestBigQueryCursor(unittest.TestCase):
             }
         }
 
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+        bq_cursor = self.hook.get_cursor()
         bq_cursor.job_id = JOB_ID
         bq_cursor.location = LOCATION
 
@@ -1625,19 +1334,14 @@ class TestBigQueryCursor(unittest.TestCase):
                                                        projectId='bq-project')
         mock_execute.assert_called_once_with(num_retries=bq_cursor.num_retries)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryCursor.flush_results")
-    def test_next_no_rows(self, mock_flush_results, mock_get_service, mock_get_creds_and_proj_id):
+    def test_next_no_rows(self, mock_flush_results, mock_get_service):
         mock_get_query_results = mock_get_service.return_value.jobs.return_value.getQueryResults
         mock_execute = mock_get_query_results.return_value.execute
         mock_execute.return_value = {}
 
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+        bq_cursor = self.hook.get_cursor()
         bq_cursor.job_id = JOB_ID
 
         result = bq_cursor.next()
@@ -1648,27 +1352,17 @@ class TestBigQueryCursor(unittest.TestCase):
         mock_execute.assert_called_once_with(num_retries=bq_cursor.num_retries)
         assert mock_flush_results.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryCursor.flush_results")
-    def test_flush_cursor_in_execute(self, _, mocked_fr, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_flush_cursor_in_execute(self, _, mocked_fr, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         bq_cursor.execute("SELECT %(foo)s", {"foo": "bar"})
         assert mocked_fr.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_flush_cursor(self, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_flush_cursor(self, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         bq_cursor.page_token = '456dcea9-fcbf-4f02-b570-83f5297c685e'
         bq_cursor.job_id = 'c0a79ae4-0e72-4593-a0d0-7dbbf726f193'
         bq_cursor.all_pages_loaded = True
@@ -1679,14 +1373,9 @@ class TestBigQueryCursor(unittest.TestCase):
         self.assertFalse(bq_cursor.all_pages_loaded)
         self.assertListEqual(bq_cursor.buffer, [])
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_arraysize(self, mock_get_service, mock_get_creds_and_proj_id):
-        bq_hook = hook.BigQueryHook()
-        bq_cursor = bq_hook.get_cursor()
+    def test_arraysize(self, mock_get_service):
+        bq_cursor = self.hook.get_cursor()
         self.assertIsNone(bq_cursor.buffersize)
         self.assertEqual(bq_cursor.arraysize, 1)
         bq_cursor.set_arraysize(10)
@@ -1694,73 +1383,34 @@ class TestBigQueryCursor(unittest.TestCase):
         self.assertEqual(bq_cursor.arraysize, 10)
 
 
-class TestLabelsInRunJob(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
+class TestDatasetsOperations(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_query_with_arg(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
-        def run_with_config(config):
-            self.assertEqual(
-                config['labels'], {'label1': 'test1', 'label2': 'test2'}
-            )
-
-        mocked_rwc.side_effect = run_with_config
-
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query(
-            sql='select 1',
-            destination_dataset_table='my_dataset.my_table',
-            labels={'label1': 'test1', 'label2': 'test2'}
-        )
-
-        assert mocked_rwc.call_count == 1
-
-
-class TestDatasetsOperations(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_empty_dataset_no_dataset_id_err(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_empty_dataset_no_dataset_id_err(self, mock_get_service):
         with self.assertRaisesRegex(
             ValueError,
             r"dataset_id not provided and datasetId not exist in the "
             r"datasetReference\. Impossible to create dataset"
         ):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.create_empty_dataset(dataset_id="", project_id="")
+            self.hook.create_empty_dataset(dataset_id="", project_id="")
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_empty_dataset_duplicates_call_err(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_empty_dataset_duplicates_call_err(self, mock_get_service):
         with self.assertRaisesRegex(
             ValueError,
             r"Values of projectId param are duplicated\. dataset_reference contained projectId param in "
             r"`query` config and projectId was also provided with arg to run_query\(\) method\. "
             r"Please remove duplicates\."
         ):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.create_empty_dataset(
+            self.hook.create_empty_dataset(
                 dataset_id="", project_id="project_test",
                 dataset_reference={
                     "datasetReference":
                         {"datasetId": "test_dataset",
                          "projectId": "project_test2"}})
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_create_empty_dataset_with_location_duplicates_call_err(
-        self, mock_get_service, mock_get_creds_and_proj_id
+        self, mock_get_service
     ):
         with self.assertRaisesRegex(
             ValueError,
@@ -1768,8 +1418,7 @@ class TestDatasetsOperations(unittest.TestCase):
             r"`query` config and location was also provided with arg to run_query\(\) method\. "
             r"Please remove duplicates\."
         ):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.create_empty_dataset(
+            self.hook.create_empty_dataset(
                 dataset_id="", project_id="project_test", location="EU",
                 dataset_reference={
                     "location": "US",
@@ -1777,17 +1426,12 @@ class TestDatasetsOperations(unittest.TestCase):
                         {"datasetId": "test_dataset",
                          "projectId": "project_test"}})
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=("CREDENTIALS", "PROJECT_ID",)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_empty_dataset_with_location(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_empty_dataset_with_location(self, mock_get_service):
         location = 'EU'
 
         method = mock_get_service.return_value.datasets.return_value.insert
-        bq_hook = hook.BigQueryHook()
-        bq_hook.create_empty_dataset(project_id=PROJECT_ID, dataset_id=DATASET_ID, location=location)
+        self.hook.create_empty_dataset(project_id=PROJECT_ID, dataset_id=DATASET_ID, location=location)
 
         expected_body = {
             "location": "EU",
@@ -1799,21 +1443,16 @@ class TestDatasetsOperations(unittest.TestCase):
 
         method.assert_called_once_with(projectId=PROJECT_ID, body=expected_body)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_create_empty_dataset_with_location_duplicates_call_no_err(
-        self, mock_get_service, mock_get_creds_and_proj_id
+        self, mock_get_service
     ):
         location = 'EU'
         dataset_reference = {"location": "EU"}
 
         method = mock_get_service.return_value.datasets.return_value.insert
-        bq_hook = hook.BigQueryHook()
-        bq_hook.create_empty_dataset(project_id=PROJECT_ID, dataset_id=DATASET_ID, location=location,
-                                     dataset_reference=dataset_reference)
+        self.hook.create_empty_dataset(project_id=PROJECT_ID, dataset_id=DATASET_ID, location=location,
+                                       dataset_reference=dataset_reference)
 
         expected_body = {
             "location": "EU",
@@ -1825,25 +1464,16 @@ class TestDatasetsOperations(unittest.TestCase):
 
         method.assert_called_once_with(projectId=PROJECT_ID, body=expected_body)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=("CREDENTIALS", "PROJECT_ID",)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_dataset_without_dataset_id(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_get_dataset_without_dataset_id(self, mock_get_service):
         with self.assertRaisesRegex(
             ValueError,
             r"ataset_id argument must be provided and has a type 'str'\. You provided: "
         ):
-            bq_hook = hook.BigQueryHook()
-            bq_hook.get_dataset(dataset_id="", project_id="project_test")
+            self.hook.get_dataset(dataset_id="", project_id="project_test")
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_dataset(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_get_dataset(self, mock_get_service):
         expected_result = {
             "kind": "bigquery#dataset",
             "location": "US",
@@ -1857,17 +1487,12 @@ class TestDatasetsOperations(unittest.TestCase):
             expected_result
         )
 
-        bq_hook = hook.BigQueryHook()
-        result = bq_hook.get_dataset(dataset_id=DATASET_ID, project_id=PROJECT_ID)
+        result = self.hook.get_dataset(dataset_id=DATASET_ID, project_id=PROJECT_ID)
 
         self.assertEqual(result, expected_result)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_get_datasets_list(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_get_datasets_list(self, mock_get_service):
         expected_result = {'datasets': [
             {
                 "kind": "bigquery#dataset",
@@ -1892,33 +1517,23 @@ class TestDatasetsOperations(unittest.TestCase):
         mock_get_service.return_value.datasets.return_value.list.return_value.execute.return_value = (
             expected_result
         )
-        bq_hook = hook.BigQueryHook()
-        result = bq_hook.get_datasets_list(project_id=PROJECT_ID)
+        result = self.hook.get_datasets_list(project_id=PROJECT_ID)
 
         mock_get_service.return_value.datasets.return_value.list.assert_called_once_with(projectId=PROJECT_ID)
         self.assertEqual(result, expected_result['datasets'])
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_delete_dataset(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_delete_dataset(self, mock_get_service):
         delete_contents = True
 
         method = mock_get_service.return_value.datasets.return_value.delete
-        bq_hook = hook.BigQueryHook()
-        bq_hook.delete_dataset(PROJECT_ID, DATASET_ID, delete_contents)
+        self.hook.delete_dataset(PROJECT_ID, DATASET_ID, delete_contents)
 
         method.assert_called_once_with(projectId=PROJECT_ID, datasetId=DATASET_ID,
                                        deleteContents=delete_contents)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=("CREDENTIALS", "PROJECT_ID",)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_patch_dataset(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_patch_dataset(self, mock_get_service):
         dataset_resource = {
             "access": [
                 {
@@ -1929,8 +1544,7 @@ class TestDatasetsOperations(unittest.TestCase):
         }
 
         method = mock_get_service.return_value.datasets.return_value.patch
-        bq_hook = hook.BigQueryHook()
-        bq_hook.patch_dataset(
+        self.hook.patch_dataset(
             dataset_id=DATASET_ID,
             project_id=PROJECT_ID,
             dataset_resource=dataset_resource
@@ -1942,12 +1556,8 @@ class TestDatasetsOperations(unittest.TestCase):
             body=dataset_resource
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_update_dataset(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_update_dataset(self, mock_get_service):
         dataset_resource = {
             "kind": "bigquery#dataset",
             "location": "US",
@@ -1959,8 +1569,7 @@ class TestDatasetsOperations(unittest.TestCase):
         }
 
         method = mock_get_service.return_value.datasets.return_value.update
-        bq_hook = hook.BigQueryHook()
-        bq_hook.update_dataset(
+        self.hook.update_dataset(
             dataset_id=DATASET_ID,
             project_id=PROJECT_ID,
             dataset_resource=dataset_resource
@@ -1973,22 +1582,16 @@ class TestDatasetsOperations(unittest.TestCase):
         )
 
 
-class TestTimePartitioningInRunJob(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
+class TestTimePartitioningInRunJob(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_load_default(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_load_default(self, mocked_rwc, mock_get_service):
         def run_with_config(config):
             self.assertIsNone(config['load'].get('timePartitioning'))
 
         mocked_rwc.side_effect = run_with_config
 
-        bq_hook = hook.BigQueryHook()
-
-        bq_hook.run_load(
+        self.hook.run_load(
             destination_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
             source_uris=[],
@@ -1996,26 +1599,17 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
 
         assert mocked_rwc.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_with_auto_detect(self, run_with_config, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_with_auto_detect(self, run_with_config, mock_get_service):
         destination_project_dataset_table = "autodetect.table"
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_load(destination_project_dataset_table, [], [], autodetect=True)
+        self.hook.run_load(destination_project_dataset_table, [], [], autodetect=True)
         args, kwargs = run_with_config.call_args
         self.assertIs(args[0]['load']['autodetect'], True)
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_load_with_arg(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_load_with_arg(self, mocked_rwc, mock_get_service):
         def run_with_config(config):
             self.assertEqual(
                 config['load']['timePartitioning'],
@@ -2028,8 +1622,7 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
 
         mocked_rwc.side_effect = run_with_config
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_load(
+        self.hook.run_load(
             destination_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
             source_uris=[],
@@ -2038,30 +1631,21 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
 
         assert mocked_rwc.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_query_default(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_query_default(self, mocked_rwc, mock_get_service):
         def run_with_config(config):
             self.assertIsNone(config['query'].get('timePartitioning'))
 
         mocked_rwc.side_effect = run_with_config
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query(sql='select 1')
+        self.hook.run_query(sql='select 1')
 
         assert mocked_rwc.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_query_with_arg(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_query_with_arg(self, mocked_rwc, mock_get_service):
         def run_with_config(config):
             self.assertEqual(
                 config['query']['timePartitioning'],
@@ -2074,8 +1658,7 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
 
         mocked_rwc.side_effect = run_with_config
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query(
+        self.hook.run_query(
             sql='select 1',
             destination_dataset_table='my_dataset.my_table',
             time_partitioning={'type': 'DAY',
@@ -2105,22 +1688,16 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
         self.assertEqual(tp_out, expect)
 
 
-class TestClusteringInRunJob(unittest.TestCase):
-
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
+class TestClusteringInRunJob(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_load_default(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_load_default(self, mocked_rwc, mock_get_service):
         def run_with_config(config):
             self.assertIsNone(config['load'].get('clustering'))
 
         mocked_rwc.side_effect = run_with_config
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_load(
+        self.hook.run_load(
             destination_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
             source_uris=[],
@@ -2128,13 +1705,9 @@ class TestClusteringInRunJob(unittest.TestCase):
 
         assert mocked_rwc.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_load_with_arg(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_load_with_arg(self, mocked_rwc, mock_get_service):
         def run_with_config(config):
             self.assertEqual(
                 config['load']['clustering'],
@@ -2145,8 +1718,7 @@ class TestClusteringInRunJob(unittest.TestCase):
 
         mocked_rwc.side_effect = run_with_config
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_load(
+        self.hook.run_load(
             destination_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
             source_uris=[],
@@ -2156,30 +1728,21 @@ class TestClusteringInRunJob(unittest.TestCase):
 
         assert mocked_rwc.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_query_default(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_query_default(self, mocked_rwc, mock_get_service):
         def run_with_config(config):
             self.assertIsNone(config['query'].get('clustering'))
 
         mocked_rwc.side_effect = run_with_config
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query(sql='select 1')
+        self.hook.run_query(sql='select 1')
 
         assert mocked_rwc.call_count == 1
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_query_with_arg(self, mocked_rwc, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_query_with_arg(self, mocked_rwc, mock_get_service):
         def run_with_config(config):
             self.assertEqual(
                 config['query']['clustering'],
@@ -2190,9 +1753,7 @@ class TestClusteringInRunJob(unittest.TestCase):
 
         mocked_rwc.side_effect = run_with_config
 
-        bq_hook = hook.BigQueryHook()
-
-        bq_hook.run_query(
+        self.hook.run_query(
             sql='select 1',
             destination_dataset_table='my_dataset.my_table',
             cluster_fields=['field1', 'field2'],
@@ -2202,20 +1763,15 @@ class TestClusteringInRunJob(unittest.TestCase):
         self.assertEqual(mocked_rwc.call_count, 1, "run_with_configuration() was not called exactly once")
 
 
-class TestBigQueryHookLegacySql(unittest.TestCase):
+class TestBigQueryHookLegacySql(_BigQueryBaseTestClass):
     """Ensure `use_legacy_sql` param in `BigQueryHook` propagates properly."""
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
     def test_hook_uses_legacy_sql_by_default(
-        self, run_with_config, mock_get_service, mock_get_creds_and_proj_id
+        self, run_with_config, mock_get_service
     ):
-        bq_hook = hook.BigQueryHook()
-        bq_hook.get_first('query')
+        self.hook.get_first('query')
         args, kwargs = run_with_config.call_args
         self.assertIs(args[0]['query']['useLegacySql'], True)
 
@@ -2228,58 +1784,33 @@ class TestBigQueryHookLegacySql(unittest.TestCase):
     def test_legacy_sql_override_propagates_properly(
         self, run_with_config, mock_get_service, mock_get_creds_and_proj_id
     ):
-        bq_hook = hook.BigQueryHook(use_legacy_sql=False)
+        bq_hook = BigQueryHook(use_legacy_sql=False)
         bq_hook.get_first('query')
         args, kwargs = run_with_config.call_args
         self.assertIs(args[0]['query']['useLegacySql'], False)
 
 
-class TestBigQueryHookLocation(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
+class TestBigQueryHookRunWithConfiguration(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_location_propagates_properly(
-        self, run_with_config, mock_get_service, mock_get_creds_and_proj_id
-    ):
-        bq_hook = hook.BigQueryHook(location=None)
-        self.assertIsNone(bq_hook.location)
-        self.assertIsNone(bq_hook.location)
-        bq_hook.run_query(sql='select 1', location='US')
-        assert run_with_config.call_count == 1
-        self.assertEqual(bq_hook.location, 'US')
-
-
-class TestBigQueryHookRunWithConfiguration(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_run_with_configuration_location(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_with_configuration_location(self, mock_get_service):
         running_job_id = 'job_vjdi28vskdui2onru23'
         location = 'asia-east1'
 
         method = mock_get_service.return_value.jobs.return_value.get
-
         mock_get_service.return_value.jobs.return_value.insert.return_value.execute.return_value = {
             'jobReference': {
                 'jobId': running_job_id,
                 'location': location
             }
         }
-
         mock_get_service.return_value.jobs.return_value.get.return_value.execute.return_value = {
             'status': {
                 'state': 'DONE'
             }
         }
 
-        bq_hook = hook.BigQueryHook()
-        bq_hook.running_job_id = running_job_id
-        bq_hook.run_with_configuration({})
+        self.hook.running_job_id = running_job_id
+        self.hook.run_with_configuration({})
 
         method.assert_called_once_with(
             projectId=PROJECT_ID,
@@ -2288,13 +1819,9 @@ class TestBigQueryHookRunWithConfiguration(unittest.TestCase):
         )
 
 
-class TestBigQueryWithKMS(unittest.TestCase):
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
+class TestBigQueryWithKMS(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_empty_table_with_kms(self, mock_get_service, mock_get_creds_and_proj_id):
+    def test_create_empty_table_with_kms(self, mock_get_service):
         schema_fields = [
             {"name": "id", "type": "STRING", "mode": "REQUIRED"}
         ]
@@ -2304,9 +1831,8 @@ class TestBigQueryWithKMS(unittest.TestCase):
 
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.insert
-        bq_hook = hook.BigQueryHook()
 
-        bq_hook.create_empty_table(
+        self.hook.create_empty_table(
             project_id=PROJECT_ID,
             dataset_id=DATASET_ID,
             table_id=TABLE_ID,
@@ -2324,12 +1850,8 @@ class TestBigQueryWithKMS(unittest.TestCase):
         )
 
     # pylint: disable=too-many-locals
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook.project_id',
-        new_callable=mock.PropertyMock,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_create_external_table_with_kms(self, mock_get_service, mock_project_id):
+    def test_create_external_table_with_kms(self, mock_get_service):
         external_project_dataset_table = "{}.{}.{}".format(
             PROJECT_ID, DATASET_ID, TABLE_ID
         )
@@ -2355,9 +1877,8 @@ class TestBigQueryWithKMS(unittest.TestCase):
 
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.insert
-        bq_hook = hook.BigQueryHook()
 
-        bq_hook.create_external_table(
+        self.hook.create_external_table(
             external_project_dataset_table=external_project_dataset_table,
             source_uris=source_uris,
             source_format=source_format,
@@ -2406,21 +1927,16 @@ class TestBigQueryWithKMS(unittest.TestCase):
             projectId=PROJECT_ID, datasetId=DATASET_ID, body=body
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook.project_id',
-        new_callable=mock.PropertyMock,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
-    def test_patch_table_with_kms(self, mock_get_service, mock_project_id):
+    def test_patch_table_with_kms(self, mock_get_service):
         encryption_configuration = {
             "kms_key_name": "projects/p/locations/l/keyRings/k/cryptoKeys/c"
         }
 
         mock_service = mock_get_service.return_value
         method = mock_service.tables.return_value.patch
-        bq_hook = hook.BigQueryHook()
 
-        bq_hook.patch_table(
+        self.hook.patch_table(
             dataset_id=DATASET_ID,
             table_id=TABLE_ID,
             project_id=PROJECT_ID,
@@ -2438,18 +1954,13 @@ class TestBigQueryWithKMS(unittest.TestCase):
             body=body
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID)
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_query_with_kms(self, run_with_config, mock_get_service, mock_get_creds_and_proj_id):
+    def test_run_query_with_kms(self, run_with_config, mock_get_service):
         encryption_configuration = {
             "kms_key_name": "projects/p/locations/l/keyRings/k/cryptoKeys/c"
         }
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_query(
+        self.hook.run_query(
             sql='query',
             encryption_configuration=encryption_configuration
         )
@@ -2459,19 +1970,13 @@ class TestBigQueryWithKMS(unittest.TestCase):
             encryption_configuration
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook.project_id',
-        new_callable=mock.PropertyMock,
-        return_value=PROJECT_ID
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_copy_with_kms(self, run_with_config, mock_get_service, mock_project_id):
+    def test_run_copy_with_kms(self, run_with_config, mock_get_service):
         encryption_configuration = {
             "kms_key_name": "projects/p/locations/l/keyRings/k/cryptoKeys/c"
         }
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_copy(
+        self.hook.run_copy(
             source_project_dataset_tables='p.d.st',
             destination_project_dataset_table='p.d.dt',
             encryption_configuration=encryption_configuration
@@ -2482,19 +1987,13 @@ class TestBigQueryWithKMS(unittest.TestCase):
             encryption_configuration
         )
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook.project_id',
-        new_callable=mock.PropertyMock,
-        return_value=PROJECT_ID
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration")
-    def test_run_load_with_kms(self, run_with_config, mock_get_service, mock_project_id):
+    def test_run_load_with_kms(self, run_with_config, mock_get_service):
         encryption_configuration = {
             "kms_key_name": "projects/p/locations/l/keyRings/k/cryptoKeys/c"
         }
-        bq_hook = hook.BigQueryHook()
-        bq_hook.run_load(
+        self.hook.run_load(
             destination_project_dataset_table='p.d.dt',
             source_uris=['abc.csv'],
             autodetect=True,
@@ -2542,7 +2041,7 @@ class TestBigQueryBaseCursorMethodsDeprecationWarning(unittest.TestCase):
         messege_regex = re.compile(message_pattern, re.MULTILINE)
 
         mocked_func = getattr(mock_bq_hook, func_name)
-        bq_cursor = hook.BigQueryCursor(mock.MagicMock(), PROJECT_ID, mock_bq_hook)
+        bq_cursor = BigQueryCursor(mock.MagicMock(), PROJECT_ID, mock_bq_hook)
         func = getattr(bq_cursor, func_name)
 
         with self.assertWarnsRegex(DeprecationWarning, messege_regex):
@@ -2551,7 +2050,3 @@ class TestBigQueryBaseCursorMethodsDeprecationWarning(unittest.TestCase):
         mocked_func.assert_called_once_with(*args, **kwargs)
         self.assertEqual(mocked_func.return_value, result)
         self.assertRegex(func.__doc__, ".*{}.*".format(new_path))
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
This PR removes a lot of replicated code:
```python
    @mock.patch(
        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
        return_value=(CREDENTIALS, PROJECT_ID)
    )
```
It also removes some unnecessary tests class while moving their tests to other classes. 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
