### PR TITLE
Fix DagRun Prefix for Performance script

### DIFF
--- a/scripts/perf/scheduler_dag_execution_timing.py
+++ b/scripts/perf/scheduler_dag_execution_timing.py
@@ -128,7 +128,6 @@ def create_dag_runs(dag, num_runs, session):
     '''
     Create  `num_runs` of dag runs for sub-sequent schedules
     '''
-    from airflow.models.dagrun import DagRun
     from airflow.utils import timezone
     from airflow.utils.state import State
 
@@ -136,7 +135,7 @@ def create_dag_runs(dag, num_runs, session):
 
     for _ in range(num_runs):
         dag.create_dagrun(
-            run_id=DagRun.ID_PREFIX + next_run_date.isoformat(),
+            run_id="scheduled__" + next_run_date.isoformat(),
             execution_date=next_run_date,
             start_date=timezone.utcnow(),
             state=State.RUNNING,


### PR DESCRIPTION
`DagRun.ID_PREFIX` no longer exists and is moved to `airflow.utils.types.DagRunType` enum.

I have hardcoded `scheduled__` so that I can use it for 1.10.* too

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
