### PR TITLE
[AIRFLOW-8875] fix Dag Run UI execution date with timezone cannot be saved issue

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -19,21 +19,49 @@
 import json
 from operator import itemgetter
 
+import pendulum
+
 from flask_appbuilder.fieldwidgets import (
     BS3PasswordFieldWidget, BS3TextAreaFieldWidget, BS3TextFieldWidget, Select2Widget,
 )
 from flask_appbuilder.forms import DynamicForm
 from flask_babel import lazy_gettext
 from flask_wtf import FlaskForm
-from wtforms import validators
+from wtforms import validators, widgets
 from wtforms.fields import (
-    BooleanField, DateTimeField, IntegerField, PasswordField, SelectField, StringField, TextAreaField,
+    Field, BooleanField, DateTimeField, IntegerField, PasswordField, SelectField, StringField, TextAreaField,
 )
 
 from airflow.models import Connection
 from airflow.utils import timezone
 from airflow.www.validators import ValidJson
 from airflow.www.widgets import AirflowDateTimePickerWidget
+
+
+class DateTimeWithTimezoneField(Field):
+    """
+    A text field which stores a `datetime.datetime` matching a format.
+    """
+    widget = widgets.TextInput()
+
+    def __init__(self, label=None, validators=None, format='%Y-%m-%d %H:%M:%S%Z', **kwargs):
+        super(DateTimeWithTimezoneField, self).__init__(label, validators, **kwargs)
+        self.format = format
+
+    def _value(self):
+        if self.raw_data:
+            return ' '.join(self.raw_data)
+        else:
+            return self.data and self.data.strftime(self.format) or ''
+
+    def process_formdata(self, valuelist):
+        if valuelist:
+            date_str = ' '.join(valuelist)
+            try:
+                self.data = pendulum.parse(date_str)
+            except ValueError:
+                self.data = None
+                raise ValueError(self.gettext('Not a valid datetime value'))
 
 
 class DateTimeForm(FlaskForm):
@@ -80,10 +108,9 @@ class DagRunForm(DynamicForm):
         lazy_gettext('State'),
         choices=(('success', 'success'), ('running', 'running'), ('failed', 'failed'),),
         widget=Select2Widget())
-    execution_date = DateTimeField(
+    execution_date = DateTimeWithTimezoneField(
         lazy_gettext('Execution Date'),
-        widget=AirflowDateTimePickerWidget(),
-        format='%Y-%m-%d %H:%M:%S%z')
+        widget=AirflowDateTimePickerWidget())
     external_trigger = BooleanField(
         lazy_gettext('External Trigger'))
     conf = TextAreaField(
@@ -92,8 +119,6 @@ class DagRunForm(DynamicForm):
         widget=BS3TextAreaFieldWidget())
 
     def populate_obj(self, item):
-        # TODO: This is probably better done as a custom field type so we can
-        # set TZ at parse time
         super().populate_obj(item)
         if item.conf:
             item.conf = json.loads(item.conf)

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -82,7 +82,8 @@ class DagRunForm(DynamicForm):
         widget=Select2Widget())
     execution_date = DateTimeField(
         lazy_gettext('Execution Date'),
-        widget=AirflowDateTimePickerWidget())
+        widget=AirflowDateTimePickerWidget(),
+        format='%Y-%m-%d %H:%M:%S%z')
     external_trigger = BooleanField(
         lazy_gettext('External Trigger'))
     conf = TextAreaField(
@@ -94,7 +95,7 @@ class DagRunForm(DynamicForm):
         # TODO: This is probably better done as a custom field type so we can
         # set TZ at parse time
         super().populate_obj(item)
-        item.execution_date = timezone.make_aware(item.execution_date)
+        # item.execution_date = timezone.make_aware(item.execution_date)
         if item.conf:
             item.conf = json.loads(item.conf)
 

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -20,7 +20,6 @@ import json
 from operator import itemgetter
 
 import pendulum
-
 from flask_appbuilder.fieldwidgets import (
     BS3PasswordFieldWidget, BS3TextAreaFieldWidget, BS3TextFieldWidget, Select2Widget,
 )
@@ -29,7 +28,7 @@ from flask_babel import lazy_gettext
 from flask_wtf import FlaskForm
 from wtforms import validators, widgets
 from wtforms.fields import (
-    Field, BooleanField, DateTimeField, IntegerField, PasswordField, SelectField, StringField, TextAreaField,
+    BooleanField, DateTimeField, Field, IntegerField, PasswordField, SelectField, StringField, TextAreaField,
 )
 
 from airflow.models import Connection

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -95,7 +95,6 @@ class DagRunForm(DynamicForm):
         # TODO: This is probably better done as a custom field type so we can
         # set TZ at parse time
         super().populate_obj(item)
-        # item.execution_date = timezone.make_aware(item.execution_date)
         if item.conf:
             item.conf = json.loads(item.conf)
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -30,6 +30,7 @@ import unittest
 import urllib
 from contextlib import contextmanager
 from datetime import datetime as dt, timedelta
+from datetime import timezone as tz
 from typing import Any, Dict, Generator, List, NamedTuple
 from unittest import mock
 from urllib.parse import quote_plus
@@ -2601,7 +2602,7 @@ class TestDagRunModelView(TestBase):
 
         dr = self.session.query(models.DagRun).one()
 
-        self.assertEqual(dr.execution_date, dt.fromisoformat('2018-07-06 05:04:03-02:00'))
+        self.assertEqual(dr.execution_date, dt(2018, 7, 6, 5, 4, 3, tzinfo=tz(timedelta(hours=-2))))
 
     def test_create_dagrun_valid_conf(self):
         conf_value = dict(Valid=True)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -29,8 +29,7 @@ import tempfile
 import unittest
 import urllib
 from contextlib import contextmanager
-from datetime import datetime as dt, timedelta
-from datetime import timezone as tz
+from datetime import datetime as dt, timedelta, timezone as tz
 from typing import Any, Dict, Generator, List, NamedTuple
 from unittest import mock
 from urllib.parse import quote_plus

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2587,11 +2587,11 @@ class TestDagRunModelView(TestBase):
     def tearDown(self):
         self.clear_table(models.DagRun)
 
-    def test_create_dagrun(self):
+    def test_create_dagrun_execution_date_with_timezone(self):
         data = {
             "state": "running",
             "dag_id": "example_bash_operator",
-            "execution_date": "2018-07-06 05:04:03",
+            "execution_date": "2018-07-06 05:04:03-02:00",
             "run_id": "test_create_dagrun",
         }
         resp = self.client.post('/dagrun/add',
@@ -2601,14 +2601,14 @@ class TestDagRunModelView(TestBase):
 
         dr = self.session.query(models.DagRun).one()
 
-        self.assertEqual(dr.execution_date, timezone.convert_to_utc(datetime(2018, 7, 6, 5, 4, 3)))
+        self.assertEqual(dr.execution_date, dt.fromisoformat('2018-07-06 05:04:03-02:00'))
 
     def test_create_dagrun_valid_conf(self):
         conf_value = dict(Valid=True)
         data = {
             "state": "running",
             "dag_id": "example_bash_operator",
-            "execution_date": "2018-07-06 05:05:03",
+            "execution_date": "2018-07-06 05:05:03-02:00",
             "run_id": "test_create_dagrun_valid_conf",
             "conf": json.dumps(conf_value)
         }


### PR DESCRIPTION
This PR is to address the following bug: https://github.com/apache/airflow/issues/8842
Airflow 1.10.10 displays datetime with timezone on the web UI. Currently, when user tries to create a dag run on the UI, it gives invalid DateTime error which prevents the dag run being created.
![image](https://user-images.githubusercontent.com/41271167/82059578-36fb8180-9694-11ea-8a60-74d1afa889ed.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
