### PR TITLE
ADD ldap and self-signed certificate

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1519,6 +1519,12 @@
       type: string
       example: ~
       default: "False"
+    - name: cert_validation
+      description: one of CERT_NONE or CERT_OPTIONAL or CERT_REQUIRED
+      version_added: 1.10.11
+      type: string
+      example: ~
+      default: "CERT_REQUIRED"
 - name: mesos
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -703,6 +703,7 @@ bind_password = insecure
 basedn = dc=example,dc=com
 cacert = /etc/ca/ldap_ca.crt
 search_scope = LEVEL
+cert_validation = CERT_REQUIRED
 
 # This setting allows the use of LDAP servers that either return a
 # broken schema, or do not return a schema.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -93,6 +93,16 @@ LDAP
 To turn on LDAP authentication configure your ``airflow.cfg`` as follows. Please note that the example uses
 an encrypted connection to the ldap server as we do not want passwords be readable on the network level.
 
+If you are using LDAPS with self-signed certificate you'll need to change the `cert_validation` configuration
+for `CERT_OPTIONAL`. By default the certificate is checked and validated. The three values possibles for the
+configuration of the validation are:
+
+  * `CERT_NONE`: certificate ignored
+  * `CERT_OPTIONAL`: certificate not required, but validated if provided
+  * `CERT_REQUIRED` by default: certificate required and validated
+
+Check the `TLS documentation of the ldap3 library <https://ldap3.readthedocs.io/en/latest/ssltls.html>` for more information.
+
 Additionally, if you are using Active Directory, and are not explicitly specifying an OU that your users are in,
 you will need to change ``search_scope`` to "SUBTREE".
 


### PR DESCRIPTION
Fixes issue #9063 : LDAPS forces ssl.CERT_REQUIRED preventing the use of self-signed certificates 