### PR TITLE
Fix failing tests from #9124

### DIFF
--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -24,6 +24,11 @@ from airflow.operators.sql import (
     SQLCheckOperator, SQLIntervalCheckOperator, SQLThresholdCheckOperator, SQLValueCheckOperator,
 )
 
+warnings.warn(
+    "This module is deprecated. Please use `airflow.operators.sql`.",
+    DeprecationWarning, stacklevel=2
+)
+
 
 class CheckOperator(SQLCheckOperator):
     """

--- a/airflow/operators/sql_branch_operator.py
+++ b/airflow/operators/sql_branch_operator.py
@@ -19,6 +19,11 @@ import warnings
 
 from airflow.operators.sql import BranchSQLOperator
 
+warnings.warn(
+    """This module is deprecated. Please use `airflow.operators.sql`.""",
+    DeprecationWarning, stacklevel=2
+)
+
 
 class BranchSqlOperator(BranchSQLOperator):
     """

--- a/tests/test_core_to_contrib.py
+++ b/tests/test_core_to_contrib.py
@@ -1170,24 +1170,24 @@ OPERATORS = [
         'airflow.operators.presto_check_operator.PrestoValueCheckOperator',
     ),
     (
-        'airflow.operators.check_operator.CheckOperator',
         'airflow.operators.sql.SQLCheckOperator',
+        'airflow.operators.check_operator.CheckOperator',
     ),
     (
-        'airflow.operators.check_operator.IntervalCheckOperator',
         'airflow.operators.sql.SQLIntervalCheckOperator',
+        'airflow.operators.check_operator.IntervalCheckOperator',
     ),
     (
-        'airflow.operators.check_operator.ValueCheckOperator',
         'airflow.operators.sql.SQLValueCheckOperator',
+        'airflow.operators.check_operator.ValueCheckOperator',
     ),
     (
-        'airflow.operators.check_operator.ThresholdCheckOperator',
         'airflow.operators.sql.SQLThresholdCheckOperator',
+        'airflow.operators.check_operator.ThresholdCheckOperator',
     ),
     (
-        'airflow.operators.sql_branch_operator.BranchSqlOperator',
         'airflow.operators.sql.BranchSQLOperator',
+        'airflow.operators.sql_branch_operator.BranchSqlOperator',
     ),
     (
         'airflow.operators.python.BranchPythonOperator',


### PR DESCRIPTION
The #9124   has failing tests

```
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_class_deprecated_100_airflow_operators_check_operator_CheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_class_deprecated_101_airflow_operators_check_operator_IntervalCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_class_deprecated_102_airflow_operators_check_operator_ValueCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_class_deprecated_103_airflow_operators_check_operator_ThresholdCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_class_deprecated_104_airflow_operators_sql_branch_operator_BranchSqlOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_subclass_274_airflow_operators_check_operator_CheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_subclass_275_airflow_operators_check_operator_IntervalCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_subclass_276_airflow_operators_check_operator_ValueCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_subclass_277_airflow_operators_check_operator_ThresholdCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_is_subclass_278_airflow_operators_sql_branch_operator_BranchSqlOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_warning_on_import_274_airflow_operators_check_operator_CheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_warning_on_import_275_airflow_operators_check_operator_IntervalCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_warning_on_import_276_airflow_operators_check_operator_ValueCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_warning_on_import_277_airflow_operators_check_operator_ThresholdCheckOperator
FAILED tests/test_core_to_contrib.py::TestMovingCoreToContrib::test_warning_on_import_278_airflow_operators_sql_branch_operator_BranchSqlOperator

```


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
