### PR TITLE
Fixed S3FileTransformOperator to support S3 Select transformation only

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3_file_transform.py
+++ b/airflow/providers/amazon/aws/operators/s3_file_transform.py
@@ -167,7 +167,7 @@ class S3FileTransformOperator(BaseOperator):
             self.log.info("Uploading transformed file to S3")
             f_dest.flush()
             dest_s3.load_file(
-                filename=f_dest.name,
+                filename=f_dest.name if self.transform_script is not None else f_source.name,
                 key=self.dest_s3_key,
                 replace=self.replace
             )

--- a/airflow/providers/amazon/aws/operators/s3_file_transform.py
+++ b/airflow/providers/amazon/aws/operators/s3_file_transform.py
@@ -167,7 +167,7 @@ class S3FileTransformOperator(BaseOperator):
             self.log.info("Uploading transformed file to S3")
             f_dest.flush()
             dest_s3.load_file(
-                filename=f_dest.name if self.transform_script is not None else f_source.name,
+                filename=f_dest.name if self.transform_script else f_source.name,
                 key=self.dest_s3_key,
                 replace=self.replace
             )

--- a/tests/providers/amazon/aws/operators/test_s3_file_transform.py
+++ b/tests/providers/amazon/aws/operators/test_s3_file_transform.py
@@ -36,6 +36,10 @@ from airflow.providers.amazon.aws.operators.s3_file_transform import S3FileTrans
 class TestS3FileTransformOperator(unittest.TestCase):
 
     def setUp(self):
+        self.bucket = "bucket"
+        self.input_key = "foo"
+        self.output_key = "bar"
+        self.bio = io.BytesIO(b"input")
         self.tmp_dir = mkdtemp(prefix='test_tmpS3FileTransform_')
         self.transform_script = os.path.join(self.tmp_dir, "transform.py")
         os.mknod(self.transform_script)
@@ -123,6 +127,10 @@ class TestS3FileTransformOperator(unittest.TestCase):
             expression=select_expression
         )
 
+        conn = boto3.client('s3')
+        result = conn.get_object(Bucket=self.bucket, Key=self.output_key)
+        self.assertEqual(b'input', result['Body'].read())
+
     @staticmethod
     def mock_process(mock_popen, return_code=0, process_output=None):
         process = mock_popen.return_value
@@ -130,19 +138,13 @@ class TestS3FileTransformOperator(unittest.TestCase):
         process.wait.return_value = None
         process.returncode = return_code
 
-    @staticmethod
-    def s3_paths():
-        bucket = "bucket"
-        input_key = "foo"
-        output_key = "bar"
-        bio = io.BytesIO(b"input")
-
+    def s3_paths(self):
         conn = boto3.client('s3')
-        conn.create_bucket(Bucket=bucket)
-        conn.upload_fileobj(Bucket=bucket, Key=input_key, Fileobj=bio)
+        conn.create_bucket(Bucket=self.bucket)
+        conn.upload_fileobj(Bucket=self.bucket, Key=self.input_key, Fileobj=self.bio)
 
         s3_url = "s3://{0}/{1}"
-        input_path = s3_url.format(bucket, input_key)
-        output_path = s3_url.format(bucket, output_key)
+        input_path = s3_url.format(self.bucket, self.input_key)
+        output_path = s3_url.format(self.bucket, self.output_key)
 
         return input_path, output_path

--- a/tests/providers/amazon/aws/operators/test_s3_file_transform.py
+++ b/tests/providers/amazon/aws/operators/test_s3_file_transform.py
@@ -129,7 +129,7 @@ class TestS3FileTransformOperator(unittest.TestCase):
 
         conn = boto3.client('s3')
         result = conn.get_object(Bucket=self.bucket, Key=self.output_key)
-        self.assertEqual(b'input', result['Body'].read())
+        assert self.bio.getvalue() == result['Body']
 
     @staticmethod
     def mock_process(mock_popen, return_code=0, process_output=None):

--- a/tests/providers/amazon/aws/operators/test_s3_file_transform.py
+++ b/tests/providers/amazon/aws/operators/test_s3_file_transform.py
@@ -129,7 +129,7 @@ class TestS3FileTransformOperator(unittest.TestCase):
 
         conn = boto3.client('s3')
         result = conn.get_object(Bucket=self.bucket, Key=self.output_key)
-        assert self.bio.getvalue() == result['Body']
+        assert self.bio.getvalue() == result['Body'].read()
 
     @staticmethod
     def mock_process(mock_popen, return_code=0, process_output=None):

--- a/tests/providers/amazon/aws/operators/test_s3_file_transform.py
+++ b/tests/providers/amazon/aws/operators/test_s3_file_transform.py
@@ -36,10 +36,11 @@ from airflow.providers.amazon.aws.operators.s3_file_transform import S3FileTrans
 class TestS3FileTransformOperator(unittest.TestCase):
 
     def setUp(self):
+        self.content = b"input"
         self.bucket = "bucket"
         self.input_key = "foo"
         self.output_key = "bar"
-        self.bio = io.BytesIO(b"input")
+        self.bio = io.BytesIO(self.content)
         self.tmp_dir = mkdtemp(prefix='test_tmpS3FileTransform_')
         self.transform_script = os.path.join(self.tmp_dir, "transform.py")
         os.mknod(self.transform_script)
@@ -129,7 +130,7 @@ class TestS3FileTransformOperator(unittest.TestCase):
 
         conn = boto3.client('s3')
         result = conn.get_object(Bucket=self.bucket, Key=self.output_key)
-        assert self.bio.getvalue() == result['Body'].read()
+        self.assertEqual(self.content, result['Body'].read())
 
     @staticmethod
     def mock_process(mock_popen, return_code=0, process_output=None):


### PR DESCRIPTION
Documentation for S3FileTransformOperator states that users
can skip transformation script if S3 Select experession is
specified, but in this case the created file is always
zero bytes long.

This fix changes the behaviour, so in case of no transformation
given, the source file (a result of S3Select) is uploaded.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
