### PR TITLE
[AIRFLOW-8605] Added docker compose

### DIFF
--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -416,3 +416,22 @@ signals). This entrypoint works as follows:
 
 * If first argument is equal to "bash" - you are dropped in bash shell.
 * If there are any arguments they are passed to "airflow" command
+
+Docker Compose
+--------------
+
+Docker Compose can be used to run Airflow installation. The provided Compose (docker-compose.yml) defines
+the necessary services to run Airflow. It also starts an ephemeral container to initialize the database
+and creates a user.
+
+This starts the Compose.
+
+.. code-block::
+
+  docker-compose -f docker-compose.yml up -d
+
+This stops the Compose.
+
+.. code-block::
+
+  docker-compose -f docker-compose.yml stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,78 @@
+version: "3.7"
+x-airflow-environment: &airflow-environment
+  AIRFLOW__CORE__EXECUTOR: CeleryExecutor
+  AIRFLOW__WEBSERVER__RBAC: "True"
+  AIRFLOW__CORE__LOAD_EXAMPLES: "False"
+  AIRFLOW__CELERY__BROKER_URL: "redis://:@redis:6379/0"
+  AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
+
+services:
+  postgres:
+    image: postgres:11.5
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_DB: airflow
+      POSTGRES_PASSWORD: airflow
+  redis:
+    image: redis:5
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    ports:
+      - 6379:6379
+  init:
+    image: apache/airflow:1.10.10
+    environment:
+      <<: *airflow-environment
+    depends_on:
+      - redis
+      - postgres
+    volumes:
+      - ./dags:/opt/airflow/dags
+    entrypoint: /bin/bash
+    command: >
+      -c "airflow list_users || (airflow initdb
+      && airflow create_user --role Admin --username airflow --password airflow -e airflow@airflow.com -f airflow -l airflow)"
+    restart: on-failure
+  webserver:
+    image: apache/airflow:1.10.10
+    ports:
+      - 8080:8080
+    environment:
+      <<: *airflow-environment
+    depends_on:
+      - init
+    volumes:
+      - ./dags:/opt/airflow/dags
+    command: "webserver"
+    restart: always
+  flower:
+    image: apache/airflow:1.10.10
+    ports:
+      - 5555:5555
+    environment:
+      <<: *airflow-environment
+    depends_on:
+      - redis
+    command: flower
+    restart: always
+  scheduler:
+    image: apache/airflow:1.10.10
+    environment:
+      <<: *airflow-environment
+    depends_on:
+      - webserver
+    volumes:
+      - ./dags:/opt/airflow/dags
+    command: scheduler
+    restart: always
+  worker:
+    image: apache/airflow:1.10.10
+    environment:
+      <<: *airflow-environment
+    depends_on:
+      - scheduler
+    volumes:
+      - ./dags:/opt/airflow/dags
+    command: worker
+    restart: always


### PR DESCRIPTION
This adds a docker compose example to run Airflow installation.

The Compose defines multiple services to run Airflow. There is an init service which is an ephemeral container to initialize the database and creates a user if necessary. The init service command tries to run `airflow list_users` and if it fails it initializes the database and creates a user. Different approaches were considered but this one is simple enough and only involves airflow commands (no database-specific commands).

Extension fields are used for airflow environment variables to reduce code duplication.

I added some lines of documentation on `IMAGES.rst` but maybe there is a better place for that.

Issues: #8605 #8606
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
