### PR TITLE
Adding support for databricks spark python and submit tasks.

### DIFF
--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -141,6 +141,8 @@ class DatabricksSubmitRunOperator(BaseOperator):
     Currently the named parameters that ``DatabricksSubmitRunOperator`` supports are
         - ``spark_jar_task``
         - ``notebook_task``
+        - ``spark_python_task``
+        - ``spark_submit_task``
         - ``new_cluster``
         - ``existing_cluster_id``
         - ``libraries``
@@ -160,19 +162,37 @@ class DatabricksSubmitRunOperator(BaseOperator):
     :type json: dict
     :param spark_jar_task: The main class and parameters for the JAR task. Note that
         the actual JAR is specified in the ``libraries``.
-        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
+        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` *OR* ``spark_python_task``
+        *OR* ``spark_submit_task`` should be specified.
         This field will be templated.
 
         .. seealso::
             https://docs.databricks.com/api/latest/jobs.html#jobssparkjartask
     :type spark_jar_task: dict
     :param notebook_task: The notebook path and parameters for the notebook task.
-        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
+        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` *OR* ``spark_python_task``
+        *OR* ``spark_submit_task`` should be specified.
         This field will be templated.
 
         .. seealso::
             https://docs.databricks.com/api/latest/jobs.html#jobsnotebooktask
     :type notebook_task: dict
+    :param spark_python_task: The python file path and parameters to run the python file with.
+        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` *OR* ``spark_python_task``
+        *OR* ``spark_submit_task`` should be specified.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/latest/jobs.html#jobssparkpythontask
+    :type spark_python_task: dict
+    :param spark_submit_task: Parameters needed to run a spark-submit command.
+        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` *OR* ``spark_python_task``
+        *OR* ``spark_submit_task`` should be specified.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/latest/jobs.html#jobssparksubmittask
+    :type spark_submit_task: dict
     :param new_cluster: Specs for a new cluster on which this task will be run.
         *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
         This field will be templated.
@@ -229,6 +249,8 @@ class DatabricksSubmitRunOperator(BaseOperator):
             json=None,
             spark_jar_task=None,
             notebook_task=None,
+            spark_python_task=None,
+            spark_submit_task=None,
             new_cluster=None,
             existing_cluster_id=None,
             libraries=None,
@@ -253,6 +275,10 @@ class DatabricksSubmitRunOperator(BaseOperator):
             self.json['spark_jar_task'] = spark_jar_task
         if notebook_task is not None:
             self.json['notebook_task'] = notebook_task
+        if spark_python_task is not None:
+            self.json['spark_python_task'] = spark_python_task
+        if spark_submit_task is not None:
+            self.json['spark_submit_task'] = spark_submit_task
         if new_cluster is not None:
             self.json['new_cluster'] = new_cluster
         if existing_cluster_id is not None:

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -35,6 +35,10 @@ DEFAULT_CONN_ID = 'databricks_default'
 NOTEBOOK_TASK = {
     'notebook_path': '/test'
 }
+SPARK_PYTHON_TASK = {
+    'python_file': 'test.py',
+    'parameters': ['--param', '123']
+}
 NEW_CLUSTER = {
     'spark_version': '2.0.x-scala2.10',
     'node_type_id': 'r3.xlarge',
@@ -283,6 +287,26 @@ class TestDatabricksHook(unittest.TestCase):
             submit_run_endpoint(HOST),
             json={
                 'notebook_task': NOTEBOOK_TASK,
+                'new_cluster': NEW_CLUSTER,
+            },
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_spark_python_submit_run(self, mock_requests):
+        mock_requests.post.return_value.json.return_value = {'run_id': '1'}
+        data = {
+            'spark_python_task': SPARK_PYTHON_TASK,
+            'new_cluster': NEW_CLUSTER
+        }
+        run_id = self.hook.submit_run(data)
+
+        self.assertEqual(run_id, '1')
+        mock_requests.post.assert_called_once_with(
+            submit_run_endpoint(HOST),
+            json={
+                'spark_python_task': SPARK_PYTHON_TASK,
                 'new_cluster': NEW_CLUSTER,
             },
             auth=(LOGIN, PASSWORD),

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -45,6 +45,18 @@ RENDERED_TEMPLATED_NOTEBOOK_TASK = {
 SPARK_JAR_TASK = {
     'main_class_name': 'com.databricks.Test'
 }
+SPARK_PYTHON_TASK = {
+    'python_file': 'test.py',
+    'parameters': ['--param', '123']
+}
+SPARK_SUBMIT_TASK = {
+    "parameters": [
+        "--class",
+        "org.apache.spark.examples.SparkPi",
+        "dbfs:/path/to/examples.jar",
+        "10"
+    ]
+}
 NEW_CLUSTER = {
     'spark_version': '2.0.x-scala2.10',
     'node_type_id': 'development-node',
@@ -90,7 +102,7 @@ class TestDatabricksOperatorSharedFunctions(unittest.TestCase):
 
 
 class TestDatabricksSubmitRunOperator(unittest.TestCase):
-    def test_init_with_named_parameters(self):
+    def test_init_with_notebook_task_named_parameters(self):
         """
         Test the initializer with the named parameters.
         """
@@ -100,6 +112,36 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
         expected = databricks_operator._deep_string_coerce({
             'new_cluster': NEW_CLUSTER,
             'notebook_task': NOTEBOOK_TASK,
+            'run_name': TASK_ID
+        })
+
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_spark_python_task_named_parameters(self):
+        """
+        Test the initializer with the named parameters.
+        """
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID,
+                                         new_cluster=NEW_CLUSTER,
+                                         spark_python_task=SPARK_PYTHON_TASK)
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': NEW_CLUSTER,
+            'spark_python_task': SPARK_PYTHON_TASK,
+            'run_name': TASK_ID
+        })
+
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_spark_submit_task_named_parameters(self):
+        """
+        Test the initializer with the named parameters.
+        """
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID,
+                                         new_cluster=NEW_CLUSTER,
+                                         spark_submit_task=SPARK_SUBMIT_TASK)
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': NEW_CLUSTER,
+            'spark_submit_task': SPARK_SUBMIT_TASK,
             'run_name': TASK_ID
         })
 


### PR DESCRIPTION
---
The Databricks Jobs API, which exposes the `Runs Submit` API, documented here: https://docs.databricks.com/dev-tools/api/latest/jobs.html#runs-submit, supports the following 4 tasks: `spark_jar_task`, `notebook_task`, `spark_python_task` and `spark_submit_task`. The databricks operator which exposes this functionality however did not support the latter 2 (`spark_python_task` and `spark_submit_task`). This PR adds support for these 2 tasks.

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).