### PR TITLE
Deploy a Dataproc cluster on top of a GKE cluster

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -154,8 +154,9 @@ class ClusterGenerator:
     :param customer_managed_key: The customer-managed key used for disk encryption
         ``projects/[PROJECT_STORING_KEYS]/locations/[LOCATION]/keyRings/[KEY_RING_NAME]/cryptoKeys/[KEY_NAME]`` # noqa # pylint: disable=line-too-long
     :type customer_managed_key: str
-    :param gke_cluster: Optional: The GKE cluster's name hosting the Dataproc cluster
-    type: gke_cluster: str
+    :param gke_cluster: Optional: The GKE cluster's name hosting the 
+        Dataproc cluster.
+    type gke_cluster: str
     """
     # pylint: disable=too-many-arguments,too-many-locals
     def __init__(self,

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -318,49 +318,49 @@ class ClusterGenerator:
         else:
             master_type_uri = self.master_machine_type
             worker_type_uri = self.worker_machine_type
-
+  
         cluster_data = {
-            'projectId': self.project_id,
-            'clusterName': self.cluster_name,
+            'project_id': self.project_id,
+            'cluster_name': self.cluster_name,
             'config': {
-                'gceClusterConfig': {
+                'gce_cluster_config': {
                 },
-                'masterConfig': {
-                    'numInstances': self.num_masters,
-                    'machineTypeUri': master_type_uri,
-                    'diskConfig': {
-                        'bootDiskType': self.master_disk_type,
-                        'bootDiskSizeGb': self.master_disk_size
+                'master_config': {
+                    'num_instances': self.num_masters,
+                    'machine_type_uri': master_type_uri,
+                    'disk_config': {
+                        'boot_disk_type': self.master_disk_type,
+                        'boot_disk_size_gb': self.master_disk_size
                     }
                 },
-                'workerConfig': {
-                    'numInstances': self.num_workers,
-                    'machineTypeUri': worker_type_uri,
-                    'diskConfig': {
-                        'bootDiskType': self.worker_disk_type,
-                        'bootDiskSizeGb': self.worker_disk_size
+                'worker_config': {
+                    'num_instances': self.num_workers,
+                    'machine_type_uri': worker_type_uri,
+                    'disk_config': {
+                        'boot_disk_type': self.worker_disk_type,
+                        'boot_disk_size_gb': self.worker_disk_size
                     }
                 },
-                'secondaryWorkerConfig': {},
-                'softwareConfig': {},
-                'lifecycleConfig': {},
-                'encryptionConfig': {},
-                'autoscalingConfig': {},
+                'secondary_worker_config': {},
+                'software_config': {},
+                'lifecycle_config': {},
+                'encryption_config': {},
+                'autoscaling_config': {},
             }
         } if self.gke_cluster is None else {
             # Deploy Dataproc on a running GKE cluster
-            'projectId': self.project_id,
-            'clusterName': self.cluster_name,
+            'project_id': self.project_id,
+            'cluster_name': self.cluster_name,
             'config': {
-                'gkeClusterConfig': {
-                    'namespacedGkeDeploymentTarget': {
-                        'targetGkeCluster': f"projects/{self.project_id}/locations/{self.region}/clusters/{self.gke_cluster}"
+                'gke_cluster_config': {
+                    'namespaced_gke_deployment_target': {
+                        'target_gke_cluster': f"projects/{self.project_id}/locations/{self.region}/clusters/{self.gke_cluster}"
                     }
                 },
-                'softwareConfig': {
-                    'imageVersion': self.image_version
+                'software_config': {
+                    'image_version': self.image_version
                 },
-                'configBucket': self.storage_bucket
+                'config_bucket': self.storage_bucket
             }
         }
         if self.num_preemptible_workers > 0:


### PR DESCRIPTION
Add the possibility to deploy a Dataproc cluster on top of a running GKE cluster. This feature has recently been released in open beta : https://cloud.google.com/dataproc/docs/concepts/jobs/dataproc-gke.

This was tested on a Composer cluster using the deprecated code of https://github.com/apache/airflow/blob/master/airflow/contrib/operators/dataproc_operator.py as a Composer plugins and it worked. 

I adapted the code to this new format but I am not able to test it since Composer doesn't use the last version of Airflow: I say that because I get the error `... airflow.providers is not recognized...` or something similar in the Airflow UI but I am may be missing something.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
