### PR TITLE
make hive macros return string type vs bytes

### DIFF
--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -685,6 +685,7 @@ class HiveMetastoreHook(BaseHook):
                            pairs will be considered as candidates of max partition.
         :type filter_map: map
         :return: Max partition or None if part_specs is empty.
+        :rtype: basestring
         """
         if not part_specs:
             return None
@@ -708,7 +709,7 @@ class HiveMetastoreHook(BaseHook):
         if not candidates:
             return None
         else:
-            return max(candidates).encode('utf-8')
+            return max(candidates)
 
     def max_partition(self, schema, table_name, field=None, filter_map=None):
         """

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -293,7 +293,7 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
                 None)
 
         # No partition will be filtered out.
-        self.assertEqual(max_partition, b'value3')
+        self.assertEqual(max_partition, 'value3')
 
     def test_get_max_partition_from_valid_part_specs(self):
         max_partition = \
@@ -302,7 +302,16 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
                  {'key1': 'value3', 'key2': 'value4'}],
                 'key1',
                 self.VALID_FILTER_MAP)
-        self.assertEqual(max_partition, b'value1')
+        self.assertEqual(max_partition, 'value1')
+
+    def test_get_max_partition_from_valid_part_specs_return_type(self):
+        max_partition = \
+            HiveMetastoreHook._get_max_partition_from_part_specs(
+                [{'key1': 'value1', 'key2': 'value2'},
+                 {'key1': 'value3', 'key2': 'value4'}],
+                'key1',
+                self.VALID_FILTER_MAP)
+        self.assertIsInstance(max_partition, str)
 
     def test_get_metastore_client(self):
         self.assertIsInstance(self.hook.get_metastore_client(), HMSClient)
@@ -375,7 +384,7 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
                                             table_name=self.table,
                                             field=self.partition_by,
                                             filter_map=filter_map)
-        self.assertEqual(partition, DEFAULT_DATE_DS.encode('utf-8'))
+        self.assertEqual(partition, DEFAULT_DATE_DS)
 
     def test_table_exists(self):
         self.assertTrue(self.hook.table_exists(self.table, db=self.database))


### PR DESCRIPTION
With the current implementation of the hive macros encoding the resultant from the metastore calls, in py2 this returns a string type still but in python3 encoding forces the representation to be a byte type. See the example below
```
ahaidrey-078HTD6:incubator-airflow ahaidrey$ python3
Python 3.7.0 (default, Oct  2 2018, 09:20:07)
[Clang 10.0.0 (clang-1000.11.45.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> a = 'apple'
>>> b = a.encode('utf-8')
>>> type(b)
<class 'bytes'>

ahaidrey-078HTD6:~ ahaidrey$ python
Python 2.7.16 (default, Dec  3 2019, 02:03:47)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> a = 'apple'
>>> b = a.encode('utf-8')
>>> type(b)
<type 'str'>
```
The issue with this is that the resultant for example being used by macros returns a byte type that isn't templatable as a string and breaks the queries it is used in. What this means is that all the templates need to be written as something like this:
```
val = "{{ macros.hive.max_partition(table='mytable', schema='myschema', field='myfield', filter_map={'key1': 'val1'}).decode('utf-8') }}"
```
Requiring from the users end to always decode the value is not the intention of this method and should use a value that can be returned as is.

This PR is to fix this ordeal. We may be able to just remove the encoding altogether but it could make things backwards incompatible.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists (not existing)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
