### PR TITLE
Add SlackAPIFileOperator impementing files.upload from Slack API

### DIFF
--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -157,6 +157,22 @@ class SlackAPIFileOperator(SlackAPIOperator):
     """
     Send a file to a slack channel
 
+    Examples:
+
+    .. code-block:: python
+
+        slack = SlackAPIFileOperator(
+            task_id="slack_file_upload",
+            dag=dag,
+            conn_id="slack",
+            channel="general",
+            initial_comment="Hello World!",
+            filename="hello_world.csv",
+            filetype="csv",
+            content="hello,world,csv,file",
+
+        )
+
     :param channel: channel in which to sent file on slack name (templated)
     :type channel: str
     :param initial_comment: message to send to slack. (templated)
@@ -197,3 +213,4 @@ class SlackAPIFileOperator(SlackAPIOperator):
             'filetype': self.filetype,
             'initial_comment': self.initial_comment
         }
+

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -165,7 +165,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
             task_id="slack_file_upload",
             dag=dag,
             slack_conn_id="slack",
-            channel="general",
+            channel="#general",
             initial_comment="Hello World!",
             filename="hello_world.csv",
             filetype="csv",

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -151,3 +151,49 @@ class SlackAPIPostOperator(SlackAPIOperator):
             'attachments': json.dumps(self.attachments),
             'blocks': json.dumps(self.blocks),
         }
+
+
+class SlackAPIFileOperator(SlackAPIOperator):
+    """
+    Send a file to a slack channel
+
+    :param channel: channel in which to sent file on slack name (templated)
+    :type channel: str
+    :param initial_comment: message to send to slack. (templated)
+    :type initial_comment: str
+    :param filename: name of the file (templated)
+    :type filename: str
+    :param filetype: slack filetype. (templated)
+        - see https://api.slack.com/types/file
+    :type filetype: str
+    :param content: file content. (templated)
+    :type content: str
+    """
+
+    template_fields = ('channel', 'initial_comment', 'filename', 'filetype', 'content')
+    ui_color = '#44BEDF'
+
+    @apply_defaults
+    def __init__(self,
+                 channel='#general',
+                 initial_comment='No message has been set!',
+                 filename='default_name.csv',
+                 filetype='csv',
+                 content='default,content,csv,file',
+                 *args, **kwargs):
+        self.method = 'files.upload'
+        self.channel = channel
+        self.initial_comment = initial_comment
+        self.filename = filename
+        self.filetype = filetype
+        self.content = content
+        super(SlackAPIFileOperator, self).__init__(method=self.method, *args, **kwargs)
+
+    def construct_api_call_params(self):
+        self.api_params = {
+            'channels': self.channel,
+            'content': self.content,
+            'filename': self.filename,
+            'filetype': self.filetype,
+            'initial_comment': self.initial_comment
+        }

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -191,11 +191,11 @@ class SlackAPIFileOperator(SlackAPIOperator):
 
     @apply_defaults
     def __init__(self,
-                 channel='#general',
-                 initial_comment='No message has been set!',
-                 filename='default_name.csv',
-                 filetype='csv',
-                 content='default,content,csv,file',
+                 channel: str = '#general',
+                 initial_comment: str = 'No message has been set!',
+                 filename: str = 'default_name.csv',
+                 filetype: str = 'csv',
+                 content: str = 'default,content,csv,file',
                  *args, **kwargs):
         self.method = 'files.upload'
         self.channel = channel
@@ -213,4 +213,3 @@ class SlackAPIFileOperator(SlackAPIOperator):
             'filetype': self.filetype,
             'initial_comment': self.initial_comment
         }
-

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -164,7 +164,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         slack = SlackAPIFileOperator(
             task_id="slack_file_upload",
             dag=dag,
-            conn_id="slack",
+            slack_conn_id="slack",
             channel="general",
             initial_comment="Hello World!",
             filename="hello_world.csv",

--- a/tests/providers/slack/operators/test_slack.py
+++ b/tests/providers/slack/operators/test_slack.py
@@ -21,7 +21,7 @@ import unittest
 
 import mock
 
-from airflow.providers.slack.operators.slack import SlackAPIPostOperator
+from airflow.providers.slack.operators.slack import SlackAPIPostOperator, SlackAPIFileOperator
 
 
 class TestSlackAPIPostOperator(unittest.TestCase):
@@ -145,5 +145,79 @@ class TestSlackAPIPostOperator(unittest.TestCase):
                         "airflow/master/airflow/www/static/pin_100.png",
             'attachments': '[]',
             'blocks': '[]',
+        }
+        self.assertEqual(expected_api_params, slack_api_post_operator.api_params)
+
+
+class TestSlackAPIFileOperator(unittest.TestCase):
+    def setUp(self):
+        self.test_username = 'test_username'
+        self.test_channel = '#test_slack_channel'
+        self.test_initial_comment = 'test text file test_filename.txt'
+        self.test_filename = 'test_filename.txt'
+        self.test_filetype = 'text'
+        self.test_content = 'This is a test text file!'
+
+        self.test_api_params = {'key': 'value'}
+
+        self.expected_method = 'files.upload'
+        self.expected_api_params = {
+            'channel': self.test_channel,
+            'initial_comment': self.test_initial_comment,
+            'filename': self.test_filename,
+            'filetype': self.test_filetype,
+            'content': self.test_content,
+        }
+
+    def __construct_operator(self, test_token, test_slack_conn_id, test_api_params=None):
+        return SlackAPIFileOperator(
+            task_id='slack',
+            token=test_token,
+            slack_conn_id=test_slack_conn_id,
+            channel=self.test_channel,
+            initial_comment=self.test_initial_comment,
+            filename=self.test_filename,
+            filetype=self.test_filetype,
+            content=self.test_content,
+            api_params=test_api_params,
+        )
+
+    def test_init_with_valid_params(self):
+        test_token = 'test_token'
+        test_slack_conn_id = 'test_slack_conn_id'
+
+        slack_api_post_operator = self.__construct_operator(test_token, None, self.test_api_params)
+        self.assertEqual(slack_api_post_operator.token, test_token)
+        self.assertEqual(slack_api_post_operator.slack_conn_id, None)
+        self.assertEqual(slack_api_post_operator.method, self.expected_method)
+        self.assertEqual(slack_api_post_operator.initial_comment, self.test_initial_comment)
+        self.assertEqual(slack_api_post_operator.channel, self.test_channel)
+        self.assertEqual(slack_api_post_operator.api_params, self.test_api_params)
+        self.assertEqual(slack_api_post_operator.filename, self.test_filename)
+        self.assertEqual(slack_api_post_operator.filetype, self.test_filetype)
+        self.assertEqual(slack_api_post_operator.content, self.test_content)
+
+        slack_api_post_operator = self.__construct_operator(None, test_slack_conn_id)
+        self.assertEqual(slack_api_post_operator.token, None)
+        self.assertEqual(slack_api_post_operator.slack_conn_id, test_slack_conn_id)
+
+    @mock.patch('airflow.providers.slack.operators.slack.SlackHook')
+    def test_api_call_params_with_default_args(self, mock_hook):
+        test_slack_conn_id = 'test_slack_conn_id'
+
+        slack_api_post_operator = SlackAPIFileOperator(
+            task_id='slack',
+            slack_conn_id=test_slack_conn_id,
+        )
+
+        slack_api_post_operator.execute()
+
+        expected_api_params = {
+            'channels': '#general',
+            'initial_comment': 'No message has been set!',
+            'filename': 'default_name.csv',
+            'filetype': 'csv',
+            'content': 'default,content,csv,file'
+
         }
         self.assertEqual(expected_api_params, slack_api_post_operator.api_params)

--- a/tests/providers/slack/operators/test_slack.py
+++ b/tests/providers/slack/operators/test_slack.py
@@ -21,7 +21,7 @@ import unittest
 
 import mock
 
-from airflow.providers.slack.operators.slack import SlackAPIPostOperator, SlackAPIFileOperator
+from airflow.providers.slack.operators.slack import SlackAPIFileOperator, SlackAPIPostOperator
 
 
 class TestSlackAPIPostOperator(unittest.TestCase):


### PR DESCRIPTION
Implementation of files.upload from Slack API. This operator will send files to any Slack channel.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
