### PR TITLE
Support num_retries field in env var for GCP connection

### DIFF
--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -251,7 +251,9 @@ class GoogleBaseHook(BaseHook):
         :rtype: int
         """
         field_value = self._get_field('num_retries', default=5)
-        if field_value is None or field_value.strip() == '':
+        if field_value is None:
+            return 5
+        if isinstance(field_value, str) and field_value.strip() == '':
             return 5
         try:
             return int(field_value)

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -250,7 +250,17 @@ class GoogleBaseHook(BaseHook):
         :return: the number of times each API request should be retried
         :rtype: int
         """
-        return self._get_field('num_retries') or 5
+        field_value = self._get_field('num_retries', default=5)
+        if field_value is None or field_value.strip() == '':
+            return 5
+        try:
+            return int(field_value)
+        except ValueError:
+            raise AirflowException(
+                f"The num_retries field should be a integer. "
+                f"Current value: \"{field_value}\" (type: {type(field_value)}). "
+                f"Please check the connection configuration."
+            )
 
     @property
     def client_info(self) -> ClientInfo:

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -724,3 +724,40 @@ class TestProvideAuthorizedGcloud(unittest.TestCase):
             ],
             any_order=False
         )
+
+
+class TestNumRetry(unittest.TestCase):
+
+    @mock.patch.dict(
+        'os.environ',
+        AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT=(
+            'google-cloud-platform://?extra__google_cloud_platform__num_retries=5'
+        )
+    )
+    def test_should_return_int_when_set_via_env_var(self):
+        instance = hook.GoogleBaseHook(gcp_conn_id="google_cloud_default")
+        self.assertIsInstance(instance.num_retries, int)
+
+    @mock.patch.dict(
+        'os.environ',
+        AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT=(
+            'google-cloud-platform://?extra__google_cloud_platform__num_retries=cat'
+        )
+    )
+    def test_should_raise_when_invalid_value_via_env_var(self):
+        instance = hook.GoogleBaseHook(gcp_conn_id="google_cloud_default")
+        with self.assertRaisesRegex(
+            AirflowException, re.escape("The num_retries field should be a integer.")
+        ):
+            self.assertIsInstance(instance.num_retries, int)
+
+    @mock.patch.dict(
+        'os.environ',
+        AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT=(
+            'google-cloud-platform://?extra__google_cloud_platform__num_retries='
+        )
+    )
+    def test_should_fallback_when_empty_string_in_env_var(self):
+        instance = hook.GoogleBaseHook(gcp_conn_id="google_cloud_default")
+        self.assertIsInstance(instance.num_retries, int)
+        self.assertEqual(5, instance.num_retries)

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -728,6 +728,15 @@ class TestProvideAuthorizedGcloud(unittest.TestCase):
 
 class TestNumRetry(unittest.TestCase):
 
+    def test_should_return_int_when_set_int_via_connection(self):
+        instance = hook.GoogleBaseHook(gcp_conn_id="google_cloud_default")
+        instance.extras = {
+            'extra__google_cloud_platform__num_retries': 10,
+        }
+
+        self.assertIsInstance(instance.num_retries, int)
+        self.assertEqual(10, instance.num_retries)
+
     @mock.patch.dict(
         'os.environ',
         AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT=(


### PR DESCRIPTION
Fix: https://github.com/apache/airflow/issues/8659

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
