### PR TITLE
fix: aws hook should work without conn id

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -42,9 +42,10 @@ class AwsBaseHook(BaseHook):
     This class is a thin wrapper around the boto3 python library.
 
     :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None then the default boto3 behaviour is used. If running Airflow
-        in a distributed manner and aws_conn_id is None, then default boto3 configuration
-        would be used (and must be maintained on each worker node).
+        If this is None or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
     :type aws_conn_id: str
     :param verify: Whether or not to verify SSL certificates.
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
@@ -62,7 +63,7 @@ class AwsBaseHook(BaseHook):
 
     def __init__(
             self,
-            aws_conn_id="aws_default",
+            aws_conn_id: str = "aws_default",
             verify: Union[bool, str, None] = None,
             region_name: Optional[str] = None,
             client_type: Optional[str] = None,
@@ -70,8 +71,6 @@ class AwsBaseHook(BaseHook):
             config: Optional[Config] = None
     ):
         super().__init__()
-        if not aws_conn_id:
-            raise AirflowException('aws_conn_id must be provided')
         self.aws_conn_id = aws_conn_id
         self.verify = verify
         self.client_type = client_type

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -253,7 +253,7 @@ class AwsBaseHook(BaseHook):
             assume_role_kwargs["ExternalId"] = extra_config.get(
                 "external_id"
             )
-        role_session_name = "Airflow_" + str(self.aws_conn_id)
+        role_session_name = f"Airflow_{self.aws_conn_id}"
         self.log.info(
             "Doing sts_client.assume_role to role_arn=%s (role_session_name=%s)",
             role_arn,

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -63,7 +63,7 @@ class AwsBaseHook(BaseHook):
 
     def __init__(
             self,
-            aws_conn_id: str = "aws_default",
+            aws_conn_id: Optional[str] = "aws_default",
             verify: Union[bool, str, None] = None,
             region_name: Optional[str] = None,
             client_type: Optional[str] = None,
@@ -253,7 +253,7 @@ class AwsBaseHook(BaseHook):
             assume_role_kwargs["ExternalId"] = extra_config.get(
                 "external_id"
             )
-        role_session_name = "Airflow_" + self.aws_conn_id
+        role_session_name = "Airflow_" + str(self.aws_conn_id)
         self.log.info(
             "Doing sts_client.assume_role to role_arn=%s (role_session_name=%s)",
             role_arn,

--- a/airflow/utils/log/s3_task_handler.py
+++ b/airflow/utils/log/s3_task_handler.py
@@ -48,7 +48,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             from airflow.providers.amazon.aws.hooks.s3 import S3Hook
             return S3Hook(remote_conn_id)
         except Exception:  # pylint: disable=broad-except
-            self.log.error(
+            self.log.exception(
                 'Could not create an S3Hook with connection id "%s". '
                 'Please make sure that airflow[aws] is installed and '
                 'the S3 connection exists.', remote_conn_id

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -210,6 +210,7 @@ class TestAwsBaseHook(unittest.TestCase):
         self.assertEqual(arn, expect_arn)
 
     def test_use_default_boto3_behaviour_without_conn_id(self):
-        hook = AwsBaseHook(aws_conn_id='', client_type='s3')
-        # should cause no exception
-        hook.get_client_type('s3')
+        for conn_id in (None, ''):
+            hook = AwsBaseHook(aws_conn_id=conn_id, client_type='s3')
+            # should cause no exception
+            hook.get_client_type('s3')

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -208,3 +208,8 @@ class TestAwsBaseHook(unittest.TestCase):
         arn = hook.expand_role('test-role')
         expect_arn = conn.get_role(RoleName='test-role').get('Role').get('Arn')
         self.assertEqual(arn, expect_arn)
+
+    def test_use_default_boto3_behaviour_without_conn_id(self):
+        hook = AwsBaseHook(aws_conn_id='', client_type='s3')
+        # should cause no exception
+        hook.get_client_type('s3')

--- a/tests/utils/log/test_s3_task_handler.py
+++ b/tests/utils/log/test_s3_task_handler.py
@@ -97,7 +97,8 @@ class TestS3TaskHandler(unittest.TestCase):
             mock_error.assert_called_once_with(
                 'Could not create an S3Hook with connection id "%s". Please make '
                 'sure that airflow[aws] is installed and the S3 connection exists.',
-                'aws_default'
+                'aws_default',
+                exc_info=True,
             )
 
     def test_log_exists(self):


### PR DESCRIPTION
This patch makes behavior of hook consistent with documentation.

AWS hooks should support falling back to using default credential chain
lookup behavior when connection id is not specified.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
