### PR TITLE
Propagate tags on ECSOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -113,7 +113,7 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
                  aws_conn_id=None, region_name=None, launch_type='EC2',
                  group=None, placement_constraints=None, platform_version='LATEST',
                  network_configuration=None, tags=None, awslogs_group=None,
-                 awslogs_region=None, awslogs_stream_prefix=None, **kwargs):
+                 awslogs_region=None, awslogs_stream_prefix=None, propagate_tags=None, **kwargs):
         super().__init__(**kwargs)
 
         self.aws_conn_id = aws_conn_id
@@ -131,6 +131,7 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
         self.awslogs_group = awslogs_group
         self.awslogs_stream_prefix = awslogs_stream_prefix
         self.awslogs_region = awslogs_region
+        self.propagate_tags = propagate_tags
 
         if self.awslogs_region is None:
             self.awslogs_region = region_name
@@ -165,6 +166,8 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
             run_opts['networkConfiguration'] = self.network_configuration
         if self.tags is not None:
             run_opts['tags'] = [{'key': k, 'value': v} for (k, v) in self.tags.items()]
+        if self.propagate_tags is not None:
+            run_opts['propagateTags'] = self.propagate_tags
 
         response = self.client.run_task(**run_opts)
 

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -72,7 +72,8 @@ class TestECSOperator(unittest.TestCase):
                     'securityGroups': ['sg-123abc'],
                     'subnets': ['subnet-123456ab']
                 }
-            }
+            },
+            'propagate_tags': 'TASK_DEFINITION'
         }
         self.ecs = ECSOperator(**self.ecs_operator_args, **kwargs)
         self.ecs.get_hook()
@@ -137,6 +138,7 @@ class TestECSOperator(unittest.TestCase):
                     'subnets': ['subnet-123456ab']
                 }
             },
+            propagateTags='TASK_DEFINITION',
             **extend_args
         )
 
@@ -173,7 +175,8 @@ class TestECSOperator(unittest.TestCase):
                     'securityGroups': ['sg-123abc'],
                     'subnets': ['subnet-123456ab'],
                 }
-            }
+            },
+            propagateTags='TASK_DEFINITION'
         )
 
     def test_wait_end_tasks(self):


### PR DESCRIPTION
Adds the option to propagate tags in the ECSOperator. 
When running a task in ECS, the existing tags in the task definition or service can be automatically propagated to the task run by setting this flag to either `TASK_DEFINITION` or `SERVICE` respectively.

More info:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
