### PR TITLE
Make loading plugins from entrypoint fault-tolerant

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -135,6 +135,7 @@ def load_entrypoint_plugins():
     Load and register plugins AirflowPlugin subclasses from the entrypoints.
     The entry_point group should be 'airflow.plugins'.
     """
+    global import_errors  # pylint: disable=global-statement
     global plugins  # pylint: disable=global-statement
 
     entry_points = pkg_resources.iter_entry_points('airflow.plugins')
@@ -149,8 +150,8 @@ def load_entrypoint_plugins():
                 if callable(getattr(plugin_obj, 'on_load', None)):
                     plugin_obj.on_load()
                     plugins.append(plugin_obj)
-        except Exception as e:  # pylint: disable=broad-except
-            log.exception(e)
+        except Exception:  # pylint: disable=broad-except
+            log.exception("Failed to import plugin %s", entry_point.name)
 
 
 def load_plugins_from_plugin_directory():

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -141,13 +141,16 @@ def load_entrypoint_plugins():
 
     log.debug("Loading plugins from entrypoints")
 
-    for entry_point in entry_points:
+    for entry_point in entry_points:  # pylint: disable=too-many-nested-blocks
         log.debug('Importing entry_point plugin %s', entry_point.name)
-        plugin_obj = entry_point.load()
-        if is_valid_plugin(plugin_obj):
-            if callable(getattr(plugin_obj, 'on_load', None)):
-                plugin_obj.on_load()
-                plugins.append(plugin_obj)
+        try:
+            plugin_obj = entry_point.load()
+            if is_valid_plugin(plugin_obj):
+                if callable(getattr(plugin_obj, 'on_load', None)):
+                    plugin_obj.on_load()
+                    plugins.append(plugin_obj)
+        except Exception as e:  # pylint: disable=broad-except
+            log.exception(e)
 
 
 def load_plugins_from_plugin_directory():

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -150,8 +150,9 @@ def load_entrypoint_plugins():
                 if callable(getattr(plugin_obj, 'on_load', None)):
                     plugin_obj.on_load()
                     plugins.append(plugin_obj)
-        except Exception:  # pylint: disable=broad-except
+        except Exception as e:  # pylint: disable=broad-except
             log.exception("Failed to import plugin %s", entry_point.name)
+            import_errors[entry_point.module_name] = str(e)
 
 
 def load_plugins_from_plugin_directory():

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -17,8 +17,7 @@
 # under the License.
 
 import unittest
-
-import mock
+from unittest import mock
 
 from airflow.www import app as application
 
@@ -77,6 +76,7 @@ def test_entrypoint_plugin_errors_dont_raise_exceptions(mock_ep_plugins, caplog)
     from airflow.plugins_manager import load_entrypoint_plugins
 
     mock_entrypoint = mock.Mock()
+    mock_entrypoint.name = 'test-entrypoint'
     mock_entrypoint.load.side_effect = Exception('Version Conflict')
     mock_ep_plugins.return_value = [mock_entrypoint]
 
@@ -87,3 +87,4 @@ def test_entrypoint_plugin_errors_dont_raise_exceptions(mock_ep_plugins, caplog)
     # Assert Traceback is shown too
     assert "Traceback (most recent call last):" in caplog.text
     assert "Version Conflict" in caplog.text
+    assert "Failed to import plugin test-entrypoint" in caplog.text

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -67,8 +67,12 @@ class TestPluginsRBAC(unittest.TestCase):
         self.assertEqual(self.app.blueprints['test_plugin'].name, bp.name)
 
 
+@mock.patch('airflow.plugins_manager.import_errors', return_value={})
+@mock.patch('airflow.plugins_manager.plugins', return_value=[])
 @mock.patch('airflow.plugins_manager.pkg_resources.iter_entry_points')
-def test_entrypoint_plugin_errors_dont_raise_exceptions(mock_ep_plugins, caplog):
+def test_entrypoint_plugin_errors_dont_raise_exceptions(
+    mock_ep_plugins, mock_plugins, mock_import_errors, caplog
+):
     """
     Test that Airflow does not raise an Error if there is any Exception because of the
     Plugin.

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import logging
 import unittest
 from unittest import mock
 
@@ -84,6 +84,8 @@ def test_entrypoint_plugin_errors_dont_raise_exceptions(
     mock_entrypoint.module_name = 'test.plugins.test_plugins_manager'
     mock_entrypoint.load.side_effect = Exception('Version Conflict')
     mock_ep_plugins.return_value = [mock_entrypoint]
+
+    caplog.set_level(logging.INFO)
 
     # Clear Logs
     caplog.clear()

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -73,10 +73,11 @@ def test_entrypoint_plugin_errors_dont_raise_exceptions(mock_ep_plugins, caplog)
     Test that Airflow does not raise an Error if there is any Exception because of the
     Plugin.
     """
-    from airflow.plugins_manager import load_entrypoint_plugins
+    from airflow.plugins_manager import load_entrypoint_plugins, import_errors
 
     mock_entrypoint = mock.Mock()
     mock_entrypoint.name = 'test-entrypoint'
+    mock_entrypoint.module_name = 'test.plugins.test_plugins_manager'
     mock_entrypoint.load.side_effect = Exception('Version Conflict')
     mock_ep_plugins.return_value = [mock_entrypoint]
 
@@ -88,3 +89,4 @@ def test_entrypoint_plugin_errors_dont_raise_exceptions(mock_ep_plugins, caplog)
     assert "Traceback (most recent call last):" in caplog.text
     assert "Version Conflict" in caplog.text
     assert "Failed to import plugin test-entrypoint" in caplog.text
+    assert "Version Conflict", "test.plugins.test_plugins_manager" in import_errors.items()

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import logging
+
 import unittest
 from unittest import mock
 
@@ -66,33 +66,30 @@ class TestPluginsRBAC(unittest.TestCase):
         self.assertTrue('test_plugin' in self.app.blueprints)
         self.assertEqual(self.app.blueprints['test_plugin'].name, bp.name)
 
+    @mock.patch('airflow.plugins_manager.import_errors', return_value={})
+    @mock.patch('airflow.plugins_manager.plugins', return_value=[])
+    @mock.patch('airflow.plugins_manager.pkg_resources.iter_entry_points')
+    def test_entrypoint_plugin_errors_dont_raise_exceptions(
+        self, mock_ep_plugins, mock_plugins, mock_import_errors
+    ):
+        """
+        Test that Airflow does not raise an Error if there is any Exception because of the
+        Plugin.
+        """
+        from airflow.plugins_manager import load_entrypoint_plugins, import_errors
 
-@mock.patch('airflow.plugins_manager.import_errors', return_value={})
-@mock.patch('airflow.plugins_manager.plugins', return_value=[])
-@mock.patch('airflow.plugins_manager.pkg_resources.iter_entry_points')
-def test_entrypoint_plugin_errors_dont_raise_exceptions(
-    mock_ep_plugins, mock_plugins, mock_import_errors, caplog
-):
-    """
-    Test that Airflow does not raise an Error if there is any Exception because of the
-    Plugin.
-    """
-    from airflow.plugins_manager import load_entrypoint_plugins, import_errors
+        mock_entrypoint = mock.Mock()
+        mock_entrypoint.name = 'test-entrypoint'
+        mock_entrypoint.module_name = 'test.plugins.test_plugins_manager'
+        mock_entrypoint.load.side_effect = Exception('Version Conflict')
+        mock_ep_plugins.return_value = [mock_entrypoint]
 
-    mock_entrypoint = mock.Mock()
-    mock_entrypoint.name = 'test-entrypoint'
-    mock_entrypoint.module_name = 'test.plugins.test_plugins_manager'
-    mock_entrypoint.load.side_effect = Exception('Version Conflict')
-    mock_ep_plugins.return_value = [mock_entrypoint]
+        with self.assertLogs("airflow.plugins_manager", level="ERROR") as log_output:
+            load_entrypoint_plugins()
 
-    caplog.set_level(logging.INFO)
-
-    # Clear Logs
-    caplog.clear()
-    load_entrypoint_plugins()
-
-    # Assert Traceback is shown too
-    assert "Traceback (most recent call last):" in caplog.text
-    assert "Version Conflict" in caplog.text
-    assert "Failed to import plugin test-entrypoint" in caplog.text
-    assert "Version Conflict", "test.plugins.test_plugins_manager" in import_errors.items()
+            received_logs = log_output.output[0]
+            # Assert Traceback is shown too
+            assert "Traceback (most recent call last):" in received_logs
+            assert "Version Conflict" in received_logs
+            assert "Failed to import plugin test-entrypoint" in received_logs
+            assert "Version Conflict", "test.plugins.test_plugins_manager" in import_errors.items()


### PR DESCRIPTION
Currently `entry_point.load()` enforces dependecies check so if there are version conflicts (or any other Exception) it would result in Airflow Webserver & Scheduler to error.

We should catch errors loading plugins. That shouldn't take down/stop Airflow

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
