### PR TITLE
Use current_app.dag_bag instead of global variable

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 from datetime import timedelta
 from typing import Optional
 
@@ -30,6 +31,7 @@ from airflow.logging_config import configure_logging
 from airflow.utils.json import AirflowJsonEncoder
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 from airflow.www.extensions.init_appbuilder_links import init_appbuilder_links
+from airflow.www.extensions.init_dagbag import init_dagbag
 from airflow.www.extensions.init_jinja_globals import init_jinja_globals
 from airflow.www.extensions.init_manifest_files import configure_manifest_files
 from airflow.www.extensions.init_security import init_api_experimental_auth, init_xframe_protection
@@ -84,6 +86,8 @@ def create_app(config=None, testing=False, app_name="Airflow"):
     db = SQLA()
     db.session = settings.Session
     db.init_app(flask_app)
+
+    init_dagbag(flask_app)
 
     init_api_experimental_auth(flask_app)
 

--- a/airflow/www/extensions/init_dagbag.py
+++ b/airflow/www/extensions/init_dagbag.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+from airflow.models import DagBag
+from airflow.settings import DAGS_FOLDER, STORE_SERIALIZED_DAGS
+
+
+def init_dagbag(app):
+    """
+    Create global DagBag for webserver and API. To access it use
+    ``flask.current_app.dag_bag``.
+    """
+    if os.environ.get('SKIP_DAGS_PARSING') == 'True':
+        app.dag_bag = DagBag(os.devnull, include_examples=False)
+    else:
+        app.dag_bag = DagBag(DAGS_FOLDER, store_serialized_dags=STORE_SERIALIZED_DAGS)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -22,7 +22,6 @@ import itertools
 import json
 import logging
 import math
-import os
 import socket
 import traceback
 from collections import defaultdict
@@ -61,7 +60,6 @@ from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import Connection, DagModel, DagTag, Log, SlaMiss, TaskFail, XCom, errors
 from airflow.models.dagcode import DagCode
 from airflow.models.dagrun import DagRun, DagRunType
-from airflow.settings import STORE_SERIALIZED_DAGS
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import RUNNING_DEPS, SCHEDULER_QUEUED_DEPS
 from airflow.utils import timezone
@@ -81,10 +79,10 @@ PAGE_SIZE = conf.getint('webserver', 'page_size')
 FILTER_TAGS_COOKIE = 'tags_filter'
 FILTER_STATUS_COOKIE = 'dag_status_filter'
 
-if os.environ.get('SKIP_DAGS_PARSING') != 'True':
-    dagbag = models.DagBag(settings.DAGS_FOLDER, store_serialized_dags=STORE_SERIALIZED_DAGS)
-else:
-    dagbag = models.DagBag(os.devnull, include_examples=False)
+
+def get_app_dag_bag():
+    """This is used only to simplify changes in tests"""
+    return current_app.dag_bag
 
 
 def get_date_time_num_runs_dag_runs_form_data(request, session, dag):
@@ -577,7 +575,7 @@ class Airflow(AirflowBaseView):
     @provide_session
     def dag_details(self, session=None):
         dag_id = request.args.get('dag_id')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         title = "DAG details"
         root = request.args.get('root', '')
 
@@ -612,7 +610,7 @@ class Airflow(AirflowBaseView):
         root = request.args.get('root', '')
 
         logging.info("Retrieving rendered templates.")
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
 
         task = copy.copy(dag.get_task(task_id))
         ti = models.TaskInstance(task=task, execution_date=dttm)
@@ -700,7 +698,7 @@ class Airflow(AirflowBaseView):
 
         try:
             if ti is not None:
-                dag = dagbag.get_dag(dag_id)
+                dag = get_app_dag_bag().get_dag(dag_id)
                 if dag:
                     ti.task = dag.get_task(ti.task_id)
             if response_format == 'json':
@@ -803,7 +801,7 @@ class Airflow(AirflowBaseView):
         dttm = timezone.parse(execution_date)
         form = DateTimeForm(data={'execution_date': dttm})
         root = request.args.get('root', '')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
 
         if not dag or task_id not in dag.task_ids:
             flash(
@@ -921,7 +919,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.form.get('dag_id')
         task_id = request.form.get('task_id')
         origin = request.form.get('origin')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         task = dag.get_task(task_id)
 
         execution_date = request.form.get('execution_date')
@@ -1052,7 +1050,7 @@ class Airflow(AirflowBaseView):
                     conf=conf
                 )
 
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         dag.create_dagrun(
             run_type=DagRunType.MANUAL,
             execution_date=execution_date,
@@ -1117,7 +1115,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.form.get('dag_id')
         task_id = request.form.get('task_id')
         origin = request.form.get('origin')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
 
         execution_date = request.form.get('execution_date')
         execution_date = timezone.parse(execution_date)
@@ -1150,7 +1148,7 @@ class Airflow(AirflowBaseView):
         execution_date = request.form.get('execution_date')
         confirmed = request.form.get('confirmed') == "true"
 
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         execution_date = timezone.parse(execution_date)
         start_date = execution_date
         end_date = execution_date
@@ -1192,7 +1190,7 @@ class Airflow(AirflowBaseView):
         payload = []
         for dag_id, active_dag_runs in dags:
             max_active_runs = 0
-            dag = dagbag.get_dag(dag_id)
+            dag = get_app_dag_bag().get_dag(dag_id)
             if dag:
                 # TODO: Make max_active_runs a column so we can query for it directly
                 max_active_runs = dag.max_active_runs
@@ -1209,7 +1207,7 @@ class Airflow(AirflowBaseView):
             return redirect(origin)
 
         execution_date = timezone.parse(execution_date)
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
 
         if not dag:
             flash('Cannot find DAG: {}'.format(dag_id), 'error')
@@ -1237,7 +1235,7 @@ class Airflow(AirflowBaseView):
             return redirect(origin)
 
         execution_date = timezone.parse(execution_date)
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
 
         if not dag:
             flash('Cannot find DAG: {}'.format(dag_id), 'error')
@@ -1287,7 +1285,7 @@ class Airflow(AirflowBaseView):
     def _mark_task_instance_state(self, dag_id, task_id, origin, execution_date,
                                   confirmed, upstream, downstream,
                                   future, past, state):
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         task = dag.get_task(task_id)
         task.dag = dag
 
@@ -1371,7 +1369,7 @@ class Airflow(AirflowBaseView):
     def tree(self):
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         if not dag:
             flash('DAG "{0}" seems to be missing from DagBag.'.format(dag_id), "error")
             return redirect(url_for('Airflow.index'))
@@ -1528,7 +1526,7 @@ class Airflow(AirflowBaseView):
     def graph(self, session=None):
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         if not dag:
             flash('DAG "{0}" seems to be missing.'.format(dag_id), "error")
             return redirect(url_for('Airflow.index'))
@@ -1627,7 +1625,7 @@ class Airflow(AirflowBaseView):
     def duration(self, session=None):
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
         num_runs = int(num_runs) if num_runs else default_dag_run
@@ -1739,7 +1737,7 @@ class Airflow(AirflowBaseView):
     def tries(self, session=None):
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
         num_runs = int(num_runs) if num_runs else default_dag_run
@@ -1804,7 +1802,7 @@ class Airflow(AirflowBaseView):
     def landing_times(self, session=None):
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
         num_runs = int(num_runs) if num_runs else default_dag_run
@@ -1902,7 +1900,7 @@ class Airflow(AirflowBaseView):
             session.merge(orm_dag)
         session.commit()
 
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         # sync dag permission
         current_app.appbuilder.sm.sync_perm_for_dag(dag_id, dag.access_control)
 
@@ -1916,7 +1914,7 @@ class Airflow(AirflowBaseView):
     @provide_session
     def gantt(self, session=None):
         dag_id = request.args.get('dag_id')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
         demo_mode = conf.getboolean('webserver', 'demo_mode')
 
         root = request.args.get('root')
@@ -2029,7 +2027,7 @@ class Airflow(AirflowBaseView):
         execution_date = request.args.get('execution_date')
         link_name = request.args.get('link_name')
         dttm = timezone.parse(execution_date)
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
 
         if not dag or task_id not in dag.task_ids:
             response = jsonify(
@@ -2066,7 +2064,7 @@ class Airflow(AirflowBaseView):
     @action_logging
     def task_instances(self):
         dag_id = request.args.get('dag_id')
-        dag = dagbag.get_dag(dag_id)
+        dag = get_app_dag_bag().get_dag(dag_id)
 
         dttm = request.args.get('execution_date')
         if dttm:
@@ -2544,7 +2542,7 @@ class DagRunModelView(AirflowModelView):
                 dirty_ids.append(dr.dag_id)
                 count += 1
                 altered_tis += \
-                    set_dag_run_state_to_failed(dagbag.get_dag(dr.dag_id),
+                    set_dag_run_state_to_failed(get_app_dag_bag().get_dag(dr.dag_id),
                                                 dr.execution_date,
                                                 commit=True,
                                                 session=session)
@@ -2571,7 +2569,7 @@ class DagRunModelView(AirflowModelView):
                 dirty_ids.append(dr.dag_id)
                 count += 1
                 altered_tis += \
-                    set_dag_run_state_to_success(dagbag.get_dag(dr.dag_id),
+                    set_dag_run_state_to_success(get_app_dag_bag().get_dag(dr.dag_id),
                                                  dr.execution_date,
                                                  commit=True,
                                                  session=session)
@@ -2665,7 +2663,7 @@ class TaskInstanceModelView(AirflowModelView):
             dag_to_tis = {}
 
             for ti in tis:
-                dag = dagbag.get_dag(ti.dag_id)
+                dag = get_app_dag_bag().get_dag(ti.dag_id)
                 tis = dag_to_tis.setdefault(dag, [])
                 tis.append(ti)
 


### PR DESCRIPTION
Currently to access dag in Webserver we use global variable `dagbag` from `airflow.www.views`. This global object is also necessary for new Connexion API (/tasks endpoint for example).  

However, it would be better to avoid any coupling between views code and API code. This PR proposes to replace this global object with an attribute of Flask app that can be accessed using `flask.current_app` as follows:

```python
from flask import current_app

@expose('/my_endpoint')
def my_endpoint():
    dag_bag: DagBag = current_app.dag_bag
    ...
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
