### PR TITLE
Remove singularity from CI images

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -184,41 +184,6 @@ RUN HADOOP_DISTRO="cdh" \
 
 ENV PATH "${PATH}:/opt/hive/bin"
 
-# Install Singularity (for Singularity executor testing)
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-       uuid-dev \
-       libgpgme11-dev \
-       squashfs-tools \
-       libseccomp-dev \
-       pkg-config \
-       cryptsetup \
-    && apt-get autoremove -yqq --purge \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV GOLANG_VERSION=1.13.8
-ENV SINGULARITY_VERSION=3.5.2
-
-RUN curl -L -o go${GOLANG_VERSION}.linux-amd64.tar.gz "https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz" \
-    && tar -C /usr/local -xzvf "go${GOLANG_VERSION}.linux-amd64.tar.gz" \
-    && rm "go${GOLANG_VERSION}.linux-amd64.tar.gz"
-
-ENV PATH="${PATH}:/usr/local/go/bin"
-
-WORKDIR /tmp
-
-RUN curl -L -o singularity-${SINGULARITY_VERSION}.tar.gz https://github.com/sylabs/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-${SINGULARITY_VERSION}.tar.gz \
-    && tar -xzf singularity-${SINGULARITY_VERSION}.tar.gz
-
-WORKDIR /tmp/singularity
-
-RUN ./mconfig \
-    && make -C builddir \
-    && make -C builddir install
-
-WORKDIR /
-
 # Install Minicluster
 ENV MINICLUSTER_HOME="/opt/minicluster"
 


### PR DESCRIPTION
The singularity operator tests _have always_ used mocking, so we were
adding 700MB to our docker image for nothing.

Fixes #8774


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.