### PR TITLE
Convert tests/jobs/test_base_job to pytest

### DIFF
--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -18,9 +18,9 @@
 #
 
 import datetime
-import unittest
 
 from mock import Mock, patch
+from pytest import raises
 from sqlalchemy.exc import OperationalError
 
 from airflow.executors.sequential_executor import SequentialExecutor
@@ -31,80 +31,77 @@ from airflow.utils.state import State
 from tests.test_utils.config import conf_vars
 
 
-class TestBaseJob(unittest.TestCase):
-    class TestJob(BaseJob):
-        __mapper_args__ = {
-            'polymorphic_identity': 'TestJob'
-        }
+class MockJob(BaseJob):
+    __mapper_args__ = {
+        'polymorphic_identity': 'MockJob'
+    }
 
-        def __init__(self, func, **kwargs):
-            self.func = func
-            super().__init__(**kwargs)
+    def __init__(self, func, **kwargs):
+        self.func = func
+        super().__init__(**kwargs)
 
-        def _execute(self):
-            return self.func()
+    def _execute(self):
+        return self.func()
 
+
+class TestBaseJob:
     def test_state_success(self):
-        job = self.TestJob(lambda: True)
+        job = MockJob(lambda: True)
         job.run()
 
-        self.assertEqual(job.state, State.SUCCESS)
-        self.assertIsNotNone(job.end_date)
+        assert job.state == State.SUCCESS
+        assert job.end_date is not None
 
     def test_state_sysexit(self):
         import sys
-        job = self.TestJob(lambda: sys.exit(0))
+        job = MockJob(lambda: sys.exit(0))
         job.run()
 
-        self.assertEqual(job.state, State.SUCCESS)
-        self.assertIsNotNone(job.end_date)
+        assert job.state == State.SUCCESS
+        assert job.end_date is not None
 
     def test_state_failed(self):
         def abort():
             raise RuntimeError("fail")
 
-        job = self.TestJob(abort)
-        with self.assertRaises(RuntimeError):
+        job = MockJob(abort)
+        with raises(RuntimeError):
             job.run()
 
-        self.assertEqual(job.state, State.FAILED)
-        self.assertIsNotNone(job.end_date)
+        assert job.state == State.FAILED
+        assert job.end_date is not None
 
     def test_most_recent_job(self):
-
         with create_session() as session:
-            old_job = self.TestJob(None, heartrate=10)
+            old_job = MockJob(None, heartrate=10)
             old_job.latest_heartbeat = old_job.latest_heartbeat - datetime.timedelta(seconds=20)
-            job = self.TestJob(None, heartrate=10)
+            job = MockJob(None, heartrate=10)
             session.add(job)
             session.add(old_job)
             session.flush()
 
-            self.assertEqual(
-                self.TestJob.most_recent_job(session=session),
-                job
-            )
+            assert MockJob.most_recent_job(session=session) == job
 
             session.rollback()
 
     def test_is_alive(self):
-        job = self.TestJob(None, heartrate=10, state=State.RUNNING)
-        self.assertTrue(job.is_alive())
+        job = MockJob(None, heartrate=10, state=State.RUNNING)
+        assert job.is_alive() is True
 
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=20)
-        self.assertTrue(job.is_alive())
+        assert job.is_alive() is True
 
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=21)
-        self.assertFalse(job.is_alive())
+        assert job.is_alive() is False
 
         # test because .seconds was used before instead of total_seconds
         # internal repr of datetime is (days, seconds)
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(days=1)
-        self.assertFalse(job.is_alive())
+        assert job.is_alive() is False
 
         job.state = State.SUCCESS
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
-        self.assertFalse(job.is_alive(), "Completed jobs even with recent heartbeat should not be alive")
+        assert job.is_alive() is False, "Completed jobs even with recent heartbeat should not be alive"
 
     @patch('airflow.jobs.base_job.create_session')
     def test_heartbeat_failed(self, mock_create_session):
@@ -113,14 +110,14 @@ class TestBaseJob(unittest.TestCase):
             mock_session = Mock(spec_set=session, name="MockSession")
             mock_create_session.return_value.__enter__.return_value = mock_session
 
-            job = self.TestJob(None, heartrate=10, state=State.RUNNING)
+            job = MockJob(None, heartrate=10, state=State.RUNNING)
             job.latest_heartbeat = when
 
             mock_session.commit.side_effect = OperationalError("Force fail", {}, None)
 
             job.heartbeat()
 
-            self.assertEqual(job.latest_heartbeat, when, "attribute not updated when heartbeat fails")
+            assert job.latest_heartbeat == when, "attribute not updated when heartbeat fails"
 
     @conf_vars({('scheduler', 'max_tis_per_query'): '100'})
     @patch('airflow.jobs.base_job.ExecutorLoader.get_default_executor')
@@ -132,12 +129,12 @@ class TestBaseJob(unittest.TestCase):
         mock_getuser.return_value = "testuser"
         mock_default_executor.return_value = mock_sequential_executor
 
-        test_job = self.TestJob(None, heartrate=10, dag_id="example_dag", state=State.RUNNING)
-        self.assertEqual(test_job.executor_class, "SequentialExecutor")
-        self.assertEqual(test_job.heartrate, 10)
-        self.assertEqual(test_job.dag_id, "example_dag")
-        self.assertEqual(test_job.hostname, "test_hostname")
-        self.assertEqual(test_job.max_tis_per_query, 100)
-        self.assertEqual(test_job.unixname, "testuser")
-        self.assertEqual(test_job.state, "running")
-        self.assertEqual(test_job.executor, mock_sequential_executor)
+        test_job = MockJob(None, heartrate=10, dag_id="example_dag", state=State.RUNNING)
+        assert test_job.executor_class == "SequentialExecutor"
+        assert test_job.heartrate == 10
+        assert test_job.dag_id == "example_dag"
+        assert test_job.hostname == "test_hostname"
+        assert test_job.max_tis_per_query == 100
+        assert test_job.unixname == "testuser"
+        assert test_job.state == "running"
+        assert test_job.executor == mock_sequential_executor


### PR DESCRIPTION
I would like to (create) and use a pytest fixture as a parameter, but
they cannot be used on unittest.TestCase functions:

> unittest.TestCase methods cannot directly receive fixture arguments as
> implementing that is likely to inflict on the ability to run general
> unittest.TestCase test suites.


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.