### PR TITLE
Add __repr__ for DagTag so it displays properly in /dagmodel/show

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1685,6 +1685,9 @@ class DagTag(Base):
     name = Column(String(100), primary_key=True)
     dag_id = Column(String(ID_LEN), ForeignKey('dag.dag_id'), primary_key=True)
 
+    def __repr__(self):
+        return self.name
+
 
 class DagModel(Base):
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -646,6 +646,15 @@ class TestDag(unittest.TestCase):
         self.assertEqual(prev_local.isoformat(), "2018-03-24T03:00:00+01:00")
         self.assertEqual(prev.isoformat(), "2018-03-24T02:00:00+00:00")
 
+    def test_dagtag_repr(self):
+        clear_db_dags()
+        dag = DAG('dag-test-dagtag', start_date=DEFAULT_DATE, tags=['tag-1', 'tag-2'])
+        dag.sync_to_db()
+        with create_session() as session:
+            self.assertEqual({'tag-1', 'tag-2'},
+                             {repr(t) for t in session.query(DagTag).filter(
+                                 DagTag.dag_id == 'dag-test-dagtag').all()})
+
     def test_bulk_sync_to_db(self):
         clear_db_dags()
         dags = [


### PR DESCRIPTION
Currently Dag Tags are not displayed properly in UI page `/dagmodel/show/<dag_id>`

This issue exists in both `master` and `1.10.10`

## How to Reproduce
<img width="794" alt="1" src="https://user-images.githubusercontent.com/11539188/81092568-0fbceb80-8f01-11ea-8f79-338ac19923f5.png">

## Before Fix
<img width="964" alt="before_fix" src="https://user-images.githubusercontent.com/11539188/81092600-1fd4cb00-8f01-11ea-87e0-73296912aa57.png">

## After fix
<img width="723" alt="after_fix" src="https://user-images.githubusercontent.com/11539188/81092611-24997f00-8f01-11ea-9560-a2e36d29223d.png">


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
