### PR TITLE
Fix incorrect Env Var to stop Scheduler from creating DagRuns

### DIFF
--- a/scripts/perf/scheduler_dag_execution_timing.py
+++ b/scripts/perf/scheduler_dag_execution_timing.py
@@ -189,7 +189,7 @@ def main(num_runs, repeat, pre_create_dag_runs, dag_ids):  # pylint: disable=too
     os.environ['AIRFLOW_BENCHMARK_MAX_DAG_RUNS'] = str(num_runs)
 
     if pre_create_dag_runs:
-        os.environ['AIRFLOW__SCHEDULER__USE_JOB_SCHEDULER'] = 'False'
+        os.environ['AIRFLOW__SCHEDULER__USE_JOB_SCHEDULE'] = 'False'
 
     from airflow.jobs.scheduler_job import SchedulerJob
     from airflow.models.dagbag import DagBag


### PR DESCRIPTION
`AIRFLOW__SCHEDULER__USE_JOB_SCHEDULER` is used instead of `AIRFLOW__SCHEDULER__USE_JOB_SCHEDULE`

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
