### PR TITLE
Further validation that only task commands are run by executors

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -456,9 +456,6 @@ class AirflowKubernetesScheduler(LoggingMixin):
         key, command, kube_executor_config = next_job
         dag_id, task_id, execution_date, try_number = key
 
-        if isinstance(command, str):
-            command = [command]
-
         if command[0:3] != ["airflow", "tasks", "run"]:
             raise ValueError('The command must start with ["airflow", "tasks", "run"].')
 

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -459,8 +459,8 @@ class AirflowKubernetesScheduler(LoggingMixin):
         if isinstance(command, str):
             command = [command]
 
-        if command[0] != "airflow":
-            raise ValueError('The first element of command must be equal to "airflow".')
+        if command[0:3] != ["airflow", "tasks", "run"]:
+            raise ValueError('The command must start with ["airflow", "tasks", "run"].')
 
         pod = PodGenerator.construct_pod(
             namespace=self.namespace,

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -46,11 +46,11 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 class TestBaseDask(unittest.TestCase):
 
     def assert_tasks_on_executor(self, executor):
+
+        success_command = ['airflow', 'tasks', 'run', '--help']
+        fail_command = ['airflow', 'tasks', 'run', 'false']
         # start the executor
         executor.start()
-
-        success_command = ['true', 'some_parameter']
-        fail_command = ['false', 'some_parameter']
 
         executor.execute_async(key='success', command=success_command)
         executor.execute_async(key='fail', command=fail_command)

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -205,7 +205,7 @@ class TestKubernetesExecutor(unittest.TestCase):
         try_number = 1
         kubernetes_executor.execute_async(key=('dag', 'task', datetime.utcnow(), try_number),
                                           queue=None,
-                                          command='command',
+                                          command=["airflow", "version"],
                                           executor_config={})
         kubernetes_executor.sync()
         kubernetes_executor.sync()

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -205,7 +205,7 @@ class TestKubernetesExecutor(unittest.TestCase):
         try_number = 1
         kubernetes_executor.execute_async(key=('dag', 'task', datetime.utcnow(), try_number),
                                           queue=None,
-                                          command=["airflow", "version"],
+                                          command=['airflow', 'tasks', 'run', 'true', 'some_parameter'],
                                           executor_config={})
         kubernetes_executor.sync()
         kubernetes_executor.sync()


### PR DESCRIPTION
#9178 added a check to raise an exception if commands don't start with `airflow tasks run`. However, the tests were passing on CI (maybe because of cache) but were failing on Breeze

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
