### PR TITLE
Fixed SOURCE_BRANCH set by tag names

### DIFF
--- a/common/_image_variables.sh
+++ b/common/_image_variables.sh
@@ -27,9 +27,5 @@ export DOCKERHUB_USER=${DOCKERHUB_USER:="apache"}
 # own docker images. In this case you can build images locally and push them
 export DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
 
-# if BRANCH_NAME is not set it will be set to either SOURCE_BRANCH
-# (if overridden by configuration) or default branch configured in /common/_default_branch.sh
-export SOURCE_BRANCH=${SOURCE_BRANCH:=${DEFAULT_BRANCH}}
-
 # read branch name from what has been set from sources (It can also be overridden)
-export BRANCH_NAME=${BRANCH_NAME:=${SOURCE_BRANCH}}
+export BRANCH_NAME=${BRANCH_NAME:=${DEFAULT_BRANCH}}

--- a/scripts/ci/ci_build_dockerhub.sh
+++ b/scripts/ci/ci_build_dockerhub.sh
@@ -20,6 +20,7 @@
 # on CI to potentially rebuild (and refresh layers that
 # are not cached) Docker images that are used to run CI jobs
 export FORCE_ANSWER_TO_QUESTIONS="yes"
+export VERBOSE_COMMANDS="true"
 
 if [[ -z ${DOCKER_REPO} ]]; then
    echo

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -31,7 +31,6 @@ services:
       - MINICLUSTER_HOME=/opt/minicluster
       - CELERY_BROKER_URLS=amqp://guest:guest@rabbitmq:5672,redis://redis:6379/0
       - BACKEND
-      - SOURCE_BRANCH
       - CI
       - CI_BUILD_ID
       - CI_JOB_ID


### PR DESCRIPTION
SOURCE_BRANCH was set to TAG_NAME in Dockerhub. Now that we changed
DockerHub to build from tags, it caused AIRFLOW_BRANCH arg
to be set to master-nightly instead of master and we had a cache
miss.

SOURCE_BRANCH variable is not really needed anymore. Removed it

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
