### PR TITLE
Pre-commit checks in Github Actions have colour and are simpler

### DIFF
--- a/scripts/ci/ci_run_all_static_checks.sh
+++ b/scripts/ci/ci_run_all_static_checks.sh
@@ -31,4 +31,4 @@ prepare_ci_build
 
 rebuild_ci_image_if_needed
 
-pre-commit run --all-files --show-diff-on-failure --verbose
+pre-commit run --all-files --show-diff-on-failure --color always

--- a/scripts/ci/ci_run_static_checks_pylint_tests.sh
+++ b/scripts/ci/ci_run_static_checks_pylint_tests.sh
@@ -31,4 +31,4 @@ prepare_ci_build
 
 rebuild_ci_image_if_needed
 
-pre-commit run pylint-tests --all-files --show-diff-on-failure --verbose
+pre-commit run pylint-tests --all-files --show-diff-on-failure --color always


### PR DESCRIPTION
We have now back color in pre-commit checks and we disabled verbose
flag. The main reason for verbose flag was to show execution time
of each commit, but this is not needed in Github Actions as we
have the "Show Timestamp" option in job log which gives
us all that we need. Also the id of failing pre-commit check
is displayed whenever it fails so we do not need --verbose flag
any more.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
