### PR TITLE
[AIRFLOW-8645] BQ: integer range partitioning support for BQ tables

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -191,6 +191,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         table_resource: Optional[Dict[str, Any]] = None,
         schema_fields: Optional[List] = None,
         time_partitioning: Optional[Dict] = None,
+        integer_range_partitioning: Optional[Dict] = None,
         cluster_fields: Optional[List[str]] = None,
         labels: Optional[Dict] = None,
         view: Optional[Dict] = None,
@@ -231,6 +232,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             .. seealso::
                 https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timePartitioning
         :type time_partitioning: dict
+        :param integer_range_partitioning: configure optional integer range partitioning.
+            Provide field and range definitions per API specifications.
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#RangePartitioning
+        :type integer_range_partitioning: dict
         :param cluster_fields: [Optional] The fields used for clustering.
             Must be specified with time_partitioning, data in the table will be first
             partitioned and subsequently clustered.
@@ -278,6 +283,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         if time_partitioning:
             _table_resource['timePartitioning'] = time_partitioning
+
+        if integer_range_partitioning:
+            _table_resource['rangePartitioning'] = integer_range_partitioning
 
         if cluster_fields:
             _table_resource['clustering'] = {
@@ -637,6 +645,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                     labels: Optional[Dict] = None,
                     schema: Optional[List] = None,
                     time_partitioning: Optional[Dict] = None,
+                    integer_range_partitioning: Optional[Dict] = None,
                     view: Optional[Dict] = None,
                     require_partition_filter: Optional[bool] = None,
                     encryption_configuration: Optional[Dict] = None) -> None:
@@ -674,9 +683,16 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                                {"name": "salary", "type": "INTEGER", "mode": "NULLABLE"}]
 
         :type schema: list
-        :param time_partitioning: [Optional] A dictionary containing time-based partitioning
-             definition for the table.
+        :param time_partitioning: [Optional] configure time partitioning fields i.e.
+            partition by field, type and  expiration as per API specifications.
+            Note that 'field' is not available in concurrency with
+            dataset.table$partition.
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timepartitioning
         :type time_partitioning: dict
+        :param integer_range_partitioning: [Optional] configure integer range partitioning.
+            Provide field and range definitions per API specifications.
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#RangePartitioning
+        :type integer_range_partitioning: dict
         :param view: [Optional] A dictionary containing definition for the view.
             If set, it will patch a view instead of a table:
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ViewDefinition
@@ -719,6 +735,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             table_resource['schema'] = {'fields': schema}
         if time_partitioning:
             table_resource['timePartitioning'] = time_partitioning
+        if integer_range_partitioning:
+            table_resource['rangePartitioning'] = integer_range_partitioning
         if view:
             table_resource['view'] = view
         if require_partition_filter is not None:
@@ -1389,6 +1407,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                  schema_update_options: Optional[Iterable] = None,
                  src_fmt_configs: Optional[Dict] = None,
                  time_partitioning: Optional[Dict] = None,
+                 integer_range_partitioning: Optional[Dict] = None,
                  cluster_fields: Optional[List] = None,
                  autodetect: bool = False,
                  encryption_configuration: Optional[Dict] = None) -> str:
@@ -1461,7 +1480,14 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :type src_fmt_configs: dict
         :param time_partitioning: configure optional time partitioning fields i.e.
             partition by field, type and  expiration as per API specifications.
+            Note that 'field' is not available in concurrency with
+            dataset.table$partition.
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timepartitioning
         :type time_partitioning: dict
+        :param integer_range_partitioning: configure optional integer range partitioning.
+            Provide field and range definitions per API specifications.
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#RangePartitioning
+        :type integer_range_partitioning: dict
         :param cluster_fields: Request that the result of this load be stored sorted
             by one or more columns. This is only available in combination with
             time_partitioning. The order of columns given determines the sort order.
@@ -1546,6 +1572,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             configuration['load'].update({
                 'timePartitioning': time_partitioning
             })
+
+        if integer_range_partitioning:
+            configuration['load'].update({'rangePartitioning': integer_range_partitioning})
 
         if cluster_fields:
             configuration['load'].update({'clustering': {'fields': cluster_fields}})
@@ -1783,6 +1812,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                   schema_update_options: Optional[Iterable] = None,
                   priority: str = 'INTERACTIVE',
                   time_partitioning: Optional[Dict] = None,
+                  integer_range_partitioning: Optional[Dict] = None,
                   api_resource_configs: Optional[Dict] = None,
                   cluster_fields: Optional[List[str]] = None,
                   location: Optional[str] = None,
@@ -1848,8 +1878,15 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             The default value is INTERACTIVE.
         :type priority: str
         :param time_partitioning: configure optional time partitioning fields i.e.
-            partition by field, type and expiration as per API specifications.
+            partition by field, type and  expiration as per API specifications.
+            Note that 'field' is not available in concurrency with
+            dataset.table$partition.
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timepartitioning
         :type time_partitioning: dict
+        :param integer_range_partitioning: configure optional integer range partitioning.
+            Provide field and range definitions per API specifications.
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#RangePartitioning
+        :type integer_range_partitioning: dict
         :param cluster_fields: Request that the result of this query be stored sorted
             by one or more columns. This is only available in combination with
             time_partitioning. The order of columns given determines the sort order.
@@ -1873,6 +1910,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         if time_partitioning is None:
             time_partitioning = {}
+
+        if integer_range_partitioning is None:
+            integer_range_partitioning = {}
 
         if location:
             self.location = location
@@ -1940,6 +1980,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             (maximum_billing_tier, 'maximumBillingTier', None, int),
             (maximum_bytes_billed, 'maximumBytesBilled', None, float),
             (time_partitioning, 'timePartitioning', {}, dict),
+            (integer_range_partitioning, 'rangePartitioning', {}, dict),
             (schema_update_options, 'schemaUpdateOptions', None, list),
             (destination_dataset_table, 'destinationTable', None, dict),
             (cluster_fields, 'clustering', None, dict),

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -451,8 +451,13 @@ class BigQueryExecuteQueryOperator(BaseOperator):
         The default value is INTERACTIVE.
     :type priority: str
     :param time_partitioning: configure optional time partitioning fields i.e.
-        partition by field, type and expiration as per API specifications.
+        partition by field, type and  expiration as per API specifications.
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timepartitioning
     :type time_partitioning: dict
+    :param integer_range_partitioning: configure optional integer range partitioning.
+        Provide field and range definitions per API specifications.
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#RangePartitioning
+    :type integer_range_partitioning: dict
     :param cluster_fields: Request that the result of this query be stored sorted
         by one or more columns. This is only available in conjunction with
         time_partitioning. The order of columns given determines the sort order.
@@ -508,6 +513,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
                  labels: Optional[dict] = None,
                  priority: Optional[str] = 'INTERACTIVE',
                  time_partitioning: Optional[dict] = None,
+                 integer_range_partitioning: Optional[dict] = None,
                  api_resource_configs: Optional[dict] = None,
                  cluster_fields: Optional[List[str]] = None,
                  location: Optional[str] = None,
@@ -539,6 +545,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
         self.labels = labels
         self.priority = priority
         self.time_partitioning = time_partitioning
+        self.integer_range_partitioning = integer_range_partitioning
         self.api_resource_configs = api_resource_configs
         self.cluster_fields = cluster_fields
         self.location = location
@@ -570,6 +577,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
                 schema_update_options=self.schema_update_options,
                 priority=self.priority,
                 time_partitioning=self.time_partitioning,
+                integer_range_partitioning=self.integer_range_partitioning,
                 api_resource_configs=self.api_resource_configs,
                 cluster_fields=self.cluster_fields,
                 encryption_configuration=self.encryption_configuration
@@ -591,6 +599,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
                     schema_update_options=self.schema_update_options,
                     priority=self.priority,
                     time_partitioning=self.time_partitioning,
+                    integer_range_partitioning=self.integer_range_partitioning,
                     api_resource_configs=self.api_resource_configs,
                     cluster_fields=self.cluster_fields,
                     encryption_configuration=self.encryption_configuration
@@ -644,6 +653,10 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         .. seealso::
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timePartitioning
     :type time_partitioning: dict
+    :param integer_range_partitioning: configure optional integer range partitioning.
+        Provide field and range definitions per API specifications.
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#RangePartitioning
+    :type integer_range_partitioning: dict
     :param bigquery_conn_id: [Optional] The connection ID used to connect to Google Cloud Platform and
         interact with the Bigquery service.
     :type bigquery_conn_id: str
@@ -732,6 +745,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                  schema_fields: Optional[List] = None,
                  gcs_schema_object: Optional[str] = None,
                  time_partitioning: Optional[Dict] = None,
+                 integer_range_partitioning: Optional[Dict] = None,
                  bigquery_conn_id: str = 'google_cloud_default',
                  google_cloud_storage_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
@@ -752,6 +766,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
         self.time_partitioning = {} if time_partitioning is None else time_partitioning
+        self.integer_range_partitioning = integer_range_partitioning
         self.labels = labels
         self.view = view
         self.encryption_configuration = encryption_configuration
@@ -785,6 +800,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                 table_id=self.table_id,
                 schema_fields=schema_fields,
                 time_partitioning=self.time_partitioning,
+                integer_range_partitioning=self.integer_range_partitioning,
                 cluster_fields=self.cluster_fields,
                 labels=self.labels,
                 view=self.view,

--- a/airflow/providers/google/cloud/operators/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/operators/gcs_to_bigquery.py
@@ -128,7 +128,12 @@ class GCSToBigQueryOperator(BaseOperator):
         partition by field, type and  expiration as per API specifications.
         Note that 'field' is not available in concurrency with
         dataset.table$partition.
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timepartitioning
     :type time_partitioning: dict
+    :param integer_range_partitioning: configure optional integer range partitioning.
+        Provide field and range definitions per API specifications.
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#RangePartitioning
+    :type integer_range_partitioning: dict
     :param cluster_fields: Request that the result of this load be stored sorted
         by one or more columns. This is only available in conjunction with
         time_partitioning. The order of columns given determines the sort order.
@@ -183,6 +188,7 @@ class GCSToBigQueryOperator(BaseOperator):
                  src_fmt_configs=None,
                  external_table=False,
                  time_partitioning=None,
+                 integer_range_partitioning=None,
                  cluster_fields=None,
                  autodetect=True,
                  encryption_configuration=None,
@@ -196,6 +202,8 @@ class GCSToBigQueryOperator(BaseOperator):
             src_fmt_configs = {}
         if time_partitioning is None:
             time_partitioning = {}
+        if integer_range_partitioning is None:
+            integer_range_partitioning = {}
         self.bucket = bucket
         self.source_objects = source_objects
         self.schema_object = schema_object
@@ -225,6 +233,7 @@ class GCSToBigQueryOperator(BaseOperator):
         self.schema_update_options = schema_update_options
         self.src_fmt_configs = src_fmt_configs
         self.time_partitioning = time_partitioning
+        self.integer_range_partitioning = integer_range_partitioning
         self.cluster_fields = cluster_fields
         self.autodetect = autodetect
         self.encryption_configuration = encryption_configuration
@@ -295,6 +304,7 @@ class GCSToBigQueryOperator(BaseOperator):
                 schema_update_options=self.schema_update_options,
                 src_fmt_configs=self.src_fmt_configs,
                 time_partitioning=self.time_partitioning,
+                integer_range_partitioning=self.integer_range_partitioning,
                 cluster_fields=self.cluster_fields,
                 encryption_configuration=self.encryption_configuration)
 

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -79,6 +79,7 @@ class TestBigQueryCreateEmptyTableOperator(unittest.TestCase):
                 table_id=TEST_TABLE_ID,
                 schema_fields=None,
                 time_partitioning={},
+                integer_range_partitioning=None,
                 cluster_fields=None,
                 labels=None,
                 view=None,
@@ -102,6 +103,7 @@ class TestBigQueryCreateEmptyTableOperator(unittest.TestCase):
                 table_id=TEST_TABLE_ID,
                 schema_fields=None,
                 time_partitioning={},
+                integer_range_partitioning=None,
                 cluster_fields=None,
                 labels=None,
                 view=VIEW_DEFINITION,
@@ -151,6 +153,56 @@ class TestBigQueryCreateEmptyTableOperator(unittest.TestCase):
                 table_id=TEST_TABLE_ID,
                 schema_fields=schema_fields,
                 time_partitioning=time_partitioning,
+                integer_range_partitioning=None,
+                cluster_fields=cluster_fields,
+                labels=None,
+                view=None,
+                encryption_configuration=None
+            )
+
+    @mock.patch('airflow.providers.google.cloud.operators.bigquery.BigQueryHook')
+    def test_create_integer_range_partitioned_table(self, mock_hook):
+
+        schema_fields = [
+            {
+                "name": "emp_name",
+                "type": "STRING",
+                "mode": "REQUIRED"
+            },
+            {
+                "name": "emp_division",
+                "type": "INTEGER",
+                "mode": "REQUIRED"
+            },
+        ]
+        integer_range_partitioning = {
+            "field": "emp_division",
+            "range": {
+                "end": "100",
+                "interval": "10",
+                "start": "0"
+            }
+        }
+        cluster_fields = ["date_birth"]
+        operator = BigQueryCreateEmptyTableOperator(task_id=TASK_ID,
+                                                    dataset_id=TEST_DATASET,
+                                                    project_id=TEST_GCP_PROJECT_ID,
+                                                    table_id=TEST_TABLE_ID,
+                                                    schema_fields=schema_fields,
+                                                    integer_range_partitioning=integer_range_partitioning,
+                                                    cluster_fields=cluster_fields
+                                                    )
+
+        operator.execute(None)
+        mock_hook.return_value \
+            .create_empty_table \
+            .assert_called_once_with(
+                dataset_id=TEST_DATASET,
+                project_id=TEST_GCP_PROJECT_ID,
+                table_id=TEST_TABLE_ID,
+                schema_fields=schema_fields,
+                time_partitioning={},
+                integer_range_partitioning=integer_range_partitioning,
                 cluster_fields=cluster_fields,
                 labels=None,
                 view=None,
@@ -337,6 +389,7 @@ class TestBigQueryOperator(unittest.TestCase):
             labels=None,
             priority='INTERACTIVE',
             time_partitioning=None,
+            integer_range_partitioning=None,
             api_resource_configs=None,
             cluster_fields=None,
             encryption_configuration=encryption_configuration
@@ -360,6 +413,7 @@ class TestBigQueryOperator(unittest.TestCase):
                 labels=None,
                 priority='INTERACTIVE',
                 time_partitioning=None,
+                integer_range_partitioning=None,
                 api_resource_configs=None,
                 cluster_fields=None,
                 encryption_configuration=encryption_configuration
@@ -388,6 +442,7 @@ class TestBigQueryOperator(unittest.TestCase):
             labels=None,
             priority='INTERACTIVE',
             time_partitioning=None,
+            integer_range_partitioning=None,
             api_resource_configs=None,
             cluster_fields=None,
             encryption_configuration=None,
@@ -412,6 +467,7 @@ class TestBigQueryOperator(unittest.TestCase):
                     labels=None,
                     priority='INTERACTIVE',
                     time_partitioning=None,
+                    integer_range_partitioning=None,
                     api_resource_configs=None,
                     cluster_fields=None,
                     encryption_configuration=None,
@@ -431,6 +487,7 @@ class TestBigQueryOperator(unittest.TestCase):
                     labels=None,
                     priority='INTERACTIVE',
                     time_partitioning=None,
+                    integer_range_partitioning=None,
                     api_resource_configs=None,
                     cluster_fields=None,
                     encryption_configuration=None,
@@ -492,6 +549,7 @@ class TestBigQueryOperator(unittest.TestCase):
                 labels=None,
                 priority='INTERACTIVE',
                 time_partitioning=None,
+                integer_range_partitioning=None,
                 api_resource_configs=None,
                 cluster_fields=None,
                 encryption_configuration=None


### PR DESCRIPTION
Support for integer range partitioning for BigQuery tables

There is already support for time partitioning while creating BQ tables and Google offers more options than only time partitioning.
We found integer range partitioning working best for our case so we customized few classes to gain this functionality.

https://github.com/apache/airflow/issues/8416

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
