### PR TITLE
Fix tree view if config contains "

### DIFF
--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -136,7 +136,7 @@ function populate_taskinstance_properties(node) {
 
 var devicePixelRatio = window.devicePixelRatio || 1;
 // JSON.parse is faster for large payloads than an object literal (because the JSON grammer is simpler!)
-var data = JSON.parse('{{ data }}');
+var data = JSON.parse({{ data|tojson }});
 var barHeight = 20;
 var axisHeight = 40;
 var square_x = parseInt(500 * devicePixelRatio);


### PR DESCRIPTION
https://github.com/apache/airflow/issues/9251

If you run DAG with `{"\"": ""}` configuration tree view will be broken:
```
tree:1 Uncaught SyntaxError: Unexpected string in JSON at position 806
    at JSON.parse (<anonymous>)
    at tree?dag_id=hightlight_test&num_runs=25:1190
```

JSON.parse is given incorrectly escaped json string.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes). Not sure for this specific case. Are there anything?
- [x] Target Github ISSUE in description if exists 
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
