### PR TITLE
#8525 Add SQL Branch Operator 

### DIFF
--- a/airflow/operators/sql_branch_operator.py
+++ b/airflow/operators/sql_branch_operator.py
@@ -1,0 +1,165 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from distutils.util import strtobool
+from typing import Dict, Iterable, Mapping, Optional, Union
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.base_hook import BaseHook
+from airflow.models import BaseOperator, SkipMixin
+from airflow.utils.decorators import apply_defaults
+
+
+class BranchSqlOperator(BaseOperator, SkipMixin):
+    """
+    Executes sql code in a specific database
+
+    :param sql: the sql code to be executed. (templated)
+    :type sql: Can receive a str representing a sql statement or reference to a template file.
+               Template reference are recognized by str ending in '.sql'.
+               Expected SQL query to return Boolean (True/False), integer (0 = False, Otherwise = 1)
+               or string (true/y/yes/1/on/false/n/no/0/off).
+
+    :param follow_task_ids_if_true: task id or task ids to follow if query return true
+    :type follow_task_ids_if_true: str or list
+
+    :param follow_task_ids_if_false: task id or task ids to follow if query return true
+    :type follow_task_ids_if_false: str or list
+
+    :param conn_id: reference to a specific database
+    :type conn_id: str
+
+    :param database: name of database which overwrite defined one in connection
+
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :type parameters: mapping or iterable
+
+
+    """
+
+    template_fields = ("sql",)
+    template_ext = (".sql",)
+    ui_color = "#a22034"
+
+    @apply_defaults
+    def __init__(
+        self,
+        sql: str,
+        follow_task_ids_if_true: str,
+        follow_task_ids_if_false: str,
+        conn_id: str = "default_conn_id",
+        database: Optional[str] = None,
+        parameters: Optional[Union[Mapping, Iterable]] = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.conn_id = conn_id
+        self.sql = sql
+        self.parameters = parameters
+        self.follow_task_ids_if_true = follow_task_ids_if_true
+        self.follow_task_ids_if_false = follow_task_ids_if_false
+        self.database = database
+        self._hook = None
+
+    def _get_hook(self):
+        self.log.debug("Get connection for %s", self.conn_id)
+        conn = BaseHook.get_connection(self.conn_id)
+
+        allowed_conn_type = {
+            "google_cloud_platform",
+            "jdbc",
+            "mssql",
+            "mysql",
+            "odbc",
+            "oracle",
+            "postgres",
+            "presto",
+            "sqlite",
+            "vertica",
+        }
+        if conn.conn_type not in allowed_conn_type:
+            raise AirflowException(
+                "The connection type is not supported by BranchSqlOperator. "
+                + "Supported connection types: {}".format(list(allowed_conn_type))
+            )
+
+        if not self._hook:
+            self._hook = conn.get_hook()
+            if self.database:
+                self._hook.schema = self.database
+
+        return self._hook
+
+    def execute(self, context: Dict):
+        # get supported hook
+        self._hook = self._get_hook()
+
+        if self._hook is None:
+            raise AirflowException(
+                "Failed to establish connection to '%s'" % self.conn_id
+            )
+
+        if self.follow_task_ids_if_true is None:
+            raise AirflowException(
+                "Expected task id or task ids assigned to follow_task_ids_if_true"
+            )
+
+        if self.follow_task_ids_if_false is None:
+            raise AirflowException(
+                "Expected task id or task ids assigned to follow_task_ids_if_false"
+            )
+
+        self.log.info(
+            "Executing: %s (with parameters %s) with connection: %s",
+            self.sql,
+            self.parameters,
+            self._hook,
+        )
+        records = self._hook.get_records(self.sql, self.parameters)
+        if not records:
+            raise AirflowException(
+                "No rows returned from sql query. Operator expected True or False return value."
+            )
+
+        query_result = records[0][0]
+
+        self.log.info("Query returns %s, type '%s'", query_result, type(query_result))
+
+        follow_branch = None
+        try:
+            if query_result is bool:
+                if query_result:
+                    follow_branch = self.follow_task_ids_if_true
+            elif isinstance(query_result, str):
+                # return result is not Boolean, try to convert from String to Boolean
+                if bool(strtobool(query_result)):
+                    follow_branch = self.follow_task_ids_if_true
+            elif isinstance(query_result, int):
+                if bool(query_result):
+                    follow_branch = self.follow_task_ids_if_true
+            else:
+                raise AirflowException(
+                    "Unexpected query return result '%s'" % query_result
+                )
+
+            if follow_branch is None:
+                follow_branch = self.follow_task_ids_if_false
+        except ValueError:
+            raise AirflowException("Unexpected query return result '%s'" % query_result)
+
+        self.skip_all_except(context["ti"], follow_branch)

--- a/airflow/operators/sql_branch_operator.py
+++ b/airflow/operators/sql_branch_operator.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from distutils.util import strtobool
-from typing import Dict, Iterable, Mapping, Optional, Union
+from typing import Dict, Iterable, List, Mapping, Optional, Union
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
@@ -54,13 +54,14 @@ class BranchSqlOperator(BaseOperator, SkipMixin):
     template_fields = ("sql",)
     template_ext = (".sql",)
     ui_color = "#a22034"
+    ui_fgcolor = "#F7F7F7"
 
     @apply_defaults
     def __init__(
         self,
         sql: str,
-        follow_task_ids_if_true: str,
-        follow_task_ids_if_false: str,
+        follow_task_ids_if_true: List[str],
+        follow_task_ids_if_false: List[str],
         conn_id: str = "default_conn_id",
         database: Optional[str] = None,
         parameters: Optional[Union[Mapping, Iterable]] = None,
@@ -130,7 +131,7 @@ class BranchSqlOperator(BaseOperator, SkipMixin):
             self.parameters,
             self._hook,
         )
-        records = self._hook.get_records(self.sql, self.parameters)
+        records = self._hook.get_first(self.sql, self.parameters)
         if not records:
             raise AirflowException(
                 "No rows returned from sql query. Operator expected True or False return value."

--- a/airflow/operators/sql_branch_operator.py
+++ b/airflow/operators/sql_branch_operator.py
@@ -23,6 +23,19 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.models import BaseOperator, SkipMixin
 from airflow.utils.decorators import apply_defaults
 
+ALLOWED_CONN_TYPE = {
+    "google_cloud_platform",
+    "jdbc",
+    "mssql",
+    "mysql",
+    "odbc",
+    "oracle",
+    "postgres",
+    "presto",
+    "sqlite",
+    "vertica",
+}
+
 
 class BranchSqlOperator(BaseOperator, SkipMixin):
     """
@@ -74,22 +87,10 @@ class BranchSqlOperator(BaseOperator, SkipMixin):
         self.log.debug("Get connection for %s", self.conn_id)
         conn = BaseHook.get_connection(self.conn_id)
 
-        allowed_conn_type = {
-            "google_cloud_platform",
-            "jdbc",
-            "mssql",
-            "mysql",
-            "odbc",
-            "oracle",
-            "postgres",
-            "presto",
-            "sqlite",
-            "vertica",
-        }
-        if conn.conn_type not in allowed_conn_type:
+        if conn.conn_type not in ALLOWED_CONN_TYPE:
             raise AirflowException(
                 "The connection type is not supported by BranchSqlOperator. "
-                + "Supported connection types: {}".format(list(allowed_conn_type))
+                + "Supported connection types: {}".format(list(ALLOWED_CONN_TYPE))
             )
 
         if not self._hook:

--- a/airflow/operators/sql_branch_operator.py
+++ b/airflow/operators/sql_branch_operator.py
@@ -138,7 +138,10 @@ class BranchSqlOperator(BaseOperator, SkipMixin):
             )
 
         if isinstance(record, list):
-            query_result = record[0][0]
+            if isinstance(record[0], list):
+                query_result = record[0][0]
+            else:
+                query_result = record[0]
         elif isinstance(record, tuple):
             query_result = record[0]
         else:
@@ -148,7 +151,7 @@ class BranchSqlOperator(BaseOperator, SkipMixin):
 
         follow_branch = None
         try:
-            if query_result is bool:
+            if isinstance(query_result, bool):
                 if query_result:
                     follow_branch = self.follow_task_ids_if_true
             elif isinstance(query_result, str):

--- a/airflow/operators/sql_branch_operator.py
+++ b/airflow/operators/sql_branch_operator.py
@@ -33,22 +33,15 @@ class BranchSqlOperator(BaseOperator, SkipMixin):
                Template reference are recognized by str ending in '.sql'.
                Expected SQL query to return Boolean (True/False), integer (0 = False, Otherwise = 1)
                or string (true/y/yes/1/on/false/n/no/0/off).
-
     :param follow_task_ids_if_true: task id or task ids to follow if query return true
     :type follow_task_ids_if_true: str or list
-
     :param follow_task_ids_if_false: task id or task ids to follow if query return true
     :type follow_task_ids_if_false: str or list
-
     :param conn_id: reference to a specific database
     :type conn_id: str
-
     :param database: name of database which overwrite defined one in connection
-
     :param parameters: (optional) the parameters to render the SQL query with.
     :type parameters: mapping or iterable
-
-
     """
 
     template_fields = ("sql",)
@@ -115,14 +108,17 @@ class BranchSqlOperator(BaseOperator, SkipMixin):
                 "Failed to establish connection to '%s'" % self.conn_id
             )
 
+        if self.sql is None:
+            raise AirflowException("Expected 'sql' parameter is missing.")
+
         if self.follow_task_ids_if_true is None:
             raise AirflowException(
-                "Expected task id or task ids assigned to follow_task_ids_if_true"
+                "Expected 'follow_task_ids_if_true' paramter is missing."
             )
 
         if self.follow_task_ids_if_false is None:
             raise AirflowException(
-                "Expected task id or task ids assigned to follow_task_ids_if_false"
+                "Expected 'follow_task_ids_if_false' parameter is missing."
             )
 
         self.log.info(

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -76,6 +76,8 @@ Fundamentals
    * - :mod:`airflow.operators.subdag_operator`
      -
 
+   * - :mod:`airflow.operators.sql_branch_operator`
+     -
 **Sensors:**
 
 .. list-table::

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -78,6 +78,7 @@ Fundamentals
 
    * - :mod:`airflow.operators.sql_branch_operator`
      -
+
 **Sensors:**
 
 .. list-table::

--- a/tests/operators/test_sql_branch_operator.py
+++ b/tests/operators/test_sql_branch_operator.py
@@ -198,7 +198,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
 
         mock_hook.get_connection("mysql_default").conn_type = "mysql"
         mock_get_records = (
-            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+            mock_hook.get_connection.return_value.get_hook.return_value.get_first
         )
 
         for true_value in SUPPORTED_TRUE_VALUES:
@@ -242,7 +242,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
 
         mock_hook.get_connection("mysql_default").conn_type = "mysql"
         mock_get_records = (
-            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+            mock_hook.get_connection.return_value.get_hook.return_value.get_first
         )
 
         for false_value in SUPPORTED_FALSE_VALUES:
@@ -288,7 +288,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
 
         mock_hook.get_connection("mysql_default").conn_type = "mysql"
         mock_get_records = (
-            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+            mock_hook.get_connection.return_value.get_hook.return_value.get_first
         )
         mock_get_records.return_value = [["1"]]
 
@@ -332,7 +332,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
 
         mock_hook.get_connection("mysql_default").conn_type = "mysql"
         mock_get_records = (
-            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+            mock_hook.get_connection.return_value.get_hook.return_value.get_first
         )
 
         mock_get_records.return_value = ["Invalid Value"]
@@ -365,7 +365,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
 
         mock_hook.get_connection("mysql_default").conn_type = "mysql"
         mock_get_records = (
-            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+            mock_hook.get_connection.return_value.get_hook.return_value.get_first
         )
 
         for true_value in SUPPORTED_TRUE_VALUES:
@@ -409,7 +409,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
 
         mock_hook.get_connection("mysql_default").conn_type = "mysql"
         mock_get_records = (
-            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+            mock_hook.get_connection.return_value.get_hook.return_value.get_first
         )
 
         for false_value in SUPPORTED_FALSE_VALUES:

--- a/tests/operators/test_sql_branch_operator.py
+++ b/tests/operators/test_sql_branch_operator.py
@@ -16,9 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# import os
-# import unittest
-# from unittest import mock
 import datetime
 import unittest
 from unittest import mock

--- a/tests/operators/test_sql_branch_operator.py
+++ b/tests/operators/test_sql_branch_operator.py
@@ -45,6 +45,11 @@ SUPPORTED_TRUE_VALUES = [
     ["1"],
     ["on"],
     [1],
+    True,
+    "true",
+    "1",
+    "on",
+    1,
 ]
 SUPPORTED_FALSE_VALUES = [
     ["False"],
@@ -52,6 +57,11 @@ SUPPORTED_FALSE_VALUES = [
     ["0"],
     ["off"],
     [0],
+    False,
+    "false",
+    "0",
+    "off",
+    0,
 ]
 
 
@@ -245,7 +255,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
         )
 
         for true_value in SUPPORTED_TRUE_VALUES:
-            mock_get_records.return_value = [true_value]
+            mock_get_records.return_value = true_value
 
             branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
@@ -289,7 +299,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
         )
 
         for false_value in SUPPORTED_FALSE_VALUES:
-            mock_get_records.return_value = [false_value]
+            mock_get_records.return_value = false_value
 
             branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 

--- a/tests/operators/test_sql_branch_operator.py
+++ b/tests/operators/test_sql_branch_operator.py
@@ -31,8 +31,6 @@ from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.providers.apache.hive import TestHiveEnvironment
 
-TEST_DAG_ID = "unit_test_sql_dag"
-
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 INTERVAL = datetime.timedelta(hours=12)
 
@@ -82,7 +80,6 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
             default_args={"owner": "airflow", "start_date": DEFAULT_DATE},
             schedule_interval=INTERVAL,
         )
-        # self.dag = DAG(TEST_DAG_ID, default_args=args)
         self.branch_1 = DummyOperator(task_id="branch_1", dag=self.dag)
         self.branch_2 = DummyOperator(task_id="branch_2", dag=self.dag)
         self.branch_3 = None

--- a/tests/operators/test_sql_branch_operator.py
+++ b/tests/operators/test_sql_branch_operator.py
@@ -1,0 +1,429 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# import os
+# import unittest
+# from unittest import mock
+import datetime
+import unittest
+from unittest import mock
+
+import pytest
+
+from airflow.exceptions import AirflowException
+from airflow.models import DAG, DagRun, TaskInstance as TI
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.sql_branch_operator import BranchSqlOperator
+from airflow.utils import timezone
+from airflow.utils.session import create_session
+from airflow.utils.state import State
+from tests.providers.apache.hive import TestHiveEnvironment
+
+TEST_DAG_ID = "unit_test_sql_dag"
+
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+INTERVAL = datetime.timedelta(hours=12)
+
+SUPPORTED_TRUE_VALUES = [
+    ["True"],
+    ["true"],
+    ["1"],
+    ["on"],
+    [1],
+]
+SUPPORTED_FALSE_VALUES = [
+    ["False"],
+    ["false"],
+    ["0"],
+    ["off"],
+    [0],
+]
+
+
+class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
+    """
+    Test for SQL Branch Operator
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TI).delete()
+
+    def setUp(self):
+        super().setUp()
+        self.dag = DAG(
+            "sql_branch_operator_test",
+            default_args={"owner": "airflow", "start_date": DEFAULT_DATE},
+            schedule_interval=INTERVAL,
+        )
+        # self.dag = DAG(TEST_DAG_ID, default_args=args)
+        self.branch_1 = DummyOperator(task_id="branch_1", dag=self.dag)
+        self.branch_2 = DummyOperator(task_id="branch_2", dag=self.dag)
+        self.branch_3 = None
+
+    def tearDown(self):
+        super().tearDown()
+
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TI).delete()
+
+    def test_unsupported_conn_type(self):
+        """ Check if BranchSqlOperator throws an exception for unsupported connection type """
+        op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="redis_default",
+            sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+
+        with self.assertRaises(AirflowException):
+            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+    def test_invalid_conn(self):
+        """ Check if BranchSqlOperator throws an exception for invalid connection """
+        op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="invalid_connection",
+            sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+
+        with self.assertRaises(AirflowException):
+            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+    def test_invalid_follow_task_true(self):
+        """ Check if BranchSqlOperator throws an exception for invalid connection """
+        op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="invalid_connection",
+            sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
+            follow_task_ids_if_true=None,
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+
+        with self.assertRaises(AirflowException):
+            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+    def test_invalid_follow_task_false(self):
+        """ Check if BranchSqlOperator throws an exception for invalid connection """
+        op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="invalid_connection",
+            sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false=None,
+            dag=self.dag,
+        )
+
+        with self.assertRaises(AirflowException):
+            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+    @pytest.mark.backend("mysql")
+    def test_sql_branch_operator_mysql(self):
+        """ Check if BranchSqlOperator works with backend """
+        branch_op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="mysql_default",
+            sql="SELECT 1",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+        branch_op.run(
+            start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True
+        )
+
+    @pytest.mark.backend("postgres")
+    def test_sql_branch_operator_postgres(self):
+        """ Check if BranchSqlOperator works with backend """
+        branch_op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="postgres_default",
+            sql="SELECT 1",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+        branch_op.run(
+            start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True
+        )
+
+    @mock.patch("airflow.operators.sql_branch_operator.BaseHook")
+    def test_branch_true_with_dag_run(self, mock_hook):
+        """ Check BranchSqlOperator branch operation """
+        branch_op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="mysql_default",
+            sql="SELECT 1",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+
+        self.branch_1.set_upstream(branch_op)
+        self.branch_2.set_upstream(branch_op)
+        self.dag.clear()
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        mock_hook.get_connection("mysql_default").conn_type = "mysql"
+        mock_get_records = (
+            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+        )
+
+        for true_value in SUPPORTED_TRUE_VALUES:
+            mock_get_records.return_value = [true_value]
+
+            branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+            tis = dr.get_task_instances()
+            for ti in tis:
+                if ti.task_id == "make_choice":
+                    self.assertEqual(ti.state, State.SUCCESS)
+                elif ti.task_id == "branch_1":
+                    self.assertEqual(ti.state, State.NONE)
+                elif ti.task_id == "branch_2":
+                    self.assertEqual(ti.state, State.SKIPPED)
+                else:
+                    raise ValueError(f"Invalid task id {ti.task_id} found!")
+
+    @mock.patch("airflow.operators.sql_branch_operator.BaseHook")
+    def test_branch_false_with_dag_run(self, mock_hook):
+        """ Check BranchSqlOperator branch operation """
+        branch_op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="mysql_default",
+            sql="SELECT 1",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+
+        self.branch_1.set_upstream(branch_op)
+        self.branch_2.set_upstream(branch_op)
+        self.dag.clear()
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        mock_hook.get_connection("mysql_default").conn_type = "mysql"
+        mock_get_records = (
+            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+        )
+
+        for false_value in SUPPORTED_FALSE_VALUES:
+            mock_get_records.return_value = [false_value]
+
+            branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+            tis = dr.get_task_instances()
+            for ti in tis:
+                if ti.task_id == "make_choice":
+                    self.assertEqual(ti.state, State.SUCCESS)
+                elif ti.task_id == "branch_1":
+                    self.assertEqual(ti.state, State.SKIPPED)
+                elif ti.task_id == "branch_2":
+                    self.assertEqual(ti.state, State.NONE)
+                else:
+                    raise ValueError(f"Invalid task id {ti.task_id} found!")
+
+    @mock.patch("airflow.operators.sql_branch_operator.BaseHook")
+    def test_branch_list_with_dag_run(self, mock_hook):
+        """ Checks if the BranchSqlOperator supports branching off to a list of tasks."""
+        branch_op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="mysql_default",
+            sql="SELECT 1",
+            follow_task_ids_if_true=["branch_1", "branch_2"],
+            follow_task_ids_if_false="branch_3",
+            dag=self.dag,
+        )
+
+        self.branch_1.set_upstream(branch_op)
+        self.branch_2.set_upstream(branch_op)
+        self.branch_3 = DummyOperator(task_id="branch_3", dag=self.dag)
+        self.branch_3.set_upstream(branch_op)
+        self.dag.clear()
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        mock_hook.get_connection("mysql_default").conn_type = "mysql"
+        mock_get_records = (
+            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+        )
+        mock_get_records.return_value = [["1"]]
+
+        branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        tis = dr.get_task_instances()
+        for ti in tis:
+            if ti.task_id == "make_choice":
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == "branch_1":
+                self.assertEqual(ti.state, State.NONE)
+            elif ti.task_id == "branch_2":
+                self.assertEqual(ti.state, State.NONE)
+            elif ti.task_id == "branch_3":
+                self.assertEqual(ti.state, State.SKIPPED)
+            else:
+                raise ValueError(f"Invalid task id {ti.task_id} found!")
+
+    @mock.patch("airflow.operators.sql_branch_operator.BaseHook")
+    def test_invalid_query_result_with_dag_run(self, mock_hook):
+        """ Check BranchSqlOperator branch operation """
+        branch_op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="mysql_default",
+            sql="SELECT 1",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+
+        self.branch_1.set_upstream(branch_op)
+        self.branch_2.set_upstream(branch_op)
+        self.dag.clear()
+
+        self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        mock_hook.get_connection("mysql_default").conn_type = "mysql"
+        mock_get_records = (
+            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+        )
+
+        mock_get_records.return_value = ["Invalid Value"]
+
+        with self.assertRaises(AirflowException):
+            branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+    @mock.patch("airflow.operators.sql_branch_operator.BaseHook")
+    def test_with_skip_in_branch_downstream_dependencies(self, mock_hook):
+        """ Test SQL Branch with skipping all downstream dependencies """
+        branch_op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="mysql_default",
+            sql="SELECT 1",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+
+        branch_op >> self.branch_1 >> self.branch_2
+        branch_op >> self.branch_2
+        self.dag.clear()
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        mock_hook.get_connection("mysql_default").conn_type = "mysql"
+        mock_get_records = (
+            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+        )
+
+        for true_value in SUPPORTED_TRUE_VALUES:
+            mock_get_records.return_value = [true_value]
+
+            branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+            tis = dr.get_task_instances()
+            for ti in tis:
+                if ti.task_id == "make_choice":
+                    self.assertEqual(ti.state, State.SUCCESS)
+                elif ti.task_id == "branch_1":
+                    self.assertEqual(ti.state, State.NONE)
+                elif ti.task_id == "branch_2":
+                    self.assertEqual(ti.state, State.NONE)
+                else:
+                    raise ValueError(f"Invalid task id {ti.task_id} found!")
+
+    @mock.patch("airflow.operators.sql_branch_operator.BaseHook")
+    def test_with_skip_in_branch_downstream_dependencies2(self, mock_hook):
+        """ Test skipping downstream dependency for false condition"""
+        branch_op = BranchSqlOperator(
+            task_id="make_choice",
+            conn_id="mysql_default",
+            sql="SELECT 1",
+            follow_task_ids_if_true="branch_1",
+            follow_task_ids_if_false="branch_2",
+            dag=self.dag,
+        )
+
+        branch_op >> self.branch_1 >> self.branch_2
+        branch_op >> self.branch_2
+        self.dag.clear()
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        mock_hook.get_connection("mysql_default").conn_type = "mysql"
+        mock_get_records = (
+            mock_hook.get_connection.return_value.get_hook.return_value.get_records
+        )
+
+        for false_value in SUPPORTED_FALSE_VALUES:
+            mock_get_records.return_value = [false_value]
+
+            branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+            tis = dr.get_task_instances()
+            for ti in tis:
+                if ti.task_id == "make_choice":
+                    self.assertEqual(ti.state, State.SUCCESS)
+                elif ti.task_id == "branch_1":
+                    self.assertEqual(ti.state, State.SKIPPED)
+                elif ti.task_id == "branch_2":
+                    self.assertEqual(ti.state, State.NONE)
+                else:
+                    raise ValueError(f"Invalid task id {ti.task_id} found!")


### PR DESCRIPTION
SQL Branch Operator allow user to execute a SQL query in any supported backend to decide which
branch of the DAG to follow. 

The SQL branch operator expects SQL query to return any of the following:
- Boolean: True/False 
- Integer: 0/1 
- String: true/y/yes/1/on/false/n/no/0/off

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
