### PR TITLE
Provide_context coma is added only when there is not one already

### DIFF
--- a/backport_packages/refactor_backport_packages.py
+++ b/backport_packages/refactor_backport_packages.py
@@ -18,6 +18,7 @@
 
 import os
 import sys
+import token
 from os.path import dirname
 from shutil import copyfile, copytree, rmtree
 from typing import List
@@ -211,7 +212,9 @@ class RefactorBackportPackages:
         # noinspection PyUnusedLocal
         def add_provide_context_to_python_operator(node: LN, capture: Capture, filename: Filename) -> None:
             fn_args = capture['function_arguments'][0]
-            fn_args.append_child(Comma())
+            if len(fn_args.children) > 0 and (not isinstance(fn_args.children[-1], Leaf)
+                                              or fn_args.children[-1].type != token.COMMA):
+                fn_args.append_child(Comma())
 
             provide_context_arg = KeywordArg(Name('provide_context'), Name('True'))
             provide_context_arg.prefix = fn_args.children[0].prefix


### PR DESCRIPTION
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
