### PR TITLE
[AIRFLOW-XXXX] remove vestigial sentence fragment in changelog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -235,7 +235,7 @@ Improvements
 - [AIRFLOW-6327] http_hook: Accept json= parameter for payload (#6886)
 - [AIRFLOW-6261] flower_basic_auth eligible to _cmd (#6825)
 - [AIRFLOW-6238] Filter dags returned by dag_stats
-- [AIRFLOW-5616] Switch PrestoHook from pyhive to prestosql-client to s
+- [AIRFLOW-5616] Switch PrestoHook from pyhive to prestosql-client
 - [AIRFLOW-6611] Add proxy_fix configs to default_airflow.cfg (#7236)
 - [AIRFLOW-6557] Add test for newly added fields in BaseOperator (#7162)
 - [AIRFLOW-6584] Pin cassandra driver (#7194)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -235,7 +235,7 @@ Improvements
 - [AIRFLOW-6327] http_hook: Accept json= parameter for payload (#6886)
 - [AIRFLOW-6261] flower_basic_auth eligible to _cmd (#6825)
 - [AIRFLOW-6238] Filter dags returned by dag_stats
-- [AIRFLOW-5616] Switch PrestoHook from pyhive to prestosql-client
+- [AIRFLOW-5616] Switch PrestoHook from pyhive to presto-python-client
 - [AIRFLOW-6611] Add proxy_fix configs to default_airflow.cfg (#7236)
 - [AIRFLOW-6557] Add test for newly added fields in BaseOperator (#7162)
 - [AIRFLOW-6584] Pin cassandra driver (#7194)


### PR DESCRIPTION
Please update this further if you know what the intended remainder of this sentence was...

PS!! The `Suggest a change on this page` link at https://airflow.apache.org/docs/stable/changelog.html redirects to open a PR on `docs/changelog.rst`, which is actually just a redirect to the edited file -- this kind of defeats the purpose of that link. Is it possible for that link to open a PR on `CHANGELOG.txt` instead?

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
