### PR TITLE
Add metavar to CLI arguments

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1355,7 +1355,7 @@ def _add_action_command(sub: ActionCommand, sub_proc: argparse.ArgumentParser) -
 
 def _add_group_command(sub: GroupCommand, sub_proc: argparse.ArgumentParser) -> None:
     subcommands = sub.subcommands
-    sub_subparsers = sub_proc.add_subparsers(dest="subcommand", metavar="COMMNAD")
+    sub_subparsers = sub_proc.add_subparsers(dest="subcommand", metavar="COMMAND")
     sub_subparsers.required = True
 
     for command in sorted(subcommands, key=lambda x: x.name):

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -160,6 +160,7 @@ ARG_OUTPUT = Arg(
         "Output table format. The specified value is passed to "
         "the tabulate module (https://pypi.org/project/tabulate/). "
     ),
+    metavar="FORMAT",
     choices=tabulate_formats,
     default="plain")
 ARG_COLOR = Arg(
@@ -1268,7 +1269,13 @@ class AirflowHelpFormatter(argparse.HelpFormatter):
     """
     def _format_action(self, action: Action):
         if isinstance(action, argparse._SubParsersAction):  # pylint: disable=protected-access
+
             parts = []
+            action_header = self._format_action_invocation(action)
+            action_header = '%*s%s\n' % (self._current_indent, '', action_header)
+            parts.append(action_header)
+
+            self._indent()
             subactions = action._get_subactions()  # pylint: disable=protected-access
             action_subcommnads, group_subcommnands = partition(
                 lambda d: isinstance(ALL_COMMANDS_DICT[d.dest], GroupCommand), subactions
@@ -1287,6 +1294,7 @@ class AirflowHelpFormatter(argparse.HelpFormatter):
             for subaction in action_subcommnads:
                 parts.append(self._format_action(subaction))
             self._dedent()
+            self._dedent()
 
             # return a single string
             return self._join_parts(parts)
@@ -1297,7 +1305,7 @@ class AirflowHelpFormatter(argparse.HelpFormatter):
 def get_parser(dag_parser: bool = False) -> argparse.ArgumentParser:
     """Creates and returns command line argument parser"""
     parser = DefaultHelpParser(prog="airflow", formatter_class=AirflowHelpFormatter)
-    subparsers = parser.add_subparsers(dest='subcommand')
+    subparsers = parser.add_subparsers(dest='subcommand', metavar="GROUP_OR_COMMAND")
     subparsers.required = True
 
     subparser_list = DAG_CLI_COMMANDS if dag_parser else ALL_COMMANDS_DICT.keys()
@@ -1347,7 +1355,7 @@ def _add_action_command(sub: ActionCommand, sub_proc: argparse.ArgumentParser) -
 
 def _add_group_command(sub: GroupCommand, sub_proc: argparse.ArgumentParser) -> None:
     subcommands = sub.subcommands
-    sub_subparsers = sub_proc.add_subparsers(dest="subcommand")
+    sub_subparsers = sub_proc.add_subparsers(dest="subcommand", metavar="COMMNAD")
     sub_subparsers.required = True
 
     for command in sorted(subcommands, key=lambda x: x.name):


### PR DESCRIPTION
Before:
```
usage: airflow [-h]
               {celery,config,connections,dags,db,info,kerberos,pools,roles,rotate_fernet_key,scheduler,sync_perm,tasks,users,variables,version,webserver}
               ...

positional arguments:

  Groups:
    celery              Start celery components. Works only when using
                        CeleryExecutor. For more information, see https://airf
                        low.readthedocs.io/en/stable/executor/celery.html
    connections         List/Add/Delete connections
    dags                List and manage DAGs
    db                  Database operations
    pools               CRUD operations on pools
    roles               Create/List roles
    tasks               List and manage tasks
    users               CRUD operations on users
    variables           CRUD operations on variables

  Commands:
    config              Show current application configuration
    info                Show information about current Airflow and environment
    kerberos            Start a kerberos ticket renewer
    rotate_fernet_key   Rotate all encrypted connection credentials and
                        variables; see
                        https://airflow.readthedocs.io/en/stable/howto/secure-
                        connections.html#rotating-encryption-keys
    scheduler           Start a scheduler instance
    sync_perm           Update permissions for existing roles and DAGs
    version             Show the version
    webserver           Start a Airflow webserver instance

optional arguments:
  -h, --help            show this help message and exit

airflow command error: the following arguments are required: subcommand, see help above.
```
After:
```
usage: airflow [-h] GROUP_OR_COMMAND ...

positional arguments:
  GROUP_OR_COMMAND

    Groups:
      celery         Start celery components. Works only when using
                     CeleryExecutor. For more information, see https://airflow
                     .readthedocs.io/en/stable/executor/celery.html
      connections    List/Add/Delete connections
      dags           List and manage DAGs
      db             Database operations
      pools          CRUD operations on pools
      roles          Create/List roles
      tasks          List and manage tasks
      users          CRUD operations on users
      variables      CRUD operations on variables

    Commands:
      config         Show current application configuration
      info           Show information about current Airflow and environment
      kerberos       Start a kerberos ticket renewer
      rotate_fernet_key
                     Rotate all encrypted connection credentials and
                     variables; see
                     https://airflow.readthedocs.io/en/stable/howto/secure-
                     connections.html#rotating-encryption-keys
      scheduler      Start a scheduler instance
      sync_perm      Update permissions for existing roles and DAGs
      version        Show the version
      webserver      Start a Airflow webserver instance

optional arguments:
  -h, --help         show this help message and exit

airflow command error: the following arguments are required: GROUP_OR_COMMAND, see help above.
```

Before:
```
usage: airflow roles [-h] {create,list} ...

positional arguments:
  {create,list}
    create       Create role
    list         List roles

optional arguments:
  -h, --help     show this help message and exit
```
After:
```
usage: airflow roles [-h] COMMNAD ...

positional arguments:
  COMMNAD
    create    Create role
    list      List roles

optional arguments:
  -h, --help  show this help message and exit
```

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
