### PR TITLE
Fix PythonVirtualenvOperator not working with Airflow context

### DIFF
--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -72,6 +72,7 @@ for i in range(5):
 # [END howto_operator_python_kwargs]
 
 
+# [START howto_operator_python_venv]
 def callable_virtualenv():
     """
     Example function that will be performed in a virtual environment.
@@ -101,3 +102,4 @@ virtualenv_task = PythonVirtualenvOperator(
     system_site_packages=False,
     dag=dag,
 )
+# [END howto_operator_python_venv]

--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -19,7 +19,10 @@
 """
 Utilities for creating a virtual environment
 """
+import os
 from typing import List, Optional
+
+import jinja2
 
 from airflow.utils.process_utils import execute_in_subprocess
 
@@ -69,3 +72,22 @@ def prepare_virtualenv(
         execute_in_subprocess(pip_cmd)
 
     return '{}/bin/python'.format(venv_directory)
+
+
+def write_python_script(jinja_context: dict, filename: str):
+    """
+    Renders the python script to a file to execute in the virtual environment.
+
+    :param jinja_context: The jinja context variables to unpack and replace with its placeholders in the
+        template file.
+    :type jinja_context: dict
+    :param filename: The name of the file to dump the rendered script to.
+    :type filename: str
+    """
+    template_loader = jinja2.FileSystemLoader(searchpath=os.path.dirname(__file__))
+    template_env = jinja2.Environment(
+        loader=template_loader,
+        undefined=jinja2.StrictUndefined
+    )
+    template = template_env.get_template('python_virtualenv_script.jinja2')
+    template.stream(**jinja_context).dump(filename)

--- a/airflow/utils/python_virtualenv_script.jinja2
+++ b/airflow/utils/python_virtualenv_script.jinja2
@@ -1,0 +1,42 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+import {{ pickling_library }}
+import sys
+
+# Read args
+{% if op_args or op_kwargs %}
+with open(sys.argv[1], "rb") as file:
+    arg_dict = {{ pickling_library }}.load(file)
+{% else %}
+arg_dict = {"args": [], "kwargs": {}}
+{% endif %}
+
+# Read string args
+with open(sys.argv[3], "r") as file:
+    virtualenv_string_args = list(map(lambda x: x.strip(), list(file)))
+
+# Script
+{{ python_callable_source }}
+res = {{ python_callable }}(*arg_dict["args"], **arg_dict["kwargs"])
+
+# Write output
+with open(sys.argv[2], "wb") as file:
+    if res:
+        {{ pickling_library }}.dump(res, file)

--- a/docs/howto/operator/python.rst
+++ b/docs/howto/operator/python.rst
@@ -50,3 +50,34 @@ argument.
 
 The ``templates_dict`` argument is templated, so each value in the dictionary
 is evaluated as a :ref:`Jinja template <jinja-templating>`.
+
+
+
+.. _howto/operator:PythonVirtualenvOperator:
+
+PythonVirtualenvOperator
+========================
+
+Use the :class:`~airflow.operators.python.PythonVirtualenvOperator` to execute
+Python callables inside a new Python virtual environment.
+
+.. exampleinclude:: ../../../airflow/example_dags/example_python_operator.py
+    :language: python
+    :start-after: [START howto_operator_python_venv]
+    :end-before: [END howto_operator_python_venv]
+
+Passing in arguments
+^^^^^^^^^^^^^^^^^^^^
+
+You can use the ``op_args`` and ``op_kwargs`` arguments the same way you use it in the PythonOperator.
+Unfortunately we currently do not support to serialize ``var`` and ``ti`` / ``task_instance`` due to incompatibilities
+with the underlying library. For airflow context variables make sure that you either have access to Airflow through
+setting ``system_site_packages`` to ``True`` or add ``apache-airflow`` to the ``requirements`` argument.
+Otherwise you won't have access to the most context variables of Airflow in ``op_kwargs``.
+If you want the context related to datetime objects like ``execution_date`` you can add ``pendulum`` and
+``lazy_object_proxy``.
+
+Templating
+^^^^^^^^^^
+
+You can use jinja Templating the same way you use it in PythonOperator.


### PR DESCRIPTION
Primarly this PR fixes an issue with PythonVirtualenvOperator not working in conjunction with airflow context arg.
 
Relates to #8177
Relates to #8256 

But it also has a QoL improvement. You don't need to manually pass `dill` as requirement anymore if you have set `use_dill` to `True`. So it won't raise an Error if you forgot to add it.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

cc @maganaluis
