### PR TITLE
Fixed BaseSensorOperator to make respect the trigger_rule in downstream tasks, when setting soft_fail="True"

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -565,6 +565,7 @@ User can preserve/achieve the original behaviour by setting every downstream tas
 because downstream tasks with trigger_rule all_success (i.e. the default) are skipped 
 when upstream task is skipped.
 
+
 #### BaseOperator uses metaclass
 
 `BaseOperator` class uses a `BaseOperatorMeta` as a metaclass. This meta class is based on

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -182,16 +182,28 @@ reference documentation for more information
 The Airflow CLI has been organized so that related commands are grouped together as subcommands,
 which means that if you use these commands in your scripts, you have to make changes to them.
 
+
 This section describes the changes that have been made, and what you need to do to update your script.
+
+
+### BaseOperator uses metaclass
+
 
 The ability to manipulate users from the command line has been changed. ``airflow create_user``,  ``airflow delete_user``
  and ``airflow list_users`` has been grouped to a single command `airflow users` with optional flags `create`, `list` and `delete`.
 
 The `airflow list_dags` command is now `airflow dags list`, `airflow pause` is `airflow dags pause`, etc.
 
+
 In Airflow 1.10 and 2.0 there is an `airflow config` command but there is a difference in behavior. In Airflow 1.10,
 it prints all config options while in Airflow 2.0, it's a command group. `airflow config` is now `airflow config list`.
 You can check other options by running the command `airflow config --help`
+
+
+
+The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
+by application logic, but was not enforced by the database schema.
+
 
 For a complete list of updated CLI commands, see https://airflow.apache.org/cli.html.
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -178,6 +178,7 @@ reference documentation for more information
 
 ### CLI changes in Airflow 2.0
 
+
 The Airflow CLI has been organized so that related commands are grouped together as subcommands,
 which means that if you use these commands in your scripts, you have to make changes to them.
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -69,25 +69,7 @@ More tips can be found in the guide:
 https://developers.google.com/style/inclusive-documentation
 
 -->
-<<<<<<< HEAD
 ### Major changes
-=======
-
-
-### Made BaseSensorOperator respect the trigger_rule of downstream tasks
-
-Previously, BaseSensorOperator with setting soft_fail=True becomes skipped itself
-and skips all its downstream tasks unconditionally when it fails.
-The point is it does not respect the trigger_rule of downstream tasks when it fails.
-In the new behavior, the trigger_rule of downstream tasks are respected.
-User can preserve/achieve the original behaviour by setting every downstream task to all_success,
-because downstream tasks with trigger_rule all_success (i.e. the default) are skipped
-when upstream task is skipped.
-
-### GCSTaskHandler has been moved
-The `GCSTaskHandler` class from `airflow.utils.log.gcs_task_handler` has been moved to
-`airflow.providers.google.cloud.log.gcs_task_handler`. This is because it has items specific to `google cloud`.
->>>>>>> Fixed docs
 
 This section describes the major changes that have been made in this release.
 
@@ -196,33 +178,19 @@ reference documentation for more information
 
 ### CLI changes in Airflow 2.0
 
-<<<<<<< HEAD
-
 The Airflow CLI has been organized so that related commands are grouped together as subcommands,
 which means that if you use these commands in your scripts, you have to make changes to them.
 
-
 This section describes the changes that have been made, and what you need to do to update your script.
-
-
-=======
->>>>>>> Fixed docs
-### BaseOperator uses metaclass
-
 
 The ability to manipulate users from the command line has been changed. ``airflow create_user``,  ``airflow delete_user``
  and ``airflow list_users`` has been grouped to a single command `airflow users` with optional flags `create`, `list` and `delete`.
 
 The `airflow list_dags` command is now `airflow dags list`, `airflow pause` is `airflow dags pause`, etc.
 
-
 In Airflow 1.10 and 2.0 there is an `airflow config` command but there is a difference in behavior. In Airflow 1.10,
 it prints all config options while in Airflow 2.0, it's a command group. `airflow config` is now `airflow config list`.
 You can check other options by running the command `airflow config --help`
-
-The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
-by application logic, but was not enforced by the database schema.
-
 
 For a complete list of updated CLI commands, see https://airflow.apache.org/cli.html.
 
@@ -589,14 +557,13 @@ if you use core operators or any other.
 
 #### BaseSensorOperator to make respect the trigger_rule of downstream tasks
 
-Previously, BaseSensorOperator with setting soft_fail=True becomes skipped itself 
-and skips all its downstream tasks unconditionally, when it fails. 
-The point is not respect the trigger_rule of downstream tasks, when it fails. 
+Previously, BaseSensorOperator with setting soft_fail=True becomes skipped itself
+and skips all its downstream tasks unconditionally, when it fails.
+The point is not respect the trigger_rule of downstream tasks, when it fails.
 In the new behavior, the trigger_rule of downstream tasks are respected.
-User can preserve/achieve the original behaviour by setting every downstream task to all_success, 
-because downstream tasks with trigger_rule all_success (i.e. the default) are skipped 
+User can preserve/achieve the original behaviour by setting every downstream task to all_success,
+because downstream tasks with trigger_rule all_success (i.e. the default) are skipped
 when upstream task is skipped.
-
 
 #### BaseOperator uses metaclass
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -199,8 +199,6 @@ In Airflow 1.10 and 2.0 there is an `airflow config` command but there is a diff
 it prints all config options while in Airflow 2.0, it's a command group. `airflow config` is now `airflow config list`.
 You can check other options by running the command `airflow config --help`
 
-
-
 The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
 by application logic, but was not enforced by the database schema.
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -69,7 +69,25 @@ More tips can be found in the guide:
 https://developers.google.com/style/inclusive-documentation
 
 -->
+<<<<<<< HEAD
 ### Major changes
+=======
+
+
+### Made BaseSensorOperator respect the trigger_rule of downstream tasks
+
+Previously, BaseSensorOperator with setting soft_fail=True becomes skipped itself
+and skips all its downstream tasks unconditionally when it fails.
+The point is it does not respect the trigger_rule of downstream tasks when it fails.
+In the new behavior, the trigger_rule of downstream tasks are respected.
+User can preserve/achieve the original behaviour by setting every downstream task to all_success,
+because downstream tasks with trigger_rule all_success (i.e. the default) are skipped
+when upstream task is skipped.
+
+### GCSTaskHandler has been moved
+The `GCSTaskHandler` class from `airflow.utils.log.gcs_task_handler` has been moved to
+`airflow.providers.google.cloud.log.gcs_task_handler`. This is because it has items specific to `google cloud`.
+>>>>>>> Fixed docs
 
 This section describes the major changes that have been made in this release.
 
@@ -178,6 +196,7 @@ reference documentation for more information
 
 ### CLI changes in Airflow 2.0
 
+<<<<<<< HEAD
 
 The Airflow CLI has been organized so that related commands are grouped together as subcommands,
 which means that if you use these commands in your scripts, you have to make changes to them.
@@ -186,6 +205,8 @@ which means that if you use these commands in your scripts, you have to make cha
 This section describes the changes that have been made, and what you need to do to update your script.
 
 
+=======
+>>>>>>> Fixed docs
 ### BaseOperator uses metaclass
 
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -555,6 +555,16 @@ release may contain changes that will require changes to your DAG files.
 This section describes the changes that have been made, and what you need to do to update your DAG File,
 if you use core operators or any other.
 
+#### BaseSensorOperator to make respect the trigger_rule of downstream tasks
+
+Previously, BaseSensorOperator with setting soft_fail=True becomes skipped itself 
+and skips all its downstream tasks unconditionally, when it fails. 
+The point is not respect the trigger_rule of downstream tasks, when it fails. 
+In the new behavior, the trigger_rule of downstream tasks are respected.
+User can preserve/achieve the original behaviour by setting every downstream task to all_success, 
+because downstream tasks with trigger_rule all_success (i.e. the default) are skipped 
+when upstream task is skipped.
+
 #### BaseOperator uses metaclass
 
 `BaseOperator` class uses a `BaseOperatorMeta` as a metaclass. This meta class is based on

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -36,8 +36,10 @@ from airflow.utils.decorators import apply_defaults
 class BaseSensorOperator(BaseOperator, SkipMixin):
     """
     Sensor operators are derived from this class and inherit these attributes.
+
     Sensor operators keep executing at a time interval and succeed when
     a criteria is met and fail if and when they time out.
+
     :param soft_fail: Set to true to mark the task as SKIPPED on failure
     :type soft_fail: bool
     :param poke_interval: Time in seconds that the job should wait in
@@ -179,8 +181,10 @@ def poke_mode_only(cls):
     """
     Class Decorator for child classes of BaseSensorOperator to indicate
     that instances of this class are only safe to use poke mode.
+
     Will decorate all methods in the class to assert they did not change
     the mode from 'poke'.
+
     :param cls: BaseSensor class to enforce methods only use 'poke' mode.
     :type cls: type
     """

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -139,7 +139,10 @@ class TestBaseSensor(unittest.TestCase):
         tis = dr.get_task_instances()
         self.assertEqual(len(tis), 2)
         for ti in tis:
-            self.assertEqual(ti.state, State.SKIPPED)
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.SKIPPED)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
 
     def test_soft_fail_with_retries(self):
         sensor = self._make_sensor(
@@ -166,7 +169,10 @@ class TestBaseSensor(unittest.TestCase):
         tis = dr.get_task_instances()
         self.assertEqual(len(tis), 2)
         for ti in tis:
-            self.assertEqual(ti.state, State.SKIPPED)
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.SKIPPED)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
 
     def test_ok_with_reschedule(self):
         sensor = self._make_sensor(
@@ -294,7 +300,10 @@ class TestBaseSensor(unittest.TestCase):
         tis = dr.get_task_instances()
         self.assertEqual(len(tis), 2)
         for ti in tis:
-            self.assertEqual(ti.state, State.SKIPPED)
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.SKIPPED)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
 
     def test_ok_with_reschedule_and_retry(self):
         sensor = self._make_sensor(


### PR DESCRIPTION
**Description**
This PR is to prevents all downstream tasks from being forcibly skipped when setting `soft_fail=True`.  

In the current specification, the downstream task will show up as skipped because its trigger_rule is set to all_success by default and skipped tasks will cascade through all_success. Therefore, It is unlikely that this change will affect the existing behavior.


**Issue link**
#8696 
>Downstream tasks with trigger_rule all_success (i.e. the default) should be skipped because of TriggerRuleDep. Tasks that are none_failed or one_success etc should not be skipped unconditionally by the soft_fail sensor.

**Code quality**
flake8 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
