### PR TITLE
WIP: Tree view tooltip to show following execution date

### DIFF
--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -75,7 +75,8 @@ export default function tiTooltip(ti, {includeTryNumber = false} = {}) {
   if (ti.task_id !== undefined) {
     tt += `Task_id: ${escapeHtml(ti.task_id)}<br>`;
   }
-  tt += `Run: ${formatDateTime(ti.execution_date)}<br>`;
+  tt += `Execution Date: ${formatDateTime(ti.execution_date)}<br>`;
+  tt += `Following Execution Date: ${formatDateTime(ti.following_execution_date)}<br>`;
   if (ti.run_id !== undefined) {
     tt += `Run Id: <nobr>${escapeHtml(ti.run_id)}</nobr><br>`;
   }
@@ -103,4 +104,4 @@ export default function tiTooltip(ti, {includeTryNumber = false} = {}) {
   return tt;
 }
 
-window.tiTooltip = tiTooltip
+window.tiTooltip = tiTooltip;

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -119,6 +119,7 @@ function populate_taskinstance_properties(node) {
     task_instance.task_id = node.name;
     task_instance.operator = node.operator;
     task_instance.execution_date = dr_instance.execution_date;
+    task_instance.following_execution_date = dr_instance.following_execution_date;
     task_instance.external_trigger = dr_instance.external_trigger;
 
     // compute start_date and end_date if applicable

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1395,6 +1395,12 @@ class Airflow(AirflowBaseView):  # noqa: D101
         dag_runs = {
             dr.execution_date: alchemy_to_dict(dr) for dr in dag_runs
         }
+        for execution_date, dag_run in dag_runs.items():
+            # following_execution_date is None when schedule_interval is None
+            following_execution_date = dag.following_schedule(execution_date)
+            if not following_execution_date or dag_run['run_id'].startswith('manual__'):
+                following_execution_date = execution_date
+            dag_run['following_execution_date'] = following_execution_date.isoformat()
 
         dates = sorted(list(dag_runs.keys()))
         max_date = max(dates) if dates else None

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -431,7 +431,7 @@ class TestAirflowBaseViews(TestBase):
             state=State.RUNNING)
 
     def test_index(self):
-        with assert_queries_count(40):
+        with assert_queries_count(41):
             resp = self.client.get('/', follow_redirects=True)
         self.check_content_in_response('DAGs', resp)
 


### PR DESCRIPTION
This proposed change modifies the tooltip on the Tree View to include "Next Execution Date". I've found that Airflow scheduling work at the end of a schedule interval is a common source of confusion for my users. When they see on the tree view that the "last run" was one schedule interval away from the current time, they often raise questions about why the latest run hasn't kicked off yet.

I believe that showing both execution date and next execution date in this tooltip better illustrates the window of time that their Airflow task is operating on.

![airflow](https://user-images.githubusercontent.com/7297387/82514204-bea12000-9ada-11ea-8569-7f0236f0c897.png)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists -- No issue
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
