### PR TITLE
Added logging of container statuses to capture OOMKilled cases when t…

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -188,6 +188,23 @@ class PodLauncher(LoggingMixin):
         wait=tenacity.wait_exponential(),
         reraise=True
     )
+    def read_pod_status(self, pod):
+        """Reads statuses from the POD"""
+        try:
+            return self._client.read_namespaced_pod_status(
+                namespace=pod.metadata.namespace,
+                name=pod.metadata.name
+            )
+        except BaseHTTPError as e:
+            raise AirflowException(
+                'There was an error reading the kubernetes API: {}'.format(e)
+            )
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_exponential(),
+        reraise=True
+    )
     def read_pod_events(self, pod):
         """Reads events from the POD"""
         try:


### PR DESCRIPTION
…he pod does not succeed (#8722)

Added an optional flag that logs container statuses when the pod fails. It helps when a container runs out of memory to log the OOMKilled status of it. Users then would know they need to request more memory for their tasks.
https://github.com/apache/airflow/issues/8722

---
Make sure to mark the boxes below before creating PR: [x]

- [ x] Description above provides context of the change
- [ x] Unit tests coverage for changes (not needed for documentation changes)
- [ x] Target Github ISSUE in description if exists
- [ x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ x] Relevant documentation is updated including usage instructions.
- [ x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
