### PR TITLE
Cope with multiple processes get_remote_image_info in parallel

### DIFF
--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -26,7 +26,6 @@ declare -a EXTRA_DOCKER_PROD_BUILD_FLAGS
 export EXTRA_DOCKER_FLAGS
 export EXTRA_DOCKER_PROD_BUILD_FLAGS
 
-declare -a FILES_TO_CLEANUP_ON_EXIT=()
 
 # In case "VERBOSE_COMMANDS" is set to "true" set -x is used to enable debugging
 function check_verbose_setup {
@@ -52,6 +51,8 @@ function verbose_docker {
 function initialize_common_environment {
     # default python Major/Minor version
     PYTHON_MAJOR_MINOR_VERSION=${PYTHON_MAJOR_MINOR_VERSION:="3.6"}
+
+    FILES_TO_CLEANUP_ON_EXIT=()
 
     # Sets to where airflow sources are located
     AIRFLOW_SOURCES=${AIRFLOW_SOURCES:=$(cd "${MY_DIR}/../../" && pwd)}

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -26,7 +26,7 @@ declare -a EXTRA_DOCKER_PROD_BUILD_FLAGS
 export EXTRA_DOCKER_FLAGS
 export EXTRA_DOCKER_PROD_BUILD_FLAGS
 
-declare -a files_to_cleanup_on_exit=()
+declare -a FILES_TO_CLEANUP_ON_EXIT=()
 
 # In case "VERBOSE_COMMANDS" is set to "true" set -x is used to enable debugging
 function check_verbose_setup {
@@ -731,7 +731,7 @@ function get_remote_image_info() {
 
     # Docker needs the file passed to --cidfile to not exist, so we can't use mktemp
     TMP_CONTAINER_ID="remote-airflow-manifest-$$.container_id"
-    files_to_cleanup_on_exit+=("$TMP_CONTAINER_ID")
+    FILES_TO_CLEANUP_ON_EXIT+=("$TMP_CONTAINER_ID")
 
     TMP_MANIFEST_REMOTE_JSON=$(mktemp)
     TMP_MANIFEST_REMOTE_SHA=$(mktemp)
@@ -908,8 +908,8 @@ function script_end {
         set +x
     fi
 
-    if [[ ${#files_to_cleanup_on_exit[@]} -gt 0 ]]; then
-      rm -rf -- "${files_to_cleanup_on_exit[@]}"
+    if [[ ${#FILES_TO_CLEANUP_ON_EXIT[@]} -gt 0 ]]; then
+      rm -rf -- "${FILES_TO_CLEANUP_ON_EXIT[@]}"
     fi
 
     END_SCRIPT_TIME=$(date +%s)

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -41,15 +41,11 @@ function check_verbose_setup {
 # In case "VERBOSE" is set to "true" (--verbose flag in Breeze) all docker commands run will be
 # printed before execution
 function verbose_docker {
-    if [[ ${VERBOSE_COMMANDS:=} == "true" ]]; then
-      # No need to echo, we're already in set -x
-      docker "${@}"
-    elif [[ ${VERBOSE:="false"} == "true" ]]; then
+    if [[ ${VERBOSE:="false"} == "true" && ${VERBOSE_COMMANDS:=} != "true" ]]; then
+       # do not print echo if VERSBOSE_COMMAND is set (set -x does it already)
         echo "docker" "${@}"
-        docker "${@}"
-    else
-        docker "${@}"
     fi
+    docker "${@}"
 }
 
 # Common environment that is initialized by both Breeze and CI scripts


### PR DESCRIPTION
When I'd made a change to a large number of python files, running the
flake8 pre-commit hook would fail without obvious error (as in no error
was printed, but exit code was 1).

In debugging this I switch the pre-commit to `require_serial: true` and
the problem went way - the fix for this is:

- Don't redirect stderr to /dev/null (that silences both our VERBOSE
  trace output, and the errors from docker)
- Use `--cidfile` option to docker to create a random name and write the
  created container ID to a file

I'm not sure why no one else has hit this before.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
