### PR TITLE
UI Fix: ensure "started"/"ended" in TI tooltips are not shown if the job not started yet

### DIFF
--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -30,16 +30,15 @@ function makeDateTimeHTML(start, end) {
 }
 
 function generateTooltipDateTimes(startDate, endDate, dagTZ) {
+  if (!startDate) {
+    return '<br><em>Not yet started</em>';
+  }
+
   const tzFormat = 'z (Z)';
   const localTZ = moment.defaultZone.name;
   startDate = moment.utc(startDate);
   endDate = moment.utc(endDate);
   dagTZ = dagTZ.toUpperCase();
-
-  // Generate UTC Start and End Date
-  if (!startDate) {
-    return '<br><em>Not yet started</em>';
-  }
 
   // Generate UTC Start and End Date
   let tooltipHTML = `<br><strong>UTC:</strong><br>`;


### PR DESCRIPTION
This is to fix the UI bug identified in another PR https://github.com/apache/airflow/pull/8663#issuecomment-622344999

This must be applied together with https://github.com/apache/airflow/pull/8663, otherwise the tooltip for DummyOperators will be shown incorrectly.

After fix:

![Screenshot 2020-05-01 at 3 15 09 PM](https://user-images.githubusercontent.com/11539188/80808187-445a3b80-8bbf-11ea-8865-1e2426e476b0.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
