### PR TITLE
Remove TaskInstance.log_filepath attribute

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -383,13 +383,6 @@ class TaskInstance(Base, LoggingMixin):
         return cmd
 
     @property
-    def log_filepath(self):
-        iso = self.execution_date.isoformat()
-        log = os.path.expanduser(conf.get('logging', 'BASE_LOG_FOLDER'))
-        return ("{log}/{dag_id}/{task_id}/{iso}.log".format(
-            log=log, dag_id=self.dag_id, task_id=self.task_id, iso=iso))
-
-    @property
     def log_url(self):
         iso = quote(self.execution_date.isoformat())
         base_url = conf.get('webserver', 'BASE_URL')
@@ -1483,7 +1476,6 @@ class TaskInstance(Base, LoggingMixin):
             'Exception:<br>{{exception_html}}<br>'
             'Log: <a href="{{ti.log_url}}">Link</a><br>'
             'Host: {{ti.hostname}}<br>'
-            'Log file: {{ti.log_filepath}}<br>'
             'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
         )
 
@@ -1505,7 +1497,6 @@ class TaskInstance(Base, LoggingMixin):
                 'Exception:<br>Failed attempt to attach error logs<br>'
                 'Log: <a href="{{ti.log_url}}">Link</a><br>'
                 'Host: {{ti.hostname}}<br>'
-                'Log file: {{ti.log_filepath}}<br>'
                 'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
             )
             html_content_err = render('html_content_template', default_html_content_err)

--- a/docs/howto/email-config.rst
+++ b/docs/howto/email-config.rst
@@ -41,7 +41,6 @@ For example a ``html_content_template`` file could look like this:
   Exception:<br>{{exception_html}}<br>
   Log: <a href="{{ti.log_url}}">Link</a><br>
   Host: {{ti.hostname}}<br>
-  Log file: {{ti.log_filepath}}<br>
   Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>
 
 .. note::


### PR DESCRIPTION
This method returns incorrect values. We have a different way of determining this path that uses the template. But more important to me is that you can't write a method that works in every case, because we're starting to support more advanced tools that don't use files, so it is impossible to determine the correct file path in every case e.g. Stackdriver doesn't use file but identifies logs based on labels.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
