### PR TITLE
Add truncate table (before copy) option to S3ToRedshiftOperator

### DIFF
--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -60,7 +60,10 @@ class S3ToRedshiftOperator(BaseOperator):
     :type truncate_table: bool
     """
 
-    template_fields = ('s3_key', 'table',)
+    template_fields = (
+        's3_key',
+        'table',
+    )
     template_ext = ()
     ui_color = '#99e699'
 

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -94,13 +94,11 @@ class S3ToRedshiftOperator(BaseOperator):
         self.copy_options = copy_options or []
         self.autocommit = autocommit
         self.truncate_table = truncate_table
-        self._s3_hook = None
-        self._postgres_hook = None
 
-    def execute(self, context):
-        self._postgres_hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)
-        self._s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
-        credentials = self._s3_hook.get_credentials()
+    def execute(self, context) -> None:
+        postgres_hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)
+        s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
+        credentials = s3_hook.get_credentials()
         copy_options = '\n\t\t\t'.join(self.copy_options)
 
         copy_statement = f"""
@@ -123,5 +121,5 @@ class S3ToRedshiftOperator(BaseOperator):
             sql = copy_statement
 
         self.log.info('Executing COPY command...')
-        self._postgres_hook.run(sql, self.autocommit)
+        postgres_hook.run(sql, self.autocommit)
         self.log.info("COPY command complete...")

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -120,7 +120,7 @@ class S3ToRedshiftOperator(BaseOperator):
         )
 
         if self.truncate_table:
-            truncate_statement = f'TRUNCATE TABLE {schema}.{table};'
+            truncate_statement = f'TRUNCATE TABLE {self.schema}.{self.table};'
             transaction = f"""
             BEGIN;
             {truncate_statement}

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -96,4 +96,13 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
             dag=None,
         )
         op.execute(None)
+        truncate_statement = f'TRUNCATE TABLE {schema}.{table}'
+        transaction = f"""
+                    BEGIN;
+                    {truncate_statement}
+                    {copy_statement}
+                    COMMIT
+                    """
+        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], transaction)
 
+        assert mock_run.call_count == 1

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -99,7 +99,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     {copy_options};
                 """
 
-        truncate_statement = f'TRUNCATE TABLE {schema}.{table}'
+        truncate_statement = f'TRUNCATE TABLE {schema}.{table};'
         transaction = f"""
                     BEGIN;
                     {truncate_statement}

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -71,3 +71,29 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
 
         assert mock_run.call_count == 1
         assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], copy_query)
+
+    def test_truncate(self, mock_run, mock_session):
+        access_key = "aws_access_key_id"
+        secret_key = "aws_secret_access_key"
+        mock_session.return_value = Session(access_key, secret_key)
+
+        schema = "schema"
+        table = "table"
+        s3_bucket = "bucket"
+        s3_key = "key"
+        copy_options = ""
+
+        op = S3ToRedshiftOperator(
+            schema=schema,
+            table=table,
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            copy_options=copy_options,
+            truncate_table=True,
+            redshift_conn_id="redshift_conn_id",
+            aws_conn_id="aws_conn_id",
+            task_id="task_id",
+            dag=None,
+        )
+        op.execute(None)
+

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -72,6 +72,8 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
         assert mock_run.call_count == 1
         assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], copy_query)
 
+    @mock.patch("boto3.session.Session")
+    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
     def test_truncate(self, mock_run, mock_session):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -53,21 +53,13 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
         )
         op.execute(None)
 
-        copy_query = """
+        copy_query = f"""
             COPY {schema}.{table}
             FROM 's3://{s3_bucket}/{s3_key}'
             with credentials
             'aws_access_key_id={access_key};aws_secret_access_key={secret_key}'
             {copy_options};
-        """.format(
-            schema=schema,
-            table=table,
-            s3_bucket=s3_bucket,
-            s3_key=s3_key,
-            access_key=access_key,
-            secret_key=secret_key,
-            copy_options=copy_options,
-        )
+        """
 
         assert mock_run.call_count == 1
         assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], copy_query)
@@ -99,21 +91,14 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
         )
         op.execute(None)
 
-        copy_statement = """
+        copy_statement = f"""
                     COPY {schema}.{table}
                     FROM 's3://{s3_bucket}/{s3_key}'
                     with credentials
                     'aws_access_key_id={access_key};aws_secret_access_key={secret_key}'
                     {copy_options};
-                """.format(
-            schema=schema,
-            table=table,
-            s3_bucket=s3_bucket,
-            s3_key=s3_key,
-            access_key=access_key,
-            secret_key=secret_key,
-            copy_options=copy_options,
-        )
+                """
+
         truncate_statement = f'TRUNCATE TABLE {schema}.{table}'
         transaction = f"""
                     BEGIN;

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -96,6 +96,22 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
             dag=None,
         )
         op.execute(None)
+
+        copy_query = """
+                    COPY {schema}.{table}
+                    FROM 's3://{s3_bucket}/{s3_key}'
+                    with credentials
+                    'aws_access_key_id={access_key};aws_secret_access_key={secret_key}'
+                    {copy_options};
+                """.format(
+            schema=schema,
+            table=table,
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            access_key=access_key,
+            secret_key=secret_key,
+            copy_options=copy_options,
+        )
         truncate_statement = f'TRUNCATE TABLE {schema}.{table}'
         transaction = f"""
                     BEGIN;

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -97,7 +97,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
         )
         op.execute(None)
 
-        copy_query = """
+        copy_statement = """
                     COPY {schema}.{table}
                     FROM 's3://{s3_bucket}/{s3_key}'
                     with credentials


### PR DESCRIPTION
This PR adds the truncate argument (bool), which makes a truncate right before the copy statement, within the same transaction. Also, the color has been changed to a more vivid one. 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).