### PR TITLE
Bump supported mysqlclient to <1.5

### DIFF
--- a/requirements/requirements-python3.6.txt
+++ b/requirements/requirements-python3.6.txt
@@ -69,9 +69,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.12.49
+boto3==1.13.0
 boto==2.49.0
-botocore==1.15.49
+botocore==1.16.0
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -110,7 +110,7 @@ ecdsa==0.15
 elasticsearch-dbapi==0.1.0
 elasticsearch-dsl==7.1.0
 elasticsearch==7.5.1
-email-validator==1.0.5
+email-validator==1.1.0
 entrypoints==0.3
 enum34==1.1.10
 execnet==1.7.1
@@ -217,7 +217,7 @@ multi-key-dict==2.0.3
 mypy-extensions==0.4.3
 mypy==0.770
 mysql-connector-python==8.0.18
-mysqlclient==1.3.14
+mysqlclient==1.4.6
 nbclient==0.2.0
 nbformat==5.0.6
 nest-asyncio==1.3.2
@@ -262,7 +262,7 @@ pycparser==2.20
 pycryptodomex==3.9.7
 pydata-google-auth==1.1.0
 pydruid==0.5.8
-pyexasol==0.12.0
+pyexasol==0.12.1
 pyflakes==2.1.1
 pykerberos==1.2.1
 pylint==2.4.4

--- a/requirements/requirements-python3.7.txt
+++ b/requirements/requirements-python3.7.txt
@@ -69,9 +69,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.12.49
+boto3==1.13.0
 boto==2.49.0
-botocore==1.15.49
+botocore==1.16.0
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -110,7 +110,7 @@ ecdsa==0.15
 elasticsearch-dbapi==0.1.0
 elasticsearch-dsl==7.1.0
 elasticsearch==7.5.1
-email-validator==1.0.5
+email-validator==1.1.0
 entrypoints==0.3
 enum34==1.1.10
 execnet==1.7.1
@@ -216,7 +216,7 @@ multi-key-dict==2.0.3
 mypy-extensions==0.4.3
 mypy==0.770
 mysql-connector-python==8.0.18
-mysqlclient==1.3.14
+mysqlclient==1.4.6
 nbclient==0.2.0
 nbformat==5.0.6
 nest-asyncio==1.3.2
@@ -260,7 +260,7 @@ pycparser==2.20
 pycryptodomex==3.9.7
 pydata-google-auth==1.1.0
 pydruid==0.5.8
-pyexasol==0.12.0
+pyexasol==0.12.1
 pyflakes==2.1.1
 pykerberos==1.2.1
 pylint==2.4.4

--- a/requirements/setup-3.6.md5
+++ b/requirements/setup-3.6.md5
@@ -1,1 +1,1 @@
-641aef6382833e43eb6dd837158c5b59  /opt/airflow/setup.py
+6a1e6943ea2d91f8c2596d924b05eb98  /opt/airflow/setup.py

--- a/requirements/setup-3.7.md5
+++ b/requirements/setup-3.7.md5
@@ -1,1 +1,1 @@
-641aef6382833e43eb6dd837158c5b59  /opt/airflow/setup.py
+6a1e6943ea2d91f8c2596d924b05eb98  /opt/airflow/setup.py

--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ mssql = [
 ]
 mysql = [
     'mysql-connector-python>=8.0.11, <=8.0.18',
-    'mysqlclient>=1.3.6,<1.4',
+    'mysqlclient>=1.3.6,<1.5',
 ]
 odbc = [
     'pyodbc',


### PR DESCRIPTION
Issue link: [#8292 ](https://github.com/apache/airflow/issues/8292)

Bumping to use the [sqlclient](https://github.com/PyMySQL/mysqlclient-python/releases) < 1.5 

Bumping to use 

---
Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
