### PR TITLE
fix db init console print

### DIFF
--- a/airflow/migrations/versions/b3b105409875_add_root_dag_id_to_dag.py
+++ b/airflow/migrations/versions/b3b105409875_add_root_dag_id_to_dag.py
@@ -17,9 +17,11 @@
 # under the License.
 
 """add root_dag_id to DAG
+
 Revision ID: b3b105409875
 Revises: d38e04c12aa2
 Create Date: 2019-09-28 23:20:01.744775
+
 """
 
 import sqlalchemy as sa


### PR DESCRIPTION
run 'python -m airflow db init' will print extra information from migration file.

```
INFO  [alembic.runtime.migration] Running upgrade 6e96a59344a4 -> d38e04c12aa2, add serialized_dag table                                                        
INFO  [alembic.runtime.migration] Running upgrade d38e04c12aa2 -> b3b105409875, add root_dag_id to DAG                                                          
Revision ID: b3b105409875                                                                                                                                       
Revises: d38e04c12aa2                                                                                                                                           
Create Date: 2019-09-28 23:20:01.744775                                                                                                                         
INFO  [alembic.runtime.migration] Running upgrade 6e96a59344a4 -> 74effc47d867, change datetime to datetime2(6) on MSSQL tables         
```                        
