### PR TITLE
Add num-executions to the "dags next_execution" cli command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -99,7 +99,7 @@ class Arg:
         parser.add_argument(*self.flags, **self.kwargs)
 
 
-def positive_int_type(value):
+def positive_int(value):
     """Define a positive int type for an argument."""
     value = int(value)
     if value > 0:
@@ -195,7 +195,7 @@ ARG_LIMIT = Arg(
 ARG_NUM_EXECUTIONS = Arg(
     ("-n", "--num-executions"),
     default=1,
-    type=positive_int_type,
+    type=positive_int,
     help="The number of next execution datetimes to show")
 
 # backfill

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -99,6 +99,15 @@ class Arg:
         parser.add_argument(*self.flags, **self.kwargs)
 
 
+def positive_int_type(value):
+    """Define a positive int type for an argument."""
+    value = int(value)
+    if value > 0:
+        return value
+    else:
+        raise argparse.ArgumentTypeError(f"invalid positive int value: '{value}'")
+
+
 # Shared
 ARG_DAG_ID = Arg(
     ("dag_id",),
@@ -186,7 +195,7 @@ ARG_LIMIT = Arg(
 ARG_NUM_EXECUTIONS = Arg(
     ("-n", "--num-executions"),
     default=1,
-    type=int,
+    type=positive_int_type,
     help="The number of next execution datetimes to show")
 
 # backfill

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -182,6 +182,13 @@ ARG_LIMIT = Arg(
     ("--limit",),
     help="Return a limited number of records")
 
+# next_execution
+ARG_NUM_EXECUTIONS = Arg(
+    ("-n", "--num-executions"),
+    default=1,
+    type=int,
+    help="The number of next execution datetimes to show")
+
 # backfill
 ARG_MARK_SUCCESS = Arg(
     ("-m", "--mark-success"),
@@ -793,9 +800,10 @@ DAGS_COMMANDS = (
     ),
     ActionCommand(
         name='next_execution',
-        help="Get the next execution datetime of a DAG",
+        help="Get the next execution datetimes of a DAG. It returns one execution unless the "
+             "num-executions option is given",
         func=lazy_load_command('airflow.cli.commands.dag_command.dag_next_execution'),
-        args=(ARG_DAG_ID, ARG_SUBDIR),
+        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_NUM_EXECUTIONS),
     ),
     ActionCommand(
         name='pause',

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -101,11 +101,13 @@ class Arg:
 
 def positive_int(value):
     """Define a positive int type for an argument."""
-    value = int(value)
-    if value > 0:
-        return value
-    else:
-        raise argparse.ArgumentTypeError(f"invalid positive int value: '{value}'")
+    try:
+        value = int(value)
+        if value > 0:
+            return value
+    except ValueError:
+        pass
+    raise argparse.ArgumentTypeError(f"invalid positive int value: '{value}'")
 
 
 # Shared

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -275,7 +275,7 @@ def dag_next_execution(args):
     dag = get_dag(args.subdir, args.dag_id)
 
     if dag.get_is_paused():
-        print("[INFO] Please be reminded this DAG is PAUSED now.")
+        print("[INFO] Please be reminded this DAG is PAUSED now.", file=sys.stderr)
 
     if args.num_executions <= 0:
         print(None)

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -277,10 +277,6 @@ def dag_next_execution(args):
     if dag.get_is_paused():
         print("[INFO] Please be reminded this DAG is PAUSED now.", file=sys.stderr)
 
-    if args.num_executions <= 0:
-        print(None)
-        return
-
     latest_execution_date = dag.get_latest_execution_date()
     if latest_execution_date:
         next_execution_dttm = dag.following_schedule(latest_execution_date)

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -296,7 +296,7 @@ def dag_next_execution(args):
                 next_execution_dttm = dag.following_schedule(next_execution_dttm)
                 print(next_execution_dttm)
     else:
-        print("[WARN] Only applicable when there is execution record found for the DAG.")
+        print("[WARN] Only applicable when there is execution record found for the DAG.", file=sys.stderr)
         print(None)
 
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -277,6 +277,10 @@ def dag_next_execution(args):
     if dag.get_is_paused():
         print("[INFO] Please be reminded this DAG is PAUSED now.")
 
+    if args.num_executions <= 0:
+        print(None)
+        return
+
     latest_execution_date = dag.get_latest_execution_date()
     if latest_execution_date:
         next_execution_dttm = dag.following_schedule(latest_execution_date)
@@ -284,8 +288,13 @@ def dag_next_execution(args):
         if next_execution_dttm is None:
             print("[WARN] No following schedule can be found. " +
                   "This DAG may have schedule interval '@once' or `None`.")
+            print(None)
+        else:
+            print(next_execution_dttm)
 
-        print(next_execution_dttm)
+            for _ in range(1, args.num_executions):
+                next_execution_dttm = dag.following_schedule(next_execution_dttm)
+                print(next_execution_dttm)
     else:
         print("[WARN] Only applicable when there is execution record found for the DAG.")
         print(None)

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -287,7 +287,7 @@ def dag_next_execution(args):
 
         if next_execution_dttm is None:
             print("[WARN] No following schedule can be found. " +
-                  "This DAG may have schedule interval '@once' or `None`.")
+                  "This DAG may have schedule interval '@once' or `None`.", file=sys.stderr)
             print(None)
         else:
             print(next_execution_dttm)

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -20,11 +20,10 @@ import io
 import os
 import tempfile
 import unittest
-from datetime import datetime, time, timedelta
+from datetime import datetime, timedelta
 
 import mock
 import pytest
-import pytz
 
 from airflow import settings
 from airflow.cli import cli_parser
@@ -249,10 +248,10 @@ class TestCliDags(unittest.TestCase):
             dr = session.query(DagRun).filter(DagRun.dag_id.in_(dag_ids))
             dr.delete(synchronize_session=False)
 
+        # Test None output
         args = self.parser.parse_args(['dags',
                                        'next_execution',
                                        dag_ids[0]])
-
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
             dag_command.dag_next_execution(args)
             out = temp_stdout.getvalue()
@@ -260,25 +259,30 @@ class TestCliDags(unittest.TestCase):
             # It prints `None` in such cases
             self.assertIn("None", out)
 
-        # The details below is determined by the schedule_interval of example DAGs
-        now = DEFAULT_DATE
-        next_execution_time_for_dag1 = pytz.utc.localize(
-            datetime.combine(
-                now.date() + timedelta(days=1),
-                time(0)
-            )
-        )
-        next_execution_time_for_dag2 = now + timedelta(hours=4)
-        expected_output = [str(next_execution_time_for_dag1),
-                           str(next_execution_time_for_dag2),
-                           "None",
-                           "None"]
-
-        for i, dag_id in enumerate(dag_ids):
+        # Test invalid num-executions
+        for i in ['0', '-1']:
             args = self.parser.parse_args(['dags',
                                            'next_execution',
-                                           dag_id])
+                                           dag_ids[0],
+                                           '--num-executions',
+                                           i])
+            with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+                dag_command.dag_next_execution(args)
+                out = temp_stdout.getvalue()
+                self.assertIn("None", out)
 
+        # The details below is determined by the schedule_interval of example DAGs
+        now = DEFAULT_DATE
+        expected_output = [str(now + timedelta(days=1)),
+                           str(now + timedelta(hours=4)),
+                           "None",
+                           "None"]
+        expected_output_2 = [str(now + timedelta(days=1)) + os.linesep + str(now + timedelta(days=2)),
+                             str(now + timedelta(hours=4)) + os.linesep + str(now + timedelta(hours=8)),
+                             "None",
+                             "None"]
+
+        for i, dag_id in enumerate(dag_ids):
             dag = self.dagbag.dags[dag_id]
             # Create a DagRun for each DAG, to prepare for next step
             dag.create_dagrun(
@@ -288,10 +292,25 @@ class TestCliDags(unittest.TestCase):
                 state=State.FAILED
             )
 
+            # Test num-executions = 1 (default)
+            args = self.parser.parse_args(['dags',
+                                           'next_execution',
+                                           dag_id])
             with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
                 dag_command.dag_next_execution(args)
                 out = temp_stdout.getvalue()
             self.assertIn(expected_output[i], out)
+
+            # Test num-executions = 2
+            args = self.parser.parse_args(['dags',
+                                           'next_execution',
+                                           dag_id,
+                                           '--num-executions',
+                                           '2'])
+            with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+                dag_command.dag_next_execution(args)
+                out = temp_stdout.getvalue()
+            self.assertIn(expected_output_2[i], out)
 
         # Clean up before leaving
         with create_session() as session:

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -259,18 +259,6 @@ class TestCliDags(unittest.TestCase):
             # It prints `None` in such cases
             self.assertIn("None", out)
 
-        # Test invalid num-executions
-        for i in ['0', '-1']:
-            args = self.parser.parse_args(['dags',
-                                           'next_execution',
-                                           dag_ids[0],
-                                           '--num-executions',
-                                           i])
-            with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
-                dag_command.dag_next_execution(args)
-                out = temp_stdout.getvalue()
-                self.assertIn("None", out)
-
         # The details below is determined by the schedule_interval of example DAGs
         now = DEFAULT_DATE
         expected_output = [str(now + timedelta(days=1)),

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -175,9 +175,9 @@ class TestCli(TestCase):
             with self.assertRaises(SystemExit):
                 parser.parse_args([*cmd_args, '--help'])
 
-    def test_positive_int_type(self):
-        self.assertEqual(1, cli_parser.positive_int_type('1'))
+    def test_positive_int(self):
+        self.assertEqual(1, cli_parser.positive_int('1'))
 
         with self.assertRaises(argparse.ArgumentTypeError):
-            cli_parser.positive_int_type('0')
-            cli_parser.positive_int_type('-1')
+            cli_parser.positive_int('0')
+            cli_parser.positive_int('-1')

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -174,3 +174,10 @@ class TestCli(TestCase):
         for cmd_args in all_command_as_args:
             with self.assertRaises(SystemExit):
                 parser.parse_args([*cmd_args, '--help'])
+
+    def test_positive_int_type(self):
+        self.assertEqual(1, cli_parser.positive_int_type('1'))
+
+        with self.assertRaises(argparse.ArgumentTypeError):
+            cli_parser.positive_int_type('0')
+            cli_parser.positive_int_type('-1')


### PR DESCRIPTION
Add `--num-executions` option to the `dags next_execution` sub-command. If the option is not present it defaults to 1, which is the command's current behavior. This option is particularly useful when analyzing irregular schedules, such as some resulting from Cron expressions.

The screenshot below shows the result of using `--num-executions 5` on a schedule generated by `0 2,3,10 * * *`.

![airflow_next_execution_n_5](https://user-images.githubusercontent.com/30055/83327792-e6b81e00-a254-11ea-8768-f67835271684.png)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
