### PR TITLE
Accessibility - Add TaskInstance State to tiTooltip in RBAC UI

### DIFF
--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -61,6 +61,9 @@ function generateTooltipDateTimes(startDate, endDate, dagTZ) {
 
 export default function tiTooltip(ti, {includeTryNumber = false} = {}) {
   let tt = '';
+  if (ti.state !== undefined) {
+    tt += `<strong>Status:</strong> ${escapeHtml(ti.state)}<br><br>`;
+  }
   if (ti.task_id !== undefined) {
     tt += `Task_id: ${escapeHtml(ti.task_id)}<br>`;
   }


### PR DESCRIPTION
Currently there is no way to determine the state of a TaskInstance in the graph view or tree view, for people with Colour blindness

An estimated 4.5% of people experience some form of colour vision deficiency

I haven't seen any testing around task-instance.js, but will gladly write a test, or update any existing test

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).