### PR TITLE
Make list trailing comma usage consistent

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -243,7 +243,7 @@ class DbApiHook(BaseHook):
         :return: The generated INSERT or REPLACE SQL statement
         :rtype: str
         """
-        placeholders = ["%s", ] * len(values)
+        placeholders = ["%s"] * len(values)
 
         if target_fields:
             target_fields = ", ".join(target_fields)

--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -129,7 +129,7 @@ def prepare_lineage(func):
         self.log.debug("Preparing lineage inlets and outlets")
 
         if isinstance(self._inlets, (str, Operator)) or attr.has(self._inlets):
-            self._inlets = [self._inlets, ]
+            self._inlets = [self._inlets]
 
         if self._inlets and isinstance(self._inlets, list):
             # get task_ids that are specified as parameter and make sure they are upstream
@@ -158,7 +158,7 @@ def prepare_lineage(func):
             raise AttributeError("inlets is not a list, operator, string or attr annotated object")
 
         if not isinstance(self._outlets, list):
-            self._outlets = [self._outlets, ]
+            self._outlets = [self._outlets]
 
         self.outlets.extend(self._outlets)
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -442,10 +442,10 @@ class BaseOperator(Operator, LoggingMixin):
         self._outlets: List = []
 
         if inlets:
-            self._inlets = inlets if isinstance(inlets, list) else [inlets, ]
+            self._inlets = inlets if isinstance(inlets, list) else [inlets]
 
         if outlets:
-            self._outlets = outlets if isinstance(outlets, list) else [outlets, ]
+            self._outlets = outlets if isinstance(outlets, list) else [outlets]
 
     def __eq__(self, other):
         if type(self) is type(other) and self.task_id == other.task_id:

--- a/airflow/providers/amazon/aws/operators/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/operators/redshift_to_s3.py
@@ -98,7 +98,7 @@ class RedshiftToS3Transfer(BaseOperator):
         self.table_as_file_name = table_as_file_name
 
         if self.include_header and 'HEADER' not in [uo.upper().strip() for uo in self.unload_options]:
-            self.unload_options = list(self.unload_options) + ['HEADER', ]
+            self.unload_options = list(self.unload_options) + ['HEADER']
 
     def execute(self, context):
         postgres_hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)

--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -50,7 +50,7 @@ class SimpleHttpOperator(BaseOperator):
     :type log_response: bool
     """
 
-    template_fields = ['endpoint', 'data', 'headers', ]
+    template_fields = ['endpoint', 'data', 'headers']
     template_ext = ()
     ui_color = '#f4a460'
 

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -108,7 +108,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                     "my_storage_container",
                     "my_fileshare",
                     "/input-data",
-                    True),],
+                    True)],
                     memory_in_gb=14.0,
                     cpu=4.0,
                     gpu=GpuResource(count=1, sku='K80'),
@@ -174,7 +174,7 @@ class AzureContainerInstancesOperator(BaseOperator):
 
         if self.registry_conn_id:
             registry_hook = AzureContainerRegistryHook(self.registry_conn_id)
-            image_registry_credentials = [registry_hook.connection, ]
+            image_registry_credentials = [registry_hook.connection]
         else:
             image_registry_credentials = None
 
@@ -223,7 +223,7 @@ class AzureContainerInstancesOperator(BaseOperator):
 
             container_group = ContainerGroup(
                 location=self.region,
-                containers=[container, ],
+                containers=[container],
                 image_registry_credentials=image_registry_credentials,
                 volumes=volumes,
                 restart_policy='Never',

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -201,7 +201,7 @@ class PostgresHook(DbApiHook):
         :return: The generated INSERT or REPLACE SQL statement
         :rtype: str
         """
-        placeholders = ["%s", ] * len(values)
+        placeholders = ["%s"] * len(values)
         replace_index = kwargs.get("replace_index", None)
 
         if target_fields:

--- a/airflow/providers/slack/operators/slack_webhook.py
+++ b/airflow/providers/slack/operators/slack_webhook.py
@@ -59,7 +59,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
     """
 
     template_fields = ['webhook_token', 'message', 'attachments', 'blocks', 'channel',
-                       'username', 'proxy', ]
+                       'username', 'proxy']
 
     # pylint: disable=too-many-arguments
     @apply_defaults

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -462,7 +462,7 @@ texinfo_documents = [(
     'Apache Airflow', 'Airflow',
     'Airflow is a system to programmatically author, schedule and monitor data pipelines.',
     'Miscellaneous'
-), ]
+)]
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/requirements/setup-3.6.md5
+++ b/requirements/setup-3.6.md5
@@ -1,1 +1,1 @@
-0e0464b2825b47f66257b054e2563e54  /opt/airflow/setup.py
+80605a94fcebdae45a455abdcf77cd2f  /opt/airflow/setup.py

--- a/requirements/setup-3.7.md5
+++ b/requirements/setup-3.7.md5
@@ -1,1 +1,1 @@
-0e0464b2825b47f66257b054e2563e54  /opt/airflow/setup.py
+80605a94fcebdae45a455abdcf77cd2f  /opt/airflow/setup.py

--- a/setup.py
+++ b/setup.py
@@ -354,7 +354,7 @@ postgres = [
     'psycopg2-binary>=2.7.4',
 ]
 presto = [
-    'presto-python-client>=0.7.0,<0.8'
+    'presto-python-client>=0.7.0,<0.8',
 ]
 qds = [
     'qds-sdk>=1.10.4',
@@ -381,7 +381,9 @@ sentry = [
     'blinker>=1.1',
     'sentry-sdk>=0.8.0',
 ]
-singularity = ['spython>=0.0.56']
+singularity = [
+    'spython>=0.0.56',
+]
 slack = [
     'slackclient>=2.0.0,<3.0.0',
 ]

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -331,7 +331,7 @@ class TestCliDags(unittest.TestCase):
 
     def test_cli_list_dag_runs(self):
         dag_command.dag_trigger(self.parser.parse_args([
-            'dags', 'trigger', 'example_bash_operator', ]))
+            'dags', 'trigger', 'example_bash_operator']))
         args = self.parser.parse_args(['dags',
                                        'list_runs',
                                        '--dag-id',

--- a/tests/lineage/test_lineage.py
+++ b/tests/lineage/test_lineage.py
@@ -44,7 +44,7 @@ class TestLineage(unittest.TestCase):
         with dag:
             op1 = DummyOperator(task_id='leave1',
                                 inlets=file1,
-                                outlets=[file2, ])
+                                outlets=[file2])
             op2 = DummyOperator(task_id='leave2')
             op3 = DummyOperator(task_id='upstream_level_1',
                                 inlets=AUTO,

--- a/tests/operators/test_generic_transfer.py
+++ b/tests/operators/test_generic_transfer.py
@@ -50,7 +50,7 @@ class TestMySql(unittest.TestCase):
             for table in drop_tables:
                 conn.execute("DROP TABLE IF EXISTS {}".format(table))
 
-    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",), ])
+    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",)])
     def test_mysql_to_mysql(self, client):
         with MySqlContext(client):
             sql = "SELECT * FROM INFORMATION_SCHEMA.TABLES LIMIT 100;"

--- a/tests/providers/amazon/aws/operators/test_redshift_to_s3.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_to_s3.py
@@ -43,7 +43,7 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
         table = "table"
         s3_bucket = "bucket"
         s3_key = "key"
-        unload_options = ['HEADER', ]
+        unload_options = ['HEADER']
 
         RedshiftToS3Transfer(
             schema=schema,

--- a/tests/providers/google/cloud/operators/test_gcs_to_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs_to_gcs.py
@@ -471,7 +471,8 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
             mock.call(TEST_BUCKET, 'test_object/file2.txt',
                       TEST_BUCKET, 'test_object/file2.txt'),
             mock.call(TEST_BUCKET, 'test_object/file3.json',
-                      TEST_BUCKET, 'test_object/file3.json'), ]
+                      TEST_BUCKET, 'test_object/file3.json'),
+        ]
         mock_hook.return_value.rewrite.assert_has_calls(mock_calls)
 
     @mock.patch('airflow.providers.google.cloud.operators.gcs_to_gcs.GCSHook')
@@ -497,7 +498,8 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
             mock.call(
                 TEST_BUCKET, 'test_object/file3.json',
                 DESTINATION_BUCKET, 'test_object/file3.json'
-            ), ]
+            ),
+        ]
         mock_hook.return_value.rewrite.assert_has_calls(mock_calls_none)
 
 

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -353,7 +353,7 @@ class TestMySql(unittest.TestCase):
             for table in drop_tables:
                 conn.execute("DROP TABLE IF EXISTS {}".format(table))
 
-    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",), ])
+    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",)])
     def test_mysql_hook_test_bulk_load(self, client):
         with MySqlContext(client):
             records = ("foo", "bar", "baz")
@@ -376,7 +376,7 @@ class TestMySql(unittest.TestCase):
                     results = tuple(result[0] for result in conn.fetchall())
                     self.assertEqual(sorted(results), sorted(records))
 
-    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",), ])
+    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",)])
     def test_mysql_hook_test_bulk_dump(self, client):
         with MySqlContext(client):
             hook = MySqlHook('airflow_db')
@@ -388,7 +388,7 @@ class TestMySql(unittest.TestCase):
                 self.skipTest("Skip test_mysql_hook_test_bulk_load "
                               "since file output is not permitted")
 
-    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",), ])
+    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",)])
     @mock.patch('airflow.providers.mysql.hooks.mysql.MySqlHook.get_conn')
     def test_mysql_hook_test_bulk_dump_mock(self, client, mock_get_conn):
         with MySqlContext(client):

--- a/tests/providers/mysql/operators/test_mysql.py
+++ b/tests/providers/mysql/operators/test_mysql.py
@@ -48,7 +48,7 @@ class TestMySql(unittest.TestCase):
             for table in drop_tables:
                 conn.execute("DROP TABLE IF EXISTS {}".format(table))
 
-    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",), ])
+    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",)])
     def test_mysql_operator_test(self, client):
         with MySqlContext(client):
             sql = """
@@ -62,7 +62,7 @@ class TestMySql(unittest.TestCase):
                 dag=self.dag)
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
-    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",), ])
+    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",)])
     def test_mysql_operator_test_multi(self, client):
         with MySqlContext(client):
             sql = [
@@ -77,7 +77,7 @@ class TestMySql(unittest.TestCase):
             )
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
-    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",), ])
+    @parameterized.expand([("mysqlclient",), ("mysql-connector-python",)])
     def test_overwrite_schema(self, client):
         """
         Verifies option to overwrite connection schema

--- a/tests/utils/test_logging_mixin.py
+++ b/tests/utils/test_logging_mixin.py
@@ -34,9 +34,9 @@ class TestLoggingMixin(unittest.TestCase):
         handler2 = mock.MagicMock()
         parent = mock.MagicMock()
         parent.propagate = False
-        parent.handlers = [handler1, ]
+        parent.handlers = [handler1]
         log = mock.MagicMock()
-        log.handlers = [handler2, ]
+        log.handlers = [handler2]
         log.parent = parent
         log.propagate = True
 


### PR DESCRIPTION
I noticed a few places in the codebase were trailing list commas were used inconsistently.  This PR is an enhancement to improve the consistency of list trailing comma usage.

More specifically this PR:

1. Updates several single-item lists that had a redundant trailing comma (meaningful for tuples but not for lists).

1. Updates some lists that had a redundant trailing comma on the same line as the closing bracket.

1. Updates a few instances were there was no trailing comma for lists where the closing bracket was on a new line.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes) - n/a
- [x] Target Github ISSUE in description if exists - n/a
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions. - n/a
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
