### PR TITLE
Support custom Variable implementation

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -366,6 +366,13 @@
       type: string
       example: "path.to.CustomXCom"
       default: "airflow.models.xcom.BaseXCom"
+    - name: variable_backend
+      description: |
+        Path to custom Variable class that will be used to store Airflow variables.
+      version_added: 2.0.0
+      type: string
+      example: "path.to.CustomVariable"
+      default: "airflow.models.variable.BaseVariable"
 
 - name: logging
   description: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -212,6 +212,10 @@ check_slas = True
 # Example: xcom_backend = path.to.CustomXCom
 xcom_backend = airflow.models.xcom.BaseXCom
 
+# Path to custom Variable class that will be used to store Airflow variables.
+# Example: variable_backend = path.to.CustomVariable
+variable_backend = airflow.models.variable.BaseVariable
+
 [logging]
 # The folder where airflow should store its log files
 # This path must be absolute

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1332,6 +1332,9 @@ class TaskInstance(Base, LoggingMixin):
             self.overwrite_params_with_dag_run_conf(params=params, dag_run=dag_run)
 
         class VariableAccessor:
+
+            __NO_DEFAULT_SENTINEL = object()
+
             """
             Wrapper around Variable. This way you can get variables in
             templates by using ``{{ var.value.variable_name }}`` or
@@ -1353,11 +1356,17 @@ class TaskInstance(Base, LoggingMixin):
             @staticmethod
             def get(
                 item: str,
-                default_var: Any = Variable._Variable__NO_DEFAULT_SENTINEL,
+                default_var: Any = __NO_DEFAULT_SENTINEL,
             ):
+                if default_var is VariableAccessor.__NO_DEFAULT_SENTINEL:
+                    return Variable.get(item)
+
                 return Variable.get(item, default_var=default_var)
 
         class VariableJsonAccessor:
+
+            __NO_DEFAULT_SENTINEL = object()
+
             """
             Wrapper around Variable. This way you can get variables in
             templates by using ``{{ var.json.variable_name }}`` or
@@ -1379,8 +1388,10 @@ class TaskInstance(Base, LoggingMixin):
             @staticmethod
             def get(
                 item: str,
-                default_var: Any = Variable._Variable__NO_DEFAULT_SENTINEL,
+                default_var: Any = __NO_DEFAULT_SENTINEL,
             ):
+                if default_var is VariableJsonAccessor.__NO_DEFAULT_SENTINEL:
+                    return Variable.get(item, deserialize_json=True)
                 return Variable.get(item, default_var=default_var, deserialize_json=True)
 
         return {

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -732,6 +732,16 @@ You can use them in your DAGs as:
     Variables set using Environment Variables would not appear in the Airflow UI but you will
     be able to use it in your DAG file.
 
+
+Custom Variable backend
+-----------------------
+
+You can provide a custom ``Variable`` implementation by creating a class
+that subclass :class:`~airflow.models.variable.BaseVariable` and set
+``variable_backend`` in the ``[core]`` section to the path of the custom
+class.
+
+
 Branching
 =========
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -232,9 +232,9 @@ class TestVariableModelView(TestBase):
                                 follow_redirects=True)
 
         # update the variable with a wrong value, given that is encrypted
-        Var = models.Variable
-        (self.session.query(Var)
-            .filter(Var.key == self.variable['key'])
+        var = models.Variable
+        (self.session.query(var)
+            .filter(var.key == self.variable['key'])
             .update({
                 'val': 'failed_value_not_encrypted'
             }, synchronize_session=False))


### PR DESCRIPTION
tl;dr: support providing custom Variable implementation.

Inspired by https://github.com/apache/airflow/pull/8560, this PR makes `Variable` implementation pluggable as well. In some cases, we may want to override the default `Variable` implementations:
- Store variable using a different backend than the airflow metastore.
- During DAG migration from an old Airflow cluster to new Airflow cluster, we may want to fallback to the old airflow cluster if variable does not exist in the new airflow cluster. We may also want to make DAGs on the old cluster double writing to the new cluster as well.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
