### PR TITLE
Profile hostname for celery executor (#8619)

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -38,9 +38,10 @@ from celery.result import AsyncResult
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.executors.base_executor import BaseExecutor, CommandType
+from airflow.executors.base_executor import BaseExecutor, CommandType, EventBufferValueType
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKeyType
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.net import get_hostname
 from airflow.utils.timeout import timeout
 
 log = logging.getLogger(__name__)
@@ -78,7 +79,8 @@ def execute_command(command_to_exec: CommandType) -> None:
     except subprocess.CalledProcessError as e:
         log.exception('execute_command encountered a CalledProcessError')
         log.error(e.output)
-        raise AirflowException('Celery command failed')
+        msg = 'Celery command failed on host: ' + get_hostname()
+        raise AirflowException(msg)
 
 
 class ExceptionWithTraceback:
@@ -220,29 +222,29 @@ class CeleryExecutor(BaseExecutor):
         """Updates states of the tasks."""
 
         self.log.debug("Inquiring about %s celery task(s)", len(self.tasks))
-        states_by_celery_task_id = self.bulk_state_fetcher.get_many(self.tasks.values())
+        state_and_info_by_celery_task_id = self.bulk_state_fetcher.get_many(self.tasks.values())
 
         self.log.debug("Inquiries completed.")
         for key, async_result in list(self.tasks.items()):
-            state_by_task_id = states_by_celery_task_id.get(async_result.task_id)
-            if state_by_task_id:
-                self.update_task_state(key, state_by_task_id)
+            state, info = state_and_info_by_celery_task_id.get(async_result.task_id)
+            if state:
+                self.update_task_state(key, state, info)
 
-    def update_task_state(self, key: TaskInstanceKeyType, state: str) -> None:
+    def update_task_state(self, key: TaskInstanceKeyType, state: str, info: Any) -> None:
         """Updates state of a single task."""
         # noinspection PyBroadException
         try:
             if self.last_state[key] != state:
                 if state == celery_states.SUCCESS:
-                    self.success(key)
+                    self.success(key, info)
                     del self.tasks[key]
                     del self.last_state[key]
                 elif state == celery_states.FAILURE:
-                    self.fail(key)
+                    self.fail(key, info)
                     del self.tasks[key]
                     del self.last_state[key]
                 elif state == celery_states.REVOKED:
-                    self.fail(key)
+                    self.fail(key, info)
                     del self.tasks[key]
                     del self.last_state[key]
                 else:
@@ -269,7 +271,8 @@ class CeleryExecutor(BaseExecutor):
         pass
 
 
-def fetch_celery_task_state(async_result: AsyncResult) -> Tuple[str, Union[str, ExceptionWithTraceback]]:
+def fetch_celery_task_state(async_result: AsyncResult) -> \
+        Tuple[str, Union[str, ExceptionWithTraceback], Any]:
     """
     Fetch and return the state of the given celery task. The scope of this function is
     global so that it can be called by subprocesses in the pool.
@@ -277,18 +280,20 @@ def fetch_celery_task_state(async_result: AsyncResult) -> Tuple[str, Union[str, 
     :param async_result: a tuple of the Celery task key and the async Celery object used
         to fetch the task's state
     :type async_result: tuple(str, celery.result.AsyncResult)
-    :return: a tuple of the Celery task key and the Celery state of the task
-    :rtype: tuple[str, str]
+    :return: a tuple of the Celery task key and the Celery state and the celery info
+        of the task
+    :rtype: tuple[str, str, str]
     """
 
     try:
         with timeout(seconds=OPERATION_TIMEOUT):
             # Accessing state property of celery task will make actual network request
             # to get the current state of the task
-            return async_result.task_id, async_result.state
+            info = async_result.info if hasattr(async_result, 'info') else None
+            return async_result.task_id, async_result.state, info
     except Exception as e:  # pylint: disable=broad-except
         exception_traceback = f"Celery Task ID: {async_result}\n{traceback.format_exc()}"
-        return async_result.task_id, ExceptionWithTraceback(e, exception_traceback)
+        return async_result.task_id, ExceptionWithTraceback(e, exception_traceback), None
 
 
 def _tasks_list_to_task_ids(async_tasks) -> Set[str]:
@@ -307,7 +312,7 @@ class BulkStateFetcher(LoggingMixin):
         super().__init__()
         self._sync_parallelism = sync_parralelism
 
-    def get_many(self, async_results) -> Mapping[str, str]:
+    def get_many(self, async_results) -> Mapping[str, EventBufferValueType]:
         """
         Gets status for many Celery tasks using the best method available.
         """
@@ -321,16 +326,16 @@ class BulkStateFetcher(LoggingMixin):
         self.log.debug("Fetched %d states for %d task", len(result), len(async_results))
         return result
 
-    def _get_many_from_kv_backend(self, async_tasks) -> Mapping[str, str]:
+    def _get_many_from_kv_backend(self, async_tasks) -> Mapping[str, EventBufferValueType]:
         task_ids = _tasks_list_to_task_ids(async_tasks)
         keys = [app.backend.get_key_for_task(k) for k in task_ids]
         values = app.backend.mget(keys)
         task_results = [app.backend.decode_result(v) for v in values if v]
         task_results_by_task_id = {task_result["task_id"]: task_result for task_result in task_results}
 
-        return self._preapre_state_by_task_dict(task_ids, task_results_by_task_id)
+        return self._prepare_state_and_info_by_task_dict(task_ids, task_results_by_task_id)
 
-    def _get_many_from_db_backend(self, async_tasks) -> Mapping[str, str]:
+    def _get_many_from_db_backend(self, async_tasks) -> Mapping[str, EventBufferValueType]:
         task_ids = _tasks_list_to_task_ids(async_tasks)
         session = app.backend.ResultSession()
         with session_cleanup(session):
@@ -338,38 +343,41 @@ class BulkStateFetcher(LoggingMixin):
 
         task_results = [app.backend.meta_from_decoded(task.to_dict()) for task in tasks]
         task_results_by_task_id = {task_result["task_id"]: task_result for task_result in task_results}
-        return self._preapre_state_by_task_dict(task_ids, task_results_by_task_id)
+        return self._prepare_state_and_info_by_task_dict(task_ids, task_results_by_task_id)
 
     @staticmethod
-    def _preapre_state_by_task_dict(task_ids, task_results_by_task_id) -> Mapping[str, str]:
-        states: MutableMapping[str, str] = {}
+    def _prepare_state_and_info_by_task_dict(task_ids,
+                                             task_results_by_task_id) -> Mapping[str, EventBufferValueType]:
+        state_info: MutableMapping[str, EventBufferValueType] = {}
         for task_id in task_ids:
             task_result = task_results_by_task_id.get(task_id)
             if task_result:
                 state = task_result["status"]
+                info = None if not hasattr(task_result, "info") else task_result["info"]
             else:
                 state = celery_states.PENDING
-            states[task_id] = state
-        return states
+                info = None
+            state_info[task_id] = state, info
+        return state_info
 
-    def _get_many_using_multiprocessing(self, async_results) -> Mapping[str, str]:
+    def _get_many_using_multiprocessing(self, async_results) -> Mapping[str, EventBufferValueType]:
         num_process = min(len(async_results), self._sync_parallelism)
 
         with Pool(processes=num_process) as sync_pool:
             chunksize = max(1, math.floor(math.ceil(1.0 * len(async_results) / self._sync_parallelism)))
 
-            task_id_to_states_or_exception = sync_pool.map(
+            task_id_to_states_and_info = sync_pool.map(
                 fetch_celery_task_state,
                 async_results,
                 chunksize=chunksize)
 
-            states_by_task_id: MutableMapping[str, str] = {}
-            for task_id, state_or_exception in task_id_to_states_or_exception:
+            states_and_info_by_task_id: MutableMapping[str, EventBufferValueType] = {}
+            for task_id, state_or_exception, info in task_id_to_states_and_info:
                 if isinstance(state_or_exception, ExceptionWithTraceback):
                     self.log.error(  # pylint: disable=logging-not-lazy
                         CELERY_FETCH_ERR_MSG_HEADER + ":%s\n%s\n",
                         state_or_exception.exception, state_or_exception.traceback
                     )
                 else:
-                    states_by_task_id[task_id] = state_or_exception
-        return states_by_task_id
+                    states_and_info_by_task_id[task_id] = state_or_exception, info
+        return states_and_info_by_task_id

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -147,7 +147,7 @@ class DebugExecutor(BaseExecutor):
     def terminate(self) -> None:
         self._terminated.set()
 
-    def change_state(self, key: TaskInstanceKeyType, state: str) -> None:
+    def change_state(self, key: TaskInstanceKeyType, state: str, info=None) -> None:
         self.log.debug("Popping %s from executor task queue.", key)
         self.running.remove(key)
-        self.event_buffer[key] = state
+        self.event_buffer[key] = state, info

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -884,7 +884,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                 self.running.remove(key)
             except KeyError:
                 self.log.debug('Could not find key: %s', str(key))
-        self.event_buffer[key] = state
+        self.event_buffer[key] = state, None
 
     def _flush_task_queue(self) -> None:
         if not self.task_queue:

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -254,7 +254,8 @@ class BackfillJob(BaseJob):
         executor = self.executor
 
         # TODO: query all instead of refresh from db
-        for key, state in list(executor.get_event_buffer().items()):
+        for key, value in list(executor.get_event_buffer().items()):
+            state, info = value
             if key not in running:
                 self.log.warning(
                     "%s state %s not in running=%s",
@@ -271,7 +272,7 @@ class BackfillJob(BaseJob):
                 if ti.state == State.RUNNING or ti.state == State.QUEUED:
                     msg = ("Executor reports task instance {} finished ({}) "
                            "although the task says its {}. Was the task "
-                           "killed externally?".format(ti, state, ti.state))
+                           "killed externally? Info: {}".format(ti, state, ti.state, info))
                     self.log.error(msg)
                     ti.handle_failure(msg)
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1490,8 +1490,9 @@ class SchedulerJob(BaseJob):
 
         TI = models.TaskInstance
         # pylint: disable=too-many-nested-blocks
-        for key, state in list(self.executor.get_event_buffer(simple_dag_bag.dag_ids)
+        for key, value in list(self.executor.get_event_buffer(simple_dag_bag.dag_ids)
                                    .items()):
+            state, info = value
             dag_id, task_id, execution_date, try_number = key
             self.log.info(
                 "Executor reports execution of %s.%s execution_date=%s "
@@ -1512,15 +1513,15 @@ class SchedulerJob(BaseJob):
                     Stats.incr('scheduler.tasks.killed_externally')
                     self.log.error(
                         "Executor reports task instance %s finished (%s) although the task says its %s. "
-                        "Was the task killed externally?",
-                        ti, state, ti.state
+                        "(Info: %s) Was the task killed externally?",
+                        ti, state, ti.state, info
                     )
                     simple_dag = simple_dag_bag.get_dag(dag_id)
                     self.processor_agent.send_callback_to_execute(
                         full_filepath=simple_dag.full_filepath,
                         task_instance=ti,
                         msg="Executor reports task instance finished ({}) although the task says its {}. "
-                            "Was the task killed externally?".format(state, ti.state)
+                            "(Info: {}) Was the task killed externally?".format(state, ti.state, info)
                     )
 
     def _execute(self):

--- a/scripts/perf/scheduler_dag_execution_timing.py
+++ b/scripts/perf/scheduler_dag_execution_timing.py
@@ -52,13 +52,13 @@ class ShortCircuitExecutorMixin:
             ) for dag_id in dag_ids_to_watch
         }
 
-    def change_state(self, key, state):
+    def change_state(self, key, state, info=None):
         '''
         Change the state of scheduler by waiting till the tasks is complete
         and then shut down the scheduler after the task is complete
         '''
         from airflow.utils.state import State
-        super().change_state(key, state)
+        super().change_state(key, state, info=info)
 
         dag_id, _, execution_date, __ = key
         if dag_id not in self.dags_to_watch:

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -34,9 +34,9 @@ class TestBaseExecutor(unittest.TestCase):
         key2 = ("my_dag2", "my_task1", date, try_number)
         key3 = ("my_dag2", "my_task2", date, try_number)
         state = State.SUCCESS
-        executor.event_buffer[key1] = state
-        executor.event_buffer[key2] = state
-        executor.event_buffer[key3] = state
+        executor.event_buffer[key1] = state, None
+        executor.event_buffer[key2] = state, None
+        executor.event_buffer[key3] = state, None
 
         self.assertEqual(len(executor.get_event_buffer(("my_dag1",))), 1)
         self.assertEqual(len(executor.get_event_buffer()), 2)

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -142,8 +142,10 @@ class TestCeleryExecutor(unittest.TestCase):
 
                 executor.end(synchronous=True)
 
-        self.assertEqual(executor.event_buffer[('success', 'fake_simple_ti', execute_date, 0)], State.SUCCESS)
-        self.assertEqual(executor.event_buffer[('fail', 'fake_simple_ti', execute_date, 0)], State.FAILED)
+        self.assertEqual(executor.event_buffer[('success', 'fake_simple_ti', execute_date, 0)][0],
+                         State.SUCCESS)
+        self.assertEqual(executor.event_buffer[('fail', 'fake_simple_ti', execute_date, 0)][0],
+                         State.FAILED)
 
         self.assertNotIn('success', executor.tasks)
         self.assertNotIn('fail', executor.tasks)
@@ -248,7 +250,7 @@ class TestBulkStateFetcher(unittest.TestCase):
         self.assertEqual(set(mget_args[0]), {b'celery-task-meta-456', b'celery-task-meta-123'})
         mock_mget.assert_called_once_with(mock.ANY)
 
-        self.assertEqual(result, {'123': 'SUCCESS', '456': "PENDING"})
+        self.assertEqual(result, {'123': ('SUCCESS', None), '456': ("PENDING", None)})
 
     @mock.patch("celery.backends.database.DatabaseBackend.ResultSession")
     @pytest.mark.integration("redis")
@@ -270,7 +272,7 @@ class TestBulkStateFetcher(unittest.TestCase):
             mock.MagicMock(task_id="456"),
         ])
 
-        self.assertEqual(result, {'123': 'SUCCESS', '456': "PENDING"})
+        self.assertEqual(result, {'123': ('SUCCESS', None), '456': ("PENDING", None)})
 
     @pytest.mark.integration("redis")
     @pytest.mark.integration("rabbitmq")
@@ -286,4 +288,4 @@ class TestBulkStateFetcher(unittest.TestCase):
                     ClassWithCustomAttributes(task_id="456", state="PENDING"),
                 ])
 
-        self.assertEqual(result, {'123': 'SUCCESS', '456': "PENDING"})
+        self.assertEqual(result, {'123': ('SUCCESS', None), '456': ("PENDING", None)})

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -240,7 +240,7 @@ class TestKubernetesExecutor(unittest.TestCase):
         executor.start()
         key = ('dag_id', 'task_id', 'ex_time', 'try_number1')
         executor._change_state(key, State.RUNNING, 'pod_id', 'default')
-        self.assertTrue(executor.event_buffer[key] == State.RUNNING)
+        self.assertTrue(executor.event_buffer[key][0] == State.RUNNING)
 
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
     @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
@@ -251,7 +251,7 @@ class TestKubernetesExecutor(unittest.TestCase):
         test_time = timezone.utcnow()
         key = ('dag_id', 'task_id', test_time, 'try_number2')
         executor._change_state(key, State.SUCCESS, 'pod_id', 'default')
-        self.assertTrue(executor.event_buffer[key] == State.SUCCESS)
+        self.assertTrue(executor.event_buffer[key][0] == State.SUCCESS)
         mock_delete_pod.assert_called_once_with('pod_id', 'default')
 
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
@@ -270,7 +270,7 @@ class TestKubernetesExecutor(unittest.TestCase):
         test_time = timezone.utcnow()
         key = ('dag_id', 'task_id', test_time, 'try_number3')
         executor._change_state(key, State.FAILED, 'pod_id', 'default')
-        self.assertTrue(executor.event_buffer[key] == State.FAILED)
+        self.assertTrue(executor.event_buffer[key][0] == State.FAILED)
         mock_delete_pod.assert_not_called()
 # pylint: enable=unused-argument
 
@@ -287,7 +287,7 @@ class TestKubernetesExecutor(unittest.TestCase):
         executor.start()
         key = ('dag_id', 'task_id', test_time, 'try_number2')
         executor._change_state(key, State.SUCCESS, 'pod_id', 'default')
-        self.assertTrue(executor.event_buffer[key] == State.SUCCESS)
+        self.assertTrue(executor.event_buffer[key][0] == State.SUCCESS)
         mock_delete_pod.assert_not_called()
 
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
@@ -301,5 +301,5 @@ class TestKubernetesExecutor(unittest.TestCase):
         executor.start()
         key = ('dag_id', 'task_id', 'ex_time', 'try_number2')
         executor._change_state(key, State.FAILED, 'pod_id', 'test-namespace')
-        self.assertTrue(executor.event_buffer[key] == State.FAILED)
+        self.assertTrue(executor.event_buffer[key][0] == State.FAILED)
         mock_delete_pod.assert_called_once_with('pod_id', 'test-namespace')

--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -54,8 +54,8 @@ class TestLocalExecutor(unittest.TestCase):
         for i in range(self.TEST_SUCCESS_COMMANDS):
             key_id = success_key.format(i)
             key = key_id, 'fake_ti', execution_date, 0
-            self.assertEqual(executor.event_buffer[key], State.SUCCESS)
-        self.assertEqual(executor.event_buffer[fail_key], State.FAILED)
+            self.assertEqual(executor.event_buffer[key][0], State.SUCCESS)
+        self.assertEqual(executor.event_buffer[fail_key][0], State.FAILED)
 
         expected = self.TEST_SUCCESS_COMMANDS + 1 if parallelism == 0 else parallelism
         self.assertEqual(executor.workers_used, expected)

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -194,7 +194,7 @@ class TestBackfillJob(unittest.TestCase):
             ("run_this_last", end_date),
         ]
         self.assertListEqual(
-            [((dag.dag_id, task_id, when, 1), State.SUCCESS)
+            [((dag.dag_id, task_id, when, 1), (State.SUCCESS, None))
              for (task_id, when) in expected_execution_order],
             executor.sorted_tasks
         )
@@ -274,7 +274,7 @@ class TestBackfillJob(unittest.TestCase):
 
         job.run()
         self.assertListEqual(
-            [((dag_id, task_id, DEFAULT_DATE, 1), State.SUCCESS)
+            [((dag_id, task_id, DEFAULT_DATE, 1), (State.SUCCESS, None))
              for task_id in expected_execution_order],
             executor.sorted_tasks
         )

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1412,7 +1412,7 @@ class TestSchedulerJob(unittest.TestCase):
         session.commit()
 
         executor = MockExecutor(do_update=False)
-        executor.event_buffer[ti1.key] = State.FAILED
+        executor.event_buffer[ti1.key] = State.FAILED, None
 
         scheduler.executor = executor
 
@@ -1431,7 +1431,7 @@ class TestSchedulerJob(unittest.TestCase):
             full_filepath='/test_path1/',
             task_instance=mock.ANY,
             msg='Executor reports task instance finished (failed) '
-                'although the task says its queued. Was the task killed externally?'
+                'although the task says its queued. (Info: None) Was the task killed externally?'
         )
         scheduler.processor_agent.reset_mock()
 
@@ -1439,7 +1439,7 @@ class TestSchedulerJob(unittest.TestCase):
         ti1.state = State.SUCCESS
         session.merge(ti1)
         session.commit()
-        executor.event_buffer[ti1.key] = State.SUCCESS
+        executor.event_buffer[ti1.key] = State.SUCCESS, None
 
         scheduler._process_executor_events(simple_dag_bag=dagbag1)
         ti1.refresh_from_db()
@@ -2483,7 +2483,7 @@ class TestSchedulerJob(unittest.TestCase):
                 len(session.query(TaskInstance).filter(TaskInstance.dag_id == dag_id).all()), 1)
             self.assertListEqual(
                 [
-                    ((dag.dag_id, 'dummy', DEFAULT_DATE, 1), State.SUCCESS),
+                    ((dag.dag_id, 'dummy', DEFAULT_DATE, 1), (State.SUCCESS, None)),
                 ],
                 bf_exec.sorted_tasks
             )

--- a/tests/test_utils/mock_executor.py
+++ b/tests/test_utils/mock_executor.py
@@ -79,11 +79,11 @@ class MockExecutor(BaseExecutor):
     def end(self):
         self.sync()
 
-    def change_state(self, key, state):
-        super().change_state(key, state)
+    def change_state(self, key, state, info=None):
+        super().change_state(key, state, info=info)
         # The normal event buffer is cleared after reading, we want to keep
         # a list of all events for testing
-        self.sorted_tasks.append((key, state))
+        self.sorted_tasks.append((key, (state, info)))
 
     def mock_task_fail(self, dag_id, task_id, date, try_number=1):
         """


### PR DESCRIPTION
---
Make sure to mark the boxes below before creating PR: [x]

Address github issue #8619 
When there is an inconsistency between executor event return state and DB state. It is hard to debug the root cause and for celery executor we need to query logs from all workers. The reason is that at this time DB hostname was not updated and we don't know which worker have picked up the task and caused the failure. If we have the hostname with the executor event, we will be able to identify the host and debug root cause on that host. It could reduce time and operations to find out problematic host.

Implementation:
Change value type of event_buffer from str state to tuple of state and info. Add hostname to the celery command failed exception information and pass celery info into event_buffer.

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

@KevinYang21 