### PR TITLE
Ensure Kerberos token is valid in SparkSubmitOperator before running `yarn kill`

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -21,8 +21,10 @@ import re
 import subprocess
 import time
 
+from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
+from airflow.security.kerberos import renew_from_kt
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 try:
@@ -617,15 +619,23 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             self._submit_sp.kill()
 
             if self._yarn_application_id:
-                self.log.info('Killing application %s on YARN', self._yarn_application_id)
-
                 kill_cmd = "yarn application -kill {}" \
                     .format(self._yarn_application_id).split()
+                env = None
+                if self._keytab is not None and self._principal is not None:
+                    # we are ignoring renewal failures from renew_from_kt
+                    # here as the failure could just be due to a non-renewable ticket,
+                    # we still attempt to kill the yarn application
+                    renew_from_kt(self._principal, self._keytab, exit_on_fail=False)
+                    env = os.environ.copy()
+                    env["KRB5CCNAME"] = airflow_conf.get('kerberos', 'ccache')
+
                 yarn_kill = subprocess.Popen(kill_cmd,
+                                             env=env,
                                              stdout=subprocess.PIPE,
                                              stderr=subprocess.PIPE)
 
-                self.log.info("YARN killed with return code: %s", yarn_kill.wait())
+                self.log.info("YARN app killed with return code: %s", yarn_kill.wait())
 
             if self._kubernetes_driver_pod:
                 self.log.info('Killing pod %s on Kubernetes', self._kubernetes_driver_pod)

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -654,7 +654,7 @@ class TestSparkSubmitHook(unittest.TestCase):
 
     @patch('airflow.providers.apache.spark.hooks.spark_submit.renew_from_kt')
     @patch('airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen')
-    def test_yarn_process_on_kill(self, mock_popen, mock_krb):
+    def test_yarn_process_on_kill(self, mock_popen, mock_renew_from_kt):
         # Given
         mock_popen.return_value.stdout = io.StringIO('stdout')
         mock_popen.return_value.stderr = io.StringIO('stderr')


### PR DESCRIPTION
---

When the spark submit hook's `on_kill` is called, it tries to kill the yarn app, but doesn't do a kinit even if the keytab and principal is supplied. This would mean that the `yarn applicaition -kill <app id>` will  fail when yarn needs kerberos authentication, and the app will continue to run. 

This change tries to do an explicit `kinit` before killing the YARN app(if keytab and principal are provided).  
 
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
