### PR TITLE
Fix Failing test for JSON Formatter on Python 3.8

### DIFF
--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -208,7 +208,6 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         if self.json_format:
             self.formatter = JSONFormatter(
-                self.formatter._fmt,  # pylint: disable=protected-access
                 json_fields=self.json_fields,
                 extras={
                     'dag_id': str(ti.dag_id),

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -254,9 +254,8 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertTrue(self.es_task_handler.mark_end_on_close)
 
     def test_set_context_w_json_format_and_write_stdout(self):
-        self.es_task_handler.formatter = mock.MagicMock()
-        self.es_task_handler.formatter._fmt = mock.MagicMock()
-        self.es_task_handler.formatter._fmt.find = mock.MagicMock(return_value=1)
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        self.es_task_handler.formatter = formatter
         self.es_task_handler.write_stdout = True
         self.es_task_handler.json_format = True
         self.es_task_handler.set_context(self.ti)


### PR DESCRIPTION
This test is failing on Master:

```
tests/utils/log/test_es_task_handler.py ..................F

_ TestElasticsearchTaskHandler.test_set_context_w_json_format_and_write_stdout _

self = <tests.utils.log.test_es_task_handler.TestElasticsearchTaskHandler testMethod=test_set_context_w_json_format_and_write_stdout>

    def test_set_context_w_json_format_and_write_stdout(self):
        self.es_task_handler.formatter = mock.MagicMock()
        self.es_task_handler.formatter._fmt = mock.MagicMock()
        self.es_task_handler.formatter._fmt.find = mock.MagicMock(return_value=1)
        self.es_task_handler.write_stdout = True
        self.es_task_handler.json_format = True
>       self.es_task_handler.set_context(self.ti)

tests/utils/log/test_es_task_handler.py:262: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
airflow/utils/log/es_task_handler.py:210: in set_context
    self.formatter = JSONFormatter(
airflow/utils/log/json_formatter.py:35: in __init__
    super().__init__(fmt, datefmt, style)
/usr/local/lib/python3.8/logging/__init__.py:576: in __init__
    self._style.validate()
```

Also, there is no need of passing the default `fmt` value explicitly as it is the default.

cc @andriisoldatenko 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
