### PR TITLE
[AIRFLOW-8472]: `PATCH` for Databricks hook `_do_api_call`

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -165,6 +165,8 @@ class DatabricksHook(BaseHook):
             request_func = requests.get
         elif method == 'POST':
             request_func = requests.post
+        elif method == 'PATCH':
+            request_func = requests.patch
         else:
             raise AirflowException('Unexpected HTTP Method: ' + method)
 

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -251,6 +251,24 @@ class TestDatabricksHook(unittest.TestCase):
                     mock_sleep.assert_has_calls(calls)
 
     @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_do_api_call_patch(self, mock_requests):
+        mock_requests.patch.return_value.json.return_value = {'cluster_name': 'new_name'}
+        data = {
+            'cluster_name': 'new_name'
+        }
+        patched_cluster_name = self.hook._do_api_call(('PATCH', 'api/2.0/jobs/runs/submit'), data)
+
+        self.assertEqual(patched_cluster_name['cluster_name'], 'new_name')
+        mock_requests.patch.assert_called_once_with(
+            submit_run_endpoint(HOST),
+            json={
+                'cluster_name': 'new_name'
+            },
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
     def test_submit_run(self, mock_requests):
         mock_requests.post.return_value.json.return_value = {'run_id': '1'}
         data = {


### PR DESCRIPTION
Support of `PATCH` for Databricks hook `_do_api_call` function

