### PR TITLE
Scheduler just checks for task instances in 'running' state in execution.

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -120,6 +120,15 @@ class BaseExecutor(LoggingMixin):
         """
         return task_instance.key in self.queued_tasks or task_instance.key in self.running
 
+    def is_task_running(self, task_instance: TaskInstance) -> bool:
+        """
+        Checks if the given task is in 'running' status.
+
+        :param task_instance: TaskInstance
+        :return: True if the task is in running state in the executor
+        """
+        return task_instance.key in self.running
+
     def sync(self) -> None:
         """
         Sync will get called periodically by the heartbeat method.

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1275,7 +1275,7 @@ class SchedulerJob(BaseJob):
                                       " this task has been reached.", task_instance)
                         continue
 
-                if self.executor.has_task(task_instance):
+                if self.executor.is_task_running(task_instance):
                     self.log.debug(
                         "Not handling task %s as the executor reports it is running",
                         task_instance.key


### PR DESCRIPTION
The 'scheduler' needs to only check if the executor has started the task by checked the 'running' dictionary of the executor instance. The entry in the `Executor.queued_tasks` will be over-written with a new task-instance. 

This change assumes the `running` instance attributes of `Executor` signals the `scheduler` to not requeue the task. 

Fixes #8691

---
Make sure to mark the boxes below before creating PR: [x]

- [ x] Description above provides context of the change
- [ x] Unit tests coverage for changes (not needed for documentation changes)
- [x ] Target Github ISSUE in description if exists
- [ x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x ] Relevant documentation is updated including usage instructions.
- [ x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
