### PR TITLE
Use Debian's provided JRE from Buster, not Sid.

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -121,13 +121,11 @@ RUN adduser airflow \
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN mkdir -pv /usr/share/man/man1 \
     && mkdir -pv /usr/share/man/man7 \
-    && echo "deb http://ftp.us.debian.org/debian sid main" \
-        > /etc/apt/sources.list.d/openjdk.list \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
       gnupg \
       libgcc-8-dev \
-      openjdk-8-jdk \
+      default-jre-headless \
       apt-transport-https \
       bash-completion \
       ca-certificates \
@@ -150,8 +148,6 @@ RUN mkdir -pv /usr/share/man/man1 \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 # Install Hadoop and Hive
 # It is done in one step to share variables.


### PR DESCRIPTION
Installing the JDK (not even the JRE) from Sid is starting to break on
Buster as the versions of packages conflict:

> The following packages have unmet dependencies:
> libgcc-8-dev : Depends: gcc-8-base (= 8.4.0-4) but 8.3.0-6 is to be installed
>                Depends: libmpx2 (>= 8.4.0-4) but 8.3.0-6 is to be installed

This changes our CI docker images to:

1. Not install something from Sid (unstable, packages change/get
   updated) when we are using Buster (stable, only security fixes).
2. Installed the JRE, not the JDK. We don't need to compile Java code.

This also saves 300mb to the image (from 5.67GB down to 5.31GB. HOLY WOW. 5.3 GB. That is insane btw.)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
