### PR TITLE
Fix retries causing constraint violation on MySQL with DAG Serialization

### DIFF
--- a/airflow/migrations/versions/a66efa278eea_add_precision_to_execution_date_in_mysql.py
+++ b/airflow/migrations/versions/a66efa278eea_add_precision_to_execution_date_in_mysql.py
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add Precision to execution_date in RenderedTaskInstanceFields table
+
+Revision ID: a66efa278eea
+Revises: 8f966b9c467a
+Create Date: 2020-06-16 21:44:02.883132
+
+"""
+
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = 'a66efa278eea'
+down_revision = '8f966b9c467a'
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = 'rendered_task_instance_fields'
+COLUMN_NAME = 'execution_date'
+
+
+def upgrade():
+    """Add Precision to execution_date in RenderedTaskInstanceFields table for MySQL"""
+    conn = op.get_bind()
+    if conn.dialect.name == "mysql":
+        op.alter_column(
+            table_name=TABLE_NAME,
+            column_name=COLUMN_NAME,
+            type_=mysql.TIMESTAMP(fsp=6),
+            nullable=False
+        )
+
+
+def downgrade():
+    """Unapply Add Precision to execution_date in RenderedTaskInstanceFields table"""
+    conn = op.get_bind()
+    if conn.dialect.name == "mysql":
+        op.alter_column(
+            table_name=TABLE_NAME,
+            column_name=COLUMN_NAME,
+            type_=mysql.TIMESTAMP(),
+            nullable=False
+        )


### PR DESCRIPTION
The issue was caused because the `rendered_task_instance_fields` table did not have precision and hence causing `_mysql_exceptions.IntegrityError`.

closes https://github.com/apache/airflow/issues/9148

Issue:
```
(Pdb) p session.query(RTIF).all()[-1].execution_date
datetime.datetime(2020, 6, 16, 20, 1, 30, tzinfo=Timezone('UTC'))
(Pdb)  p rttif.execution_date
datetime.datetime(2020, 6, 16, 20, 1, 29, 759742, tzinfo=Timezone('UTC'))
(Pdb)
```


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
