### PR TITLE
Warn about incompatible plugins

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -275,6 +275,13 @@ def initialize_web_ui_plugins():
             'blueprint': bp
         } for bp in plugin.flask_blueprints])
 
+        if (admin_views and not flask_appbuilder_views) or (menu_links and flask_appbuilder_menu_links):
+            log.warning(
+                "Plugin \'%s\' may not be compatible with the current Airflow version. "
+                "Please contact the author of the plugin.",
+                plugin.name
+            )
+
 
 def initialize_extra_operators_links_plugins():
     """Creates modules for loaded extension from extra operators links plugins"""


### PR DESCRIPTION
I suggest you add a warning when the plugin has elements for non-RBAC UI, but at the same time, it has no elements for RBAC Web UI.

Now there will be a message after running the airflow plugins command that will allow easier diagnosis of problems.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
