### PR TITLE
Add operator to list subfolders from s3 bucket

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3_list_prefixes.py
+++ b/airflow/providers/amazon/aws/operators/s3_list_prefixes.py
@@ -1,0 +1,97 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Iterable
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.utils.decorators import apply_defaults
+
+
+class S3ListPrefixesOperator(BaseOperator):
+    """
+    List all objects from the bucket with the given string prefix in name.
+
+    This operator returns a python list with the name of objects which can be
+    used by `xcom` in the downstream task.
+
+    :param bucket: The S3 bucket where to find the objects. (templated)
+    :type bucket: str
+    :param prefix: Prefix string to filters the objects whose name begin with
+        such prefix. (templated)
+    :type prefix: str
+    :param delimiter: the delimiter marks key hierarchy. (templated)
+    :type delimiter: str
+    :param aws_conn_id: The connection ID to use when connecting to S3 storage.
+    :type aws_conn_id: str
+    :param verify: Whether or not to verify SSL certificates for S3 connection.
+        By default SSL certificates are verified.
+        You can provide the following values:
+
+        - ``False``: do not validate SSL certificates. SSL will still be used
+                 (unless use_ssl is False), but SSL certificates will not be
+                 verified.
+        - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
+                 You can specify this argument if you want to use a different
+                 CA cert bundle than the one used by botocore.
+    :type verify: bool or str
+
+
+    **Example**:
+        The following operator would list all the subfolders
+        from the S3 ``customers/2018/04/`` key in the ``data`` bucket. ::
+
+            s3_file = S3ListPrefixesOperator(
+                task_id='list_3s_subfolders',
+                bucket='data',
+                prefix='customers/2018/04/',
+                delimiter='/',
+                aws_conn_id='aws_customers_conn'
+            )
+    """
+    template_fields = ('bucket', 'prefix', 'delimiter')  # type: Iterable[str]
+    ui_color = '#ffd700'
+
+    @apply_defaults
+    def __init__(self,
+                 bucket,
+                 prefix='',
+                 delimiter='',
+                 aws_conn_id='aws_default',
+                 verify=None,
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bucket = bucket
+        self.prefix = prefix
+        self.delimiter = delimiter
+        self.aws_conn_id = aws_conn_id
+        self.verify = verify
+
+    def execute(self, context):
+        hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
+
+        self.log.info(
+            'Getting the list of files from bucket: %s in prefix: %s (Delimiter {%s)',
+            self.bucket, self.prefix, self.delimiter
+        )
+
+        return hook.list_prefixes(
+            bucket_name=self.bucket,
+            prefix=self.prefix,
+            delimiter=self.delimiter)

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -429,11 +429,12 @@ These integrations allow you to perform various operations within the Amazon Web
 
    * - `Amazon Simple Storage Service (S3) <https://aws.amazon.com/s3/>`__
      -
-     - :mod:`airflow.providers.amazon.aws.hooks.s3`
+     - :mod:`airflow.providers.amazon.aws.hooks.s3`,
      - :mod:`airflow.providers.amazon.aws.operators.s3_file_transform`,
        :mod:`airflow.providers.amazon.aws.operators.s3_copy_object`,
        :mod:`airflow.providers.amazon.aws.operators.s3_delete_objects`,
-       :mod:`airflow.providers.amazon.aws.operators.s3_list`
+       :mod:`airflow.providers.amazon.aws.operators.s3_list`,
+       :mod:`airflow.providers.amazon.aws.operators.s3_list_prefixes`,
      - :mod:`airflow.providers.amazon.aws.sensors.s3_key`,
        :mod:`airflow.providers.amazon.aws.sensors.s3_prefix`
 

--- a/tests/providers/amazon/aws/operators/test_s3_prefixes.py
+++ b/tests/providers/amazon/aws/operators/test_s3_prefixes.py
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import mock
+
+from airflow.providers.amazon.aws.operators.s3_list_prefixes import S3ListPrefixesOperator
+
+TASK_ID = 'test-s3-list-operator'
+BUCKET = 'test-bucket'
+DELIMITER = '/'
+PREFIX = 'TEST'
+MOCK_SUBFOLDERS = ["foo/bar.parquet", "bar/", "baz/file.csv"]
+
+
+class TestS3ListOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.amazon.aws.operators.s3_list.S3Hook')
+    def test_execute(self, mock_hook):
+
+        mock_hook.return_value.list_keys.return_value = MOCK_SUBFOLDERS
+
+        operator = S3ListPrefixesOperator(
+            task_id=TASK_ID, bucket=BUCKET, prefix=PREFIX, delimiter=DELIMITER)
+
+        files = operator.execute(None)
+
+        mock_hook.return_value.list_keys.assert_called_once_with(
+            bucket_name=BUCKET, prefix=PREFIX, delimiter=DELIMITER)
+        self.assertEqual(sorted(files), sorted(MOCK_SUBFOLDERS))

--- a/tests/providers/amazon/aws/operators/test_s3_prefixes.py
+++ b/tests/providers/amazon/aws/operators/test_s3_prefixes.py
@@ -25,9 +25,9 @@ from airflow.providers.amazon.aws.operators.s3_list_prefixes import S3ListPrefix
 TASK_ID = 'test-s3-list-operator'
 BUCKET = 'test-bucket'
 DELIMITER = '/'
-PREFIX = 'TEST'
-MOCK_SUBFOLDERS = ["foo/bar.parquet", "bar/", "baz/file.csv"]
-
+PREFIX = 'TEST/'
+# assuming these bucket contents: "year=foo/bar.parquet", "bar/", "baz/file.csv"
+MOCK_SUBFOLDERS = ["bar", "baz", "year=foo]
 
 class TestS3ListOperator(unittest.TestCase):
     @mock.patch('airflow.providers.amazon.aws.operators.s3_list.S3Hook')


### PR DESCRIPTION
Create S3 List Prefixes Operator

- New operator to return list of subfolders in a s3 bucket

Issue Link: https://github.com/apache/airflow/issues/8448

---
Make sure to mark the boxes below before creating PR: [x]

- [ x] Description above provides context of the change
- [ x] Unit tests coverage for changes (not needed for documentation changes)
- [x ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x ] Relevant documentation is updated including usage instructions.
- [x ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
