### PR TITLE
Remove side-effect of session in FAB

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -194,7 +194,7 @@ def webserver(args):
         print(
             "Starting the web server on port {0} and host {1}.".format(
                 args.port, args.hostname))
-        app, _ = create_app(None, testing=conf.getboolean('core', 'unit_test_mode'))
+        app, _ = create_app(testing=conf.getboolean('core', 'unit_test_mode'))
         app.run(debug=True, use_reloader=not app.config['TESTING'],
                 port=args.port, host=args.hostname,
                 ssl_context=(ssl_cert, ssl_key) if ssl_cert and ssl_key else None)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -98,12 +98,12 @@ def create_app(config=None, testing=False, app_name="Airflow"):
 
         class AirflowAppBuilder(AppBuilder):
 
-            def add_view(self, baseview, *args, **kwargs):
+            def _check_and_init(self, baseview):
                 if hasattr(baseview, 'datamodel'):
                     # Delete sessions if initiated previously to limit side effects. We want to use
                     # the current session in the current application.
                     baseview.datamodel.session = None
-                return super().add_view(baseview, *args, **kwargs)
+                return super()._check_and_init(baseview)
 
         appbuilder = AirflowAppBuilder(
             app=app,

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -46,7 +46,7 @@ csrf = CSRFProtect()
 log = logging.getLogger(__name__)
 
 
-def create_app(config=None, session=None, testing=False, app_name="Airflow"):
+def create_app(config=None, testing=False, app_name="Airflow"):
     global app, appbuilder
     app = Flask(__name__)
     app.secret_key = conf.get('webserver', 'SECRET_KEY')
@@ -70,8 +70,9 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     app.json_encoder = AirflowJsonEncoder
 
     csrf.init_app(app)
-
-    db = SQLA(app)
+    db = SQLA()
+    db.session = settings.Session
+    db.init_app(app)
 
     from airflow import api
     api.load_auth()
@@ -95,9 +96,18 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
                 """Your CUSTOM_SECURITY_MANAGER must now extend AirflowSecurityManager,
                  not FAB's security manager.""")
 
-        appbuilder = AppBuilder(
-            app,
-            db.session if not session else session,
+        class AirflowAppBuilder(AppBuilder):
+
+            def add_view(self, baseview, *args, **kwargs):
+                if hasattr(baseview, 'datamodel'):
+                    # Delete sessions if initiated previously to limit side effects. We want to use
+                    # the current session in the current application.
+                    baseview.datamodel.session = None
+                return super().add_view(baseview, *args, **kwargs)
+
+        appbuilder = AirflowAppBuilder(
+            app=app,
+            session=settings.Session,
             security_manager_class=security_manager_class,
             base_template='airflow/master.html',
             update_perms=conf.getboolean('webserver', 'UPDATE_FAB_PERMS'))
@@ -272,10 +282,6 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
                 response.headers["X-Frame-Options"] = "DENY"
             return response
 
-        @app.teardown_appcontext
-        def shutdown_session(exception=None):  # pylint: disable=unused-variable
-            settings.Session.remove()
-
         @app.before_request
         def make_session_permanent():
             flask_session.permanent = True
@@ -288,14 +294,14 @@ def root_app(env, resp):
     return [b'Apache Airflow is not at this location']
 
 
-def cached_app(config=None, session=None, testing=False):
+def cached_app(config=None, testing=False):
     global app, appbuilder
     if not app or not appbuilder:
         base_url = urlparse(conf.get('webserver', 'base_url'))[2]
         if not base_url or base_url == '/':
             base_url = ""
 
-        app, _ = create_app(config, session, testing)
+        app, _ = create_app(config=config, testing=testing)
         app = DispatcherMiddleware(root_app, {base_url: app})
         if conf.getboolean('webserver', 'ENABLE_PROXY_FIX'):
             app = ProxyFix(

--- a/tests/cli/commands/test_role_command.py
+++ b/tests/cli/commands/test_role_command.py
@@ -23,7 +23,6 @@ from contextlib import redirect_stdout
 from airflow import models
 from airflow.cli import cli_parser
 from airflow.cli.commands import role_command
-from airflow.settings import Session
 
 TEST_USER1_EMAIL = 'test-user1@example.com'
 TEST_USER2_EMAIL = 'test-user2@example.com'

--- a/tests/cli/commands/test_role_command.py
+++ b/tests/cli/commands/test_role_command.py
@@ -37,7 +37,7 @@ class TestCliRoles(unittest.TestCase):
 
     def setUp(self):
         from airflow.www import app as application
-        self.app, self.appbuilder = application.create_app(session=Session, testing=True)
+        self.app, self.appbuilder = application.create_app(testing=True)
         self.clear_roles_and_roles()
 
     def tearDown(self):

--- a/tests/cli/commands/test_sync_perm_command.py
+++ b/tests/cli/commands/test_sync_perm_command.py
@@ -34,7 +34,7 @@ class TestCliSyncPerm(unittest.TestCase):
 
     def setUp(self):
         from airflow.www import app as application
-        self.app, self.appbuilder = application.create_app(session=Session, testing=True)
+        self.app, self.appbuilder = application.create_app(testing=True)
 
     @mock.patch("airflow.cli.commands.sync_perm_command.DagBag")
     def test_cli_sync_perm(self, dagbag_mock):

--- a/tests/cli/commands/test_sync_perm_command.py
+++ b/tests/cli/commands/test_sync_perm_command.py
@@ -23,7 +23,6 @@ from airflow.cli import cli_parser
 from airflow.cli.commands import sync_perm_command
 from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
-from airflow.settings import Session
 
 
 class TestCliSyncPerm(unittest.TestCase):

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -48,7 +48,7 @@ class TestCliUsers(unittest.TestCase):
 
     def setUp(self):
         from airflow.www import app as application
-        self.app, self.appbuilder = application.create_app(session=Session, testing=True)
+        self.app, self.appbuilder = application.create_app(testing=True)
         self.clear_roles_and_roles()
 
     def tearDown(self):

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -25,7 +25,6 @@ from contextlib import redirect_stdout
 from airflow import models
 from airflow.cli import cli_parser
 from airflow.cli.commands import user_command
-from airflow.settings import Session
 
 TEST_USER1_EMAIL = 'test-user1@example.com'
 TEST_USER2_EMAIL = 'test-user2@example.com'

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -42,7 +42,7 @@ ROOT_FOLDER = os.path.realpath(
 
 class TestBase(unittest.TestCase):
     def setUp(self):
-        self.app, self.appbuilder = application.create_app(session=Session, testing=True)
+        self.app, self.appbuilder = application.create_app(testing=True)
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
         self.app.config['SECRET_KEY'] = 'secret_key'
         self.app.config['CSRF_ENABLED'] = False


### PR DESCRIPTION
Previously, if you ran the tests in the wrong order, there was a side effect that was very difficult to diagnose. When you use MySQL, side-effect can be triggered by the following command.
```
pytest \
tests/www/test_app.py::TestApp::test_should_respect_base_url_and_proxy_when_proxy_fix_and_base_url_is_set_up \
tests/www/test_views.py::TestPoolModelView::test_create_pool_with_same_name \
tests/www/test_views.py::TestPoolModelView::test_odd_name
```

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
