### PR TITLE
Carefully parse warning messages when building documentation

### DIFF
--- a/docs/build
+++ b/docs/build
@@ -228,11 +228,19 @@ def parse_sphinx_warnings(warning_text: str) -> List[DocBuildError]:
             continue
         warning_parts = sphinx_warning.split(":", 2)
         if len(warning_parts) == 3:
-            sphinx_build_errors.append(
-                DocBuildError(
-                    file_path=warning_parts[0], line_no=int(warning_parts[1]), message=warning_parts[2]
+            try:
+                sphinx_build_errors.append(
+                    DocBuildError(
+                        file_path=warning_parts[0], line_no=int(warning_parts[1]), message=warning_parts[2]
+                    )
                 )
-            )
+            except Exception:  # pylint: disable=broad-except
+                # If an error occurred while parsing the warning message, display the raw warning message.
+                sphinx_build_errors.append(
+                    DocBuildError(
+                        file_path=None, line_no=None, message=sphinx_warning
+                    )
+                )
         else:
             sphinx_build_errors.append(DocBuildError(file_path=None, line_no=None, message=sphinx_warning))
     return sphinx_build_errors

--- a/docs/build
+++ b/docs/build
@@ -235,7 +235,7 @@ def parse_sphinx_warnings(warning_text: str) -> List[DocBuildError]:
                     )
                 )
             except Exception:  # pylint: disable=broad-except
-                # If an error occurred while parsing the warning message, display the raw warning message.
+                # If an exception occurred while parsing the warning message, display the raw warning message.
                 sphinx_build_errors.append(
                     DocBuildError(
                         file_path=None, line_no=None, message=sphinx_warning


### PR DESCRIPTION
When the sphinx returns a warning that the script cannot process properly, an exception is raised

For example:

>  /opt/airflow/docs/howto/use-user-defined-exec-context.rst: WARNING: document isn't included in any toctree

Results in the following exception
```
Traceback (most recent call last):
  File "/opt/airflow/docs/build", line 288, in <module>
    build_sphinx_docs()
  File "/opt/airflow/docs/build", line 270, in build_sphinx_docs
    sphinx_build_errors = parse_sphinx_warnings(warning_text)
  File "/opt/airflow/docs/build", line 233, in parse_sphinx_warnings
    file_path=warning_parts[0], line_no=int(warning_parts[1]), message=warning_parts[2]
ValueError: invalid literal for int() with base 10: ' WARNING'
```

After this change, problems with warning processing do not result in an exception, but a raw message is displayed.

Related slack discussion: https://apache-airflow.slack.com/archives/C012FP2T9NW/p1588515270029000

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
