### PR TITLE
Relax Flask-Appbuilder version to ~=2.3.4

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -41,7 +41,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 
     LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
 
 # By increasing this number we can do force build of all dependencies
-ARG DEPENDENCIES_EPOCH_NUMBER="2"
+ARG DEPENDENCIES_EPOCH_NUMBER="3"
 # Increase the value below to force renstalling of all dependencies
 ENV DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
 

--- a/requirements/requirements-python3.6.txt
+++ b/requirements/requirements-python3.6.txt
@@ -1,7 +1,7 @@
 # Editable install with no version control (apache-airflow==2.0.0.dev0)
 Authlib==0.14.2
 Babel==2.8.0
-Flask-AppBuilder==2.3.2
+Flask-AppBuilder==2.3.4
 Flask-Babel==1.0.0
 Flask-Bcrypt==0.7.1
 Flask-Caching==1.3.3

--- a/requirements/requirements-python3.7.txt
+++ b/requirements/requirements-python3.7.txt
@@ -1,7 +1,7 @@
 # Editable install with no version control (apache-airflow==2.0.0.dev0)
 Authlib==0.14.2
 Babel==2.8.0
-Flask-AppBuilder==2.3.2
+Flask-AppBuilder==2.3.4
 Flask-Babel==1.0.0
 Flask-Bcrypt==0.7.1
 Flask-Caching==1.3.3

--- a/requirements/setup-3.6.md5
+++ b/requirements/setup-3.6.md5
@@ -1,1 +1,1 @@
-36e9b868ac8fdad390381775aa3e9db8  /opt/airflow/setup.py
+6124cdb98149bd218d161403e09705da  /opt/airflow/setup.py

--- a/requirements/setup-3.7.md5
+++ b/requirements/setup-3.7.md5
@@ -1,1 +1,1 @@
-36e9b868ac8fdad390381775aa3e9db8  /opt/airflow/setup.py
+6124cdb98149bd218d161403e09705da  /opt/airflow/setup.py

--- a/setup.py
+++ b/setup.py
@@ -583,9 +583,8 @@ INSTALL_REQUIREMENTS = [
     'croniter>=0.3.17, <0.4',
     'cryptography>=0.9.3',
     'dill>=0.2.2, <0.4',
-    'email_validator>=1.0.5, <2',   # Needed by WTForms (dependency of FAB)
     'flask>=1.1.0, <2.0',
-    'flask-appbuilder==2.3.2',
+    'flask-appbuilder~=2.3.4',
     'flask-caching>=1.3.3, <1.4.0',
     'flask-login>=0.3, <0.5',
     'flask-swagger==0.2.13',


### PR DESCRIPTION
"Bump jQuery to 3.5" was reverted. And so we can upgrade and remove email_validator dependency
See also: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/CHANGELOG.rst#improvements-and-bug-fixes-on-234

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
