### PR TITLE
Ensure test_logging_config.test_reload_module works in spawn mode.

### DIFF
--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -105,39 +105,43 @@ def settings_context(content, directory=None, name='LOGGING_CONFIG'):
     :param content:
           The content of the settings file
     """
-    settings_root = tempfile.mkdtemp()
-    filename = f"{SETTINGS_DEFAULT_NAME}.py"
+    initial_logging_config = os.environ.get("AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS", "")
+    try:
+        settings_root = tempfile.mkdtemp()
+        filename = f"{SETTINGS_DEFAULT_NAME}.py"
+        if directory:
+            # Replace slashes by dots
+            module = directory.replace('/', '.') + '.' + SETTINGS_DEFAULT_NAME + '.' + name
 
-    if directory:
-        # Replace slashes by dots
-        module = directory.replace('/', '.') + '.' + SETTINGS_DEFAULT_NAME + '.' + name
+            # Create the directory structure
+            dir_path = os.path.join(settings_root, directory)
+            pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
 
-        # Create the directory structure
-        dir_path = os.path.join(settings_root, directory)
-        pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
-
-        # Add the __init__ for the directories
-        # This is required for Python 2.7
-        basedir = settings_root
-        for part in directory.split('/'):
+            # Add the __init__ for the directories
+            # This is required for Python 2.7
+            basedir = settings_root
+            for part in directory.split('/'):
+                open(os.path.join(basedir, '__init__.py'), 'w').close()
+                basedir = os.path.join(basedir, part)
             open(os.path.join(basedir, '__init__.py'), 'w').close()
-            basedir = os.path.join(basedir, part)
-        open(os.path.join(basedir, '__init__.py'), 'w').close()
 
-        settings_file = os.path.join(dir_path, filename)
-    else:
-        module = SETTINGS_DEFAULT_NAME + '.' + name
-        settings_file = os.path.join(settings_root, filename)
+            settings_file = os.path.join(dir_path, filename)
+        else:
+            module = SETTINGS_DEFAULT_NAME + '.' + name
+            settings_file = os.path.join(settings_root, filename)
 
-    with open(settings_file, 'w') as handle:
-        handle.writelines(content)
-    sys.path.append(settings_root)
+        with open(settings_file, 'w') as handle:
+            handle.writelines(content)
+        sys.path.append(settings_root)
 
-    with conf_vars({('logging', 'logging_config_class'): module}):
+        # Using environment vars instead of conf_vars so value is accessible
+        # to parent and child processes when using 'spawn' for multiprocessing.
         os.environ["AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS"] = module
         yield settings_file
 
-    sys.path.remove(settings_root)
+    finally:
+        os.environ["AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS"] = initial_logging_config
+        sys.path.remove(settings_root)
 
 
 class TestLoggingSettings(unittest.TestCase):

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -134,6 +134,7 @@ def settings_context(content, directory=None, name='LOGGING_CONFIG'):
     sys.path.append(settings_root)
 
     with conf_vars({('logging', 'logging_config_class'): module}):
+        os.environ["AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS"] = module
         yield settings_file
 
     sys.path.remove(settings_root)

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -327,7 +327,6 @@ class TestDagFileProcessorAgent(unittest.TestCase):
             # reload the logging module.
             test_dag_path = os.path.join(TEST_DAG_FOLDER, 'test_scheduler_dags.py')
             async_mode = 'sqlite' not in conf.get('core', 'sql_alchemy_conn')
-
             log_file_loc = conf.get('logging', 'DAG_PROCESSOR_MANAGER_LOG_LOCATION')
 
             try:


### PR DESCRIPTION
Currently, the test_logging_config.test_reload_module test fails when processes are created in spawn mode, because the change in how memory is shared between processes means the test logging configs don't get loaded properly in the child.

This saves the logging config to an environment variable, which is accessible from the child process.
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
