### PR TITLE
Correctly pass sleep time from AWSAthenaOperator down to the hook.

### DIFF
--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -81,7 +81,7 @@ class AWSAthenaOperator(BaseOperator):
 
     def get_hook(self):
         """Create and return an AWSAthenaHook."""
-        return AWSAthenaHook(self.aws_conn_id, self.sleep_time)
+        return AWSAthenaHook(self.aws_conn_id, sleep_time=self.sleep_time)
 
     def execute(self, context):
         """

--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -62,7 +62,7 @@ class TestAWSAthenaOperator(unittest.TestCase):
         self.athena = AWSAthenaOperator(task_id='test_aws_athena_operator', query='SELECT * FROM TEST_TABLE',
                                         database='TEST_DATABASE', output_location='s3://test_s3_bucket/',
                                         client_request_token='eac427d0-1c6d-4dfb-96aa-2835d3ac6595',
-                                        sleep_time=1, max_tries=3, dag=self.dag)
+                                        sleep_time=0, max_tries=3, dag=self.dag)
 
     def test_init(self):
         self.assertEqual(self.athena.task_id, MOCK_DATA['task_id'])
@@ -70,7 +70,10 @@ class TestAWSAthenaOperator(unittest.TestCase):
         self.assertEqual(self.athena.database, MOCK_DATA['database'])
         self.assertEqual(self.athena.aws_conn_id, 'aws_default')
         self.assertEqual(self.athena.client_request_token, MOCK_DATA['client_request_token'])
-        self.assertEqual(self.athena.sleep_time, 1)
+        self.assertEqual(self.athena.sleep_time, 0)
+
+        hook = self.athena.get_hook()
+        self.assertEqual(hook.sleep_time, 0)
 
     @mock.patch.object(AWSAthenaHook, 'check_query_status', side_effect=("SUCCESS",))
     @mock.patch.object(AWSAthenaHook, 'run_query', return_value=ATHENA_QUERY_ID)


### PR DESCRIPTION
Sleep time in AthenaHook was defined as a kwarg-only key.

This one change makes tests go from 270s to 0.3s :D


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.