### PR TITLE
Fix handling of subprocess error handling in s3_file_transform and gcs

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3_file_transform.py
+++ b/airflow/providers/amazon/aws/operators/s3_file_transform.py
@@ -154,7 +154,7 @@ class S3FileTransformOperator(BaseOperator):
 
                 process.wait()
 
-                if process.returncode > 0:
+                if process.returncode:
                     raise AirflowException(
                         "Transform script failed: {0}".format(process.returncode)
                     )

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -609,7 +609,7 @@ class GCSFileTransformOperator(BaseOperator):
                     self.log.info(line.decode(self.output_encoding).rstrip())
 
             process.wait()
-            if process.returncode > 0:
+            if process.returncode:
                 raise AirflowException(
                     "Transform script failed: {0}".format(process.returncode)
                 )


### PR DESCRIPTION
As outlined in #9104 the python subprocess return code can be less than 0, which _also_ indicates an error.

The previous version only captures errors ( `>0` ) of the subprocess itself, not the negative error codes, as cause by host SIGKILL, SIGHUP, ... 
see [Python subprocess documentation](https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.returncode)

We now treat all non-zero return codes as a script failure - similar to what most other operators do.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).