### PR TITLE
Pin Pylint to 2.4.4

### DIFF
--- a/requirements/requirements-python3.6.txt
+++ b/requirements/requirements-python3.6.txt
@@ -1,7 +1,7 @@
 # Editable install with no version control (apache-airflow==2.0.0.dev0)
 Authlib==0.14.1
 Babel==2.8.0
-Flask-AppBuilder==2.3.2
+Flask-AppBuilder==2.3.3
 Flask-Babel==1.0.0
 Flask-Bcrypt==0.7.1
 Flask-Caching==1.3.3
@@ -28,7 +28,7 @@ Pygments==2.6.1
 SQLAlchemy-JSONField==0.9.0
 SQLAlchemy-Utils==0.36.3
 SQLAlchemy==1.3.16
-Sphinx==3.0.2
+Sphinx==3.0.3
 Unidecode==1.1.1
 WTForms==2.2.1
 Werkzeug==0.16.1
@@ -86,7 +86,7 @@ cgroupspy==0.1.6
 chardet==3.0.4
 click==6.7
 cloudant==2.13.0
-cloudpickle==1.3.0
+cloudpickle==1.4.0
 colorama==0.4.3
 colorlog==4.0.2
 coverage==5.1
@@ -110,6 +110,7 @@ ecdsa==0.15
 elasticsearch-dbapi==0.1.0
 elasticsearch-dsl==7.1.0
 elasticsearch==7.5.1
+email-validator==1.0.5
 entrypoints==0.3
 execnet==1.7.1
 facebook-business==6.0.3
@@ -175,7 +176,7 @@ idna==2.9
 ijson==2.6.1
 imagesize==1.2.0
 importlib-metadata==1.6.0
-importlib-resources==1.4.0
+importlib-resources==1.5.0
 inflection==0.4.0
 ipdb==0.13.2
 ipython-genutils==0.2.0
@@ -201,7 +202,7 @@ lazy-object-proxy==1.4.3
 ldap3==2.7
 lockfile==0.12.2
 marshmallow-enum==1.5.1
-marshmallow-sqlalchemy==0.22.3
+marshmallow-sqlalchemy==0.23.0
 marshmallow==2.21.0
 mccabe==0.6.1
 mock==4.0.2
@@ -364,7 +365,7 @@ websocket-client==0.57.0
 wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.23.0
-yandexcloud==0.33.0
+yandexcloud==0.34.0
 zdesk==2.7.1
 zict==2.0.0
 zipp==3.1.0

--- a/requirements/requirements-python3.7.txt
+++ b/requirements/requirements-python3.7.txt
@@ -1,7 +1,7 @@
 # Editable install with no version control (apache-airflow==2.0.0.dev0)
 Authlib==0.14.1
 Babel==2.8.0
-Flask-AppBuilder==2.3.2
+Flask-AppBuilder==2.3.3
 Flask-Babel==1.0.0
 Flask-Bcrypt==0.7.1
 Flask-Caching==1.3.3
@@ -28,7 +28,7 @@ Pygments==2.6.1
 SQLAlchemy-JSONField==0.9.0
 SQLAlchemy-Utils==0.36.3
 SQLAlchemy==1.3.16
-Sphinx==3.0.2
+Sphinx==3.0.3
 Unidecode==1.1.1
 WTForms==2.2.1
 Werkzeug==0.16.1
@@ -86,7 +86,7 @@ cgroupspy==0.1.6
 chardet==3.0.4
 click==6.7
 cloudant==2.13.0
-cloudpickle==1.3.0
+cloudpickle==1.4.0
 colorama==0.4.3
 colorlog==4.0.2
 coverage==5.1
@@ -110,6 +110,7 @@ ecdsa==0.15
 elasticsearch-dbapi==0.1.0
 elasticsearch-dsl==7.1.0
 elasticsearch==7.5.1
+email-validator==1.0.5
 entrypoints==0.3
 execnet==1.7.1
 facebook-business==6.0.3
@@ -200,7 +201,7 @@ lazy-object-proxy==1.4.3
 ldap3==2.7
 lockfile==0.12.2
 marshmallow-enum==1.5.1
-marshmallow-sqlalchemy==0.22.3
+marshmallow-sqlalchemy==0.23.0
 marshmallow==2.21.0
 mccabe==0.6.1
 mock==4.0.2
@@ -361,7 +362,7 @@ websocket-client==0.57.0
 wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.23.0
-yandexcloud==0.33.0
+yandexcloud==0.34.0
 zdesk==2.7.1
 zict==2.0.0
 zipp==3.1.0

--- a/requirements/setup-3.6.md5
+++ b/requirements/setup-3.6.md5
@@ -1,1 +1,1 @@
-62ecf8b76ba00c5d680606d585a7164b  /opt/airflow/setup.py
+343f81df478e038bd0b7a2d47641d2fe  /opt/airflow/setup.py

--- a/requirements/setup-3.7.md5
+++ b/requirements/setup-3.7.md5
@@ -1,1 +1,1 @@
-62ecf8b76ba00c5d680606d585a7164b  /opt/airflow/setup.py
+077e53583e5bbd62a70f89e58d5e6cd2  /opt/airflow/setup.py

--- a/setup.py
+++ b/setup.py
@@ -444,7 +444,7 @@ devel = [
     'parameterized',
     'paramiko',
     'pre-commit',
-    'pylint~=2.4',
+    'pylint==2.4.4',
     'pysftp',
     'pytest',
     'pytest-cov',


### PR DESCRIPTION
Pylint 2.5.0 was released 8 hours ago ([link](https://pypi.org/project/pylint/2.5.0/)) which has added bunch of new rules & checks.

Pinning to 2.4.4 till we check the new rules & disable the ones we don't want to use

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
