### PR TITLE
Decrypt secrets from SystemsManagerParameterStoreBackend

### DIFF
--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -103,7 +103,7 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         ssm_path = self.build_path(path_prefix, secret_id)
         try:
             response = self.client.get_parameter(
-                Name=ssm_path, WithDecryption=False
+                Name=ssm_path, WithDecryption=True
             )
             value = response["Parameter"]["Value"]
             return value

--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -81,6 +81,18 @@ class TestSsmSecrets(TestCase):
         self.assertEqual('world', returned_uri)
 
     @mock_ssm
+    def test_get_variable_secret_string(self):
+        param = {
+            'Name': '/airflow/variables/hello',
+            'Type': 'SecureString',
+            'Value': 'world'
+        }
+        ssm_backend = SystemsManagerParameterStoreBackend()
+        ssm_backend.client.put_parameter(**param)
+        returned_uri = ssm_backend.get_variable('hello')
+        self.assertEqual('world', returned_uri)
+
+    @mock_ssm
     def test_get_variable_non_existent_key(self):
         """
         Test that if Variable key is not present in SSM,


### PR DESCRIPTION
This is my first PR, so pardon me if I missed any steps, but this proposed change is also _very_ simple. 


The current implementation of `SystemsManagerParameterStoreBackend` `_get_secret` uses

```python
            response = self.client.get_parameter(
                Name=ssm_path, WithDecryption=False
            )
```

but this only allows for secrets to be stored in clear text. 

This PR changes the value to `WithDecryption=True`, which is backwards compatible with clear text values, but also supports KMS decryption in the API call.

for reference in the API docs:
https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameter.html

> WithDecryption
Return decrypted values for secure string parameters. This flag is ignored for String and StringList parameter types.
>
>Type: Boolean
>
>Required: No

After reviewing the test coverage and the documentation, I don't think there are any changes that need to be made. The are no behavior changes for users other than this will support a storage option and will natively support tools like [chamber cli tooling](https://github.com/segmentio/chamber)

I guess there could be an argument made to update documentation stating this feature is now supported? 

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
