### PR TITLE
Add more precise tests (tests for jinja params) for AirflowVersion

### DIFF
--- a/requirements/requirements-python3.6.txt
+++ b/requirements/requirements-python3.6.txt
@@ -26,13 +26,13 @@ PySmbClient==0.1.5
 PyYAML==5.3.1
 Pygments==2.6.1
 SQLAlchemy-JSONField==0.9.0
-SQLAlchemy-Utils==0.36.4
+SQLAlchemy-Utils==0.36.5
 SQLAlchemy==1.3.16
 Sphinx==3.0.3
 Unidecode==1.1.1
 WTForms==2.3.1
 Werkzeug==0.16.1
-adal==1.2.2
+adal==1.2.3
 alabaster==0.7.12
 alembic==1.4.2
 amqp==2.5.2
@@ -69,9 +69,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.12.49
+boto3==1.13.1
 boto==2.49.0
-botocore==1.15.49
+botocore==1.16.1
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -100,7 +100,7 @@ decorator==4.4.2
 defusedxml==0.6.0
 dill==0.3.1.1
 distlib==0.3.0
-distributed==2.15.1
+distributed==2.15.2
 dnspython==1.16.0
 docker-pycreds==0.4.0
 docker==3.7.3
@@ -110,7 +110,7 @@ ecdsa==0.15
 elasticsearch-dbapi==0.1.0
 elasticsearch-dsl==7.1.0
 elasticsearch==7.5.1
-email-validator==1.0.5
+email-validator==1.1.0
 entrypoints==0.3
 enum34==1.1.10
 execnet==1.7.1
@@ -181,7 +181,7 @@ importlib-resources==1.5.0
 inflection==0.4.0
 ipdb==0.13.2
 ipython-genutils==0.2.0
-ipython==7.13.0
+ipython==7.14.0
 iso8601==0.1.12
 isodate==0.6.0
 isort==4.3.21
@@ -220,12 +220,12 @@ mysql-connector-python==8.0.18
 mysqlclient==1.3.14
 nbclient==0.2.0
 nbformat==5.0.6
-nest-asyncio==1.3.2
+nest-asyncio==1.3.3
 networkx==2.4
 nodeenv==1.3.5
 nteract-scrapbook==0.4.1
 ntlm-auth==1.4.0
-numpy==1.18.3
+numpy==1.18.4
 oauthlib==3.1.0
 oscrypto==1.2.0
 packaging==20.3
@@ -262,7 +262,7 @@ pycparser==2.20
 pycryptodomex==3.9.7
 pydata-google-auth==1.1.0
 pydruid==0.5.8
-pyexasol==0.12.0
+pyexasol==0.12.1
 pyflakes==2.1.1
 pykerberos==1.2.1
 pylint==2.4.4
@@ -278,7 +278,7 @@ pytest-forked==1.1.3
 pytest-instafail==0.4.1.post0
 pytest-rerunfailures==9.0
 pytest-timeout==1.3.4
-pytest-xdist==1.31.0
+pytest-xdist==1.32.0
 pytest==5.4.1
 python-daemon==2.1.2
 python-dateutil==2.8.1
@@ -295,7 +295,7 @@ qds-sdk==1.15.2
 redis==3.5.0
 regex==2020.4.4
 requests-kerberos==0.12.0
-requests-mock==1.7.0
+requests-mock==1.8.0
 requests-ntlm==1.1.0
 requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1
@@ -332,7 +332,7 @@ sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-spython==0.0.79
+spython==0.0.80
 sshpubkeys==3.1.0
 sshtunnel==0.1.5
 statsd==3.3.0
@@ -348,7 +348,7 @@ thrift==0.13.0
 toml==0.10.0
 toolz==0.10.0
 tornado==5.1.1
-tqdm==4.45.0
+tqdm==4.46.0
 traitlets==4.3.3
 typed-ast==1.4.1
 typing-extensions==3.7.4.2
@@ -359,7 +359,7 @@ uritemplate==3.0.1
 urllib3==1.25.9
 vertica-python==0.10.3
 vine==1.3.0
-virtualenv==20.0.18
+virtualenv==20.0.19
 watchtower==0.7.3
 wcwidth==0.1.9
 websocket-client==0.57.0

--- a/requirements/requirements-python3.7.txt
+++ b/requirements/requirements-python3.7.txt
@@ -26,13 +26,13 @@ PySmbClient==0.1.5
 PyYAML==5.3.1
 Pygments==2.6.1
 SQLAlchemy-JSONField==0.9.0
-SQLAlchemy-Utils==0.36.4
+SQLAlchemy-Utils==0.36.5
 SQLAlchemy==1.3.16
 Sphinx==3.0.3
 Unidecode==1.1.1
 WTForms==2.3.1
 Werkzeug==0.16.1
-adal==1.2.2
+adal==1.2.3
 alabaster==0.7.12
 alembic==1.4.2
 amqp==2.5.2
@@ -69,9 +69,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.12.49
+boto3==1.13.1
 boto==2.49.0
-botocore==1.15.49
+botocore==1.16.1
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -100,7 +100,7 @@ decorator==4.4.2
 defusedxml==0.6.0
 dill==0.3.1.1
 distlib==0.3.0
-distributed==2.15.1
+distributed==2.15.2
 dnspython==1.16.0
 docker-pycreds==0.4.0
 docker==3.7.3
@@ -110,7 +110,7 @@ ecdsa==0.15
 elasticsearch-dbapi==0.1.0
 elasticsearch-dsl==7.1.0
 elasticsearch==7.5.1
-email-validator==1.0.5
+email-validator==1.1.0
 entrypoints==0.3
 enum34==1.1.10
 execnet==1.7.1
@@ -180,7 +180,7 @@ importlib-metadata==1.6.0
 inflection==0.4.0
 ipdb==0.13.2
 ipython-genutils==0.2.0
-ipython==7.13.0
+ipython==7.14.0
 iso8601==0.1.12
 isodate==0.6.0
 isort==4.3.21
@@ -219,12 +219,12 @@ mysql-connector-python==8.0.18
 mysqlclient==1.3.14
 nbclient==0.2.0
 nbformat==5.0.6
-nest-asyncio==1.3.2
+nest-asyncio==1.3.3
 networkx==2.4
 nodeenv==1.3.5
 nteract-scrapbook==0.4.1
 ntlm-auth==1.4.0
-numpy==1.18.3
+numpy==1.18.4
 oauthlib==3.1.0
 oscrypto==1.2.0
 packaging==20.3
@@ -260,7 +260,7 @@ pycparser==2.20
 pycryptodomex==3.9.7
 pydata-google-auth==1.1.0
 pydruid==0.5.8
-pyexasol==0.12.0
+pyexasol==0.12.1
 pyflakes==2.1.1
 pykerberos==1.2.1
 pylint==2.4.4
@@ -276,7 +276,7 @@ pytest-forked==1.1.3
 pytest-instafail==0.4.1.post0
 pytest-rerunfailures==9.0
 pytest-timeout==1.3.4
-pytest-xdist==1.31.0
+pytest-xdist==1.32.0
 pytest==5.4.1
 python-daemon==2.1.2
 python-dateutil==2.8.1
@@ -293,7 +293,7 @@ qds-sdk==1.15.2
 redis==3.5.0
 regex==2020.4.4
 requests-kerberos==0.12.0
-requests-mock==1.7.0
+requests-mock==1.8.0
 requests-ntlm==1.1.0
 requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1
@@ -330,7 +330,7 @@ sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-spython==0.0.79
+spython==0.0.80
 sshpubkeys==3.1.0
 sshtunnel==0.1.5
 statsd==3.3.0
@@ -346,7 +346,7 @@ thrift==0.13.0
 toml==0.10.0
 toolz==0.10.0
 tornado==5.1.1
-tqdm==4.45.0
+tqdm==4.46.0
 traitlets==4.3.3
 typed-ast==1.4.1
 typing-extensions==3.7.4.2
@@ -356,7 +356,7 @@ uritemplate==3.0.1
 urllib3==1.25.9
 vertica-python==0.10.3
 vine==1.3.0
-virtualenv==20.0.18
+virtualenv==20.0.19
 watchtower==0.7.3
 wcwidth==0.1.9
 websocket-client==0.57.0

--- a/requirements/setup-3.6.md5
+++ b/requirements/setup-3.6.md5
@@ -1,1 +1,1 @@
-641aef6382833e43eb6dd837158c5b59  /opt/airflow/setup.py
+1c8c45f111011d478a9b18f5592d0d5f  /opt/airflow/setup.py

--- a/requirements/setup-3.7.md5
+++ b/requirements/setup-3.7.md5
@@ -1,1 +1,1 @@
-641aef6382833e43eb6dd837158c5b59  /opt/airflow/setup.py
+1c8c45f111011d478a9b18f5592d0d5f  /opt/airflow/setup.py

--- a/setup.py
+++ b/setup.py
@@ -427,6 +427,7 @@ all_dbs = (cassandra + cloudant + druid + exasol + hdfs + hive + mongo + mssql +
 ############################################################################################################
 devel = [
     'beautifulsoup4~=4.7.1',
+    'blinker',
     'bowler',
     'click==6.7',
     'contextdecorator;python_version<"3.4"',

--- a/tests/test_utils/asserts.py
+++ b/tests/test_utils/asserts.py
@@ -18,7 +18,6 @@
 import logging
 import re
 from contextlib import contextmanager
-from unittest import mock
 
 from sqlalchemy import event
 
@@ -72,33 +71,3 @@ def assert_queries_count(expected_count, message_fmt=None):
                                  "The current number is {current_count}."
     message = message_fmt.format(current_count=result.count, expected_count=expected_count)
     assert expected_count == result.count, message
-
-
-class CatchJinjaParmasResult:
-    def __init__(self):
-        self.template_name = None
-        self.template_params = None
-
-
-@contextmanager
-def catch_jinja_params():
-    """Catch jinja parameters."""
-    result = CatchJinjaParmasResult()
-
-    from flask_appbuilder import BaseView
-
-    with mock.patch(
-        'flask_appbuilder.BaseView.render_template',
-        side_effect=BaseView.render_template,
-        autospec=True
-    ) as mock_render_template:
-        yield result
-
-    assert mock_render_template.call_count == 1, (
-        "It was expected that the BaseView.render_template method would only be called once. "
-        f"This was called {mock_render_template.call_count} times."
-    )
-    args, kwargs = mock_render_template.call_args
-    assert len(args) == 2  # self, template
-    result.template_name = args[1]
-    result.template_params = kwargs

--- a/tests/test_utils/asserts.py
+++ b/tests/test_utils/asserts.py
@@ -95,9 +95,8 @@ def catch_jinja_params():
         yield result
 
     assert mock_render_template.call_count == 1, (
-        "BaseView.render_template was not called once.This method has been called {} times.".format(
-            mock_render_template.call_count
-        )
+        "It was expected that the BaseView.render_template method would only be called once. "
+        f"This was called {mock_render_template} times."
     )
     args, kwargs = mock_render_template.call_args
     assert len(args) == 2  # self, template

--- a/tests/test_utils/asserts.py
+++ b/tests/test_utils/asserts.py
@@ -96,7 +96,7 @@ def catch_jinja_params():
 
     assert mock_render_template.call_count == 1, (
         "It was expected that the BaseView.render_template method would only be called once. "
-        f"This was called {mock_render_template} times."
+        f"This was called {mock_render_template.call_count} times."
     )
     args, kwargs = mock_render_template.call_args
     assert len(args) == 2  # self, template

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -34,7 +34,7 @@ from urllib.parse import quote_plus
 
 import jinja2
 import pytest
-from flask import Markup, session as flask_session, url_for
+from flask import Markup, make_response, session as flask_session, url_for
 from parameterized import parameterized
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
@@ -1154,6 +1154,23 @@ class TestVersionView(TestBase):
             password='test'
         ), follow_redirects=True)
         self.check_content_in_response('Version Info', resp)
+
+    @mock.patch('airflow.www.views.BaseView.render_template')
+    def test_version_jinja_context(self, mock_render_template):
+        with self.app.app_context():
+            mock_render_template.return_value = make_response("RESPONSE", 200)
+            self.client.get('version', data=dict(
+                username='test',
+                password='test'
+            ), follow_redirects=True)
+
+        mock_render_template.assert_called_once_with(
+            'airflow/version.html',
+            airflow_version=version.version,
+            git_version=mock.ANY,
+            scheduler_job=mock.ANY,
+            title='Version Info'
+        )
 
 
 class ViewWithDateTimeAndNumRunsAndDagRunsFormTester:

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -28,13 +28,15 @@ import sys
 import tempfile
 import unittest
 import urllib
+from contextlib import contextmanager
 from datetime import datetime as dt, timedelta
+from typing import Any, Dict, Generator, List, NamedTuple
 from unittest import mock
 from urllib.parse import quote_plus
 
 import jinja2
 import pytest
-from flask import Markup, session as flask_session, url_for
+from flask import Markup, session as flask_session, template_rendered, url_for
 from parameterized import parameterized
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
@@ -59,9 +61,53 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 from airflow.www import app as application
-from tests.test_utils.asserts import catch_jinja_params
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_runs
+
+
+class TemplateWithContext(NamedTuple):
+    template: jinja2.environment.Template
+    context: Dict[str, Any]
+
+    @property
+    def name(self):
+        return self.template.name
+
+    @property
+    def local_context(self):
+        """Returns context without global arguments"""
+        result = copy.copy(self.context)
+        keys_to_delete = [
+            # flask.templating._default_template_ctx_processor
+            'g',
+            'request',
+            'session',
+            # flask_wtf.csrf.CSRFProtect.init_app
+            'csrf_token',
+            # flask_login.utils._user_context_processor
+            'current_user',
+            # flask_appbuilder.baseviews.BaseView.render_template
+            'appbuilder',
+            'base_template',
+            # airflow.www.app.py.create_app (inner method - jinja_globals)
+            'server_timezone',
+            'default_ui_timezone',
+            'hostname',
+            'navbar_color',
+            'log_fetch_delay_sec',
+            'log_auto_tailing_offset',
+            'log_animation_speed',
+            # airflow.www.static_config.configure_manifest_files
+            'url_for_asset',
+            # airflow.www.views.AirflowBaseView.render_template
+            'scheduler_job',
+            # airflow.www.views.AirflowBaseView.extra_args
+            'macros',
+        ]
+        for key in keys_to_delete:
+            del result[key]
+
+        return result
 
 
 class TestBase(unittest.TestCase):
@@ -99,6 +145,20 @@ class TestBase(unittest.TestCase):
 
     def logout(self):
         return self.client.get('/logout/')
+
+    @contextmanager
+    def capture_templates(self) -> Generator[List[TemplateWithContext], None, None]:
+        recorded = []
+
+        def record(sender, template, context, **extra):  # pylint: disable=unused-argument
+            recorded.append(TemplateWithContext(template, context))
+        template_rendered.connect(record, self.app)  # type: ignore
+        try:
+            yield recorded
+        finally:
+            template_rendered.disconnect(record, self.app)  # type: ignore
+
+        assert recorded, "Failed to catch the templates"
 
     @classmethod
     def clear_table(cls, model):
@@ -1150,18 +1210,18 @@ class TestLogView(TestBase):
 
 class TestVersionView(TestBase):
     def test_version(self):
-        with catch_jinja_params() as jinja_params:
+        with self.capture_templates() as templates:
             resp = self.client.get('version', data=dict(
                 username='test',
                 password='test'
             ), follow_redirects=True)
             self.check_content_in_response('Version Info', resp)
 
-        self.assertEqual(jinja_params.template_name, 'airflow/version.html')
-        self.assertEqual(jinja_params.template_params, dict(
+        self.assertEqual(len(templates), 1)
+        self.assertEqual(templates[0].name, 'airflow/version.html')
+        self.assertEqual(templates[0].local_context, dict(
             airflow_version=version.version,
             git_version=mock.ANY,
-            scheduler_job=mock.ANY,
             title='Version Info'
         ))
 


### PR DESCRIPTION
Recently, I talked to @kaxil about testing our views. I suggested that we should test templates and flask views separately  I have prepared a POC that shows how it can be done. I think this can increase confidence in these tests. We are currently testing only random words, but very much logic has no coverage and it is very difficult to make changes. If you want to make changes, you always have to test everything manually to see if the logic is behaving correctly. If we have automatic tests with a higher level of confidence then the changes will be easier to review and we will trust them more.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
