### PR TITLE
fix help message display for dags test subcommand

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -257,10 +257,10 @@ ARG_SHOW_DAGRUN = Arg(
 ARG_IMGCAT_DAGRUN = Arg(
     ("--imgcat-dagrun", ),
     help=(
-        "After completing the backfill, prints a diagram on the screen for the "
+        "After completing the dag run, prints a diagram on the screen for the "
         "current DAG Run using the imgcat tool.\n"
         "\n"
-        "For more information, see: https://www.iterm2.com/documentation-images.html",
+        "For more information, see: https://www.iterm2.com/documentation-images.html"
     ),
     action='store_true')
 ARG_SAVE_DAGRUN = Arg(
@@ -844,9 +844,9 @@ DAGS_COMMANDS = (
         ),
     ),
     ActionCommand(
-        func=lazy_load_command('airflow.cli.commands.dag_command.dag_test'),
         name='test',
         help="Execute one run of a DAG",
+        func=lazy_load_command('airflow.cli.commands.dag_command.dag_test'),
         args=(
             ARG_DAG_ID, ARG_EXECUTION_DATE, ARG_SUBDIR, ARG_SHOW_DAGRUN, ARG_IMGCAT_DAGRUN, ARG_SAVE_DAGRUN
         ),


### PR DESCRIPTION
Without this fix, `airflow dags test` crashes with the following error:

```
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/argparse.py", line 531, in _format_action
    help_text = self._expand_help(action)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/argparse.py", line 620, in _expand_help
    return self._get_help_string(action) % params
TypeError: unsupported operand type(s) for %: 'tuple' and 'dict'
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
