### PR TITLE
Add /version endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/version_endpoint.py
+++ b/airflow/api_connexion/endpoints/version_endpoint.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import NamedTuple, Optional
+
+import airflow
+from airflow.api_connexion.schemas.version_schema import version_info_schema
+from airflow.utils.platform import get_airflow_git_version
+
+log = logging.getLogger(__name__)
+
+
+class VersionInfo(NamedTuple):
+    """Version information"""
+    version: str
+    git_version: Optional[str]
+
+
+def get_version():
+    """Get version information"""
+    airflow_version = airflow.__version__
+
+    git_version = get_airflow_git_version()
+    version_info = VersionInfo(version=airflow_version, git_version=git_version)
+    return version_info_schema.dump(version_info)

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1134,6 +1134,19 @@ paths:
               schema:
                 type: string
 
+  /version:
+    get:
+      summary: Get version information
+      operationId: airflow.api_connexion.endpoints.version_endpoint.get_version
+      tags: [Monitoring]
+      responses:
+        '200':
+          description: Return current configuration.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionInfo'
+
 
 components:
   # Reusable schemas (data models)
@@ -1732,6 +1745,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConfigSection'
+
+    VersionInfo:
+      type: object
+      description: Version information.
+      properties:
+        version:
+          type: string
+          description: The version of Airflow
+        git_version:
+          type: string
+          description: The git version (including git commit hash)
+          nullable: true
 
     # From
     ClearTaskInstance:

--- a/airflow/api_connexion/schemas/version_schema.py
+++ b/airflow/api_connexion/schemas/version_schema.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from marshmallow import Schema, fields
+
+
+class VersionInfoSchema(Schema):
+    """Version information schema"""
+    version = fields.String(dump_only=True)
+    git_version = fields.String(dump_only=True)
+
+
+version_info_schema = VersionInfoSchema(strict=True)

--- a/airflow/utils/platform.py
+++ b/airflow/utils/platform.py
@@ -18,8 +18,12 @@
 """
 Platform and system specific function.
 """
+import logging
 import os
+import pkgutil
 import sys
+
+log = logging.getLogger(__name__)
 
 
 def is_tty():
@@ -45,3 +49,14 @@ def is_terminal_support_colors() -> bool:
     if term in ("xterm", "linux") or "color" in term:
         return True
     return False
+
+
+def get_airflow_git_version():
+    """Returns the git commit hash representing the current version of the application."""
+    git_version = None
+    try:
+        git_version = str(pkgutil.get_data('airflow', 'git_version'), encoding="UTF-8")
+    except Exception as e:  # pylint: disable=broad-except
+        log.error(e)
+
+    return git_version

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -23,7 +23,6 @@ import json
 import logging
 import math
 import os
-import pkgutil
 import socket
 import traceback
 from collections import defaultdict
@@ -68,6 +67,7 @@ from airflow.ti_deps.dependencies_deps import RUNNING_DEPS, SCHEDULER_QUEUED_DEP
 from airflow.utils import timezone
 from airflow.utils.dates import infer_time_unit, scale_time_units
 from airflow.utils.helpers import alchemy_to_dict, render_log_filename
+from airflow.utils.platform import get_airflow_git_version
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.www import utils as wwwutils
@@ -2095,13 +2095,7 @@ class VersionView(AirflowBaseView):
             airflow_version = None
             logging.error(e)
 
-        # Get the Git repo and git hash
-        git_version = None
-        try:
-            git_version = str(pkgutil.get_data('airflow', 'git_version'), encoding="UTF-8")
-        except Exception as e:
-            logging.error(e)
-
+        git_version = get_airflow_git_version()
         # Render information
         title = "Version Info"
         return self.render_template(

--- a/tests/api_connexion/endpoints/test_version_endpoint.py
+++ b/tests/api_connexion/endpoints/test_version_endpoint.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+from unittest import mock
+
+from airflow.www import app
+
+
+class TestGetHealthTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.app = app.create_app(testing=True)  # type:ignore
+
+    def setUp(self) -> None:
+        self.client = self.app.test_client()  # type:ignore
+
+    @mock.patch(
+        "airflow.api_connexion.endpoints.version_endpoint.airflow.__version__", "MOCK_VERSION"
+    )
+    @mock.patch(
+        "airflow.api_connexion.endpoints.version_endpoint.get_airflow_git_version", return_value="GIT_COMMIT"
+    )
+    def test_should_response_200(self, mock_get_airflow_get_commit):
+        response = self.client.get("/api/v1/version")
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({'git_version': 'GIT_COMMIT', 'version': 'MOCK_VERSION'}, response.json)
+        mock_get_airflow_get_commit.assert_called_once_with()

--- a/tests/api_connexion/schemas/test_version_schema.py
+++ b/tests/api_connexion/schemas/test_version_schema.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from parameterized import parameterized
+
+from airflow.api_connexion.endpoints.version_endpoint import VersionInfo
+from airflow.api_connexion.schemas.version_schema import version_info_schema
+
+
+class TestVersionInfoSchema(unittest.TestCase):
+
+    @parameterized.expand([
+        ("GIT_COMMIT", ),
+        (None, ),
+    ])
+    def test_serialize(self, git_commit):
+        version_info = VersionInfo("VERSION", git_commit)
+        current_data = version_info_schema.dump(version_info).data
+
+        expected_result = {'version': 'VERSION', 'git_version': git_commit}
+        self.assertEqual(expected_result, current_data)


### PR DESCRIPTION
This endpoint wasn't previously in the specification, but I think it's worth adding it. This will allow the client to operate several versions of Airflow and react to subtle differences between versions. When we add new endpoints in Airflow 2.1, the client can use them without dropping support for Airflow 2.0 in their product.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
