### PR TITLE
Mark task as failed when it fails in Celery

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -42,6 +42,7 @@ from airflow.executors.base_executor import BaseExecutor, CommandType, EventBuff
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKeyType
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
+from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 
 log = logging.getLogger(__name__)
@@ -188,14 +189,13 @@ class CeleryExecutor(BaseExecutor):
         self.log.debug('Sent all tasks.')
 
         for key, _, result in key_and_async_results:
+            self.queued_tasks.pop(key)
             if isinstance(result, ExceptionWithTraceback):
                 self.log.error(  # pylint: disable=logging-not-lazy
                     CELERY_SEND_ERR_MSG_HEADER + ":%s\n%s\n", result.exception, result.traceback
                 )
+                self.event_buffer[key] = (State.FAILED, result.exception)
             elif result is not None:
-                # Only pops when enqueued successfully, otherwise keep it
-                # and expect scheduler loop to deal with it.
-                self.queued_tasks.pop(key)
                 result.backend = cached_celery_backend
                 self.running.add(key)
                 self.tasks[key] = result


### PR DESCRIPTION
If a task failed _hard_ on celery, the task would end up stuck in queued state until the scheduler was restarted. This change makes it get retried.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
