### PR TITLE
Option to simply set end_date for performance testing dag.

### DIFF
--- a/scripts/perf/dags/elastic_dag.py
+++ b/scripts/perf/dags/elastic_dag.py
@@ -155,9 +155,16 @@ START_DATE_ENV = os.environ.get("PERF_START_AGO", "1h")
 START_DATE = datetime.now() - parse_time_delta(START_DATE_ENV)
 SCHEDULE_INTERVAL_ENV = os.environ.get("PERF_SCHEDULE_INTERVAL", "@once")
 SCHEDULE_INTERVAL = parse_schedule_interval(SCHEDULE_INTERVAL_ENV)
+
 SHAPE = DagShape(os.environ["PERF_SHAPE"])
 
 args = {"owner": "airflow", "start_date": START_DATE}
+
+if "PERF_MAX_RUNS" in os.environ:
+    if isinstance(SCHEDULE_INTERVAL, str):
+        raise ValueError("Can't set max runs with string-based schedule_interval")
+    num_runs = int(os.environ["PERF_MAX_RUNS"])
+    args['end_date'] = START_DATE + (SCHEDULE_INTERVAL * (num_runs - 1))
 
 for dag_no in range(1, DAG_COUNT + 1):
     dag = DAG(


### PR DESCRIPTION
I wanted an option to run a specific number of dag runs to completion,
so this feature lets me control the end_date of the dag without having
to know exactly what value it would have.

The "is string" check is more simplistic than it needs to be, but it's
Good Enough for now for an optional feature.


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.