### PR TITLE
Fixed optimistions of non-py-code builds

### DIFF
--- a/scripts/ci/ci_count_changed_files.sh
+++ b/scripts/ci/ci_count_changed_files.sh
@@ -31,7 +31,7 @@ git remote add target "https://github.com/${CI_TARGET_REPO}"
 
 git fetch target "${CI_TARGET_BRANCH}:${CI_TARGET_BRANCH}" --depth=1
 
-CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r "${1}" "${CI_TARGET_BRANCH}")
+CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r "${1}" "${CI_TARGET_BRANCH}" || true)
 
 echo
 echo "Changed files:"
@@ -48,7 +48,7 @@ echo
 echo
 echo "Count changed files matching the ${2} pattern"
 echo
-COUNT_CHANGED_FILES=$(echo "${CHANGED_FILES}" | grep -c "${2}")
+COUNT_CHANGED_FILES=$(echo "${CHANGED_FILES}" | grep -c "${2}" || true)
 echo "${COUNT_CHANGED_FILES}"
 echo
 


### PR DESCRIPTION
Count of changed files returned exit code 1 not 0 when there
was no files matching the pattern, so the whole optimisation
did not work as intended.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
