### PR TITLE
Extract TaskLogReader from views.py

### DIFF
--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -41,17 +41,6 @@ class TaskLogReader:
         :param metadata: A dictionary containing information about how to read the task log
         :type metadata: dict
         :rtype: Tuple[List[str], Dict[str, Any]]
-
-        The following is an example of how to use this method to read log:
-
-        .. code-block:: python
-
-            logs, metadata = task_log_reader.read_log_chunks(ti, try_number, metadata)
-            logs = logs[0] if try_number is not None else logs
-
-        where task_log_reader is an instance of TaskLogReader. The metadata will always
-        contain information about the task log which can enable you read logs to the
-        end.
         """
 
         logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -31,10 +31,11 @@ class TaskLogReader:
     def read_log_chunks(self, ti: TaskInstance, try_number: Optional[int],
                         metadata) -> Tuple[List[str], Dict[str, Any]]:
         """
-         Reads logs in chunks
+        Reads chunks of Task Instance logs.
+
         :param ti: The taskInstance
         :type ti: TaskInstance
-        :param try_number: The taskInstance try_number
+        :param try_number: If provided, logs for the given try will be returned. Otherwise, logs from all attempts are returned.
         :type try_number: Optional[int]
         :param metadata: A dictionary containing information about how to read the task
         :type metadata: dict
@@ -73,7 +74,7 @@ class TaskLogReader:
 
     @cached_property
     def log_handler(self):
-        """The log handler"""
+        """Log handler, which is configured to read logs."""
 
         logger = logging.getLogger('airflow.task')
         task_log_reader = conf.get('logging', 'task_log_reader')
@@ -82,7 +83,7 @@ class TaskLogReader:
 
     @property
     def is_supported(self):
-        """ Checks if read method is supported by a given log handler"""
+        """Checks if a read operation is supported by a current log handler."""
 
         return hasattr(self.log_handler, 'read')
 

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from cached_property import cached_property
 
@@ -35,18 +35,20 @@ class TaskLogReader:
 
         :param ti: The taskInstance
         :type ti: TaskInstance
-        :param try_number: If provided, logs for the given try will be returned. Otherwise, logs from all attempts are returned.
+        :param try_number: If provided, logs for the given try will be returned.
+            Otherwise, logs from all attempts are returned.
         :type try_number: Optional[int]
-        :param metadata: A dictionary containing information about how to read the task
+        :param metadata: A dictionary containing information about how to read the task log
         :type metadata: dict
-
+        :rtype: Tuple[List[str], Dict[str, Any]]
         """
 
         logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)
         metadata = metadatas[0]
         return logs, metadata
 
-    def read_log_stream(self, ti: TaskInstance, try_number: Optional[int], metadata: dict):
+    def read_log_stream(self, ti: TaskInstance, try_number: Optional[int],
+                        metadata: dict) -> Iterator[str]:
         """
         Used to continuously read log to the end
 
@@ -54,9 +56,9 @@ class TaskLogReader:
         :type ti: TaskInstance
         :param try_number: the task try number
         :type try_number: Optional[int]
-        :param metadata: A dictionary containing information about how to read the task
+        :param metadata: A dictionary containing information about how to read the task log
         :type metadata: dict
-
+        :rtype: Iterator[str]
         """
 
         if try_number is None:
@@ -95,6 +97,7 @@ class TaskLogReader:
         :type ti: TaskInstance
         :param try_number: The task try number
         :type try_number: Optional[int]
+        :rtype: str
         """
 
         filename_template = conf.get('logging', 'LOG_FILENAME_TEMPLATE')

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -41,6 +41,17 @@ class TaskLogReader:
         :param metadata: A dictionary containing information about how to read the task log
         :type metadata: dict
         :rtype: Tuple[List[str], Dict[str, Any]]
+
+        The following is an example of how to use this method to read log:
+
+        .. code-block:: python
+
+            logs, metadata = task_log_reader.read_log_chunks(ti, try_number, metadata)
+            logs = logs[0] if try_number is not None else logs
+
+        where task_log_reader is an instance of TaskLogReader. The metadata will always
+        contain information about the task log which can enable you read logs to the
+        end.
         """
 
         logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from cached_property import cached_property
+
+from airflow.configuration import conf
+from airflow.models import TaskInstance
+from airflow.utils.helpers import render_log_filename
+
+
+class TaskLogReader:
+    """ Task log reader"""
+
+    def read_log_chunks(self, ti: TaskInstance, try_number: Optional[int],
+                        metadata) -> Tuple[List[str], Dict[str, Any]]:
+        """
+         Reads logs in chunks
+        :param ti: The taskInstance
+        :type ti: TaskInstance
+        :param try_number: The taskInstance try_number
+        :type try_number: Optional[int]
+        :param metadata: A dictionary containing information about how to read the task
+        :type metadata: dict
+
+        """
+
+        logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)
+        metadata = metadatas[0]
+        return logs, metadata
+
+    def read_log_stream(self, ti: TaskInstance, try_number: Optional[int], metadata: dict):
+        """
+        Used to continuously read log to the end
+
+        :param ti: The Task Instance
+        :type ti: TaskInstance
+        :param try_number: the task try number
+        :type try_number: Optional[int]
+        :param metadata: A dictionary containing information about how to read the task
+        :type metadata: dict
+
+        """
+
+        if try_number is None:
+            next_try = ti.next_try_number
+            try_numbers = list(range(1, next_try))
+        else:
+            try_numbers = [try_number]
+        for current_try_number in try_numbers:
+            metadata.pop('end_of_log', None)
+            metadata.pop('max_offset', None)
+            metadata.pop('offset', None)
+            while 'end_of_log' not in metadata or not metadata['end_of_log']:
+                logs, metadata = self.read_log_chunks(ti, current_try_number, metadata)
+                yield "\n".join(logs) + "\n"
+
+    @cached_property
+    def log_handler(self):
+        """The log handler"""
+
+        logger = logging.getLogger('airflow.task')
+        task_log_reader = conf.get('logging', 'task_log_reader')
+        handler = next((handler for handler in logger.handlers if handler.name == task_log_reader), None)
+        return handler
+
+    @property
+    def is_supported(self):
+        """ Checks if read method is supported by a given log handler"""
+
+        return hasattr(self.log_handler, 'read')
+
+    def render_log_filename(self, ti: TaskInstance, try_number: Optional[int] = None):
+        """
+        Renders the log attachment filename
+
+        :param ti: The task instance
+        :type ti: TaskInstance
+        :param try_number: The task try number
+        :type try_number: Optional[int]
+        """
+
+        filename_template = conf.get('logging', 'LOG_FILENAME_TEMPLATE')
+        attachment_filename = render_log_filename(
+            ti=ti,
+            try_number="all" if try_number is None else try_number,
+            filename_template=filename_template)
+        return attachment_filename

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -1,0 +1,211 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import copy
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+from airflow import DAG, settings
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
+from airflow.models import TaskInstance
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils import timezone
+from airflow.utils.log.log_reader import TaskLogReader
+from airflow.utils.session import create_session
+from tests.test_utils.config import conf_vars
+from tests.test_utils.db import clear_db_runs
+
+
+class TestLogView(unittest.TestCase):
+    DAG_ID = "dag_log_reader"
+    TASK_ID = "task_log_reader"
+    DEFAULT_DATE = timezone.datetime(2017, 9, 1)
+
+    def setUp(self):
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+        # Make sure that the configure_logging is not cached
+        self.old_modules = dict(sys.modules)
+
+        self.settings_folder = tempfile.mkdtemp()
+        self.log_dir = tempfile.mkdtemp()
+
+        self._configure_loggers()
+        self._prepare_db()
+        self._prepare_log_files()
+
+    def _prepare_log_files(self):
+        dir_path = f"{self.log_dir}/{self.DAG_ID}/{self.TASK_ID}/2017-09-01T00.00.00+00.00/"
+        os.makedirs(dir_path)
+        for try_number in range(1, 4):
+            with open(f"{dir_path}/{try_number}.log", "w+") as file:
+                file.write(f"try_number={try_number}.\n")
+                file.flush()
+
+    def _prepare_db(self):
+        dag = DAG(self.DAG_ID, start_date=self.DEFAULT_DATE)
+        dag.sync_to_db()
+        with create_session() as session:
+            op = DummyOperator(task_id=self.TASK_ID, dag=dag)
+            self.ti = TaskInstance(task=op, execution_date=self.DEFAULT_DATE)
+            self.ti.try_number = 3
+
+            session.merge(self.ti)
+
+    def _configure_loggers(self):
+        logging_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
+        logging_config["handlers"]["task"]["base_log_folder"] = self.log_dir
+        logging_config["handlers"]["task"][
+            "filename_template"
+        ] = "{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts | replace(':', '.') }}/{{ try_number }}.log"
+        settings_file = os.path.join(self.settings_folder, "airflow_local_settings.py")
+        with open(settings_file, "w") as handle:
+            new_logging_file = "LOGGING_CONFIG = {}".format(logging_config)
+            handle.writelines(new_logging_file)
+        sys.path.append(self.settings_folder)
+        with conf_vars({("logging", "logging_config_class"): "airflow_local_settings.LOGGING_CONFIG"}):
+            settings.configure_logging()
+
+    def tearDown(self):
+        logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+        clear_db_runs()
+
+        # Remove any new modules imported during the test run. This lets us
+        # import the same source files for more than one test.
+        for mod in [m for m in sys.modules if m not in self.old_modules]:
+            del sys.modules[mod]
+
+        sys.path.remove(self.settings_folder)
+        shutil.rmtree(self.settings_folder)
+        shutil.rmtree(self.log_dir)
+        super().tearDown()
+
+    def test_test_read_log_chunks_should_read_one_try(self):
+        task_log_reader = TaskLogReader()
+        logs, metadatas = task_log_reader.read_log_chunks(ti=self.ti, try_number=1, metadata={})
+
+        self.assertEqual(
+            [
+                f"*** Reading local file: "
+                f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
+                f"try_number=1.\n"
+            ],
+            logs,
+        )
+        self.assertEqual({"end_of_log": True}, metadatas)
+
+    def test_test_read_log_chunks_should_read_all_files(self):
+        task_log_reader = TaskLogReader()
+        logs, metadatas = task_log_reader.read_log_chunks(ti=self.ti, try_number=None, metadata={})
+
+        self.assertEqual(
+            [
+                "*** Reading local file: "
+                f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
+                "try_number=1.\n",
+                f"*** Reading local file: "
+                f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/2.log\n"
+                f"try_number=2.\n",
+                f"*** Reading local file: "
+                f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log\n"
+                f"try_number=3.\n",
+            ],
+            logs,
+        )
+        self.assertEqual({"end_of_log": True}, metadatas)
+
+    def test_test_test_read_log_stream_should_read_one_try(self):
+        task_log_reader = TaskLogReader()
+        stream = task_log_reader.read_log_stream(ti=self.ti, try_number=1, metadata={})
+
+        self.assertEqual(
+            [
+                "*** Reading local file: "
+                f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
+                "try_number=1.\n"
+                "\n"
+            ],
+            list(stream),
+        )
+
+    def test_test_test_read_log_stream_should_read_all_logs(self):
+        task_log_reader = TaskLogReader()
+        stream = task_log_reader.read_log_stream(ti=self.ti, try_number=None, metadata={})
+        self.assertEqual(
+            [
+                "*** Reading local file: "
+                f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
+                "try_number=1.\n"
+                "\n",
+                "*** Reading local file: "
+                f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/2.log\n"
+                "try_number=2.\n"
+                "\n",
+                "*** Reading local file: "
+                f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log\n"
+                "try_number=3.\n"
+                "\n",
+            ],
+            list(stream),
+        )
+
+    @mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read")
+    def test_read_log_stream_should_support_multiple_chunks(self, mock_read):
+        first_return = (["1st line"], [{}])
+        second_return = (["2nd line"], [{"end_of_log": False}])
+        third_return = (["3rd line"], [{"end_of_log": True}])
+        fourth_return = (["should never be read"], [{"end_of_log": True}])
+        mock_read.side_effect = [first_return, second_return, third_return, fourth_return]
+
+        task_log_reader = TaskLogReader()
+        log_stream = task_log_reader.read_log_stream(ti=self.ti, try_number=1, metadata={})
+        self.assertEqual(["1st line\n", "2nd line\n", "3rd line\n"], list(log_stream))
+
+        mock_read.assert_has_calls(
+            [
+                mock.call(self.ti, 1, metadata={}),
+                mock.call(self.ti, 1, metadata={}),
+                mock.call(self.ti, 1, metadata={"end_of_log": False}),
+            ],
+            any_order=False,
+        )
+
+    @mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read")
+    def test_read_log_stream_should_read_each_try_in_turn(self, mock_read):
+        first_return = (["try_number=1."], [{"end_of_log": True}])
+        second_return = (["try_number=2."], [{"end_of_log": True}])
+        third_return = (["try_number=3."], [{"end_of_log": True}])
+        fourth_return = (["should never be read"], [{"end_of_log": True}])
+        mock_read.side_effect = [first_return, second_return, third_return, fourth_return]
+
+        task_log_reader = TaskLogReader()
+        log_stream = task_log_reader.read_log_stream(ti=self.ti, try_number=None, metadata={})
+        self.assertEqual(['try_number=1.\n', 'try_number=2.\n', 'try_number=3.\n'], list(log_stream))
+
+        mock_read.assert_has_calls(
+            [
+                mock.call(self.ti, 1, metadata={}),
+                mock.call(self.ti, 2, metadata={}),
+                mock.call(self.ti, 3, metadata={}),
+            ],
+            any_order=False,
+        )


### PR DESCRIPTION
---
Currently the logic for reading task logs is implemented inside `views.py`. 

This logic is also needed in API and it would be better if the logic is extracted from the view and tested separately. This will enable reuse of the logic in API `log_endpoint`.


Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
