### PR TITLE
Add google_api_to_s3_transfer example dags and system tests

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -482,7 +482,7 @@ run Google Cloud system tests.
       pip install /dist/apache_airflow_providers_{google,postgres,mysql}*.whl || true
   fi
 
-To execute system tests, specify the ``--system SYSTEM`
+To execute system tests, specify the ``--system SYSTEM``
 flag where ``SYSTEM`` is a system to run the system tests for. It can be repeated.
 
 
@@ -510,7 +510,7 @@ tests are run in our CI system. But to enable the test automation, we encourage 
 tests whenever an operator/hook/sensor is added/modified in a given system.
 
 * To add your own system tests, derive them from the
-  ``tests.test_utils.system_tests_class.SystemTest` class and mark with the
+  ``tests.test_utils.system_tests_class.SystemTest`` class and mark with the
   ``@pytest.mark.system(SYSTEM_NAME)`` marker. The system name should follow the path defined in
   the ``providers`` package (for example, the system tests from ``tests.providers.google.cloud``
   package should be marked with ``@pytest.mark.system("google.cloud")``.
@@ -547,12 +547,12 @@ Preparing backport packages for System Tests for Airflow 1.10.* series
 ----------------------------------------------------------------------
 
 To run system tests with old Airflow version you need to prepare backport packages. This
-can be done by running ``./scripts/ci/ci_prepare_backport_packages.sh <PACKAGES TO BUILD>``. For
+can be done by running ``./scripts/ci/ci_prepare_packages.sh <PACKAGES TO BUILD>``. For
 example the below command will build google postgres and mysql packages:
 
 .. code-block:: bash
 
-  ./scripts/ci/ci_prepare_backport_packages.sh google postgres mysql
+  ./scripts/ci/ci_prepare_packages.sh google postgres mysql
 
 Those packages will be prepared in ./dist folder. This folder is mapped to /dist folder
 when you enter Breeze, so it is easy to automate installing those packages for testing.
@@ -606,7 +606,7 @@ want to add ``-o faulthandler_timeout=2400`` (2400s = 40 minutes for example) to
 pytest command.
 
 The typical system test session
----------------------------
+-------------------------------
 
 Here is the typical session that you need to do to run system tests:
 
@@ -614,7 +614,7 @@ Here is the typical session that you need to do to run system tests:
 
 .. code-block:: bash
 
-  ./scripts/ci/ci_prepare_backport_packages.sh google postgres mysql
+  ./scripts/ci/ci_prepare_packages.sh google postgres mysql
 
 2. Enter breeze with installing Airflow 1.10.*, forwarding credentials and installing
    backported packages (you need an appropriate line in ``./files/airflow-breeze-config/variables.env``)
@@ -686,7 +686,7 @@ The typical session then looks as follows:
 
 .. code-block:: bash
 
-  ./scripts/ci/ci_prepare_backport_packages.sh google postgres mysql
+  ./scripts/ci/ci_prepare_packages.sh google postgres mysql
 
 2. Enter breeze with installing Airflow 1.10.*, forwarding credentials and installing
    backported packages (you need an appropriate line in ``./files/airflow-breeze-config/variables.env``)
@@ -716,7 +716,7 @@ In the host:
 
 .. code-block:: bash
 
-  ./scripts/ci/ci_prepare_backport_packages.sh google
+  ./scripts/ci/ci_prepare_packages.sh google
 
 In the container:
 

--- a/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+++ b/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
@@ -1,0 +1,132 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This is a more advanced example dag for using `GoogleApiToS3Transfer` which uses xcom to pass data between
+tasks to retrieve specific information about YouTube videos:
+
+First it searches for up to 50 videos (due to pagination) in a given time range
+(YOUTUBE_VIDEO_PUBLISHED_AFTER, YOUTUBE_VIDEO_PUBLISHED_BEFORE) on a YouTube channel (YOUTUBE_CHANNEL_ID)
+saves the response in S3 + passes over the YouTube IDs to the next request which then gets the information
+(YOUTUBE_VIDEO_FIELDS) for the requested videos and saves them in S3 (S3_DESTINATION_KEY).
+
+Further information:
+
+YOUTUBE_VIDEO_PUBLISHED_AFTER and YOUTUBE_VIDEO_PUBLISHED_BEFORE needs to be formatted
+"YYYY-MM-DDThh:mm:ss.sZ". See https://developers.google.com/youtube/v3/docs/search/list for more information.
+YOUTUBE_VIDEO_PARTS depends on the fields you pass via YOUTUBE_VIDEO_FIELDS. See
+https://developers.google.com/youtube/v3/docs/videos/list#parameters for more information.
+YOUTUBE_CONN_ID is optional for public videos. It does only need to authenticate when there are private videos
+on a YouTube channel you want to retrieve.
+"""
+
+from os import getenv
+
+from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.python import BranchPythonOperator
+from airflow.providers.amazon.aws.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+from airflow.utils.dates import days_ago
+
+# [START howto_operator_google_api_to_s3_transfer_advanced_env_variables]
+YOUTUBE_CONN_ID = getenv("YOUTUBE_CONN_ID", "google_cloud_default")
+YOUTUBE_CHANNEL_ID = getenv("YOUTUBE_CHANNEL_ID", "UCSXwxpWZQ7XZ1WL3wqevChA")  # "Apache Airflow"
+YOUTUBE_VIDEO_PUBLISHED_AFTER = getenv("YOUTUBE_VIDEO_PUBLISHED_AFTER", "2019-09-25T00:00:00Z")
+YOUTUBE_VIDEO_PUBLISHED_BEFORE = getenv("YOUTUBE_VIDEO_PUBLISHED_BEFORE", "2019-10-18T00:00:00Z")
+S3_DESTINATION_KEY = getenv("S3_DESTINATION_KEY", "s3://bucket/key.json")
+YOUTUBE_VIDEO_PARTS = getenv("YOUTUBE_VIDEO_PARTS", "snippet")
+YOUTUBE_VIDEO_FIELDS = getenv("YOUTUBE_VIDEO_FIELDS", "items(id,snippet(description,publishedAt,tags,title))")
+# [END howto_operator_google_api_to_s3_transfer_advanced_env_variables]
+
+default_args = {"start_date": days_ago(1)}
+
+
+# pylint: disable=unused-argument
+# [START howto_operator_google_api_to_s3_transfer_advanced_task_1_2]
+def _check_and_transform_video_ids(xcom_key, task_ids, task_instance, **kwargs):
+    video_ids_response = task_instance.xcom_pull(task_ids=task_ids, key=xcom_key)
+    video_ids = [item['id']['videoId'] for item in video_ids_response['items']]
+
+    if video_ids:
+        task_instance.xcom_push(key='video_ids', value={'id': ','.join(video_ids)})
+        return 'video_data_to_s3'
+    return 'no_video_ids'
+
+
+# [END howto_operator_google_api_to_s3_transfer_advanced_task_1_2]
+# pylint: enable=unused-argument
+
+s3_directory, s3_file = S3_DESTINATION_KEY.rsplit('/', 1)
+s3_file_name, _ = s3_file.rsplit('.', 1)
+
+with DAG(
+    dag_id="example_google_api_to_s3_transfer_advanced",
+    default_args=default_args,
+    schedule_interval=None,
+    tags=['example']
+) as dag:
+    # [START howto_operator_google_api_to_s3_transfer_advanced_task_1]
+    task_video_ids_to_s3 = GoogleApiToS3Transfer(
+        gcp_conn_id=YOUTUBE_CONN_ID,
+        google_api_service_name='youtube',
+        google_api_service_version='v3',
+        google_api_endpoint_path='youtube.search.list',
+        google_api_endpoint_params={
+            'part': 'snippet',
+            'channelId': YOUTUBE_CHANNEL_ID,
+            'maxResults': 50,
+            'publishedAfter': YOUTUBE_VIDEO_PUBLISHED_AFTER,
+            'publishedBefore': YOUTUBE_VIDEO_PUBLISHED_BEFORE,
+            'type': 'video',
+            'fields': 'items/id/videoId'
+        },
+        google_api_response_via_xcom='video_ids_response',
+        s3_destination_key=f'{s3_directory}/youtube_search_{s3_file_name}.json',
+        task_id='video_ids_to_s3'
+    )
+    # [END howto_operator_google_api_to_s3_transfer_advanced_task_1]
+    # [START howto_operator_google_api_to_s3_transfer_advanced_task_1_1]
+    task_check_and_transform_video_ids = BranchPythonOperator(
+        python_callable=_check_and_transform_video_ids,
+        op_args=[
+            task_video_ids_to_s3.google_api_response_via_xcom,
+            task_video_ids_to_s3.task_id
+        ],
+        task_id='check_and_transform_video_ids'
+    )
+    # [END howto_operator_google_api_to_s3_transfer_advanced_task_1_1]
+    # [START howto_operator_google_api_to_s3_transfer_advanced_task_2]
+    task_video_data_to_s3 = GoogleApiToS3Transfer(
+        gcp_conn_id=YOUTUBE_CONN_ID,
+        google_api_service_name='youtube',
+        google_api_service_version='v3',
+        google_api_endpoint_path='youtube.videos.list',
+        google_api_endpoint_params={
+            'part': YOUTUBE_VIDEO_PARTS,
+            'maxResults': 50,
+            'fields': YOUTUBE_VIDEO_FIELDS
+        },
+        google_api_endpoint_params_via_xcom='video_ids',
+        s3_destination_key=f'{s3_directory}/youtube_videos_{s3_file_name}.json',
+        task_id='video_data_to_s3'
+    )
+    # [END howto_operator_google_api_to_s3_transfer_advanced_task_2]
+    # [START howto_operator_google_api_to_s3_transfer_advanced_task_2_1]
+    task_no_video_ids = DummyOperator(
+        task_id='no_video_ids'
+    )
+    # [END howto_operator_google_api_to_s3_transfer_advanced_task_2_1]
+    task_video_ids_to_s3 >> task_check_and_transform_video_ids >> [task_video_data_to_s3, task_no_video_ids]

--- a/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.py
+++ b/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This is a basic example dag for using `GoogleApiToS3Transfer` to retrieve Google Sheets data:
+
+You need to set all env variables to request the data.
+"""
+
+from os import getenv
+
+from airflow import DAG
+from airflow.providers.amazon.aws.operators.google_api_to_s3_transfer import GoogleApiToS3Transfer
+from airflow.utils.dates import days_ago
+
+# [START howto_operator_google_api_to_s3_transfer_basic_env_variables]
+GOOGLE_SHEET_ID = getenv("GOOGLE_SHEET_ID")
+GOOGLE_SHEET_RANGE = getenv("GOOGLE_SHEET_RANGE")
+S3_DESTINATION_KEY = getenv("S3_DESTINATION_KEY", "s3://bucket/key.json")
+# [END howto_operator_google_api_to_s3_transfer_basic_env_variables]
+
+default_args = {"start_date": days_ago(1)}
+
+with DAG(
+    dag_id="example_google_api_to_s3_transfer_basic",
+    default_args=default_args,
+    schedule_interval=None,
+    tags=['example']
+) as dag:
+    # [START howto_operator_google_api_to_s3_transfer_basic_task_1]
+    task_google_sheets_values_to_s3 = GoogleApiToS3Transfer(
+        google_api_service_name='sheets',
+        google_api_service_version='v4',
+        google_api_endpoint_path='sheets.spreadsheets.values.get',
+        google_api_endpoint_params={
+            'spreadsheetId': GOOGLE_SHEET_ID,
+            'range': GOOGLE_SHEET_RANGE
+        },
+        s3_destination_key=S3_DESTINATION_KEY,
+        task_id='google_sheets_values_to_s3',
+        dag=dag
+    )
+    # [END howto_operator_google_api_to_s3_transfer_basic_task_1]

--- a/backport_packages/setup_backport_packages.py
+++ b/backport_packages/setup_backport_packages.py
@@ -251,6 +251,13 @@ def change_import_paths_to_deprecated():
         .modify(add_provide_context_to_python_operator)
     )
 
+    (
+        qry.select_function("BranchPythonOperator")
+        .is_call()
+        .is_filename(include=r"example_google_api_to_s3_transfer_advanced.py$")
+        .modify(add_provide_context_to_python_operator)
+    )
+
     # Remove new class and rename usages of old
     remove_class(qry, "GKEStartPodOperator")
     (

--- a/docs/howto/operator/amazon/aws/google_api_to_s3_transfer.rst
+++ b/docs/howto/operator/amazon/aws/google_api_to_s3_transfer.rst
@@ -1,0 +1,141 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+.. _howto/operator:GoogleApiToS3Transfer:
+
+Google API To S3 Transfer
+=========================
+
+.. contents::
+  :depth: 1
+  :local:
+
+Overview
+--------
+
+The ``GoogleApiToS3Transfer`` can call requests to any Google API which supports discovery and save its response on S3.
+
+Two example_dags are provided which showcase the
+:class:`~airflow.providers.amazon.aws.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer`
+in action.
+
+ - example_google_api_to_s3_transfer_basic.py
+ - example_google_api_to_s3_transfer_advanced.py
+
+example_google_api_to_s3_transfer_basic.py
+------------------------------------------
+
+Purpose
+"""""""
+This is a basic example dag for using ``GoogleApiToS3Transfer`` to retrieve Google Sheets data.
+
+Environment variables
+"""""""""""""""""""""
+
+These examples rely on the following variables, which can be passed via OS environment variables.
+
+.. exampleinclude:: ../../../../../airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.py
+    :language: python
+    :start-after: [START howto_operator_google_api_to_s3_transfer_basic_env_variables]
+    :end-before: [END howto_operator_google_api_to_s3_transfer_basic_env_variables]
+
+All of them are required.
+
+Get Google Sheets Sheet Values
+""""""""""""""""""""""""""""""
+
+In the following code we are requesting a Google Sheet via the ``sheets.spreadsheets.values.get`` endpoint.
+
+.. exampleinclude:: ../../../../../airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.py
+    :language: python
+    :start-after: [START howto_operator_google_api_to_s3_transfer_basic_task_1]
+    :end-before: [END howto_operator_google_api_to_s3_transfer_basic_task_1]
+
+You can find more information to the API endpoint used
+`here <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get>`__.
+
+example_google_api_to_s3_transfer_advanced.py
+---------------------------------------------
+
+Purpose
+"""""""
+
+This is a more advanced example dag for using ``GoogleApiToS3Transfer`` which uses xcom to pass data between
+tasks to retrieve specific information about YouTube videos.
+
+Environment variables
+"""""""""""""""""""""
+
+This example relies on the following variables, which can be passed via OS environment variables.
+
+.. exampleinclude:: ../../../../../airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+    :language: python
+    :start-after: [START howto_operator_google_api_to_s3_transfer_advanced_env_variables]
+    :end-before: [END howto_operator_google_api_to_s3_transfer_advanced_env_variables]
+
+``S3_DESTINATION_KEY`` is required.
+
+Get YouTube Videos
+""""""""""""""""""
+
+First it searches for up to 50 videos (due to pagination) in a given time range
+(``YOUTUBE_VIDEO_PUBLISHED_AFTER``, ``YOUTUBE_VIDEO_PUBLISHED_BEFORE``) on a YouTube channel (``YOUTUBE_CHANNEL_ID``)
+saves the response in S3 and also pushes the data to xcom.
+
+.. exampleinclude:: ../../../../../airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+    :language: python
+    :start-after: [START howto_operator_google_api_to_s3_transfer_advanced_task_1]
+    :end-before: [END howto_operator_google_api_to_s3_transfer_advanced_task_1]
+
+From there a ``BranchPythonOperator`` will extract the xcom data and bring the IDs in a format the next
+request needs it + it also decides whether we need to request any videos or not.
+
+.. exampleinclude:: ../../../../../airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+    :language: python
+    :start-after: [START howto_operator_google_api_to_s3_transfer_advanced_task_1_2]
+    :end-before: [END howto_operator_google_api_to_s3_transfer_advanced_task_1_2]
+
+.. exampleinclude:: ../../../../../airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+    :language: python
+    :start-after: [START howto_operator_google_api_to_s3_transfer_advanced_task_1_1]
+    :end-before: [END howto_operator_google_api_to_s3_transfer_advanced_task_1_1]
+
+If there are YouTube Video IDs available, it passes over the YouTube IDs to the next request which then gets the
+information (``YOUTUBE_VIDEO_FIELDS``) for the requested videos and saves them in S3 (``S3_DESTINATION_KEY``).
+
+.. exampleinclude:: ../../../../../airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+    :language: python
+    :start-after: [START howto_operator_google_api_to_s3_transfer_advanced_task_2]
+    :end-before: [END howto_operator_google_api_to_s3_transfer_advanced_task_2]
+
+If not do nothing - and track it.
+
+.. exampleinclude:: ../../../../../airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+    :language: python
+    :start-after: [START howto_operator_google_api_to_s3_transfer_advanced_task_2_1]
+    :end-before: [END howto_operator_google_api_to_s3_transfer_advanced_task_2_1]
+
+Reference
+---------
+
+For further information, look at:
+
+* `Google API Client library <https://github.com/googleapis/google-api-python-client>`__
+* `Google Sheets API v4 Documentation <https://developers.google.com/sheets/api/guides/concepts>`__
+* `YouTube Data API v3 Documentation <https://developers.google.com/youtube/v3/docs>`__
+* `AWS boto3 Library Documentation for S3 <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html>`__

--- a/tests/providers/amazon/aws/operators/test_google_api_to_s3_transfer_system.py
+++ b/tests/providers/amazon/aws/operators/test_google_api_to_s3_transfer_system.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import pytest
+
+from airflow.providers.amazon.aws.example_dags.example_google_api_to_s3_transfer_advanced import (
+    S3_DESTINATION_KEY as ADVANCED_S3_DESTINATION_KEY,
+)
+from airflow.providers.amazon.aws.example_dags.example_google_api_to_s3_transfer_basic import (
+    S3_DESTINATION_KEY as BASIC_S3_DESTINATION_KEY,
+)
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from tests.providers.google.cloud.utils.gcp_authenticator import GMP_KEY
+from tests.test_utils.amazon_system_helpers import (
+    AWS_DAG_FOLDER, AmazonSystemTest, provide_aws_context, provide_aws_s3_bucket,
+)
+from tests.test_utils.gcp_system_helpers import GoogleSystemTest, provide_gcp_context
+
+BASIC_BUCKET, _ = S3Hook.parse_s3_url(BASIC_S3_DESTINATION_KEY)
+ADVANCED_BUCKET, _ = S3Hook.parse_s3_url(ADVANCED_S3_DESTINATION_KEY)
+
+
+@pytest.fixture
+def provide_s3_bucket_basic():
+    with provide_aws_s3_bucket(BASIC_BUCKET):
+        yield
+
+
+@pytest.fixture
+def provide_s3_bucket_advanced():
+    with provide_aws_s3_bucket(ADVANCED_BUCKET):
+        yield
+
+
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.credential_file(GMP_KEY)
+class GoogleApiToS3TransferExampleDagsSystemTest(GoogleSystemTest, AmazonSystemTest):
+
+    @pytest.mark.usefixtures("provide_s3_bucket_basic")
+    @provide_aws_context()
+    @provide_gcp_context(GMP_KEY, scopes=['https://www.googleapis.com/auth/spreadsheets.readonly'])
+    def test_run_example_dag_google_api_to_s3_transfer_basic(self):
+        self.run_dag('example_google_api_to_s3_transfer_basic', AWS_DAG_FOLDER)
+
+    @pytest.mark.usefixtures("provide_s3_bucket_advanced")
+    @provide_aws_context()
+    @provide_gcp_context(GMP_KEY, scopes=['https://www.googleapis.com/auth/youtube.readonly'])
+    def test_run_example_dag_google_api_to_s3_transfer_advanced(self):
+        self.run_dag('example_google_api_to_s3_transfer_advanced', AWS_DAG_FOLDER)

--- a/tests/test_utils/amazon_system_helpers.py
+++ b/tests/test_utils/amazon_system_helpers.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+from contextlib import contextmanager
+from typing import List
+
+import pytest
+
+from tests.test_utils import AIRFLOW_MAIN_FOLDER
+from tests.test_utils.system_tests_class import SystemTest
+from tests.utils.logging_command_executor import get_executor
+
+AWS_DAG_FOLDER = os.path.join(
+    AIRFLOW_MAIN_FOLDER, "airflow", "providers", "amazon", "aws", "example_dags"
+)
+
+
+@contextmanager
+def provide_aws_context():
+    """
+    Authenticates the context to be able use aws resources.
+
+    Falls back to awscli default authentication methods via `.aws`` folder.
+    """
+    # TODO: Implement more authentication methods
+    yield
+
+
+@contextmanager
+def provide_aws_s3_bucket(name):
+    AmazonSystemTest.create_aws_s3_bucket(name)
+    yield
+    AmazonSystemTest.delete_aws_s3_bucket(name)
+
+
+@pytest.mark.system("amazon")
+class AmazonSystemTest(SystemTest):
+
+    @classmethod
+    def execute_with_ctx(cls, cmd: List[str]):
+        """
+        Executes command with context created by provide_aws_context.
+        """
+        executor = get_executor()
+        with provide_aws_context():
+            executor.execute_cmd(cmd=cmd)
+
+    @classmethod
+    def create_aws_s3_bucket(cls, name: str) -> None:
+        """
+        Creates the aws bucket with the given name.
+
+        :param name: name of the bucket
+        """
+        cmd = ["aws", "s3api", "create-bucket", "--bucket", name]
+        cls.execute_with_ctx(cmd)
+
+    @classmethod
+    def delete_aws_s3_bucket(cls, name: str) -> None:
+        """
+        Deletes the aws bucket with the given name. It needs to empty the bucket before it can be deleted.
+
+        :param name: name of the bucket
+        """
+        cmd = ["aws", "s3", "rm", f"s3://{name}", "--recursive"]
+        cls.execute_with_ctx(cmd)
+        cmd = ["aws", "s3api", "delete-bucket", "--bucket", name]
+        cls.execute_with_ctx(cmd)


### PR DESCRIPTION
This PR / change adds google_api_to_s3_transfer systems tests by running the newly added example dags. It also adds a aws system helper which can be used for providing aws context like connection or a s3 bucket for example to the system tests so you do not need to care about how to create or delete resources.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

cc @xinbinhuang @mustafagok - PTAL :)