### PR TITLE
Retry initialization of environment in case it fails

### DIFF
--- a/scripts/ci/ci_run_airflow_testing.sh
+++ b/scripts/ci/ci_run_airflow_testing.sh
@@ -17,6 +17,39 @@
 # under the License.
 export VERBOSE=${VERBOSE:="false"}
 
+function run_airflow_testing_in_docker_with_kubernetes() {
+    export KUBERNETES_MODE=${KUBERNETES_MODE:="git_mode"}
+    export KUBERNETES_VERSION=${KUBERNETES_VERSION:="v1.15.3"}
+
+    # shellcheck disable=SC2016
+    docker-compose --log-level INFO \
+      -f "${MY_DIR}/docker-compose/base.yml" \
+      -f "${MY_DIR}/docker-compose/backend-${BACKEND}.yml" \
+      -f "${MY_DIR}/docker-compose/runtime-kubernetes.yml" \
+      "${INTEGRATIONS[@]}" \
+      "${DOCKER_COMPOSE_LOCAL[@]}" \
+         run airflow \
+           '/opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"' \
+           /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"
+         # Note the command is there twice (!) because it is passed via bash -c
+         # and bash -c starts passing parameters from $0. TODO: fixme
+}
+
+function run_airflow_testing_in_docker() {
+    # shellcheck disable=SC2016
+    docker-compose --log-level INFO \
+      -f "${MY_DIR}/docker-compose/base.yml" \
+      -f "${MY_DIR}/docker-compose/backend-${BACKEND}.yml" \
+      "${INTEGRATIONS[@]}" \
+      "${DOCKER_COMPOSE_LOCAL[@]}" \
+         run airflow \
+           '/opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"' \
+           /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"
+         # Note the command is there twice (!) because it is passed via bash -c
+         # and bash -c starts passing parameters from $0. TODO: fixme
+}
+
+
 # shellcheck source=scripts/ci/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/_script_init.sh"
 
@@ -90,36 +123,29 @@ done
 
 RUN_INTEGRATION_TESTS=${RUN_INTEGRATION_TESTS:=""}
 
-if [[ ${RUNTIME:=} == "kubernetes" ]]; then
-    export KUBERNETES_MODE=${KUBERNETES_MODE:="git_mode"}
-    export KUBERNETES_VERSION=${KUBERNETES_VERSION:="v1.15.3"}
-
-    set +u
-    # shellcheck disable=SC2016
-    docker-compose --log-level INFO \
-      -f "${MY_DIR}/docker-compose/base.yml" \
-      -f "${MY_DIR}/docker-compose/backend-${BACKEND}.yml" \
-      -f "${MY_DIR}/docker-compose/runtime-kubernetes.yml" \
-      "${INTEGRATIONS[@]}" \
-      "${DOCKER_COMPOSE_LOCAL[@]}" \
-         run airflow \
-           '/opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"' \
-           /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"
-         # Note the command is there twice (!) because it is passed via bash -c
-         # and bash -c starts passing parameters from $0. TODO: fixme
-    set -u
-else
-    set +u
-    # shellcheck disable=SC2016
-    docker-compose --log-level INFO \
-      -f "${MY_DIR}/docker-compose/base.yml" \
-      -f "${MY_DIR}/docker-compose/backend-${BACKEND}.yml" \
-      "${INTEGRATIONS[@]}" \
-      "${DOCKER_COMPOSE_LOCAL[@]}" \
-         run airflow \
-           '/opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"' \
-           /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"
-         # Note the command is there twice (!) because it is passed via bash -c
-         # and bash -c starts passing parameters from $0. TODO: fixme
-    set -u
-fi
+# Repeat tests in case initialization failed
+set +u
+MAX_RETRIES=4
+while [[ ${MAX_RETRIES} -ge "0" ]]
+do
+    set +e
+    if [[ ${RUNTIME:=} == "kubernetes" ]]; then
+        run_airflow_testing_in_docker_with_kubernetes "${@}"
+    else
+        run_airflow_testing_in_docker "${@}"
+    fi
+    EXIT_CODE=$?
+    set -e
+    if [[ ${EXIT_CODE} == 254 ]] ; then
+        echo
+        echo "Retrying on initialization failure. Remaining ${MAX_RETRIES} retries left"
+        echo
+        MAX_RETRIES=$(( MAX_RETRIES - 1 ))
+        # Cleanup docker containers and images to make sure everything is retried from scratch
+        docker-compose down --remove-orphans -f "${MY_DIR}/docker-compose/base.yml" --timeout 20
+        docker system prune --force --volumes
+        continue
+    fi
+    exit ${EXIT_CODE}
+done
+set -u

--- a/scripts/ci/in_container/entrypoint_ci.sh
+++ b/scripts/ci/in_container/entrypoint_ci.sh
@@ -113,7 +113,17 @@ unset AIRFLOW__CORE__UNIT_TEST_MODE
 mkdir -pv "${AIRFLOW_HOME}/logs/"
 cp -f "${MY_DIR}/airflow_ci.cfg" "${AIRFLOW_HOME}/unittests.cfg"
 
+set +e
 "${MY_DIR}/check_environment.sh"
+ENVIRONMENT_EXIT_CODE=$?
+set -e
+if [[ ${ENVIRONMENT_EXIT_CODE} != 0 ]]; then
+    echo
+    echo "Error: check_environment returned ${ENVIRONMENT_EXIT_CODE}. Exiting."
+    echo
+    exit ${ENVIRONMENT_EXIT_CODE}
+fi
+
 
 if [[ ${INTEGRATION_KERBEROS:="false"} == "true" ]]; then
     set +e


### PR DESCRIPTION
Sometimes the docker-compose environment fails to initialise. It is
one of two problems:

* DNS fwd/rev mismatch on checking the docker compose integration
* Missing name for the docker compose intagration

This is likely due to some race conditions when setting up docker
compose network and DNS. It happens very rarely and it seems that
it's not easily reproducible. It is very likely that detecting
this case, cleaning the docker environment and retrying will
work fine. This is what this PR tries to attempt

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
