### PR TITLE
Update GoogleBaseHook to not follow 308 and use 60s timeout

### DIFF
--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -32,6 +32,7 @@ import google.auth
 import google.auth.credentials
 import google.oauth2.service_account
 import google_auth_httplib2
+import httplib2
 import tenacity
 from google.api_core.exceptions import Forbidden, ResourceExhausted, TooManyRequests
 from google.api_core.gapic_v1.client_info import ClientInfo
@@ -206,13 +207,20 @@ class GoogleBaseHook(BaseHook):
         """
         return self._get_credentials().token
 
+    @staticmethod
+    def _build_http() -> httplib2.Http:
+        """
+        Returns a HTTP object using the defaults from google api client
+        """
+        return build_http()
+
     def _authorize(self) -> google_auth_httplib2.AuthorizedHttp:
         """
         Returns an authorized HTTP object to be used to build a Google cloud
         service hook connection.
         """
         credentials = self._get_credentials()
-        http = build_http()
+        http = self._build_http()
         http = set_user_agent(http, "airflow/" + version.version)
         authed_http = google_auth_httplib2.AuthorizedHttp(credentials, http=http)
         return authed_http

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -32,14 +32,13 @@ import google.auth
 import google.auth.credentials
 import google.oauth2.service_account
 import google_auth_httplib2
-import httplib2
 import tenacity
 from google.api_core.exceptions import Forbidden, ResourceExhausted, TooManyRequests
 from google.api_core.gapic_v1.client_info import ClientInfo
 from google.auth import _cloud_sdk
 from google.auth.environment_vars import CREDENTIALS
 from googleapiclient.errors import HttpError
-from googleapiclient.http import MediaIoBaseDownload, set_user_agent
+from googleapiclient.http import MediaIoBaseDownload, build_http, set_user_agent
 
 from airflow import version
 from airflow.exceptions import AirflowException
@@ -213,16 +212,7 @@ class GoogleBaseHook(BaseHook):
         service hook connection.
         """
         credentials = self._get_credentials()
-        http = httplib2.Http()
-
-        # Since Google Drive APIs use 308 status code as "Resume Incomplete" for resumable uploads,
-        # explicitly tell httplib2 to not redirect/ follow 308 status code.
-        try:
-            http.redirect_codes = http.redirect_codes - {308}
-        except AttributeError:
-            # http.redirect_codes does not exist for httplib2<0.17.0
-            pass
-
+        http = build_http()
         http = set_user_agent(http, "airflow/" + version.version)
         authed_http = google_auth_httplib2.AuthorizedHttp(credentials, http=http)
         return authed_http

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -214,6 +214,15 @@ class GoogleBaseHook(BaseHook):
         """
         credentials = self._get_credentials()
         http = httplib2.Http()
+
+        # Since Google Drive APIs use 308 status code as "Resume Incomplete" for resumable uploads,
+        # explicitly tell httplib2 to not redirect/ follow 308 status code.
+        try:
+            http.redirect_codes = http.redirect_codes - {308}
+        except AttributeError:
+            # http.redirect_codes does not exist for httplib2<0.17.0
+            pass
+
         http = set_user_agent(http, "airflow/" + version.version)
         authed_http = google_auth_httplib2.AuthorizedHttp(credentials, http=http)
         return authed_http

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -32,7 +32,6 @@ import google.auth
 import google.auth.credentials
 import google.oauth2.service_account
 import google_auth_httplib2
-import httplib2
 import tenacity
 from google.api_core.exceptions import Forbidden, ResourceExhausted, TooManyRequests
 from google.api_core.gapic_v1.client_info import ClientInfo
@@ -207,20 +206,13 @@ class GoogleBaseHook(BaseHook):
         """
         return self._get_credentials().token
 
-    @staticmethod
-    def _build_http() -> httplib2.Http:
-        """
-        Returns a HTTP object using the defaults from google api client
-        """
-        return build_http()
-
     def _authorize(self) -> google_auth_httplib2.AuthorizedHttp:
         """
         Returns an authorized HTTP object to be used to build a Google cloud
         service hook connection.
         """
         credentials = self._get_credentials()
-        http = self._build_http()
+        http = build_http()
         http = set_user_agent(http, "airflow/" + version.version)
         authed_http = google_auth_httplib2.AuthorizedHttp(credentials, http=http)
         return authed_http

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -624,6 +624,14 @@ class TestGoogleBaseHook(unittest.TestCase):
         http_authorized = self.instance._authorize()
         self.assertTrue(308 not in http_authorized.http.redirect_codes)
 
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials")
+    def test_authorize_assert_timeout_is_present(self, mock_get_credentials):
+        """
+        Verify that http client has a timeout set
+        """
+        http_authorized = self.instance._authorize()
+        self.assertNotEqual(http_authorized.http.timeout, None)
+
 
 class TestProvideAuthorizedGcloud(unittest.TestCase):
     def setUp(self):

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -616,6 +616,14 @@ class TestGoogleBaseHook(unittest.TestCase):
         self.assertEqual(response, new_response)
         self.assertEqual(content, new_content)
 
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials")
+    def test_authorize_assert_308_is_excluded(self, mock_get_credentials):
+        """
+        Verify that 308 status code is excluded from httplib2's redirect codes
+        """
+        http_authorized = self.instance._authorize()
+        self.assertTrue(308 not in http_authorized.http.redirect_codes)
+
 
 class TestProvideAuthorizedGcloud(unittest.TestCase):
     def setUp(self):

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -591,7 +591,7 @@ class TestGoogleBaseHook(unittest.TestCase):
         }
         self.assertEqual(self.instance.num_retries, 5)
 
-    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._build_http")
+    @mock.patch("airflow.providers.google.common.hooks.base_google.build_http")
     @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials")
     def test_authorize_assert_user_agent_is_sent(self, mock_get_credentials, mock_http):
         """
@@ -616,19 +616,21 @@ class TestGoogleBaseHook(unittest.TestCase):
         self.assertEqual(response, new_response)
         self.assertEqual(content, new_content)
 
-    def test_build_http_308_is_excluded(self):
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials")
+    def test_authorize_assert_http_308_is_excluded(self, mock_get_credentials):
         """
         Verify that 308 status code is excluded from httplib2's redirect codes
         """
-        http = self.instance._build_http()
-        self.assertTrue(308 not in http.redirect_codes)
+        http_authorized = self.instance._authorize().http
+        self.assertTrue(308 not in http_authorized.redirect_codes)
 
-    def test_build_http_timeout_is_present(self):
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials")
+    def test_authorize_assert_http_timeout_is_present(self, mock_get_credentials):
         """
         Verify that http client has a timeout set
         """
-        http = self.instance._build_http()
-        self.assertNotEqual(http.timeout, None)
+        http_authorized = self.instance._authorize().http
+        self.assertNotEqual(http_authorized.timeout, None)
 
 
 class TestProvideAuthorizedGcloud(unittest.TestCase):

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -591,7 +591,7 @@ class TestGoogleBaseHook(unittest.TestCase):
         }
         self.assertEqual(self.instance.num_retries, 5)
 
-    @mock.patch("airflow.providers.google.common.hooks.base_google.httplib2.Http")
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._build_http")
     @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials")
     def test_authorize_assert_user_agent_is_sent(self, mock_get_credentials, mock_http):
         """
@@ -616,21 +616,19 @@ class TestGoogleBaseHook(unittest.TestCase):
         self.assertEqual(response, new_response)
         self.assertEqual(content, new_content)
 
-    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials")
-    def test_authorize_assert_308_is_excluded(self, mock_get_credentials):
+    def test_build_http_308_is_excluded(self):
         """
         Verify that 308 status code is excluded from httplib2's redirect codes
         """
-        http_authorized = self.instance._authorize()
-        self.assertTrue(308 not in http_authorized.http.redirect_codes)
+        http = self.instance._build_http()
+        self.assertTrue(308 not in http.redirect_codes)
 
-    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials")
-    def test_authorize_assert_timeout_is_present(self, mock_get_credentials):
+    def test_build_http_timeout_is_present(self):
         """
         Verify that http client has a timeout set
         """
-        http_authorized = self.instance._authorize()
-        self.assertNotEqual(http_authorized.http.timeout, None)
+        http = self.instance._build_http()
+        self.assertNotEqual(http.timeout, None)
 
 
 class TestProvideAuthorizedGcloud(unittest.TestCase):


### PR DESCRIPTION
This PR fixes https://github.com/apache/airflow/issues/8810.

`httplib2` recently made changes to redirect / follow 308 status code. This conflicts with some Google Drive APIs which are using 308 for [resumable uploads](https://developers.google.com/drive/api/v3/manage-uploads#resumable). This PR replicates the [google-api-python-client fix](https://github.com/googleapis/google-api-python-client/pull/813) that addresses the exact same issue.

For backward compatibility, I decided against reusing [build_http](https://github.com/googleapis/google-api-python-client/blob/v1.8.0/googleapiclient/http.py#L1874) from `googleapiclient.http` since it will introduce a default timeout of 60s if no timeout was set previously.

EDIT

After discussing with @mik-laj, agreed that using `build_http` is a better approach. Updated the PR with code changes and test cases accordingly.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
