### PR TITLE
Show Deprecation warning on duplicate Task ids

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -546,7 +546,7 @@ class BaseOperator(LoggingMixin):
                 "The DAG assigned to {} can not be changed.".format(self))
         elif self.task_id not in dag.task_dict:
             dag.add_task(self)
-        elif self.task_id in dag.task_dict and dag.task_dict[self.task_id] != self:
+        elif self.task_id in dag.task_dict and dag.task_dict[self.task_id] is not self:
             dag.add_task(self)
         self._dag = dag
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -546,7 +546,8 @@ class BaseOperator(LoggingMixin):
                 "The DAG assigned to {} can not be changed.".format(self))
         elif self.task_id not in dag.task_dict:
             dag.add_task(self)
-
+        elif self.task_id in dag.task_dict and dag.task_dict[self.task_id] != self:
+            dag.add_task(self)
         self._dag = dag
 
     def has_dag(self):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1329,7 +1329,7 @@ class DAG(BaseDag, LoggingMixin):
         elif task.end_date and self.end_date:
             task.end_date = min(task.end_date, self.end_date)
 
-        if task.task_id in self.task_dict and self.task_dict[task.task_id] != task:
+        if task.task_id in self.task_dict and self.task_dict[task.task_id] is not task:
             # TODO: raise an error in Airflow 2.0
             warnings.warn(
                 'The requested task could not be added to the DAG because a '

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1329,7 +1329,7 @@ class DAG(BaseDag, LoggingMixin):
         elif task.end_date and self.end_date:
             task.end_date = min(task.end_date, self.end_date)
 
-        if task.task_id in self.task_dict:
+        if task.task_id in self.task_dict and self.task_dict[task.task_id] != task:
             # TODO: raise an error in Airflow 2.0
             warnings.warn(
                 'The requested task could not be added to the DAG because a '

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -903,7 +903,7 @@ class DagTest(unittest.TestCase):
         self.assertEqual(dag.normalized_schedule_interval, expected_n_schedule_interval)
         self.assertEqual(dag.schedule_interval, schedule_interval)
 
-    def test_duplicate_task_ids_not_allowed_with_dag_context_manager(self):
+    def test_duplicate_task_ids_raise_warning_with_dag_context_manager(self):
         """Verify tasks with Duplicate task_id show warning"""
         with self.assertWarnsRegex(
             PendingDeprecationWarning,
@@ -918,7 +918,7 @@ class DagTest(unittest.TestCase):
 
         self.assertEqual(dag.task_dict, {t1.task_id: t1})
 
-    def test_duplicate_task_ids_not_allowed(self):
+    def test_duplicate_task_ids_raise_warning(self):
         """Verify tasks with Duplicate task_id show warning"""
         with self.assertWarnsRegex(
             PendingDeprecationWarning,
@@ -932,15 +932,3 @@ class DagTest(unittest.TestCase):
             t1 >> t2
 
         self.assertEqual(dag.task_dict, {t1.task_id: t1})
-
-    def test_duplicate_task_ids_for_same_task_is_allowed(self):
-        """Verify that same tasks with Duplicate task_id do not raise warning"""
-        with DAG("test_dag", start_date=DEFAULT_DATE) as dag:
-            t1 = t2 = DummyOperator(task_id="t1")
-            t3 = DummyOperator(task_id="t3")
-            t1 >> t3
-            t2 >> t3
-
-        self.assertEqual(t1, t2)
-        self.assertEqual(dag.task_dict, {t1.task_id: t1, t3.task_id: t3})
-        self.assertEqual(dag.task_dict, {t2.task_id: t2, t3.task_id: t3})

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -918,15 +918,7 @@ class DagTest(unittest.TestCase):
 
         self.assertEqual(dag.task_dict, {t1.task_id: t1})
 
-        # Also verify that DAGs with duplicate task_ids don't raise errors
-        with DAG("test_dag_1", start_date=DEFAULT_DATE) as dag1:
-            t3 = DummyOperator(task_id="t3")
-            t4 = DummyOperator(task_id="t3")
-            t3 >> t4
-
-        self.assertEqual(dag1.task_dict, {t3.task_id: t3, t4.task_id: t4})
-
-    def test_duplicate_task_ids_not_allowed_without_dag_context_manager(self):
+    def test_duplicate_task_ids_not_allowed(self):
         """Verify tasks with Duplicate task_id show warning"""
         with self.assertWarnsRegex(
             PendingDeprecationWarning,
@@ -940,14 +932,6 @@ class DagTest(unittest.TestCase):
             t1 >> t2
 
         self.assertEqual(dag.task_dict, {t1.task_id: t1})
-
-        # Also verify that DAGs with duplicate task_ids don't raise errors
-        dag1 = DAG("test_dag_1", start_date=DEFAULT_DATE)
-        t3 = DummyOperator(task_id="t3", dag=dag1)
-        t4 = DummyOperator(task_id="t4", dag=dag1)
-        t3 >> t4
-
-        self.assertEqual(dag1.task_dict, {t3.task_id: t3, t4.task_id: t4})
 
     def test_duplicate_task_ids_for_same_task_is_allowed(self):
         """Verify that same tasks with Duplicate task_id do not raise warning"""


### PR DESCRIPTION
We already raise the warning at https://github.com/apache/airflow/blob/1.10.10/airflow/models/dag.py#L1318-L1328 but that wasn't enough. 

We raise an error for Airflow 2.0 . PR where we did that: https://github.com/apache/airflow/pull/6549/files

**Before**:

```
airflow ❯ python -c "import airflow; from airflow.operators.dummy_operator import DummyOperator; dag = airflow.DAG(dag_id='test', start_date=airflow.utils.timezone.utcnow()); t1 = DummyOperator(dag=dag, task_id='t1'); t1_2 = DummyOperator(dag=dag, task_id='t1')"
```

**After**:

```
airflow ❯ python -c "import airflow; from airflow.operators.dummy_operator import DummyOperator; dag = airflow.DAG(dag_id='test', start_date=airflow.utils.timezone.utcnow()); t1 = DummyOperator(dag=dag, task_id='t1'); t1_2 = DummyOperator(dag=dag, task_id='t1')"
/opt/airflow/airflow/models/baseoperator.py:555: PendingDeprecationWarning: The requested task could not be added to the DAG because a task with task_id t1 is already in the DAG. Starting in Airflow 2.0, trying to overwrite a task will raise an exception.
  category=PendingDeprecationWarning)
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
