### PR TITLE
Add default `conf` parameter to Spark JDBC Hook

### DIFF
--- a/airflow/providers/apache/spark/example_dags/example_spark_dag.py
+++ b/airflow/providers/apache/spark/example_dags/example_spark_dag.py
@@ -48,7 +48,6 @@ with DAG(
     jdbc_to_spark_job = SparkJDBCOperator(
         cmd_type='jdbc_to_spark',
         jdbc_table="foo",
-        spark_conf={},
         spark_jars="${SPARK_HOME}/jars/postgresql-42.2.12.jar",
         jdbc_driver="org.postgresql.Driver",
         metastore_table="bar",
@@ -60,7 +59,6 @@ with DAG(
     spark_to_jdbc_job = SparkJDBCOperator(
         cmd_type='spark_to_jdbc',
         jdbc_table="foo",
-        spark_conf={},
         spark_jars="${SPARK_HOME}/jars/postgresql-42.2.12.jar",
         jdbc_driver="org.postgresql.Driver",
         metastore_table="bar",

--- a/airflow/providers/apache/spark/hooks/spark_jdbc.py
+++ b/airflow/providers/apache/spark/hooks/spark_jdbc.py
@@ -147,7 +147,7 @@ class SparkJDBCHook(SparkSubmitHook):
         super().__init__(*args, **kwargs)
         self._name = spark_app_name
         self._conn_id = spark_conn_id
-        self._conf = spark_conf
+        self._conf = spark_conf or {}
         self._py_files = spark_py_files
         self._files = spark_files
         self._jars = spark_jars


### PR DESCRIPTION
When spark_conf parameter is not set, the SparkJdbcHook raises an error because it is not iterable. Following the same behaviour than SparkSubmitHook.
Resolves #8723

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
