### PR TITLE
Fix --forward-credentials flag in Breeze

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -500,7 +500,6 @@ Currently forwarded credentials are:
   * credentials stored in ``${HOME}/.aws``, ``${HOME}/.boto``, and ``${HOME}/.s3`` (for AWS authentication)
   * credentials stored in ``${HOME}/.docker`` for docker
   * credentials stored in ``${HOME}/.kube`` for kubectl
-  * credentials stored in ``${HOME}/.ssh`` for SSH
 
 
 Adding a New System Test

--- a/scripts/ci/docker-compose/forward-credentials.yml
+++ b/scripts/ci/docker-compose/forward-credentials.yml
@@ -30,4 +30,3 @@ services:
       - ${HOME}/.gsutil:/root/.gsutil:cached
       - ${HOME}/.kube:/root/.kube:cached
       - ${HOME}/.s3:/root/.s3:cached
-      - ${HOME}/.ssh:/root/.ssh:cached


### PR DESCRIPTION
When running Breeze with `--forward-credentials` flag it overrides the current .ssh config of the host which is very critical. This PR does not forward the .ssh directory anymore.

For me breeze also failed to initialize because of it.
```
###########################################################################################
                   EXITING /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh WITH STATUS CODE 1
###########################################################################################
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
