### PR TITLE
Use existing DagBag for 'dag_details' & 'trigger' Endpoints

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -31,7 +31,6 @@ from pygments.formatters import HtmlFormatter
 
 from airflow.configuration import conf
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.dag import DagBag, DagModel
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils import timezone
 from airflow.utils.code_utils import get_python_source
@@ -425,19 +424,3 @@ FieldConverter.conversion_table = (
     (('is_utcdatetime', DateTimeField, AirflowDateTimePickerWidget),) +
     FieldConverter.conversion_table
 )
-
-
-def get_dag(orm_dag: DagModel, store_serialized_dags=False):
-    """Creates a dagbag to load and return a DAG.
-
-    Calling it from UI should set store_serialized_dags = STORE_SERIALIZED_DAGS.
-    There may be a delay for scheduler to write serialized DAG into database,
-    loads from file in this case.
-    FIXME: remove it when webserver does not access to DAG folder in future.
-    """
-    dag = DagBag(
-        dag_folder=orm_dag.fileloc, store_serialized_dags=store_serialized_dags).get_dag(orm_dag.dag_id)
-    if store_serialized_dags and dag is None:
-        dag = DagBag(
-            dag_folder=orm_dag.fileloc, store_serialized_dags=False).get_dag(orm_dag.dag_id)
-    return dag

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -77,7 +77,6 @@ from airflow.www.decorators import action_logging, gzipped, has_dag_access
 from airflow.www.forms import (
     ConnectionForm, DagRunForm, DateTimeForm, DateTimeWithNumRunsForm, DateTimeWithNumRunsWithDagRunsForm,
 )
-from airflow.www.utils import get_dag
 from airflow.www.widgets import AirflowModelListWidget
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
@@ -575,9 +574,7 @@ class Airflow(AirflowBaseView):
     @provide_session
     def dag_details(self, session=None):
         dag_id = request.args.get('dag_id')
-        dag_orm = DagModel.get_dagmodel(dag_id, session=session)
-        # FIXME: items needed for this view should move to the database
-        dag = get_dag(dag_orm, STORE_SERIALIZED_DAGS)
+        dag = dagbag.get_dag(dag_id)
         title = "DAG details"
         root = request.args.get('root', '')
 
@@ -1057,7 +1054,7 @@ class Airflow(AirflowBaseView):
                     conf=conf
                 )
 
-        dag = get_dag(dag_orm, STORE_SERIALIZED_DAGS)
+        dag = dagbag.get_dag(dag_id)
         dag.create_dagrun(
             run_id=run_id,
             execution_date=execution_date,


### PR DESCRIPTION
`dag_details` and `trigger_endpoint` were recreating the DagBag. It was creating the DagBag with a single DagFile, so wasn't a huge problem but it didn't needed to since we have the DagBag at the top level in `views.py` which will keep the DAGs in DagBag once it fetches it.

Added tests to check this for Graph and Tree views too

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
