### PR TITLE
[AIRFLOW-8474]: Adding possibility to get job_id from Databricks run

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -236,6 +236,18 @@ class DatabricksHook(BaseHook):
         response = self._do_api_call(GET_RUN_ENDPOINT, json)
         return response['run_page_url']
 
+    def get_job_id_from_run(self, run_id: str) -> str:
+        """
+        Retrieves job_id from run_id.
+
+        :param run_id: id of the run
+        :type run_id: str
+        :return: Job id for given Databricks run
+        """
+        json = {'run_id': run_id}
+        response = self._do_api_call(GET_RUN_ENDPOINT, json)
+        return response['job_id']
+
     def get_run_state(self, run_id: str) -> RunState:
         """
         Retrieves run state of the run.

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -236,7 +236,7 @@ class DatabricksHook(BaseHook):
         response = self._do_api_call(GET_RUN_ENDPOINT, json)
         return response['run_page_url']
 
-    def get_job_id_from_run(self, run_id: str) -> str:
+    def get_job_id(self, run_id: str) -> str:
         """
         Retrieves job_id from run_id.
 

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -312,10 +312,10 @@ class TestDatabricksHook(unittest.TestCase):
             timeout=self.hook.timeout_seconds)
 
     @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
-    def test_get_job_id_from_run(self, mock_requests):
+    def test_get_job_id(self, mock_requests):
         mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
 
-        job_id = self.hook.get_job_id_from_run(RUN_ID)
+        job_id = self.hook.get_job_id(RUN_ID)
 
         self.assertEqual(job_id, JOB_ID)
         mock_requests.get.assert_called_once_with(

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -53,6 +53,7 @@ RUN_PAGE_URL = 'https://XX.cloud.databricks.com/#jobs/1/runs/1'
 LIFE_CYCLE_STATE = 'PENDING'
 STATE_MESSAGE = 'Waiting for cluster'
 GET_RUN_RESPONSE = {
+    'job_id': JOB_ID,
     'run_page_url': RUN_PAGE_URL,
     'state': {
         'life_cycle_state': LIFE_CYCLE_STATE,
@@ -303,6 +304,20 @@ class TestDatabricksHook(unittest.TestCase):
         run_page_url = self.hook.get_run_page_url(RUN_ID)
 
         self.assertEqual(run_page_url, RUN_PAGE_URL)
+        mock_requests.get.assert_called_once_with(
+            get_run_endpoint(HOST),
+            json={'run_id': RUN_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_get_job_id_from_run(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+
+        job_id = self.hook.get_job_id_from_run(RUN_ID)
+
+        self.assertEqual(job_id, JOB_ID)
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
             json={'run_id': RUN_ID},


### PR DESCRIPTION
Basically adding function to get job_id from `api/2.0/jobs/runs/get` Databricks API