### PR TITLE
Test deprecation warning for back-compat secrets

### DIFF
--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1436,6 +1436,25 @@ OPERATOR = [
     ),
 ]
 
+SECRETS = [
+    (
+        "airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend",
+        "airflow.contrib.secrets.aws_secrets_manager.SecretsManagerBackend",
+    ),
+    (
+        "airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend",
+        "airflow.contrib.secrets.aws_systems_manager.SystemsManagerParameterStoreBackend",
+    ),
+    (
+        "airflow.providers.google.cloud.secrets.secrets_manager.CloudSecretsManagerBackend",
+        "airflow.contrib.secrets.gcp_secrets_manager.CloudSecretsManagerBackend",
+    ),
+    (
+        "airflow.providers.hashicorp.secrets.vault.VaultBackend",
+        "airflow.contrib.secrets.hashicorp_vault.VaultBackend",
+    ),
+]
+
 SENSOR = [
     (
         "airflow.providers.google.cloud.sensors.bigtable.BigtableTableReplicationCompletedSensor",
@@ -1641,11 +1660,11 @@ PROTOCOLS = [
     ),
 ]
 
-ALL = HOOK + OPERATOR + SENSOR + PROTOCOLS
+ALL = HOOK + OPERATOR + SECRETS + SENSOR + PROTOCOLS
 
 RENAMED_HOOKS = [
     (old_class, new_class)
-    for old_class, new_class in HOOK + OPERATOR + SENSOR
+    for old_class, new_class in HOOK + OPERATOR + SECRETS + SENSOR
     if old_class.rpartition(".")[2] != new_class.rpartition(".")[2]
 ]
 


### PR DESCRIPTION
Based on https://github.com/apache/airflow/pull/8413#issuecomment-616535528

Add contrib secrets to TestMovingCoreToContrib to test deprecation warning is raised

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
