### PR TITLE
Bug fix for issue #9127: EmrAddStepOperator init with cluster_name error

### DIFF
--- a/airflow/contrib/operators/emr_add_steps_operator.py
+++ b/airflow/contrib/operators/emr_add_steps_operator.py
@@ -66,12 +66,14 @@ class EmrAddStepsOperator(BaseOperator):
         self.steps = steps
 
     def execute(self, context):
-        emr = EmrHook(aws_conn_id=self.aws_conn_id).get_conn()
+        emr_hook = EmrHook(aws_conn_id=self.aws_conn_id)
 
-        job_flow_id = self.job_flow_id
+        emr = emr_hook.get_conn()
 
+        job_flow_id = self.job_flow_id or emr_hook.get_cluster_id_by_name(self.job_flow_name,
+                                                                          self.cluster_states)
         if not job_flow_id:
-            job_flow_id = emr.get_cluster_id_by_name(self.job_flow_name, self.cluster_states)
+            raise AirflowException(f'No cluster found for name: {self.job_flow_name}')
 
         if self.do_xcom_push:
             context['ti'].xcom_push(key='job_flow_id', value=job_flow_id)

--- a/tests/contrib/operators/test_emr_add_steps_operator.py
+++ b/tests/contrib/operators/test_emr_add_steps_operator.py
@@ -105,10 +105,11 @@ class TestEmrAddStepsOperator(unittest.TestCase):
         with patch('boto3.session.Session', self.boto3_session_mock):
             self.assertEqual(self.operator.execute(self.mock_context), ['s-2LH3R5GW3A53T'])
 
+    @patch.multiple('airflow.contrib.hooks.emr_hook.EmrHook',
+                    get_cluster_id_by_name=MagicMock(return_value='j-1231231234'))
     def test_init_with_cluster_name(self):
         expected_job_flow_id = 'j-1231231234'
 
-        self.emr_client_mock.get_cluster_id_by_name.return_value = expected_job_flow_id
         self.emr_client_mock.add_job_flow_steps.return_value = ADD_STEPS_SUCCESS_RETURN
 
         with patch('boto3.session.Session', self.boto3_session_mock):


### PR DESCRIPTION
Description: 

 - Resolves / Fixes: #9127 
 - The current Airflow 1.10.10 API for `EmrAddStepOperator` throws an error when it is initialized with `job_flow_name` (aka EMR cluster name) as opposed to `job_flow_id` (`AttributeError: 'EMR' object has no attribute 'get_cluster_id_by_name'`, see issue #9127 for more details). As a result, the task instance associated with the `EmrStep` as well as the corresponding `DagRun` fails. There is a bug in the `execute()` method of `emr_add_step_operator.py` class in which the EMR client uses the wrong API to retrieve the `job_flow_id` for the given `job_flow_name` passed to the `EmrAddStepOperator`. In other words, instead of calling the `get_cluster_id_by_name()` method from the `airflow.contrib.hooks.emr_hook.EmrHook` object, it is called from `botocore.client.EMR` object, which obviously throws an error. This is a very _simple_ fix for this bug. 

 - Updated the current unit tests and passes. 

 - Tested against Python 3.7.7 local environment

 - Airflow version used in the development: 1.10.10

- Please Note: Latest `master` branch (Airflow 2.0.0dev) already fixes this issue, however the fix is not present in stable Airflow 1.10.10 version.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
