### PR TITLE
[AIRFLOW-3973] Commit after each alembic migration

### DIFF
--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -81,6 +81,7 @@ def run_migrations_online():
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
+            transaction_per_migration=True,
             target_metadata=target_metadata,
             compare_type=COMPARE_TYPE,
             render_as_batch=True


### PR DESCRIPTION
If `Variable`s are used in DAGs, and Postgres is used for the internal
database, a fresh `$ airflow initdb` (or `$ airflow resetdb`) spams the
logs with error messages (but does not fail).

This commit corrects this by running each migration in a separate
transaction.