### PR TITLE
Fix AwsGlueJobSensor

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -113,7 +113,7 @@ class AwsGlueJobHook(AwsBaseHook):
             self.log.error("Failed to run aws glue job, error: %s", general_error)
             raise
 
-    def get_job_state(self, job_name=None, run_id=None):
+    def get_job_state(self, job_name: str = None, run_id: str = None) -> str:
         """
         Get state of the Glue job. The job state can be
         running, finished, failed, stopped or timeout.
@@ -124,15 +124,15 @@ class AwsGlueJobHook(AwsBaseHook):
         :return: State of the Glue job
         """
         glue_client = self.get_conn()
-        job_status = glue_client.get_job_run(
+        job_run = glue_client.get_job_run(
             JobName=job_name,
             RunId=run_id,
             PredecessorsIncluded=True
         )
-        job_run_state = job_status['JobRun']['JobRunState']
+        job_run_state = job_run['JobRun']['JobRunState']
         return job_run_state
 
-    def job_completion(self, job_name=None, run_id=None):
+    def job_completion(self, job_name: str = None, run_id: str = None) -> Dict[str, str]:
         """
         Waits until Glue job with job_name completes or
         fails and return final state if finished.

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -108,14 +108,15 @@ class AwsGlueJobHook(AwsBaseHook):
                 JobName=job_name,
                 Arguments=script_arguments
             )
-            return self.job_completion(job_name, job_run['JobRunId'])
+            return job_run
         except Exception as general_error:
             self.log.error("Failed to run aws glue job, error: %s", general_error)
             raise
 
     def get_job_state(self, job_name=None, run_id=None):
         """
-        Get state of the Glue job. The job state can be running, finished, failed, stopped or timeout.
+        Get state of the Glue job. The job state can be
+        running, finished, failed, stopped or timeout.
         :param job_name: unique job name per AWS account
         :type job_name: str
         :param run_id: The job-run ID of the predecessor job run
@@ -133,7 +134,8 @@ class AwsGlueJobHook(AwsBaseHook):
 
     def job_completion(self, job_name=None, run_id=None):
         """
-        Waits until Glue job with job_name completes or fails and return final state if finished.
+        Waits until Glue job with job_name completes or
+        fails and return final state if finished.
         Raises AirflowException when the job failed
         :param job_name: unique job name per AWS account
         :type job_name: str

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -113,7 +113,7 @@ class AwsGlueJobHook(AwsBaseHook):
             self.log.error("Failed to run aws glue job, error: %s", general_error)
             raise
 
-    def get_job_state(self, job_name: str = None, run_id: str = None) -> str:
+    def get_job_state(self, job_name: str, run_id: str) -> str:
         """
         Get state of the Glue job. The job state can be
         running, finished, failed, stopped or timeout.
@@ -132,7 +132,7 @@ class AwsGlueJobHook(AwsBaseHook):
         job_run_state = job_run['JobRun']['JobRunState']
         return job_run_state
 
-    def job_completion(self, job_name: str = None, run_id: str = None) -> Dict[str, str]:
+    def job_completion(self, job_name: str, run_id: str) -> Dict[str, str]:
         """
         Waits until Glue job with job_name completes or
         fails and return final state if finished.

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -115,11 +115,12 @@ class AwsGlueJobHook(AwsBaseHook):
 
     def get_job_state(self, job_name=None, run_id=None):
         """
+        Get state of the Glue job. The job state can be running, finished, failed, stopped or timeout.
         :param job_name: unique job name per AWS account
         :type job_name: str
         :param run_id: The job-run ID of the predecessor job run
         :type run_id: str
-        :return: Status of the Job if succeeded or stopped
+        :return: State of the Glue job
         """
         glue_client = self.get_conn()
         job_status = glue_client.get_job_run(
@@ -132,6 +133,8 @@ class AwsGlueJobHook(AwsBaseHook):
 
     def job_completion(self, job_name=None, run_id=None):
         """
+        Waits until Glue job with job_name completes or fails and return final state if finished.
+        Raises AirflowException when the job failed
         :param job_name: unique job name per AWS account
         :type job_name: str
         :param run_id: The job-run ID of the predecessor job run

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -108,6 +108,7 @@ class AwsGlueJobOperator(BaseOperator):
                                   iam_role_name=self.iam_role_name)
         self.log.info("Initializing AWS Glue Job: %s", self.job_name)
         glue_job_run = glue_job.initialize_job(self.script_args)
+        glue_job_run = glue_job.job_completion(self.job_name, glue_job_run['JobRunId'])
         self.log.info(
             "AWS Glue Job: %s status: %s. Run Id: %s",
             self.job_name, glue_job_run['JobRunState'], glue_job_run['JobRunId'])

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -46,13 +46,13 @@ class AwsGlueJobSensor(BaseSensorOperator):
         self.aws_conn_id = aws_conn_id
         self.success_states = ['SUCCEEDED']
         self.errored_states = ['FAILED', 'STOPPED', 'TIMEOUT']
-        self.hook = AwsGlueJobHook(aws_conn_id=self.aws_conn_id)
 
     def poke(self, context):
+        hook = AwsGlueJobHook(aws_conn_id=self.aws_conn_id)
         self.log.info(
             "Poking for job run status :"
             "for Glue Job %s and ID %s", self.job_name, self.run_id)
-        job_state = self.hook.get_job_state(job_name=self.job_name, run_id=self.run_id)
+        job_state = hook.get_job_state(job_name=self.job_name, run_id=self.run_id)
         if job_state in self.success_states:
             self.log.info("Exiting Job %s Run State: %s", self.run_id, job_state)
             return True

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -52,8 +52,7 @@ class AwsGlueJobSensor(BaseSensorOperator):
             "Poking for job run status :"
             "for Glue Job %s and ID %s", self.job_name, self.run_id)
         hook = AwsGlueJobHook(aws_conn_id=self.aws_conn_id)
-        job_state = hook.job_completion(job_name=self.job_name,
-                                        run_id=self.run_id)
+        job_state = hook.get_job_state(job_name=self.job_name, run_id=self.run_id)
         if job_state in self.success_states:
             self.log.info("Exiting Job %s Run State: %s", self.run_id, job_state)
             return True

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -46,13 +46,13 @@ class AwsGlueJobSensor(BaseSensorOperator):
         self.aws_conn_id = aws_conn_id
         self.success_states = ['SUCCEEDED']
         self.errored_states = ['FAILED', 'STOPPED', 'TIMEOUT']
+        self.hook = AwsGlueJobHook(aws_conn_id=self.aws_conn_id)
 
     def poke(self, context):
         self.log.info(
             "Poking for job run status :"
             "for Glue Job %s and ID %s", self.job_name, self.run_id)
-        hook = AwsGlueJobHook(aws_conn_id=self.aws_conn_id)
-        job_state = hook.get_job_state(job_name=self.job_name, run_id=self.run_id)
+        job_state = self.hook.get_job_state(job_name=self.job_name, run_id=self.run_id)
         if job_state in self.success_states:
             self.log.info("Exiting Job %s Run State: %s", self.run_id, job_state)
             return True

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -43,11 +43,13 @@ class TestAwsGlueJobOperator(unittest.TestCase):
                                        s3_bucket='some_bucket',
                                        iam_role_name='my_test_role')
 
+    @mock.patch.object(AwsGlueJobHook, 'get_job_state')
     @mock.patch.object(AwsGlueJobHook, 'initialize_job')
     @mock.patch.object(AwsGlueJobHook, "get_conn")
     @mock.patch.object(S3Hook, "load_file")
-    def test_execute_without_failure(self, mock_load_file, mock_get_conn, mock_initialize_job):
+    def test_execute_without_failure(self, mock_load_file, mock_get_conn, mock_initialize_job, mock_get_job_state):
         mock_initialize_job.return_value = {'JobRunState': 'RUNNING', 'JobRunId': '11111'}
+        mock_get_job_state.return_value = 'SUCCEEDED'
         self.glue.execute(None)
 
         mock_initialize_job.assert_called_once_with({})

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -47,7 +47,11 @@ class TestAwsGlueJobOperator(unittest.TestCase):
     @mock.patch.object(AwsGlueJobHook, 'initialize_job')
     @mock.patch.object(AwsGlueJobHook, "get_conn")
     @mock.patch.object(S3Hook, "load_file")
-    def test_execute_without_failure(self, mock_load_file, mock_get_conn, mock_initialize_job, mock_get_job_state):
+    def test_execute_without_failure(self,
+                                     mock_load_file,
+                                     mock_get_conn,
+                                     mock_initialize_job,
+                                     mock_get_job_state):
         mock_initialize_job.return_value = {'JobRunState': 'RUNNING', 'JobRunId': '11111'}
         mock_get_job_state.return_value = 'SUCCEEDED'
         self.glue.execute(None)

--- a/tests/providers/amazon/aws/sensors/test_glue.py
+++ b/tests/providers/amazon/aws/sensors/test_glue.py
@@ -32,10 +32,10 @@ class TestAwsGlueJobSensor(unittest.TestCase):
         configuration.load_test_config()
 
     @mock.patch.object(AwsGlueJobHook, 'get_conn')
-    @mock.patch.object(AwsGlueJobHook, 'job_completion')
-    def test_poke(self, mock_job_completion, mock_conn):
+    @mock.patch.object(AwsGlueJobHook, 'get_job_state')
+    def test_poke(self, mock_get_job_state, mock_conn):
         mock_conn.return_value.get_job_run()
-        mock_job_completion.return_value = 'SUCCEEDED'
+        mock_get_job_state.return_value = 'SUCCEEDED'
         op = AwsGlueJobSensor(task_id='test_glue_job_sensor',
                               job_name='aws_test_glue_job',
                               run_id='5152fgsfsjhsh61661',
@@ -45,10 +45,10 @@ class TestAwsGlueJobSensor(unittest.TestCase):
         self.assertTrue(op.poke(None))
 
     @mock.patch.object(AwsGlueJobHook, 'get_conn')
-    @mock.patch.object(AwsGlueJobHook, 'job_completion')
-    def test_poke_false(self, mock_job_completion, mock_conn):
+    @mock.patch.object(AwsGlueJobHook, 'get_job_state')
+    def test_poke_false(self, mock_get_job_state, mock_conn):
         mock_conn.return_value.get_job_run()
-        mock_job_completion.return_value = 'RUNNING'
+        mock_get_job_state.return_value = 'RUNNING'
         op = AwsGlueJobSensor(task_id='test_glue_job_sensor',
                               job_name='aws_test_glue_job',
                               run_id='5152fgsfsjhsh61661',


### PR DESCRIPTION
There is a mismatch between return value of job_completion of AwsGlueJobHook and end condition in poke of AwsGlueJobSensor. While job_completion returns a dictionary of JobRunState and JobRunId, poke checks if it is 'SUCCEEDED' or 'FAILED' which should be only JobRunState. So the condition always fails and poke always returns False which leads GlueSensor to run indefinitely even if Glue job finished.
Also, I think while loop in job_completion is useless. It should return immediately after it gets response from glue client but doesn't have to wait until it finishes or fails. It is duplicated with execution loop of Sensor.

Closes: https://github.com/apache/airflow/issues/9021

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
