### PR TITLE
[WIP] [8649] Add support for multiple cron expressions as schedule interval

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -49,7 +49,7 @@ from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.utils import timezone
-from airflow.utils.dates import cron_presets, date_range as utils_date_range
+from airflow.utils.dates import Cron, cron_presets, date_range as utils_date_range
 from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.helpers import validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -59,7 +59,7 @@ from airflow.utils.state import State
 
 log = logging.getLogger(__name__)
 
-ScheduleInterval = Union[str, timedelta, relativedelta]
+ScheduleInterval = Union[str, list, timedelta, relativedelta]
 DEFAULT_VIEW_PRESETS = ['tree', 'graph', 'duration', 'gantt', 'landing_times']
 ORIENTATION_PRESETS = ['LR', 'TB', 'RL', 'BT']
 
@@ -383,13 +383,23 @@ class DAG(BaseDag, LoggingMixin):
         :return: True if the schedule has a fixed time, False if not.
         """
         now = datetime.now()
-        cron = croniter(self.normalized_schedule_interval, now)
 
-        start = cron.get_next(datetime)
-        cron_next = cron.get_next(datetime)
+        schedule_intervals = self.normalized_schedule_interval
 
-        if cron_next.minute == start.minute and cron_next.hour == start.hour:
-            return True
+        if isinstance(schedule_intervals, str):
+            schedule_intervals = [schedule_intervals]
+
+        if isinstance(schedule_intervals, list):
+            crons = [croniter(interval, now) for interval in schedule_intervals]
+
+            starts = [cron.get_next(datetime) for cron in crons]
+            cron_nexts = [cron.get_next(datetime) for cron in crons]
+
+            minutes = [dttm.minute for dttm in starts + cron_nexts]
+            hours = [dttm.hour for dttm in starts + cron_nexts]
+
+            if len(set(minutes)) == 1 and len(set(hours)) == 1:
+                return True
 
         return False
 
@@ -400,21 +410,20 @@ class DAG(BaseDag, LoggingMixin):
         :param dttm: utc datetime
         :return: utc datetime
         """
-        if isinstance(self.normalized_schedule_interval, str):
+        if isinstance(self.normalized_schedule_interval, (str, list)):
             # we don't want to rely on the transitions created by
             # croniter as they are not always correct
             dttm = pendulum.instance(dttm)
             naive = timezone.make_naive(dttm, self.timezone)
-            cron = croniter(self.normalized_schedule_interval, naive)
-
+            cron = Cron(self.normalized_schedule_interval, naive)
             # We assume that DST transitions happen on the minute/hour
             if not self.is_fixed_time_schedule():
                 # relative offset (eg. every 5 minutes)
-                delta = cron.get_next(datetime) - naive
+                delta = cron.get_next() - naive
                 following = dttm.in_timezone(self.timezone).add_timedelta(delta)
             else:
                 # absolute (e.g. 3 AM)
-                naive = cron.get_next(datetime)
+                naive = cron.get_next()
                 tz = pendulum.timezone(self.timezone.name)
                 following = timezone.make_aware(naive, tz)
             return timezone.convert_to_utc(following)
@@ -428,21 +437,21 @@ class DAG(BaseDag, LoggingMixin):
         :param dttm: utc datetime
         :return: utc datetime
         """
-        if isinstance(self.normalized_schedule_interval, str):
+        if isinstance(self.normalized_schedule_interval, (str, list)):
             # we don't want to rely on the transitions created by
             # croniter as they are not always correct
             dttm = pendulum.instance(dttm)
             naive = timezone.make_naive(dttm, self.timezone)
-            cron = croniter(self.normalized_schedule_interval, naive)
+            cron = Cron(self.normalized_schedule_interval, naive)
 
             # We assume that DST transitions happen on the minute/hour
             if not self.is_fixed_time_schedule():
                 # relative offset (eg. every 5 minutes)
-                delta = naive - cron.get_prev(datetime)
+                delta = naive - cron.get_prev()
                 previous = dttm.in_timezone(self.timezone).subtract_timedelta(delta)
             else:
                 # absolute (e.g. 3 AM)
-                naive = cron.get_prev(datetime)
+                naive = cron.get_prev()
                 tz = pendulum.timezone(self.timezone.name)
                 previous = timezone.make_aware(naive, tz)
             return timezone.convert_to_utc(previous)
@@ -650,6 +659,9 @@ class DAG(BaseDag, LoggingMixin):
         """
         if isinstance(self.schedule_interval, str) and self.schedule_interval in cron_presets:
             _schedule_interval = cron_presets.get(self.schedule_interval)  # type: Optional[ScheduleInterval]
+        elif isinstance(self.schedule_interval, list):
+            _schedule_interval = [cron_presets.get(schedule_interval, schedule_interval)
+                                  for schedule_interval in self.schedule_interval]
         elif self.schedule_interval == '@once':
             _schedule_interval = None
         else:

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -289,6 +289,8 @@ class DagBag(BaseDagBag, LoggingMixin):
                         self.bag_dag(dag, parent_dag=dag, root_dag=dag)
                         if isinstance(dag.normalized_schedule_interval, str):
                             croniter(dag.normalized_schedule_interval)
+                        elif isinstance(dag.normalized_schedule_interval, list):
+                            [croniter(interval) for interval in dag.normalized_schedule_interval]
                         found_dags.append(dag)
                         found_dags += dag.subdags
                     except (CroniterBadCronError,

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -42,7 +42,7 @@
     </h3>
     <h4 class="pull-right">
       <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}" style="user-select: none;-moz-user-select: auto;">
-        schedule: {{ dag.schedule_interval }}
+        schedule: {{ dag.schedule_interval | join(", ") if dag.schedule_interval is iterable and dag.schedule_interval is not string else dag.schedule_interval }}
       </a>
     </h4>
   </div>

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -38,7 +38,7 @@
     <table class="table table-striped table-bordered">
       <tr>
         <th>schedule_interval</td>
-        <td>{{ dag.schedule_interval }}</td>
+        <td>{{ dag.schedule_interval | join(", ") if dag.schedule_interval is iterable and dag.schedule_interval is not string else dag.schedule_interval }}</td>
       </tr>
       <tr>
         <th>start_date</td>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -128,7 +128,7 @@
             <!-- Column 4: Dag Schedule -->
             <td>
               <a class="label label-default schedule" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
-                {{ dag.schedule_interval }}
+                {{ dag.schedule_interval | join(", ") if dag.schedule_interval is iterable and dag.schedule_interval is not string else dag.schedule_interval }}
               </a>
             </td>
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1358,12 +1358,6 @@ class TestDag(unittest.TestCase):
 
     @parameterized.expand([
         (None, None),
-        ("@daily", "0 0 * * *"),
-        ("@weekly", "0 0 * * 0"),
-        ("@monthly", "0 0 1 * *"),
-        ("@quarterly", "0 0 1 */3 *"),
-        ("@yearly", "0 0 1 1 *"),
-        (["@yearly", "1 * * * *"], ["0 0 1 1 *", "1 * * * *"]),
         ("@once", None),
         (datetime.timedelta(days=1), datetime.timedelta(days=1)),
     ])

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -426,7 +426,7 @@ class TestStringifiedDAGs(unittest.TestCase):
 
     @parameterized.expand([
         (None, None, None),
-        ("@weekly", "@weekly", "0 0 * * 0"),
+        ("@weekly", "@weekly", "@weekly"),
         ("@once", "@once", None),
         ({"__type": "timedelta", "__var": 86400.0}, timedelta(days=1), timedelta(days=1)),
     ])


### PR DESCRIPTION
Currently Airflow can't execute some schedules, e.g., every 10 min between 16:30 and 18:10. This type of schedule becomes possible if defined as multiple cron expressions.

This PR is still a work in progress, meant for discussing the viability of such feature.

Some points to consider:

- The first commit shows what is possible with minimal code changes. The second commit goes further and replaces all uses of `croniter` with the new `Cron` class. Which one is preferable?

- The second commit changes `normalized_schedule_interval` in DAG, moving the translation of cron presets (e.g `@daily`) into the `Cron` class? Is it a good idea? Maybe not, as at least one serialization test broke and had to be fixed, I imagine other things may also break.

- How should this type of schedule interval be displayed on the web UI? For up to three or four elements it looks fine, but for example a schedule interval with 10 cron expressions in the list is difficult to show, starting with the `Schedule` column in the Home page.

- At the moment the class lives in `utils/dates.py`, should it be somewhere else? Maybe create a `models/scheduleinterval.py`?

- Missing documentation.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
