### PR TITLE
Update (previously null) imap_default conn_type

### DIFF
--- a/airflow/migrations/versions/8f966b9c467a_set_conn_type_as_non_nullable.py
+++ b/airflow/migrations/versions/8f966b9c467a_set_conn_type_as_non_nullable.py
@@ -26,6 +26,7 @@ Create Date: 2020-06-08 22:36:34.534121
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.ext.declarative import declarative_base
 
 # revision identifiers, used by Alembic.
 revision = "8f966b9c467a"
@@ -36,6 +37,26 @@ depends_on = None
 
 def upgrade():
     """Apply Set conn_type as non-nullable"""
+
+    Base = declarative_base()
+
+    class Connection(Base):
+        __tablename__ = "connection"
+
+        id = sa.Column(sa.Integer(), primary_key=True)
+        conn_id = sa.Column(sa.String(250))
+        conn_type = sa.Column(sa.String(500))
+
+    # Generate run type for existing records
+    connection = op.get_bind()
+    sessionmaker = sa.orm.sessionmaker()
+    session = sessionmaker(bind=connection)
+
+    # imap_default was missing it's type, let's fix that up
+    session.query(Connection).filter_by(conn_id="imap_default", conn_type=None).update(
+        {Connection.conn_type: "imap"}, synchronize_session=False
+    )
+    session.commit()
 
     with op.batch_alter_table("connection", schema=None) as batch_op:
         batch_op.alter_column("conn_type", existing_type=sa.VARCHAR(length=500), nullable=False)

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -64,6 +64,7 @@ CONN_TYPE_TO_HOOK = {
     "grpc": ("airflow.providers.grpc.hooks.grpc.GrpcHook", "grpc_conn_id"),
     "hive_cli": ("airflow.providers.apache.hive.hooks.hive.HiveCliHook", "hive_cli_conn_id"),
     "hiveserver2": ("airflow.providers.apache.hive.hooks.hive.HiveServer2Hook", "hiveserver2_conn_id"),
+    "imap": ("airflow.providers.imap.hooks.imap.ImapHook", "imap_conn_id"),
     "jdbc": ("airflow.providers.jdbc.hooks.jdbc.JdbcHook", "jdbc_conn_id"),
     "jira": ("airflow.providers.jira.hooks.jira.JiraHook", "jira_conn_id"),
     "kubernetes": ("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook", "kubernetes_conn_id"),
@@ -172,6 +173,7 @@ class Connection(Base, LoggingMixin):
         ('tableau', 'Tableau'),
         ('kubernetes', 'Kubernetes cluster Connection'),
         ('spark', 'Spark'),
+        ('imap', 'IMAP')
     ]
 
     def __init__(

--- a/tests/providers/imap/hooks/test_imap.py
+++ b/tests/providers/imap/hooks/test_imap.py
@@ -55,6 +55,7 @@ class TestImapHook(unittest.TestCase):
         db.merge_conn(
             Connection(
                 conn_id='imap_default',
+                conn_type='imap',
                 host='imap_server_address',
                 login='imap_user',
                 password='imap_password'


### PR DESCRIPTION
This is a test fixup to #9187, and updates the possibly existing
imap_default connection, and adds that hook type to the various lists

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
