### PR TITLE
User-friendly error messages when the configuration is incorrect

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -62,6 +62,12 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Unify `hostname_callable` option in `core` section
+
+The previous option used a colon(`:`) to split the module from function. Now the dot(`.`) is used.
+
+The change aims to unify the format of all options that refer to objects in the `airflow.cfg` file.
+
 ### Changes in BigQueryHook
 - `create_empty_table` method accepts now `table_resource` parameter. If provided all
 other parameters are ignored.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -31,17 +31,17 @@
     - name: hostname_callable
       description: |
         Hostname by providing a path to a callable, which will resolve the hostname.
-        The format is "package:function".
+        The format is "package.function".
 
-        For example, default value "socket:getfqdn" means that result from getfqdn() of "socket"
+        For example, default value "socket.getfqdn" means that result from getfqdn() of "socket"
         package will be used as hostname.
 
         No argument should be required in the function specified.
-        If using IP address as hostname is preferred, use value ``airflow.utils.net:get_host_ip_address``
+        If using IP address as hostname is preferred, use value ``airflow.utils.net.get_host_ip_address``
       version_added: ~
       type: string
       example: ~
-      default: "socket:getfqdn"
+      default: "socket.getfqdn"
     - name: default_timezone
       description: |
         Default timezone in case supplied date times are naive

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -34,14 +34,14 @@
 dags_folder = {AIRFLOW_HOME}/dags
 
 # Hostname by providing a path to a callable, which will resolve the hostname.
-# The format is "package:function".
+# The format is "package.function".
 #
-# For example, default value "socket:getfqdn" means that result from getfqdn() of "socket"
+# For example, default value "socket.getfqdn" means that result from getfqdn() of "socket"
 # package will be used as hostname.
 #
 # No argument should be required in the function specified.
-# If using IP address as hostname is preferred, use value ``airflow.utils.net:get_host_ip_address``
-hostname_callable = socket:getfqdn
+# If using IP address as hostname is preferred, use value ``airflow.utils.net.get_host_ip_address``
+hostname_callable = socket.getfqdn
 
 # Default timezone in case supplied date times are naive
 # can be utc (default), system, or any IANA timezone string (e.g. Europe/Amsterdam)

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -42,7 +42,7 @@ dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
 enable_xcom_pickling = False
 killed_task_cleanup_time = 5
-hostname_callable = socket:getfqdn
+hostname_callable = socket.getfqdn
 worker_precheck = False
 default_task_retries = 0
 

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -38,7 +38,6 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor, CommandType
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKeyType, TaskInstanceStateType
-from airflow.utils.module_loading import import_string
 from airflow.utils.timeout import timeout
 
 log = logging.getLogger(__name__)
@@ -56,9 +55,7 @@ airflow celery worker
 '''
 
 if conf.has_option('celery', 'celery_config_options'):
-    celery_configuration = import_string(
-        conf.get('celery', 'celery_config_options')
-    )
+    celery_configuration = conf.getimport('celery', 'celery_config_options')
 else:
     celery_configuration = DEFAULT_CELERY_CONFIG
 

--- a/airflow/secrets/__init__.py
+++ b/airflow/secrets/__init__.py
@@ -76,18 +76,17 @@ def initialize_secrets_backends() -> List[BaseSecretsBackend]:
     * import secrets backend classes
     * instantiate them and return them in a list
     """
-    alternative_secrets_backend = conf.get(section=CONFIG_SECTION, key='backend', fallback='')
-    try:
-        alternative_secrets_config_dict = json.loads(
-            conf.get(section=CONFIG_SECTION, key='backend_kwargs', fallback='{}')
-        )
-    except JSONDecodeError:
-        alternative_secrets_config_dict = {}
-
+    secrets_backend_cls = conf.getimport(section=CONFIG_SECTION, key='backend')
     backend_list = []
 
-    if alternative_secrets_backend:
-        secrets_backend_cls = import_string(alternative_secrets_backend)
+    if secrets_backend_cls:
+        try:
+            alternative_secrets_config_dict = json.loads(
+                conf.get(section=CONFIG_SECTION, key='backend_kwargs', fallback='{}')
+            )
+        except JSONDecodeError:
+            alternative_secrets_config_dict = {}
+
         backend_list.append(secrets_backend_cls(**alternative_secrets_config_dict))
 
     for class_name in DEFAULT_SECRETS_SEARCH_PATH:

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -34,7 +34,6 @@ from sqlalchemy.pool import NullPool
 from airflow import api
 from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # NOQA F401
 from airflow.logging_config import configure_logging
-from airflow.utils.module_loading import import_string
 from airflow.utils.sqlalchemy import setup_event_handlers
 
 log = logging.getLogger(__name__)
@@ -186,9 +185,7 @@ def configure_orm(disable_connection_pool=False):
     engine_args['encoding'] = conf.get('core', 'SQL_ENGINE_ENCODING', fallback='utf-8')
 
     if conf.has_option('core', 'sql_alchemy_connect_args'):
-        connect_args = import_string(
-            conf.get('core', 'sql_alchemy_connect_args')
-        )
+        connect_args = conf.getimport('core', 'sql_alchemy_connect_args')
     else:
         connect_args = {}
 

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -17,7 +17,6 @@
 # under the License.
 
 import collections
-import importlib
 import logging
 import os
 import smtplib
@@ -39,9 +38,7 @@ def send_email(to, subject, html_content,
     """
     Send email using backend specified in EMAIL_BACKEND.
     """
-    path, attr = conf.get('email', 'EMAIL_BACKEND').rsplit('.', 1)
-    module = importlib.import_module(path)
-    backend = getattr(module, attr)
+    backend = conf.getimport('email', 'EMAIL_BACKEND')
     to = get_email_address_list(to)
     to = ", ".join(to)
 

--- a/airflow/utils/net.py
+++ b/airflow/utils/net.py
@@ -16,10 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import importlib
 import socket
 
-from airflow.configuration import AirflowConfigException, conf
+from airflow.configuration import conf
 
 
 def get_host_ip_address():
@@ -34,19 +33,4 @@ def get_hostname():
     Fetch the hostname using the callable from the config or using
     `socket.getfqdn` as a fallback.
     """
-    # First we attempt to fetch the callable path from the config.
-    try:
-        callable_path = conf.get('core', 'hostname_callable')
-    except AirflowConfigException:
-        callable_path = None
-
-    # Then we handle the case when the config is missing or empty. This is the
-    # default behavior.
-    if not callable_path:
-        return socket.getfqdn()
-
-    # Since we have a callable path, we try to import and run it next.
-    module_path, attr_name = callable_path.split(':')
-    module = importlib.import_module(module_path)
-    func = getattr(module, attr_name)
-    return func()
+    return conf.getimport('core', 'hostname_callable', fallback='socket.getfqdn')()

--- a/tests/test_sqlalchemy_config.py
+++ b/tests/test_sqlalchemy_config.py
@@ -22,6 +22,7 @@ from mock import patch
 from sqlalchemy.pool import NullPool
 
 from airflow import settings
+from airflow.exceptions import AirflowConfigException
 from tests.test_utils.config import conf_vars
 
 SQL_ALCHEMY_CONNECT_ARGS = {
@@ -100,6 +101,6 @@ class TestSqlAlchemySettings(unittest.TestCase):
             ('core', 'sql_alchemy_connect_args'): 'does.not.exist',
             ('core', 'sql_alchemy_pool_enabled'): 'False'
         }
-        with self.assertRaises(ImportError):
+        with self.assertRaises(AirflowConfigException):
             with conf_vars(config):
                 settings.configure_orm()


### PR DESCRIPTION
When we import objects specified in the configuration file, the operation may fail. We should say which configuration option the user should check.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
