### PR TITLE
Add optional network profile configuration parameter

### DIFF
--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -158,7 +158,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                  fail_if_exists=True,
                  restart_policy='Never',
                  ip_address=None,
-                 network_profile=None,
+                 network_profile='',
                  tags=None,
                  *args,
                  **kwargs):
@@ -180,7 +180,7 @@ class AzureContainerInstancesOperator(BaseOperator):
         self.remove_on_error = remove_on_error
         self.fail_if_exists = fail_if_exists
         self.restart_policy = self._check_restart_policy(restart_policy)
-        self.network_profile = self._check_network_profile(network_profile or dict())
+        self.network_profile = self._check_network_profile(network_profile)
         self.ip_address, self.container_ports = self._check_ip_address(ip_address or dict())
         self._ci_hook = None
         self.tags = tags

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -22,8 +22,8 @@ from time import sleep
 from typing import Dict, Sequence
 
 from azure.mgmt.containerinstance.models import (
-    Container, ContainerGroup, EnvironmentVariable, ResourceRequests, ResourceRequirements, VolumeMount,
-    IpAddress, Port, ContainerGroupNetworkProfile, ContainerPort
+    Container, ContainerGroup, ContainerGroupNetworkProfile, ContainerPort, EnvironmentVariable, IpAddress,
+    Port, ResourceRequests, ResourceRequirements, VolumeMount,
 )
 from msrestazure.azure_exceptions import CloudError
 


### PR DESCRIPTION
This PR adds optional parameters for the AzureContainerInstanceGroupOperator to forward IP Address cconfiguration, Network Profile and Restart policy to the Azure Container group. This is useful if your container instance needs to access ressources that are protected by VPN settings 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
