### PR TITLE
[Airflow-7044] - add ability to specify RSA public key in extra field of SSH connection.

### DIFF
--- a/airflow/migrations/versions/449b4072c2da_increase_size_of_connection_extra_field_.py
+++ b/airflow/migrations/versions/449b4072c2da_increase_size_of_connection_extra_field_.py
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Increase size of connection.extra field to handle multiple RSA keys
+
+Revision ID: 449b4072c2da
+Revises: 952da73b5eff
+Create Date: 2020-03-16 19:02:55.337710
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '449b4072c2da'
+down_revision = '952da73b5eff'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply increase_length_for_connection_password"""
+    with op.batch_alter_table('connection', schema=None) as batch_op:
+        batch_op.alter_column('extra',
+                              existing_type=sa.VARCHAR(length=5000),
+                              type_=sa.String(length=10000),
+                              existing_nullable=True)
+
+
+def downgrade():
+    """Unapply increase_length_for_connection_password"""
+    with op.batch_alter_table('connection', schema=None) as batch_op:
+        batch_op.alter_column('extra',
+                              existing_type=sa.String(length=10000),
+                              type_=sa.VARCHAR(length=5000),
+                              existing_nullable=True)

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -120,7 +120,7 @@ class Connection(Base, LoggingMixin):
     port = Column(Integer())
     is_encrypted = Column(Boolean, unique=False, default=False)
     is_extra_encrypted = Column(Boolean, unique=False, default=False)
-    _extra = Column('extra', String(5000))
+    _extra = Column('extra', String(10000))
 
     def __init__(
             self, conn_id=None, conn_type=None,

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -17,14 +17,13 @@
 # under the License.
 """Hook for SSH connections."""
 import getpass
-import codecs
 import os
 import warnings
+from base64 import decodebytes
 from io import StringIO
 from typing import Optional
 
 import paramiko
-from paramiko import py3compat
 from paramiko.config import SSH_PORT
 from sshtunnel import SSHTunnelForwarder
 
@@ -181,15 +180,15 @@ class SSHHook(BaseHook):
         else:
             if self.host_key is not None:
                 try:
-                    encoded_host_key = py3compat.decodebytes(self.host_key.encode('utf-8'))
+                    encoded_host_key = decodebytes(self.host_key.encode('utf-8'))
                     pkey = paramiko.RSAKey(data=encoded_host_key)
                 except Exception:
                     raise AirflowException('Connection extra host_key is malformed.')
                 client_host_keys = client.get_host_keys()
                 client_host_keys.add(self.remote_host, 'ssh-rsa', pkey)
             else:
-                raise AirflowException('No public key supplied for remote_host. '
-                                       'Please set a value for "host_key" in SSH Connection extras.')
+                pass  # will fallback to system host keys if none explicitly specified in conn extra
+
         connect_kwargs = dict(
             hostname=self.remote_host,
             username=self.username,

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -196,7 +196,6 @@ class SSHHook(BaseHook):
         if self.password:
             password = self.password.strip()
             connect_kwargs.update(password=password)
-            connect_kwargs.update(look_for_keys=False)
 
         if self.pkey:
             connect_kwargs.update(pkey=self.pkey)

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -309,7 +309,7 @@ class SSHHook(BaseHook):
         :param host_key: The base64-ecoded public key of the remote host.
         :type host_key: str
         """
-        # The .ssh hidden directory is required and not present on all airflow deployments
+        # The .ssh hidden directory is required and not present on all airflow deployments.
         try:
             known_hosts_file_ref = SSHHook._create_known_hosts()
         except PermissionError:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -124,12 +124,8 @@ class SSHHook(BaseHook):
                         str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:
-                    try:
-                        encoded_host_key = decodebytes(extra_options["host_key"].encode('utf-8'))
-                        self.host_key = paramiko.RSAKey(data=encoded_host_key)
-                    except Exception:
-                        raise AirflowException('Connection extra host_key is malformed.')
-
+                    encoded_host_key = decodebytes(extra_options["host_key"].encode('utf-8'))
+                    self.host_key = paramiko.RSAKey(data=encoded_host_key)
         if self.pkey and self.key_file:
             raise AirflowException(
                 "Params key_file and private_key both provided.  Must provide no more than one.")

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -289,7 +289,7 @@ class SSHHook(BaseHook):
     @staticmethod
     def add_host_to_known_hosts(host: str, key_type: str, host_key: str) -> None:
         """
-        Adds a specified remote_host public key to the known_hosts file  
+        Adds a specified remote_host public key to the known_hosts file
             in order to prevent man-in-the-middle attacks.
 
         The format of the new line in known_hosts will be:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -124,11 +124,6 @@ class SSHHook(BaseHook):
                         str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:
-                    # self.update_host_in_known_hosts(
-                    #     self.remote_host,
-                    #     'ssh-rsa',
-                    #     extra_options["host_key"]
-                    # )
                     self.host_key = extra_options["host_key"]
 
         if self.pkey and self.key_file:
@@ -188,9 +183,9 @@ class SSHHook(BaseHook):
                 client_host_keys = client.get_host_keys()
                 client_host_keys.add(self.remote_host, 'ssh-rsa', pkey)
                 if not client_host_keys.check(self.remote_host, pkey):
-                    self.log.warning('host_key was not added - could be malformed.')
+                    raise AirflowException('host_key was not added - could be malformed.')
             else:
-                self.log.warning('No public key supplied for remote_host. '
+                raise AirflowException('No public key supplied for remote_host. '
                                  'Please set a value for "host_key" in SSH Connection extras.')
         connect_kwargs = dict(
             hostname=self.remote_host,

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -110,16 +110,16 @@ class SSHHook(BaseHook):
                 if "timeout" in extra_options:
                     self.timeout = int(extra_options["timeout"], 10)
 
-                if "compress" in extra_options\
-                        and str(extra_options["compress"]).lower() == 'false':
+                if "compress" in extra_options \
+                    and str(extra_options["compress"]).lower() == 'false':
                     self.compress = False
-                if "no_host_key_check" in extra_options\
-                        and\
-                        str(extra_options["no_host_key_check"]).lower() == 'false':
+                if "no_host_key_check" in extra_options \
+                    and \
+                    str(extra_options["no_host_key_check"]).lower() == 'false':
                     self.no_host_key_check = False
-                if "allow_host_key_change" in extra_options\
-                        and\
-                        str(extra_options["allow_host_key_change"]).lower() == 'true':
+                if "allow_host_key_change" in extra_options \
+                    and \
+                    str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:
                     self.add_host_to_known_hosts(
@@ -291,7 +291,11 @@ class SSHHook(BaseHook):
         """This adds a specified remote_host public key to the known_hosts
             in order to prevent man-in-the-middle attacks."""
         # The .ssh hidden directory is required and not present on all airflow deployments
-        known_hosts_file_ref = SSHHook._create_known_hosts()
+        try:
+            known_hosts_file_ref = SSHHook._create_known_hosts()
+        except PermissionError:
+            raise AirflowException("The user running airflow on this system does not have the neccesary permissions "
+                                   "to make changes to the ~/.ssh directory and its contents.")
         record = SSHHook._format_known_hosts_record(host, key_type, host_key)
         with open(known_hosts_file_ref, 'r') as known_hosts:
             file_content = known_hosts.read()

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -338,19 +338,11 @@ class SSHHook(BaseHook):
             # the host may be in the file with a different (possibly old) key
             # in this case, we should replace the existing record
             with open(known_hosts_file_ref, 'w+') as f:
-                SSHHook._update_record_in_known_hosts(
-                    host,
-                    record,
-                    file_content,
-                    f
-                )
+                SSHHook._update_record_in_known_hosts(host, record, file_content, f)
         else:
             # in this case the file is empty or the record doesn't exist in the file so add it
             with open(known_hosts_file_ref, 'a') as f:
-                SSHHook._add_new_record_to_known_hosts(
-                    record,
-                    f
-                )
+                SSHHook._add_new_record_to_known_hosts(record, f)
 
     @staticmethod
     def _format_known_hosts_record(host: str, key_type: str, public_key: str) -> str:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -289,7 +289,7 @@ class SSHHook(BaseHook):
     @staticmethod
     def add_host_to_known_hosts(host: str, key_type: str, host_key: str) -> None:
         """
-        Adds a specified remote_host public key to the known_hosts file
+        Adds a specified remote_host public key to the known_hosts file 
             in order to prevent man-in-the-middle attacks.
 
         The format of the new line in known_hosts will be:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -122,7 +122,7 @@ class SSHHook(BaseHook):
                         str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:
-                    self.add_host_to_known_hosts(
+                    self.update_host_in_known_hosts(
                         self.remote_host,
                         'ssh-rsa',
                         extra_options["host_key"]
@@ -297,7 +297,7 @@ class SSHHook(BaseHook):
         file.write(new_file_contents)
 
     @staticmethod
-    def add_host_to_known_hosts(host: str, key_type: str, host_key: str) -> None:
+    def update_host_in_known_hosts(host: str, key_type: str, host_key: str) -> None:
         """
         Adds a specified remote_host public key to the known_hosts file
             in order to prevent man-in-the-middle attacks.

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -289,7 +289,7 @@ class SSHHook(BaseHook):
     @staticmethod
     def add_host_to_known_hosts(host: str, key_type: str, host_key: str) -> None:
         """
-        Adds a specified remote_host public key to the known_hosts file 
+        Adds a specified remote_host public key to the known_hosts file  
             in order to prevent man-in-the-middle attacks.
 
         The format of the new line in known_hosts will be:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -304,7 +304,7 @@ class SSHHook(BaseHook):
 
         :param host: FQDN of the remote host.
         :type host: str
-        :param key_type: The algorithm format of the public key.
+        :param key_type: The algorithm format of the provided public key.
         :type key_type: str
         :param host_key: The base64-ecoded public key of the remote host.
         :type host_key: str

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -110,15 +110,15 @@ class SSHHook(BaseHook):
                 if "timeout" in extra_options:
                     self.timeout = int(extra_options["timeout"], 10)
 
-                if "compress" in extra_options \
+                if "compress" in extra_options\
                         and str(extra_options["compress"]).lower() == 'false':
                     self.compress = False
-                if "no_host_key_check" in extra_options \
-                        and \
+                if "no_host_key_check" in extra_options\
+                        and\
                         str(extra_options["no_host_key_check"]).lower() == 'false':
                     self.no_host_key_check = False
-                if "allow_host_key_change" in extra_options \
-                        and \
+                if "allow_host_key_change" in extra_options\
+                        and\
                         str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -332,7 +332,9 @@ class SSHHook(BaseHook):
         with open(known_hosts_file_ref, 'r') as f:
             file_content = f.read()
 
-        if host in file_content:
+        if record in file_content:
+            pass
+        elif host in file_content:
             # the host may be in the file with a different (possibly old) key
             # in this case, we should replace the existing record
             with open(known_hosts_file_ref, 'w+') as f:
@@ -342,8 +344,8 @@ class SSHHook(BaseHook):
                     file_content,
                     f
                 )
-        elif len(file_content) == 0 or record not in file_content:
-            # if file is empty or the record doesn't exist in the file, add it
+        else:
+            # in this case the file is empty or the record doesn't exist in the file so add it
             with open(known_hosts_file_ref, 'a') as f:
                 SSHHook._add_new_record_to_known_hosts(
                     record,

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -111,15 +111,15 @@ class SSHHook(BaseHook):
                     self.timeout = int(extra_options["timeout"], 10)
 
                 if "compress" in extra_options \
-                    and str(extra_options["compress"]).lower() == 'false':
+                        and str(extra_options["compress"]).lower() == 'false':
                     self.compress = False
                 if "no_host_key_check" in extra_options \
-                    and \
-                    str(extra_options["no_host_key_check"]).lower() == 'false':
+                        and \
+                        str(extra_options["no_host_key_check"]).lower() == 'false':
                     self.no_host_key_check = False
                 if "allow_host_key_change" in extra_options \
-                    and \
-                    str(extra_options["allow_host_key_change"]).lower() == 'true':
+                        and \
+                        str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
                 if "host_key" in extra_options and self.no_host_key_check is False:
                     self.add_host_to_known_hosts(
@@ -294,8 +294,8 @@ class SSHHook(BaseHook):
         try:
             known_hosts_file_ref = SSHHook._create_known_hosts()
         except PermissionError:
-            raise AirflowException("The user running airflow on this system does not have the neccesary permissions "
-                                   "to make changes to the ~/.ssh directory and its contents.")
+            raise AirflowException("The user running airflow on this system does not have the necessary "
+                                   "permissions to make changes to the ~/.ssh directory and its contents.")
         record = SSHHook._format_known_hosts_record(host, key_type, host_key)
         with open(known_hosts_file_ref, 'r') as known_hosts:
             file_content = known_hosts.read()

--- a/docs/howto/connection/ssh.rst
+++ b/docs/howto/connection/ssh.rst
@@ -48,6 +48,7 @@ Extra (optional)
     * ``compress`` - ``true`` to ask the remote client/server to compress traffic; ``false`` to refuse compression. Default is ``true``.
     * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
     * ``allow_host_key_change`` - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This wont protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
+    * ``host_key`` - The base64 encoded ssh-rsa public key of the host. Specifying this, along with ``no_host_key_check=False`` allows you to only make the connection if the public key of the endpoint matches this value. If this value doesn't already exist in ``~/.ssh/known_hosts`` then it is created there when instantiating the SSHHook class.
 
     Example "extras" field:
 
@@ -58,7 +59,8 @@ Extra (optional)
           "timeout": "10",
           "compress": "false",
           "no_host_key_check": "false",
-          "allow_host_key_change": "false"
+          "allow_host_key_change": "false",
+          "host_key": "AAAHD...YDWwq=="
        }
 
     When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it

--- a/docs/howto/connection/ssh.rst
+++ b/docs/howto/connection/ssh.rst
@@ -46,9 +46,9 @@ Extra (optional)
     * ``private_key`` - Content of the private key used to connect to the remote_host.
     * ``timeout`` - An optional timeout (in seconds) for the TCP connect. Default is ``10``.
     * ``compress`` - ``true`` to ask the remote client/server to compress traffic; ``false`` to refuse compression. Default is ``true``.
-    * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
+    * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with either no entries in ``~/.ssh/known_hosts`` (Hosts file) or not present in the ``host_key`` extra. This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
     * ``allow_host_key_change`` - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This wont protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
-    * ``host_key`` - The base64 encoded ssh-rsa public key of the host. Specifying this, along with ``no_host_key_check=False`` allows you to only make the connection if the public key of the endpoint matches this value. If this value doesn't already exist in ``~/.ssh/known_hosts`` then it is created there when instantiating the SSHHook class.
+    * ``host_key`` - The base64 encoded ssh-rsa public key of the host. Specifying this, along with ``no_host_key_check=False`` allows you to only make the connection if the public key of the endpoint matches this value.
 
     Example "extras" field:
 

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -179,7 +179,6 @@ class TestSSHHook(unittest.TestCase):
                 port='port',
                 sock=None,
                 password='password',
-                look_for_keys=False,
                 key_filename='fake.file',
             )
 

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -174,12 +174,13 @@ class TestSSHHook(unittest.TestCase):
             ssh_mock.return_value.connect.assert_called_once_with(
                 hostname='remote_host',
                 username='username',
-                password='password',
-                key_filename='fake.file',
                 timeout=10,
                 compress=True,
                 port='port',
-                sock=None
+                sock=None,
+                password='password',
+                look_for_keys=False,
+                key_filename='fake.file',
             )
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
@@ -345,11 +346,6 @@ class TestSSHHook(unittest.TestCase):
         with hook.get_conn():
             assert ssh_client.return_value.connect.called is True
             assert ssh_client.return_value.get_host_keys.return_value.add.called is True
-            assert ssh_client.return_value.get_host_keys.return_value.add.assert_called_once_with(
-                'remote_host',
-                'ssh-rsa',
-                TEST_HOST_PKEY
-            )
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_no_host_key_where_no_host_key_check_is_false(self, ssh_client):

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -342,10 +342,15 @@ class TestSSHHook(unittest.TestCase):
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_host_key_where_no_host_key_check_is_false(self, ssh_client):
         hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE)
-        assert hook.host_key == TEST_HOST_KEY
+        assert hook.host_key.get_base64() == TEST_HOST_KEY
         with hook.get_conn():
             assert ssh_client.return_value.connect.called is True
             assert ssh_client.return_value.get_host_keys.return_value.add.called is True
+            assert ssh_client.return_value.get_host_keys.return_value.add.call_args == mock.call(
+                hook.remote_host,
+                'ssh-rsa',
+                hook.host_key
+            )
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_no_host_key_where_no_host_key_check_is_false(self, ssh_client):

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -330,7 +330,6 @@ class TestSSHHook(unittest.TestCase):
         with hook.get_conn():
             assert ssh_client.return_value.connect.called is True
             assert ssh_client.return_value.get_host_keys.return_value.add.called is False
-            assert ssh_client.return_value.get_host_keys.return_value.check.called is False
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_host_key_where_no_host_key_check_is_true(self, ssh_client):
@@ -339,7 +338,6 @@ class TestSSHHook(unittest.TestCase):
         with hook.get_conn():
             assert ssh_client.return_value.connect.called is True
             assert ssh_client.return_value.get_host_keys.return_value.add.called is False
-            assert ssh_client.return_value.get_host_keys.return_value.check.called is False
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_host_key_where_no_host_key_check_is_false(self, ssh_client):
@@ -348,7 +346,6 @@ class TestSSHHook(unittest.TestCase):
         with hook.get_conn():
             assert ssh_client.return_value.connect.called is True
             assert ssh_client.return_value.get_host_keys.return_value.add.called is True
-            assert ssh_client.return_value.get_host_keys.return_value.check.called is True
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_no_host_key_where_no_host_key_check_is_false(self, ssh_client):

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -306,7 +306,6 @@ class TestSSHHook(unittest.TestCase):
                 sock=None
             )
 
-    @mock.patch('airflow.providers.ssh.hooks.ssh.open', mock.mock_open(read_data=''))
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_host_key_extra(self, ssh_mock):
         hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_EXTRA)
@@ -318,71 +317,6 @@ class TestSSHHook(unittest.TestCase):
         hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_TRUE)
         with hook.get_conn():
             assert ssh_mock.return_value.connect.called is True
-
-    @mock.patch('airflow.providers.ssh.hooks.ssh.open', mock.mock_open(read_data=''))
-    @mock.patch('airflow.providers.ssh.hooks.ssh.SSHHook._add_new_record_to_known_hosts')
-    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
-    def test_ssh_connection_with_host_key_where_known_hosts_is_empty(
-        self,
-        ssh_mock,
-        _add_new_record_to_known_hosts
-    ):
-        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE)
-        with hook.get_conn():
-            assert ssh_mock.return_value.connect.called is True
-        assert _add_new_record_to_known_hosts.call_count == 1
-
-    @mock.patch(
-        'airflow.providers.ssh.hooks.ssh.open',
-        mock.mock_open(read_data='some_host ssh-rsa AAA\n')
-    )
-    @mock.patch('airflow.providers.ssh.hooks.ssh.SSHHook._add_new_record_to_known_hosts')
-    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
-    def test_ssh_connection_with_host_key_where_this_record_is_not_in_known_hosts(
-        self,
-        ssh_mock,
-        _add_new_record_to_known_hosts
-    ):
-        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE)
-        with hook.get_conn():
-            assert ssh_mock.return_value.connect.called is True
-        assert _add_new_record_to_known_hosts.call_count == 1
-
-    @mock.patch(
-        'airflow.providers.ssh.hooks.ssh.open',
-        mock.mock_open(read_data=f'localhost ssh-rsa {TEST_HOST_KEY}\n')
-    )
-    @mock.patch('airflow.providers.ssh.hooks.ssh.SSHHook._add_new_record_to_known_hosts')
-    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
-    def test_ssh_connection_with_host_key_where_this_record_is_in_known_hosts(
-        self,
-        ssh_mock,
-        _add_new_record_to_known_hosts
-    ):
-        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE)
-        with hook.get_conn():
-            assert ssh_mock.return_value.connect.called is True
-        assert _add_new_record_to_known_hosts.call_count == 0
-
-    @mock.patch(
-        'airflow.providers.ssh.hooks.ssh.open',
-        mock.mock_open(read_data=f'localhost ssh-rsa BBB\n')
-    )
-    @mock.patch('airflow.providers.ssh.hooks.ssh.SSHHook._update_record_in_known_hosts')
-    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
-    def test_ssh_connection_with_host_key_where_host_with_old_key_is_in_known_hosts(
-        self,
-        ssh_mock,
-        _update_record_in_known_hosts
-    ):
-        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE)
-        with hook.get_conn():
-            assert ssh_mock.return_value.connect.called is True
-        assert _update_record_in_known_hosts.call_count == 1
-
-    def test_format_known_hosts_record(self):
-        assert f'remote_host ssh-rsa {TEST_HOST_KEY}' == \
-               SSHHook._format_known_hosts_record('remote_host', 'ssh-rsa', TEST_HOST_KEY)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

This PR adds functionality that allows a RSA public key part to be specified in the extra field of the SSH Connection. This will improve security by making it easier to specify a host key to verify connections against. Previously, you had to edit the `~.ssh/known_hosts` file directly which I have found cumbersome to maintain when running Airflow on Kubernetes.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
