### PR TITLE
Reduce duplication of functions called in ci scripts

### DIFF
--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -717,6 +717,8 @@ function compare_layers() {
 }
 
 function rebuild_ci_image_if_needed() {
+    prepare_ci_build
+
     if [[ ${SKIP_CI_IMAGE_CHECK:="false"} == "true" ]]; then
         echo
         echo "Skip checking CI image"

--- a/scripts/ci/ci_build_dockerhub.sh
+++ b/scripts/ci/ci_build_dockerhub.sh
@@ -72,7 +72,6 @@ if [[ ${DOCKER_TAG} == *python*-ci ]]; then
     echo "Building CI image"
     echo
     rm -rf "${BUILD_CACHE_DIR}"
-    prepare_ci_build
     rebuild_ci_image_if_needed
     push_ci_image
 elif [[ ${DOCKER_TAG} == *python* ]]; then

--- a/scripts/ci/ci_docs.sh
+++ b/scripts/ci/ci_docs.sh
@@ -36,8 +36,6 @@ function run_docs() {
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 run_docs

--- a/scripts/ci/ci_flake8.sh
+++ b/scripts/ci/ci_flake8.sh
@@ -52,8 +52,6 @@ function run_flake8() {
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 run_flake8 "$@"

--- a/scripts/ci/ci_generate_requirements.sh
+++ b/scripts/ci/ci_generate_requirements.sh
@@ -22,8 +22,6 @@ export PYTHON_MAJOR_MINOR_VERSION=${PYTHON_MAJOR_MINOR_VERSION:-3.6}
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 run_generate_requirements

--- a/scripts/ci/ci_mypy.sh
+++ b/scripts/ci/ci_mypy.sh
@@ -42,8 +42,6 @@ function run_mypy() {
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 run_mypy "$@"

--- a/scripts/ci/ci_prepare_packages.sh
+++ b/scripts/ci/ci_prepare_packages.sh
@@ -22,8 +22,6 @@ export PYTHON_MAJOR_MINOR_VERSION=${PYTHON_MAJOR_MINOR_VERSION:-3.6}
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 run_prepare_packages "$@"

--- a/scripts/ci/ci_pylint_tests.sh
+++ b/scripts/ci/ci_pylint_tests.sh
@@ -52,8 +52,6 @@ function run_pylint_tests() {
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 if [[ "${#@}" != "0" ]]; then

--- a/scripts/ci/ci_refresh_pylint_todo.sh
+++ b/scripts/ci/ci_refresh_pylint_todo.sh
@@ -35,8 +35,6 @@ function refresh_pylint_todo() {
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 refresh_pylint_todo

--- a/scripts/ci/ci_run_airflow_testing.sh
+++ b/scripts/ci/ci_run_airflow_testing.sh
@@ -62,8 +62,6 @@ fi
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 # Test environment

--- a/scripts/ci/ci_run_static_checks.sh
+++ b/scripts/ci/ci_run_static_checks.sh
@@ -29,8 +29,6 @@ fi
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 if [[ $# == "0" ]]; then

--- a/scripts/ci/ci_test_backport_packages.sh
+++ b/scripts/ci/ci_test_backport_packages.sh
@@ -40,8 +40,6 @@ function run_test_package_installation() {
 
 get_ci_environment
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed
 
 run_test_package_installation

--- a/scripts/ci/pre_commit_ci_build.sh
+++ b/scripts/ci/pre_commit_ci_build.sh
@@ -23,6 +23,4 @@ export REMEMBER_LAST_ANSWER="${2}"
 
 forget_last_answer
 
-prepare_ci_build
-
 rebuild_ci_image_if_needed_and_confirmed


### PR DESCRIPTION
Every place we called rebuild_ci_image_if_needed we were also calling
preprepare_ci_build -- there's no need.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
