### PR TITLE
Fix the incorrect description of pod_mutation_hook in kubernetes.rst

### DIFF
--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -59,20 +59,20 @@ The structure of 'pod' that is an argument of pod_mutation_hook are as follows.
     args: []
     cmds: []
     configmaps:  []
-    dnspolicy:    
+    dnspolicy:
     Noneenvs:   {}
-    hostnetwork: 
-    image: 
-    image_pull_policy:   
-    IfNotPresentimage_pull_secrets: 
+    hostnetwork:
+    image:
+    image_pull_policy:
+    IfNotPresentimage_pull_secrets:
     init_containers:    []
     labels:   {'airflow_version': '1.10.10', 'kubernetes_pod_operator': 'True'}
-    name:  
-    namespace:    
+    name:
+    namespace:
     node_selectors:  {}
     pod_runtime_info_envs:    []
     ports:    []
-    resources:    
+    resources:
     Request: [cpu: None, memory: None], Limit: [cpu: None, memory: None, gpu: None]
     result:  None
     secrets:    []
@@ -81,4 +81,3 @@ The structure of 'pod' that is an argument of pod_mutation_hook are as follows.
     tolerations: []
     volume_mounts:    []
     volumes:  []
-

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -40,7 +40,7 @@ that has the ability to mutate pod objects before sending them to the Kubernetes
 for scheduling. It receives a single argument as a reference to pod objects, and
 is expected to alter its attributes.
 
-This could be used, for instance, to add sidecar or init containers
+This could be used, for instance, to add init containers
 to every worker pod launched by KubernetesExecutor or KubernetesPodOperator.
 
 
@@ -48,3 +48,37 @@ to every worker pod launched by KubernetesExecutor or KubernetesPodOperator.
 
     def pod_mutation_hook(pod: Pod):
       pod.annotations['airflow.apache.org/launched-by'] = 'Tests'
+
+
+The structure of 'pod' that is an argument of pod_mutation_hook are as follows.
+
+.. code:: python
+
+    affinity:   {}
+    annotations:  {}
+    args: []
+    cmds: []
+    configmaps:  []
+    dnspolicy:    
+    Noneenvs:   {}
+    hostnetwork: 
+    image: 
+    image_pull_policy:   
+    IfNotPresentimage_pull_secrets: 
+    init_containers:    []
+    labels:   {'airflow_version': '1.10.10', 'kubernetes_pod_operator': 'True'}
+    name:  
+    namespace:    
+    node_selectors:  {}
+    pod_runtime_info_envs:    []
+    ports:    []
+    resources:    
+    Request: [cpu: None, memory: None], Limit: [cpu: None, memory: None, gpu: None]
+    result:  None
+    secrets:    []
+    security_context: {}
+    service_account_name: default
+    tolerations: []
+    volume_mounts:    []
+    volumes:  []
+

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -60,7 +60,7 @@ The structure of 'pod' that is an argument of pod_mutation_hook are as follows.
     cmds: []
     configmaps:  []
     dnspolicy:
-    Noneenvs:   {}
+    envs:   {}
     hostnetwork:
     image:
     image_pull_policy:


### PR DESCRIPTION
In versions less than 2.0, can not add sidecar container by using pod_mutation_hook because of using kubernetes_request_factory.py. 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
