### PR TITLE
Correctly store non-default Nones in serialized tasks/dags

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -436,8 +436,9 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             :py:meth:`BaseSerialization._value_is_hardcoded_default`
         """
 
-        def _is_default():
-            nonlocal ctor_params, attrname, value
+        def _is_default(ctor_params, attrname, value):
+            if attrname not in ctor_params:
+                return False
             ctor_default = ctor_params[attrname].default
 
             # Also returns True if the value is an empty list or empty dict.
@@ -448,7 +449,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         for typ in type(instance).mro():
             ctor_params = cls.__constructor_params_for_subclass(typ)
 
-            if attrname in ctor_params and _is_default():
+            if _is_default(ctor_params, attrname, value):
                 if typ is BaseOperator:
                     return True
                 # For added fun, if a subclass sets a different default value to the

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -18,7 +18,6 @@
 """Serialized DAG and BaseOperator"""
 import datetime
 import enum
-import functools
 import logging
 from inspect import Parameter, signature
 from typing import Any, Dict, Iterable, List, Optional, Set, Union
@@ -283,7 +282,7 @@ class BaseSerialization:
         """
         # pylint: disable=unused-argument
         if attrname in cls._CONSTRUCTOR_PARAMS and \
-                (cls._CONSTRUCTOR_PARAMS[attrname].default is value or (value in [{}, []])):
+                (cls._CONSTRUCTOR_PARAMS[attrname] is value or (value in [{}, []])):
             return True
         return False
 
@@ -297,19 +296,10 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
     _decorated_fields = {'executor_config'}
 
-    # Calling `signature` is a relatively costly operation, we don't want to
-    # call it each time. But we also need to call it for each operator subclass
-    # we serialize. So we cache the most 128 recently asked for signatures --
-    # each time we ask it goes to the front of the queue, and the oldest are
-    # deleted once the size is exceeded.
-    @staticmethod
-    @functools.lru_cache(maxsize=128)
-    def __constructor_params_for_subclass(typ):
-        return {
-            k: v for k, v in signature(typ).parameters.items()
-            if v.default is not v.empty
-        }
-    _CONSTRUCTOR_PARAMS = __constructor_params_for_subclass.__func__(BaseOperator)  # type: ignore
+    _CONSTRUCTOR_PARAMS = {
+        k: v.default for k, v in signature(BaseOperator).parameters.items()
+        if v.default is not v.empty
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -415,60 +405,6 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 setattr(op, field, None)
 
         return op
-
-    @classmethod
-    def _is_constructor_param(cls, attrname: str, instance: Any) -> bool:
-        # Check all super classes too
-        return any(
-            attrname in cls.__constructor_params_for_subclass(typ)
-            for typ in type(instance).mro()
-        )
-
-    @classmethod
-    def _value_is_hardcoded_default(cls, attrname: str, value: Any, instance: Any) -> bool:
-        """
-        Check if ``value`` is the default value for ``attrname`` as set by the
-        constructor of ``instance``, or any of it's parent classes up
-        to-and-including BaseOperator.
-
-        .. seealso::
-
-            :py:meth:`BaseSerialization._value_is_hardcoded_default`
-        """
-
-        def _is_default(ctor_params, attrname, value):
-            if attrname not in ctor_params:
-                return False
-            ctor_default = ctor_params[attrname].default
-
-            # Also returns True if the value is an empty list or empty dict.
-            # This is done to account for the case where the default value of
-            # the field is None but has the ``field = field or {}`` set.
-            return ctor_default is value or (ctor_default is None and value in [{}, []])
-
-        for typ in type(instance).mro():
-            ctor_params = cls.__constructor_params_for_subclass(typ)
-
-            if _is_default(ctor_params, attrname, value):
-                if typ is BaseOperator:
-                    return True
-                # For added fun, if a subclass sets a different default value to the
-                # same argument, (i.e. a subclass changes default of do_xcom_push from
-                # True to False), we then do want to include it.
-                #
-                # This is because we set defaults based on BaseOperators
-                # defaults, so if we didn't set this when inflating we'd
-                # have the wrong value
-
-                base_op_ctor_params = cls.__constructor_params_for_subclass(BaseOperator)
-                if attrname not in base_op_ctor_params:
-                    return True
-                return base_op_ctor_params[attrname].default == value
-
-            if typ is BaseOperator:
-                break
-
-        return False
 
     @classmethod
     def _is_excluded(cls, var: Any, attrname: str, op: BaseOperator):
@@ -599,7 +535,7 @@ class SerializedDAG(DAG, BaseSerialization):
             'access_control': '_access_control',
         }
         return {
-            param_to_attr.get(k, k): v for k, v in signature(DAG).parameters.items()
+            param_to_attr.get(k, k): v.default for k, v in signature(DAG).parameters.items()
             if v.default is not v.empty
         }
     _CONSTRUCTOR_PARAMS = __get_constructor_defaults.__func__()  # type: ignore

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -345,13 +345,22 @@ class TestStringifiedDAGs(unittest.TestCase):
 
             # We store the string, real dag has the actual code
             'on_failure_callback', 'on_success_callback', 'on_retry_callback',
+
+            # Checked separately
+            'resources',
         }
 
         assert serialized_task.task_type == task.task_type
+        assert set(serialized_task.template_fields) == set(task.template_fields)
 
         for field in fields_to_check:
             assert getattr(serialized_task, field) == getattr(task, field), \
                 f'{task.dag.dag_id}.{task.task_id}.{field} does not match'
+
+        if serialized_task.resources is None:
+            assert task.resources is None or task.resources == []
+        else:
+            assert serialized_task.resources == task.resources
 
         # Check that for Deserialised task, task.subdag is None for all other Operators
         # except for the SubDagOperator where task.subdag is an instance of DAG object


### PR DESCRIPTION
The default schedule_interval for a DAG is `@daily`, so
`schedule_interval=None` is actually not the default, but we were not
storing _any_ null attributes previously.

This meant that upon re-inflating the DAG the schedule_interval would
become @daily.

This fixes that problem, and extends the test to look at _all_ the
serialized attributes in our round-trip tests, rather than just the few
that the webserver cared about.

It doesn't change the serialization format, it just changes what/when
values were stored.

This solution was more complex than I hoped for, but the test case in
test_operator_subclass_changing_base_defaults is a real one that the
round trip tests discovered from the DatabricksSubmitRunOperator -- I
have just captured it in this test in case that specific operator
changes in future.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
