### PR TITLE
Allow passing secrets backend_kwargs to AWS SSM client

### DIFF
--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -20,6 +20,8 @@ from unittest import TestCase, mock
 from moto import mock_ssm
 
 from airflow.providers.amazon.aws.secrets.systems_manager import SystemsManagerParameterStoreBackend
+from airflow.secrets import initialize_secrets_backends
+from tests.test_utils.config import conf_vars
 
 
 class TestSsmSecrets(TestCase):
@@ -94,3 +96,19 @@ class TestSsmSecrets(TestCase):
         ssm_backend.client.put_parameter(**param)
 
         self.assertIsNone(ssm_backend.get_variable("test_mysql"))
+
+    @conf_vars({
+        ('secrets', 'backend'): 'airflow.providers.amazon.aws.secrets.systems_manager.'
+                                'SystemsManagerParameterStoreBackend',
+        ('secrets', 'backend_kwargs'): '{"use_ssl": false}'
+    })
+    @mock.patch("airflow.providers.amazon.aws.secrets.systems_manager.boto3.Session.client")
+    def test_passing_client_kwargs(self, mock_ssm_client):
+        backends = initialize_secrets_backends()
+        systems_manager = [
+            backend for backend in backends
+            if backend.__class__.__name__ == 'SystemsManagerParameterStoreBackend'
+        ][0]
+
+        systems_manager.client
+        mock_ssm_client.assert_called_once_with('ssm', use_ssl=False)

--- a/tests/secrets/test_secrets.py
+++ b/tests/secrets/test_secrets.py
@@ -57,6 +57,20 @@ class TestConnectionsFromSecrets(unittest.TestCase):
     @conf_vars({
         ("secrets", "backend"):
             "airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend",
+        ("secrets", "backend_kwargs"): '{"use_ssl": false}',
+    })
+    def test_backends_kwargs(self):
+        backends = initialize_secrets_backends()
+        systems_manager = [
+            backend for backend in backends
+            if backend.__class__.__name__ == 'SystemsManagerParameterStoreBackend'
+        ][0]
+
+        self.assertEqual(systems_manager.kwargs, {'use_ssl': False})
+
+    @conf_vars({
+        ("secrets", "backend"):
+            "airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend",
         ("secrets", "backend_kwargs"): '{"connections_prefix": "/airflow", "profile_name": null}',
     })
     @mock.patch.dict('os.environ', {


### PR DESCRIPTION
Allow passing secrets backend_kwargs to AWS SSM client

We were already doing this for all other Secret backends.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
