### PR TITLE
Expose option: look_for_keys in ssh_hook via extras

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -83,6 +83,7 @@ class SSHHook(BaseHook):
         self.no_host_key_check = True
         self.allow_host_key_change = False
         self.host_proxy = None
+        self.look_for_keys = True
 
         # Placeholder for deprecated __enter__
         self.client = None
@@ -121,6 +122,10 @@ class SSHHook(BaseHook):
                         and\
                         str(extra_options["allow_host_key_change"]).lower() == 'true':
                     self.allow_host_key_change = True
+                if "look_for_keys" in extra_options\
+                        and\
+                        str(extra_options["look_for_keys"]).lower() == 'false':
+                    self.look_for_keys = False
 
         if self.pkey and self.key_file:
             raise AirflowException(
@@ -178,7 +183,8 @@ class SSHHook(BaseHook):
             timeout=self.timeout,
             compress=self.compress,
             port=self.port,
-            sock=self.host_proxy
+            sock=self.host_proxy,
+            look_for_keys=self.look_for_keys
         )
 
         if self.password:

--- a/docs/howto/connection/ssh.rst
+++ b/docs/howto/connection/ssh.rst
@@ -48,6 +48,7 @@ Extra (optional)
     * ``compress`` - ``true`` to ask the remote client/server to compress traffic; ``false`` to refuse compression. Default is ``true``.
     * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
     * ``allow_host_key_change`` - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This wont protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
+    * ``look_for_keys`` - Set to ``false`` if you want to disable searching for discoverable private key files in ``~/.ssh/``
 
     Example "extras" field:
 
@@ -58,7 +59,8 @@ Extra (optional)
           "timeout": "10",
           "compress": "false",
           "no_host_key_check": "false",
-          "allow_host_key_change": "false"
+          "allow_host_key_change": "false",
+          "look_for_keys": "false"
        }
 
     When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -107,7 +107,8 @@ class TestSSHHook(unittest.TestCase):
                 timeout=10,
                 compress=True,
                 port='port',
-                sock=None
+                sock=None,
+                look_for_keys=True
             )
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
@@ -126,7 +127,8 @@ class TestSSHHook(unittest.TestCase):
                 timeout=10,
                 compress=True,
                 port='port',
-                sock=None
+                sock=None,
+                look_for_keys=True
             )
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder')
@@ -247,5 +249,6 @@ class TestSSHHook(unittest.TestCase):
                 timeout=10,
                 compress=True,
                 port='port',
-                sock=None
+                sock=None,
+                look_for_keys=True
             )

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -56,6 +56,7 @@ TEST_PRIVATE_KEY = generate_key_string(pkey=TEST_PKEY)
 class TestSSHHook(unittest.TestCase):
     CONN_SSH_WITH_PRIVATE_KEY_EXTRA = 'ssh_with_private_key_extra'
     CONN_SSH_WITH_EXTRA = 'ssh_with_extra'
+    CONN_SSH_WITH_EXTRA_FALSE_LOOK_FOR_KEYS = 'ssh_with_extra_false_look_for_keys'
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -76,6 +77,15 @@ class TestSSHHook(unittest.TestCase):
                 conn_type='ssh',
                 extra='{"compress" : true, "no_host_key_check" : "true", '
                       '"allow_host_key_change": false}'
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=cls.CONN_SSH_WITH_EXTRA_FALSE_LOOK_FOR_KEYS,
+                host='localhost',
+                conn_type='ssh',
+                extra='{"compress" : true, "no_host_key_check" : "true", '
+                      '"allow_host_key_change": false, "look_for_keys": false}'
             )
         )
         db.merge_conn(
@@ -175,6 +185,11 @@ class TestSSHHook(unittest.TestCase):
         self.assertEqual(ssh_hook.compress, True)
         self.assertEqual(ssh_hook.no_host_key_check, True)
         self.assertEqual(ssh_hook.allow_host_key_change, False)
+        self.assertEqual(ssh_hook.look_for_keys, True)
+
+    def test_conn_with_extra_parameters_false_look_for_keys(self):
+        ssh_hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_EXTRA_FALSE_LOOK_FOR_KEYS)
+        self.assertEqual(ssh_hook.look_for_keys, False)
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder')
     def test_tunnel_with_private_key(self, ssh_mock):


### PR DESCRIPTION
Exposes additional paramiko option in ssh_hook via extras

This commit exposes an additional paramiko connect option for the ssh_hook via extras.

The default matches the current default of the library https://github.com/paramiko/paramiko/blob/master/paramiko/client.py#L228

I've also made a branch for v1.10 but didn't submit a pr yet as I'm not sure on what the maintainers desired workflow is for that.
https://github.com/r-richmond/airflow/commit/ae2041089126c78a87c3b1a87c2b67fb05c3abf1


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
