### PR TITLE
Restore airflow.www.app.csrf to avoid breaking change

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -44,6 +44,10 @@ from airflow.www.extensions.init_wsgi_middlewares import init_wsg_middleware
 
 app: Optional[Flask] = None
 
+# Initializes at the module level so plugins can access it.
+# See: /docs/plugins.rst
+csrf = CSRFProtect()
+
 
 def sync_appbuilder_roles(flask_app):
     """Sync appbuilder roles to DB"""
@@ -79,7 +83,7 @@ def create_app(config=None, testing=False, app_name="Airflow"):
     # Configure the JSON encoder used by `|tojson` filter from Flask
     flask_app.json_encoder = AirflowJsonEncoder
 
-    CSRFProtect(flask_app)
+    csrf.init_app(flask_app)
 
     init_wsg_middleware(flask_app)
 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -44,7 +44,7 @@ from airflow.www.extensions.init_wsgi_middlewares import init_wsg_middleware
 
 app: Optional[Flask] = None
 
-# Initializes at the module level so plugins can access it.
+# Initializes at the module level, so plugins can access it.
 # See: /docs/plugins.rst
 csrf = CSRFProtect()
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -256,7 +256,7 @@ the fields ``appbuilder_views`` and ``appbuilder_menu_items`` were added to the 
 Exclude views from CSRF protection
 ----------------------------------
 
-We strongly suggest that you protect all your views with CSRF. But if needed, you can exclude
+We strongly suggest that you should protect all your views with CSRF. But if needed, you can exclude
 some views using a decorator.
 
 .. code-block:: python

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -253,6 +253,20 @@ Airflow 1.10 introduced role based views using FlaskAppBuilder. You can configur
 ``rbac = True``. To support plugin views and links for both versions of the UI and maintain backwards compatibility,
 the fields ``appbuilder_views`` and ``appbuilder_menu_items`` were added to the ``AirflowTestPlugin`` class.
 
+Exclude views from CSRF protection
+----------------------------------
+
+We strongly suggest that you protect all your views with CSRF. But if needed, you can exclude
+some views using a decorator.
+
+.. code-block:: python
+
+    from airflow.www.app import csrf
+
+    @csrf.exempt
+    def my_handler():
+        # ...
+        return 'ok'
 
 Plugins as Python packages
 --------------------------


### PR DESCRIPTION
This field has been deleted in https://github.com/apache/airflow/pull/9291/files

There was no described reason why this should be initialized at the module level, but @ash noted that users use it in their own plugins.
Slack conversation: https://apache-airflow.slack.com/archives/CCR6P6JRL/p1592553233200300

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
