### PR TITLE
Get all pod logs on Kube CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,139 +42,139 @@ env:
 
 jobs:
 
-  static-checks-1:
-    timeout-minutes: 60
-    name: "Checks: some checks"
-    runs-on: ubuntu-latest
-    env:
-      MOUNT_SOURCE_DIR_FOR_STATIC_CHECKS: "true"
-      CI_JOB_TYPE: "Static checks"
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - name: Cache pre-commit env
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-pre-commit-v2
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Static checks"
-        if: success()
-        env:
-          PYTHON_VERSION: 3.6
-        run: |
-          python -m pip install pre-commit \
-              --constraint requirements/requirements-python${PYTHON_MAJOR_MINOR_VERSION}.txt
-          ./scripts/ci/ci_run_static_checks.sh pylint-tests mypy yamllint flake8
-
-  static-checks-2:
-    timeout-minutes: 60
-    name: "Checks: all other"
-    runs-on: ubuntu-latest
-    env:
-      SKIP: pylint-tests,mypy,yamllint,flake8
-      MOUNT_SOURCE_DIR_FOR_STATIC_CHECKS: "true"
-      CI_JOB_TYPE: "Static checks"
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - name: Cache pre-commit env
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-pre-commit
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Static checks"
-        run: |
-          python -m pip install pre-commit \
-              --constraint requirements/requirements-python${PYTHON_MAJOR_MINOR_VERSION}.txt
-          ./scripts/ci/ci_run_static_checks.sh
-
-  docs:
-    timeout-minutes: 60
-    name: Build docs
-    runs-on: ubuntu-latest
-    env:
-      CI_JOB_TYPE: "Documentation"
-    steps:
-      - uses: actions/checkout@master
-      - name: "Build CI image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Build docs"
-        run: ./scripts/ci/ci_docs.sh
-
-  build-prod-image:
-    timeout-minutes: 60
-    name: "Build prod image Py${{ matrix.python-version }}"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-    env:
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      CI_JOB_TYPE: "Prod image"
-    steps:
-      - uses: actions/checkout@master
-      - name: "Build PROD image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_build_production_images.sh
-
-  prepare-backport-packages:
-    timeout-minutes: 60
-    name: "Backport packages"
-    runs-on: ubuntu-latest
-    env:
-      INSTALL_AIRFLOW_VERSION: "1.10.10"
-      CI_JOB_TYPE: "Prepare & test packages"
-      PYTHON_MAJOR_MINOR_VERSION: 3.6
-    steps:
-      - uses: actions/checkout@master
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Prepare & test backport packages"
-        run: |
-          ./scripts/ci/ci_prepare_and_test_backport_packages.sh
-
-  pyfiles:
-    timeout-minutes: 10
-    name: "Count changed important files"
-    runs-on: ubuntu-latest
-    outputs:
-      count: ${{ steps.pyfiles.outputs.count }}
-    steps:
-      - uses: actions/checkout@master
-      - name: "Get count of changed python files"
-        run: |
-          set +e
-          ./scripts/ci/ci_count_changed_files.sh ${GITHUB_SHA} '\.py$|.github/workflows/|^Dockerfile|^scripts'
-          echo "::set-output name=count::$?"
-        id: pyfiles
+#  static-checks-1:
+#    timeout-minutes: 60
+#    name: "Checks: some checks"
+#    runs-on: ubuntu-latest
+#    env:
+#      MOUNT_SOURCE_DIR_FOR_STATIC_CHECKS: "true"
+#      CI_JOB_TYPE: "Static checks"
+#    steps:
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@v1
+#        with:
+#          python-version: '3.x'
+#      - name: Cache pre-commit env
+#        uses: actions/cache@v2
+#        env:
+#          cache-name: cache-pre-commit-v2
+#        with:
+#          path: ~/.cache/pre-commit
+#          key: ${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('.pre-commit-config.yaml') }}
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Static checks"
+#        if: success()
+#        env:
+#          PYTHON_VERSION: 3.6
+#        run: |
+#          python -m pip install pre-commit \
+#              --constraint requirements/requirements-python${PYTHON_MAJOR_MINOR_VERSION}.txt
+#          ./scripts/ci/ci_run_static_checks.sh pylint-tests mypy yamllint flake8
+#
+#  static-checks-2:
+#    timeout-minutes: 60
+#    name: "Checks: all other"
+#    runs-on: ubuntu-latest
+#    env:
+#      SKIP: pylint-tests,mypy,yamllint,flake8
+#      MOUNT_SOURCE_DIR_FOR_STATIC_CHECKS: "true"
+#      CI_JOB_TYPE: "Static checks"
+#    steps:
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@v1
+#        with:
+#          python-version: '3.x'
+#      - name: Cache pre-commit env
+#        uses: actions/cache@v1
+#        env:
+#          cache-name: cache-pre-commit
+#        with:
+#          path: ~/.cache/pre-commit
+#          key: ${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('.pre-commit-config.yaml') }}
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Static checks"
+#        run: |
+#          python -m pip install pre-commit \
+#              --constraint requirements/requirements-python${PYTHON_MAJOR_MINOR_VERSION}.txt
+#          ./scripts/ci/ci_run_static_checks.sh
+#
+#  docs:
+#    timeout-minutes: 60
+#    name: Build docs
+#    runs-on: ubuntu-latest
+#    env:
+#      CI_JOB_TYPE: "Documentation"
+#    steps:
+#      - uses: actions/checkout@master
+#      - name: "Build CI image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Build docs"
+#        run: ./scripts/ci/ci_docs.sh
+#
+#  build-prod-image:
+#    timeout-minutes: 60
+#    name: "Build prod image Py${{ matrix.python-version }}"
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7, 3.8]
+#    env:
+#      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+#      CI_JOB_TYPE: "Prod image"
+#    steps:
+#      - uses: actions/checkout@master
+#      - name: "Build PROD image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_build_production_images.sh
+#
+#  prepare-backport-packages:
+#    timeout-minutes: 60
+#    name: "Backport packages"
+#    runs-on: ubuntu-latest
+#    env:
+#      INSTALL_AIRFLOW_VERSION: "1.10.10"
+#      CI_JOB_TYPE: "Prepare & test packages"
+#      PYTHON_MAJOR_MINOR_VERSION: 3.6
+#    steps:
+#      - uses: actions/checkout@master
+#        with:
+#          fetch-depth: 0
+#      - uses: actions/setup-python@v1
+#        with:
+#          python-version: '3.x'
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Prepare & test backport packages"
+#        run: |
+#          ./scripts/ci/ci_prepare_and_test_backport_packages.sh
+#
+#  pyfiles:
+#    timeout-minutes: 10
+#    name: "Count changed important files"
+#    runs-on: ubuntu-latest
+#    outputs:
+#      count: ${{ steps.pyfiles.outputs.count }}
+#    steps:
+#      - uses: actions/checkout@master
+#      - name: "Get count of changed python files"
+#        run: |
+#          set +e
+#          ./scripts/ci/ci_count_changed_files.sh ${GITHUB_SHA} '\.py$|.github/workflows/|^Dockerfile|^scripts'
+#          echo "::set-output name=count::$?"
+#        id: pyfiles
 
   tests-kubernetes:
     timeout-minutes: 80
     name: "K8s: ${{matrix.kube-mode}} ${{matrix.python-version}} ${{matrix.kubernetes-version}}"
     runs-on: ubuntu-latest
-    needs: [static-checks-1, static-checks-2, pyfiles]
+#    needs: [static-checks-1, static-checks-2, pyfiles]
     strategy:
       matrix:
         python-version: [3.6, 3.7]
@@ -195,7 +195,7 @@ jobs:
       KUBERNETES_MODE: "${{ matrix.kube-mode }}"
       KUBERNETES_VERSION: "${{ matrix.kubernetes-version }}"
     # For pull requests only run tests when python files changed
-    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
+#    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v1
@@ -226,242 +226,242 @@ ${{ hashFiles('requirements/requirements-python${{matrix.python-version}}.txt') 
           name: 'Kind logs'
           path: '/tmp/kind_logs_*.tar.gz'
 
-  tests-postgres:
-    timeout-minutes: 80
-    name: "${{matrix.test-type}}:Pg${{matrix.postgres-version}},Py${{matrix.python-version}}"
-    runs-on: ubuntu-latest
-    needs: [static-checks-1, static-checks-2, pyfiles]
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-        postgres-version: [9.6, 10]
-        test-type: [Core, Integration]
-      fail-fast: false
-    env:
-      BACKEND: postgres
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      POSTGRES_VERSION: ${{ matrix.postgres-version }}
-      RUN_TESTS: "true"
-      CI_JOB_TYPE: "Tests"
-      TEST_TYPE: ${{ matrix.test-type }}
-    # For pull requests only run tests when python files changed
-    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Tests"
-        run: ./scripts/ci/ci_run_airflow_testing.sh
-
-  tests-mysql:
-    timeout-minutes: 80
-    name: "${{matrix.test-type}}:MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}"
-    runs-on: ubuntu-latest
-    needs: [static-checks-1, static-checks-2, pyfiles]
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-        mysql-version: [5.7]
-        test-type: [Core, Integration]
-      fail-fast: false
-    env:
-      BACKEND: mysql
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      MYSQL_VERSION: ${{ matrix.mysql-version }}
-      RUN_TESTS: "true"
-      CI_JOB_TYPE: "Tests"
-      TEST_TYPE: ${{ matrix.test-type }}
-    # For pull requests only run tests when python files changed
-    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Tests"
-        run: ./scripts/ci/ci_run_airflow_testing.sh
-
-  tests-sqlite:
-    timeout-minutes: 80
-    name: "${{matrix.test-type}}:Sqlite Py${{matrix.python-version}}"
-    runs-on: ubuntu-latest
-    needs: [static-checks-1, static-checks-2, pyfiles]
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-        test-type: [Core, Integration]
-      fail-fast: false
-    env:
-      BACKEND: sqlite
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      TEST_TYPE: ${{ matrix.test-type }}
-      RUN_TESTS: "true"
-      CI_JOB_TYPE: "Tests"
-    # For pull requests only run tests when python files changed
-    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Tests"
-        run: ./scripts/ci/ci_run_airflow_testing.sh
-
-  tests-quarantined:
-    timeout-minutes: 80
-    name: "${{matrix.test-type}}:Pg${{matrix.postgres-version}},Py${{matrix.python-version}}"
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    needs: [static-checks-1, static-checks-2, pyfiles]
-    strategy:
-      matrix:
-        python-version: [3.6]
-        postgres-version: [9.6]
-        test-type: [Quarantined]
-      fail-fast: false
-    env:
-      BACKEND: postgres
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      POSTGRES_VERSION: ${{ matrix.postgres-version }}
-      RUN_TESTS: "true"
-      CI_JOB_TYPE: "Tests"
-      TEST_TYPE: ${{ matrix.test-type }}
-    # For pull requests only run tests when python files changed
-    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Tests"
-        run: ./scripts/ci/ci_run_airflow_testing.sh
-
-  requirements:
-    timeout-minutes: 80
-    name: "Requirements"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-      fail-fast: false
-    env:
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      CHECK_REQUIREMENTS_ONLY: true
-      UPGRADE_WHILE_GENERATING_REQUIREMENTS: ${{ github.event_name == 'schedule' }}
-      CI_JOB_TYPE: "Requirements"
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Generate requirements"
-        run: ./scripts/ci/ci_generate_requirements.sh
-
-  push-prod-images-to-github-cache:
-    timeout-minutes: 80
-    name: "Push PROD images"
-    runs-on: ubuntu-latest
-    needs:
-      - tests-sqlite
-      - tests-postgres
-      - tests-mysql
-      - requirements
-      - prepare-backport-packages
-      - build-prod-image
-      - docs
-    if: github.ref == 'refs/heads/master' && github.event_name != 'schedule'
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-    env:
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      CI_JOB_TYPE: "Prod image"
-    steps:
-      - uses: actions/checkout@master
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build PROD images ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_build_production_images.sh
-      - name: "Push PROD images ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_push_production_images.sh
-
-  push-ci-images-to-github-cache:
-    timeout-minutes: 40
-    name: "Push CI images"
-    runs-on: ubuntu-latest
-    needs:
-      - tests-sqlite
-      - tests-postgres
-      - tests-mysql
-      - requirements
-      - prepare-backport-packages
-      - build-prod-image
-      - docs
-    if: |
-      (github.ref == 'refs/heads/master' ||
-      github.ref == 'refs/heads/v1-10-test' ) &&
-      github.event_name != 'schedule'
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-    env:
-      PULL_PYTHON_BASE_IMAGES_FROM_CACHE: "false"
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      CI_JOB_TYPE: "Prod image"
-    steps:
-      - uses: actions/checkout@master
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Build CI image"
-        run: ./scripts/ci/ci_prepare_image_on_ci.sh
-      - name: "Push CI image ${{ matrix.python-version }}"
-        run: ./scripts/ci/ci_push_ci_image.sh
-
-  tag-repo-nightly:
-    timeout-minutes: 60
-    name: "Tag repo nightly"
-    runs-on: ubuntu-latest
-    needs:
-      - tests-sqlite
-      - tests-postgres
-      - tests-mysql
-      - requirements
-      - prepare-backport-packages
-      - build-prod-image
-      - docs
-    if: github.event_name == 'schedule'
-    steps:
-      - uses: actions/checkout@master
-      - name: "Free space"
-        run: ./scripts/ci/ci_free_space_on_ci.sh
-      - name: "Tag commit"
-        run: |
-          BRANCH_NAME=$(echo "${{ github.ref }}" | sed 's/refs\/heads\///')
-          echo "Tagging ${BRANCH_NAME}"
-          git tag -f nightly-${BRANCH_NAME} HEAD
-      - name: Push tags
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: true
-          force: true
-          branch: master
+#  tests-postgres:
+#    timeout-minutes: 80
+#    name: "${{matrix.test-type}}:Pg${{matrix.postgres-version}},Py${{matrix.python-version}}"
+#    runs-on: ubuntu-latest
+#    needs: [static-checks-1, static-checks-2, pyfiles]
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7, 3.8]
+#        postgres-version: [9.6, 10]
+#        test-type: [Core, Integration]
+#      fail-fast: false
+#    env:
+#      BACKEND: postgres
+#      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+#      POSTGRES_VERSION: ${{ matrix.postgres-version }}
+#      RUN_TESTS: "true"
+#      CI_JOB_TYPE: "Tests"
+#      TEST_TYPE: ${{ matrix.test-type }}
+#    # For pull requests only run tests when python files changed
+#    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
+#    steps:
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@v1
+#        with:
+#          python-version: '3.x'
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Tests"
+#        run: ./scripts/ci/ci_run_airflow_testing.sh
+#
+#  tests-mysql:
+#    timeout-minutes: 80
+#    name: "${{matrix.test-type}}:MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}"
+#    runs-on: ubuntu-latest
+#    needs: [static-checks-1, static-checks-2, pyfiles]
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7, 3.8]
+#        mysql-version: [5.7]
+#        test-type: [Core, Integration]
+#      fail-fast: false
+#    env:
+#      BACKEND: mysql
+#      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+#      MYSQL_VERSION: ${{ matrix.mysql-version }}
+#      RUN_TESTS: "true"
+#      CI_JOB_TYPE: "Tests"
+#      TEST_TYPE: ${{ matrix.test-type }}
+#    # For pull requests only run tests when python files changed
+#    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
+#    steps:
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@v1
+#        with:
+#          python-version: '3.x'
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Tests"
+#        run: ./scripts/ci/ci_run_airflow_testing.sh
+#
+#  tests-sqlite:
+#    timeout-minutes: 80
+#    name: "${{matrix.test-type}}:Sqlite Py${{matrix.python-version}}"
+#    runs-on: ubuntu-latest
+#    needs: [static-checks-1, static-checks-2, pyfiles]
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7, 3.8]
+#        test-type: [Core, Integration]
+#      fail-fast: false
+#    env:
+#      BACKEND: sqlite
+#      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+#      TEST_TYPE: ${{ matrix.test-type }}
+#      RUN_TESTS: "true"
+#      CI_JOB_TYPE: "Tests"
+#    # For pull requests only run tests when python files changed
+#    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
+#    steps:
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@v1
+#        with:
+#          python-version: '3.x'
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Tests"
+#        run: ./scripts/ci/ci_run_airflow_testing.sh
+#
+#  tests-quarantined:
+#    timeout-minutes: 80
+#    name: "${{matrix.test-type}}:Pg${{matrix.postgres-version}},Py${{matrix.python-version}}"
+#    runs-on: ubuntu-latest
+#    continue-on-error: true
+#    needs: [static-checks-1, static-checks-2, pyfiles]
+#    strategy:
+#      matrix:
+#        python-version: [3.6]
+#        postgres-version: [9.6]
+#        test-type: [Quarantined]
+#      fail-fast: false
+#    env:
+#      BACKEND: postgres
+#      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+#      POSTGRES_VERSION: ${{ matrix.postgres-version }}
+#      RUN_TESTS: "true"
+#      CI_JOB_TYPE: "Tests"
+#      TEST_TYPE: ${{ matrix.test-type }}
+#    # For pull requests only run tests when python files changed
+#    if: needs.pyfiles.outputs.count != '0' || github.event_name != 'pull_request'
+#    steps:
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@v1
+#        with:
+#          python-version: '3.x'
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Tests"
+#        run: ./scripts/ci/ci_run_airflow_testing.sh
+#
+#  requirements:
+#    timeout-minutes: 80
+#    name: "Requirements"
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7, 3.8]
+#      fail-fast: false
+#    env:
+#      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+#      CHECK_REQUIREMENTS_ONLY: true
+#      UPGRADE_WHILE_GENERATING_REQUIREMENTS: ${{ github.event_name == 'schedule' }}
+#      CI_JOB_TYPE: "Requirements"
+#    steps:
+#      - uses: actions/checkout@master
+#      - uses: actions/setup-python@v1
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Generate requirements"
+#        run: ./scripts/ci/ci_generate_requirements.sh
+#
+#  push-prod-images-to-github-cache:
+#    timeout-minutes: 80
+#    name: "Push PROD images"
+#    runs-on: ubuntu-latest
+#    needs:
+#      - tests-sqlite
+#      - tests-postgres
+#      - tests-mysql
+#      - requirements
+#      - prepare-backport-packages
+#      - build-prod-image
+#      - docs
+#    if: github.ref == 'refs/heads/master' && github.event_name != 'schedule'
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7, 3.8]
+#    env:
+#      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+#      CI_JOB_TYPE: "Prod image"
+#    steps:
+#      - uses: actions/checkout@master
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build PROD images ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_build_production_images.sh
+#      - name: "Push PROD images ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_push_production_images.sh
+#
+#  push-ci-images-to-github-cache:
+#    timeout-minutes: 40
+#    name: "Push CI images"
+#    runs-on: ubuntu-latest
+#    needs:
+#      - tests-sqlite
+#      - tests-postgres
+#      - tests-mysql
+#      - requirements
+#      - prepare-backport-packages
+#      - build-prod-image
+#      - docs
+#    if: |
+#      (github.ref == 'refs/heads/master' ||
+#      github.ref == 'refs/heads/v1-10-test' ) &&
+#      github.event_name != 'schedule'
+#    strategy:
+#      matrix:
+#        python-version: [3.6, 3.7, 3.8]
+#    env:
+#      PULL_PYTHON_BASE_IMAGES_FROM_CACHE: "false"
+#      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+#      CI_JOB_TYPE: "Prod image"
+#    steps:
+#      - uses: actions/checkout@master
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Build CI image"
+#        run: ./scripts/ci/ci_prepare_image_on_ci.sh
+#      - name: "Push CI image ${{ matrix.python-version }}"
+#        run: ./scripts/ci/ci_push_ci_image.sh
+#
+#  tag-repo-nightly:
+#    timeout-minutes: 60
+#    name: "Tag repo nightly"
+#    runs-on: ubuntu-latest
+#    needs:
+#      - tests-sqlite
+#      - tests-postgres
+#      - tests-mysql
+#      - requirements
+#      - prepare-backport-packages
+#      - build-prod-image
+#      - docs
+#    if: github.event_name == 'schedule'
+#    steps:
+#      - uses: actions/checkout@master
+#      - name: "Free space"
+#        run: ./scripts/ci/ci_free_space_on_ci.sh
+#      - name: "Tag commit"
+#        run: |
+#          BRANCH_NAME=$(echo "${{ github.ref }}" | sed 's/refs\/heads\///')
+#          echo "Tagging ${BRANCH_NAME}"
+#          git tag -f nightly-${BRANCH_NAME} HEAD
+#      - name: Push tags
+#        uses: ad-m/github-push-action@master
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          tags: true
+#          force: true
+#          branch: master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,11 @@ jobs:
         run: ./scripts/ci/ci_perform_kind_cluster_operation.sh start
       - name: "Deploy app to cluster"
         run: ./scripts/ci/ci_deploy_app_to_kubernetes.sh
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: 'Kind logs'
+          path: '/tmp/kind_logs_*.tar.gz'
       - name: Cache virtualenv for kubernetes testing
         uses: actions/cache@v2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
         python-version: [3.6, 3.7]
         kube-mode:
           - image
+          - git
         kubernetes-version:
           - "v1.15.11"
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,11 +209,6 @@ jobs:
         run: ./scripts/ci/ci_perform_kind_cluster_operation.sh start
       - name: "Deploy app to cluster"
         run: ./scripts/ci/ci_deploy_app_to_kubernetes.sh
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: 'Kind logs'
-          path: '/tmp/kind_logs_*.tar.gz'
       - name: Cache virtualenv for kubernetes testing
         uses: actions/cache@v2
         env:
@@ -224,6 +219,12 @@ jobs:
 ${{ hashFiles('requirements/requirements-python${{matrix.python-version}}.txt') }}"
       - name: "Tests"
         run: ./scripts/ci/ci_run_kubernetes_tests.sh
+      - uses: actions/upload-artifact@v2
+        # Always run this, even if one of th previous steps failed.
+        if: always()
+        with:
+          name: 'Kind logs'
+          path: '/tmp/kind_logs_*.tar.gz'
 
   tests-postgres:
     timeout-minutes: 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
         kube-mode:
           - image
         kubernetes-version:
-          - "v1.15.3"
+          - "v1.15.11"
       fail-fast: false
     env:
       BACKEND: postgres

--- a/scripts/ci/ci_deploy_app_to_kubernetes.sh
+++ b/scripts/ci/ci_deploy_app_to_kubernetes.sh
@@ -25,6 +25,11 @@ export PYTHON_MAJOR_MINOR_VERSION=${PYTHON_MAJOR_MINOR_VERSION:="3.6"}
 export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:="airflow-python-${PYTHON_MAJOR_MINOR_VERSION}-${KUBERNETES_VERSION}"}
 export KUBERNETES_MODE=${KUBERNETES_MODE:="image"}
 
+# adding trap to exiting trap
+HANDLERS="$( trap -p EXIT | cut -f2 -d \' )"
+# shellcheck disable=SC2064
+trap "${HANDLERS}${HANDLERS:+;}send_kubernetes_logs_to_file_io" EXIT
+
 get_ci_environment
 check_kind_and_kubectl_are_installed
 build_kubernetes_image

--- a/scripts/ci/ci_deploy_app_to_kubernetes.sh
+++ b/scripts/ci/ci_deploy_app_to_kubernetes.sh
@@ -28,7 +28,7 @@ export KUBERNETES_MODE=${KUBERNETES_MODE:="image"}
 # adding trap to exiting trap
 HANDLERS="$( trap -p EXIT | cut -f2 -d \' )"
 # shellcheck disable=SC2064
-trap "${HANDLERS}${HANDLERS:+;}send_kubernetes_logs_to_file_io" EXIT
+trap "${HANDLERS}${HANDLERS:+;}dump_kind_logs" EXIT
 
 get_ci_environment
 check_kind_and_kubectl_are_installed

--- a/scripts/ci/ci_perform_kind_cluster_operation.sh
+++ b/scripts/ci/ci_perform_kind_cluster_operation.sh
@@ -22,7 +22,7 @@
 # adding trap to exiting trap
 HANDLERS="$( trap -p EXIT | cut -f2 -d \' )"
 # shellcheck disable=SC2064
-trap "${HANDLERS}${HANDLERS:+;}send_kubernetes_logs_to_file_io" EXIT
+trap "${HANDLERS}${HANDLERS:+;}dump_kind_logs" EXIT
 
 check_kind_and_kubectl_are_installed
 

--- a/scripts/ci/ci_perform_kind_cluster_operation.sh
+++ b/scripts/ci/ci_perform_kind_cluster_operation.sh
@@ -19,6 +19,11 @@
 # shellcheck source=scripts/ci/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/_script_init.sh"
 
+# adding trap to exiting trap
+HANDLERS="$( trap -p EXIT | cut -f2 -d \' )"
+# shellcheck disable=SC2064
+trap "${HANDLERS}${HANDLERS:+;}send_kubernetes_logs_to_file_io" EXIT
+
 check_kind_and_kubectl_are_installed
 
 perform_kind_cluster_operation "${@}"

--- a/scripts/ci/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/ci_run_kubernetes_tests.sh
@@ -18,6 +18,11 @@
 # shellcheck source=scripts/ci/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/_script_init.sh"
 
+# adding trap to exiting trap
+HANDLERS="$( trap -p EXIT | cut -f2 -d \' )"
+# shellcheck disable=SC2064
+trap "${HANDLERS}${HANDLERS:+;}send_kubernetes_logs_to_file_io" EXIT
+
 INTERACTIVE="false"
 
 declare -a TESTS

--- a/scripts/ci/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/ci_run_kubernetes_tests.sh
@@ -21,7 +21,7 @@
 # adding trap to exiting trap
 HANDLERS="$( trap -p EXIT | cut -f2 -d \' )"
 # shellcheck disable=SC2064
-trap "${HANDLERS}${HANDLERS:+;}send_kubernetes_logs_to_file_io" EXIT
+trap "${HANDLERS}${HANDLERS:+;}dump_kind_logs" EXIT
 
 INTERACTIVE="false"
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -218,7 +218,7 @@ function initialize_common_environment {
     export VERSION_SUFFIX_FOR_SVN=""
 
     # Version of Kubernetes to run
-    export KUBERNETES_VERSION="${KUBERNETES_VERSION:="v1.15.3"}"
+    export KUBERNETES_VERSION="${KUBERNETES_VERSION:="v1.15.11"}"
 
     # Name of the KinD cluster to connect to
     export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:="airflow-python-${PYTHON_MAJOR_MINOR_VERSION}-${KUBERNETES_VERSION}"}

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -104,6 +104,12 @@ function create_cluster() {
     echo
     echo "Restarted CoreDNS"
     echo
+    set -x
+    cat /var/lib/kubelet/kubeadm-flags.env  || true
+    cat /etc/default/kubelet || true
+    cat /etc/resolv.conf || true
+    cat /run/systemd/resolve/resolv.conf || true
+    set +x
 }
 
 function delete_cluster() {

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -21,25 +21,12 @@ function dump_kind_logs() {
     echo "                   Dumping logs from KIND"
     echo "###########################################################################################"
 
-    FILE_NAME="${1}"
-    kind --name "${KIND_CLUSTER_NAME}" export logs "${FILE_NAME}"
-}
+    echo "EXIT_CODE is ${EXIT_CODE:=}"
 
-function send_kubernetes_logs_to_file_io() {
-    echo "##############################################################################"
-    echo
-    echo "   DUMPING LOG FILES FROM KIND AND SENDING THEM TO file.io"
-    echo
-    echo "##############################################################################"
-    DUMP_DIR_NAME=$(date "+%Y-%m-%d")_kind_${CI_BUILD_ID:="default"}_${CI_JOB_ID:="default"}
-    DUMP_DIR=/tmp/${DUMP_DIR_NAME}
-    dump_kind_logs "${DUMP_DIR}"
+    local DUMP_DIR_NAME=kind_logs_$(date "+%Y-%m-%d")_${CI_BUILD_ID:="default"}_${CI_JOB_ID:="default"}
+    local DUMP_DIR=/tmp/${DUMP_DIR_NAME}
+    kind --name "${KIND_CLUSTER_NAME}" export logs "${DUMP_DIR}"
     tar -cvzf "${DUMP_DIR}.tar.gz" -C /tmp "${DUMP_DIR_NAME}"
-    echo
-    echo "   Logs saved to ${DUMP_DIR}.tar.gz"
-    echo
-    echo "##############################################################################"
-    curl -F "file=@${DUMP_DIR}.tar.gz" https://file.io
 }
 
 function check_kind_and_kubectl_are_installed() {

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -23,8 +23,9 @@ function dump_kind_logs() {
 
     echo "EXIT_CODE is ${EXIT_CODE:=}"
 
-    local DUMP_DIR_NAME=kind_logs_$(date "+%Y-%m-%d")_${CI_BUILD_ID:="default"}_${CI_JOB_ID:="default"}
-    local DUMP_DIR=/tmp/${DUMP_DIR_NAME}
+    local DUMP_DIR_NAME DUMP_DIR
+    DUMP_DIR_NAME=kind_logs_$(date "+%Y-%m-%d")_${CI_BUILD_ID:="default"}_${CI_JOB_ID:="default"}
+    DUMP_DIR="/tmp/${DUMP_DIR_NAME}"
     kind --name "${KIND_CLUSTER_NAME}" export logs "${DUMP_DIR}"
     tar -cvzf "${DUMP_DIR}.tar.gz" -C /tmp "${DUMP_DIR_NAME}"
 }

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -192,6 +192,7 @@ function perform_kind_cluster_operation() {
             echo "Creating cluster"
             echo
             create_cluster
+
         elif [[ ${OPERATION} == "stop" || ${OEPRATON} == "deploy" || ${OPERATION} == "test" ]]; then
             echo
             echo "Cluster ${KIND_CLUSTER_NAME} does not exist. It should exist for ${OPERATION} operation"
@@ -378,19 +379,12 @@ function apply_kubernetes_resources() {
 function dump_kubernetes_logs() {
     POD=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' \
         --cluster "${KUBECTL_CLUSTER_NAME}" | grep airflow | head -1)
+    kubectl get all
+    kubectl get all --namespace kube-system
     echo "------- pod description -------"
     kubectl describe pod "${POD}" --cluster "${KUBECTL_CLUSTER_NAME}"
-    echo "------- webserver init container logs - init -------"
-    kubectl logs "${POD}" -c init --cluster "${KUBECTL_CLUSTER_NAME}" || true
-    if [[ "${KUBERNETES_MODE}" == "git" ]]; then
-        echo "------- webserver init container logs - git-sync-clone -------"
-        kubectl logs "${POD}" -c git-sync-clone --cluster "${KUBECTL_CLUSTER_NAME}" || true
-    fi
-    echo "------- webserver logs -------"
-    kubectl logs "${POD}" -c webserver --cluster "${KUBECTL_CLUSTER_NAME}" || true
-    echo "------- scheduler logs -------"
-    kubectl logs "${POD}" -c scheduler --cluster "${KUBECTL_CLUSTER_NAME}" || true
-    echo "--------------"
+    echo "------- airflow pod logs -------"
+    kubectl logs "${POD}" --all-containers=true || true
 }
 
 function wait_for_airflow_pods_up_and_running() {


### PR DESCRIPTION
uses `--all-containers=true` flag to get all k8s logs

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
