### PR TITLE
Fix list formatting of plugins doc.

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -282,7 +282,6 @@ will automatically load the registered plugins from the entrypoint list.
       operators = [MyOperator]
       hooks = [MyHook]
 
-
 .. code-block:: python
 
     from setuptools import setup
@@ -297,7 +296,7 @@ will automatically load the registered plugins from the entrypoint list.
         }
     )
 
-
 This will create a hook, and an operator accessible at:
- - ``airflow.hooks.my_namespace.MyHook``
- - ``airflow.operators.my_namespace.MyOperator``
+
+- ``airflow.hooks.my_namespace.MyHook``
+- ``airflow.operators.my_namespace.MyOperator``


### PR DESCRIPTION
This was causing it to be picked up as a `<dl>/<dd>` containing a list,
instead of a paragraph and a list.

```
<dl class="simple">
  <dt>This will create a hook, and an operator accessible at:</dt>
  <dd>
    <ul class="simple">
      <li><p><code><span class="pre">airflow.hooks.my_namespace.MyHook</span></code></p></li>
      <li><p><code><span class="pre">airflow.operators.my_namespace.MyOperator</span></code></p></li>
    </ul>
  </dd>
</dl>
```

I have tested this locally and looked at the html produced -- this fixes the problem (I can't include screenshot as it doesn't look noticably different as I don't have the theme installed.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.