### PR TITLE
Set store_serialized_dags from config in UI

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -363,6 +363,9 @@ class DagBag(BaseDagBag, LoggingMixin):
         un-anchored regexes, not shell-like glob patterns.
         """
         if self.store_serialized_dags:
+            self.log.info(
+                "Not filling up the DagBag because store_serialized_dags is set to true"
+            )
             return
 
         self.log.info("Filling up the DagBag from %s", dag_folder)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -86,7 +86,7 @@ FILTER_STATUS_COOKIE = 'dag_status_filter'
 if os.environ.get('SKIP_DAGS_PARSING') != 'True':
     dagbag = models.DagBag(settings.DAGS_FOLDER, store_serialized_dags=STORE_SERIALIZED_DAGS)
 else:
-    dagbag = models.DagBag(os.devnull, include_examples=False)
+    dagbag = models.DagBag(os.devnull, include_examples=False, store_serialized_dags=STORE_SERIALIZED_DAGS)
 
 
 def get_date_time_num_runs_dag_runs_form_data(request, session, dag):
@@ -1884,7 +1884,8 @@ class Airflow(AirflowBaseView):
         dag_id = request.args.get('dag_id')
         is_paused = True if request.args.get('is_paused') == 'false' else False
         models.DagModel.get_dagmodel(dag_id).set_is_paused(
-            is_paused=is_paused)
+            is_paused=is_paused,
+            store_serialized_dags=STORE_SERIALIZED_DAGS)
         return "OK"
 
     @expose('/refresh', methods=['POST'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,11 @@ license_files =
    LICENSE
    NOTICE
 # Start of licenses generated automatically
+   licenses/LICENSE-bootstrap3-typeahead.txt
    licenses/LICENSE-bootstrap-toggle.txt
    licenses/LICENSE-bootstrap.txt
-   licenses/LICENSE-bootstrap3-typeahead.txt
-   licenses/LICENSE-d3-tip.txt
    licenses/LICENSE-d3js.txt
+   licenses/LICENSE-d3-tip.txt
    licenses/LICENSE-dagre-d3.txt
    licenses/LICENSE-datatables.txt
    licenses/LICENSE-elasticmock.txt


### PR DESCRIPTION
store_serialized_dags should be set to false everywhere except UI,
experimental API and dag import

Added missing store_serialized_dags to the _DagBag class.

When I have applied store_serialized_dags from config everywhere I did
not know/understand how this parameter works.

It caused some problems:
* migrations failed as they have used DagBag with SerializedDag before serialized_dags table was created
* code that runs after all migrations and clean up dags took much longer as it was creating and saving serialized representations of dags
* and, first of all, scheduler stopped parsing dags because
DagBag::collect_dags method that it uses, returned no dags, as it does
not collect dags when stored_serialized_dags is on.
Generally, even though store_serialized_dags parameter is used in
models and throughout common code, it should only be set to True in web
server.
If it is set to true in other parts of the system, they will stop
working.
CLI will stop working.
Scheduler is the element that creates serialized dags and it should
always read from disk to keep other parts of the system up to date.
But there is no way to check whether dag_bag was called by web server and
store_serialized_dags should be applied or if it was called from
scheduler and dags should be read from files on the disk not from the db.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
