### PR TITLE
Use strict API  schemas

### DIFF
--- a/airflow/api_connexion/schemas/connection_schema.py
+++ b/airflow/api_connexion/schemas/connection_schema.py
@@ -61,6 +61,6 @@ class ConnectionCollectionSchema(Schema):
     total_entries = fields.Int()
 
 
-connection_schema = ConnectionSchema()
-connection_collection_item_schema = ConnectionCollectionItemSchema()
-connection_collection_schema = ConnectionCollectionSchema()
+connection_schema = ConnectionSchema(strict=True)
+connection_collection_item_schema = ConnectionCollectionItemSchema(strict=True)
+connection_collection_schema = ConnectionCollectionSchema(strict=True)

--- a/airflow/api_connexion/schemas/error_schema.py
+++ b/airflow/api_connexion/schemas/error_schema.py
@@ -52,5 +52,5 @@ class ImportErrorCollectionSchema(Schema):
     total_entries = fields.Int()
 
 
-import_error_schema = ImportErrorSchema()
-import_error_collection_schema = ImportErrorCollectionSchema()
+import_error_schema = ImportErrorSchema(strict=True)
+import_error_collection_schema = ImportErrorCollectionSchema(strict=True)

--- a/airflow/api_connexion/schemas/event_log_schema.py
+++ b/airflow/api_connexion/schemas/event_log_schema.py
@@ -53,5 +53,5 @@ class EventLogCollectionSchema(Schema):
     total_entries = fields.Int()
 
 
-event_log_schema = EventLogSchema()
-event_log_collection_schema = EventLogCollectionSchema()
+event_log_schema = EventLogSchema(strict=True)
+event_log_collection_schema = EventLogCollectionSchema(strict=True)

--- a/airflow/api_connexion/schemas/pool_schema.py
+++ b/airflow/api_connexion/schemas/pool_schema.py
@@ -83,5 +83,5 @@ class PoolCollectionSchema(Schema):
     total_entries = fields.Int()
 
 
-pool_collection_schema = PoolCollectionSchema()
-pool_schema = PoolSchema()
+pool_collection_schema = PoolCollectionSchema(strict=True)
+pool_schema = PoolSchema(strict=True)

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -98,7 +98,7 @@ def init_api_connexion(app: Flask) -> None:
     connexion_app = connexion.App(__name__, specification_dir=spec_dir, skip_error_handlers=True)
     connexion_app.app = app
     api_bp = connexion_app.add_api(
-        specification='v1.yaml', base_path='/api/v1', validate_responses=True, strict_validation=False
+        specification='v1.yaml', base_path='/api/v1', validate_responses=True, strict_validation=True
     ).blueprint
     app.register_error_handler(ProblemException, connexion_app.common_error_handler)
     app.extensions['csrf'].exempt(api_bp)

--- a/tests/api_connexion/schemas/test_connection_schema.py
+++ b/tests/api_connexion/schemas/test_connection_schema.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import re
 import unittest
+
+import marshmallow
 
 from airflow.api_connexion.schemas.connection_schema import (
     ConnectionCollection, connection_collection_item_schema, connection_collection_schema, connection_schema,
@@ -70,7 +72,8 @@ class TestConnectionCollectionItemSchema(unittest.TestCase):
             'port': 80
         }
         connection_dump_2 = {
-            'connection_id': "mysql_default_2"
+            'connection_id': "mysql_default_2",
+            'conn_type': "postgres",
         }
         result_1 = connection_collection_item_schema.load(connection_dump_1)
         result_2 = connection_collection_item_schema.load(connection_dump_2)
@@ -90,8 +93,19 @@ class TestConnectionCollectionItemSchema(unittest.TestCase):
             result_2[0],
             {
                 'conn_id': "mysql_default_2",
+                'conn_type': "postgres",
             }
         )
+
+    def test_deserialize_required_fields(self):
+        connection_dump_1 = {
+            'connection_id': "mysql_default_2",
+        }
+        with self.assertRaisesRegex(
+            marshmallow.exceptions.ValidationError,
+            re.escape("{'conn_type': ['Missing data for required field.']}")
+        ):
+            connection_collection_item_schema.load(connection_dump_1)
 
 
 class TestConnectionCollectionSchema(unittest.TestCase):


### PR DESCRIPTION
The rules are already verified by connexion, but it's still worth forcing some unexpected errors to not be accidentally ignored.

```
    :param bool strict: If `True`, raise errors if invalid data are passed in
        instead of failing silently and storing the errors.
```
CC: @ephraimbuddy 

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
