### PR TITLE
[8878] Add the ability for the webserver to sync dags to the DB

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1011,6 +1011,13 @@
       type: string
       example: ~
       default: "30"
+    - name: locally_sync_dagbag
+      description: |
+        Have the webserver save the dagbag to the DB every refresh. Set to true if you're
+        running without a scheduler and want DAGS to show up in the webserver
+      version_added: 1.10.10
+      type: boolean
+      default: "False"
 
 - name: email
   description: |

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -495,6 +495,10 @@ force_log_out_after = 0
 # The UI cookie lifetime in days
 session_lifetime_days = 30
 
+# Have the webserver save the dagbag to the DB every refresh. Set to true if you're
+# running without a scheduler and want DAGS to show up in the webserver
+locally_sync_dagbag = False
+
 [email]
 
 # Configuration email backend and whether to

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -87,6 +87,8 @@ if os.environ.get('SKIP_DAGS_PARSING') != 'True':
     dagbag = models.DagBag(settings.DAGS_FOLDER, store_serialized_dags=STORE_SERIALIZED_DAGS)
 else:
     dagbag = models.DagBag(os.devnull, include_examples=False)
+if conf.getboolean('webserver', 'locally_sync_dagbag'):
+    dagbag.sync_to_db()
 
 
 def get_date_time_num_runs_dag_runs_form_data(request, session, dag):


### PR DESCRIPTION
This is related to https://github.com/apache/airflow/issues/8878
The issue is that sync_to_db is only called from two places:
   The scheduler (which is not running)
   initdb (which runs once)

Therefore, we need another way to update the  model in the DB, so a flag and sync should do it. I think that statement will also be reevaluated every worker restart time, so it should be pretty up to date

If anyone has advice on how I should test this change, I would appreciate it. 
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
