### PR TITLE
Reduce response payload size of /dag_stats and /task_stats

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1212,7 +1212,6 @@ Now the `dag_id` will not appear repeated in the payload, and the response forma
 }
 ```
 
-
 ## Airflow 1.10.10
 
 ### Setting Empty string to a Airflow Variable will return an empty string

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1164,6 +1164,55 @@ The goal of this change is to achieve a more consistent and configurale cascadin
 
 When initializing a Snowflake hook or operator, the value used for `snowflake_conn_id` was always `snowflake_conn_id`, regardless of whether or not you specified a value for it. The default `snowflake_conn_id` value is now switched to `snowflake_default` for consistency and will be properly overriden when specified.
 
+### Simplify the response payload of endpoints /dag_stats and /task_stats
+
+The response of endpoints `/dag_stats` and `/task_stats` help UI fetch brief statistics about DAGs and Tasks. The format was like
+
+```json
+{
+    "example_http_operator": [
+        {
+            "state": "success",
+            "count": 0,
+            "dag_id": "example_http_operator",
+            "color": "green"
+        },
+        {
+            "state": "running",
+            "count": 0,
+            "dag_id": "example_http_operator",
+            "color": "lime"
+        },
+        ...
+],
+...
+}
+```
+
+The `dag_id` was repeated in the payload, which makes the response payload unnecessarily bigger.
+
+Now the `dag_id` will not appear repeated in the payload, and the response format is like
+
+```json
+{
+    "example_http_operator": [
+        {
+            "state": "success",
+            "count": 0,
+            "color": "green"
+        },
+        {
+            "state": "running",
+            "count": 0,
+            "color": "lime"
+        },
+        ...
+],
+...
+}
+```
+
+
 ## Airflow 1.10.10
 
 ### Setting Empty string to a Airflow Variable will return an empty string

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -395,7 +395,6 @@ class Airflow(AirflowBaseView):
                 payload[dag_id].append({
                     'state': state,
                     'count': count,
-                    'dag_id': dag_id,
                     'color': State.color(state)
                 })
 
@@ -496,7 +495,6 @@ class Airflow(AirflowBaseView):
                 payload[dag_id].append({
                     'state': state,
                     'count': count,
-                    'dag_id': dag_id,
                     'color': State.color(state)
                 })
         return wwwutils.json_response(payload)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -521,6 +521,8 @@ class TestAirflowBaseViews(TestBase):
     def test_task_stats(self):
         resp = self.client.post('task_stats', follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(set(resp.json().items()[0][1][0].keys()),
+                         {'state', 'count', 'color'})
 
     def test_task_stats_only_noncompleted(self):
         conf.set("webserver", "show_recent_stats_for_completed_runs", "False")
@@ -1616,6 +1618,8 @@ class TestDagACLView(TestBase):
         self.login()
         resp = self.client.post('dag_stats', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
+        self.assertEqual(set(resp.json().items()[0][1][0].keys()),
+                         {'state', 'count', 'color'})
 
     def test_dag_stats_failure(self):
         self.logout()

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -521,7 +521,7 @@ class TestAirflowBaseViews(TestBase):
     def test_task_stats(self):
         resp = self.client.post('task_stats', follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(set(resp.json().items()[0][1][0].keys()),
+        self.assertEqual(set(list(resp.json.items())[0][1][0].keys()),
                          {'state', 'count', 'color'})
 
     def test_task_stats_only_noncompleted(self):
@@ -1618,7 +1618,7 @@ class TestDagACLView(TestBase):
         self.login()
         resp = self.client.post('dag_stats', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
-        self.assertEqual(set(resp.json().items()[0][1][0].keys()),
+        self.assertEqual(set(list(resp.json.items())[0][1][0].keys()),
                          {'state', 'count', 'color'})
 
     def test_dag_stats_failure(self):


### PR DESCRIPTION
Their response payload of `/dag_stats` and `/task_stats` are like 

```json
{
    "example_short_circuit_operator": [
        {
            "state": "success",
            "count": 0,
            "dag_id": "example_short_circuit_operator",
            "color": "green"
        },
        {
            "state": "running",
            "count": 0,
            "dag_id": "example_short_circuit_operator",
            "color": "lime"
        },
        ...
    ],
...
}
```

The `dag_id` is already present as the key, but still repeatedly appear in each element,
which makes the response payload size unnecessarily bigger. 

In one of the tests I did, this change reduces the response payload size of `/task_stats` to 23Kb from 33Kb.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
