### PR TITLE
Added SalesforceHook missing method to return only dataframe (#8565)

### DIFF
--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -237,7 +237,7 @@ class SalesforceHook(BaseHook):
             raise ValueError("Format value is not recognized: {}".format(fmt))
 
         if filename is None:
-            raise ValueError("Format value is not recognized: {}".format(fmt))
+            raise ValueError("Filename cannot be None.")
 
         df = self.object_to_df(query_results=query_results, coerce_to_timestamp=coerce_to_timestamp,
                                record_time_added=record_time_added)

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -236,9 +236,6 @@ class SalesforceHook(BaseHook):
         if fmt not in ['csv', 'json', 'ndjson']:
             raise ValueError("Format value is not recognized: {}".format(fmt))
 
-        if filename is None:
-            raise ValueError("Filename cannot be None.")
-
         df = self.object_to_df(query_results=query_results, coerce_to_timestamp=coerce_to_timestamp,
                                record_time_added=record_time_added)
 

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -236,6 +236,61 @@ class SalesforceHook(BaseHook):
         if fmt not in ['csv', 'json', 'ndjson']:
             raise ValueError("Format value is not recognized: {}".format(fmt))
 
+        if filename is None:
+            raise ValueError("Format value is not recognized: {}".format(fmt))
+
+        df = self.object_to_df(query_results=query_results, coerce_to_timestamp=coerce_to_timestamp,
+                               record_time_added=record_time_added)
+
+        # write the CSV or JSON file depending on the option
+        # NOTE:
+        #   datetimes here are an issue.
+        #   There is no good way to manage the difference
+        #   for to_json, the options are an epoch or a ISO string
+        #   but for to_csv, it will be a string output by datetime
+        #   For JSON we decided to output the epoch timestamp in seconds
+        #   (as is fairly standard for JavaScript)
+        #   And for csv, we do a string
+        if fmt == "csv":
+            # there are also a ton of newline objects that mess up our ability to write to csv
+            # we remove these newlines so that the output is a valid CSV format
+            self.log.info("Cleaning data and writing to CSV")
+            possible_strings = df.columns[df.dtypes == "object"]
+            df[possible_strings] = df[possible_strings].astype(str).apply(
+                lambda x: x.str.replace("\r\n", "").str.replace("\n", "")
+            )
+            # write the dataframe
+            df.to_csv(filename, index=False)
+        elif fmt == "json":
+            df.to_json(filename, "records", date_unit="s")
+        elif fmt == "ndjson":
+            df.to_json(filename, "records", lines=True, date_unit="s")
+
+        return df
+
+    def object_to_df(self, query_results, coerce_to_timestamp=False,
+                     record_time_added=False):
+        """
+        Export query results to dataframe.
+
+        By default, this function will try and leave all values as they are represented in Salesforce.
+        You use the `coerce_to_timestamp` flag to force all datetimes to become Unix timestamps (UTC).
+        This is can be greatly beneficial as it will make all of your datetime fields look the same,
+        and makes it easier to work with in other database environments
+
+        :param query_results: the results from a SQL query
+        :type query_results: list of dict
+        :param coerce_to_timestamp: True if you want all datetime fields to be converted into Unix timestamps.
+            False if you want them to be left in the same format as they were in Salesforce.
+            Leaving the value as False will result in datetimes being strings. Default: False
+        :type coerce_to_timestamp: bool
+        :param record_time_added: True if you want to add a Unix timestamp field
+            to the resulting data that marks when the data was fetched from Salesforce. Default: False
+        :type record_time_added: bool
+        :return: the dataframe.
+        :rtype: pd.Dataframe
+        """
+
         # this line right here will convert all integers to floats
         # if there are any None/np.nan values in the column
         # that's because None/np.nan cannot exist in an integer column
@@ -271,29 +326,5 @@ class SalesforceHook(BaseHook):
         if record_time_added:
             fetched_time = time.time()
             df["time_fetched_from_salesforce"] = fetched_time
-
-        # write the CSV or JSON file depending on the option
-        # NOTE:
-        #   datetimes here are an issue.
-        #   There is no good way to manage the difference
-        #   for to_json, the options are an epoch or a ISO string
-        #   but for to_csv, it will be a string output by datetime
-        #   For JSON we decided to output the epoch timestamp in seconds
-        #   (as is fairly standard for JavaScript)
-        #   And for csv, we do a string
-        if fmt == "csv":
-            # there are also a ton of newline objects that mess up our ability to write to csv
-            # we remove these newlines so that the output is a valid CSV format
-            self.log.info("Cleaning data and writing to CSV")
-            possible_strings = df.columns[df.dtypes == "object"]
-            df[possible_strings] = df[possible_strings].astype(str).apply(
-                lambda x: x.str.replace("\r\n", "").str.replace("\n", "")
-            )
-            # write the dataframe
-            df.to_csv(filename, index=False)
-        elif fmt == "json":
-            df.to_json(filename, "records", date_unit="s")
-        elif fmt == "ndjson":
-            df.to_json(filename, "records", lines=True, date_unit="s")
 
         return df

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -106,10 +106,6 @@ class TestSalesforceHook(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.salesforce_hook.write_object_to_file(query_results=[], filename="test", fmt="test")
 
-    def test_write_object_to_file_no_filename(self):
-        with self.assertRaises(ValueError):
-            self.salesforce_hook.write_object_to_file(query_results=[], filename=None)
-
     @patch(
         "airflow.providers.salesforce.hooks.salesforce.pd.DataFrame.from_records",
         return_value=pd.DataFrame({"test": [1, 2, 3], "dict": [None, None, {"foo": "bar"}]}),

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -106,6 +106,10 @@ class TestSalesforceHook(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.salesforce_hook.write_object_to_file(query_results=[], filename="test", fmt="test")
 
+    def test_write_object_to_file_no_filename(self):
+        with self.assertRaises(ValueError):
+            self.salesforce_hook.write_object_to_file(query_results=[], filename=None)
+
     @patch(
         "airflow.providers.salesforce.hooks.salesforce.pd.DataFrame.from_records",
         return_value=pd.DataFrame({"test": [1, 2, 3], "dict": [None, None, {"foo": "bar"}]}),
@@ -163,6 +167,51 @@ class TestSalesforceHook(unittest.TestCase):
         mock_data_frame.return_value.to_json.assert_called_once_with(
             filename, "records", lines=True, date_unit="s"
         )
+        pd.testing.assert_frame_equal(
+            data_frame,
+            pd.DataFrame(
+                {
+                    "test": [1, 2, 3],
+                    "time_fetched_from_salesforce": [
+                        mock_time.return_value,
+                        mock_time.return_value,
+                        mock_time.return_value,
+                    ],
+                }
+            ),
+        )
+
+    @patch(
+        "airflow.providers.salesforce.hooks.salesforce.SalesforceHook.describe_object",
+        return_value={"fields": [{"name": "field_1", "type": "date"}]},
+    )
+    @patch(
+        "airflow.providers.salesforce.hooks.salesforce.pd.DataFrame.from_records",
+        return_value=pd.DataFrame({"test": [1, 2, 3], "field_1": ["2019-01-01", "2019-01-02", "2019-01-03"]}),
+    )
+    def test_obect_to_df_with_timestamp_conversion(self, mock_data_frame, mock_describe_object):
+        obj_name = "obj_name"
+
+        data_frame = self.salesforce_hook.object_to_df(
+            query_results=[{"attributes": {"type": obj_name}}],
+            coerce_to_timestamp=True,
+        )
+
+        mock_describe_object.assert_called_once_with(obj_name)
+        pd.testing.assert_frame_equal(
+            data_frame, pd.DataFrame({"test": [1, 2, 3], "field_1": [1.546301e09, 1.546387e09, 1.546474e09]})
+        )
+
+    @patch("airflow.providers.salesforce.hooks.salesforce.time.time", return_value=1.23)
+    @patch(
+        "airflow.providers.salesforce.hooks.salesforce.pd.DataFrame.from_records",
+        return_value=pd.DataFrame({"test": [1, 2, 3]}),
+    )
+    def test_object_to_df_with_record_time(self, mock_data_frame, mock_time):
+        data_frame = self.salesforce_hook.object_to_df(
+            query_results=[], record_time_added=True
+        )
+
         pd.testing.assert_frame_equal(
             data_frame,
             pd.DataFrame(


### PR DESCRIPTION
---
SalesforceHook function `write_object_to_file` is divided to `object_to_df` which returns a dataframe and then the `write_object_to_file` uses `object_to_df` as the first step before exporting to file.

Issue: https://github.com/apache/airflow/issues/8565

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
