### PR TITLE
Support same short flags for `create user` as 1.10 did for `user_create`

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -629,41 +629,41 @@ ARG_INCLUDE_SECRETS = Arg(
     default=False)
 # users
 ARG_USERNAME = Arg(
-    ('--username', '-u'),
+    ('-u', '--username'),
     help='Username of the user',
     required=True,
     type=str)
 ARG_USERNAME_OPTIONAL = Arg(
-    ('--username', '-u'),
+    ('-u', '--username'),
     help='Username of the user',
     type=str)
 ARG_FIRSTNAME = Arg(
-    ('--firstname', '-f'),
+    ('-f', '--firstname'),
     help='First name of the user',
     required=True,
     type=str)
 ARG_LASTNAME = Arg(
-    ('--lastname', '-l'),
+    ('-l', '--lastname'),
     help='Last name of the user',
     required=True,
     type=str)
 ARG_ROLE = Arg(
-    ('--role', '-r'),
+    ('-r', '--role'),
     help='Role of the user. Existing roles include Admin, '
          'User, Op, Viewer, and Public',
     required=True,
     type=str,)
 ARG_EMAIL = Arg(
-    ('--email', '-e'),
+    ('-e', '--email'),
     help='Email of the user',
     required=True,
     type=str)
 ARG_EMAIL_OPTIONAL = Arg(
-    ('--email', '-e'),
+    ('-e', '--email'),
     help='Email of the user',
     type=str)
 ARG_PASSWORD = Arg(
-    ('--password', '-p'),
+    ('-p', '--password'),
     help='Password of the user, required to create a user '
          'without --use-random-password',
     type=str)

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -629,41 +629,41 @@ ARG_INCLUDE_SECRETS = Arg(
     default=False)
 # users
 ARG_USERNAME = Arg(
-    ('--username',),
+    ('--username', '-u'),
     help='Username of the user',
     required=True,
     type=str)
 ARG_USERNAME_OPTIONAL = Arg(
-    ('--username',),
+    ('--username', '-u'),
     help='Username of the user',
     type=str)
 ARG_FIRSTNAME = Arg(
-    ('--firstname',),
+    ('--firstname', '-f'),
     help='First name of the user',
     required=True,
     type=str)
 ARG_LASTNAME = Arg(
-    ('--lastname',),
+    ('--lastname', '-l'),
     help='Last name of the user',
     required=True,
     type=str)
 ARG_ROLE = Arg(
-    ('--role',),
+    ('--role', '-r'),
     help='Role of the user. Existing roles include Admin, '
          'User, Op, Viewer, and Public',
     required=True,
     type=str,)
 ARG_EMAIL = Arg(
-    ('--email',),
+    ('--email', '-e'),
     help='Email of the user',
     required=True,
     type=str)
 ARG_EMAIL_OPTIONAL = Arg(
-    ('--email',),
+    ('--email', '-e'),
     help='Email of the user',
     type=str)
 ARG_PASSWORD = Arg(
-    ('--password',),
+    ('--password', '-p'),
     help='Password of the user, required to create a user '
          'without --use-random-password',
     type=str)


### PR DESCRIPTION
This will make it easier to transition between versions.


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.