### PR TITLE
Support extra config options for Sentry

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1124,7 +1124,11 @@
       default: "airflow@example.com"
 - name: sentry
   description: |
-    Sentry (https://docs.sentry.io) integration
+    Sentry (https://docs.sentry.io) integration. Here you can supply
+    additional configuration options based on the Python platform. See:
+    https://docs.sentry.io/error-reporting/configuration/?platform=python.
+    Unsupported options: ``integrations``, ``in_app_include``, ``in_app_exclude``,
+    ``ignore_errors``, ``before_breadcrumb``, ``before_send``, ``transport``.
   options:
     - name: sentry_dsn
       description: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -547,7 +547,11 @@ smtp_mail_from = airflow@example.com
 
 [sentry]
 
-# Sentry (https://docs.sentry.io) integration
+# Sentry (https://docs.sentry.io) integration. Here you can supply
+# additional configuration options based on the Python platform. See:
+# https://docs.sentry.io/error-reporting/configuration/?platform=python.
+# Unsupported options: ``integrations``, ``in_app_include``, ``in_app_exclude``,
+# ``ignore_errors``, ``before_breadcrumb``, ``before_send``, ``transport``.
 sentry_dsn =
 
 [celery]

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -67,6 +67,11 @@ class ConfiguredSentry(DummySentry):
     )
     SCOPE_CRUMBS = frozenset(("task_id", "state", "operator", "duration"))
 
+    UNSUPPORTED_SENTRY_OPTIONS = frozenset(
+        ("integrations", "in_app_include", "in_app_exclude", "ignore_errors",
+         "before_breadcrumb", "before_send", "transport")
+    )
+
     def __init__(self):
         """
         Initialize the Sentry SDK.
@@ -86,13 +91,28 @@ class ConfiguredSentry(DummySentry):
             sentry_celery = CeleryIntegration()
             integrations.append(sentry_celery)
 
-        dsn = conf.get("sentry", "sentry_dsn")
+        dsn = None
+        sentry_config_opts = conf.getsection("sentry") or {}
+        if sentry_config_opts:
+            old_way_dsn = sentry_config_opts.pop("sentry_dsn", None)
+            new_way_dsn = sentry_config_opts.pop("dsn", None)
+            # supported backward compability with old way dsn option
+            dsn = old_way_dsn or new_way_dsn
+
+            unsupported_options = self.UNSUPPORTED_SENTRY_OPTIONS.intersection(
+                sentry_config_opts.keys())
+            if unsupported_options:
+                log.warning(
+                    "There are unsupported options in [sentry] section: %s",
+                    ", ".join(unsupported_options)
+                )
+
         if dsn:
-            init(dsn=dsn, integrations=integrations)
+            init(dsn=dsn, integrations=integrations, **sentry_config_opts)
         else:
             # Setting up Sentry using environment variables.
             log.debug("Defaulting to SENTRY_DSN in environment.")
-            init(integrations=integrations)
+            init(integrations=integrations, **sentry_config_opts)
 
     def add_tagging(self, task_instance):
         """

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -39,6 +39,9 @@ Add your ``SENTRY_DSN`` to your configuration file e.g. ``airflow.cfg`` under ``
 .. note::
     If this value is not provided, the SDK will try to read it from the ``SENTRY_DSN`` environment variable.
 
+You can supply `additional configuration options <https://docs.sentry.io/error-reporting/configuration/?platform=python>`__ based on the Python platform via [sentry] section.
+Unsupported options: ``integrations``, ``in_app_include``, ``in_app_exclude``, ``ignore_errors``, ``before_breadcrumb``, ``before_send``, ``transport``.
+
 Tags
 -----
 


### PR DESCRIPTION
For now only dsn can be configured through the airflow.cfg. Need support 'http_proxy' option for example (it can't be configured through the environment variables). This change implements solution for supporting all existed (and maybe future) options for sentry configuration.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
