### PR TITLE
Get connections uri with AWS Secrets Manager backend

### DIFF
--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -166,7 +166,8 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
                     port, database = self._get_port_and_database(secret)
 
                     conn_string = f'{conn_type}://{user}:{password}@{host}:{port}/{database}'
-                    connection = conn_string
+
+                    connection = self._get_extra(secret, conn_string)
             except UnboundLocalError:
                 conn_string = self._get_secret(conn_id)
                 connection = f'{{{conn_string[:-1]}}}'  # without this line, the secret_string

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -19,7 +19,6 @@
 Objects relating to sourcing secrets from AWS Secrets Manager
 """
 import ast
-from typing import Optional
 
 import boto3
 from cached_property import cached_property
@@ -60,10 +59,10 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
     def __init__(
         self,
-        connections_prefix: Optional[str] = None,
-        variables_prefix: Optional[str] = None,
-        profile_name: Optional[str] = None,
-        sep: Optional[str] = None,
+        connections_prefix=None,
+        variables_prefix=None,
+        profile_name=None,
+        sep=None,
         **kwargs
     ):
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -60,15 +60,23 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
     def __init__(
         self,
-        connections_prefix: str = 'airflow/connections',
-        variables_prefix: str = 'airflow/variables',
+        connections_prefix: Optional[str] = None,
+        variables_prefix: Optional[str] = None,
         profile_name: Optional[str] = None,
-        sep: str = "/",
+        sep: Optional[str] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
-        self.connections_prefix = connections_prefix.rstrip("/")
-        self.variables_prefix = variables_prefix.rstrip('/')
+
+        if connections_prefix:
+            self.connections_prefix = connections_prefix.rstrip('/')
+        else:
+            self.connections_prefix = connections_prefix
+        if variables_prefix:
+            self.variables_prefix = variables_prefix.rstrip('/')
+        else:
+            self.connections_prefix = variables_prefix
+
         self.profile_name = profile_name
         self.sep = sep
         self.kwargs = kwargs
@@ -90,7 +98,54 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: connection id
         :type conn_id: str
         """
-        return self._get_secret(self.connections_prefix, conn_id)
+        if self.connections_prefix and self.sep:
+            conn_id = self.build_path(self.connections_prefix, conn_id, self.sep)
+
+        try:
+            secret_string = self._get_secret(conn_id)
+            secret = ast.literal_eval(secret_string)
+
+            user = None
+            password = None
+            host = None
+
+            # These lines will check if we have with some denomination stored an username, password and host
+            for user_denomination in ['user', 'username', 'login']:
+                if user_denomination in secret:
+                    user = secret[user_denomination]
+            for password_denomination in ['pass', 'password', 'key']:
+                if password_denomination in secret:
+                    password = secret[password_denomination]
+            for host_denomination in ['host', 'remote_host', 'server']:
+                if host_denomination in secret:
+                    host = secret[host_denomination]
+
+            if user and password and host:
+                for type_word in ['conn_type', 'conn_id', 'connection_type', 'engine']:
+                    if type_word in secret:
+                        conn_type = secret[type_word]
+                        conn_type = 'postgresql' if conn_type == 'redshift' else conn_type
+                    else:
+                        conn_type = 'connection'
+
+                if 'port' in secret:
+                    port = secret['port']
+                else:
+                    port = 5432
+                if 'database' in secret:
+                    database = secret['database']
+                else:
+                    database = ''
+
+                conn_string = f'{conn_type}://{user}:{password}@{host}:{port}/{database}'
+
+                return conn_string
+            else:
+                conn_string = self._get_secret(conn_id)
+                return f'{{{conn_string[:-1]}}}'  # without this line, the secret_string will end with a bracket }
+                # and the literal_eval (needed later on to get the values from conn.schema) won't work
+        except ValueError:  # ('malformed node or string), when a conn is empty, i.e s3/aws conn in an EC2
+            pass
 
     def get_variable(self, key: str) -> Optional[str]:
         """
@@ -99,7 +154,9 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param key: Variable Key
         :return: Variable Value
         """
-        return self._get_secret(self.variables_prefix, key)
+        if self.variables_prefix and self.sep:
+            key = self.build_path(self.variables_prefix, key, self.sep)
+        return self._get_secret(key)
 
     def _get_secret(self, path_prefix: str, secret_id: str) -> Optional[str]:
         """

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -125,6 +125,20 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         return port, database
 
+    def _get_extra(self, secret, conn_string):
+        if 'extra' in secret:
+            extra_dict = ast.literal_eval(secret['extra'])
+            counter = 0
+            for key, value in extra_dict.values():
+                if counter == 0:
+                    conn_string += f'{key}={value}'
+                else:
+                    conn_string += f'&{key}={value}'
+
+                counter += 1
+
+        return conn_string
+
     def get_conn_uri(self, conn_id: str):
         """
         Get Connection Value
@@ -152,16 +166,6 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
                     port, database = self._get_port_and_database(secret)
 
                     conn_string = f'{conn_type}://{user}:{password}@{host}:{port}/{database}'
-
-                    if 'extra' in secret:
-                        extra_dict = ast.literal_eval(secret['extra'])
-                        counter = 0
-                        for key, value in extra_dict.values():
-                            if counter == 0:
-                                conn_string += f'{key}={value}'
-                            else:
-                                conn_string += f'&{key}={value}'
-
                     connection = conn_string
             except UnboundLocalError:
                 conn_string = self._get_secret(conn_id)

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -86,7 +86,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         )
         return session.client(service_name="secretsmanager", **self.kwargs)
 
-    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+    def get_conn_uri(self, conn_id: str):
         """
         Get Connection Value
 
@@ -133,14 +133,14 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
                     connection = conn_string
             except UnboundLocalError:
                 conn_string = self._get_secret(conn_id)
-                connection = f'{{{conn_string[:-1]}}}'  # without this line, the secret_string will end with a bracket }
-                # and the literal_eval won't work
+                connection = f'{{{conn_string[:-1]}}}'  # without this line, the secret_string
+                # will end with a bracket } # and the literal_eval won't work
         except ValueError:  # 'malformed node or string: ' error, for empty conns
             connection = None
 
         return connection
 
-    def get_variable(self, key: str) -> Optional[str]:
+    def get_variable(self, key: str):
         """
         Get Airflow Variable from Environment Variable
 
@@ -151,7 +151,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
             key = self.build_path(self.variables_prefix, key, self.sep)
         return self._get_secret(key)
 
-    def _get_secret(self, secret_id: str) -> Optional[str]:
+    def _get_secret(self, secret_id: str):
         """
         Get secret value from Secrets Manager
         :param secret_id: Secret Key

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -69,8 +69,12 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         if connections_prefix is not None:
             self.connections_prefix = connections_prefix.rstrip('/')
+        else:
+            self.connections_prefix = connections_prefix
         if variables_prefix is not None:
             self.variables_prefix = variables_prefix.rstrip('/')
+        else:
+            self.variables_prefix = variables_prefix
 
         self.profile_name = profile_name
         self.sep = sep


### PR DESCRIPTION
One of the main advantages of using AWS Secrets Manager is its ability to automatically create secrets of RDS databases and Redshift databases. Those secrets consist of several keys with their values, i.e user, pass, etc. Also, it is normal to store API Keys, sftp, or whatever using different values, as shown in the picture below:
![Captura de pantalla 2020-05-22 a las 10 41 07](https://user-images.githubusercontent.com/11339132/82648933-c23ac100-9c18-11ea-9f7c-6a36d0333bbe.png)

With the current code, all the keys and values obtained from a secret are stored in the schema attribute of the conn object, unless you have just one key with the conn_uri in the value. Thus, the current situation is forcing to use Secrets Manager in a way it is not intended to.

With this proposed modification, you can use AWS Secrets Manager using keys and values and have some kind of freedom to choose different words for each key to make the get_conn work.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
