### PR TITLE
Remove redundant code from breeze initialization

### DIFF
--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -52,15 +52,11 @@ function initialize_common_environment {
     # Temporary dir used well ... temporarily
     export TMP_DIR="${AIRFLOW_SOURCES}/tmp"
 
-    # Create those folders above in case they do not exist
+    # Create useful directories if not yet created
     mkdir -p "${TMP_DIR}"
     mkdir -p "${FILES_DIR}"
-
-    # Create useful directories if not yet created
     mkdir -p "${AIRFLOW_SOURCES}/.mypy_cache"
     mkdir -p "${AIRFLOW_SOURCES}/logs"
-    mkdir -p "${AIRFLOW_SOURCES}/tmp"
-    mkdir -p "${AIRFLOW_SOURCES}/files"
     mkdir -p "${AIRFLOW_SOURCES}/dist"
 
     # Read common values used across Breeze and CI scripts


### PR DESCRIPTION
At line 56 and 57 both directories will be created. So we do not need to do this again.

>  mkdir -p "${TMP_DIR}"
>  mkdir -p "${FILES_DIR}"

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
