### PR TITLE
Fix case when the pidfile is empty during the pidfile check

### DIFF
--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -270,6 +270,8 @@ def check_if_pidfile_process_is_running(pid_file: str, process_name: str):
     if pid_lock_file.is_locked():
         # Read the pid
         pid = pid_lock_file.read_pid()
+        if pid is None:
+            return
         try:
             # Check if process is still running
             proc = psutil.Process(pid)


### PR DESCRIPTION
Bug was introduced with commit that has not been cherry-picked to 1.10: 77bc480

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
