### PR TITLE
[8830] Fix Yandex.Cloud hook to work with 1.10

### DIFF
--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -36,7 +36,7 @@ class YandexCloudBaseHook(BaseHook):
                  default_folder_id=None,
                  default_public_ssh_key=None
                  ):
-        super().__init__()
+        # parent class constructor is not called to provide Airflow 1.10 compatibility
         self.connection_id = connection_id or 'yandexcloud_default'
         self.connection = self.get_connection(self.connection_id)
         self.extras = self.connection.extra_dejson


### PR DESCRIPTION
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---

https://github.com/apache/airflow/issues/8830

Yandex.Cloud hook at the moment calls the parent class constructor with no args.
This breaks the provider when it is backported to 1.10.* (in 1.10 one positional arg is required)
I've tested -- works well with no parent class constructor call in both 1.10 and 2.

