### PR TITLE
Set conn_type as not-nullable

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -62,6 +62,14 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Not-nullable conn_type collumn in connection table
+
+The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
+by application logic, but was not enforced by the database schema.
+
+If you made any modifications to the table directly, make sure you don't have
+null in the conn_type column.
+
 ### DAG.create_dagrun accepts run_type and does not require run_id
 This change is caused by adding `run_type` column to `DagRun`.
 

--- a/airflow/migrations/versions/8f966b9c467a_set_conn_type_as_non_nullable.py
+++ b/airflow/migrations/versions/8f966b9c467a_set_conn_type_as_non_nullable.py
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Set conn_type as non-nullable
+
+Revision ID: 8f966b9c467a
+Revises: 3c20cacc0044
+Create Date: 2020-06-08 22:36:34.534121
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8f966b9c467a"
+down_revision = "3c20cacc0044"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply Set conn_type as non-nullable"""
+
+    with op.batch_alter_table("connection", schema=None) as batch_op:
+        batch_op.alter_column("conn_type", existing_type=sa.VARCHAR(length=500), nullable=False)
+
+
+def downgrade():
+    """Unapply Set conn_type as non-nullable"""
+    with op.batch_alter_table("connection", schema=None) as batch_op:
+        batch_op.alter_column("conn_type", existing_type=sa.VARCHAR(length=500), nullable=True)

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -109,7 +109,7 @@ class Connection(Base, LoggingMixin):
 
     id = Column(Integer(), primary_key=True)
     conn_id = Column(String(ID_LEN))
-    conn_type = Column(String(500))
+    conn_type = Column(String(500), nullable=False)
     host = Column(String(500))
     schema = Column(String(500))
     login = Column(String(500))


### PR DESCRIPTION
The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced by application logic, but was not enforced by the database schema.

Before:
```
                                          Table "public.connection"
       Column       |          Type           | Collation | Nullable |                Default
--------------------+-------------------------+-----------+----------+----------------------------------------
 id                 | integer                 |           | not null | nextval('connection_id_seq'::regclass)
 conn_id            | character varying(250)  |           |          |
 conn_type          | character varying(500)  |           |          |
 host               | character varying(500)  |           |          |
 schema             | character varying(500)  |           |          |
 login              | character varying(500)  |           |          |
 password           | character varying(5000) |           |          |
 port               | integer                 |           |          |
 extra              | character varying(5000) |           |          |
 is_encrypted       | boolean                 |           |          |
 is_extra_encrypted | boolean                 |           |          |
Indexes:
    "connection_pkey" PRIMARY KEY, btree (id)

```
After:
```
                                          Table "public.connection"
       Column       |          Type           | Collation | Nullable |                Default
--------------------+-------------------------+-----------+----------+----------------------------------------
 id                 | integer                 |           | not null | nextval('connection_id_seq'::regclass)
 conn_id            | character varying(250)  |           |          |
 conn_type          | character varying(500)  |           | not null |
 host               | character varying(500)  |           |          |
 schema             | character varying(500)  |           |          |
 login              | character varying(500)  |           |          |
 password           | character varying(5000) |           |          |
 port               | integer                 |           |          |
 extra              | character varying(5000) |           |          |
 is_encrypted       | boolean                 |           |          |
 is_extra_encrypted | boolean                 |           |          |
Indexes:
    "connection_pkey" PRIMARY KEY, btree (id)

```

I think we should also set conn_id as non-nullable: 
https://github.com/apache/airflow/pull/9067#issuecomment-640912099

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
