### PR TITLE
Add nullable and required to some fields in OpenAPI spec

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1171,6 +1171,9 @@ components:
         port:
           type: integer
           nullable: true
+      required:
+        - connection_id
+        - conn_type
 
     ConnectionCollection:
       type: object
@@ -1282,6 +1285,7 @@ components:
           type: string
           format: date-time
           readOnly: True
+          nullable: true
         state:
           $ref: '#/components/schemas/DagState'
         external_trigger:
@@ -1333,6 +1337,7 @@ components:
         extra:
           type: string
           readOnly: true
+          nullable: true
 
     EventLogCollection:
       type: object


### PR DESCRIPTION
---
For connection endpoint:
`connection_id` and `conn_type` are required fields.

For DAGRun, the `end_date` is null when it's in running state

For EventLog endpoint: The `extra` can be null

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
