### PR TITLE
Fix extracting job_id for gcp dataflow provider

### DIFF
--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -618,11 +618,19 @@ class TestDataflowJob(unittest.TestCase):
 
 class TestDataflow(unittest.TestCase):
 
-    def test_data_flow_valid_job_id(self):
+    def test_data_flow_valid_job_id_old_format(self):
         cmd = [
             'echo', 'additional unit test lines.\n' +
             'https://console.cloud.google.com/dataflow/jobsDetail/locations/us-central1/'
             'jobs/{}?project=XXX'.format(TEST_JOB_ID)
+        ]
+        self.assertEqual(_DataflowRunner(cmd).wait_for_done(), TEST_JOB_ID)
+
+    def test_data_flow_valid_job_id(self):
+        cmd = [
+            'echo', 'additional unit test lines.\n' +
+            'https://console.cloud.google.com/dataflow/jobs/us-central1/'
+            '{}?project=XXX'.format(TEST_JOB_ID)
         ]
         self.assertEqual(_DataflowRunner(cmd).wait_for_done(), TEST_JOB_ID)
 


### PR DESCRIPTION
In the new version of apache-beam the link from which the airflow is extracting the job id has changed. This commit is fixing the regex for extracting the job_id.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
