### PR TITLE
Remove WTforms from setup.py

### DIFF
--- a/requirements/requirements-python3.6.txt
+++ b/requirements/requirements-python3.6.txt
@@ -29,7 +29,7 @@ SQLAlchemy-Utils==0.36.3
 SQLAlchemy==1.3.16
 Sphinx==3.0.2
 Unidecode==1.1.1
-WTForms==2.2.1
+WTForms==2.3.1
 Werkzeug==0.16.1
 adal==1.2.2
 alabaster==0.7.12
@@ -67,9 +67,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.12.43
+boto3==1.12.44
 boto==2.49.0
-botocore==1.15.43
+botocore==1.15.44
 cached-property==1.5.1
 cachetools==4.1.0
 cassandra-driver==3.20.2

--- a/requirements/requirements-python3.7.txt
+++ b/requirements/requirements-python3.7.txt
@@ -29,7 +29,7 @@ SQLAlchemy-Utils==0.36.3
 SQLAlchemy==1.3.16
 Sphinx==3.0.2
 Unidecode==1.1.1
-WTForms==2.2.1
+WTForms==2.3.1
 Werkzeug==0.16.1
 adal==1.2.2
 alabaster==0.7.12
@@ -67,9 +67,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.12.43
+boto3==1.12.44
 boto==2.49.0
-botocore==1.15.43
+botocore==1.15.44
 cached-property==1.5.1
 cachetools==4.1.0
 cassandra-driver==3.20.2
@@ -146,7 +146,7 @@ google-cloud-redis==0.4.0
 google-cloud-secret-manager==0.2.0
 google-cloud-spanner==1.15.1
 google-cloud-speech==1.3.2
-google-cloud-storage==1.27.0
+google-cloud-storage==1.28.0
 google-cloud-tasks==1.5.0
 google-cloud-texttospeech==1.0.1
 google-cloud-translate==2.0.1

--- a/requirements/setup-3.6.md5
+++ b/requirements/setup-3.6.md5
@@ -1,1 +1,1 @@
-d353a3cc6876e76d66261929ef6e459f  /opt/airflow/setup.py
+a83d618cf60f585307063fd0f39cf1b3  /opt/airflow/setup.py

--- a/requirements/setup-3.7.md5
+++ b/requirements/setup-3.7.md5
@@ -1,1 +1,1 @@
-d353a3cc6876e76d66261929ef6e459f  /opt/airflow/setup.py
+a83d618cf60f585307063fd0f39cf1b3  /opt/airflow/setup.py

--- a/setup.py
+++ b/setup.py
@@ -598,8 +598,6 @@ INSTALL_REQUIREMENTS = [
     'tzlocal>=1.4,<2.0.0',
     'unicodecsv>=0.14.1',
     'werkzeug<1.0.0',
-    'WTforms<2.3.0',
-    # TODO: Remove after https://github.com/dpgaspar/Flask-AppBuilder/issues/1356 is fixed and released.
 ]
 
 


### PR DESCRIPTION
WTForms released 2.3.1 by bringing in the function back.

- https://github.com/wtforms/wtforms/pull/583
- https://pypi.org/project/WTForms/
- https://wtforms.readthedocs.io/en/2.3.x/changes/#version-2-3-1

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
