### PR TITLE
Mark sure airflow get the right job status after log stream interrupt when schedule spark job on k8s

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -443,8 +443,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         max_retry_times_by_describe_cmd = 24
         retry_delay_by_describe_cmd = 300
         retry_time = 1
-        while(self._spark_exit_code == None and retry_time <= max_retry_times_by_describe_cmd):
-            self.log.info("log stream lost, the {} time(s) trying to get Exit Code using kubectl describe pod...", retry_time)
+        while(self._spark_exit_code is None and retry_time <= max_retry_times_by_describe_cmd):
+            self.log.info("log stream lost, the {} time(s) trying cmd kubectl describe pod...", retry_time)
             time.sleep(retry_delay_by_describe_cmd)
             spark_exit_code = self._get_exitcode_by_k8s_describe_cmd()
             if spark_exit_code:
@@ -459,8 +459,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         """
         execute k8s cmd to catch Exit Code
         """
-        cmd_get_exitcode = "kubectl describe pod -n " + self._connection['namespace'] + " " + self._driver_id + \
-            "|grep 'Exit Code'|awk -F ' ' '{print $3}'"
+        cmd_get_exitcode = "kubectl describe pod -n " + self._connection['namespace'] + " " + \
+            self._driver_id + "|grep 'Exit Code'|awk -F ' ' '{print $3}'"
         self.log.info("cmd:{}", cmd_get_exitcode)
         spark_exit_code = subprocess.getoutput(cmd_get_exitcode)
         return spark_exit_code

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -403,7 +403,10 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         # if exit code did not return when spark running on k8s, try use 'kubectl describe pod xxx' cmd
         if self._is_kubernetes:
-            self._get_exitcode_by_k8s_describe_cmd_with_loop()
+            try:
+                self._get_exitcode_by_k8s_describe_cmd_with_loop()
+            except Exception:
+                pass
 
         # Check spark-submit return code. In Kubernetes mode, also check the value
         # of exit code in the log, as it may differ.

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -444,12 +444,12 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         retry_delay_by_describe_cmd = 300
         retry_time = 1
         while(self._spark_exit_code is None and retry_time <= max_retry_times_by_describe_cmd):
-            self.log.info("log interrupt, the {} time(s) trying...", retry_time)
+            self.log.info("log interrupt, the %s time(s) trying...", retry_time)
             time.sleep(retry_delay_by_describe_cmd)
             spark_exit_code = self._get_exitcode_by_k8s_describe_cmd()
             if spark_exit_code:
                 self._spark_exit_code = spark_exit_code
-                self.log.info("get Exit Code:{}", self._spark_exit_code)
+                self.log.info("get Exit Code:%s", self._spark_exit_code)
                 break
             self.log.info("no exit code return, try next time")
             retry_time += 1
@@ -460,7 +460,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         """
         cmd_get_exitcode = "kubectl describe pod -n " + self._connection['namespace'] + " " + \
             self._driver_id + "|grep 'Exit Code'|awk -F ' ' '{print $3}'"
-        self.log.info("cmd:{}", cmd_get_exitcode)
+        self.log.info("cmd:%s", cmd_get_exitcode)
         spark_exit_code = subprocess.getoutput(cmd_get_exitcode)
         return spark_exit_code
 

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -403,10 +403,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         # if exit code did not return when spark running on k8s, try use 'kubectl describe pod xxx' cmd
         if self._is_kubernetes:
-            try:
-                self._get_exitcode_by_k8s_describe_cmd_with_loop()
-            except Exception:
-                pass
+            self._get_exitcode_by_k8s_describe_cmd_with_loop()
 
         # Check spark-submit return code. In Kubernetes mode, also check the value
         # of exit code in the log, as it may differ.

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -401,7 +401,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._process_spark_submit_log(iter(self._submit_sp.stdout))
         returncode = self._submit_sp.wait()
 
-        #if log did not return exit_code,then use 'kubectl describe pod xxx' cmd to get it
+        # if log did not return exit_code,then use 'kubectl describe pod xxx' cmd to get it
         self._get_exitcode_by_k8s_describe_cmd_with_loop()
 
         # Check spark-submit return code. In Kubernetes mode, also check the value
@@ -440,27 +440,28 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         this is a loop to execute k8s cmd.
         try max 24 times,delay between retries is 5 mins. so max 2h totally
         """
-        max_retry_times_by_describe_cmd=24
-        retry_delay_by_describe_cmd=300
-        retry_time=1
-        while(self._spark_exit_code==None and retry_time <= max_retry_times_by_describe_cmd):
-            self.log.info("log stream lost, the {} time(s) trying to get Exit Code using kubectl describe pod...",retry_time)
+        max_retry_times_by_describe_cmd = 24
+        retry_delay_by_describe_cmd = 300
+        retry_time = 1
+        while(self._spark_exit_code == None and retry_time <= max_retry_times_by_describe_cmd):
+            self.log.info("log stream lost, the {} time(s) trying to get Exit Code using kubectl describe pod...", retry_time)
             time.sleep(retry_delay_by_describe_cmd)
-            spark_exit_code=self._get_exitcode_by_k8s_describe_cmd()
+            spark_exit_code = self._get_exitcode_by_k8s_describe_cmd()
             if spark_exit_code:
-                self._spark_exit_code=spark_exit_code
-                self.log.info("after lost log stream,get Exit Code:{}",self._spark_exit_code)
+                self._spark_exit_code = spark_exit_code
+                self.log.info("after lost log stream,get Exit Code:{}", self._spark_exit_code)
                 break
             else:
                 self.log.info("after lost log stream,did not get exit code, try next time")
-            retry_time+=1
+            retry_time += 1
 
     def _get_exitcode_by_k8s_describe_cmd(self):
         """
         execute k8s cmd to catch Exit Code
         """
-        cmd_get_exitcode = "kubectl describe pod -n "+self._connection['namespace']+" "+self._driver_id+"|grep 'Exit Code'|awk -F ' ' '{print $3}'"
-        self.log.info("cmd:{}",cmd_get_exitcode)
+        cmd_get_exitcode = "kubectl describe pod -n " + self._connection['namespace'] + " " + self._driver_id
+        + "|grep 'Exit Code'|awk -F ' ' '{print $3}'"
+        self.log.info("cmd:{}", cmd_get_exitcode)
         spark_exit_code = subprocess.getoutput(cmd_get_exitcode)
         return spark_exit_code
 

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -459,8 +459,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         """
         execute k8s cmd to catch Exit Code
         """
-        cmd_get_exitcode = "kubectl describe pod -n " + self._connection['namespace'] + " " + self._driver_id
-        + "|grep 'Exit Code'|awk -F ' ' '{print $3}'"
+        cmd_get_exitcode = "kubectl describe pod -n " + self._connection['namespace'] + " " + self._driver_id + \
+            "|grep 'Exit Code'|awk -F ' ' '{print $3}'"
         self.log.info("cmd:{}", cmd_get_exitcode)
         spark_exit_code = subprocess.getoutput(cmd_get_exitcode)
         return spark_exit_code

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -440,7 +440,11 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         """
         this is a loop to execute k8s cmd.
         try max 24 times,delay between retries is 5 mins. so max 2h totally
+        similar with _start_driver_status_tracking(), but work on k8s.
         """
+        # When your Kubernetes cluster is not performing well or get too old resource version exception
+        # it is possible that the log stream will be interrupted and lost 'Exit Code'.
+        # Therefore we use a simple retry mechanism.
         max_retry_times_by_describe_cmd = 24
         retry_delay_by_describe_cmd = 300
         retry_time = 1

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -401,6 +401,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._process_spark_submit_log(iter(self._submit_sp.stdout))
         returncode = self._submit_sp.wait()
 
+        #if log did not return exit_code,then use 'kubectl describe pod xxx' cmd to get it
+        self._get_exitcode_by_k8s_describe_cmd_with_loop()
+
         # Check spark-submit return code. In Kubernetes mode, also check the value
         # of exit code in the log, as it may differ.
         if returncode or (self._is_kubernetes and self._spark_exit_code != 0):
@@ -431,6 +434,35 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     "ERROR : Driver {} badly exited with status {}"
                     .format(self._driver_id, self._driver_status)
                 )
+
+    def _get_exitcode_by_k8s_describe_cmd_with_loop(self):
+        """
+        this is a loop to execute k8s cmd.
+        try max 24 times,delay between retries is 5 mins. so max 2h totally
+        """
+        max_retry_times_by_describe_cmd=24
+        retry_delay_by_describe_cmd=300
+        retry_time=1
+        while(self._spark_exit_code==None and retry_time <= max_retry_times_by_describe_cmd):
+            self.log.info("log stream lost, the {} time(s) trying to get Exit Code using kubectl describe pod...",retry_time)
+            time.sleep(retry_delay_by_describe_cmd)
+            spark_exit_code=self._get_exitcode_by_k8s_describe_cmd()
+            if spark_exit_code:
+                self._spark_exit_code=spark_exit_code
+                self.log.info("after lost log stream,get Exit Code:{}",self._spark_exit_code)
+                break
+            else:
+                self.log.info("after lost log stream,did not get exit code, try next time")
+            retry_time+=1
+
+    def _get_exitcode_by_k8s_describe_cmd(self):
+        """
+        execute k8s cmd to catch Exit Code
+        """
+        cmd_get_exitcode = "kubectl describe pod -n "+self._connection['namespace']+" "+self._driver_id+"|grep 'Exit Code'|awk -F ' ' '{print $3}'"
+        self.log.info("cmd:{}",cmd_get_exitcode)
+        spark_exit_code = subprocess.getoutput(cmd_get_exitcode)
+        return spark_exit_code
 
     def _process_spark_submit_log(self, itr):
         """

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -407,7 +407,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             # double check by spark driver pod status (blocking function)
             self._start_k8s_pod_status_tracking()
 
-            if(self._spark_exit_code != 0):
+            if self._spark_exit_code != 0:
                 raise AirflowException(
                     "Cannot execute: {}. Error code is: {}.".format(
                         self._mask_cmd(spark_submit_cmd), returncode
@@ -572,60 +572,58 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     )
 
     def _start_k8s_pod_status_tracking(self):
-            """
-            Polls the driver based on self._kubernetes_driver_pod to get the status.
-            Finish successfully when the status is Succeeded.
-            Finish failed when the status is Failed/Unknown.
+        """
+        Polls the driver based on self._kubernetes_driver_pod to get the status.
+        Finish successfully when the status is Succeeded.
+        Finish failed when the status is Failed/Unknown.
 
-            Pod phase(https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/)
+        Pod phase(https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/)
 
-            Here are the possible values for phase:
+        Here are the possible values for phase:
 
-            Pending
-                The Pod has been accepted by the Kubernetes system, but one or more of the Container images
-                has not been created. This includes time before being scheduled as well as time spent
-                downloading images over the network, which could take a while.
-            Running
-                The Pod has been bound to a node, and all of the Containers have been created.
-                At least one Container is still running, or is in the process of starting or restarting.
-            Succeeded
-                All Containers in the Pod have terminated in success, and will not be restarted.
-            Failed
-                All Containers in the Pod have terminated, and at least one Container has terminated
-                in failure. That is, the Container either exited with non-zero status or was terminated
-                by the system.
-            Unknown
-                For some reason the state of the Pod could not be obtained,
-                typically due to an error in communicating with the host of the Pod.
-            """
+        Pending
+            The Pod has been accepted by the Kubernetes system, but one or more of the Container images
+            has not been created. This includes time before being scheduled as well as time spent
+            downloading images over the network, which could take a while.
+        Running
+            The Pod has been bound to a node, and all of the Containers have been created.
+            At least one Container is still running, or is in the process of starting or restarting.
+        Succeeded
+            All Containers in the Pod have terminated in success, and will not be restarted.
+        Failed
+            All Containers in the Pod have terminated, and at least one Container has terminated in failure
+            That is, the Container either exited with non-zero status or was terminated by the system.
+        Unknown
+            For some reason the state of the Pod could not be obtained,
+            typically due to an error in communicating with the host of the Pod.
+        """
 
-            # When your Kubernetes cluster is not performing well or get too old resource version exception
-            # it is possible that the log stream will be interrupted and lost 'Exit Code'.
-            # Therefore we use a simple retry mechanism and try to get pod phase status.
-            # Keep polling as long as the driver is processing
-            while self._spark_exit_code not in ["Succeeded", "Failed","Unknown"]:
+        # When your Kubernetes cluster is not performing well or get too old resource version exception
+        # it is possible that the log stream will be interrupted and lost 'Exit Code'.
+        # Therefore we use a simple retry mechanism and try to get pod phase status.
+        # Keep polling as long as the driver is processing
+        while self._spark_exit_code not in ["Succeeded", "Failed", "Unknown"]:
 
-                # Sleep for n seconds as we do not want to spam the cluster
-                time.sleep(self._status_poll_interval)
+            # Sleep for n seconds as we do not want to spam the cluster
+            time.sleep(self._status_poll_interval)
 
-                self.log.debug("polling status of spark driver pod with id %s", self._kubernetes_driver_pod)
+            self.log.debug("polling status of spark driver pod with id %s", self._kubernetes_driver_pod)
 
-                try:
-                    import kubernetes
-                    client = kube_client.get_kube_client()
-                    phaseStatus = client.read_namespaced_pod(
-                        self._kubernetes_driver_pod,
-                        self._connection['namespace'],
-                        async_req=False,
-                        pretty=True).status.phase
-                    if phaseStatus == 'Succeeded':
-                        self._spark_exit_code = 0
-                    else:
-                        self._spark_exit_code = phaseStatus
+            try:
+                client = kube_client.get_kube_client()
+                phase_status = client.read_namespaced_pod(
+                    self._kubernetes_driver_pod,
+                    self._connection['namespace'],
+                    async_req=False,
+                    pretty=True).status.phase
+                if phase_status == 'Succeeded':
+                    self._spark_exit_code = 0
+                else:
+                    self._spark_exit_code = phase_status
 
-                except kube_client.ApiException as e:
-                    self.log.error("Exception when attempting to poll status of spark driver pod on K8s")
-                    self.log.exception(e)
+            except kube_client.ApiException as e:
+                self.log.error("Exception when attempting to poll status of spark driver pod on K8s")
+                self.log.exception(e)
 
     def _build_spark_driver_kill_command(self):
         """

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -444,15 +444,14 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         retry_delay_by_describe_cmd = 300
         retry_time = 1
         while(self._spark_exit_code is None and retry_time <= max_retry_times_by_describe_cmd):
-            self.log.info("log stream lost, the {} time(s) trying cmd kubectl describe pod...", retry_time)
+            self.log.info("log interrupt, the {} time(s) trying...", retry_time)
             time.sleep(retry_delay_by_describe_cmd)
             spark_exit_code = self._get_exitcode_by_k8s_describe_cmd()
             if spark_exit_code:
                 self._spark_exit_code = spark_exit_code
-                self.log.info("after lost log stream,get Exit Code:{}", self._spark_exit_code)
+                self.log.info("get Exit Code:{}", self._spark_exit_code)
                 break
-            else:
-                self.log.info("after lost log stream,did not get exit code, try next time")
+            self.log.info("no exit code return, try next time")
             retry_time += 1
 
     def _get_exitcode_by_k8s_describe_cmd(self):

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -620,7 +620,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                         pretty=True).status.phase
                     if phaseStatus == 'Succeeded':
                         self._spark_exit_code = 0
-                    else
+                    else:
                         self._spark_exit_code = phaseStatus
 
                 except kube_client.ApiException as e:

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -624,6 +624,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             except kube_client.ApiException as e:
                 self.log.error("Exception when attempting to poll status of spark driver pod on K8s")
                 self.log.exception(e)
+                # deal with ModuleNotFoundError: No module named 'kubernetes'
+                break
 
     def _build_spark_driver_kill_command(self):
         """


### PR DESCRIPTION
#8963 

## Description

I am using airflow SparkSubmitOperator to schedule my spark jobs on kubernetes cluster. 

But for some reason, kubernetes often throw 'too old resource version' exception which will interrupt spark watcher, then airflow will lost the log stream and could not get 'Exit Code' eventually. So airflow will mark job failed once log stream lost but the job is still running.

This is  a solution about an simple retry mechanism which is when the log stream is interrupted, then airflow try to get 'Exit Code' by 'kubectl describe pod xxxx-driver ' command.

--------
## update
There is no method like cmd 'describe pod ' in kubernetes python client api, so call 'read_namespaced_pod()' to get spark driver pod status instead.

## Target Github ISSUE

https://github.com/apache/airflow/issues/8963

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.