### PR TITLE
Avoid color info in response of /dag_stats & /task_stats

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -246,6 +246,7 @@
 
     const DAGS_INDEX = "{{ url_for('Airflow.index') }}";
     const ENTER_KEY_CODE = 13;
+    const STATE_COLOR = {{ state_color|tojson }};
 
     $('#tags_filter').select2({
       placeholder: "Filter dags",
@@ -414,7 +415,7 @@
           })
           .attr('stroke', function(d) {
             if (d.count > 0)
-              return d.color;
+              return STATE_COLOR[d.state];
             else {
               return 'gainsboro';
             }
@@ -491,7 +492,7 @@
           })
           .attr('stroke', function(d) {
             if (d.count > 0)
-              return d.color;
+              return STATE_COLOR[d.state];
             else {
               return 'gainsboro';
             }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -337,6 +337,9 @@ class Airflow(AirflowBaseView):
 
         num_of_pages = int(math.ceil(num_of_all_dags / float(dags_per_page)))
 
+        state_color_mapping = State.state_color.copy()
+        state_color_mapping["null"] = state_color_mapping.pop(None)
+
         return self.render_template(
             'airflow/dags.html',
             dags=dags,
@@ -353,6 +356,7 @@ class Airflow(AirflowBaseView):
                                            status=arg_status_filter if arg_status_filter else None),
             num_runs=num_runs,
             tags=tags,
+            state_color=state_color_mapping,
             status_filter=arg_status_filter,
             status_count_all=all_dags_count,
             status_count_active=status_count_active,
@@ -399,8 +403,7 @@ class Airflow(AirflowBaseView):
                 count = data.get(dag_id, {}).get(state, 0)
                 payload[dag_id].append({
                     'state': state,
-                    'count': count,
-                    'color': State.color(state)
+                    'count': count
                 })
 
         return wwwutils.json_response(payload)
@@ -499,8 +502,7 @@ class Airflow(AirflowBaseView):
                 count = data.get(dag_id, {}).get(state, 0)
                 payload[dag_id].append({
                     'state': state,
-                    'count': count,
-                    'color': State.color(state)
+                    'count': count
                 })
         return wwwutils.json_response(payload)
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -505,6 +505,14 @@ class TestAirflowBaseViews(TestBase):
     def test_home(self):
         resp = self.client.get('home', follow_redirects=True)
         self.check_content_in_response('DAGs', resp)
+        val_state_color_mapping = 'const STATE_COLOR = {"failed": "red", ' \
+                                  '"null": "lightblue", "queued": "gray", ' \
+                                  '"removed": "lightgrey", "running": "lime", ' \
+                                  '"scheduled": "tan", "shutdown": "blue", ' \
+                                  '"skipped": "pink", "success": "green", ' \
+                                  '"up_for_reschedule": "turquoise", ' \
+                                  '"up_for_retry": "gold", "upstream_failed": "orange"};'
+        self.check_content_in_response(val_state_color_mapping, resp)
 
     def test_users_list(self):
         resp = self.client.get('users/list', follow_redirects=True)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -503,16 +503,23 @@ class TestAirflowBaseViews(TestBase):
         self.assertIsNone(None, resp_json['scheduler']['latest_scheduler_heartbeat'])
 
     def test_home(self):
-        resp = self.client.get('home', follow_redirects=True)
-        self.check_content_in_response('DAGs', resp)
-        val_state_color_mapping = 'const STATE_COLOR = {"failed": "red", ' \
-                                  '"null": "lightblue", "queued": "gray", ' \
-                                  '"removed": "lightgrey", "running": "lime", ' \
-                                  '"scheduled": "tan", "shutdown": "blue", ' \
-                                  '"skipped": "pink", "success": "green", ' \
-                                  '"up_for_reschedule": "turquoise", ' \
-                                  '"up_for_retry": "gold", "upstream_failed": "orange"};'
-        self.check_content_in_response(val_state_color_mapping, resp)
+        with self.capture_templates() as templates:
+            resp = self.client.get('home', follow_redirects=True)
+            self.check_content_in_response('DAGs', resp)
+            val_state_color_mapping = 'const STATE_COLOR = {"failed": "red", ' \
+                                      '"null": "lightblue", "queued": "gray", ' \
+                                      '"removed": "lightgrey", "running": "lime", ' \
+                                      '"scheduled": "tan", "shutdown": "blue", ' \
+                                      '"skipped": "pink", "success": "green", ' \
+                                      '"up_for_reschedule": "turquoise", ' \
+                                      '"up_for_retry": "gold", "upstream_failed": "orange"};'
+            self.check_content_in_response(val_state_color_mapping, resp)
+
+        self.assertEqual(len(templates), 1)
+        self.assertEqual(templates[0].name, 'airflow/dags.html')
+        state_color_mapping = State.state_color.copy()
+        state_color_mapping["null"] = state_color_mapping.pop(None)
+        self.assertEqual(templates[0].local_context['state_color'], state_color_mapping)
 
     def test_users_list(self):
         resp = self.client.get('users/list', follow_redirects=True)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -585,7 +585,7 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.post('task_stats', follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(set(list(resp.json.items())[0][1][0].keys()),
-                         {'state', 'count', 'color'})
+                         {'state', 'count'})
 
     @conf_vars({("webserver", "show_recent_stats_for_completed_runs"): "False"})
     def test_task_stats_only_noncompleted(self):
@@ -1681,7 +1681,7 @@ class TestDagACLView(TestBase):
         resp = self.client.post('dag_stats', follow_redirects=True)
         self.check_content_in_response('example_bash_operator', resp)
         self.assertEqual(set(list(resp.json.items())[0][1][0].keys()),
-                         {'state', 'count', 'color'})
+                         {'state', 'count'})
 
     def test_dag_stats_failure(self):
         self.logout()


### PR DESCRIPTION
Currently the color for each state is repeatedly appearing in the response payload of endpoints `/dag_stats` and `/task_stats`.

This can be avoided by having the mapping between state and color in the static file, and map each state into different color at client side after client receives the necessary info, instead of passing duplicated color information in the response payload.

This significantly reduces the size of data to be transferred from server to client.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests updated
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
