### PR TITLE
Move modules in `airflow.contrib.utils.log` to `airflow.utils.log`

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -62,6 +62,16 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### airflow.contrib.utils.log has been moved
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
+package was supported by the community. The project was passed to the Apache community and currently the
+entire code is maintained by the community, so now the division has no justification, and it is only due
+to historical reasons.
+
+To clean up, modules in `airflow.contrib.utils.log` have been moved into `airflow.utils.log`
+this includes:
+* `TaskHandlerWithCustomFormatter` class
+
 ### BaseOperator uses metaclass
 
 `BaseOperator` class uses a `BaseOperatorMeta` as a metaclass. This meta class is based on

--- a/airflow/contrib/utils/log/__init__.py
+++ b/airflow/contrib/utils/log/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,3 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+This module is deprecated. Please use `airflow.utils.log`.
+"""
+
+import warnings
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.utils.log`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,46 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Custom logging formatter for Airflow
+This module is deprecated. Please use `airflow.utils.log.task_handler_with_custom_formatter`.
 """
 
-import logging
-from logging import StreamHandler
+import warnings
 
-from airflow.configuration import conf
-from airflow.utils.helpers import parse_template_string
+# pylint: disable=unused-import
+from airflow.utils.log.task_handler_with_custom_formatter import TaskHandlerWithCustomFormatter  # noqa
 
-
-class TaskHandlerWithCustomFormatter(StreamHandler):
-    """
-    Custom implementation of StreamHandler, a class which writes logging records for Airflow
-    """
-    def __init__(self, stream):
-        super().__init__()
-        self.prefix_jinja_template = None
-
-    def set_context(self, ti):
-        """
-        Accept the run-time context (i.e. the current task) and configure the formatter accordingly.
-
-        :param ti:
-        :return:
-        """
-        if ti.raw:
-            return
-        prefix = conf.get('logging', 'task_log_prefix_template')
-
-        rendered_prefix = ""
-        if prefix:
-            _, self.prefix_jinja_template = parse_template_string(prefix)
-            rendered_prefix = self._render_prefix(ti)
-        formatter = logging.Formatter(rendered_prefix + ":" + self.formatter._fmt)  # pylint: disable=W0212
-        self.setFormatter(formatter)
-        self.setLevel(self.level)
-
-    def _render_prefix(self, ti):
-        if self.prefix_jinja_template:
-            jinja_context = ti.get_template_context()
-            return self.prefix_jinja_template.render(**jinja_context)
-        logging.warning("'task_log_prefix_template' is in invalid format, ignoring the variable value")
-        return ""
+warnings.warn(
+    "This module is deprecated. Please use `airflow.utils.log.task_handler_with_custom_formatter`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/utils/log/task_handler_with_custom_formatter.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Custom logging formatter for Airflow
+"""
+
+import logging
+from logging import StreamHandler
+
+from airflow.configuration import conf
+from airflow.utils.helpers import parse_template_string
+
+
+class TaskHandlerWithCustomFormatter(StreamHandler):
+    """
+    Custom implementation of StreamHandler, a class which writes logging records for Airflow
+    """
+    def __init__(self, stream):
+        super().__init__()
+        self.prefix_jinja_template = None
+
+    def set_context(self, ti):
+        """
+        Accept the run-time context (i.e. the current task) and configure the formatter accordingly.
+
+        :param ti:
+        :return:
+        """
+        if ti.raw:
+            return
+        prefix = conf.get('logging', 'task_log_prefix_template')
+
+        rendered_prefix = ""
+        if prefix:
+            _, self.prefix_jinja_template = parse_template_string(prefix)
+            rendered_prefix = self._render_prefix(ti)
+        formatter = logging.Formatter(rendered_prefix + ":" + self.formatter._fmt)  # pylint: disable=W0212
+        self.setFormatter(formatter)
+        self.setLevel(self.level)
+
+    def _render_prefix(self, ti):
+        if self.prefix_jinja_template:
+            jinja_context = ti.get_template_context()
+            return self.prefix_jinja_template.render(**jinja_context)
+        logging.warning("'task_log_prefix_template' is in invalid format, ignoring the variable value")
+        return ""

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1742,10 +1742,17 @@ TRANSFERS = [
     ),
 ]
 
-ALL = HOOKS + OPERATORS + SECRETS + SENSORS + TRANSFERS
+UTILS = [
+    (
+        'airflow.utils.log.task_handler_with_custom_formatter.TaskHandlerWithCustomFormatter',
+        'airflow.contrib.utils.log.task_handler_with_custom_formatter.TaskHandlerWithCustomFormatter',
+    )
+]
+
+ALL = HOOKS + OPERATORS + SECRETS + SENSORS + TRANSFERS + UTILS
 
 RENAMED_ALL = [
     (old_class, new_class)
-    for old_class, new_class in HOOKS + OPERATORS + SECRETS + SENSORS
+    for old_class, new_class in HOOKS + OPERATORS + SECRETS + SENSORS + UTILS
     if old_class.rpartition(".")[2] != new_class.rpartition(".")[2]
 ]

--- a/tests/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/utils/test_task_handler_with_custom_formatter.py
@@ -29,7 +29,7 @@ from tests.test_utils.config import conf_vars
 DEFAULT_DATE = datetime(2019, 1, 1)
 TASK_LOGGER = 'airflow.task'
 TASK_HANDLER = 'task'
-TASK_HANDLER_CLASS = 'airflow.contrib.utils.log.task_handler_with_custom_formatter.' \
+TASK_HANDLER_CLASS = 'airflow.utils.log.task_handler_with_custom_formatter.' \
                      'TaskHandlerWithCustomFormatter'
 PREV_TASK_HANDLER = DEFAULT_LOGGING_CONFIG['handlers']['task']
 


### PR DESCRIPTION
Clean up modules in `airflow.contrib.utils.log` from #9382 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
