### PR TITLE
Make it possible to silence warnings from Airflow

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -41,10 +41,11 @@ from airflow.utils.module_loading import import_string
 log = logging.getLogger(__name__)
 
 # show Airflow's deprecation warnings
-warnings.filterwarnings(
-    action='default', category=DeprecationWarning, module='airflow')
-warnings.filterwarnings(
-    action='default', category=PendingDeprecationWarning, module='airflow')
+if not sys.warnoptions:
+    warnings.filterwarnings(
+        action='default', category=DeprecationWarning, module='airflow')
+    warnings.filterwarnings(
+        action='default', category=PendingDeprecationWarning, module='airflow')
 
 
 def expand_env_var(env_var):


### PR DESCRIPTION
If we blindly set the warnings filter, it is _impossible_ to silence these warnings. This is the approach suggested in https://docs.python.org/3/library/warnings.html#overriding-the-default-filter


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.