### PR TITLE
Improve TestCliConfig in local env

### DIFF
--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -32,7 +32,7 @@ class TestCliConfig(unittest.TestCase):
     @mock.patch("airflow.cli.commands.config_command.io.StringIO")
     @mock.patch("airflow.cli.commands.config_command.conf")
     def test_cli_show_config_should_write_data(self, mock_conf, mock_stringio):
-        config_command.show_config(self.parser.parse_args(['config']))
+        config_command.show_config(self.parser.parse_args(['config', '--color', 'off']))
         mock_conf.write.assert_called_once_with(mock_stringio.return_value.__enter__.return_value)
 
     @conf_vars({
@@ -40,6 +40,6 @@ class TestCliConfig(unittest.TestCase):
     })
     def test_cli_show_config_should_display_key(self):
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
-            config_command.show_config(self.parser.parse_args(['config']))
+            config_command.show_config(self.parser.parse_args(['config', '--color', 'off']))
         self.assertIn('[core]', temp_stdout.getvalue())
         self.assertIn('testkey = test_value', temp_stdout.getvalue())


### PR DESCRIPTION
This test does not pass when it is run on a computer that has a user connected.  When the user is not connected, there is no problem, but eliminating users would be difficult, so I only added a flag to CLI.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
