### PR TITLE
Add airflow plugin command

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -109,7 +109,9 @@ labelPRBasedOnFilePath:
     - docs/lineage.rst
 
   area:Plugins:
+    - airflow/cli/commands/plugins_command.py
     - airflow/plugins_manager.py
+    - tests/cli/commands/test_plugins_command.py
     - tests/plugins/*
     - docs/plugins.rst
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1245,6 +1245,12 @@ airflow_commands: List[CLICommand] = [
         func=lazy_load_command('airflow.cli.commands.info_command.show_info'),
         args=(ARG_ANONYMIZE, ARG_FILE_IO, ),
     ),
+    ActionCommand(
+        name='plugins',
+        help='Dump information about loaded plugins',
+        func=lazy_load_command('airflow.cli.commands.plugins_command.dump_plugins'),
+        args=(),
+    ),
     GroupCommand(
         name="celery",
         help=(

--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import shutil
+from pprint import pprint
+
+from airflow import plugins_manager
+
+# list to maintain the order of items.
+PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP = [
+    "plugins",
+    "import_errors",
+    "operators_modules",
+    "sensors_modules",
+    "hooks_modules",
+    "macros_modules",
+    "executors_modules",
+    "admin_views",
+    "flask_blueprints",
+    "menu_links",
+    "flask_appbuilder_views",
+    "flask_appbuilder_menu_links",
+    "global_operator_extra_links",
+    "operator_extra_links",
+    "registered_operator_link_classes",
+]
+# list to maintain the order of items.
+PLUGINS_ATTRIBUTES_TO_DUMP = [
+    "operators",
+    "sensors",
+    "hooks",
+    "executors",
+    "macros",
+    "admin_views",
+    "flask_blueprints",
+    "menu_links",
+    "appbuilder_views",
+    "appbuilder_menu_items",
+    "global_operator_extra_links",
+    "operator_extra_links",
+]
+
+
+def _header(text, fillchar):
+    terminal_size_size = shutil.get_terminal_size((80, 20))
+    print(f" {text} ".center(terminal_size_size.columns, fillchar))
+
+
+def dump_plugins(args):
+    """Dump plugins information"""
+    plugins_manager.log.setLevel(logging.DEBUG)
+
+    plugins_manager.ensure_plugins_loaded()
+    plugins_manager.integrate_dag_plugins()
+    plugins_manager.integrate_executor_plugins()
+    plugins_manager.initialize_extra_operators_links_plugins()
+    plugins_manager.initialize_web_ui_plugins()
+
+    _header("PLUGINS MANGER:", "#")
+
+    for attr_name in PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP:
+        attr_value = getattr(plugins_manager, attr_name)
+        print(f"{attr_name} = ", end='')
+        pprint(attr_value)
+    print()
+
+    _header("PLUGINS:", "#")
+    if not plugins_manager.plugins:
+        print("No plugins loaded")
+    else:
+        print(f"Loaded {len(plugins_manager.plugins)} plugins")
+        for plugin_no, plugin in enumerate(plugins_manager.plugins):
+            _header(f"{plugin_no} {plugin.name}", "=")
+            for attr_name in PLUGINS_ATTRIBUTES_TO_DUMP:
+                attr_value = getattr(plugin, attr_name)
+                print(f"{attr_name} = ", end='')
+                pprint(attr_value)
+            print()

--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -85,7 +85,7 @@ def dump_plugins(args):
     else:
         print(f"Loaded {len(plugins_manager.plugins)} plugins")
         for plugin_no, plugin in enumerate(plugins_manager.plugins):
-            _header(f"{plugin_no} {plugin.name}", "=")
+            _header(f"{plugin_no}. {plugin.name}", "=")
             for attr_name in PLUGINS_ATTRIBUTES_TO_DUMP:
                 attr_value = getattr(plugin, attr_name)
                 print(f"{attr_name} = ", end='')

--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -84,7 +84,7 @@ def dump_plugins(args):
         print("No plugins loaded")
     else:
         print(f"Loaded {len(plugins_manager.plugins)} plugins")
-        for plugin_no, plugin in enumerate(plugins_manager.plugins):
+        for plugin_no, plugin in enumerate(plugins_manager.plugins, 1):
             _header(f"{plugin_no}. {plugin.name}", "=")
             for attr_name in PLUGINS_ATTRIBUTES_TO_DUMP:
                 attr_value = getattr(plugin, attr_name)

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -28,6 +28,9 @@ The python modules in the ``plugins`` folder get imported,
 and **hooks**, **operators**, **sensors**, **macros** and web **views**
 get integrated to Airflow's main collections and become available for use.
 
+To troubleshoot plugins issue, you can use ``airflow plugins`` command.
+This command dumps information about loaded plugins.
+
 What for?
 ---------
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -28,7 +28,7 @@ The python modules in the ``plugins`` folder get imported,
 and **hooks**, **operators**, **sensors**, **macros** and web **views**
 get integrated to Airflow's main collections and become available for use.
 
-To troubleshoot plugins issue, you can use ``airflow plugins`` command.
+To troubleshoot issue with plugins, you can use ``airflow plugins`` command.
 This command dumps information about loaded plugins.
 
 What for?

--- a/tests/cli/commands/test_plugins_command.py
+++ b/tests/cli/commands/test_plugins_command.py
@@ -56,6 +56,20 @@ PLUGINS_MANAGER_NULLABLE_ATTRIBUTES = [
 
 @contextmanager
 def keep_plugin_manager_state():
+    """
+    Protects the initial state and sets the default state for the airflow.plugins module.
+
+    airflow.plugins_manager uses many global variables. To avoid side effects, this decorator performs
+    the following operations:
+
+    1. saves variables state,
+    2. set variables to default value,
+    3. executes context code,
+    4. restores the state of variables to the state from point 1.
+
+    Use this context if you want your test to not have side effects in airflow.plugins_manager, and
+    other tests do not affect the results of this test.
+    """
     with ExitStack() as exit_stack:
         for attr in PLUGINS_MANAGER_NULLABLE_ATTRIBUTES:
             exit_stack.enter_context(  # pylint: disable=no-member

--- a/tests/cli/commands/test_plugins_command.py
+++ b/tests/cli/commands/test_plugins_command.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from airflow.cli import cli_parser
+from airflow.cli.commands import plugins_command
+from airflow.models.baseoperator import BaseOperator
+from airflow.plugins_manager import AirflowPlugin
+
+
+class PluginOperator(BaseOperator):
+    pass
+
+
+class TestPlugin(AirflowPlugin):
+    name = "test-plugin-cli"
+
+    operators = [PluginOperator]
+
+
+class TestPluginsCommand(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @mock.patch('airflow.plugins_manager.plugins', [])
+    def test_should_display_no_plugins(self):
+        with redirect_stdout(io.StringIO()) as temp_stdout:
+            plugins_command.dump_plugins(self.parser.parse_args(['plugins']))
+            stdout = temp_stdout.getvalue()
+
+        self.assertIn('plugins = []', stdout)
+        self.assertIn('No plugins loaded', stdout)
+        self.assertIn("PLUGINS MANGER:", stdout)
+        self.assertIn("PLUGINS:", stdout)
+
+    @mock.patch('airflow.plugins_manager.plugins', [TestPlugin])
+    def test_should_display_one_plugins(self):
+        with redirect_stdout(io.StringIO()) as temp_stdout:
+            plugins_command.dump_plugins(self.parser.parse_args(['plugins']))
+            stdout = temp_stdout.getvalue()
+        self.assertIn('plugins = [<class ', stdout)
+        self.assertIn('test-plugin-cli', stdout)
+        self.assertIn('test_plugins_command.PluginOperator', stdout)


### PR DESCRIPTION
A small command that makes it easier to troubleshoot plugins.
```
[2020-05-24 22:02:21,845] {plugins_manager.py:224} DEBUG - Loading plugins
[2020-05-24 22:02:21,845] {plugins_manager.py:164} DEBUG - Loading plugins from directory: /opt/airflow/airflow/contrib/plugins
[2020-05-24 22:02:21,857] {plugins_manager.py:178} DEBUG - Importing plugin module /opt/airflow/airflow/contrib/plugins/metastore_browser/main.py
/opt/airflow/airflow/contrib/plugins/metastore_browser/main.py:45: FutureWarning: Passing a negative integer is deprecated in version 1.0 and will not be supported in future version. Instead, use None to not limit the column width.
  pd.set_option('display.max_colwidth', -1)
[2020-05-24 22:02:22,476] {plugins_manager.py:143} DEBUG - Loading plugins from entrypoints
[2020-05-24 22:02:22,508] {plugins_manager.py:218} DEBUG - Plugins are already loaded. Skipping.
[2020-05-24 22:02:22,508] {plugins_manager.py:362} DEBUG - Integrate DAG plugins
[2020-05-24 22:02:22,510] {plugins_manager.py:199} DEBUG - Creating module airflow.operators.metastore_browser
[2020-05-24 22:02:22,513] {plugins_manager.py:199} DEBUG - Creating module airflow.sensors.metastore_browser
[2020-05-24 22:02:22,513] {plugins_manager.py:199} DEBUG - Creating module airflow.hooks.metastore_browser
[2020-05-24 22:02:22,514] {plugins_manager.py:199} DEBUG - Creating module airflow.macros.metastore_browser
[2020-05-24 22:02:22,514] {plugins_manager.py:218} DEBUG - Plugins are already loaded. Skipping.
[2020-05-24 22:02:22,515] {plugins_manager.py:325} DEBUG - Integrate executor plugins
[2020-05-24 22:02:22,516] {plugins_manager.py:199} DEBUG - Creating module airflow.executors.metastore_browser
[2020-05-24 22:02:22,517] {plugins_manager.py:218} DEBUG - Plugins are already loaded. Skipping.
[2020-05-24 22:02:22,518] {plugins_manager.py:293} DEBUG - Initialize extra operators links plugins
[2020-05-24 22:02:22,518] {plugins_manager.py:218} DEBUG - Plugins are already loaded. Skipping.
[2020-05-24 22:02:22,519] {plugins_manager.py:256} DEBUG - Initialize Web UI plugin
########################################## PLUGINS MANGER: ##########################################
plugins = [<class 'main.MetastoreBrowserPlugin'>]
import_errors = {}
operators_modules = [<module 'airflow.operators.metastore_browser'>]
sensors_modules = [<module 'airflow.sensors.metastore_browser'>]
hooks_modules = [<module 'airflow.hooks.metastore_browser'>]
macros_modules = [<module 'airflow.macros.metastore_browser'>]
executors_modules = [<module 'airflow.executors.metastore_browser'>]
admin_views = []
flask_blueprints = [{'blueprint': <flask.blueprints.Blueprint object at 0x7f2c9b7f70f0>,
  'name': 'metastore_browser'}]
menu_links = []
flask_appbuilder_views = [{'category': 'Plugins',
  'name': 'Hive Metadata Browser',
  'view': <main.MetastoreBrowserView object at 0x7f2c888620b8>}]
flask_appbuilder_menu_links = []
global_operator_extra_links = []
operator_extra_links = []
registered_operator_link_classes = {}

############################################## PLUGINS: #############################################
Loaded 1 plugins
======================================= 1. metastore_browser ========================================
operators = []
sensors = []
hooks = []
executors = []
macros = []
admin_views = []
flask_blueprints = [<flask.blueprints.Blueprint object at 0x7f2c9b7f70f0>]
menu_links = []
appbuilder_views = [{'category': 'Plugins',
  'name': 'Hive Metadata Browser',
  'view': <main.MetastoreBrowserView object at 0x7f2c888620b8>}]
appbuilder_menu_items = []
global_operator_extra_links = []
operator_extra_links = []
```
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
