### PR TITLE
[AIRFLOW-8058] Add configurable execution context

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -366,6 +366,17 @@
       type: string
       example: "path.to.CustomXCom"
       default: "airflow.models.xcom.BaseXCom"
+    - name: additional_execute_contextmanager
+      description: |
+        Custom user function that returns a context manager. Syntax is "package.method".
+        Context is entered when operator starts executing task. ``__enter__()`` will be called
+        before the operator's execute method, and ``__exit__()`` shortly after.
+        Function's signature should accept two positional parameters - task instance
+        and execution context
+      version_added: 2.0.0
+      type: string
+      example: my.path.my_context_manager
+      default: ""
 
 - name: logging
   description: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -213,6 +213,14 @@ check_slas = True
 # Example: xcom_backend = path.to.CustomXCom
 xcom_backend = airflow.models.xcom.BaseXCom
 
+# Custom user function that returns a context manager. Syntax is "package.method".
+# Context is entered when operator starts executing task. ``__enter__()`` will be called
+# before the operator's execute method, and ``__exit__()`` shortly after.
+# Function's signature should accept two positional parameters - task instance
+# and execution context
+# Example: additional_execute_contextmanager = my.path.my_context_manager
+additional_execute_contextmanager =
+
 [logging]
 # The folder where airflow should store its log files
 # This path must be absolute

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1036,7 +1036,7 @@ class TaskInstance(Base, LoggingMixin):
                     self.log.error("Failed when executing execute callback")
                     self.log.exception(e3)
 
-                with set_current_context(context):
+                with set_current_context(context, task_copy):
                     result = self._execute_task(task_copy, context)
 
                 # If the task returns a result, push an XCom containing it

--- a/airflow/task/context/__init__.py
+++ b/airflow/task/context/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/task/context/current.py
+++ b/airflow/task/context/current.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+import logging
+from typing import Any, Dict
+
+from airflow.exceptions import AirflowException
+
+_CURRENT_CONTEXT = []
+log = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def set_current_context(context: Dict[str, Any]):
+    """
+    Sets the current execution context to the provided context object.
+    This method should be called once per Task execution, before calling operator.execute
+    """
+    _CURRENT_CONTEXT.append(context)
+    try:
+        yield context
+    finally:
+        expected_state = _CURRENT_CONTEXT.pop()
+        if expected_state != context:
+            log.warning(
+                "Current context is not equal to the state at context stack. Expected=%s, got=%s",
+                context,
+                expected_state,
+            )
+
+
+def get_current_context() -> Dict[str, Any]:
+    """
+    Obtain the execution context for the currently executing operator without
+    altering user method's signature.
+    This is the simplest method of retrieving the execution context dictionary.
+    ** Old style:
+        def my_task(**context):
+            ti = context["ti"]
+    ** New style:
+        from airflow.task.context import get_current_context
+        def my_task():
+            context = get_current_context()
+            ti = context["ti"]
+
+    Current context will only have value if this method was called after an operator
+    was starting to execute.
+    """
+    if not _CURRENT_CONTEXT:
+        raise AirflowException(
+            "Current context was requested but no context was found! "
+            "Are you running within an airflow task?"
+        )
+    return _CURRENT_CONTEXT[-1]

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -47,3 +47,4 @@ configuring an Airflow environment.
     tracking-user-activity
     email-config
     use-alternative-secrets-backend
+    use-additional-execute-contextmanager

--- a/docs/howto/use-additional-execute-contextmanager.rst
+++ b/docs/howto/use-additional-execute-contextmanager.rst
@@ -1,0 +1,68 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+Defining Additional Execute Context Manager
+===========================================
+
+Creating new context manager
+----------------------------
+
+Users can create their own execution context manager to allow context management on a higher level.
+To do so, one must define a new context manager in one of their files. This context manager is entered
+before calling ``execute`` method and is exited shortly after it. Here is an example context manager
+which provides authentication to Google Cloud Platform:
+
+    .. code-block:: python
+
+      import os
+      import subprocess
+      from contextlib import contextmanager
+      from tempfile import TemporaryDirectory
+      from unittest import mock
+      from google.auth.environment_vars import CLOUD_SDK_CONFIG_DIR
+      from airflow.providers.google.cloud.utils.credentials_provider import provide_gcp_conn_and_credentials
+
+      def execute_cmd(cmd):
+          with open(os.devnull, 'w') as dev_null:
+            return subprocess.call(args=cmd, stdout=dev_null, stderr=subprocess.STDOUT)
+
+      @contextmanager
+      def provide_gcp_context(task_instance, execution_context):
+          """
+          Context manager that provides:
+
+          - GCP credentials for application supporting `Application Default Credentials (ADC)
+          strategy <https://cloud.google.com/docs/authentication/production>`__.
+          - temporary value of ``AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT`` connection
+          - the ``gcloud`` config directory isolated from user configuration
+          """
+          project_id = os.environ["GCP_PROJECT_ID"]
+          key_file_path = os.environ["GCP_DEFAULT_SERVICE_KEY"]
+          with provide_gcp_conn_and_credentials(key_file_path, project_id=project_id), \
+                TemporaryDirectory() as gcloud_config_tmp, \
+                mock.patch.dict('os.environ', {CLOUD_SDK_CONFIG_DIR: gcloud_config_tmp}):
+
+            execute_cmd(["gcloud", "config", "set", "core/project", project_id])
+            execute_cmd(["gcloud", "auth", "activate-service-account", f"--key-file={key_file_path}"])
+            yield
+            execute_cmd(["gcloud", "config", "set", "account", "none", f"--project={project_id}"])
+
+Your custom context manager has to accept two arguments:
+1. ``task_instance`` - the executing task instance object (can also be retrieved from execution context via ``"ti"`` key.
+2. ``execution_context`` - the execution context that is provided to an operator's ``execute`` function.

--- a/tests/task/context/__init__.py
+++ b/tests/task/context/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/task/context/test_additional_execute_contextmanager.py
+++ b/tests/task/context/test_additional_execute_contextmanager.py
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+import os
+import sys
+from datetime import datetime, timedelta
+from unittest import mock
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from airflow import DAG, configuration
+from airflow.exceptions import AirflowException
+from airflow.models import TaskInstance
+from airflow.models.baseoperator import BaseOperator
+from airflow.utils.dates import days_ago
+
+DEFAULT_ARGS = {
+    "owner": "test",
+    "depends_on_past": True,
+    "start_date": days_ago(1),
+    "end_date": datetime.today(),
+    "schedule_interval": "@once",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+
+@contextlib.contextmanager
+def user_defined_contextmanager(task_instance, execution_context):  # pylint: disable=W0613
+    try:
+        yield True
+    finally:
+        pass
+
+
+@contextlib.contextmanager
+def incorrect_user_defined_context_func():
+    return 8
+
+
+def not_ctx_manager(task_instance, execution_context):  # pylint: disable=W0613
+    return None
+
+
+def get_user_contextmanager(section="core", key="additional_execute_contextmanager",
+                            value="test_additional_execute_contextmanager.user_defined_contextmanager"):
+    configuration.conf.set(section, key, value)
+    sys.path.append(os.path.dirname(__file__))
+    ti = Mock(TaskInstance)
+    ti.configure_mock(
+        get_additional_execution_contextmanager=TaskInstance.get_additional_execution_contextmanager)
+    context = ti.get_additional_execution_contextmanager(None, None)
+
+    return context
+
+
+class TestUserDefinedContextLoad:
+    def test_config_read(self):
+        user_ctx = get_user_contextmanager()
+        assert user_ctx
+
+    def test_assert_exception_on_invalid_value(self):
+        with pytest.raises(AirflowException):
+            get_user_contextmanager(value="INVALID_PACKAGE.INVALID_MODULE.INVALID_FUNC")
+
+    def test_user_func_incorrect_signature(self):
+        with pytest.raises(TypeError):
+            get_user_contextmanager(
+                value="test_additional_execute_contextmanager.incorrect_user_defined_context_func")
+
+    def test_user_func_not_ctx_manager(self):
+        with pytest.raises(AirflowException):
+            get_user_contextmanager(value="test_additional_execute_contextmanager.not_ctx_manager")
+
+    def test_enter_exit_exists(self):
+        user_ctx = get_user_contextmanager()
+        assert user_ctx
+        # Ensure these attributes were loaded
+        assert user_ctx.__enter__
+        assert user_ctx.__exit__
+
+
+class TestUserDefinedContextRuntime:
+    marker = MagicMock()
+    enter_counter = 0
+    exit_counter = 0
+
+    @staticmethod
+    def increment_enter_counter(p):  # pylint: disable=W0613
+        TestUserDefinedContextRuntime.enter_counter += 1
+
+    @staticmethod
+    def increment_exit_counter(p1, p2, p3, p4):  # pylint: disable=W0613
+        TestUserDefinedContextRuntime.exit_counter += 1
+
+    def test_simple_runtime(self):
+        # Configure mock so user context manager received is our mock marker object:
+        # (TestUserDefinedContextRuntime.marker)
+        attrs = {"__enter__": TestUserDefinedContextRuntime.increment_enter_counter,
+                 "__exit__": TestUserDefinedContextRuntime.increment_exit_counter}
+        TestUserDefinedContextRuntime.marker.configure_mock(**attrs)
+
+        with mock.patch("test_additional_execute_contextmanager.user_defined_contextmanager",
+                        return_value=TestUserDefinedContextRuntime.marker):
+            configuration.conf.set(
+                "core", "additional_execute_contextmanager", ""
+                                                             "test_additional_execute_contextmanager"
+                                                             ".user_defined_contextmanager")
+            sys.path.append(os.path.dirname(__file__))
+
+            with DAG(dag_id="context_runtime_dag", default_args=DEFAULT_ARGS):
+                op = self.MySimpleOperator(task_id="check_affected_value")
+            op.run(ignore_ti_state=True, ignore_first_depends_on_past=True)
+
+            assert TestUserDefinedContextRuntime.marker.call_count == 1
+            assert TestUserDefinedContextRuntime.enter_counter == 1
+            assert TestUserDefinedContextRuntime.exit_counter == 1
+
+    class MySimpleOperator(BaseOperator):
+        def execute(self, context):
+            TestUserDefinedContextRuntime.marker()

--- a/tests/task/context/test_current_context.py
+++ b/tests/task/context/test_current_context.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.models.baseoperator import BaseOperator
+from airflow.operators.python import PythonOperator
+from airflow.task.context.current import get_current_context, set_current_context
+from airflow.utils.dates import days_ago
+
+DEFAULT_ARGS = {
+    "owner": "test",
+    "depends_on_past": True,
+    "start_date": days_ago(1),
+    "end_date": datetime.today(),
+    "schedule_interval": "@once",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+
+class TestCurrentContext:
+    def test_current_context_no_context_raise(self):
+        with pytest.raises(AirflowException):
+            get_current_context()
+
+    def test_current_context_roundtrip(self):
+        example_context = {"Hello": "World"}
+
+        with set_current_context(example_context):
+            assert get_current_context() == example_context
+
+    def test_context_removed_after_exit(self):
+        example_context = {"Hello": "World"}
+
+        with set_current_context(example_context):
+            pass
+        with pytest.raises(AirflowException, ):
+            get_current_context()
+
+    def test_nested_context(self):
+        """
+        Nested execution context should be supported in case the user uses multiple context managers.
+        Each time the execute method of an operator is called, we set a new 'current' context.
+        This test verifies that no matter how many contexts are entered - order is preserved
+        """
+        max_stack_depth = 15
+        ctx_list = []
+        for i in range(max_stack_depth):
+            # Create all contexts in ascending order
+            new_context = {"ContextId": i}
+            # Like 15 nested with statements
+            ctx_obj = set_current_context(new_context)
+            ctx_obj.__enter__()  # pylint: disable=E1101
+            ctx_list.append(ctx_obj)
+        for i in reversed(range(max_stack_depth)):
+            # Iterate over contexts in reverse order - stack is LIFO
+            ctx = get_current_context()
+            assert ctx["ContextId"] == i
+            # End of with statement
+            ctx_list[i].__exit__(None, None, None)
+
+
+class MyContextAssertOperator(BaseOperator):
+    def execute(self, context):
+        assert context == get_current_context()
+
+
+def get_all_the_context(**context):
+    current_context = get_current_context()
+    assert context == current_context
+
+
+class TestCurrentContextRuntime:
+    def test_context_in_task(self):
+        with DAG(dag_id="assert_context_dag", default_args=DEFAULT_ARGS):
+            op = MyContextAssertOperator(task_id="assert_context")
+            op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
+
+    def test_get_context_in_old_style_context_task(self):
+        with DAG(dag_id="edge_case_context_dag", default_args=DEFAULT_ARGS):
+            op = PythonOperator(python_callable=get_all_the_context, task_id="get_all_the_context")
+            op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)


### PR DESCRIPTION
This PR is a part of [AIP-31], and closes #8058 
The goal of this issue is to detach the execution context from the executing method's signature.
Before, the only way to retrieve execution context was via `**kwargs` in the function's signature.
Now, it is possible to retrieve it using a simple external function call (only works when function is within execute context).
This develops AIP-31 to allow a more functional way of writing code, without being coupled to airflow's current implementation.
Collaborated with: @turbaszek @casassg @evgenyshulman 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
