### PR TITLE
Task logging handlers can provide custom log links

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -234,6 +234,7 @@ if REMOTE_LOGGING:
     elif ELASTICSEARCH_HOST:
         ELASTICSEARCH_LOG_ID_TEMPLATE: str = conf.get('elasticsearch', 'LOG_ID_TEMPLATE')
         ELASTICSEARCH_END_OF_LOG_MARK: str = conf.get('elasticsearch', 'END_OF_LOG_MARK')
+        ELASTICSEARCH_FRONTEND: str = conf.get('elasticsearch', 'frontend')
         ELASTICSEARCH_WRITE_STDOUT: bool = conf.getboolean('elasticsearch', 'WRITE_STDOUT')
         ELASTICSEARCH_JSON_FORMAT: bool = conf.getboolean('elasticsearch', 'JSON_FORMAT')
         ELASTICSEARCH_JSON_FIELDS: str = conf.get('elasticsearch', 'JSON_FIELDS')
@@ -247,6 +248,7 @@ if REMOTE_LOGGING:
                 'filename_template': FILENAME_TEMPLATE,
                 'end_of_log_mark': ELASTICSEARCH_END_OF_LOG_MARK,
                 'host': ELASTICSEARCH_HOST,
+                'frontend': ELASTICSEARCH_FRONTEND,
                 'write_stdout': ELASTICSEARCH_WRITE_STDOUT,
                 'json_format': ELASTICSEARCH_JSON_FORMAT,
                 'json_fields': ELASTICSEARCH_JSON_FIELDS

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -275,6 +275,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin, ExternalLoggingMix
     def get_external_log_url(self, task_instance: TaskInstance, try_number: int) -> str:
         """
         Creates an address for an external log collecting service.
+
         :param task_instance: task instance object
         :type: task_instance: TaskInstance
         :param try_number: task instance try_number to read logs from.

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+from urllib.parse import quote
 
 # Using `from elasticsearch import *` would break elasticsearch mocking used in unit test.
 import elasticsearch
@@ -25,14 +26,15 @@ import pendulum
 from elasticsearch_dsl import Search
 
 from airflow.configuration import conf
+from airflow.models import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.helpers import parse_template_string
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.json_formatter import JSONFormatter
-from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.log.logging_mixin import LoggingMixin, RemoteLoggingMixin
 
 
-class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
+class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin, RemoteLoggingMixin):
     """
     ElasticsearchTaskHandler is a python log handler that
     reads logs from Elasticsearch. Note logs are not directly
@@ -51,11 +53,13 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
     PAGE = 0
     MAX_LINE_PER_PAGE = 1000
+    REMOTE_LOG_NAME = 'Elasticsearch'
 
-    def __init__(self, base_log_folder, filename_template,
+    def __init__(self, base_log_folder, filename_template,  # pylint: disable=too-many-arguments
                  log_id_template, end_of_log_mark,
                  write_stdout, json_format, json_fields,
                  host='localhost:9200',
+                 frontend='localhost:5601',
                  es_kwargs=conf.getsection("elasticsearch_configs")):
         """
         :param base_log_folder: base folder to store logs locally
@@ -72,6 +76,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         self.client = elasticsearch.Elasticsearch([host], **es_kwargs)
 
+        self.frontend = frontend
         self.mark_end_on_close = True
         self.end_of_log_mark = end_of_log_mark
         self.write_stdout = write_stdout
@@ -262,3 +267,21 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         super().close()
 
         self.closed = True
+
+    def get_remote_log_url(self, task_instance: TaskInstance, try_number: int) -> str:
+        """
+        Creates an address for an external log collecting service.
+        :param task_instance: task instance object
+        :type: task_instance: TaskInstance
+        :param try_number: task instance try_number to read logs from.
+        :type try_number: Optional[int]
+        :return: URL to the external log collection service
+        :rtype: str
+        """
+        log_id = self.log_id_template.format(
+            dag_id=task_instance.dag_id,
+            task_id=task_instance.task_id,
+            execution_date=task_instance.execution_date,
+            try_number=try_number)
+        url = 'https://' + self.frontend.format(log_id=quote(log_id))
+        return url

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -268,6 +268,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin, ExternalLoggingMix
 
         self.closed = True
 
+    @property
     def log_name(self):
         return self.LOG_NAME
 

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -31,10 +31,10 @@ from airflow.utils import timezone
 from airflow.utils.helpers import parse_template_string
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.json_formatter import JSONFormatter
-from airflow.utils.log.logging_mixin import LoggingMixin, RemoteLoggingMixin
+from airflow.utils.log.logging_mixin import ExternalLoggingMixin, LoggingMixin
 
 
-class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin, RemoteLoggingMixin):
+class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin, ExternalLoggingMixin):
     """
     ElasticsearchTaskHandler is a python log handler that
     reads logs from Elasticsearch. Note logs are not directly
@@ -53,7 +53,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin, RemoteLoggingMixin
 
     PAGE = 0
     MAX_LINE_PER_PAGE = 1000
-    REMOTE_LOG_NAME = 'Elasticsearch'
+    LOG_NAME = 'Elasticsearch'
 
     def __init__(self, base_log_folder, filename_template,  # pylint: disable=too-many-arguments
                  log_id_template, end_of_log_mark,
@@ -268,7 +268,10 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin, RemoteLoggingMixin
 
         self.closed = True
 
-    def get_remote_log_url(self, task_instance: TaskInstance, try_number: int) -> str:
+    def log_name(self):
+        return self.LOG_NAME
+
+    def get_external_log_url(self, task_instance: TaskInstance, try_number: int) -> str:
         """
         Creates an address for an external log collecting service.
         :param task_instance: task instance object

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -96,7 +96,7 @@ class TaskLogReader:
         return handler
 
     @property
-    def is_supported(self):
+    def supports_read(self):
         """Checks if a read operation is supported by a current log handler."""
 
         return hasattr(self.log_handler, 'read')

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -23,6 +23,7 @@ from cached_property import cached_property
 from airflow.configuration import conf
 from airflow.models import TaskInstance
 from airflow.utils.helpers import render_log_filename
+from airflow.utils.log.logging_mixin import ExternalLoggingMixin
 
 
 class TaskLogReader:
@@ -99,6 +100,11 @@ class TaskLogReader:
         """Checks if a read operation is supported by a current log handler."""
 
         return hasattr(self.log_handler, 'read')
+
+    @property
+    def is_external(self):
+        """Check if the logging handler is external (e.g. Elasticsearch, Stackdriver, etc)."""
+        return isinstance(self.log_handler, ExternalLoggingMixin)
 
     def render_log_filename(self, ti: TaskInstance, try_number: Optional[int] = None):
         """

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -102,8 +102,8 @@ class TaskLogReader:
         return hasattr(self.log_handler, 'read')
 
     @property
-    def is_external(self):
-        """Check if the logging handler is external (e.g. Elasticsearch, Stackdriver, etc)."""
+    def supports_external_link(self):
+        """Check if the logging handler supports external links (e.g. to Elasticsearch, Stackdriver, etc)."""
         return isinstance(self.log_handler, ExternalLoggingMixin)
 
     def render_log_filename(self, ti: TaskInstance, try_number: Optional[int] = None):

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -58,6 +58,20 @@ class LoggingMixin:
             set_context(self.log, context)
 
 
+class RemoteLoggingMixin:
+    """
+    Define a logging handler based on a remote service (e.g. ELK, StackDriver). Subclasses must override
+    REMOTE_LOG_NAME and get_remote_log_url().
+    """
+    REMOTE_LOG_NAME: str = 'RemoteLog'
+
+    def get_remote_log_url(self, task_instance, try_number) -> str:
+        """
+        Return the URL for log visualization in the the remote service.
+        """
+        raise NotImplementedError('Remote logger must provide remote URL')
+
+
 # TODO: Formally inherit from io.IOBase
 class StreamLogWriter:
     """

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -58,18 +58,20 @@ class LoggingMixin:
             set_context(self.log, context)
 
 
-class RemoteLoggingMixin:
+class ExternalLoggingMixin:
     """
     Define a logging handler based on a remote service (e.g. ELK, StackDriver). Subclasses must override
-    REMOTE_LOG_NAME and get_remote_log_url().
+    "log_name" and "get_external_log_url".
     """
-    REMOTE_LOG_NAME: str = 'RemoteLog'
+    def log_name(self) -> str:
+        """Return log name"""
+        raise NotImplementedError('External logger must provide a name')
 
-    def get_remote_log_url(self, task_instance, try_number) -> str:
+    def get_external_log_url(self, task_instance, try_number) -> str:
         """
-        Return the URL for log visualization in the the remote service.
+        Return the URL for log visualization in the remote service.
         """
-        raise NotImplementedError('Remote logger must provide remote URL')
+        raise NotImplementedError('External logger must provide remote URL')
 
 
 # TODO: Formally inherit from io.IOBase

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import abc
 import logging
 import re
 import sys
@@ -60,18 +61,17 @@ class LoggingMixin:
 
 class ExternalLoggingMixin:
     """
-    Define a logging handler based on a remote service (e.g. ELK, StackDriver). Subclasses must override
-    "log_name" and "get_external_log_url".
+    Define a log handler based on an external service (e.g. ELK, StackDriver).
     """
+    @abc.abstractproperty
     def log_name(self) -> str:
         """Return log name"""
-        raise NotImplementedError('External logger must provide a name')
 
+    @abc.abstractmethod
     def get_external_log_url(self, task_instance, try_number) -> str:
         """
-        Return the URL for log visualization in the remote service.
+        Return the URL for log visualization in the external service.
         """
-        raise NotImplementedError('External logger must provide remote URL')
 
 
 # TODO: Formally inherit from io.IOBase

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -168,7 +168,7 @@
             <hr/>
           </div>
           <div id="dag_redir_logs">
-            <label style="display:inline"> View Logs in {{ remote_log_name }} (by attempts): </label>
+            <label style="display:inline"> View Logs in {{ external_log_name }} (by attempts): </label>
             <ul class="nav nav-pills" role="tablist" id="redir_log_try_index" style="display:inline">
             </ul>
             <hr/>
@@ -366,9 +366,9 @@ function updateQueryStringParameter(uri, key, value) {
     var task_id = '';
     var execution_date = '';
     var subdag_id = '';
-    var show_remote_log_redirect = false;
-    {% if show_remote_log_redirect is defined %}
-      show_remote_log_redirect = '{{ show_remote_log_redirect }}' == "True";
+    var show_external_log_redirect = false;
+    {% if show_external_log_redirect is defined %}
+      show_external_log_redirect = '{{ show_external_log_redirect }}' == "True";
     {% endif %}
 
     var buttons = Array.from(document.querySelectorAll('a[id^="btn_"][data-base-url]')).reduce(function(obj, elm) {
@@ -444,7 +444,7 @@ function updateQueryStringParameter(uri, key, value) {
       $("#dag_redir_logs").hide();
       if (try_numbers > 0) {
           $("#dag_dl_logs").show();
-          if (show_remote_log_redirect) {
+          if (show_external_log_redirect) {
               $("#dag_redir_logs").show();
           }
       }
@@ -474,8 +474,8 @@ function updateQueryStringParameter(uri, key, value) {
           </li>`
         );
 
-        if (index == 0 || !show_remote_log_redirect) continue;
-        var redir_log_url = "{{ url_for('Airflow.redirect_to_remote_log') }}" +
+        if (index == 0 || !show_external_log_redirect) continue;
+        var redir_log_url = "{{ url_for('Airflow.redirect_to_external_log') }}" +
           "?dag_id=" + encodeURIComponent(dag_id) +
           "&task_id=" + encodeURIComponent(task_id) +
           "&execution_date=" + encodeURIComponent(execution_date) +

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -168,11 +168,13 @@
             <hr/>
           </div>
           <div id="dag_redir_logs">
+            {% if external_log_name is defined %}
             <label style="display:inline"> View Logs in {{ external_log_name }} (by attempts): </label>
             <ul class="nav nav-pills" role="tablist" id="redir_log_try_index" style="display:inline">
             </ul>
             <hr/>
             <hr/>
+            {% endif %}
           </div>
           <form method="POST">
             <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -167,9 +167,9 @@
             <hr/>
             <hr/>
           </div>
-          <div id="dag_es_logs">
-            <label style="display:inline"> View Logs in Elasticsearch (by attempts): </label>
-            <ul class="nav nav-pills" role="tablist" id="es_try_index" style="display:inline">
+          <div id="dag_redir_logs">
+            <label style="display:inline"> View Logs in {{ remote_log_name }} (by attempts): </label>
+            <ul class="nav nav-pills" role="tablist" id="redir_log_try_index" style="display:inline">
             </ul>
             <hr/>
             <hr/>
@@ -366,9 +366,9 @@ function updateQueryStringParameter(uri, key, value) {
     var task_id = '';
     var execution_date = '';
     var subdag_id = '';
-    var show_es_logs = false;
-    {% if show_external_logs is defined %}
-      show_es_logs = '{{ show_external_logs }}' == "True";
+    var show_remote_log_redirect = false;
+    {% if show_remote_log_redirect is defined %}
+      show_remote_log_redirect = '{{ show_remote_log_redirect }}' == "True";
     {% endif %}
 
     var buttons = Array.from(document.querySelectorAll('a[id^="btn_"][data-base-url]')).reduce(function(obj, elm) {
@@ -441,18 +441,18 @@ function updateQueryStringParameter(uri, key, value) {
       }
 
       $("#dag_dl_logs").hide();
-      $("#dag_es_logs").hide();
+      $("#dag_redir_logs").hide();
       if (try_numbers > 0) {
           $("#dag_dl_logs").show();
-          if (show_es_logs) {
-              $("#dag_es_logs").show();
+          if (show_remote_log_redirect) {
+              $("#dag_redir_logs").show();
           }
       }
 
       updateModalUrls();
 
       $("#try_index > li").remove();
-      $("#es_try_index > li").remove();
+      $("#redir_log_try_index > li").remove();
       var startIndex = (try_numbers > 2 ? 0 : 1)
       for (var index = startIndex; index <  try_numbers; index++) {
         var url = "{{ url_for('Airflow.get_logs_with_metadata') }}" +
@@ -474,14 +474,14 @@ function updateQueryStringParameter(uri, key, value) {
           </li>`
         );
 
-        if (index == 0 || !show_es_logs) continue;
-        var es_url = "{{ url_for('Airflow.elasticsearch') }}" +
+        if (index == 0 || !show_remote_log_redirect) continue;
+        var redir_log_url = "{{ url_for('Airflow.redirect_to_remote_log') }}" +
           "?dag_id=" + encodeURIComponent(dag_id) +
           "&task_id=" + encodeURIComponent(task_id) +
           "&execution_date=" + encodeURIComponent(execution_date) +
           "&try_number=" + index;
-        $("#es_try_index").append(`<li role="presentation" style="display:inline">
-          <a href="${es_url}"> ${showLabel} </a>
+        $("#redir_log_try_index").append(`<li role="presentation" style="display:inline">
+          <a href="${redir_log_url}"> ${showLabel} </a>
           </li>`
         );
       }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1510,7 +1510,7 @@ class Airflow(AirflowBaseView):  # noqa: D101
         doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None), css_class='dag-doc')
 
         task_log_reader = TaskLogReader()
-        external_log_name = task_log_reader.log_handler.log_name() if task_log_reader.is_external else None
+        external_log_name = task_log_reader.log_handler.log_name if task_log_reader.is_external else None
 
         # avoid spaces to reduce payload size
         data = htmlsafe_json_dumps(data, separators=(',', ':'))
@@ -1608,7 +1608,7 @@ class Airflow(AirflowBaseView):  # noqa: D101
         doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None), css_class='dag-doc')
 
         task_log_reader = TaskLogReader()
-        external_log_name = task_log_reader.log_handler.log_name() if task_log_reader.is_external else None
+        external_log_name = task_log_reader.log_handler.log_name if task_log_reader.is_external else None
 
         return self.render_template(
             'airflow/graph.html',

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -678,7 +678,7 @@ class Airflow(AirflowBaseView):  # noqa: D101
             return response
 
         task_log_reader = TaskLogReader()
-        if not task_log_reader.is_supported:
+        if not task_log_reader.supports_read:
             return jsonify(
                 message="Task log handler does not support read logs.",
                 error=True,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -782,8 +782,8 @@ class Airflow(AirflowBaseView):  # noqa: D101
             return redirect(url_for('Airflow.index'))
 
         task_log_reader = TaskLogReader()
-        if not task_log_reader.supports_external_links:
-            flash("Ttask log handler is not support external links", "error")
+        if not task_log_reader.supports_external_link:
+            flash("Task log handler does not support external links", "error")
             return redirect(url_for('Airflow.index'))
 
         handler = task_log_reader.log_handler
@@ -1510,7 +1510,10 @@ class Airflow(AirflowBaseView):  # noqa: D101
         doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None), css_class='dag-doc')
 
         task_log_reader = TaskLogReader()
-        external_log_name = task_log_reader.log_handler.log_name if task_log_reader.is_external else None
+        if task_log_reader.supports_external_link:
+            external_log_name = task_log_reader.log_handler.log_name
+        else:
+            external_log_name = None
 
         # avoid spaces to reduce payload size
         data = htmlsafe_json_dumps(data, separators=(',', ':'))
@@ -1524,7 +1527,7 @@ class Airflow(AirflowBaseView):  # noqa: D101
             doc_md=doc_md,
             data=data,
             blur=blur, num_runs=num_runs,
-            show_external_log_redirect=task_log_reader.is_external,
+            show_external_log_redirect=task_log_reader.supports_external_link,
             external_log_name=external_log_name)
 
     @expose('/graph')
@@ -1608,7 +1611,10 @@ class Airflow(AirflowBaseView):  # noqa: D101
         doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None), css_class='dag-doc')
 
         task_log_reader = TaskLogReader()
-        external_log_name = task_log_reader.log_handler.log_name if task_log_reader.is_external else None
+        if task_log_reader.supports_external_link:
+            external_log_name = task_log_reader.log_handler.log_name
+        else:
+            external_log_name = None
 
         return self.render_template(
             'airflow/graph.html',
@@ -1627,7 +1633,7 @@ class Airflow(AirflowBaseView):  # noqa: D101
             tasks=tasks,
             nodes=nodes,
             edges=edges,
-            show_external_log_redirect=task_log_reader.is_external,
+            show_external_log_redirect=task_log_reader.supports_external_link,
             external_log_name=external_log_name)
 
     @expose('/duration')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -781,14 +781,14 @@ class Airflow(AirflowBaseView):  # noqa: D101
             flash(f"Task [{dag_id}.{task_id}] does not exist", "error")
             return redirect(url_for('Airflow.index'))
 
-        try:
-            task_log_reader = TaskLogReader()
-            handler = task_log_reader.log_handler
-            url = handler.get_external_log_url(ti, try_number)
-            return redirect(url)
-        except AttributeError:
-            flash("Cannot redirect to external log, task log handler is not external", "error")
+        task_log_reader = TaskLogReader()
+        if not task_log_reader.supports_external_links:
+            flash("Ttask log handler is not support external links", "error")
             return redirect(url_for('Airflow.index'))
+
+        handler = task_log_reader.log_handler
+        url = handler.get_external_log_url(ti, try_number)
+        return redirect(url)
 
     @expose('/task')
     @has_dag_access(can_dag_read=True)

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -234,6 +234,7 @@ First, to use the handler, ``airflow.cfg`` must be configured as follows:
     remote_logging = True
 
     [elasticsearch]
+    host = <host>:<port>
     log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
     end_of_log_mark = end_of_log
     write_stdout =
@@ -251,6 +252,7 @@ To output task logs to stdout in JSON format, the following config could be used
     remote_logging = True
 
     [elasticsearch]
+    host = <host>:<port>
     log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
     end_of_log_mark = end_of_log
     write_stdout = True

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -318,3 +318,27 @@ be used.
 By using the ``logging_config_class`` option you can get :ref:`advanced features <write-logs-advanced>` of
 this handler. Details are available in the handler's documentation -
 :class:`~airflow.utils.log.stackdriver_task_handler.StackdriverTaskHandler`.
+
+External Links
+==============
+
+When using remote logging, users can configure Airflow to show a link to an external UI within the Airflow Web UI. Clicking the link redirects a user to the external UI.
+
+Some external systems require specific configuration in Airflow for redirection to work but others do not.
+
+.. _log-link-elasticsearch:
+
+Elasticsearch External Link
+------------------------------------
+
+A user can configure Airflow to show a link to an Elasticsearch log viewing system (e.g. Kibana).
+
+To enable it, ``airflow.cfg`` must be configured as in the example below. Note the required ``{log_id}`` in the URL, when constructing the external link, Airflow replaces this parameter with the same ``log_id_template`` used for writing logs (see `Writing Logs to Elasticsearch`_).
+
+.. code-block:: ini
+
+    [elasticsearch]
+    # Qualified URL for an elasticsearch frontend (like Kibana) with a template argument for log_id
+    # Code will construct log_id using the log_id template from the argument above.
+    # NOTE: The code will prefix the https:// automatically, don't include that here.
+    frontend = <host_port>/{log_id}

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -355,7 +355,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         # Ignore template if "{log_id}"" is missing in the URL
         ('localhost:5601', 'https://localhost:5601'),
     ])
-    def test_get_remote_log_url(self, es_frontend, expected_url):
+    def test_get_external_log_url(self, es_frontend, expected_url):
         es_task_handler = ElasticsearchTaskHandler(
             self.local_log_location,
             self.filename_template,
@@ -366,5 +366,5 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.json_fields,
             frontend=es_frontend
         )
-        url = es_task_handler.get_remote_log_url(self.ti, self.ti.try_number)
+        url = es_task_handler.get_external_log_url(self.ti, self.ti.try_number)
         self.assertEqual(expected_url, url)

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -21,9 +21,11 @@ import os
 import shutil
 import unittest
 from unittest import mock
+from urllib.parse import quote
 
 import elasticsearch
 import pendulum
+from parameterized import parameterized
 
 from airflow.configuration import conf
 from airflow.models import DAG, TaskInstance
@@ -346,3 +348,23 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
     def test_clean_execution_date(self):
         clean_execution_date = self.es_task_handler._clean_execution_date(datetime(2016, 7, 8, 9, 10, 11, 12))
         self.assertEqual('2016_07_08T09_10_11_000012', clean_execution_date)
+
+    @parameterized.expand([
+        # Common case
+        ('localhost:5601/{log_id}', 'https://localhost:5601/' + quote(LOG_ID.replace('T', ' '))),
+        # Ignore template if "{log_id}"" is missing in the URL
+        ('localhost:5601', 'https://localhost:5601'),
+    ])
+    def test_get_remote_log_url(self, es_frontend, expected_url):
+        es_task_handler = ElasticsearchTaskHandler(
+            self.local_log_location,
+            self.filename_template,
+            self.log_id_template,
+            self.end_of_log_mark,
+            self.write_stdout,
+            self.json_format,
+            self.json_fields,
+            frontend=es_frontend
+        )
+        url = es_task_handler.get_remote_log_url(self.ti, self.ti.try_number)
+        self.assertEqual(expected_url, url)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -997,7 +997,7 @@ class TestAirflowBaseViews(TestBase):
         """Do not show remote links if log handler is local."""
         url = f'{endpoint}?dag_id=example_bash_operator'
         with self.capture_templates() as templates:
-            resp = self.client.get(url, follow_redirects=True)
+            self.client.get(url, follow_redirects=True)
             ctx = templates[0].local_context
             self.assertFalse(ctx['show_remote_log_redirect'])
             self.assertIsNone(ctx['remote_log_name'])
@@ -1012,7 +1012,7 @@ class TestAirflowBaseViews(TestBase):
         get_log_handler_function.return_value = RemoteHandler()
         url = f'{endpoint}?dag_id=example_bash_operator'
         with self.capture_templates() as templates:
-            resp = self.client.get(url, follow_redirects=True)
+            self.client.get(url, follow_redirects=True)
             ctx = templates[0].local_context
             self.assertTrue(ctx['show_remote_log_redirect'])
             self.assertEqual(ctx['remote_log_name'], RemoteHandler.REMOTE_LOG_NAME)
@@ -1314,6 +1314,7 @@ class TestLogView(TestBase):
     def test_redirect_to_remote_log_remote_logger(self, get_log_handler_function):
         class RemoteHandler(RemoteLoggingMixin):
             REMOTE_URL = 'http://remote-service.com'
+
             def get_remote_log_url(self, *args, **kwargs):
                 return self.REMOTE_URL
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1281,7 +1281,7 @@ class TestLogView(TestBase):
 
     @mock.patch("airflow.www.views.TaskLogReader")
     def test_get_logs_for_handler_without_read_method(self, mock_log_reader):
-        type(mock_log_reader.return_value).is_supported = PropertyMock(return_value=False)
+        type(mock_log_reader.return_value).supports_read = PropertyMock(return_value=False)
 
         url_template = "get_logs_with_metadata?dag_id={}&" \
                        "task_id={}&execution_date={}&" \

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1009,6 +1009,7 @@ class TestAirflowBaseViews(TestBase):
         class ExternalHandler(ExternalLoggingMixin):
             LOG_NAME = 'ExternalLog'
 
+            @property
             def log_name(self):
                 return self.LOG_NAME
 


### PR DESCRIPTION
Airflow provides logging handlers that send logs to external services (Elasticsearch, StackDriver, etc). At the moment, if Elasticsearch is in use, links to its logs show up in the UI. This PR generalizes this functionality to other logging handlers.

To provide links to remote logs, a logging handler must inherit from `ExternalLoggingMixin` and implement `get_remote_log_url()` and `log_name()` methods. The view identifies when a remote logging handler is in use and renders the link to the external logs in the UI.

This PR does not close but is related to issue #9083.    

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
