### PR TITLE
Remove incorrect docstrings in check_migrations

### DIFF
--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -51,11 +51,7 @@ def upgradedb(args):
 
 
 def check_migrations(args):
-    """
-    Function to wait for all airflow migrations to complete. Used for launching airflow in k8s
-    @param timeout:
-    @return:
-    """
+    """Function to wait for all airflow migrations to complete. Used for launching airflow in k8s"""
     db.check_migrations(timeout=args.migration_wait_timeout)
 
 


### PR DESCRIPTION
No point in having docstrings like:

```
@param timeout:
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
