### PR TITLE
Produce less verbose output when building up docker mounts

### DIFF
--- a/tests/bats/test_local_mounts.bats
+++ b/tests/bats/test_local_mounts.bats
@@ -23,19 +23,18 @@
 
   initialize_common_environment
 
-  run convert_local_mounts_to_docker_params
+  read -r -a RES <<< "$(convert_local_mounts_to_docker_params)"
 
-  RES="${output}"
-  COUNT_LINES=$(grep -c '' <(echo "${RES}"))
-  COUNT_MINUS_V_LINES=$(grep -c '^-v$' <(echo "${RES}"))
-  if (( COUNT_LINES != 2*COUNT_MINUS_V_LINES )); then
-      echo "The output produced by the convert_local_mounts_to_docker_params function is wrong"
-      echo "There are ${COUNT_LINES} lines in total and ${COUNT_MINUS_V_LINES} lines with -v"
-      echo "They seconf number should be exactly 1/2 of the first."
-      echo
-      echo "The output below should contain interleaving -v / volume lines"
-      echo
-      echo "${RES}"
-      exit 1
-  fi
+  [[ ${#RES[@]} -gt 0 ]] # Array should be non-zero length
+  [[ $((${#RES[@]} % 2)) == 0 ]] # Array should be even length
+
+  for i in "${!RES[@]}"; do
+    if [[ $((i % 2)) == 0 ]]; then
+      # Every other value should be `-v`
+      [[ ${RES[$i]} == "-v" ]]
+    else
+      # And the options should be of form <src>:<dest>:cached
+      [[ ${RES[$i]} = *:*:cached ]]
+    fi
+  done
 }


### PR DESCRIPTION
The previous method of generating this list had two "problems"/niggles
that this PR solves, when running with VERBOSE=true

- Firstly, LOCAL_MOUNTS was set at the top level, so running with
  `set -x` produced 30 extra lines of output when ever the \_util.sh was sourced
- Because of the `while read` used, it created 4 or 5 lines _per_ mount,
  resulting in a lot verbose output.

Nothing I've changed here is "critical", it's just making it a bit
easier to see with the debug output what is going on, by running fewer
commands.

I have also expanded the BATS test a little bit to check each pair (`-v`
and its following option)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.