### PR TITLE
[AIP-31] Implement XComArg model to functionally pass output from one operator to the next

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1069,15 +1069,21 @@ class BaseOperator(Operator, LoggingMixin):
         """Sets relatives for the task or task list."""
         from airflow.models.xcom_arg import XComArg
 
-        try:
-            task_list = list(task_or_task_list)  # type: ignore
-        except TypeError:
-            task_list = [task_or_task_list]  # type: ignore
+        if isinstance(task_or_task_list, XComArg):
+            # otherwise we will start to iterate over xcomarg
+            # because of the "list" check below
+            # with current XComArg.__getitem__ implementation
+            task_list = [task_or_task_list.operator]
+        else:
+            try:
+                task_list = list(task_or_task_list)  # type: ignore
+            except TypeError:
+                task_list = [task_or_task_list]  # type: ignore
 
-        task_list = [
-            t.operator if isinstance(t, XComArg) else t  # type: ignore
-            for t in task_list
-        ]
+            task_list = [
+                t.operator if isinstance(t, XComArg) else t  # type: ignore
+                for t in task_list
+            ]
 
         for task in task_list:
             if not isinstance(task, BaseOperator):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -804,7 +804,9 @@ class BaseOperator(Operator, LoggingMixin):
         if not jinja_env:
             jinja_env = self.get_template_env()
 
+        # Imported here to avoid ciruclar dependency
         from airflow.models.xcom_arg import XComArg
+
         if isinstance(content, str):
             if any(content.endswith(ext) for ext in self.template_ext):
                 # Content contains a filepath

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -804,12 +804,15 @@ class BaseOperator(Operator, LoggingMixin):
         if not jinja_env:
             jinja_env = self.get_template_env()
 
+        from airflow.models.xcom_arg import XComArg
         if isinstance(content, str):
             if any(content.endswith(ext) for ext in self.template_ext):
                 # Content contains a filepath
                 return jinja_env.get_template(content).render(**context)
             else:
                 return jinja_env.from_string(content).render(**context)
+        elif isinstance(content, XComArg):
+            return content.resolve(context)
 
         if isinstance(content, tuple):
             if type(content) is not tuple:  # pylint: disable=unidiomatic-typecheck

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1075,7 +1075,7 @@ class BaseOperator(Operator, LoggingMixin):
             task_list = [task_or_task_list]  # type: ignore
 
         task_list = [
-            t._operator if isinstance(t, XComArg) else t  # pylint: disable=protected-access  type: ignore
+            t.operator if isinstance(t, XComArg) else t  # type: ignore
             for t in task_list
         ]
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -1,0 +1,59 @@
+from typing import Any, List, Dict, Optional
+
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.xcom import XCOM_RETURN_KEY
+
+
+class XComArg:
+    """
+    Class that represents a XCom push from a previous operator. Defaults to "return_value" as only key.
+    """
+    def __init__(self, operator: BaseOperator, keys: Optional[List[str]] = None):
+        self._operator = operator
+        self._keys = keys or [XCOM_RETURN_KEY]
+
+    def set_upstream(self, t):
+        self._operator.set_upstream(t)
+
+    def set_downstream(self, t):
+        self._operator.set_downstream(t)
+
+    def __lshift__(self, other):
+        self.set_upstream(other)
+
+    def __rshift__(self, other):
+        self.set_downstream(other)
+
+    def resolve(self, context: dict):
+        """
+        Pull XCom value for the existing arg.
+        """
+        resolved_value = self._operator.xcom_pull(context=context, task_ids=[self._operator.task_id], key=self._keys[0], dag_id=self._operator.dag.dag_id)
+        if not resolved_value:
+            raise
+        return resolved_value[0]
+        # dict_result = {}
+        # i = dict_result
+        # for key in self._keys:
+        #     # Always set resolved value - will be overridden until last iteration
+        #     i[key] = resolved_value
+        #     i = i[key]
+        #
+        # return dict_result
+
+    # def __getitem__(self, key: str) -> 'XComArg':
+    #     """Return an XComArg for the specified key and the same operator as the current one.
+    # """
+    #     return XComArg(self._operator, [key])
+
+
+#  __iter__
+#   return x[1]
+#
+#
+#
+# xcom[restul]["a"]["b"]    xcom (keys= "result, a, ,b") -> 3
+# return {"a": {"b": 3}}
+#
+#
+# XcomCombine( a= Xcom, b=Xcom)

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -17,6 +17,7 @@
 
 from typing import Any, Dict, List, Optional, Union
 
+from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.xcom import XCOM_RETURN_KEY
 
@@ -25,31 +26,69 @@ class XComArg:
     """
     Class that represents a XCom push from a previous operator.
     Defaults to "return_value" as only key.
+
+    Current implementations supports
+      xcomarg >> op
+      xcomarg << op
+      op >> xcomarg   (by BaseOperator code)
+      op << xcomarg   (by BaseOperator code)
+
+    **Example**:
+        The moment you got result from any op (functional or regular one) you can ::
+            xcomarg = ...
+            my_op = MyOperator()
+            my_op >> xcomarg
+
+    This object can be used in legacy Operators via Jinja:
+    **Example**:
+        You can make this result to be part of any generated string ::
+            xcomarg = ...
+            op1 = MyOperator(my_text_message=f"{xcomarg}")
+            op2 = MyOperator(my_text_message=f"{xcomarg['topic']}")
+
+
     """
 
-    def __init__(self, operator: BaseOperator, keys: Optional[List[str]] = None):
+    def __init__(self, operator: BaseOperator, key: Optional[str] = XCOM_RETURN_KEY,
+                 runtime_sub_keys: Optional[List[str]] = None):
         self._operator = operator
-        self._keys = keys or [XCOM_RETURN_KEY]
+
+        # _key is used for xcompull (key in the XCom table)
+        # _runtime_sub_keys are used for runtime access of deserialized value from XCom data provider
+        self._key = key
+        self._runtime_sub_keys = runtime_sub_keys or []
 
     def __eq__(self, other):
-        return self._operator == other.operator and self.keys == other.keys
+        return (self._operator == other.operator
+                and self.key == other.key
+                and self.runtime_sub_keys == other.runtime_sub_keys)
 
     def __lshift__(self, other):
+        """
+        Implements xcomresult << op
+        """
         self.set_upstream(other)
         return self
 
     def __rshift__(self, other):
+        """
+        Implements xcomresult << op
+        """
         self.set_downstream(other)
         return self
 
     @property
-    def operator(self):
+    def operator(self) -> BaseOperator:
         """Operator"""
         return self._operator
 
     @property
-    def keys(self):
-        return self._keys
+    def key(self):
+        return self._key
+
+    @property
+    def runtime_sub_keys(self):
+        return self._runtime_sub_keys
 
     def set_upstream(self, task_or_task_list: Union[BaseOperator, List[BaseOperator]]):
         """
@@ -68,38 +107,49 @@ class XComArg:
     def resolve(self, context: Dict) -> Any:
         """
         Pull XCom value for the existing arg.
+        this function likely to run during at op.execute() context
         """
         resolved_value = self._operator.xcom_pull(
             context=context,
             task_ids=[self._operator.task_id],
-            key=self._keys[0],
+            key=self.key,
             dag_id=self._operator.dag.dag_id,
         )
         if not resolved_value:
-            raise
-        return resolved_value[0]
-        # dict_result = {}
-        # i = dict_result
-        # for key in self._keys:
-        #     # Always set resolved value - will be overridden until last iteration
-        #     i[key] = resolved_value
-        #     i = i[key]
-        #
-        # return dict_result
+            raise AirflowException(
+                f'XComArg result from {self._operator.task_id} at {self._operator.dag.dag_id} '
+                f'with key="{self.key}"" is not found!')
+        resolved_value = resolved_value[0]
 
-    # def __getitem__(self, key: str) -> 'XComArg':
-    #     """Return an XComArg for the specified key and the same operator as the current one.
-    # """
-    #     return XComArg(self._operator, [key])
+        # now we can follow on user defined dereference path
+        if len(self._runtime_sub_keys) > 1:
+            for key in self._runtime_sub_keys:
+                resolved_value = resolved_value[key]
+        return resolved_value
 
+    def __getitem__(self, key: Any) -> 'XComArg':
+        """Return an XComArg that will access the following """
+        return XComArg(operator=self._operator,
+                       key=self.key,
+                       runtime_sub_keys=self._runtime_sub_keys + [key])
 
-#  __iter__
-#   return x[1]
-#
-#
-#
-# xcom[restul]["a"]["b"]    xcom (keys= "result, a, ,b") -> 3
-# return {"a": {"b": 3}}
-#
-#
-# XcomCombine( a= Xcom, b=Xcom)
+    def __str__(self):
+        """
+        Backward compatibility for old-style jinja used in Airflow Operators
+        **Example**: to use XArg at BashOperator::
+            BashOperator(cmd=f"... { xcomarg } ...")
+        :return:
+        """
+        xcom_pull_kwargs = [f"task_ids='{self._operator.task_id}'",
+                            f"dag_id='{self._operator.dag.dag_id}'",
+                            ]
+        if self.key is not None:
+            xcom_pull_kwargs.append(f"key='{self.key}'")
+
+        xcom_pull_kwargs = ", ".join(xcom_pull_kwargs)
+        xcom_pull = f"task_instance.xcom_pull({xcom_pull_kwargs})"
+        if self._runtime_sub_keys:
+            result_access = [f"[{repr(k)}]" for k in self._runtime_sub_keys]
+            result_access = "".join(result_access)
+            xcom_pull += result_access
+        return xcom_pull

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -27,7 +27,7 @@ class XComArg:
     Class that represents a XCom push from a previous operator.
     Defaults to "return_value" as only key.
 
-    Current implementations supports
+    Current implementation supports
         xcomarg >> op
         xcomarg << op
         op >> xcomarg   (by BaseOperator code)
@@ -67,14 +67,14 @@ class XComArg:
 
     def __lshift__(self, other):
         """
-        Implements xcomresult << op
+        Implements XComArg << op
         """
         self.set_upstream(other)
         return self
 
     def __rshift__(self, other):
         """
-        Implements xcomresult >> op
+        Implements XComArg >> op
         """
         self.set_downstream(other)
         return self
@@ -89,7 +89,7 @@ class XComArg:
         """
         Backward compatibility for old-style jinja used in Airflow Operators
 
-        **Example**: to use XArg at BashOperator::
+        **Example**: to use XComArg at BashOperator::
 
             BashOperator(cmd=f"... { xcomarg } ...")
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -33,7 +33,7 @@ class XComArg:
         op >> xcomarg   (by BaseOperator code)
         op << xcomarg   (by BaseOperator code)
 
-    **Example**: The moment you got result from any op (functional or regular one) you can ::
+    **Example**: The moment you get a result from any operator (functional or regular) you can ::
 
         xcomarg = ...
         my_op = MyOperator()
@@ -58,7 +58,7 @@ class XComArg:
         self._key = key
 
     def __eq__(self, other):
-        return (self._operator == other.operator
+        return (self.operator == other.operator
                 and self.key == other.key)
 
     def __lshift__(self, other):
@@ -85,8 +85,8 @@ class XComArg:
 
         :return:
         """
-        xcom_pull_kwargs = [f"task_ids='{self._operator.task_id}'",
-                            f"dag_id='{self._operator.dag.dag_id}'",
+        xcom_pull_kwargs = [f"task_ids='{self.operator.task_id}'",
+                            f"dag_id='{self.operator.dag.dag_id}'",
                             ]
         if self.key is not None:
             xcom_pull_kwargs.append(f"key='{self.key}'")
@@ -109,7 +109,7 @@ class XComArg:
         """
         Proxy to underlying operator set_upstream method
         """
-        self._operator.set_upstream(task_or_task_list)
+        self.operator.set_upstream(task_or_task_list)
 
     def set_downstream(
         self, task_or_task_list: Union[BaseOperator, List[BaseOperator]]
@@ -117,22 +117,22 @@ class XComArg:
         """
         Proxy to underlying operator set_downstream method
         """
-        self._operator.set_downstream(task_or_task_list)
+        self.operator.set_downstream(task_or_task_list)
 
     def resolve(self, context: Dict) -> Any:
         """
         Pull XCom value for the existing arg. This method is run during ``op.execute()``
         in respectable context.
         """
-        resolved_value = self._operator.xcom_pull(
+        resolved_value = self.operator.xcom_pull(
             context=context,
-            task_ids=[self._operator.task_id],
+            task_ids=[self.operator.task_id],
             key=self.key,
-            dag_id=self._operator.dag.dag_id,
+            dag_id=self.operator.dag.dag_id,
         )
         if not resolved_value:
             raise AirflowException(
-                f'XComArg result from {self._operator.task_id} at {self._operator.dag.dag_id} '
+                f'XComArg result from {self.operator.task_id} at {self.operator.dag.dag_id} '
                 f'with key="{self.key}"" is not found!')
         resolved_value = resolved_value[0]
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -32,7 +32,7 @@ class XComArg:
         self._keys = keys or [XCOM_RETURN_KEY]
 
     def __eq__(self, other):
-        return self._operator == other._operator  # pylint: disable=protected-access
+        return self._operator == other.operator and self.keys == other.keys
 
     def __lshift__(self, other):
         self.set_upstream(other)
@@ -41,6 +41,15 @@ class XComArg:
     def __rshift__(self, other):
         self.set_downstream(other)
         return self
+
+    @property
+    def operator(self):
+        """Operator"""
+        return self._operator
+
+    @property
+    def keys(self):
+        return self._keys
 
     def set_upstream(self, task_or_task_list: Union[BaseOperator, List[BaseOperator]]):
         """

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -36,7 +36,7 @@ class XComArg:
     **Example**: The moment you get a result from any operator (functional or regular) you can ::
 
         any_op = AnyOperator()
-        xcomarg = XComArg(any_op)
+        xcomarg = XComArg(any_op) OR xcomarg = any_op.output
         my_op = MyOperator()
         my_op >> xcomarg
 
@@ -45,7 +45,7 @@ class XComArg:
     **Example**: You can make this result to be part of any generated string ::
 
         any_op = AnyOperator()
-        xcomarg = XComArg(any_op)
+        xcomarg = any_op.output
         op1 = MyOperator(my_text_message=f"the value is {xcomarg}")
         op2 = MyOperator(my_text_message=f"the value is {xcomarg['topic']}")
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -36,7 +36,9 @@ class XComArg:
     **Example**: The moment you get a result from any operator (functional or regular) you can ::
 
         any_op = AnyOperator()
-        xcomarg = XComArg(any_op) OR xcomarg = any_op.output
+        xcomarg = XComArg(any_op)
+        # or equivalently
+        xcomarg = any_op.output
         my_op = MyOperator()
         my_op >> xcomarg
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -18,7 +18,7 @@
 from typing import Any, Dict, List, Union
 
 from airflow.exceptions import AirflowException
-from airflow.models.baseoperator import BaseOperator
+from airflow.models.baseoperator import BaseOperator  # pylint: disable=R0401
 from airflow.models.xcom import XCOM_RETURN_KEY
 
 
@@ -35,7 +35,8 @@ class XComArg:
 
     **Example**: The moment you get a result from any operator (functional or regular) you can ::
 
-        xcomarg = ...
+        any_op = AnyOperator()
+        xcomarg = XComArg(any_op)
         my_op = MyOperator()
         my_op >> xcomarg
 
@@ -43,7 +44,8 @@ class XComArg:
 
     **Example**: You can make this result to be part of any generated string ::
 
-        xcomarg = ...
+        any_op = AnyOperator()
+        xcomarg = XComArg(any_op)
         op1 = MyOperator(my_text_message=f"the value is {xcomarg}")
         op2 = MyOperator(my_text_message=f"the value is {xcomarg['topic']}")
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -1,4 +1,21 @@
-from typing import Any, List, Dict, Optional
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Dict, List, Optional, Union
 
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.xcom import XCOM_RETURN_KEY
@@ -6,29 +23,49 @@ from airflow.models.xcom import XCOM_RETURN_KEY
 
 class XComArg:
     """
-    Class that represents a XCom push from a previous operator. Defaults to "return_value" as only key.
+    Class that represents a XCom push from a previous operator.
+    Defaults to "return_value" as only key.
     """
+
     def __init__(self, operator: BaseOperator, keys: Optional[List[str]] = None):
         self._operator = operator
         self._keys = keys or [XCOM_RETURN_KEY]
 
-    def set_upstream(self, t):
-        self._operator.set_upstream(t)
-
-    def set_downstream(self, t):
-        self._operator.set_downstream(t)
+    def __eq__(self, other):
+        return self._operator == other._operator  # pylint: disable=protected-access
 
     def __lshift__(self, other):
         self.set_upstream(other)
+        return self
 
     def __rshift__(self, other):
         self.set_downstream(other)
+        return self
 
-    def resolve(self, context: dict):
+    def set_upstream(self, task_or_task_list: Union[BaseOperator, List[BaseOperator]]):
+        """
+        Proxy to underlying operator set_upstream method
+        """
+        self._operator.set_upstream(task_or_task_list)
+
+    def set_downstream(
+        self, task_or_task_list: Union[BaseOperator, List[BaseOperator]]
+    ):
+        """
+        Proxy to underlying operator set_downstream method
+        """
+        self._operator.set_downstream(task_or_task_list)
+
+    def resolve(self, context: Dict) -> Any:
         """
         Pull XCom value for the existing arg.
         """
-        resolved_value = self._operator.xcom_pull(context=context, task_ids=[self._operator.task_id], key=self._keys[0], dag_id=self._operator.dag.dag_id)
+        resolved_value = self._operator.xcom_pull(
+            context=context,
+            task_ids=[self._operator.task_id],
+            key=self._keys[0],
+            dag_id=self._operator.dag.dag_id,
+        )
         if not resolved_value:
             raise
         return resolved_value[0]

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -75,6 +75,12 @@ class XComArg:
         self.set_downstream(other)
         return self
 
+    def __getitem__(self, item):
+        """
+        Implements xcomresult['some_result_key']
+        """
+        return XComArg(operator=self.operator, key=item)
+
     def __str__(self):
         """
         Backward compatibility for old-style jinja used in Airflow Operators
@@ -127,7 +133,7 @@ class XComArg:
         resolved_value = self.operator.xcom_pull(
             context=context,
             task_ids=[self.operator.task_id],
-            key=self.key,
+            key=str(self.key),  # xcom_pull supports only key as str
             dag_id=self.operator.dag.dag_id,
         )
         if not resolved_value:

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -24,7 +24,6 @@
 ./airflow/models/taskinstance.py
 ./airflow/models/variable.py
 ./airflow/models/xcom.py
-./airflow/models/xcom_arg.py
 ./airflow/settings.py
 ./airflow/stats.py
 ./airflow/www/api/experimental/endpoints.py

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -24,6 +24,7 @@
 ./airflow/models/taskinstance.py
 ./airflow/models/variable.py
 ./airflow/models/xcom.py
+./airflow/models/xcom_arg.py
 ./airflow/settings.py
 ./airflow/stats.py
 ./airflow/www/api/experimental/endpoints.py

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -57,7 +57,7 @@ class TestXComArgBuild:
         assert actual.operator == python_op
         assert actual.key == "test_key"
         # Asserting the overridden __eq__ method
-        assert actual == actual  # pylint: disable=comparison-with-itself
+        assert actual == XComArg(python_op, "test_key")
         assert str(actual) == "task_instance.xcom_pull(" \
                               "task_ids=\'test_xcom_op\', " \
                               "dag_id=\'test_xcom_dag\', " \

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -60,29 +60,6 @@ class TestXComArgBuild:
         assert actual == actual  # pylint: disable=comparison-with-itself
         assert str(actual)
 
-    def test_xcom_runtime_access_ctor(self):
-        python_op = build_python_op()
-        actual = XComArg(python_op, "test_key")
-        assert actual.runtime_sub_keys == []
-
-        with_runime_access = actual[0]["a"]
-        assert with_runime_access.runtime_sub_keys == [0, "a"]
-
-    def test_xcom_jinja_repr(self):
-        python_op = build_python_op()
-        actual = XComArg(python_op, "test_key")
-
-        assert str(actual) == "task_instance.xcom_pull(" \
-                              "task_ids='test_xcom_op', " \
-                              "dag_id='test_xcom_dag', " \
-                              "key='test_key')"
-        with_runime_access = actual[0]["a"]
-        assert str(
-            with_runime_access) == "task_instance.xcom_pull(" \
-                                   "task_ids='test_xcom_op', " \
-                                   "dag_id='test_xcom_dag', " \
-                                   "key='test_key')[0]['a']"
-
     def test_xcom_key_is_empty_str(self):
         python_op = build_python_op()
         actual = XComArg(python_op, key="")
@@ -126,7 +103,6 @@ class TestXComArgBuild:
 
 
 class TestXComArgRuntime:
-
     def test_xcom_pass_to_op(self):
         with DAG(dag_id="test_xcom_pass_to_op", default_args=DEFAULT_ARGS):
             operator = PythonOperator(

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -100,6 +100,13 @@ class TestXComArgBuild:
 
         assert op_a.output == XComArg(op_a)
 
+    def test_xcom_key_getitem(self):
+        python_op = build_python_op()
+        actual = XComArg(python_op, key="another_key")
+        assert actual.key == "another_key"
+        actual_new_key = actual["another_key_2"]
+        assert actual_new_key.key == "another_key_2"
+
 
 class TestXComArgRuntime:
     def test_xcom_pass_to_op(self):

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -1,45 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.models.xcom_arg import XComArg
+from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 
 default_args = {
-    'owner': 'dbnd',
-    'depends_on_past': True,
-    'start_date': datetime(2020, 4, 22),
-    'retries': 1,
-    'retry_delay': timedelta(minutes=1),
+    "owner": "dbnd",
+    "depends_on_past": True,
+    "start_date": datetime(2020, 4, 22),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
 }
 
-value_1 = 8
+VALUE_1 = 8
+
 
 def return_value_1():
-    return value_1
+    return VALUE_1
 
 
 def assert_is_value_1(num: int):
-    assert num == value_1
+    assert num == VALUE_1
+
 
 def push_xcom_value(key, value, **context):
     ti = context["task_instance"]
     ti.xcom_push(key, value)
 
-class TestXComArg(object):
+
+class TestXComArg:
     def test_xcom_pass_to_op(self):
-        with DAG(dag_id="test_xcom_pass_to_op", default_args=default_args, schedule_interval="* * * * *") as dag:
-            operator = PythonOperator(python_callable=return_value_1, task_id="return_value_1", do_xcom_push=True)
+        with DAG(dag_id="test_xcom_pass_to_op", default_args=default_args):
+            operator = PythonOperator(
+                python_callable=return_value_1,
+                task_id="return_value_1",
+                do_xcom_push=True,
+            )
             xarg = XComArg(operator)
-            operator2 = PythonOperator(python_callable=assert_is_value_1, op_args=[xarg], task_id="assert_is_value_1")
+            operator2 = PythonOperator(
+                python_callable=assert_is_value_1,
+                op_args=[xarg],
+                task_id="assert_is_value_1",
+            )
             operator >> operator2
         operator.run(ignore_ti_state=True, ignore_first_depends_on_past=True)
         operator2.run(ignore_ti_state=True, ignore_first_depends_on_past=True)
 
     def test_xcom_push_and_pass(self):
-        with DAG(dag_id="test_xcom_push_and_pass", default_args=default_args, schedule_interval="* * * * *") as dag:
-            op1 = PythonOperator(python_callable=push_xcom_value, task_id="push_xcom_value", op_args=["my_key", value_1])
+        with DAG(dag_id="test_xcom_push_and_pass", default_args=default_args):
+            op1 = PythonOperator(
+                python_callable=push_xcom_value,
+                task_id="push_xcom_value",
+                op_args=["my_key", VALUE_1],
+            )
             xarg = XComArg(op1, keys=["my_key"])
-            op2 = PythonOperator(python_callable=assert_is_value_1, task_id="assert_is_value_1", op_args=[xarg])
+            op2 = PythonOperator(
+                python_callable=assert_is_value_1,
+                task_id="assert_is_value_1",
+                op_args=[xarg],
+            )
             op1 >> op2
         op1.run(ignore_ti_state=True, ignore_first_depends_on_past=True)
         op2.run(ignore_ti_state=True, ignore_first_depends_on_past=True)
+
+    def test_set_downstream(self):
+        with DAG("test_set_downstream", default_args=default_args):
+            op_a = BashOperator(task_id="a", bash_command="echo a")
+            op_b = BashOperator(task_id="b", bash_command="echo b")
+            bash_op = BashOperator(task_id="c", bash_command="echo c")
+            xcom_args_a = XComArg(op_a)
+            xcom_args_b = XComArg(op_b)
+
+            xcom_args_a >> xcom_args_b >> bash_op
+
+        assert len(op_a.downstream_list) == 2
+        assert op_b in op_a.downstream_list
+        assert bash_op in op_a.downstream_list
+
+    def test_set_upstream(self):
+        with DAG("test_set_downstream", default_args=default_args):
+            op_a = BashOperator(task_id="a", bash_command="echo a")
+            op_b = BashOperator(task_id="b", bash_command="echo b")
+            bash_op = BashOperator(task_id="c", bash_command="echo c")
+            xcom_args_a = XComArg(op_a)
+            xcom_args_b = XComArg(op_b)
+
+            xcom_args_a << xcom_args_b << bash_op
+
+        assert len(op_a.upstream_list) == 2
+        assert op_b in op_a.upstream_list
+        assert bash_op in op_a.upstream_list
+
+    def test_xcom_arg_property_of_base_operator(self):
+        with DAG("test_set_downstream", default_args=default_args):
+            op_a = BashOperator(task_id="a", bash_command="echo a")
+
+        assert op_a.output == XComArg(op_a)

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.models.xcom_arg import XComArg
+from airflow.operators.python import PythonOperator
+
+default_args = {
+    'owner': 'dbnd',
+    'depends_on_past': True,
+    'start_date': datetime(2020, 4, 22),
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+}
+
+value_1 = 8
+
+def return_value_1():
+    return value_1
+
+
+def assert_is_value_1(num: int):
+    assert num == value_1
+
+def push_xcom_value(key, value, **context):
+    ti = context["task_instance"]
+    ti.xcom_push(key, value)
+
+class TestXComArg(object):
+    def test_xcom_pass_to_op(self):
+        with DAG(dag_id="test_xcom_pass_to_op", default_args=default_args, schedule_interval="* * * * *") as dag:
+            operator = PythonOperator(python_callable=return_value_1, task_id="return_value_1", do_xcom_push=True)
+            xarg = XComArg(operator)
+            operator2 = PythonOperator(python_callable=assert_is_value_1, op_args=[xarg], task_id="assert_is_value_1")
+            operator >> operator2
+        operator.run(ignore_ti_state=True, ignore_first_depends_on_past=True)
+        operator2.run(ignore_ti_state=True, ignore_first_depends_on_past=True)
+
+    def test_xcom_push_and_pass(self):
+        with DAG(dag_id="test_xcom_push_and_pass", default_args=default_args, schedule_interval="* * * * *") as dag:
+            op1 = PythonOperator(python_callable=push_xcom_value, task_id="push_xcom_value", op_args=["my_key", value_1])
+            xarg = XComArg(op1, keys=["my_key"])
+            op2 = PythonOperator(python_callable=assert_is_value_1, task_id="assert_is_value_1", op_args=[xarg])
+            op1 >> op2
+        op1.run(ignore_ti_state=True, ignore_first_depends_on_past=True)
+        op2.run(ignore_ti_state=True, ignore_first_depends_on_past=True)

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -56,8 +56,12 @@ class TestXComArgBuild:
         assert actual
         assert actual.operator == python_op
         assert actual.key == "test_key"
+        # Asserting the overridden __eq__ method
         assert actual == actual  # pylint: disable=comparison-with-itself
-        assert str(actual)
+        assert str(actual) == "task_instance.xcom_pull(" \
+                              "task_ids=\'test_xcom_op\', " \
+                              "dag_id=\'test_xcom_dag\', " \
+                              "key=\'test_key\')"
 
     def test_xcom_key_is_empty_str(self):
         python_op = build_python_op()


### PR DESCRIPTION
This PR is a part of [AIP-31], and closes the following issues:  
closes #8055, closes #8053,  closes #8052 .
The goal of the XComArg model is to create a communication token to be passed between operators. In this fashion, we can wire the output of one operator to the next in a functional and "comfortable" (code-writing-wise) manner.
Collaborated with: @turbaszek @casassg @evgenyshulman

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
