### PR TITLE
Add deletion by prefix to S3DeleteObjectsOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -71,8 +71,8 @@ class S3DeleteObjectsOperator(BaseOperator):
             verify=None,
             *args, **kwargs):
 
-        if not (keys is None) ^ (prefix is None):
-            raise ValueError("Either keys or prefix should be set.")
+        if not keys and not prefix:
+            raise ValueError("Either keys or prefix should be set. Both are None")
 
         super().__init__(*args, **kwargs)
         self.bucket = bucket
@@ -84,7 +84,7 @@ class S3DeleteObjectsOperator(BaseOperator):
     def execute(self, context):
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
-        if self.keys is not None:
+        if self.keys:
             keys = self.keys
         else:
             keys = s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -71,8 +71,8 @@ class S3DeleteObjectsOperator(BaseOperator):
             verify=None,
             *args, **kwargs):
 
-        if not keys and not prefix:
-            raise ValueError("Either keys or prefix should be set. Both are None")
+        if not (keys is None) ^ (prefix is None):
+            raise ValueError("Either keys or prefix should be set.")
 
         super().__init__(*args, **kwargs)
         self.bucket = bucket
@@ -84,7 +84,7 @@ class S3DeleteObjectsOperator(BaseOperator):
     def execute(self, context):
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
-        if self.keys:
+        if self.keys is not None:
             keys = self.keys
         else:
             keys = s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -71,8 +71,8 @@ class S3DeleteObjectsOperator(BaseOperator):
             verify=None,
             *args, **kwargs):
 
-        if not keys and not prefix:
-            raise ValueError("Either keys or prefix should be set. Both are None")
+        if not bool(keys) ^ bool(prefix):
+            raise ValueError("Either keys or prefix should be set.")
 
         super().__init__(*args, **kwargs)
         self.bucket = bucket

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -85,5 +85,5 @@ class S3DeleteObjectsOperator(BaseOperator):
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
         keys = self.keys or s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)
-
-        s3_hook.delete_objects(bucket=self.bucket, keys=keys)
+        if keys:
+            s3_hook.delete_objects(bucket=self.bucket, keys=keys)

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -40,6 +40,9 @@ class S3DeleteObjectsOperator(BaseOperator):
 
         You may specify up to 1000 keys.
     :type keys: str or list
+    :param prefix: Prefix of objects to delete. (templated)
+        All objects matching this prefix in the bucket will be deleted.
+    :type prefix: str
     :param aws_conn_id: Connection id of the S3 connection to use
     :type aws_conn_id: str
     :param verify: Whether or not to verify SSL certificates for S3 connection.
@@ -56,22 +59,34 @@ class S3DeleteObjectsOperator(BaseOperator):
     :type verify: bool or str
     """
 
-    template_fields = ('keys', 'bucket')
+    template_fields = ('keys', 'bucket', 'prefix')
 
     @apply_defaults
     def __init__(
             self,
             bucket,
-            keys,
+            keys=None,
+            prefix=None,
             aws_conn_id='aws_default',
             verify=None,
             *args, **kwargs):
+
+        if not keys and not prefix:
+            raise ValueError("Either keys or prefix should be set. Both are None")
+
         super().__init__(*args, **kwargs)
         self.bucket = bucket
         self.keys = keys
+        self.prefix = prefix
         self.aws_conn_id = aws_conn_id
         self.verify = verify
 
     def execute(self, context):
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
-        s3_hook.delete_objects(bucket=self.bucket, keys=self.keys)
+
+        if self.keys:
+            keys = self.keys
+        else:
+            keys = s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)
+
+        s3_hook.delete_objects(bucket=self.bucket, keys=keys)

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -84,9 +84,6 @@ class S3DeleteObjectsOperator(BaseOperator):
     def execute(self, context):
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
-        if self.keys:
-            keys = self.keys
-        else:
-            keys = s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)
+        keys = self.keys or s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)
 
         s3_hook.delete_objects(bucket=self.bucket, keys=keys)

--- a/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
+++ b/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
@@ -112,3 +112,17 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
         # There should be no object found in the bucket created earlier
         self.assertFalse('Contents' in conn.list_objects(Bucket=bucket,
                                                          Prefix=key_pattern))
+
+    @mock_s3
+    def test_s3_delete_empty_list_and_does_nothing(self):
+        bucket = "testbucket"
+
+        conn = boto3.client('s3')
+        conn.create_bucket(Bucket=bucket)
+
+        op = S3DeleteObjectsOperator(task_id="test_task_s3_delete_empty_list_and_does_nothing",
+                                     bucket=bucket,
+                                     keys=list())
+
+        # Even if key is an empty list, there should be no exception.
+        op.execute(None)

--- a/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
+++ b/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
@@ -112,17 +112,3 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
         # There should be no object found in the bucket created earlier
         self.assertFalse('Contents' in conn.list_objects(Bucket=bucket,
                                                          Prefix=key_pattern))
-
-    @mock_s3
-    def test_s3_delete_empty_list_and_does_nothing(self):
-        bucket = "testbucket"
-
-        conn = boto3.client('s3')
-        conn.create_bucket(Bucket=bucket)
-
-        op = S3DeleteObjectsOperator(task_id="test_task_s3_delete_empty_list_and_does_nothing",
-                                     bucket=bucket,
-                                     keys=list())
-
-        # Even if key is an empty list, there should be no exception.
-        op.execute(None)


### PR DESCRIPTION
Adds an option that can be removed by specifying a prefix.

This option is useful for deleting objects that are created under a specific path at once, such as EMR or Athena's partitions.

I referred to the [GCSDeleteObjectsOperator implementation](https://github.com/apache/airflow/blob/54667d1eaa626358702d07051f9cb4b1754a1481/airflow/providers/google/cloud/operators/gcs.py#L229).

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
