### PR TITLE
Add "Next scheduled run" to Tree View

### DIFF
--- a/airflow/www/static/css/tree.css
+++ b/airflow/www/static/css/tree.css
@@ -114,3 +114,9 @@ g.axis path {
 g.tick line {
   shape-rendering: crispEdges;
 }
+
+.middle-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -27,15 +27,20 @@
 
 {% block content %}
 {{ super() }}
-<div style="float: left" class="form-inline">
-  <form method="get" style="float:left;">
-    Base date: {{ form.base_date(class_="form-control") }}
-    Number of runs: {{ form.num_runs(class_="form-control") }}
-    <input type="hidden" name="root" value="{{ root if root else '' }}">
-    <input type="hidden" value="{{ dag.dag_id }}" name="dag_id">
-    <input type="submit" value="Go" class="btn btn-default">
-    <input name="_csrf_token" type="hidden" value="{{ csrf_token() }}">
-  </form>
+<div class="middle-bar">
+  <div class="form-inline">
+    <form method="get" style="float:left;">
+      Base date: {{ form.base_date(class_="form-control") }}
+      Number of runs: {{ form.num_runs(class_="form-control") }}
+      <input type="hidden" name="root" value="{{ root if root else '' }}">
+      <input type="hidden" value="{{ dag.dag_id }}" name="dag_id">
+      <input type="submit" value="Go" class="btn btn-default">
+      <input name="_csrf_token" type="hidden" value="{{ csrf_token() }}">
+    </form>
+  </div>
+  <div>
+    <b>Next scheduled run: {{ next_scheduled_run or "None" }}</b>
+  </div>
 </div>
 <div style="clear: both;"></div>
 <hr/>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1498,6 +1498,13 @@ class Airflow(AirflowBaseView):
                 node['extra_links'] = task.extra_links
             return node
 
+        latest_execution_date = dag.get_latest_execution_date()
+        next_scheduled_run = (
+            dag.following_schedule(latest_execution_date)
+            if latest_execution_date
+            else None
+        )
+
         data = {
             'name': '[DAG]',
             'children': [recurse_nodes(t, set()) for t in dag.roots],
@@ -1523,7 +1530,9 @@ class Airflow(AirflowBaseView):
             form=form,
             dag=dag,
             data=data,
-            blur=blur, num_runs=num_runs,
+            blur=blur,
+            num_runs=num_runs,
+            next_scheduled_run=next_scheduled_run,
             show_external_logs=bool(external_logs))
 
     @expose('/graph')


### PR DESCRIPTION
This change adds to the Tree View information for when the next scheduled run will execute. I've had some users be confused about when the DAG is due to run next when they troubleshoot, and believe this information can be helpful to display.

A screenshot of the change is shown below:

![airflow](https://user-images.githubusercontent.com/7297387/82362036-5286c500-99d1-11ea-87d5-46ed92683bad.png)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists -- No issue exists.
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
