### PR TITLE
Fix gzip option of sql_to_gcs operator

### DIFF
--- a/airflow/providers/google/cloud/operators/sql_to_gcs.py
+++ b/airflow/providers/google/cloud/operators/sql_to_gcs.py
@@ -292,4 +292,4 @@ class BaseSQLToGCSOperator(BaseOperator, metaclass=abc.ABCMeta):
             hook.upload(self.bucket, tmp_file.get('file_name'),
                         tmp_file.get('file_handle').name,
                         mime_type=tmp_file.get('file_mime_type'),
-                        gzip=self.gzip if tmp_file.get('file_name') == self.schema_filename else False)
+                        gzip=self.gzip if tmp_file.get('file_name') != self.schema_filename else False)


### PR DESCRIPTION
This small PR solves the issue described at https://github.com/apache/airflow/issues/9139

**Solution**

There's a small logic error on [sql_to_gcs.py](https://github.com/apache/airflow/blob/master/airflow/providers/google/cloud/operators/sql_to_gcs.py#L295). When `gzip` option is set to `True` the line:

```
self.gzip if tmp_file.get('file_name') == self.schema_filename else False
```
Returns `hook.upload(..., gzip=True)` **if the file is the schema file** and keep the data file intact. What we want instead is a compressed data file and keep the schema file intact. 

We implemented this fix in our production environment to overwrite this function, but would be nice to get It released back to the community. We've been using It for weeks now and no issues from this small change were reported.

No changes in documentation/tests/signature of functions.

---

Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes) `(unnecessary)`
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions. `(unnecessary)`
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
