### PR TITLE
Stop DockerSwarmOperator from pulling Docker images

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -265,7 +265,7 @@ class DockerOperator(BaseOperator):
                 return None
 
     def execute(self, context):
-        self._set_cli()
+        self.cli = self._get_cli()
 
         # Pull the docker image if `force_pull` is set or image does not exist locally
         if self.force_pull or not self.cli.images(name=self.image):
@@ -279,13 +279,12 @@ class DockerOperator(BaseOperator):
 
         return self._run_image()
 
-    def _set_cli(self):
-        tls_config = self.__get_tls_config()
-
+    def _get_cli(self):
         if self.docker_conn_id:
-            self.cli = self.get_hook().get_conn()
+            return self.get_hook().get_conn()
         else:
-            self.cli = APIClient(
+            tls_config = self.__get_tls_config()
+            return APIClient(
                 base_url=self.docker_url,
                 version=self.api_version,
                 tls=tls_config

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -265,17 +265,7 @@ class DockerOperator(BaseOperator):
                 return None
 
     def execute(self, context):
-
-        tls_config = self.__get_tls_config()
-
-        if self.docker_conn_id:
-            self.cli = self.get_hook().get_conn()
-        else:
-            self.cli = APIClient(
-                base_url=self.docker_url,
-                version=self.api_version,
-                tls=tls_config
-            )
+        self._set_cli()
 
         # Pull the docker image if `force_pull` is set or image does not exist locally
         if self.force_pull or not self.cli.images(name=self.image):
@@ -288,6 +278,18 @@ class DockerOperator(BaseOperator):
         self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
 
         return self._run_image()
+
+    def _set_cli(self):
+        tls_config = self.__get_tls_config()
+
+        if self.docker_conn_id:
+            self.cli = self.get_hook().get_conn()
+        else:
+            self.cli = APIClient(
+                base_url=self.docker_url,
+                version=self.api_version,
+                tls=tls_config
+            )
 
     def get_command(self):
         """

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -102,7 +102,7 @@ class DockerSwarmOperator(DockerOperator):
         self.service = None
 
     def execute(self, context):
-        self._set_cli()
+        self.cli = self._get_cli()
 
         self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
 

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -101,7 +101,14 @@ class DockerSwarmOperator(DockerOperator):
 
         self.service = None
 
-    def _run_image(self):
+    def execute(self, context):
+        self._set_cli()
+
+        self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
+
+        return self._run_service()
+
+    def _run_service(self):
         self.log.info('Starting docker service from image %s', self.image)
 
         self.service = self.cli.create_service(


### PR DESCRIPTION
---
Refers to issue #8420. 
Some functionality of `DockerOperator.execute()` was moved into its own function in order to use it in the overwritten `DockerSwarmOperator.execute()` function. No functionality changed except the DockerSwarmOperator will not unnecessarily download Docker images anymore!

I also renamed `DockerSwarmOperator._run_image()` to `DockerSwarmOperator._run_service()` since it is more descriptive. Not sure if I went to far with this change for the pull request?

---

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
