### PR TITLE
Move out weekday from airflow.contrib

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -61,6 +61,13 @@ More tips can be found in the guide:
 https://developers.google.com/style/inclusive-documentation
 
 -->
+### Weekday enum has been moved
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
+package was supported by the community. The project was passed to the Apache community and currently the
+entire code is maintained by the community, so now the division has no justification, and it is only due
+to historical reasons.
+
+To clean up, `Weekday` enum has been moved from `airflow.contrib.utils` into `airflow.utils` module.
 
 ### BaseOperator uses metaclass
 

--- a/airflow/contrib/utils/weekday.py
+++ b/airflow/contrib/utils/weekday.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,38 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Get the ISO standard day number of the week from a given day string
+This module is deprecated. Please use `airflow.utils.weekday`.
 """
-import enum
+import warnings
 
+# pylint: disable=unused-import
+from airflow.utils.weekday import WeekDay  # noqa
 
-@enum.unique
-class WeekDay(enum.IntEnum):
-    """
-    Python Enum containing Days of the Week
-    """
-    MONDAY = 1
-    TUESDAY = 2
-    WEDNESDAY = 3
-    THURSDAY = 4
-    FRIDAY = 5
-    SATURDAY = 6
-    SUNDAY = 7
-
-    @classmethod
-    def get_weekday_number(cls, week_day_str):
-        """
-        Return the ISO Week Day Number for a Week Day
-
-        :param week_day_str: Full Name of the Week Day. Example: "Sunday"
-        :type week_day_str: str
-        :return: ISO Week Day Number corresponding to the provided Weekday
-        """
-        sanitized_week_day_str = week_day_str.upper()
-
-        if sanitized_week_day_str not in cls.__members__:
-            raise AttributeError(
-                'Invalid Week Day passed: "{}"'.format(week_day_str)
-            )
-
-        return cls[sanitized_week_day_str]
+warnings.warn(
+    "This module is deprecated. Please use `airflow.utils.weekday`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/sensors/weekday_sensor.py
+++ b/airflow/sensors/weekday_sensor.py
@@ -16,10 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.contrib.utils.weekday import WeekDay
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.weekday import WeekDay
 
 
 class DayOfWeekSensor(BaseSensorOperator):
@@ -44,10 +44,10 @@ class DayOfWeekSensor(BaseSensorOperator):
             use_task_execution_day=True,
             dag=dag)
 
-    **Example** (with :class:`~airflow.contrib.utils.weekday.WeekDay` enum): ::
+    **Example** (with :class:`~airflow.utils.weekday.WeekDay` enum): ::
 
         # import WeekDay Enum
-        from airflow.contrib.utils.weekday import WeekDay
+        from airflow.utils.weekday import WeekDay
 
         weekend_check = DayOfWeekSensor(
             task_id='weekend_check',
@@ -64,7 +64,7 @@ class DayOfWeekSensor(BaseSensorOperator):
             * ``{WeekDay.TUESDAY}``
             * ``{WeekDay.SATURDAY, WeekDay.SUNDAY}``
 
-    :type week_day: set or str or airflow.contrib.utils.weekday.WeekDay
+    :type week_day: set or str or airflow.utils.weekday.WeekDay
     :param use_task_execution_day: If ``True``, uses task's execution day to compare
         with week_day. Execution Date is Useful for backfilling.
         If ``False``, uses system's day of the week. Useful when you

--- a/airflow/utils/weekday.py
+++ b/airflow/utils/weekday.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Get the ISO standard day number of the week from a given day string
+"""
+import enum
+
+
+@enum.unique
+class WeekDay(enum.IntEnum):
+    """
+    Python Enum containing Days of the Week
+    """
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6
+    SUNDAY = 7
+
+    @classmethod
+    def get_weekday_number(cls, week_day_str):
+        """
+        Return the ISO Week Day Number for a Week Day
+
+        :param week_day_str: Full Name of the Week Day. Example: "Sunday"
+        :type week_day_str: str
+        :return: ISO Week Day Number corresponding to the provided Weekday
+        """
+        sanitized_week_day_str = week_day_str.upper()
+
+        if sanitized_week_day_str not in cls.__members__:
+            raise AttributeError(
+                'Invalid Week Day passed: "{}"'.format(week_day_str)
+            )
+
+        return cls[sanitized_week_day_str]

--- a/tests/sensors/test_weekday_sensor.py
+++ b/tests/sensors/test_weekday_sensor.py
@@ -21,13 +21,13 @@ import unittest
 
 from parameterized import parameterized
 
-from airflow.contrib.utils.weekday import WeekDay
 from airflow.exceptions import AirflowSensorTimeout
 from airflow.models import DagBag, TaskFail, TaskInstance
 from airflow.models.dag import DAG
 from airflow.sensors.weekday_sensor import DayOfWeekSensor
 from airflow.settings import Session
 from airflow.utils.timezone import datetime
+from airflow.utils.weekday import WeekDay
 
 DEFAULT_DATE = datetime(2018, 12, 10)
 WEEKDAY_DATE = datetime(2018, 12, 20)

--- a/tests/utils/test_weekday.py
+++ b/tests/utils/test_weekday.py
@@ -18,7 +18,7 @@
 import unittest
 from enum import Enum
 
-from airflow.contrib.utils.weekday import WeekDay
+from airflow.utils.weekday import WeekDay
 
 
 class TestWeekDay(unittest.TestCase):


### PR DESCRIPTION
Close item in #9382 
This PR moves `weekday` from `airflow.contrib` into `airflow.utils`
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
