### PR TITLE
Add options to extend list of sensitive keywords

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1678,6 +1678,13 @@
       type: string
       example: ~
       default: "True"
+    - name: sensitive_variable_fields
+      description: |
+        Sensitive keywords to look for in variables names
+      version_added: ~
+      type: string
+      example: ~
+      default: ""
 - name: elasticsearch
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1680,7 +1680,7 @@
       default: "True"
     - name: sensitive_variable_fields
       description: |
-        Sensitive keywords to look for in variables names
+        A comma-separated list of sensitive keywords to look for in variables names.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -795,6 +795,9 @@ api_rev = v3
 # UI to hide sensitive variable fields when set to True
 hide_sensitive_variable_fields = True
 
+# Sensitive keywords to look for in variables names
+sensitive_variable_fields =
+
 [elasticsearch]
 # Elasticsearch host
 host =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -795,7 +795,7 @@ api_rev = v3
 # UI to hide sensitive variable fields when set to True
 hide_sensitive_variable_fields = True
 
-# Sensitive keywords to look for in variables names
+# A comma-separated list of sensitive keywords to look for in variables names.
 sensitive_variable_fields =
 
 [elasticsearch]

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -110,6 +110,7 @@ max_tis_per_query = 512
 
 [admin]
 hide_sensitive_variable_fields = True
+sensitive_variable_fields =
 
 [elasticsearch]
 host =

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -49,16 +49,15 @@ DEFAULT_SENSITIVE_VARIABLE_FIELDS = {
     'access_token',
 }
 
+sensitive_variable_fields = conf.get('admin', 'sensitive_variable_fields')
+if sensitive_variable_fields:
+    DEFAULT_SENSITIVE_VARIABLE_FIELDS.update(sensitive_variable_fields.split(','))
+
 
 def should_hide_value_for_key(key_name):
     # It is possible via importing variables from file that a key is empty.
     if key_name:
         config_set = conf.getboolean('admin', 'hide_sensitive_variable_fields')
-
-        sensitive_variable_fields = conf.get('admin', 'sensitive_variable_fields')
-
-        if sensitive_variable_fields:
-            DEFAULT_SENSITIVE_VARIABLE_FIELDS.update(sensitive_variable_fields.split(','))
 
         field_comp = any(s in key_name.strip().lower() for s in DEFAULT_SENSITIVE_VARIABLE_FIELDS)
         return config_set and field_comp

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -39,7 +39,7 @@ from airflow.utils.state import State
 from airflow.www.forms import DateTimeWithTimezoneField
 from airflow.www.widgets import AirflowDateTimePickerWidget
 
-DEFAULT_SENSITIVE_VARIABLE_FIELDS = (
+DEFAULT_SENSITIVE_VARIABLE_FIELDS = {
     'password',
     'secret',
     'passwd',
@@ -47,7 +47,7 @@ DEFAULT_SENSITIVE_VARIABLE_FIELDS = (
     'api_key',
     'apikey',
     'access_token',
-)
+}
 
 
 def should_hide_value_for_key(key_name):
@@ -57,10 +57,10 @@ def should_hide_value_for_key(key_name):
 
         sensitive_variable_fields = conf.get('admin', 'sensitive_variable_fields')
 
-        field_comp = any(
-            s in key_name.strip().lower()
-            for s in DEFAULT_SENSITIVE_VARIABLE_FIELDS.extend(sensitive_variable_fields.split(','))
-        )
+        if sensitive_variable_fields:
+            DEFAULT_SENSITIVE_VARIABLE_FIELDS.update(sensitive_variable_fields.split(','))
+
+        field_comp = any(s in key_name.strip().lower() for s in DEFAULT_SENSITIVE_VARIABLE_FIELDS)
         return config_set and field_comp
     return False
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -53,9 +53,14 @@ DEFAULT_SENSITIVE_VARIABLE_FIELDS = (
 def should_hide_value_for_key(key_name):
     # It is possible via importing variables from file that a key is empty.
     if key_name:
-        config_set = conf.getboolean('admin',
-                                     'hide_sensitive_variable_fields')
-        field_comp = any(s in key_name.lower() for s in DEFAULT_SENSITIVE_VARIABLE_FIELDS)
+        config_set = conf.getboolean('admin', 'hide_sensitive_variable_fields')
+
+        sensitive_variable_fields = conf.get('admin', 'sensitive_variable_fields')
+
+        field_comp = any(
+            s in key_name.strip().lower()
+            for s in DEFAULT_SENSITIVE_VARIABLE_FIELDS.extend(sensitive_variable_fields.split(','))
+        )
         return config_set and field_comp
     return False
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -421,3 +421,15 @@ the new key to the ``fernet_key`` setting, run
 #. Set ``fernet_key`` to ``new_fernet_key,old_fernet_key``
 #. Run ``airflow rotate_fernet_key`` to re-encrypt existing credentials with the new fernet key
 #. Set ``fernet_key`` to ``new_fernet_key``
+
+Sensitive Variable fields
+-------------------------
+
+By default, Airflow Value of a variable will be hidden if the key contains any words in
+(‘password’, ‘secret’, ‘passwd’, ‘authorization’, ‘api_key’, ‘apikey’, ‘access_token’), but can be configured
+to extend this list by using the following configurations option:
+
+.. code-block:: ini
+
+    [admin]
+    hide_sensitive_variable_fields = comma_seperated_sensitive_variable_fields_list

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -79,6 +79,13 @@ of a variable used during jobs. Value of a variable will be hidden if the key co
 any words in ('password', 'secret', 'passwd', 'authorization', 'api_key', 'apikey', 'access_token')
 by default, but can be configured to show in clear-text.
 
+It's also can be configured to extend this list by using the following configurations option:
+
+.. code-block:: ini
+
+    [admin]
+    hide_sensitive_variable_fields = comma_seperated_sensitive_variable_fields_list
+
 ------------
 
 .. image:: img/variable_hidden.png

--- a/scripts/ci/kubernetes/app/templates/configmaps.template.yaml
+++ b/scripts/ci/kubernetes/app/templates/configmaps.template.yaml
@@ -326,6 +326,9 @@ data:
     # UI to hide sensitive variable fields when set to True
     hide_sensitive_variable_fields = True
 
+    # Sensitive keywords to look for in variables names
+    sensitive_variable_fields =
+
     [elasticsearch]
     host =
   # yamllint enable rule:line-length

--- a/scripts/ci/kubernetes/app/templates/configmaps.template.yaml
+++ b/scripts/ci/kubernetes/app/templates/configmaps.template.yaml
@@ -326,7 +326,7 @@ data:
     # UI to hide sensitive variable fields when set to True
     hide_sensitive_variable_fields = True
 
-    # Sensitive keywords to look for in variables names
+    # A comma-separated list of sensitive keywords to look for in variables names.
     sensitive_variable_fields =
 
     [elasticsearch]


### PR DESCRIPTION
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

this PR addressed the following issue: https://github.com/apache/airflow/issues/9372

basically it's adding support for additional labels from the configuration so users can extend the matching of sensitive keywords in variables name.

