### PR TITLE
Improved compatibility with Python 3.5+ - Convert signal.SIGTERM to int

### DIFF
--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -73,7 +73,7 @@ def reap_process_group(pgid, logger, sig=signal.SIGTERM, timeout=DEFAULT_TIME_TO
             # use sudo -n(--non-interactive) to kill the process
             if err.errno == errno.EPERM:
                 subprocess.check_call(
-                    ["sudo", "-n", "kill", "-" + str(sig)] + [str(p.pid) for p in children]
+                    ["sudo", "-n", "kill", "-" + str(int(sig))] + [str(p.pid) for p in children]
                 )
             else:
                 raise


### PR DESCRIPTION
Solves the issue #9202 

**File changed**: ``airflow/utils/process_utils.py``

**Problem**
Since python3.5, signals have become ``IntEnum`` instead of ``int``, therefore ``str(signal.SIGTERM)`` yields the string literal ``signal.SIGTERM`` instead of ``15``.

**Solution**
convert ``signal.SIGTERM`` to ``int`` first and then ``str``

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions. ``unnecessary``
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).