### PR TITLE
Make celery worker_prefetch_multiplier configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1141,7 +1141,7 @@
         https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
       version_added: ~
       type: int
-      example: 1
+      example: ~
       default: ~
     - name: worker_log_server_port
       description: |

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1132,16 +1132,16 @@
       default: ~
     - name: worker_prefetch_multiplier
       description: |
-        Due to an issue with Celery, worker_prefetch_multiplier must also be set to an int
-        greater than 1 for autoscaling to work.  Be aware that this causes the number of
-        records that a worker prefetchs to be greater than the available worker processes.
-        If you have multiple workers this can cause some jobs to be unnecessarily blocked if
-        one worker prefetches tasks and those tasks are blocked by long running work then another
-        worker with available process workers can't grab those tasks.
+        Used to increase the number of tasks that a worker prefetches which can improve performance.
+        The number of processes multiplied by worker_prefetch_multiplier is the number of tasks
+        that are prefetched by a worker.  A value greater than 1 can result in tasks being unnecessarily
+        blocked if there are multiple workers and one worker prefetches tasks that sit behind long
+        running tasks while another worker has unutilized processes that are unable to process the already
+        claimed blocked tasks.
         https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
       version_added: ~
       type: int
-      example: ~
+      example: "1"
       default: ~
     - name: worker_log_server_port
       description: |

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1130,6 +1130,19 @@
       type: string
       example: 16,12
       default: ~
+    - name: worker_prefetch_multiplier
+      description: |
+        Due to an issue with Celery, worker_prefetch_multiplier must also be set to an int
+        greater than 1 for autoscaling to work.  Be aware that this causes the number of
+        records that a worker prefetchs to be greater than the available worker processes.
+        If you have multiple workers this can cause some jobs to be unnecessarily blocked if
+        one worker prefetches tasks and those tasks are blocked by long running work then another
+        worker with available process workers can't grab those tasks.
+        https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
+      version_added: ~
+      type: int
+      example: 1
+      default: ~
     - name: worker_log_server_port
       description: |
         When you start an airflow worker, airflow starts a tiny web server

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -550,13 +550,14 @@ worker_concurrency = 8
 # Example: worker_autoscale = 16,12
 # worker_autoscale =
 
-# Due to an issue with Celery, worker_prefetch_multiplier must also be set to an int
-# greater than 1 for autoscaling to work.  Be aware that this causes the number of
-# records that a worker prefetchs to be greater than the available worker processes.
-# If you have multiple workers this can cause some jobs to be unnecessarily blocked if
-# one worker prefetches tasks and those tasks are blocked by long running work then another
-# worker with available process workers can't grab those tasks.
+# Used to increase the number of tasks that a worker prefetches which can improve performance.
+# The number of processes multiplied by worker_prefetch_multiplier is the number of tasks
+# that are prefetched by a worker.  A value greater than 1 can result in tasks being unnecessarily
+# blocked if there are multiple workers and one worker prefetches tasks that sit behind long
+# running tasks while another worker has unutilized processes that are unable to process the already
+# claimed blocked tasks.
 # https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
+# Example: worker_prefetch_multiplier = 1
 # worker_prefetch_multiplier =
 
 # When you start an airflow worker, airflow starts a tiny web server

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -550,6 +550,15 @@ worker_concurrency = 8
 # Example: worker_autoscale = 16,12
 # worker_autoscale =
 
+# Due to an issue with Celery, worker_prefetch_multiplier must also be set to an int
+# greater than 1 for autoscaling to work.  Be aware that this causes the number of
+# records that a worker prefetchs to be greater than the available worker processes.
+# If you have multiple workers this can cause some jobs to be unnecessarily blocked if
+# one worker prefetches tasks and those tasks are blocked by long running work then another
+# worker with available process workers can't grab those tasks.
+# https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
+# worker_prefetch_multiplier =
+
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main
 # web server, who then builds pages and sends them to users. This defines

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -549,14 +549,6 @@ worker_concurrency = 8
 # http://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-autoscale
 # Example: worker_autoscale = 16,12
 # worker_autoscale =
-# Due to an issue with Celery, worker_prefetch_multiplier must also be set to an int
-# greater than 1 for autoscaling to work.  Be aware that this causes the number of
-# records that a worker prefetchs to be greater than the available worker processes.
-# If you have multiple workers this can cause some jobs to be unnecessarily blocked if
-# one worker prefetches tasks and those tasks are blocked by long running work then another
-# worker with available process workers can't grab those tasks.
-# https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
-# worker_prefetch_multiplier =
 
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -549,6 +549,15 @@ worker_concurrency = 8
 # http://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-autoscale
 # Example: worker_autoscale = 16,12
 # worker_autoscale =
+# Due to an issue with Celery, worker_prefetch_multiplier must also be set to an int 
+# greater than 1 for autoscaling to work.  Be aware that this causes the number of 
+# records that a worker prefetchs to be greater than the available worker processes.  
+# If you have multiple workers this can cause some jobs to be blocked if one worker 
+# prefetches tasks that are blocked by long running work on that worker when another 
+# worker is available and could have processed that work.
+# https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
+# worker_prefetch_multiplier = 
+
 
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -549,15 +549,14 @@ worker_concurrency = 8
 # http://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-autoscale
 # Example: worker_autoscale = 16,12
 # worker_autoscale =
-# Due to an issue with Celery, worker_prefetch_multiplier must also be set to an int 
-# greater than 1 for autoscaling to work.  Be aware that this causes the number of 
-# records that a worker prefetchs to be greater than the available worker processes.  
-# If you have multiple workers this can cause some jobs to be blocked if one worker 
-# prefetches tasks that are blocked by long running work on that worker when another 
-# worker is available and could have processed that work.
+# Due to an issue with Celery, worker_prefetch_multiplier must also be set to an int
+# greater than 1 for autoscaling to work.  Be aware that this causes the number of
+# records that a worker prefetchs to be greater than the available worker processes.
+# If you have multiple workers this can cause some jobs to be unnecessarily blocked if
+# one worker prefetches tasks and those tasks are blocked by long running work then another
+# worker with available process workers can't grab those tasks.
 # https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
-# worker_prefetch_multiplier = 
-
+# worker_prefetch_multiplier =
 
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -39,7 +39,7 @@ if 'visibility_timeout' not in broker_transport_options:
 DEFAULT_CELERY_CONFIG = {
     'accept_content': ['json'],
     'event_serializer': 'json',
-    'worker_prefetch_multiplier': 1,
+    'worker_prefetch_multiplier': conf.getint('celery', 'worker_prefetch_multiplier', fallback=1),
     'task_acks_late': True,
     'task_default_queue': conf.get('celery', 'DEFAULT_QUEUE'),
     'task_default_exchange': conf.get('celery', 'DEFAULT_QUEUE'),


### PR DESCRIPTION
There is some debate about whether Celery autoscale actually works, as discussed in the comments to this PR:
https://github.com/apache/airflow/pull/3989#issuecomment-535882666

This is also related to the discussion in this issue:
https://github.com/apache/airflow/issues/8480

I ran into this issue as well with Airflow (autoscale not working) and had a look at the celery code and I think the issue is that for the worker process count to grow this is dependent on the number of tasks the worker has claimed, known as the prefetch_count.  If the prefetch_count isn't above the worker process count, then the number of worker processes won't budge. It seems like a catch-22. Airflow runs into this problem because `worker_prefetch_multiplier` is set to 1 (and `task_acks_late` is set to True...setting this to False also bumps the prefetch_count).

This issue can be worked around by setting the `worker_prefetch_multiplier` setting to an int greater than 1.  In this PR I included a note about the implications of this in the config and a link to relevant documentation.   Currently in airflow `worker_prefetch_multiplier` is set to 1 so a worker can't prefetch and lay claim to more tasks than it has process workers.  So in theory setting this to 2 can get you into trouble if you have worker A that has 6 processes and has grabbed 10 tasks and the 6 tasks it is working on are long running causing the other 4 tasks to be blocked.  Meanwhile worker B just finished up processing its own 6 tasks and is available to work on the 4 that are backed up on worker A but A has already claimed those tasks.  If you are running one worker, though, then this shouldn't be a problem.

This PR makes `worker_prefetch_multiplier` configurable so that the user can get autoscale working if they feel that for their use case `worker_prefetch_multiplier` of greater than 1 won't be an issue.

I also [opened up a Celery PR](https://github.com/celery/celery/pull/6069) with a suggested fix for this issue.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).


---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
