### PR TITLE
Remove DELETE /importErrors/{import_error_id} endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -25,13 +25,6 @@ from airflow.models.errors import ImportError  # pylint: disable=redefined-built
 from airflow.utils.session import provide_session
 
 
-def delete_import_error():
-    """
-    Delete an import error
-    """
-    raise NotImplementedError("Not implemented yet.")
-
-
 @provide_session
 def get_import_error(import_error_id, session):
     """

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -487,20 +487,6 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-    delete:
-      summary: Delete an import error
-      operationId: airflow.api_connexion.endpoints.import_error_endpoint.delete_import_error
-      tags: [ImportError]
-      responses:
-        '204':
-          description: No content.
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthenticated'
-        '403':
-          $ref: '#/components/responses/PermissionDenied'
-
   /pools:
     get:
       summary: Get all pools

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -46,13 +46,6 @@ class TestBaseImportError(unittest.TestCase):
             import_error["import_error_id"] = i
 
 
-class TestDeleteImportErrorEndpoint(TestBaseImportError):
-    @unittest.skip("Not implemented yet")
-    def test_delete_endpoint(self):
-        response = self.client.delete("/api/v1/importErrors/1")
-        assert response.status_code == 200
-
-
 class TestGetImportErrorEndpoint(TestBaseImportError):
     @provide_session
     def test_response_200(self, session):


### PR DESCRIPTION
This table is managed by the scheduler. The user should not be able to influence its content.
Errors are removed by scheduler here:
https://github.com/apache/airflow/blob/master/airflow/utils/dag_processing.py#L862-L875

Close: https://github.com/apache/airflow/issues/9113

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
