### PR TITLE
CI: Propogate Exit Code Correctly

### DIFF
--- a/scripts/ci/ci_run_airflow_testing.sh
+++ b/scripts/ci/ci_run_airflow_testing.sh
@@ -106,25 +106,4 @@ done
 
 RUN_INTEGRATION_TESTS=${RUN_INTEGRATION_TESTS:=""}
 
-# Repeat tests in case initialization failed
-set +u
-MAX_RETRIES=4
-while [[ ${MAX_RETRIES} -ge "0" ]]
-do
-    set +e
-    run_airflow_testing_in_docker "${@}"
-    EXIT_CODE=$?
-    set -e
-    if [[ ${EXIT_CODE} == 254 ]] ; then
-        echo
-        echo "Retrying on initialization failure. Remaining ${MAX_RETRIES} retries left"
-        echo
-        MAX_RETRIES=$(( MAX_RETRIES - 1 ))
-        # Cleanup docker containers and images to make sure everything is retried from scratch
-        docker-compose -f "${MY_DIR}/docker-compose/base.yml" down --remove-orphans --timeout 20
-        docker system prune --force --volumes
-        continue
-    fi
-    exit ${EXIT_CODE}
-done
-set -u
+run_airflow_testing_in_docker "${@}"

--- a/scripts/ci/ci_run_airflow_testing.sh
+++ b/scripts/ci/ci_run_airflow_testing.sh
@@ -127,16 +127,4 @@ do
     fi
     exit ${EXIT_CODE}
 done
-
-# shellcheck disable=SC2016
-docker-compose --log-level INFO \
-  -f "${MY_DIR}/docker-compose/base.yml" \
-  -f "${MY_DIR}/docker-compose/backend-${BACKEND}.yml" \
-  "${INTEGRATIONS[@]}" \
-  "${DOCKER_COMPOSE_LOCAL[@]}" \
-     run airflow \
-       '/opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"' \
-       /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh "${@}"
-     # Note the command is there twice (!) because it is passed via bash -c
-     # and bash -c starts passing parameters from $0. TODO: fixme
 set -u


### PR DESCRIPTION
Exit Code is not propagated properly to the CI.

This merged commit caused it: https://github.com/apache/airflow/commit/ff5dcccbbd49e7a4632f93fa915565ac31730110

Before that commit was merged, EXIT_CODE was used to end the script.

**Note**: This PR will just expose the CI errors not fix them

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
