### PR TITLE
Extend docker swarm operator configuration

### DIFF
--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -143,13 +143,17 @@ class DockerSwarmOperator(DockerOperator):
             self._stream_logs_to_output()
 
         self._block_until_service_terminated()
-        self.log.info('Service status before exiting: %s',
-                      self._service_status())
+
+        # Cache status and service to access it after removing the service
+        status = self._service_status()
+        service_repr = repr(self.service)
+        self.log.info('Service status before exiting: %s', status)
 
         if self.auto_remove:
             self.cli.remove_service(self.service['ID'])
-        if self._service_status() == 'failed':
-            raise AirflowException('Service failed: ' + repr(self.service))
+
+        if status == 'failed':
+            raise AirflowException('Service failed: ' + service_repr)
 
     def _create_service(self):
         return self.cli.create_service(

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -16,6 +16,8 @@
 # under the License.
 """Run ephemeral Docker Swarm services"""
 
+from time import sleep
+
 import requests
 from docker import types
 
@@ -163,6 +165,7 @@ class DockerSwarmOperator(DockerOperator):
             if self._has_service_terminated():
                 self.log.info('Service status before exiting: %s', self._service_status())
                 break
+            sleep(0.05)
 
         if self.auto_remove:
             self.cli.remove_service(self.service['ID'])

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -128,7 +128,8 @@ class DockerSwarmOperator(DockerOperator):
         return self._run_service()
 
     def _run_service(self):
-        self.log.info('Starting docker service from image %s', self.image)
+        self.log.info('Starting docker service %s from image %s',
+                      self._get_service_name(), self.image)
 
         self.service = self.cli.create_service(
             types.TaskTemplate(
@@ -145,7 +146,7 @@ class DockerSwarmOperator(DockerOperator):
                 resources=types.Resources(mem_limit=self.mem_limit),
                 networks=self.networks,
             ),
-            name='airflow-%s' % get_random_string(),
+            name=self._get_service_name(),
             labels={'name': 'airflow__%s__%s' % (self.dag_id, self.task_id)}
         )
 
@@ -237,6 +238,9 @@ class DockerSwarmOperator(DockerOperator):
         # flush any remaining log stream
         if line:
             self.log.info(line)
+
+    def _get_service_name(self):
+        return '%s__af_%s' % (self.task_id, get_random_string())
 
     def on_kill(self):
         if self.cli is not None:

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -69,7 +69,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         operator = DockerSwarmOperator(
             api_version='1.19', command='env', environment={'UNIT': 'TEST'}, image='ubuntu:latest',
             mem_limit='128m', user='unittest', task_id='unittest', auto_remove=True, tty=True,
-            networks=['net1','net2'], configs=configs, secrets=secrets
+            networks=['net1', 'net2'], configs=configs, secrets=secrets
         )
         operator.execute(None)
 
@@ -87,7 +87,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
 
         types_mock.ContainerSpec.assert_called_once_with(
             image='ubuntu:latest', command='env', user='unittest', tty=True,
-            env={'UNIT': 'TEST', 'AIRFLOW_TMP_DIR': '/tmp/airflow'}, 
+            env={'UNIT': 'TEST', 'AIRFLOW_TMP_DIR': '/tmp/airflow'},
             configs=[mock_obj], secrets=[mock_obj]
         )
         types_mock.RestartPolicy.assert_called_once_with(condition='none')

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -107,7 +107,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         )
         self.assertEqual(csargs, (mock_obj, ))
         self.assertEqual(cskwargs['labels'], {'name': 'airflow__adhoc_airflow__unittest'})
-        self.assertTrue(cskwargs['name'].startswith('airflow-'))
+        self.assertTrue(cskwargs['name'].startswith('unittest__af_'))
         self.assertEqual(client_mock.tasks.call_count, 5)
         client_mock.remove_service.assert_called_once_with('some_id')
 

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -108,7 +108,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         self.assertEqual(csargs, (mock_obj, ))
         self.assertEqual(cskwargs['labels'], {'name': 'airflow__adhoc_airflow__unittest'})
         self.assertTrue(cskwargs['name'].startswith('unittest__af_'))
-        self.assertEqual(client_mock.tasks.call_count, 5)
+        self.assertEqual(client_mock.tasks.call_count, 4)
         client_mock.remove_service.assert_called_once_with('some_id')
 
     @mock.patch('airflow.providers.docker.operators.docker.APIClient')


### PR DESCRIPTION
While working with the operator I had to change a few things to work better for my use cases.
I thought I'd make a pull request, perhaps some changes seem relevant.
I'm happy to cherry pick code changes that makes sense for the project. Here is a list of the changes:
- Additional options to define configs, secrets and networks for the new service to use
- The service name now contains the Airflow `task_id` to easier distinguish between multiple services started through Airflow
- Short sleeping intervals between service status polls to reduce cpu usage
- Minor refactoring to improve readability of the `_run_service()` method

---
- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).