### PR TITLE
Prevent clickable sorting on non sortable columns in TI view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2627,6 +2627,8 @@ class TaskInstanceModelView(AirflowModelView):
                     'unixname', 'priority_weight', 'queue', 'queued_dttm', 'try_number',
                     'pool', 'log_url']
 
+    order_columns = [item for item in list_columns if item not in ['try_number', 'log_url']]
+
     search_columns = ['state', 'dag_id', 'task_id', 'execution_date', 'hostname',
                       'queue', 'pool', 'operator', 'start_date', 'end_date']
 


### PR DESCRIPTION
The purpose of this PR is to address the error view we get once a user tries to click on columns that are properties and not sortable in the view. Currently the task instance view does not show all runs anyways and rather shows just the number of times it ran this task for a given execution date. We need to remove these from the order_columns to prevent them from being clickable and rather have them be static.

Because this is a cosmetic change we have attached the UI shots from our instances within Pinterest and do not have any unit tests for this change.

Before this change you can see the try number is clickable. 
<img width="255" alt="Screen Shot 2020-05-02 at 6 37 46 PM" src="https://user-images.githubusercontent.com/10408007/80896610-19e2ae00-8ca5-11ea-8164-7b59ecd08fdc.png">

Once you click you get this properties error.
<img width="1156" alt="Screen Shot 2020-05-02 at 6 37 55 PM" src="https://user-images.githubusercontent.com/10408007/80896581-a8a2fb00-8ca4-11ea-8161-54a8f2b9e0d5.png">
With the change we prevent them being sortable on property columns that shouldn't be sortable to begin with.
<img width="1680" alt="Screen Shot 2020-05-02 at 6 31 45 PM" src="https://user-images.githubusercontent.com/10408007/80896583-accf1880-8ca4-11ea-9e28-b1b2313a5387.png">


---
Make sure to mark the boxes below before creating PR: [x]

- [x ] Description above provides context of the change
- [ x] Unit tests coverage for changes (not needed for documentation changes)
- [x ] Target Github ISSUE in description if exists
- [x ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x ] Relevant documentation is updated including usage instructions.
- [x ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
