### PR TITLE
Implement airflow lazy execution context retrieval

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -25,6 +25,7 @@ import os
 import signal
 import time
 import warnings
+from contextlib import ExitStack
 from datetime import datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from urllib.parse import quote
@@ -52,6 +53,7 @@ from airflow.models.xcom import XCOM_RETURN_KEY, XCom
 from airflow.sentry import Sentry
 from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.stats import Stats
+from airflow.task.context.execution_context import ExecutionContext
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
 from airflow.utils import timezone
@@ -1009,19 +1011,21 @@ class TaskInstance(Base, LoggingMixin):
                     self.log.error("Failed when executing execute callback")
                     self.log.exception(e3)
 
-                # If a timeout is specified for the task, make it fail
-                # if it goes beyond
-                result = None
-                if task_copy.execution_timeout:
-                    try:
-                        with timeout(int(
-                                task_copy.execution_timeout.total_seconds())):
+                with ExitStack() as exit_stack:
+                    from airflow.task.context.current import set_current_context
+                    exit_stack.enter_context(set_current_context(context))
+                    if task_copy.execution_timeout:
+                        try:
+                            # If a timeout is specified for the task, make it fail
+                            # if it goes beyond
+                            exit_stack.enter_context(timeout(int(
+                                task_copy.execution_timeout.total_seconds())))
                             result = task_copy.execute(context=context)
-                    except AirflowTaskTimeout:
-                        task_copy.on_kill()
-                        raise
-                else:
-                    result = task_copy.execute(context=context)
+                        except AirflowTaskTimeout:
+                            task_copy.on_kill()
+                            raise
+                    else:
+                        result = task_copy.execute(context=context)
 
                 # If the task returns a result, push an XCom containing it
                 if task_copy.do_xcom_push and result is not None:
@@ -1266,7 +1270,7 @@ class TaskInstance(Base, LoggingMixin):
         return self.task.retries and self.try_number <= self.max_tries
 
     @provide_session
-    def get_template_context(self, session=None) -> Dict[str, Any]:
+    def get_template_context(self, session=None) -> ExecutionContext:
         task = self.task
         from airflow import macros
 
@@ -1385,7 +1389,7 @@ class TaskInstance(Base, LoggingMixin):
             ):
                 return Variable.get(item, default_var=default_var, deserialize_json=True)
 
-        return {
+        context = {
             'conf': conf,
             'dag': task.dag,
             'dag_run': dag_run,
@@ -1424,6 +1428,8 @@ class TaskInstance(Base, LoggingMixin):
             'yesterday_ds': yesterday_ds,
             'yesterday_ds_nodash': yesterday_ds_nodash,
         }
+
+        return ExecutionContext(**context)
 
     def get_rendered_template_fields(self):
         """

--- a/airflow/task/context/__init__.py
+++ b/airflow/task/context/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/task/context/current.py
+++ b/airflow/task/context/current.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+
+from airflow.exceptions import AirflowException
+from airflow.task.context.execution_context import ExecutionContext
+
+_CURRENT_CONTEXT = []
+
+
+@contextlib.contextmanager
+def set_current_context(context):
+    """
+    Sets the current execution context to the provided context object.
+    This method should be called once per execution, before calling operator.execute
+    """
+    _CURRENT_CONTEXT.append(context)
+    try:
+        yield context
+    finally:
+        stack_state = _CURRENT_CONTEXT.pop()
+        if stack_state != context:
+            print("TODO WARNING")
+
+
+def get_current_context() -> ExecutionContext:
+    """
+    Obtain the execution context for the currently executing operator without
+    altering user method's signature.
+    This is the simplest method of retrieving the execution context dictionary.
+    ** Old style:
+        def my_task(**context):
+            ti = context["ti"]
+    ** New style:
+        def my_task():
+            from airflow.task.context import get_current_context
+            context = get_current_context()
+            ti = context["ti"]
+
+    Current context will only have value if this method was called after an operator
+    was starting to execute.
+    """
+    if not _CURRENT_CONTEXT:
+        raise AirflowException("Current context was requested but no context was found! "
+                               "Are you running within an airflow task?")
+    return _CURRENT_CONTEXT[-1]

--- a/airflow/task/context/execution_context.py
+++ b/airflow/task/context/execution_context.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from types import ModuleType
+from typing import Any, NamedTuple
+
+from pendulum import Pendulum
+
+from airflow.exceptions import AirflowException
+
+
+class ExecutionContext(NamedTuple):
+    """
+    Defines all stateful properties during execution.
+    This context can be passed to any task either via task.context.current.get_current_context, or via
+    requesting specific properties through the task's ctor, as in:
+
+        def f(execution_date):
+            print(execution_date) # This property is filled automatically by airflow
+    """
+    conf: Any
+    dag: Any
+    dag_run: str
+    ds: str
+    ds_nodash: str
+    execution_date: Pendulum
+    inlets: list
+    macros: ModuleType
+    next_ds: str
+    next_ds_nodash: str
+    next_execution_date: Pendulum
+    outlets: list
+    params: dict
+    prev_ds: str
+    prev_ds_nodash: str
+    prev_execution_date: Pendulum
+    prev_execution_date_success: Pendulum
+    prev_start_date_success: Pendulum
+    run_id: str
+    task: Any
+    task_instance: Any
+    task_instance_key_str: str
+    test_mode: bool
+    ti: Any
+    tomorrow_ds: str
+    tomorrow_ds_nodash: str
+    ts: str
+    ts_nodash: str
+    ts_nodash_with_tz: str
+    var: dict
+    yesterday_ds: str
+    yesterday_ds_nodash: str
+
+    def __getitem__(self, *args, **kwargs):
+        """
+        Allow slicing syntax for backwards compatibility to old-style context (dict access style)
+        """
+        if len(args) == 1 and isinstance(args[0], str):
+            return getattr(self, args[0])
+        raise AirflowException("Can only retrieve execution context properties via single string argument")
+
+    def get(self, key):
+        """
+        Retrieve property via key (dict access style)
+        """
+        try:
+            return getattr(self, key)
+        except Exception as e:
+            raise AirflowException(f"Key {key} not found in execution context!", e)

--- a/tests/task/context/__init__.py
+++ b/tests/task/context/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/task/context/test_current_context.py
+++ b/tests/task/context/test_current_context.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.models.baseoperator import BaseOperator
+from airflow.operators.python import PythonOperator
+from airflow.task.context.current import get_current_context, set_current_context
+
+DEFAULT_ARGS = {
+    "owner": "test",
+    "depends_on_past": True,
+    "start_date": datetime(2020, 4, 22),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+
+class TestCurrentContext:
+    def test_current_context_no_context_raise(self):
+        with pytest.raises(AirflowException):
+            get_current_context()
+
+    def test_current_context_roundtrip(self):
+        example_context = {"Hello": "World"}
+
+        with set_current_context(example_context):
+            assert get_current_context() == example_context
+
+    def test_context_removed_after_exit(self):
+        example_context = {"Hello": "World"}
+
+        with set_current_context(example_context):
+            pass
+        with pytest.raises(AirflowException, ):
+            get_current_context()
+
+    def test_nested_context(self):
+        max_stack_depth = 15
+        ctx_list = []
+        for i in range(max_stack_depth):
+            # Create all contexts in ascending order
+            new_context = {"ContextId": i}
+            # Like 15 nested with statements
+            ctx_obj = set_current_context(new_context)
+            ctx_obj.__enter__()  # pylint: disable=E1101
+            ctx_list.append(ctx_obj)
+        for i in reversed(range(max_stack_depth)):
+            # Iterate over contexts in reverse order - stack is LIFO
+            ctx = get_current_context()
+            assert ctx["ContextId"] == i
+            # End of with statement
+            ctx_list[i].__exit__(None, None, None)
+
+
+class MyContextAssertOperator(BaseOperator):
+    def execute(self, context):
+        assert context == get_current_context()
+
+
+def get_all_the_context(**context):
+    current_context = get_current_context()
+    assert context == current_context
+
+
+class TestCurrentContextRuntime:
+    def test_context_in_task(self):
+        with DAG(dag_id="assert_context_dag", default_args=DEFAULT_ARGS):
+            op = MyContextAssertOperator(task_id="assert_context")
+            op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
+
+    def test_get_context_in_old_style_context_task(self):
+        with DAG(dag_id="edge_case_context_dag", default_args=DEFAULT_ARGS):
+            op = PythonOperator(python_callable=get_all_the_context, task_id="get_all_the_context")
+            op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)


### PR DESCRIPTION
Description: Allow users to access airflow's execution context without altering their function signature, in a lazy and comfortable way.
Github Issue: https://github.com/apache/airflow/issues/8058 #8058 
---
Make sure to mark the boxes below before creating PR: [x]

- [ x] Description above provides context of the change
- [x ] Unit tests coverage for changes (not needed for documentation changes)
- [ x] Target Github ISSUE in description if exists
- [ x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x ] Relevant documentation is updated including usage instructions.
- [ x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
