### PR TITLE
Add system test and doc to http

### DIFF
--- a/airflow/providers/http/example_dags/example_http.py
+++ b/airflow/providers/http/example_dags/example_http.py
@@ -41,8 +41,9 @@ dag = DAG('example_http_operator', default_args=default_args, tags=['example'])
 
 dag.doc_md = __doc__
 
-# t1, t2 and t3 are examples of tasks created by instantiating operators
-t1 = SimpleHttpOperator(
+# task_post_op, task_get_op and task_put_op are examples of tasks created by instantiating operators
+# [START howto_operator_http_task_post_op]
+task_post_op = SimpleHttpOperator(
     task_id='post_op',
     endpoint='post',
     data=json.dumps({"priority": 5}),
@@ -50,16 +51,18 @@ t1 = SimpleHttpOperator(
     response_check=lambda response: response.json()['json']['priority'] == 5,
     dag=dag,
 )
-
-t5 = SimpleHttpOperator(
+# [END howto_operator_http_task_post_op]
+# [START howto_operator_http_task_post_op_formenc]
+task_post_op_formenc = SimpleHttpOperator(
     task_id='post_op_formenc',
     endpoint='post',
     data="name=Joe",
     headers={"Content-Type": "application/x-www-form-urlencoded"},
     dag=dag,
 )
-
-t2 = SimpleHttpOperator(
+# [END howto_operator_http_task_post_op_formenc]
+# [START howto_operator_http_task_get_op]
+task_get_op = SimpleHttpOperator(
     task_id='get_op',
     method='GET',
     endpoint='get',
@@ -67,8 +70,9 @@ t2 = SimpleHttpOperator(
     headers={},
     dag=dag,
 )
-
-t3 = SimpleHttpOperator(
+# [END howto_operator_http_task_get_op]
+# [START howto_operator_http_task_put_op]
+task_put_op = SimpleHttpOperator(
     task_id='put_op',
     method='PUT',
     endpoint='put',
@@ -76,8 +80,9 @@ t3 = SimpleHttpOperator(
     headers={"Content-Type": "application/json"},
     dag=dag,
 )
-
-t4 = SimpleHttpOperator(
+# [END howto_operator_http_task_put_op]
+# [START howto_operator_http_task_del_op]
+task_del_op = SimpleHttpOperator(
     task_id='del_op',
     method='DELETE',
     endpoint='delete',
@@ -85,8 +90,9 @@ t4 = SimpleHttpOperator(
     headers={"Content-Type": "application/x-www-form-urlencoded"},
     dag=dag,
 )
-
-sensor = HttpSensor(
+# [END howto_operator_http_task_del_op]
+# [START howto_operator_http_http_sensor_check]
+task_http_sensor_check = HttpSensor(
     task_id='http_sensor_check',
     http_conn_id='http_default',
     endpoint='',
@@ -95,5 +101,5 @@ sensor = HttpSensor(
     poke_interval=5,
     dag=dag,
 )
-
-sensor >> t1 >> t2 >> t3 >> t4 >> t5
+# [END howto_operator_http_http_sensor_check]
+task_http_sensor_check >> task_post_op >> task_get_op >> task_put_op >> task_del_op >> task_post_op_formenc

--- a/docs/howto/operator/http/http.rst
+++ b/docs/howto/operator/http/http.rst
@@ -1,0 +1,77 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+HTTP Operators
+==============
+
+The following code examples use the ``http_default`` connection which means the requests are sent against
+`httpbin <https://www.httpbin.org/>`__ site to perform basic HTTP operations.
+
+.. _howto/operator:HttpSensor:
+
+Use the :class:`~airflow.providers.http.sensors.http.HttpSensor` to poke until the ``response_check`` callable evaluates
+to ``true``.
+
+Here we are poking until httpbin gives us a response text containing ``httpbin``.
+
+.. exampleinclude:: ../../../../airflow/providers/http/example_dags/example_http.py
+    :language: python
+    :start-after: [START howto_operator_http_http_sensor_check]
+    :end-before: [END howto_operator_http_http_sensor_check]
+
+.. _howto/operator:SimpleHttpOperator:
+
+Use the :class:`~airflow.providers.http.operators.http.SimpleHttpOperator` to call HTTP requests and get
+the response text back.
+
+In the first example we are calling a ``POST`` with json data and succeed when we get the same json data back
+otherwise the task will fail.
+
+.. exampleinclude:: ../../../../airflow/providers/http/example_dags/example_http.py
+    :language: python
+    :start-after: [START howto_operator_http_task_post_op]
+    :end-before: [END howto_operator_http_task_post_op]
+
+Here we are calling a ``GET`` request and pass params to it. The task will succeed regardless of the response text.
+
+.. exampleinclude:: ../../../../airflow/providers/http/example_dags/example_http.py
+    :language: python
+    :start-after: [START howto_operator_http_task_get_op]
+    :end-before: [END howto_operator_http_task_get_op]
+
+In the third example we are performing a ``PUT`` operation to put / set data according to the data that is being
+provided to the request.
+
+.. exampleinclude:: ../../../../airflow/providers/http/example_dags/example_http.py
+    :language: python
+    :start-after: [START howto_operator_http_task_put_op]
+    :end-before: [END howto_operator_http_task_put_op]
+
+In this example we call a ``DELETE`` operation to the ``delete`` endpoint. This time we are passing form data to the
+request.
+
+.. exampleinclude:: ../../../../airflow/providers/http/example_dags/example_http.py
+    :language: python
+    :start-after: [START howto_operator_http_task_del_op]
+    :end-before: [END howto_operator_http_task_del_op]
+
+Here we pass form data to a ``POST`` operation which is equal to a usual form submit.
+
+.. exampleinclude:: ../../../../airflow/providers/http/example_dags/example_http.py
+    :language: python
+    :start-after: [START howto_operator_http_task_post_op_formenc]
+    :end-before: [END howto_operator_http_task_post_op_formenc]

--- a/docs/howto/operator/http/index.rst
+++ b/docs/howto/operator/http/index.rst
@@ -17,27 +17,16 @@
 
 
 
-Using Operators
-===============
+HTTP Operators
+==============
 
-An operator represents a single, ideally idempotent, task. Operators
-determine what actually executes when your DAG runs.
-
-.. note::
-    See the :ref:`Operators Concepts <concepts:operators>` documentation and the
-    :doc:`Operators API Reference <../../_api/index>` for more
-    information.
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
+    :glob:
 
-    bash
-    amazon/aws/index
-    dingding
-    gcp/index
-    http/index
-    kubernetes
-    papermill
-    python
-    external
-    yandexcloud
+    *
+
+.. note::
+    You can learn how to use HTTP integrations by analyzing the
+    `source code <https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags/>`_ of the particular example DAGs.

--- a/tests/providers/http/operators/test_http_system.py
+++ b/tests/providers/http/operators/test_http_system.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import pytest
+
+from tests.test_utils import AIRFLOW_MAIN_FOLDER
+from tests.test_utils.system_tests_class import SystemTest
+
+HTTP_DAG_FOLDER = os.path.join(
+    AIRFLOW_MAIN_FOLDER, "airflow", "providers", "http", "example_dags"
+)
+
+
+@pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("http")
+class HttpExampleDagsSystemTest(SystemTest):
+
+    def test_run_example_dag_http(self):
+        self.run_dag('example_http_operator', HTTP_DAG_FOLDER)


### PR DESCRIPTION
Add http system test calling the pre-existing http example dag.
The example dag contains different HTTP operations. All requests will be called against the httpbin host.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
