### PR TITLE
show correct duration on graph view for running task (#8311)

### DIFF
--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -80,6 +80,17 @@ export default function tiTooltip(ti, {includeTryNumber = false} = {}) {
   } else {
     tt += `Started: ${escapeHtml(ti.start_date)}<br>`;
   }
+  // Calculate duration on the fly if task instance is still running
+  if(ti.state === "running") {
+    let start_date;
+    if (ti.start_date instanceof moment) {
+      start_date = ti.start_date
+    } else {
+      start_date = moment(ti.start_date)
+    }
+    ti.duration = moment().diff(start_date, 'second')
+  }
+
   tt += `Duration: ${escapeHtml(convertSecsToHumanReadable(ti.duration))}<br>`;
 
   if (includeTryNumber) {

--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -20,12 +20,18 @@
 /* global window, dagTZ, moment, convertSecsToHumanReadable */
 
 // We don't re-import moment again, otherwise webpack will include it twice in the bundle!
-import { defaultFormat, formatDateTime } from './datetime-utils';
 import { escapeHtml } from './base';
+import { defaultFormat, formatDateTime } from './datetime-utils';
 
 function makeDateTimeHTML(start, end) {
+  // check task ended or not
+  if (end && end instanceof moment) {
+    return (
+      `Started: ${start.format(defaultFormat)} <br> Ended: ${end.format(defaultFormat)} <br>`
+    )
+  }
   return (
-    `Started: ${start.format(defaultFormat)} <br> Ended: ${end.format(defaultFormat)} <br>`
+    `Started: ${start.format(defaultFormat)} <br> Ended: Not ended yet <br>`
   )
 }
 
@@ -47,13 +53,15 @@ function generateTooltipDateTimes(startDate, endDate, dagTZ) {
   // Generate User's Local Start and End Date
   startDate.tz(localTZ);
   tooltipHTML += `<br><strong>Local: ${startDate.format(tzFormat)}</strong><br>`;
-  tooltipHTML += makeDateTimeHTML(startDate, endDate.tz(localTZ));
+  const localEndDate = endDate && endDate instanceof moment ? endDate.tz(localTZ) : endDate;
+  tooltipHTML += makeDateTimeHTML(startDate, localEndDate);
 
   // Generate DAG's Start and End Date
   if (dagTZ !== 'UTC' && dagTZ !== localTZ) {
     startDate.tz(dagTZ);
     tooltipHTML += `<br><strong>DAG's TZ: ${startDate.format(tzFormat)}</strong><br>`;
-    tooltipHTML += makeDateTimeHTML(startDate, endDate.tz(dagTZ));
+    const dagTZEndDate = endDate && endDate instanceof moment ? endDate.tz(dagTZ) : endDate;
+    tooltipHTML += makeDateTimeHTML(startDate, dagTZEndDate);
   }
 
   return tooltipHTML;

--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -90,12 +90,7 @@ export default function tiTooltip(ti, {includeTryNumber = false} = {}) {
   }
   // Calculate duration on the fly if task instance is still running
   if(ti.state === "running") {
-    let start_date;
-    if (ti.start_date instanceof moment) {
-      start_date = ti.start_date
-    } else {
-      start_date = moment(ti.start_date)
-    }
+    let start_date = ti.start_date instanceof moment ? ti.start_date : moment(ti.start_date);
     ti.duration = moment().diff(start_date, 'second')
   }
 


### PR DESCRIPTION
This PR is aim to fix issue https://github.com/apache/airflow/issues/8311

#### Idea:

1. Check if a task is still running.
2. If so, disregard the duration field fetched from backend,
3. calculate duration with current timestamp - ti.start_time

#### Tooltip before fix:

![Screenshot 2020-05-01 at 22 11 23](https://user-images.githubusercontent.com/295515/80839203-10047080-8bfb-11ea-97af-5e9bc7fd6ef4.png)


#### Tooltip after fix:

![screenshot1](https://user-images.githubusercontent.com/295515/85921198-d5295c80-b87a-11ea-887a-16604eff1a18.png)


The original bug of not showing duration at all on graph view is not the case on master branch, but, the value shows in the tooltip is not correct, since it is read from database and scheduler doesn't update duration frequently to reflect the actual duration till current timestamp for running tasks.

Note: The bug reported in issue 8311 is on v1.10.10 but this PR is based on master branch. Since there are fundamental change between master and v1.10.10 branch, separate PR might be needed to for v1.10.10.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.