### PR TITLE
Get spark driver pod status if log stream interrupted accidentally

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -403,7 +403,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         # Check spark-submit return code. In Kubernetes mode, also check the value
         # of exit code in the log, as it may differ.
-        if returncode or (self._is_kubernetes and self._spark_exit_code not in [0,None]):
+        if returncode or (self._is_kubernetes and self._spark_exit_code not in [0, None]):
             raise AirflowException(
                 "Cannot execute: {}. Error code is: {}.".format(
                     self._mask_cmd(spark_submit_cmd), returncode

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -401,24 +401,25 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._process_spark_submit_log(iter(self._submit_sp.stdout))
         returncode = self._submit_sp.wait()
 
-        # Check spark-submit return code.
-        if returncode:
+        # Check spark-submit return code. In Kubernetes mode, also check the value
+        # of exit code in the log, as it may differ.
+        if returncode or (self._is_kubernetes and self._spark_exit_code not in [0,None]):
             raise AirflowException(
                 "Cannot execute: {}. Error code is: {}.".format(
                     self._mask_cmd(spark_submit_cmd), returncode
                 )
             )
 
-        # In Kubernetes mode, also check the value of exit code in the log, as it may differ.
-        if self._is_kubernetes and self._spark_exit_code != 0:
+        # In Kubernetes mode, if 'self._spark_exit_code' is still default value.
+        if self._is_kubernetes and self._spark_exit_code is None:
             self.log.info("Monitoring status of spark driver pod on K8s...")
             # double check by spark driver pod status (blocking function)
             spark_driver_pod_status = self._start_k8s_pod_status_tracking()
             self.log.info("The final status of spark driver pod on K8s is %s", spark_driver_pod_status)
             if spark_driver_pod_status != 'Succeeded':
                 raise AirflowException(
-                    "Cannot execute: {}. Error code is: {}.".format(
-                        self._mask_cmd(spark_submit_cmd), returncode
+                    "Cannot execute: {}. Spark driver pod status is: {}.".format(
+                        self._mask_cmd(spark_submit_cmd), spark_driver_pod_status
                     )
                 )
 

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -401,8 +401,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._process_spark_submit_log(iter(self._submit_sp.stdout))
         returncode = self._submit_sp.wait()
 
-        # Check spark-submit return code. In Kubernetes mode, also check the value
-        # of exit code in the log, as it may differ.
+        # Check spark-submit return code.
         if returncode:
             raise AirflowException(
                 "Cannot execute: {}. Error code is: {}.".format(
@@ -410,8 +409,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 )
             )
 
+        # In Kubernetes mode, also check the value of exit code in the log, as it may differ.
         if self._is_kubernetes and self._spark_exit_code != 0:
-            self.log.info("Monitoring status of spark driver pod on K8s, pod name is %s", spark_driver_pod_status)
+            self.log.info("Monitoring status of spark driver pod on K8s...")
             # double check by spark driver pod status (blocking function)
             spark_driver_pod_status = self._start_k8s_pod_status_tracking()
             self.log.info("The final status of spark driver pod on K8s is %s", spark_driver_pod_status)

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -626,6 +626,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 self.log.exception(e)
 
             self.log.debug("Status of spark driver pod on K8s is %s", spark_driver_pod_status)
+        return spark_driver_pod_status
 
     def _build_spark_driver_kill_command(self):
         """


### PR DESCRIPTION
#8963 

## Description

I am using airflow SparkSubmitOperator to schedule my spark jobs on kubernetes cluster. 

But for some reason, kubernetes often throw 'too old resource version' exception which will interrupt spark watcher, then airflow will lost the log stream and could not get 'Exit Code' eventually. So airflow will mark job failed once log stream lost but the job is still running.

This is  a solution about a simple retry mechanism which is when the log stream is interrupted, then call  method  'read_namespaced_pod()', which is provided by kubernetes client api,  to get spark driver pod status.

## Target Github ISSUE

https://github.com/apache/airflow/issues/8963

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
