### PR TITLE
Correctly dump logs from init containers names on CI failure

### DIFF
--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -367,8 +367,10 @@ function dump_kubernetes_logs() {
         --cluster "${KUBECTL_CLUSTER_NAME}" | grep airflow | head -1)
     echo "------- pod description -------"
     kubectl describe pod "${POD}" --cluster "${KUBECTL_CLUSTER_NAME}"
-    echo "------- webserver init container logs - init -------"
-    kubectl logs "${POD}" -c init --cluster "${KUBECTL_CLUSTER_NAME}" || true
+    echo "-------  init container logs - init-db -------"
+    kubectl logs "${POD}" -c init-db --cluster "${KUBECTL_CLUSTER_NAME}" || true
+    echo "-------  init container logs - init-dags -------"
+    kubectl logs "${POD}" -c init-dags --cluster "${KUBECTL_CLUSTER_NAME}" || true
     if [[ "${KUBERNETES_MODE}" == "git" ]]; then
         echo "------- webserver init container logs - git-sync-clone -------"
         kubectl logs "${POD}" -c git-sync-clone --cluster "${KUBECTL_CLUSTER_NAME}" || true


### PR DESCRIPTION
```
------- webserver init container logs - init -------
error: container init is not valid for pod airflow-594f8b87d-6ph6k
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
