### PR TITLE
Add support for fetching logs from running pods

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -167,7 +167,7 @@ class PodLauncher(LoggingMixin):
         wait=tenacity.wait_exponential(),
         reraise=True
     )
-    def read_pod_logs(self, pod: V1Pod):
+    def read_pod_logs(self, pod: V1Pod, tail_lines: int = 10):
         """Reads log from the POD"""
         try:
             return self._client.read_namespaced_pod_log(
@@ -175,7 +175,7 @@ class PodLauncher(LoggingMixin):
                 namespace=pod.metadata.namespace,
                 container='base',
                 follow=True,
-                tail_lines=10,
+                tail_lines=tail_lines,
                 _preload_content=False
             )
         except BaseHTTPError as e:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -122,7 +122,7 @@ class FileTaskHandler(logging.Handler):
                 for line in PodLauncher.read_pod_logs(pod, 100):
                     log += line.decode()
 
-            except Exception as f:
+            except Exception as f:  # pylint: disable=broad-except
                 log += '*** Unable to fetch logs from worker pod {} ***\n{}\n\n'.format(
                     ti.hostname, str(f)
                 )

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -108,7 +108,8 @@ class FileTaskHandler(logging.Handler):
                 log = "*** Failed to load local log file: {}\n".format(location)
                 log += "*** {}\n".format(str(e))
         elif conf.get('core', 'executor') == 'KubernetesExecutor':
-            log += '*** Trying to get logs from worker pod {} ***\n'.format(ti.hostname)
+            log += '*** Trying to get logs (last 100 lines) from worker pod {} ***\n'\
+                .format(ti.hostname)
 
             try:
                 from kubernetes.client.models import V1Pod, V1ObjectMeta

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -111,16 +111,16 @@ class FileTaskHandler(logging.Handler):
             log += '*** Trying to get logs from worker pod {} ***\n'.format(ti.hostname)
 
             try:
-                from airflow.kubernetes.pod_launcher import read_pod_logs
                 from kubernetes.client.models import V1Pod, V1ObjectMeta
+                from airflow.kubernetes.pod_launcher import PodLauncher
 
                 pod = V1Pod()
                 pod.metadata = V1ObjectMeta()
                 pod.metadata.name = ti.hostname
                 pod.metadata.namespace = conf.get('kubernetes', 'namespace')
 
-                for l in read_pod_logs(pod, 100):
-                    log += l.decode()
+                for line in PodLauncher.read_pod_logs(pod, 100):
+                    log += line.decode()
 
             except Exception as f:
                 log += '*** Unable to fetch logs from worker pod {} ***\n{}\n\n'.format(

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -75,6 +75,24 @@ class TestPodLauncher(unittest.TestCase):
             mock.sentinel
         )
 
+    def test_read_pod_logs_successfully_with_tail_lines(self):
+        mock.sentinel.metadata = mock.MagicMock()
+        self.mock_kube_client.read_namespaced_pod_log.side_effect = [
+            mock.sentinel.logs
+        ]
+        logs = self.pod_launcher.read_pod_logs(mock.sentinel, 100)
+        self.assertEqual(mock.sentinel.logs, logs)
+        self.mock_kube_client.read_namespaced_pod_log.assert_has_calls([
+            mock.call(
+                _preload_content=False,
+                container='base',
+                follow=True,
+                name=mock.sentinel.metadata.name,
+                namespace=mock.sentinel.metadata.namespace,
+                tail_lines=100
+            ),
+        ])
+
     def test_read_pod_events_successfully_returns_events(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.list_namespaced_event.return_value = mock.sentinel.events


### PR DESCRIPTION
We are using KubernetesExecutor without any centralized PV for log storage, and hate to wait to see logs until the task finishes and pushes them to GCS. Felt that trying to fetch logs from workers via Airflow serve_logs API isn't of any use in the case of K8sExecutors. 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
