### PR TITLE
graph view mouseover task should increase stroke width of upstream / downstream

### DIFF
--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -208,24 +208,26 @@
     });
 
 
-    function highlight_nodes(nodes, color) {
+    function highlight_nodes(nodes, color, stroke_width) {
         nodes.forEach (function (nodeid) {
             my_node = d3.select('[id="' + nodeid + '"]').node().parentNode;
-            d3.select(my_node).selectAll("rect").style("stroke", color) ;
+            d3.select(my_node)
+                .selectAll("rect")
+                .style("stroke", color)
+                .style("stroke-width", stroke_width) ;
         })
     }
 
     d3.selectAll("g.node").on("mouseover", function(d){
         d3.select(this).selectAll("rect").style("stroke", highlight_color) ;
-        highlight_nodes(g.predecessors(d), upstream_color);
-        highlight_nodes(g.successors(d), downstream_color)
-
+        highlight_nodes(g.predecessors(d), upstream_color, highlightStrokeWidth);
+        highlight_nodes(g.successors(d), downstream_color, highlightStrokeWidth)
     });
 
     d3.selectAll("g.node").on("mouseout", function(d){
         d3.select(this).selectAll("rect").style("stroke", null) ;
-        highlight_nodes(g.predecessors(d), null)
-        highlight_nodes(g.successors(d), null)
+        highlight_nodes(g.predecessors(d), null, initialStrokeWidth)
+        highlight_nodes(g.successors(d), null, initialStrokeWidth)
     });
 
 


### PR DESCRIPTION
**Summary**

This change applies stroke-width `highlightStrokeWidth` to upstream and downstream dependencies when mousing over a task (and restores `initialStrokeWidth` on mouseout).

**More context**

In graph view, on mouseover task, upstream and downstream tasks will change color.

But it doesn't increase the stroke width for the task box outline (i.e. it does not embolden the task outline).

This is something that is done when we search for tasks or mouseover a task state and the tasks are filtered -- just was not implemented for mouseover.

**Before**
![image](https://user-images.githubusercontent.com/15932138/84625350-ee540580-ae97-11ea-819e-444df9f28442.png)

**After**
![image](https://user-images.githubusercontent.com/15932138/84625363-f449e680-ae97-11ea-8d35-29a820d36302.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
