### PR TITLE
Added optional logging for pod container statuses once a pod fails. T…

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -188,6 +188,23 @@ class PodLauncher(LoggingMixin):
         wait=tenacity.wait_exponential(),
         reraise=True
     )
+    def read_pod_status(self, pod):
+        """Reads statuses from the POD"""
+        try:
+            return self._client.read_namespaced_pod_status(
+                namespace=pod.metadata.namespace,
+                name=pod.metadata.name
+            )
+        except BaseHTTPError as e:
+            raise AirflowException(
+                'There was an error reading the kubernetes API: {}'.format(e)
+            )
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_exponential(),
+        reraise=True
+    )
     def read_pod_events(self, pod):
         """Reads events from the POD"""
         try:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -130,6 +130,10 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     :type init_containers: list[kubernetes.client.models.V1Container]
     :param log_events_on_failure: Log the pod's events if a failure occurs
     :type log_events_on_failure: bool
+    :param log_container_statuses_on_failure: Log the pod's containers statuses if a failure occurs.
+        This is particularly useful if the container runs out of memory. The pod will fail silently
+        if we do not log container statuses to surface OOMKilled status of the container.
+    :type log_container_statuses_on_failure: bool
     :param do_xcom_push: If True, the content of the file
         /airflow/xcom/return.json in the container will also be pushed to an
         XCom when the container completes.
@@ -177,6 +181,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  full_pod_spec: Optional[k8s.V1Pod] = None,
                  init_containers: Optional[List[k8s.V1Container]] = None,
                  log_events_on_failure: bool = False,
+                 log_container_statuses_on_failure: bool = False,
                  do_xcom_push: bool = False,
                  pod_template_file: Optional[str] = None,
                  priority_class_name: Optional[str] = None,
@@ -221,6 +226,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.full_pod_spec = full_pod_spec
         self.init_containers = init_containers or []
         self.log_events_on_failure = log_events_on_failure
+        self.log_container_statuses_on_failure = log_container_statuses_on_failure
         self.priority_class_name = priority_class_name
         self.pod_template_file = pod_template_file
         self.name = self._set_name(name)
@@ -287,28 +293,25 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
             launcher = pod_launcher.PodLauncher(kube_client=client,
                                                 extract_xcom=self.do_xcom_push)
 
+            final_state, result = None, None
             try:
                 (final_state, result) = launcher.run_pod(
                     pod,
                     startup_timeout=self.startup_timeout_seconds,
                     get_logs=self.get_logs)
-            except AirflowException:
-                if self.log_events_on_failure:
-                    for event in launcher.read_pod_events(pod).items:
-                        self.log.error("Pod Event: %s - %s", event.reason, event.message)
-                raise
             finally:
+                if final_state != State.SUCCESS:
+                    # Before deleting the pod we get events and status of the pod (events can be fetched
+                    # after pod deletion but not statuses. For consistency both are fetched before deletion.
+                    self._log_pod_events_on_failure(pod, launcher)
+                    self._log_pod_status_on_failure(pod, launcher)
                 if self.is_delete_operator_pod:
                     launcher.delete_pod(pod)
 
             if final_state != State.SUCCESS:
-                if self.log_events_on_failure:
-                    for event in launcher.read_pod_events(pod).items:
-                        self.log.error("Pod Event: %s - %s", event.reason, event.message)
                 raise AirflowException(
                     'Pod returned a failure: {state}'.format(state=final_state)
                 )
-
             return result
         except AirflowException as ex:
             raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
@@ -318,6 +321,20 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         if not resources:
             return []
         return [Resources(**resources)]
+
+    def _log_pod_events_on_failure(self, pod, launcher):
+        if self.log_events_on_failure:
+            for event in launcher.read_pod_events(pod).items:
+                self.log.error("Pod Event: %s - %s", event.reason, event.message)
+
+    def _log_pod_status_on_failure(self, pod, launcher):
+        if self.log_container_statuses_on_failure:
+            try:
+                pod_status = launcher.read_pod_status(pod)
+                self.log.error('Pod not succeeded, look for OOMKilled in containers statuses.')
+                self.log.error(pod_status.status.container_statuses)
+            except AirflowException as ex:
+                self.log.exception('Failed to get container statuses: %s', ex)
 
     def _set_name(self, name):
         if self.pod_template_file or self.full_pod_spec:


### PR DESCRIPTION
…his will surface OOMKilled cases by kubernetes (#8722)

Added an optional flag that logs container statuses when the pod fails. It helps when a container runs out of memory to log the OOMKilled status of it. Users then would know they need to request more memory for their tasks.
https://github.com/apache/airflow/issues/8722

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
