### PR TITLE
Add note that the RBAC UI is required for extra links

### DIFF
--- a/docs/howto/define_extra_link.rst
+++ b/docs/howto/define_extra_link.rst
@@ -29,6 +29,11 @@ will be available on the task page:
 
 The following code shows how to add extra links to an operator:
 
+  .. note::
+
+    In order for extra links to be rendered you must be using the
+    ``RBAC UI``, *NOT* the ``Flask UI``.
+
 .. code-block:: python
 
     from airflow.models.baseoperator import BaseOperator, BaseOperatorLink


### PR DESCRIPTION
After trying unsuccessfully to add extra links based on the [guide](https://airflow.apache.org/docs/stable/howto/define_extra_link.html), I came across some stackoverflow posts, [here](https://stackoverflow.com/a/58615552) and [here](https://stackoverflow.com/a/60253995) mentioning that extra link only work with the `RBAC UI`, which I was not running.

This PR updates the `define_extra_links` howto guide to include a note mentioning extra links only work with the `RBAC UI`.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
