### PR TITLE
Cache 1 10 ci images (#8955)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@
 name: CI Build
 on:
   push:
-    branches: ['master', 'v1-10-test']
+    branches: ['master', 'v1-10-test', 'v1-10-stable']
   pull_request:
-    branches: ['master', 'v1-10-test']
+    branches: ['master', 'v1-10-test', 'v1-10-stable']
 env:
   MOUNT_LOCAL_SOURCES: "false"
   FORCE_ANSWER_TO_QUESTIONS: "yes"
@@ -277,7 +277,10 @@ jobs:
       - requirements
       - build-prod-image
       - docs
-    if: github.ref == 'refs/heads/master' && github.event_name != 'schedule'
+    if: |
+      (github.ref == 'refs/heads/master' ||
+      github.ref == 'refs/heads/v1-10-test' ) &&
+      github.event_name != 'schedule'
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7]


### PR DESCRIPTION
* Push CI images to Docker packcage cache for v1-10 branches

This is done as a commit to master so that we can keep the two branches
in sync

Co-Authored-By: Ash Berlin-Taylor <ash_github@firemirror.com>

* Run Github Actions against v1-10-stable too

Co-authored-by: Ash Berlin-Taylor <ash_github@firemirror.com>
(cherry picked from commit 90a07d81845f033fd9875d4b0393052b767eac46)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
