### PR TITLE
Fix KubernetesPodOperator pod name length validation

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -49,8 +49,8 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     :param image: Docker image you wish to launch. Defaults to hub.docker.com,
         but fully qualified URLS will point to custom repositories.
     :type image: str
-    :param name: name of the pod in which the task will run, will be used to
-        generate a pod id (DNS-1123 subdomain, containing only [a-z0-9.-]).
+    :param name: name of the pod in which the task will run, will be used (plus a random
+        suffix) to generate a pod id (DNS-1123 subdomain, containing only [a-z0-9.-]).
     :type name: str
     :param cmds: entrypoint of the container. (templated)
         The docker images's entrypoint is used if this is not provided.
@@ -322,5 +322,5 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     def _set_name(self, name):
         if self.pod_template_file or self.full_pod_spec:
             return None
-        validate_key(name, max_length=63)
+        validate_key(name, max_length=220)
         return re.sub(r'[^a-z0-9.-]+', '-', name.lower())

--- a/tests/runtime/kubernetes/test_kubernetes_pod_operator.py
+++ b/tests/runtime/kubernetes/test_kubernetes_pod_operator.py
@@ -819,5 +819,20 @@ class TestKubernetesPodOperator(unittest.TestCase):
         self.expected_pod['spec']['priorityClassName'] = priority_class_name
         self.assertEqual(self.expected_pod, actual_pod)
 
+    def test_pod_name(self):
+        pod_name_too_long = "a" * 221
+        with self.assertRaises(AirflowException):
+            KubernetesPodOperator(
+                namespace='default',
+                image="ubuntu:16.04",
+                cmds=["bash", "-cx"],
+                arguments=["echo 10"],
+                labels={"foo": "bar"},
+                name=pod_name_too_long,
+                task_id="task",
+                in_cluster=False,
+                do_xcom_push=False,
+            )
+
 
 # pylint: enable=unused-argument


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/6523 a validation was added to `KubernetesPodOperator` that verifies the provided `name` conforms to the maximum number of characters for _Kubernetes_ pods.

The provided character limit in such PR is not correct as it's using the maximum number of characters for a _Kubernetes_ label, which is `63`, instead of the maximum number of characters for _Kubernetes_ name, which is `253` [1].

However, the char limit set in this module depends on the implementation of `airflow.kubernetes.pod_generator.PodGenerator`. Upon the [_commit_ this PR is based](https://github.com/apache/airflow/blob/f410d64de56e3a2c9f3f0bec1f25aa4ad8fc815d/airflow/kubernetes/pod_generator.py#L473), whatever the length of the given name, such name will be shortened to conform to the norm (`253` characters). In the referenced _commit_ an additional `33` characters are added (`-` + `32` random), which in turns means that **this should validate that the name is no longer that `220` characters** (the value proposed).

Bear also in mind that current v.10.10 does not have the implementation of the [_commit_ mentioned](https://github.com/apache/airflow/blob/f410d64de56e3a2c9f3f0bec1f25aa4ad8fc815d/airflow/kubernetes/pod_generator.py#L473) but a [different one](https://github.com/apache/airflow/blob/185cab52aee657eb8a95b97cf28bb87646650299/airflow/contrib/kubernetes/pod_generator.py#L167) where the name is not shortened but directly concatenated to another `9` characters (`-` + 8 random) and thus the name this limit could be set to `244` (instead of the `220` characters proposed).

[1] [Identifiers and Names in Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
