### PR TITLE
Remove duplicate error message on chart connection failure

### DIFF
--- a/airflow/www/templates/airflow/nvd3.html
+++ b/airflow/www/templates/airflow/nvd3.html
@@ -142,7 +142,7 @@ body {
     <script src="{{ url_for('static', filename='nv.d3.js') }}"></script>
     <script>
     function error(msg){
-      $('#error_msg').html(msg);
+      $('#error_msg').text(msg);
       $('#error').show();
       $('#loading').hide();
       $('#chart_section').hide(1000);
@@ -160,9 +160,6 @@ body {
       url = "{{ url_for('airflow.chart_data') }}" + location.search;
       $.getJSON(url, function(payload) {
         $('#loading').hide();
-        if (payload.error !== undefined) {
-          $('#chart_body').html('<div class="alert alert-danger">' + payload.error + '</div>');
-        }
         $("#sql_panel_body").html(payload.sql_html);
         $("#label").text(payload.label);
         if (payload.state == "SUCCESS") {


### PR DESCRIPTION
This caused the error message to be shown twice - once in the chart body
(which is faded out) and again at the "top-level" error


- [x] Description above provides context of the change
- [x] Commit message contains [\[AIRFLOW-XXXX\]](https://issues.apache.org/jira/browse/AIRFLOW-XXXX) or `[AIRFLOW-XXXX]` for document-only changes
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.