### PR TITLE
Finding cross-provider dependencies fails when encoding wrong

### DIFF
--- a/tests/build_provider_packages_dependencies.py
+++ b/tests/build_provider_packages_dependencies.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import io
 import json
 import os
 import sys
@@ -153,8 +154,12 @@ def get_imports_from_file(file_name: str) -> List[str]:
     :param file_name: name of the file
     :return: list of import names
     """
-    with open(file_name) as f:
-        root = parse(f.read(), file_name)
+    try:
+        with io.open(file_name, "rt", encoding="utf-8") as f:
+            root = parse(f.read(), file_name)
+    except Exception:
+        print(f"Error when opening file {file_name}", file=sys.stderr)
+        raise
     visitor = ImportFinder(file_name)
     visitor.visit(root)
     return visitor.imports
@@ -243,7 +248,7 @@ if __name__ == '__main__':
         print(f"Written provider dependencies to the file {provider_dependencies_file_name}")
         print()
     if documentation_file_name:
-        with open(documentation_file_name, "r") as documentation_file:
+        with io.open(documentation_file_name, "r", encoding="utf-8") as documentation_file:
             text = documentation_file.readlines()
         replacing = False
         result: List[str] = []
@@ -256,7 +261,7 @@ if __name__ == '__main__':
                 replacing = False
             if not replacing:
                 result.append(line)
-        with open(documentation_file_name, "w") as documentation_file:
+        with io.open(documentation_file_name, "w", encoding="utf-8") as documentation_file:
             documentation_file.write("".join(result))
         print()
         print(f"Written package extras to the file {documentation_file_name}")


### PR DESCRIPTION
This forces encoding of read python files to utf-8

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
