### PR TITLE
Correctly colour full warning/error log message with parameters.

### DIFF
--- a/airflow/utils/log/colored_log.py
+++ b/airflow/utils/log/colored_log.py
@@ -24,9 +24,7 @@ from logging import LogRecord
 from typing import Any, Union
 
 from colorlog import TTYColoredFormatter
-from termcolor import colored
-
-ARGS = {"attrs": ["bold"]}
+from colorlog.escape_codes import esc, escape_codes
 
 DEFAULT_COLORS = {
     "DEBUG": "red",
@@ -35,6 +33,9 @@ DEFAULT_COLORS = {
     "ERROR": "red",
     "CRITICAL": "red",
 }
+
+BOLD_ON = escape_codes['bold']
+BOLD_OFF = esc('22')
 
 
 class CustomTTYColoredFormatter(TTYColoredFormatter):
@@ -53,7 +54,7 @@ class CustomTTYColoredFormatter(TTYColoredFormatter):
         if isinstance(arg, (int, float)):
             # In case of %d or %f formatting
             return arg
-        return colored(str(arg), **ARGS)  # type: ignore
+        return BOLD_ON + str(arg) + BOLD_OFF
 
     @staticmethod
     def _count_number_of_arguments_in_message(record: LogRecord) -> int:
@@ -84,7 +85,9 @@ class CustomTTYColoredFormatter(TTYColoredFormatter):
                 record.exc_text = self.formatException(record.exc_info)
 
             if record.exc_text:
-                record.exc_text = colored(record.exc_text, DEFAULT_COLORS["ERROR"])
+                record.exc_text = self.color(self.log_colors, record.levelname) + \
+                    record.exc_text + escape_codes['reset']
+
         return record
 
     def format(self, record: LogRecord) -> str:

--- a/requirements/requirements-python3.6.txt
+++ b/requirements/requirements-python3.6.txt
@@ -45,7 +45,7 @@ apispec==1.3.3
 appdirs==1.4.4
 argcomplete==1.11.1
 asn1crypto==1.3.0
-astroid==2.4.2
+astroid==2.3.3
 async-generator==1.10
 async-timeout==3.0.1
 atlasclient==1.0.0
@@ -72,9 +72,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.13.26
+boto3==1.14.0
 boto==2.49.0
-botocore==1.16.26
+botocore==1.17.0
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -100,7 +100,7 @@ croniter==0.3.32
 cryptography==2.9.2
 curlify==2.2.1
 cx-Oracle==7.3.0
-dask==2.18.0
+dask==2.18.1
 datadog==0.36.0
 decorator==4.4.2
 defusedxml==0.6.0
@@ -138,8 +138,8 @@ gcsfs==0.6.2
 gevent==20.6.0
 gitdb==4.0.5
 google-ads==4.0.0
-google-api-core==1.19.1
-google-api-python-client==1.9.1
+google-api-core==1.20.0
+google-api-python-client==1.9.2
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1
 google-auth==1.16.1
@@ -151,12 +151,12 @@ google-cloud-container==0.5.0
 google-cloud-core==1.3.0
 google-cloud-datacatalog==0.7.0
 google-cloud-dataproc==0.8.1
-google-cloud-dlp==0.15.0
+google-cloud-dlp==1.0.0
 google-cloud-kms==1.4.0
 google-cloud-language==1.3.0
 google-cloud-logging==1.15.0
 google-cloud-monitoring==1.0.0
-google-cloud-pubsub==1.5.0
+google-cloud-pubsub==1.6.0
 google-cloud-redis==1.0.0
 google-cloud-secret-manager==1.0.0
 google-cloud-spanner==1.17.0
@@ -165,7 +165,7 @@ google-cloud-storage==1.28.1
 google-cloud-tasks==1.5.0
 google-cloud-texttospeech==1.0.1
 google-cloud-translate==2.0.1
-google-cloud-videointelligence==1.14.0
+google-cloud-videointelligence==1.15.0
 google-cloud-vision==1.0.0
 google-resumable-media==0.5.1
 googleapis-common-protos==1.52.0
@@ -187,7 +187,7 @@ ijson==2.6.1
 imagesize==1.2.0
 immutables==0.14
 importlib-metadata==1.6.1
-importlib-resources==1.5.0
+importlib-resources==2.0.0
 inflection==0.5.0
 ipdb==0.13.2
 ipython-genutils==0.2.0
@@ -232,7 +232,7 @@ mypy==0.770
 mysql-connector-python==8.0.18
 mysqlclient==1.3.14
 natsort==7.0.1
-nbclient==0.3.1
+nbclient==0.4.0
 nbformat==5.0.7
 nest-asyncio==1.3.3
 networkx==2.4
@@ -259,7 +259,7 @@ pickleshare==0.7.5
 pinotdb==0.1.1
 pipdeptree==0.13.2
 pluggy==0.13.1
-pre-commit==2.5.0
+pre-commit==2.5.1
 presto-python-client==0.7.0
 prison==0.1.3
 prompt-toolkit==3.0.5
@@ -361,7 +361,6 @@ tableauserverclient==0.9
 tabulate==0.8.7
 tblib==1.6.0
 tenacity==4.12.0
-termcolor==1.1.0
 text-unidecode==1.3
 textwrap3==0.9.2
 thrift-sasl==0.4.2
@@ -384,7 +383,7 @@ virtualenv==20.0.21
 watchtower==0.7.3
 wcwidth==0.2.4
 websocket-client==0.57.0
-wrapt==1.12.1
+wrapt==1.11.2
 xmltodict==0.12.0
 yamllint==1.23.0
 yandexcloud==0.41.0

--- a/requirements/requirements-python3.7.txt
+++ b/requirements/requirements-python3.7.txt
@@ -45,7 +45,7 @@ apispec==1.3.3
 appdirs==1.4.4
 argcomplete==1.11.1
 asn1crypto==1.3.0
-astroid==2.3.3
+astroid==2.4.2
 async-generator==1.10
 async-timeout==3.0.1
 atlasclient==1.0.0
@@ -72,9 +72,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.13.26
+boto3==1.14.0
 boto==2.49.0
-botocore==1.16.26
+botocore==1.17.0
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -99,7 +99,7 @@ croniter==0.3.32
 cryptography==2.9.2
 curlify==2.2.1
 cx-Oracle==7.3.0
-dask==2.18.0
+dask==2.18.1
 datadog==0.36.0
 decorator==4.4.2
 defusedxml==0.6.0
@@ -137,8 +137,8 @@ gcsfs==0.6.2
 gevent==20.6.0
 gitdb==4.0.5
 google-ads==5.1.0
-google-api-core==1.19.1
-google-api-python-client==1.9.1
+google-api-core==1.20.0
+google-api-python-client==1.9.2
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1
 google-auth==1.16.1
@@ -150,12 +150,12 @@ google-cloud-container==0.5.0
 google-cloud-core==1.3.0
 google-cloud-datacatalog==0.7.0
 google-cloud-dataproc==0.8.1
-google-cloud-dlp==0.15.0
+google-cloud-dlp==1.0.0
 google-cloud-kms==1.4.0
 google-cloud-language==1.3.0
 google-cloud-logging==1.15.0
 google-cloud-monitoring==1.0.0
-google-cloud-pubsub==1.5.0
+google-cloud-pubsub==1.6.0
 google-cloud-redis==1.0.0
 google-cloud-secret-manager==1.0.0
 google-cloud-spanner==1.17.0
@@ -164,7 +164,7 @@ google-cloud-storage==1.28.1
 google-cloud-tasks==1.5.0
 google-cloud-texttospeech==1.0.1
 google-cloud-translate==2.0.1
-google-cloud-videointelligence==1.14.0
+google-cloud-videointelligence==1.15.0
 google-cloud-vision==1.0.0
 google-resumable-media==0.5.1
 googleapis-common-protos==1.52.0
@@ -228,7 +228,7 @@ mypy==0.770
 mysql-connector-python==8.0.18
 mysqlclient==1.3.14
 natsort==7.0.1
-nbclient==0.3.1
+nbclient==0.4.0
 nbformat==5.0.7
 nest-asyncio==1.3.3
 networkx==2.4
@@ -254,7 +254,7 @@ pickleshare==0.7.5
 pinotdb==0.1.1
 pipdeptree==0.13.2
 pluggy==0.13.1
-pre-commit==2.5.0
+pre-commit==2.5.1
 presto-python-client==0.7.0
 prison==0.1.3
 prompt-toolkit==3.0.5
@@ -356,7 +356,6 @@ tableauserverclient==0.9
 tabulate==0.8.7
 tblib==1.6.0
 tenacity==4.12.0
-termcolor==1.1.0
 text-unidecode==1.3
 textwrap3==0.9.2
 thrift-sasl==0.4.2
@@ -378,7 +377,7 @@ virtualenv==20.0.21
 watchtower==0.7.3
 wcwidth==0.2.4
 websocket-client==0.57.0
-wrapt==1.11.2
+wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.23.0
 yandexcloud==0.41.0

--- a/requirements/requirements-python3.8.txt
+++ b/requirements/requirements-python3.8.txt
@@ -45,7 +45,7 @@ apispec==1.3.3
 appdirs==1.4.4
 argcomplete==1.11.1
 asn1crypto==1.3.0
-astroid==2.3.3
+astroid==2.4.2
 async-generator==1.10
 async-timeout==3.0.1
 atlasclient==1.0.0
@@ -72,9 +72,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.13.26
+boto3==1.14.0
 boto==2.49.0
-botocore==1.16.26
+botocore==1.17.0
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -99,7 +99,7 @@ croniter==0.3.32
 cryptography==2.9.2
 curlify==2.2.1
 cx-Oracle==7.3.0
-dask==2.18.0
+dask==2.18.1
 datadog==0.36.0
 decorator==4.4.2
 defusedxml==0.6.0
@@ -137,8 +137,8 @@ gcsfs==0.6.2
 gevent==20.6.0
 gitdb==4.0.5
 google-ads==5.1.0
-google-api-core==1.19.1
-google-api-python-client==1.9.1
+google-api-core==1.20.0
+google-api-python-client==1.9.2
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1
 google-auth==1.16.1
@@ -150,12 +150,12 @@ google-cloud-container==0.5.0
 google-cloud-core==1.3.0
 google-cloud-datacatalog==0.7.0
 google-cloud-dataproc==0.8.1
-google-cloud-dlp==0.15.0
+google-cloud-dlp==1.0.0
 google-cloud-kms==1.4.0
 google-cloud-language==1.3.0
 google-cloud-logging==1.15.0
 google-cloud-monitoring==1.0.0
-google-cloud-pubsub==1.5.0
+google-cloud-pubsub==1.6.0
 google-cloud-redis==1.0.0
 google-cloud-secret-manager==1.0.0
 google-cloud-spanner==1.17.0
@@ -164,7 +164,7 @@ google-cloud-storage==1.28.1
 google-cloud-tasks==1.5.0
 google-cloud-texttospeech==1.0.1
 google-cloud-translate==2.0.1
-google-cloud-videointelligence==1.14.0
+google-cloud-videointelligence==1.15.0
 google-cloud-vision==1.0.0
 google-resumable-media==0.5.1
 googleapis-common-protos==1.52.0
@@ -228,7 +228,7 @@ mypy==0.770
 mysql-connector-python==8.0.18
 mysqlclient==1.3.14
 natsort==7.0.1
-nbclient==0.3.1
+nbclient==0.4.0
 nbformat==5.0.7
 nest-asyncio==1.3.3
 networkx==2.4
@@ -254,7 +254,7 @@ pickleshare==0.7.5
 pinotdb==0.1.1
 pipdeptree==0.13.2
 pluggy==0.13.1
-pre-commit==2.5.0
+pre-commit==2.5.1
 presto-python-client==0.7.0
 prison==0.1.3
 prompt-toolkit==3.0.5
@@ -315,7 +315,7 @@ requests-oauthlib==1.1.0
 requests-toolbelt==0.9.1
 requests==2.23.0
 responses==0.10.14
-rsa==4.0
+rsa==4.1
 s3transfer==0.3.3
 sasl==0.2.1
 semver==2.10.1
@@ -355,7 +355,6 @@ tableauserverclient==0.9
 tabulate==0.8.7
 tblib==1.6.0
 tenacity==4.12.0
-termcolor==1.1.0
 text-unidecode==1.3
 textwrap3==0.9.2
 thrift-sasl==0.4.2
@@ -377,7 +376,7 @@ virtualenv==20.0.21
 watchtower==0.7.3
 wcwidth==0.2.4
 websocket-client==0.57.0
-wrapt==1.11.2
+wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.23.0
 yandexcloud==0.41.0

--- a/requirements/setup-3.6.md5
+++ b/requirements/setup-3.6.md5
@@ -1,1 +1,1 @@
-72eff355caceb467d3c4e62b06f49beb  /opt/airflow/setup.py
+773e1cd4e57de0345eb61f767e89a472  /opt/airflow/setup.py

--- a/requirements/setup-3.7.md5
+++ b/requirements/setup-3.7.md5
@@ -1,1 +1,1 @@
-72eff355caceb467d3c4e62b06f49beb  /opt/airflow/setup.py
+773e1cd4e57de0345eb61f767e89a472  /opt/airflow/setup.py

--- a/requirements/setup-3.8.md5
+++ b/requirements/setup-3.8.md5
@@ -1,1 +1,1 @@
-72eff355caceb467d3c4e62b06f49beb  /opt/airflow/setup.py
+773e1cd4e57de0345eb61f767e89a472  /opt/airflow/setup.py

--- a/setup.py
+++ b/setup.py
@@ -723,7 +723,6 @@ INSTALL_REQUIREMENTS = [
     'sqlalchemy_jsonfield~=0.9',
     'tabulate>=0.7.5, <0.9',
     'tenacity==4.12.0',
-    'termcolor==1.1.0',
     'thrift>=0.9.2',
     'typing;python_version<"3.6"',
     'typing-extensions>=3.7.4;python_version<"3.8"',


### PR DESCRIPTION
Previously after the first parameter the colour was lost, as `color()` included the reset code always.

I have fixed it by using `\e[22m` -- which resets the bold/thin state, but not the colour.

Before:
![log-before](https://user-images.githubusercontent.com/34150/84318688-bcc0fe80-ab66-11ea-859c-bceba33ede25.png)

After:
![logging-after](https://user-images.githubusercontent.com/34150/84318694-be8ac200-ab66-11ea-9986-f843f12eb01b.png)

The "\e[22m" escape sequence has been tested on Konsole, iTerm2 and Terminal.app `echo -e "\033[31mHello \033[1mbold\033[22m after\033[0m"` if you would like to test it yourself.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
