### PR TITLE
Remove unused variables in backport_packages

### DIFF
--- a/backport_packages/import_all_provider_classes.py
+++ b/backport_packages/import_all_provider_classes.py
@@ -45,7 +45,7 @@ def import_all_provider_classes(source_path: str,
 
     imported_classes = []
     tracebacks = []
-    for root, dirs, files in os.walk(source_path):
+    for root, _, files in os.walk(source_path):
         if all([not root.startswith(prefix_provider_path)
                 for prefix_provider_path in prefixed_provider_paths]) or root.endswith("__pycache__"):
             # Skip loading module if it is not in the list of providers that we are looking for

--- a/backport_packages/setup_backport_packages.py
+++ b/backport_packages/setup_backport_packages.py
@@ -952,7 +952,7 @@ def check_if_classes_are_properly_named(class_summary: Dict[str, List[str]]) -> 
     badly_named_class_number = 0
     for key, class_suffix in EXPECTED_SUFFIXES.items():
         for class_full_name in class_summary[key]:
-            module_name, class_name = class_full_name.rsplit(".", maxsplit=1)
+            _, class_name = class_full_name.rsplit(".", maxsplit=1)
             error_encountered = False
             if not is_camel_case_with_acronyms(class_name):
                 print(f"The class {class_full_name} is wrongly named. The "
@@ -1032,7 +1032,7 @@ def update_release_notes_for_package(provider_package_id: str, current_release_v
         with open(readme_file_path, "rt") as readme_file_read:
             old_text = readme_file_read.read()
     if old_text != readme:
-        file, temp_file_path = tempfile.mkstemp(".md")
+        _, temp_file_path = tempfile.mkstemp(".md")
         try:
             if os.path.isfile(readme_file_path):
                 copyfile(readme_file_path, temp_file_path)


### PR DESCRIPTION
There were few instances where we didn't need all the variables from the returned functions. We can remove them.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
