### PR TITLE
(For v1-10-*) Reduce response payload size of /dag_stats and /task_stats

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -597,7 +597,6 @@ class Airflow(AirflowViewMixin, BaseView):
                 payload[dag_id].append({
                     'state': state,
                     'count': count,
-                    'dag_id': dag_id,
                     'color': State.color(state)
                 })
         return wwwutils.json_response(payload)
@@ -681,7 +680,6 @@ class Airflow(AirflowViewMixin, BaseView):
                 payload[dag_id].append({
                     'state': state,
                     'count': count,
-                    'dag_id': dag_id,
                     'color': State.color(state)
                 })
         return wwwutils.json_response(payload)

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -391,7 +391,6 @@ class Airflow(AirflowBaseView):
                 payload[dag_id].append({
                     'state': state,
                     'count': count,
-                    'dag_id': dag_id,
                     'color': State.color(state)
                 })
 
@@ -486,7 +485,6 @@ class Airflow(AirflowBaseView):
                 payload[dag_id].append({
                     'state': state,
                     'count': count,
-                    'dag_id': dag_id,
                     'color': State.color(state)
                 })
         return wwwutils.json_response(payload)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1307,6 +1307,8 @@ class TestTaskStats(unittest.TestCase):
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertIn('example_bash_operator', stats)
         self.assertIn('example_xcom', stats)
+        self.assertEqual(set(stats['example_bash_operator'][0].keys()),
+                         {'state', 'count', 'color'})
 
     def test_selected_dags(self):
         resp = self.app.get(
@@ -1328,6 +1330,13 @@ class TestTaskStats(unittest.TestCase):
         self.assertIn('example_bash_operator', stats)
         self.assertIn('example_xcom', stats)
         self.assertNotIn('example_subdag_operator', stats)
+
+    def test_dag_stats(self):
+        resp = self.app.get('/admin/airflow/dag_stats', follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        stats = json.loads(resp.data.decode('utf-8'))
+        self.assertEqual(set(list(stats.items())[0][1][0].keys()),
+                         {'state', 'count', 'color'})
 
 
 if __name__ == '__main__':

--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -552,6 +552,8 @@ class TestAirflowBaseViews(TestBase):
     def test_task_stats(self):
         resp = self.client.post('task_stats', follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(set(list(resp.json.items())[0][1][0].keys()),
+                         {'state', 'count', 'color'})
 
     def test_task_stats_only_noncompleted(self):
         conf.set("webserver", "show_recent_stats_for_completed_runs", "False")
@@ -1518,6 +1520,8 @@ class TestDagACLView(TestBase):
         self.login()
         resp = self.client.post('dag_stats', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
+        self.assertEqual(set(list(resp.json.items())[0][1][0].keys()),
+                         {'state', 'count', 'color'})
 
     def test_dag_stats_failure(self):
         self.logout()


### PR DESCRIPTION
This PR is to replicate the changes done in https://github.com/apache/airflow/pull/8633 for `1.10.*` branch