### PR TITLE
Correct argument in create user command

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -31,7 +31,7 @@ following CLI commands to create an account:
 .. code-block:: bash
 
     # create an admin user
-    airflow users create --username admin --firstname Peter --lastname Parker --role Admin --email spiderman@superhero.org
+    airflow create_user --username admin --firstname Peter --lastname Parker --role Admin --email spiderman@superhero.org
 
 It is however possible to switch on authentication by either using one of the supplied
 backends or creating your own.


### PR DESCRIPTION
the `users create` argument in the create user command has replaced by `create_user`. So when we call `users create`, it will raise a error message (`airflow command error: argument subcommand: invalid choice: 'users'`)

---
Make sure to mark the boxes below before creating PR: [x]

- [ x] Description above provides context of the change
- [x ] Unit tests coverage for changes (not needed for documentation changes)
- [x ] Target Github ISSUE in description if exists
- [ x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ x] Relevant documentation is updated including usage instructions.
- [ x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
