### PR TITLE
[AIRFLOW-5262] Update timeout exception to include dag

### DIFF
--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -106,6 +106,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
     def execute(self, context: Dict) -> Any:
         started_at = timezone.utcnow()
         try_number = 1
+        log_dag_id = self.dag.dag_id if self.has_dag() else ""
         if self.reschedule:
             # If reschedule, use first start date of current try
             task_reschedules = TaskReschedule.find_for_task_instance(context['ti'])
@@ -120,10 +121,10 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 if self.soft_fail and not context['ti'].is_eligible_to_retry():
                     self._do_skip_downstream_tasks(context)
                     raise AirflowSkipException(
-                        "Snap. Time is OUT. {d}".format(d=self.dag.dag_id if self.has_dag() else ""))
+                        f"Snap. Time is OUT. DAG id: {log_dag_id}")
                 else:
                     raise AirflowSensorTimeout(
-                        "Snap. Time is OUT. {d}".format(d=self.dag.dag_id if self.has_dag() else ""))
+                        f"Snap. Time is OUT. DAG id: {log_dag_id}")
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
                     seconds=self._get_next_poke_interval(started_at, try_number))

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -119,9 +119,11 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 # This gives the ability to set up non-blocking AND soft-fail sensors.
                 if self.soft_fail and not context['ti'].is_eligible_to_retry():
                     self._do_skip_downstream_tasks(context)
-                    raise AirflowSkipException('Snap. Time is OUT.')
+                    raise AirflowSkipException(
+                        "Snap. Time is OUT. {d}".format(d=self.dag.dag_id if self.has_dag() else ""))
                 else:
-                    raise AirflowSensorTimeout('Snap. Time is OUT.')
+                    raise AirflowSensorTimeout(
+                        "Snap. Time is OUT. {d}".format(d=self.dag.dag_id if self.has_dag() else ""))
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
                     seconds=self._get_next_poke_interval(started_at, try_number))


### PR DESCRIPTION
### Jira
- My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5262) 

### Description

- This change will help expedite log investigation in third party logging services, making the dag's name visible in the top-level exception message. 
- I retained the conditional logic because of this [build error](https://github.com/apache/airflow/pull/5919#issuecomment-555877417) caught during `tests.sensors.test_hdfs_sensor.TestHdfsSensor`, displaying that a DAG had not been assigned yet. While tasks won't begin without a DAG, they can exist in some scenarios without an assigned DAG. 

### Tests

- My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: does not need testing

### Code Quality

- [x] Passes `flake8`

Continuation of this old, closed PR: https://github.com/apache/airflow/pull/5919
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
