### PR TITLE
fix task and dag stats on home page

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -379,155 +379,163 @@
       d3.selectAll(".loading-last-run").remove();
     }
 
+    function drawDagStatsForDag(dag_id, stats) {
+      g = d3.select('svg#dag-run-' + dag_id.replace(/\./g, '__dot__'))
+        .attr('height', diameter + (stroke_width_hover * 2))
+        .attr('width', '110px')
+        .selectAll("g")
+        .data(states)
+        .enter()
+        .append('g')
+        .attr('transform', function(d, i) {
+          x = (i * (diameter + circle_margin)) + (diameter/2 + circle_margin);
+          y = (diameter/2) + stroke_width_hover;
+          return 'translate(' + x + ',' + y + ')';
+        });
+
+      g.append('text')
+        .attr('fill', 'black')
+        .attr('text-anchor', 'middle')
+        .attr('vertical-align', 'middle')
+        .attr('font-size', 8)
+        .attr('y', 3)
+        .text(function(d){ return d.count > 0 ? d.count : ''; });
+
+      g.append('circle')
+        .attr('id', function(d) {return 'run-' + dag_id.replace(/\./g, '_') + d.state || 'none'})
+        .attr('class', 'has-svg-tooltip')
+        .attr('stroke-width', function(d) {
+          if (d.count > 0)
+            return stroke_width;
+          else {
+            return 1;
+          }
+        })
+        .attr('stroke', function(d) {
+          if (d.count > 0)
+            return STATE_COLOR[d.state];
+          else {
+            return 'gainsboro';
+          }
+        })
+        .attr('fill-opacity', 0)
+        .attr('r', diameter/2)
+        .attr('title', function(d) {return d.state})
+        .attr('style', function(d) {
+          if (d.count > 0)
+              return"cursor:pointer;"
+        })
+        .on('click', function(d, i) {
+          if (d.count > 0)
+            window.location = "{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id=" + dag_id + "&_flt_3_state=" + d.state;
+        })
+        .on('mouseover', function(d, i) {
+          if (d.count > 0) {
+            d3.select(this).transition().duration(400)
+              .attr('fill-opacity', 0.3)
+              .style("stroke-width", stroke_width_hover);
+          }
+        })
+        .on('mouseout', function(d, i) {
+          if (d.count > 0) {
+            d3.select(this).transition().duration(400)
+              .attr('fill-opacity', 0)
+              .style("stroke-width", stroke_width);
+          }
+        })
+        .style("opacity", 0)
+        .transition()
+        .duration(500)
+        .delay(function(d, i){return i*50;})
+        .style("opacity", 1);
+      d3.select(".loading-dag-stats").remove();
+    }
+
     function dagStatsHandler(error, json) {
       for(var dag_id in json) {
         states = json[dag_id];
-        g = d3.select('svg#dag-run-' + dag_id.replace(/\./g, '__dot__'))
-          .attr('height', diameter + (stroke_width_hover * 2))
-          .attr('width', '110px')
-          .selectAll("g")
-          .data(states)
-          .enter()
-          .append('g')
-          .attr('transform', function(d, i) {
-            x = (i * (diameter + circle_margin)) + (diameter/2 + circle_margin);
-            y = (diameter/2) + stroke_width_hover;
-            return 'translate(' + x + ',' + y + ')';
-          });
-
-        g.append('text')
-          .attr('fill', 'black')
-          .attr('text-anchor', 'middle')
-          .attr('vertical-align', 'middle')
-          .attr('font-size', 8)
-          .attr('y', 3)
-          .text(function(d){ return d.count > 0 ? d.count : ''; });
-
-        g.append('circle')
-          .attr('id', function(d) {return 'run-' + dag_id.replace(/\./g, '_') + d.state || 'none'})
-          .attr('class', 'has-svg-tooltip')
-          .attr('stroke-width', function(d) {
-            if (d.count > 0)
-              return stroke_width;
-            else {
-              return 1;
-            }
-          })
-          .attr('stroke', function(d) {
-            if (d.count > 0)
-              return STATE_COLOR[d.state];
-            else {
-              return 'gainsboro';
-            }
-          })
-          .attr('fill-opacity', 0)
-          .attr('r', diameter/2)
-          .attr('title', function(d) {return d.state})
-          .attr('style', function(d) {
-            if (d.count > 0)
-                return"cursor:pointer;"
-          })
-          .on('click', function(d, i) {
-            if (d.count > 0)
-              window.location = "{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id=" + d.dag_id + "&_flt_3_state=" + d.state;
-          })
-          .on('mouseover', function(d, i) {
-            if (d.count > 0) {
-              d3.select(this).transition().duration(400)
-                .attr('fill-opacity', 0.3)
-                .style("stroke-width", stroke_width_hover);
-            }
-          })
-          .on('mouseout', function(d, i) {
-            if (d.count > 0) {
-              d3.select(this).transition().duration(400)
-                .attr('fill-opacity', 0)
-                .style("stroke-width", stroke_width);
-            }
-          })
-          .style("opacity", 0)
-          .transition()
-          .duration(500)
-          .delay(function(d, i){return i*50;})
-          .style("opacity", 1);
-        d3.select(".loading-dag-stats").remove();
+        drawDagStatsForDag(dag_id, states);
       }
       $("#pause_header").tooltip();
       $("#statuses_info").tooltip();
     }
 
+    function drawTaskStatsForDag(dag_id, states) {
+      g = d3.select('svg#task-run-' + dag_id.replace(/\./g, '__dot__'))
+        .attr('height', diameter + (stroke_width_hover * 2))
+        .attr('width', '300px')
+        .selectAll("g")
+        .data(states)
+        .enter()
+        .append('g')
+        .attr('transform', function(d, i) {
+          x = (i * (diameter + circle_margin)) + (diameter/2 + circle_margin);
+          y = (diameter/2) + stroke_width_hover;
+          return 'translate(' + x + ',' + y + ')';
+        });
+
+      g.append('text')
+        .attr('fill', 'black')
+        .attr('text-anchor', 'middle')
+        .attr('vertical-align', 'middle')
+        .attr('font-size', 8)
+        .attr('y', 3)
+        .text(function(d){ return d.count > 0 ? d.count : ''; });
+
+      g.append('circle')
+        .attr('id', function(d) {return 'task-' + dag_id.replace(/\./g, '_') + d.state || 'none'})
+        .attr('class', 'has-svg-tooltip')
+        .attr('stroke-width', function(d) {
+          if (d.count > 0)
+            return stroke_width;
+          else {
+            return 1;
+          }
+        })
+        .attr('stroke', function(d) {
+          if (d.count > 0)
+            return STATE_COLOR[d.state];
+          else {
+            return 'gainsboro';
+          }
+        })
+        .attr('fill-opacity', 0)
+        .attr('r', diameter/2)
+        .attr('title', function(d) {return d.state || 'none'})
+        .attr('style', function(d) {
+          if (d.count > 0)
+              return"cursor:pointer;"
+        })
+        .on('click', function(d, i) {
+          if (d.count > 0)
+            window.location = "{{ url_for('TaskInstanceModelView.list') }}?_flt_3_dag_id=" + dag_id + "&_flt_3_state=" + d.state;
+        })
+        .on('mouseover', function(d, i) {
+          if (d.count > 0) {
+            d3.select(this).transition().duration(400)
+              .attr('fill-opacity', 0.3)
+              .style("stroke-width", stroke_width_hover);
+          }
+        })
+        .on('mouseout', function(d, i) {
+          if (d.count > 0) {
+            d3.select(this).transition().duration(400)
+              .attr('fill-opacity', 0)
+              .style("stroke-width", stroke_width);
+          }
+        })
+        .style("opacity", 0)
+        .transition()
+        .duration(500)
+        .delay(function(d, i){return i*50;})
+        .style("opacity", 1);
+      d3.select(".loading-task-stats").remove();
+    }
+
     function taskStatsHandler(error, json) {
       for(var dag_id in json) {
         states = json[dag_id];
-        g = d3.select('svg#task-run-' + dag_id.replace(/\./g, '__dot__'))
-          .attr('height', diameter + (stroke_width_hover * 2))
-          .attr('width', '300px')
-          .selectAll("g")
-          .data(states)
-          .enter()
-          .append('g')
-          .attr('transform', function(d, i) {
-            x = (i * (diameter + circle_margin)) + (diameter/2 + circle_margin);
-            y = (diameter/2) + stroke_width_hover;
-            return 'translate(' + x + ',' + y + ')';
-          });
-
-        g.append('text')
-          .attr('fill', 'black')
-          .attr('text-anchor', 'middle')
-          .attr('vertical-align', 'middle')
-          .attr('font-size', 8)
-          .attr('y', 3)
-          .text(function(d){ return d.count > 0 ? d.count : ''; });
-
-        g.append('circle')
-          .attr('id', function(d) {return 'task-' + dag_id.replace(/\./g, '_') + d.state || 'none'})
-          .attr('class', 'has-svg-tooltip')
-          .attr('stroke-width', function(d) {
-            if (d.count > 0)
-              return stroke_width;
-            else {
-              return 1;
-            }
-          })
-          .attr('stroke', function(d) {
-            if (d.count > 0)
-              return STATE_COLOR[d.state];
-            else {
-              return 'gainsboro';
-            }
-          })
-          .attr('fill-opacity', 0)
-          .attr('r', diameter/2)
-          .attr('title', function(d) {return d.state || 'none'})
-          .attr('style', function(d) {
-            if (d.count > 0)
-                return"cursor:pointer;"
-          })
-          .on('click', function(d, i) {
-            if (d.count > 0)
-              window.location = "{{ url_for('TaskInstanceModelView.list') }}?_flt_3_dag_id=" + d.dag_id + "&_flt_3_state=" + d.state;
-          })
-          .on('mouseover', function(d, i) {
-            if (d.count > 0) {
-              d3.select(this).transition().duration(400)
-                .attr('fill-opacity', 0.3)
-                .style("stroke-width", stroke_width_hover);
-            }
-          })
-          .on('mouseout', function(d, i) {
-            if (d.count > 0) {
-              d3.select(this).transition().duration(400)
-                .attr('fill-opacity', 0)
-                .style("stroke-width", stroke_width);
-            }
-          })
-          .style("opacity", 0)
-          .transition()
-          .duration(500)
-          .delay(function(d, i){return i*50;})
-          .style("opacity", 1);
-        d3.select(".loading-task-stats").remove();
+        drawTaskStatsForDag(dag_id, states);
       }
       $("#pause_header").tooltip();
       $("#statuses_info").tooltip();


### PR DESCRIPTION
In latest master, icon for all task and dag stats are broken on the home page.

root cause:

d.dag_id is not a valid attribute. in order to use dag_id variable
in a closure callback, it needs to be passed in as a fuction so the
right value can be captured for each for loop.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
