### PR TITLE
Move API page limit and offset parameters to views as kwargs Arguments

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -20,7 +20,7 @@ from flask import request
 from marshmallow import ValidationError
 from sqlalchemy import func
 
-from airflow.api_connexion.exceptions import NotFound, BadRequest, AlreadyExists
+from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
 from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.connection_schema import (
     ConnectionCollection, connection_collection_item_schema, connection_collection_schema, connection_schema,

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -20,7 +20,8 @@ from flask import request
 from marshmallow import ValidationError
 from sqlalchemy import func
 
-from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
+from airflow.api_connexion.exceptions import NotFound, BadRequest, AlreadyExists
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.connection_schema import (
     ConnectionCollection, connection_collection_item_schema, connection_collection_schema, connection_schema,
 )
@@ -33,8 +34,7 @@ def delete_connection(connection_id, session):
     """
     Delete a connection entry
     """
-    query = session.query(Connection).filter_by(conn_id=connection_id)
-    connection = query.one_or_none()
+    connection = session.query(Connection).filter_by(conn_id=connection_id).one_or_none()
     if connection is None:
         raise NotFound('Connection not found')
     session.delete(connection)
@@ -52,6 +52,9 @@ def get_connection(connection_id, session):
     return connection_collection_item_schema.dump(connection)
 
 
+@format_parameters({
+    'limit': check_limit
+})
 @provide_session
 def get_connections(session, limit, offset=0):
     """

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -18,7 +18,7 @@
 from sqlalchemy import func
 
 from airflow.api_connexion.exceptions import NotFound
-from airflow.api_connexion.parameters import format_datetime, format_parameters
+from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters
 from airflow.api_connexion.schemas.dag_run_schema import (
     DAGRunCollection, dagrun_collection_schema, dagrun_schema,
 )
@@ -52,6 +52,7 @@ def get_dag_run(dag_id, dag_run_id, session):
     'execution_date_lte': format_datetime,
     'end_date_gte': format_datetime,
     'end_date_lte': format_datetime,
+    'limit': check_limit
 })
 @provide_session
 def get_dag_runs(session, dag_id, start_date_gte=None, start_date_lte=None,

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -18,12 +18,11 @@
 from sqlalchemy import func
 
 from airflow.api_connexion.exceptions import NotFound
-from airflow.api_connexion.parameters import check_limit, format_parameters
+from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters
 from airflow.api_connexion.schemas.dag_run_schema import (
     DAGRunCollection, dagrun_collection_schema, dagrun_schema,
 )
 from airflow.models import DagRun
-from airflow.utils import timezone
 from airflow.utils.session import provide_session
 
 
@@ -46,7 +45,15 @@ def get_dag_run(dag_id, dag_run_id, session):
     return dagrun_schema.dump(dag_run)
 
 
-@format_parameters({"limit": check_limit})
+@format_parameters({
+    'start_date_gte': format_datetime,
+    'start_date_lte': format_datetime,
+    'execution_date_gte': format_datetime,
+    'execution_date_lte': format_datetime,
+    'end_date_gte': format_datetime,
+    'end_date_lte': format_datetime,
+    'limit': check_limit
+})
 @provide_session
 def get_dag_runs(session, dag_id, start_date_gte=None, start_date_lte=None,
                  execution_date_gte=None, execution_date_lte=None,
@@ -63,24 +70,24 @@ def get_dag_runs(session, dag_id, start_date_gte=None, start_date_lte=None,
 
     # filter start date
     if start_date_gte:
-        query = query.filter(DagRun.start_date >= timezone.parse(start_date_gte))
+        query = query.filter(DagRun.start_date >= start_date_gte)
 
     if start_date_lte:
-        query = query.filter(DagRun.start_date <= timezone.parse(start_date_lte))
+        query = query.filter(DagRun.start_date <= start_date_lte)
 
     # filter execution date
     if execution_date_gte:
-        query = query.filter(DagRun.execution_date >= timezone.parse(execution_date_gte))
+        query = query.filter(DagRun.execution_date >= execution_date_gte)
 
     if execution_date_lte:
-        query = query.filter(DagRun.execution_date <= timezone.parse(execution_date_lte))
+        query = query.filter(DagRun.execution_date <= execution_date_lte)
 
     # filter end date
     if end_date_gte:
-        query = query.filter(DagRun.end_date >= timezone.parse(end_date_gte))
+        query = query.filter(DagRun.end_date >= end_date_gte)
 
     if end_date_lte:
-        query = query.filter(DagRun.end_date <= timezone.parse(end_date_lte))
+        query = query.filter(DagRun.end_date <= end_date_lte)
 
     # apply offset and limit
     dag_run = query.order_by(DagRun.id).offset(offset).limit(limit).all()

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -18,11 +18,12 @@
 from sqlalchemy import func
 
 from airflow.api_connexion.exceptions import NotFound
-from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.dag_run_schema import (
     DAGRunCollection, dagrun_collection_schema, dagrun_schema,
 )
 from airflow.models import DagRun
+from airflow.utils import timezone
 from airflow.utils.session import provide_session
 
 
@@ -45,15 +46,7 @@ def get_dag_run(dag_id, dag_run_id, session):
     return dagrun_schema.dump(dag_run)
 
 
-@format_parameters({
-    'start_date_gte': format_datetime,
-    'start_date_lte': format_datetime,
-    'execution_date_gte': format_datetime,
-    'execution_date_lte': format_datetime,
-    'end_date_gte': format_datetime,
-    'end_date_lte': format_datetime,
-    'limit': check_limit
-})
+@format_parameters({"limit": check_limit})
 @provide_session
 def get_dag_runs(session, dag_id, start_date_gte=None, start_date_lte=None,
                  execution_date_gte=None, execution_date_lte=None,
@@ -70,24 +63,24 @@ def get_dag_runs(session, dag_id, start_date_gte=None, start_date_lte=None,
 
     # filter start date
     if start_date_gte:
-        query = query.filter(DagRun.start_date >= start_date_gte)
+        query = query.filter(DagRun.start_date >= timezone.parse(start_date_gte))
 
     if start_date_lte:
-        query = query.filter(DagRun.start_date <= start_date_lte)
+        query = query.filter(DagRun.start_date <= timezone.parse(start_date_lte))
 
     # filter execution date
     if execution_date_gte:
-        query = query.filter(DagRun.execution_date >= execution_date_gte)
+        query = query.filter(DagRun.execution_date >= timezone.parse(execution_date_gte))
 
     if execution_date_lte:
-        query = query.filter(DagRun.execution_date <= execution_date_lte)
+        query = query.filter(DagRun.execution_date <= timezone.parse(execution_date_lte))
 
     # filter end date
     if end_date_gte:
-        query = query.filter(DagRun.end_date >= end_date_gte)
+        query = query.filter(DagRun.end_date >= timezone.parse(end_date_gte))
 
     if end_date_lte:
-        query = query.filter(DagRun.end_date <= end_date_lte)
+        query = query.filter(DagRun.end_date <= timezone.parse(end_date_lte))
 
     # apply offset and limit
     dag_run = query.order_by(DagRun.id).offset(offset).limit(limit).all()

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -19,6 +19,7 @@
 from sqlalchemy import func
 
 from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.event_log_schema import (
     EventLogCollection, event_log_collection_schema, event_log_schema,
 )
@@ -37,6 +38,9 @@ def get_event_log(event_log_id, session):
     return event_log_schema.dump(event_log)
 
 
+@format_parameters({
+    'limit': check_limit
+})
 @provide_session
 def get_event_logs(session, limit, offset=None):
     """

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -18,6 +18,7 @@
 from sqlalchemy import func
 
 from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.error_schema import (
     ImportErrorCollection, import_error_collection_schema, import_error_schema,
 )
@@ -37,6 +38,9 @@ def get_import_error(import_error_id, session):
     return import_error_schema.dump(error)
 
 
+@format_parameters({
+    'limit': check_limit
+})
 @provide_session
 def get_import_errors(session, limit, offset=None):
     """

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -14,10 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from flask import request
+
 from sqlalchemy import func
 
-from airflow.api_connexion import parameters
 from airflow.api_connexion.exceptions import NotFound
 from airflow.api_connexion.schemas.error_schema import (
     ImportErrorCollection, import_error_collection_schema, import_error_schema,
@@ -39,12 +38,10 @@ def get_import_error(import_error_id, session):
 
 
 @provide_session
-def get_import_errors(session):
+def get_import_errors(session, limit, offset=None):
     """
     Get all import errors
     """
-    offset = request.args.get(parameters.page_offset, 0)
-    limit = min(int(request.args.get(parameters.page_limit, 100)), 100)
 
     total_entries = session.query(func.count(ImportError.id)).scalar()
     import_errors = session.query(ImportError).order_by(ImportError.id).offset(offset).limit(limit).all()

--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -22,6 +22,7 @@ from sqlalchemy.exc import IntegrityError
 
 from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
 from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.pool_schema import PoolCollection, pool_collection_schema, pool_schema
 from airflow.models.pool import Pool
 from airflow.utils.session import provide_session
@@ -51,6 +52,9 @@ def get_pool(pool_name, session):
     return pool_schema.dump(obj)
 
 
+@format_parameters({
+    'limit': check_limit
+})
 @provide_session
 def get_pools(session, limit, offset=None):
     """

--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -16,11 +16,12 @@
 # under the License.
 from flask import Response, request
 from marshmallow import ValidationError
+
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
-from airflow.api_connexion import parameters
 from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
+from airflow.api_connexion.exceptions import NotFound
 from airflow.api_connexion.schemas.pool_schema import PoolCollection, pool_collection_schema, pool_schema
 from airflow.models.pool import Pool
 from airflow.utils.session import provide_session
@@ -51,12 +52,10 @@ def get_pool(pool_name, session):
 
 
 @provide_session
-def get_pools(session):
+def get_pools(session, limit, offset=None):
     """
     Get all pools
     """
-    offset = request.args.get(parameters.page_offset, 0)
-    limit = min(int(request.args.get(parameters.page_limit, 100)), 100)
 
     total_entries = session.query(func.count(Pool.id)).scalar()
     pools = session.query(Pool).order_by(Pool.id).offset(offset).limit(limit).all()

--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -16,12 +16,10 @@
 # under the License.
 from flask import Response, request
 from marshmallow import ValidationError
-
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
 from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
-from airflow.api_connexion.exceptions import NotFound
 from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.pool_schema import PoolCollection, pool_collection_schema, pool_schema
 from airflow.models.pool import Pool

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -21,6 +21,7 @@ from marshmallow import ValidationError
 from sqlalchemy import func
 
 from airflow.api_connexion.exceptions import BadRequest, NotFound
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.variable_schema import variable_collection_schema, variable_schema
 from airflow.models import Variable
 from airflow.utils.session import provide_session
@@ -46,6 +47,9 @@ def get_variable(variable_key: str) -> Response:
     return variable_schema.dump({"key": variable_key, "val": var})
 
 
+@format_parameters({
+    'limit': check_limit
+})
 @provide_session
 def get_variables(session, limit: Optional[int], offset: Optional[int] = None) -> Response:
     """

--- a/airflow/api_connexion/endpoints/xcom_endpoint.py
+++ b/airflow/api_connexion/endpoints/xcom_endpoint.py
@@ -14,12 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from flask import request
+from typing import Optional
+
 from sqlalchemy import and_, func
 from sqlalchemy.orm.session import Session
 
-from airflow.api_connexion import parameters
 from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.xcom_schema import (
     XComCollection, XComCollectionItemSchema, XComCollectionSchema, xcom_collection_item_schema,
     xcom_collection_schema,
@@ -35,18 +36,22 @@ def delete_xcom_entry():
     raise NotImplementedError("Not implemented yet.")
 
 
+@format_parameters({
+    'limit': check_limit
+})
 @provide_session
 def get_xcom_entries(
     dag_id: str,
     dag_run_id: str,
     task_id: str,
-    session: Session
+    session: Session,
+    limit: Optional[int],
+    offset: Optional[int] = None
 ) -> XComCollectionSchema:
     """
     Get all XCom values
     """
-    offset = request.args.get(parameters.page_offset, 0)
-    limit = min(int(request.args.get(parameters.page_limit, 100)), 100)
+
     query = session.query(XCom)
     if dag_id != '~':
         query = query.filter(XCom.dag_id == dag_id)

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2160,7 +2160,6 @@ components:
       required: false
       schema:
         type: integer
-        minimum: 1
         default: 100
       description: The numbers of items to return.
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2161,6 +2161,7 @@ components:
       schema:
         type: integer
         minimum: 1
+        maximum: 100
         default: 100
       description: The numbers of items to return.
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1278,16 +1278,16 @@ components:
 
             This together with DAG_ID are a unique key.
           type: string
-          format: timezone-datetime
+          format: date-time
         start_date:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             The start time. The time when DAG Run was actually created..
           readOnly: True
         end_date:
           type: string
-          format: timezone-datetime
+          format: date-time
           readOnly: True
           nullable: true
         state:
@@ -1610,7 +1610,7 @@ components:
               readOnly: true
             start_date:
               type: string
-              format: 'timezone-datetime'
+              format: 'date-time'
               readOnly: true
             dag_run_timeout:
               nullable: true
@@ -1655,11 +1655,11 @@ components:
           readOnly: true
         start_date:
           type: string
-          format: 'timezone-datetime'
+          format: 'date-time'
           readOnly: true
         end_date:
           type: string
-          format: 'timezone-datetime'
+          format: 'date-time'
           readOnly: true
           nullable: true
         trigger_rule:
@@ -1839,7 +1839,7 @@ components:
 
         execution_date_gte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects greater or equal to the specified date.
 
@@ -1847,7 +1847,7 @@ components:
 
         execution_date_lte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects less than or equal to the specified date.
 
@@ -1855,7 +1855,7 @@ components:
 
         start_date_gte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects greater or equal the specified date.
 
@@ -1863,7 +1863,7 @@ components:
 
         start_date_lte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects less or equal the specified date.
 
@@ -1871,14 +1871,14 @@ components:
 
         end_date_gte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects greater or equal the specified date.
 
             This can be combined with end_date_lte parameter to receive only the selected period.
         end_date_lte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects less than or equal to the specified date.
 
@@ -1898,42 +1898,42 @@ components:
 
         execution_date_gte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects greater or equal to the specified date.
 
             This can be combined with execution_date_lte parameter to receive only the selected period.
         execution_date_lte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects less than or equal to the specified date.
 
             This can be combined with execution_date_gte parameter to receive only the selected period.
         start_date_gte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects greater or equal the specified date.
 
             This can be combined with startd_ate_lte parameter to receive only the selected period.
         start_date_lte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects less or equal the specified date.
 
             This can be combined with start_date_gte parameter to receive only the selected period.
         end_date_gte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects greater or equal the specified date.
 
             This can be combined with start_date_lte parameter to receive only the selected period.
         end_date_lte:
           type: string
-          format: timezone-datetime
+          format: date-time
           description: >
             Returns objects less than or equal to the specified date.
 
@@ -2270,7 +2270,7 @@ components:
       name: execution_date_gte
       schema:
         type: string
-        format: timezone-datetime
+        format: date-time
       required: false
       description: >
         Returns objects greater or equal to the specified date.
@@ -2281,7 +2281,7 @@ components:
       name: execution_date_lte
       schema:
         type: string
-        format: timezone-datetime
+        format: date-time
       required: false
       description: >
         Returns objects less than or equal to the specified date.
@@ -2292,7 +2292,7 @@ components:
       name: start_date_gte
       schema:
         type: string
-        format: timezone-datetime
+        format: date-time
       required: false
       description: >
         Returns objects greater or equal the specified date.
@@ -2303,7 +2303,7 @@ components:
       name: start_date_lte
       schema:
         type: string
-        format: timezone-datetime
+        format: date-time
       required: false
       description: >
         Returns objects less or equal the specified date.
@@ -2314,7 +2314,7 @@ components:
       name: end_date_gte
       schema:
         type: string
-        format: timezone-datetime
+        format: date-time
       required: false
       description: >
         Returns objects greater or equal the specified date.
@@ -2325,7 +2325,7 @@ components:
       name: end_date_lte
       schema:
         type: string
-        format: timezone-datetime
+        format: date-time
       required: false
       description: >
         Returns objects less than or equal to the specified date.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2161,7 +2161,6 @@ components:
       schema:
         type: integer
         minimum: 1
-        maximum: 100
         default: 100
       description: The numbers of items to return.
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1278,16 +1278,16 @@ components:
 
             This together with DAG_ID are a unique key.
           type: string
-          format: date-time
+          format: timezone-datetime
         start_date:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             The start time. The time when DAG Run was actually created..
           readOnly: True
         end_date:
           type: string
-          format: date-time
+          format: timezone-datetime
           readOnly: True
           nullable: true
         state:
@@ -1610,7 +1610,7 @@ components:
               readOnly: true
             start_date:
               type: string
-              format: 'date-time'
+              format: 'timezone-datetime'
               readOnly: true
             dag_run_timeout:
               nullable: true
@@ -1655,11 +1655,11 @@ components:
           readOnly: true
         start_date:
           type: string
-          format: 'date-time'
+          format: 'timezone-datetime'
           readOnly: true
         end_date:
           type: string
-          format: 'date-time'
+          format: 'timezone-datetime'
           readOnly: true
           nullable: true
         trigger_rule:
@@ -1839,7 +1839,7 @@ components:
 
         execution_date_gte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects greater or equal to the specified date.
 
@@ -1847,7 +1847,7 @@ components:
 
         execution_date_lte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects less than or equal to the specified date.
 
@@ -1855,7 +1855,7 @@ components:
 
         start_date_gte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects greater or equal the specified date.
 
@@ -1863,7 +1863,7 @@ components:
 
         start_date_lte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects less or equal the specified date.
 
@@ -1871,14 +1871,14 @@ components:
 
         end_date_gte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects greater or equal the specified date.
 
             This can be combined with end_date_lte parameter to receive only the selected period.
         end_date_lte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects less than or equal to the specified date.
 
@@ -1898,42 +1898,42 @@ components:
 
         execution_date_gte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects greater or equal to the specified date.
 
             This can be combined with execution_date_lte parameter to receive only the selected period.
         execution_date_lte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects less than or equal to the specified date.
 
             This can be combined with execution_date_gte parameter to receive only the selected period.
         start_date_gte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects greater or equal the specified date.
 
             This can be combined with startd_ate_lte parameter to receive only the selected period.
         start_date_lte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects less or equal the specified date.
 
             This can be combined with start_date_gte parameter to receive only the selected period.
         end_date_gte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects greater or equal the specified date.
 
             This can be combined with start_date_lte parameter to receive only the selected period.
         end_date_lte:
           type: string
-          format: date-time
+          format: timezone-datetime
           description: >
             Returns objects less than or equal to the specified date.
 
@@ -2270,7 +2270,7 @@ components:
       name: execution_date_gte
       schema:
         type: string
-        format: date-time
+        format: timezone-datetime
       required: false
       description: >
         Returns objects greater or equal to the specified date.
@@ -2281,7 +2281,7 @@ components:
       name: execution_date_lte
       schema:
         type: string
-        format: date-time
+        format: timezone-datetime
       required: false
       description: >
         Returns objects less than or equal to the specified date.
@@ -2292,7 +2292,7 @@ components:
       name: start_date_gte
       schema:
         type: string
-        format: date-time
+        format: timezone-datetime
       required: false
       description: >
         Returns objects greater or equal the specified date.
@@ -2303,7 +2303,7 @@ components:
       name: start_date_lte
       schema:
         type: string
-        format: date-time
+        format: timezone-datetime
       required: false
       description: >
         Returns objects less or equal the specified date.
@@ -2314,7 +2314,7 @@ components:
       name: end_date_gte
       schema:
         type: string
-        format: date-time
+        format: timezone-datetime
       required: false
       description: >
         Returns objects greater or equal the specified date.
@@ -2325,7 +2325,7 @@ components:
       name: end_date_lte
       schema:
         type: string
-        format: date-time
+        format: timezone-datetime
       required: false
       description: >
         Returns objects less than or equal to the specified date.

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -23,13 +23,6 @@ from airflow.api_connexion.exceptions import BadRequest
 from airflow.configuration import conf
 from airflow.utils import timezone
 
-MAXIMUM_PAGE_LIMIT = 1000
-PAGE_LIMIT_DEFAULT = 100
-
-# Database entity fields
-dag_id = "dag_id"
-pool_id = "pool_id"
-
 
 def format_datetime(value: str):
     """

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -35,6 +35,7 @@ def format_datetime(value: str):
 
     This should only be used within connection views because it raises 400
     """
+    value = value.strip()
     if value[-1] != 'Z':
         value = value.replace(" ", '+')
     try:

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -50,18 +50,12 @@ def check_limit(value: int):
     This checks the limit passed to view and raises BadRequest if
     limit exceed user configured value
     """
-    max_val = int(conf.get("api", "maximum_page_limit"))
-    spec = {'default': 100, 'maximum': max_val,
-            'minimum': 1, 'type': 'integer'}
+    max_val = conf.getint("api", "maximum_page_limit")
+
     if value > max_val:
-        # This message should not be formatted. If formatted please
-        # run tests
-        message = ("{value} is greater than the maximum of {max_val}\n"
-                   "\n"
-                   "Failed validating 'maximum' in schema:\n"
-                   "    {spec}\n"
-                   "\nOn instance:\n    {value}").format(value=value,
-                                                         max_val=max_val, spec=spec)
+        message = f"{value} is greater than the maximum limit of {max_val}" \
+            .format(value=value,
+                    max_val=max_val)
         raise BadRequest(title="Bad Request", detail=message)
     return value
 

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -17,32 +17,36 @@
 from functools import wraps
 from typing import Callable, Dict
 
-from jsonschema import draft4_format_checker
 from pendulum.parsing import ParserError
 
 from airflow.api_connexion.exceptions import BadRequest
 from airflow.configuration import conf
 from airflow.utils import timezone
 
+MAXIMUM_PAGE_LIMIT = 1000
+PAGE_LIMIT_DEFAULT = 100
+
 # Database entity fields
 dag_id = "dag_id"
 pool_id = "pool_id"
 
 
-@draft4_format_checker.checks('timezone-datetime')
-def is_custom_date(val):
-    """ Custom datetime format"""
-    if val is None:  # this avoids validating nullable fields
-        return True
-    if not isinstance(val, str):
-        return False
-    if ' ' in val:
-        return False
+def format_datetime(value: str):
+    """
+    Datetime format parser for args since connexion doesn't parse datetimes
+    https://github.com/zalando/connexion/issues/476
+
+    This should only be used within connection views because it raises 400
+    """
+    value = value.strip()
+    if value[-1] != 'Z':
+        value = value.replace(" ", '+')
     try:
-        _ = timezone.parse(val)
-    except (ParserError, TypeError):
-        return False
-    return True
+        return timezone.parse(value)
+    except (ParserError, TypeError) as err:
+        raise BadRequest(
+            "Incorrect datetime argument", detail=str(err)
+        )
 
 
 def check_limit(value: int):

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -17,8 +17,32 @@
 from functools import wraps
 from typing import Callable, Dict
 
+from jsonschema import draft4_format_checker
+from pendulum.parsing import ParserError
+
 from airflow.api_connexion.exceptions import BadRequest
 from airflow.configuration import conf
+from airflow.utils import timezone
+
+# Database entity fields
+dag_id = "dag_id"
+pool_id = "pool_id"
+
+
+@draft4_format_checker.checks('timezone-datetime')
+def is_custom_date(val):
+    """ Custom datetime format"""
+    if val is None:  # this avoids validating nullable fields
+        return True
+    if not isinstance(val, str):
+        return False
+    if ' ' in val:
+        return False
+    try:
+        _ = timezone.parse(val)
+    except (ParserError, TypeError):
+        return False
+    return True
 
 
 def check_limit(value: int):

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -17,36 +17,32 @@
 from functools import wraps
 from typing import Callable, Dict
 
+from jsonschema import draft4_format_checker
 from pendulum.parsing import ParserError
 
 from airflow.api_connexion.exceptions import BadRequest
 from airflow.configuration import conf
 from airflow.utils import timezone
 
-MAXIMUM_PAGE_LIMIT = 1000
-PAGE_LIMIT_DEFAULT = 100
-
 # Database entity fields
 dag_id = "dag_id"
 pool_id = "pool_id"
 
 
-def format_datetime(value: str):
-    """
-    Datetime format parser for args since connexion doesn't parse datetimes
-    https://github.com/zalando/connexion/issues/476
-
-    This should only be used within connection views because it raises 400
-    """
-    value = value.strip()
-    if value[-1] != 'Z':
-        value = value.replace(" ", '+')
+@draft4_format_checker.checks('timezone-datetime')
+def is_custom_date(val):
+    """ Custom datetime format"""
+    if val is None:  # this avoids validating nullable fields
+        return True
+    if not isinstance(val, str):
+        return False
+    if ' ' in val:
+        return False
     try:
-        return timezone.parse(value)
-    except (ParserError, TypeError) as err:
-        raise BadRequest(
-            "Incorrect datetime argument", detail=str(err)
-        )
+        _ = timezone.parse(val)
+    except (ParserError, TypeError):
+        return False
+    return True
 
 
 def check_limit(value: int):

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -54,14 +54,15 @@ def check_limit(value: int):
     This checks the limit passed to view and raises BadRequest if
     limit exceed user configured value
     """
-    max_val = conf.getint("api", "maximum_page_limit")  # user configured page limit
+    max_val = conf.getint("api", "maximum_page_limit")  # user configured max page limit
+    fallback = conf.getint("api", "fallback_page_limit")
 
-    if value >= max_val:
-        if max_val > MAXIMUM_PAGE_LIMIT:
-            return MAXIMUM_PAGE_LIMIT
+    if value > max_val:
         return max_val
-    if value <= 0:
-        return PAGE_LIMIT_DEFAULT
+    if value == 0:
+        return fallback
+    if value < 0:
+        raise BadRequest("Page limit must be a positive integer")
     return value
 
 

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -23,6 +23,9 @@ from airflow.api_connexion.exceptions import BadRequest
 from airflow.configuration import conf
 from airflow.utils import timezone
 
+MAXIMUM_PAGE_LIMIT = 1000
+PAGE_LIMIT_DEFAULT = 100
+
 # Database entity fields
 dag_id = "dag_id"
 pool_id = "pool_id"
@@ -51,13 +54,14 @@ def check_limit(value: int):
     This checks the limit passed to view and raises BadRequest if
     limit exceed user configured value
     """
-    max_val = conf.getint("api", "maximum_page_limit")
+    max_val = conf.getint("api", "maximum_page_limit")  # user configured page limit
 
-    if value > max_val:
-        message = f"{value} is greater than the maximum limit of {max_val}" \
-            .format(value=value,
-                    max_val=max_val)
-        raise BadRequest(title="Bad Request", detail=message)
+    if value >= max_val:
+        if max_val > MAXIMUM_PAGE_LIMIT:
+            return MAXIMUM_PAGE_LIMIT
+        return max_val
+    if value <= 0:
+        return PAGE_LIMIT_DEFAULT
     return value
 
 

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -17,32 +17,8 @@
 from functools import wraps
 from typing import Callable, Dict
 
-from jsonschema import draft4_format_checker
-from pendulum.parsing import ParserError
-
 from airflow.api_connexion.exceptions import BadRequest
 from airflow.configuration import conf
-from airflow.utils import timezone
-
-# Database entity fields
-dag_id = "dag_id"
-pool_id = "pool_id"
-
-
-@draft4_format_checker.checks('timezone-datetime')
-def is_custom_date(val):
-    """ Custom datetime format"""
-    if val is None:  # this avoids validating nullable fields
-        return True
-    if not isinstance(val, str):
-        return False
-    if ' ' in val:
-        return False
-    try:
-        _ = timezone.parse(val)
-    except (ParserError, TypeError):
-        return False
-    return True
 
 
 def check_limit(value: int):

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -22,10 +22,6 @@ from pendulum.parsing import ParserError
 from airflow.api_connexion.exceptions import BadRequest
 from airflow.utils import timezone
 
-# Page parameters
-page_offset = "offset"
-page_limit = "limit"
-
 # Database entity fields
 dag_id = "dag_id"
 pool_id = "pool_id"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -588,6 +588,15 @@
       type: integer
       example: ~
       default: "100"
+    - name: fallback_page_limit
+      description: |
+        Used to set the default page limit when limit is zero. A default limit
+        of 100 is set on OpenApi spec. However, this particular default limit
+        only work when limit is set equal to zero(0) from API requests.
+        If no limit is supplied, the OpenApi spec default is used.
+      type: integer
+      example: ~
+      default: "100"
 - name: lineage
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -581,6 +581,13 @@
       type: string
       example: ~
       default: "airflow.api.auth.backend.deny_all"
+    - name: maximum_page_limit
+      description: |
+        Used to set the maximum page limit for API requests
+      version_added: ~
+      type: integer
+      example: ~
+      default: "100"
 - name: lineage
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -319,6 +319,12 @@ auth_backend = airflow.api.auth.backend.deny_all
 # Used to set the maximum page limit for API requests
 maximum_page_limit = 100
 
+# Used to set the default page limit when limit is zero. A default limit
+# of 100 is set on OpenApi spec. However, this particular default limit
+# only work when limit is set equal to zero(0) from API requests.
+# If no limit is supplied, the OpenApi spec default is used.
+fallback_page_limit = 100
+
 [lineage]
 # what lineage backend to use
 backend =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -316,6 +316,9 @@ fail_fast = False
 # ("airflow.api.auth.backend.default" allows all requests for historic reasons)
 auth_backend = airflow.api.auth.backend.deny_all
 
+# Used to set the maximum page limit for API requests
+maximum_page_limit = 100
+
 [lineage]
 # what lineage backend to use
 backend =

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,5 +108,6 @@ Content
     CLI <cli-ref>
     Macros <macros-ref>
     Python API <_api/index>
-    REST API <rest-api-ref>
+    EXPERIMENTAL REST API <rest-api-ref>
+    STABLE REST API <stable-rest-api-ref>
     Configurations <configurations-ref>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,5 +109,5 @@ Content
     CLI <cli-ref>
     Macros <macros-ref>
     Python API <_api/index>
-    EXPERIMENTAL REST API <rest-api-ref>
+    Experimental REST API <rest-api-ref>
     Configurations <configurations-ref>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,6 +95,7 @@ Content
     kubernetes
     lineage
     dag-serialization
+    Using the REST API <stable-rest-api/index.rst>
     changelog
     best-practices
     faq
@@ -109,5 +110,4 @@ Content
     Macros <macros-ref>
     Python API <_api/index>
     EXPERIMENTAL REST API <rest-api-ref>
-    STABLE REST API <stable-rest-api-ref>
     Configurations <configurations-ref>

--- a/docs/stable-rest-api-ref.rst
+++ b/docs/stable-rest-api-ref.rst
@@ -1,0 +1,44 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+REST API Reference
+==================
+
+Airflow stable REST API exposes a lot of endpoints for working with Apache Airflow.
+
+Configuration
+-------------
+There are default configurations available for airflow REST API which can be changed in
+``airflow.cfg``.
+
+.. note::
+    For more information on setting the configuration, see :doc:`howto/set-config`
+
+The default configurations for the REST API are as follows:
+
+.. list-table:: REST API CONFIGURATION DEFAULTS
+   :widths: 25, 25, 50
+   :header-rows: 1
+
+   * - Configuration
+     - Default
+     - Description
+
+   * - maximum_page_limit
+     - 100
+     - A positive integer, used to set the maximum page limit for API requests

--- a/docs/stable-rest-api/index.rst
+++ b/docs/stable-rest-api/index.rst
@@ -24,7 +24,9 @@ Airflow has a REST API that allows third-party application to perform a wide wid
 Page size limit
 ---------------
 
-To protect against requests that may lead to application instability, the API has a limit of items in response. The default is 100 items, but you can change it using `maximum_page_limit`  option in `[api]` section in the `airflow.cfg` file. 
+To protect against requests that may lead to application instability, the API has a limit of items in response.
+The default is 100 items, but you can change it using ``maximum_page_limit``  option in ``[api]``
+section in the ``airflow.cfg`` file.
 
 .. note::
     For more information on setting the configuration, see :doc:`../howto/set-config`

--- a/docs/stable-rest-api/index.rst
+++ b/docs/stable-rest-api/index.rst
@@ -16,8 +16,8 @@
     under the License.
 
 
-REST API Reference
-==================
+REST API Documentation
+======================
 
 Airflow stable REST API exposes a lot of endpoints for working with Apache Airflow.
 
@@ -27,7 +27,7 @@ There are default configurations available for airflow REST API which can be cha
 ``airflow.cfg``.
 
 .. note::
-    For more information on setting the configuration, see :doc:`howto/set-config`
+    For more information on setting the configuration, see :doc:`../howto/set-config`
 
 The default configurations for the REST API are as follows:
 

--- a/docs/stable-rest-api/index.rst
+++ b/docs/stable-rest-api/index.rst
@@ -19,26 +19,12 @@
 REST API Documentation
 ======================
 
-Airflow stable REST API exposes a lot of endpoints for working with Apache Airflow.
+Airflow has a REST API that allows third-party application to perform a wide wide range of operations.
 
-Configuration
--------------
-There are default configurations available for airflow REST API which can be changed in
-``airflow.cfg``.
+Page size limit
+---------------
+
+To protect against requests that may lead to application instability, the API has a limit of items in response. The default is 100 items, but you can change it using `maximum_page_limit`  option in `[api]` section in the `airflow.cfg` file. 
 
 .. note::
     For more information on setting the configuration, see :doc:`../howto/set-config`
-
-The default configurations for the REST API are as follows:
-
-.. list-table:: REST API CONFIGURATION DEFAULTS
-   :widths: 25, 25, 50
-   :header-rows: 1
-
-   * - Configuration
-     - Default
-     - Description
-
-   * - maximum_page_limit
-     - 100
-     - A positive integer, used to set the maximum page limit for API requests

--- a/setup.py
+++ b/setup.py
@@ -588,7 +588,7 @@ EXTRAS_REQUIREMENTS: Dict[str, Iterable[str]] = {
     'jdbc': jdbc,
     'jira': jira,
     'kerberos': kerberos,
-    'kubernetes': kubernetes,   # TODO: remove this in Airflow 2.1
+    'kubernetes': kubernetes,  # TODO: remove this in Airflow 2.1
     'ldap': ldap,
     "microsoft.azure": azure,
     "microsoft.mssql": mssql,
@@ -721,6 +721,7 @@ INSTALL_REQUIREMENTS = [
     'python-nvd3~=0.15.0',
     'python-slugify>=3.0.0,<5.0',
     'requests>=2.20.0, <3',
+    'rfc3339-validator>=0.1.2',
     'setproctitle>=1.1.8, <2',
     'sqlalchemy~=1.3',
     'sqlalchemy_jsonfield~=0.9',
@@ -732,6 +733,7 @@ INSTALL_REQUIREMENTS = [
     'tzlocal>=1.4,<2.0.0',
     'unicodecsv>=0.14.1',
     'werkzeug<1.0.0',
+
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -588,7 +588,7 @@ EXTRAS_REQUIREMENTS: Dict[str, Iterable[str]] = {
     'jdbc': jdbc,
     'jira': jira,
     'kerberos': kerberos,
-    'kubernetes': kubernetes,  # TODO: remove this in Airflow 2.1
+    'kubernetes': kubernetes,   # TODO: remove this in Airflow 2.1
     'ldap': ldap,
     "microsoft.azure": azure,
     "microsoft.mssql": mssql,
@@ -721,7 +721,6 @@ INSTALL_REQUIREMENTS = [
     'python-nvd3~=0.15.0',
     'python-slugify>=3.0.0,<5.0',
     'requests>=2.20.0, <3',
-    'rfc3339-validator>=0.1.2',
     'setproctitle>=1.1.8, <2',
     'sqlalchemy~=1.3',
     'sqlalchemy_jsonfield~=0.9',
@@ -733,7 +732,6 @@ INSTALL_REQUIREMENTS = [
     'tzlocal>=1.4,<2.0.0',
     'unicodecsv>=0.14.1',
     'werkzeug<1.0.0',
-
 ]
 
 

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
-from unittest import mock
 
 from parameterized import parameterized
 
 from airflow.models import Connection
 from airflow.utils.session import create_session, provide_session
 from airflow.www import app
+from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_connections
 
 
@@ -223,9 +223,8 @@ class TestGetConnectionsPagination(TestConnectionEndpoint):
         self.assertEqual(len(response.json["connections"]), 100)
 
     @provide_session
-    @mock.patch("airflow.api_connexion.parameters.conf.get")
-    def test_should_raise_when_page_size_limit_exceeded(self, mock_get, session):
-        mock_get.return_value = 100
+    @conf_vars({("api", "maximum_page_limit"): "100"})
+    def test_should_raise_when_page_size_limit_exceeded(self, session):
         connection_models = self._create_connections(200)
         session.add_all(connection_models)
         session.commit()
@@ -235,11 +234,7 @@ class TestGetConnectionsPagination(TestConnectionEndpoint):
         self.assertEqual(
             response.json,
             {
-                'detail': "150 is greater than the maximum of 100\n"
-                          "\nFailed validating 'maximum' in schema:\n    "
-                          "{'default': 100, 'maximum': 100, "
-                          "'minimum': 1, 'type': 'integer'}\n"
-                          "\nOn instance:\n    150",
+                'detail': "150 is greater than the maximum limit of 100",
                 'status': 400,
                 'title': 'Bad Request',
                 'type': 'about:blank'

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -312,15 +312,15 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
         [
             (
                 "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00+00:00",
-                "'2020-06-18T18:00:00 00:00' is not a 'timezone-datetime'"
+                "'2020-06-18T18:00:00 00:00' is not a 'date-time'"
             ),
             (
                 "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_gte=2020-06-18T18:00:00+00:00",
-                "'2020-06-18T18:00:00 00:00' is not a 'timezone-datetime'"
+                "'2020-06-18T18:00:00 00:00' is not a 'date-time'"
             ),
             (
                 "api/v1/dags/TEST_DAG_ID/dagRuns?end_date_gte=20209080:00+00:00",
-                "'20209080:00 00:00' is not a 'timezone-datetime'"
+                "'20209080:00 00:00' is not a 'date-time'"
             ),
         ]
     )

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -237,24 +237,28 @@ class TestGetDagRunsPagination(TestDagRunEndpoint):
         self.assertEqual(len(response.json["dag_runs"]), 100)  # default is 100
 
     @provide_session
-    @conf_vars({("api", "maximum_page_limit"): "100"})
-    def test_should_raise_when_page_size_limit_exceeded(self, session):
+    @conf_vars({("api", "maximum_page_limit"): "150"})
+    def test_should_return_conf_max_if_req_max_above_conf(self, session):
         dagrun_models = self._create_dag_runs(200)
         session.add_all(dagrun_models)
         session.commit()
 
-        response = self.client.get("api/v1/dags/TEST_DAG_ID/dagRuns?limit=150")
-        assert response.status_code == 400
-        self.assertEqual(
-            response.json,
-            {
-                'detail': "150 is greater than the maximum limit of 100",
-                'status': 400,
-                'title': 'Bad Request',
-                'type': 'about:blank'
-            }
+        response = self.client.get("api/v1/dags/TEST_DAG_ID/dagRuns?limit=180")
+        assert response.status_code == 200
+        self.assertEqual(len(response.json['dag_runs']), 150)
 
+    @provide_session
+    @conf_vars({("api", "maximum_page_limit"): "1500"})  # current_app coff 1500
+    def test_should_return_site_max_if_conf_max_above_site_max(self, session):
+        dagrun_models = self._create_dag_runs(2000)
+        session.add_all(dagrun_models)
+        session.commit()
+
+        response = self.client.get(
+            "api/v1/dags/TEST_DAG_ID/dagRuns?limit=1501"  # requesting 1500
         )
+        assert response.status_code == 200
+        self.assertEqual(len(response.json['dag_runs']), 1000)
 
     def _create_dag_runs(self, count):
         return [

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -247,19 +247,6 @@ class TestGetDagRunsPagination(TestDagRunEndpoint):
         assert response.status_code == 200
         self.assertEqual(len(response.json['dag_runs']), 150)
 
-    @provide_session
-    @conf_vars({("api", "maximum_page_limit"): "1500"})  # current_app coff 1500
-    def test_should_return_site_max_if_conf_max_above_site_max(self, session):
-        dagrun_models = self._create_dag_runs(2000)
-        session.add_all(dagrun_models)
-        session.commit()
-
-        response = self.client.get(
-            "api/v1/dags/TEST_DAG_ID/dagRuns?limit=1501"  # requesting 1500
-        )
-        assert response.status_code == 200
-        self.assertEqual(len(response.json['dag_runs']), 1000)
-
     def _create_dag_runs(self, count):
         return [
             DagRun(

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -16,7 +16,6 @@
 # under the License.
 import unittest
 from datetime import timedelta
-from urllib.parse import quote_plus
 
 import pytest
 from parameterized import parameterized
@@ -266,31 +265,26 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
     @parameterized.expand(
         [
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte="
-                f"{quote_plus('2020-06-18T18:00:00+00:00')}",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00+00:00",
                 ["TEST_START_EXEC_DAY_18", "TEST_START_EXEC_DAY_19"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte="
-                f"{quote_plus('2020-06-11T18:00:00+00:00')}",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte=2020-06-11T18:00:00+00:00",
                 ["TEST_START_EXEC_DAY_10", "TEST_START_EXEC_DAY_11"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?"
-                f"start_date_lte={quote_plus('2020-06-15T18:00:00+00:00')}"
-                f"&start_date_gte={quote_plus('2020-06-12T18:00:00Z')}",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte= 2020-06-15T18:00:00+00:00"
+                "&start_date_gte=2020-06-12T18:00:00Z",
                 ["TEST_START_EXEC_DAY_12", "TEST_START_EXEC_DAY_13",
                  "TEST_START_EXEC_DAY_14", "TEST_START_EXEC_DAY_15"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_lte="
-                f"{quote_plus('2020-06-13T18:00:00+00:00')}",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_lte=2020-06-13T18:00:00+00:00",
                 ["TEST_START_EXEC_DAY_10", "TEST_START_EXEC_DAY_11",
                  "TEST_START_EXEC_DAY_12", "TEST_START_EXEC_DAY_13"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?"
-                f"execution_date_gte={quote_plus('2020-06-16T18:00:00+00:00')}",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_gte=2020-06-16T18:00:00+00:00",
                 ["TEST_START_EXEC_DAY_16", "TEST_START_EXEC_DAY_17",
                  "TEST_START_EXEC_DAY_18", "TEST_START_EXEC_DAY_19"],
             ),
@@ -307,32 +301,6 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
         self.assertEqual(response.json["total_entries"], 10)
         dag_run_ids = [dag_run["dag_run_id"] for dag_run in response.json["dag_runs"]]
         self.assertEqual(dag_run_ids, expected_dag_run_ids)
-
-    @parameterized.expand(
-        [
-            (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00+00:00",
-                "'2020-06-18T18:00:00 00:00' is not a 'timezone-datetime'"
-            ),
-            (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_gte=2020-06-18T18:00:00+00:00",
-                "'2020-06-18T18:00:00 00:00' is not a 'timezone-datetime'"
-            ),
-            (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?end_date_gte=20209080:00+00:00",
-                "'20209080:00 00:00' is not a 'timezone-datetime'"
-            ),
-        ]
-    )
-    @provide_session
-    def test_invalid_date_filters_gte_and_lte_raises(self, url, error_message, session):
-        dagrun_models = self._create_dag_runs()
-        session.add_all(dagrun_models)
-        session.commit()
-        response = self.client.get(url)
-
-        assert response.status_code == 400
-        self.assertIn(error_message, response.json['detail'])
 
     def _create_dag_runs(self):
         dates = [
@@ -367,12 +335,12 @@ class TestGetDagRunsEndDateFilters(TestDagRunEndpoint):
         [
             (
                 f"api/v1/dags/TEST_DAG_ID/dagRuns?end_date_gte="
-                f"{quote_plus((timezone.utcnow() + timedelta(days=1)).isoformat())}",
+                f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}",
                 [],
             ),
             (
                 f"api/v1/dags/TEST_DAG_ID/dagRuns?end_date_lte="
-                f"{quote_plus((timezone.utcnow() + timedelta(days=1)).isoformat())}",
+                f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}",
                 ["TEST_DAG_RUN_ID_1"],
             ),
         ]

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -282,7 +282,7 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
                 ["TEST_START_EXEC_DAY_10", "TEST_START_EXEC_DAY_11"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte=2020-06-15T18:00:00+00:00"
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte= 2020-06-15T18:00:00+00:00"
                 "&start_date_gte=2020-06-12T18:00:00Z",
                 ["TEST_START_EXEC_DAY_12", "TEST_START_EXEC_DAY_13",
                  "TEST_START_EXEC_DAY_14", "TEST_START_EXEC_DAY_15"],

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -16,6 +16,7 @@
 # under the License.
 import unittest
 from datetime import timedelta
+from urllib.parse import quote_plus
 
 import pytest
 from parameterized import parameterized
@@ -265,26 +266,31 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
     @parameterized.expand(
         [
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00+00:00",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte="
+                f"{quote_plus('2020-06-18T18:00:00+00:00')}",
                 ["TEST_START_EXEC_DAY_18", "TEST_START_EXEC_DAY_19"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte=2020-06-11T18:00:00+00:00",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte="
+                f"{quote_plus('2020-06-11T18:00:00+00:00')}",
                 ["TEST_START_EXEC_DAY_10", "TEST_START_EXEC_DAY_11"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte= 2020-06-15T18:00:00+00:00"
-                "&start_date_gte=2020-06-12T18:00:00Z",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?"
+                f"start_date_lte={quote_plus('2020-06-15T18:00:00+00:00')}"
+                f"&start_date_gte={quote_plus('2020-06-12T18:00:00Z')}",
                 ["TEST_START_EXEC_DAY_12", "TEST_START_EXEC_DAY_13",
                  "TEST_START_EXEC_DAY_14", "TEST_START_EXEC_DAY_15"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_lte=2020-06-13T18:00:00+00:00",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_lte="
+                f"{quote_plus('2020-06-13T18:00:00+00:00')}",
                 ["TEST_START_EXEC_DAY_10", "TEST_START_EXEC_DAY_11",
                  "TEST_START_EXEC_DAY_12", "TEST_START_EXEC_DAY_13"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_gte=2020-06-16T18:00:00+00:00",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?"
+                f"execution_date_gte={quote_plus('2020-06-16T18:00:00+00:00')}",
                 ["TEST_START_EXEC_DAY_16", "TEST_START_EXEC_DAY_17",
                  "TEST_START_EXEC_DAY_18", "TEST_START_EXEC_DAY_19"],
             ),
@@ -301,6 +307,32 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
         self.assertEqual(response.json["total_entries"], 10)
         dag_run_ids = [dag_run["dag_run_id"] for dag_run in response.json["dag_runs"]]
         self.assertEqual(dag_run_ids, expected_dag_run_ids)
+
+    @parameterized.expand(
+        [
+            (
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00+00:00",
+                "'2020-06-18T18:00:00 00:00' is not a 'timezone-datetime'"
+            ),
+            (
+                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_gte=2020-06-18T18:00:00+00:00",
+                "'2020-06-18T18:00:00 00:00' is not a 'timezone-datetime'"
+            ),
+            (
+                "api/v1/dags/TEST_DAG_ID/dagRuns?end_date_gte=20209080:00+00:00",
+                "'20209080:00 00:00' is not a 'timezone-datetime'"
+            ),
+        ]
+    )
+    @provide_session
+    def test_invalid_date_filters_gte_and_lte_raises(self, url, error_message, session):
+        dagrun_models = self._create_dag_runs()
+        session.add_all(dagrun_models)
+        session.commit()
+        response = self.client.get(url)
+
+        assert response.status_code == 400
+        self.assertIn(error_message, response.json['detail'])
 
     def _create_dag_runs(self):
         dates = [
@@ -335,12 +367,12 @@ class TestGetDagRunsEndDateFilters(TestDagRunEndpoint):
         [
             (
                 f"api/v1/dags/TEST_DAG_ID/dagRuns?end_date_gte="
-                f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}",
+                f"{quote_plus((timezone.utcnow() + timedelta(days=1)).isoformat())}",
                 [],
             ),
             (
                 f"api/v1/dags/TEST_DAG_ID/dagRuns?end_date_lte="
-                f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}",
+                f"{quote_plus((timezone.utcnow() + timedelta(days=1)).isoformat())}",
                 ["TEST_DAG_RUN_ID_1"],
             ),
         ]

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -312,15 +312,15 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
         [
             (
                 "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00+00:00",
-                "'2020-06-18T18:00:00 00:00' is not a 'date-time'"
+                "'2020-06-18T18:00:00 00:00' is not a 'timezone-datetime'"
             ),
             (
                 "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_gte=2020-06-18T18:00:00+00:00",
-                "'2020-06-18T18:00:00 00:00' is not a 'date-time'"
+                "'2020-06-18T18:00:00 00:00' is not a 'timezone-datetime'"
             ),
             (
                 "api/v1/dags/TEST_DAG_ID/dagRuns?end_date_gte=20209080:00+00:00",
-                "'20209080:00 00:00' is not a 'date-time'"
+                "'20209080:00 00:00' is not a 'timezone-datetime'"
             ),
         ]
     )

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -212,17 +212,6 @@ class TestGetEventLogPagination(TestEventLogEndpoint):
         assert response.status_code == 200
         self.assertEqual(len(response.json['event_logs']), 150)
 
-    @provide_session
-    @conf_vars({("api", "maximum_page_limit"): "1500"})
-    def test_should_return_site_max_if_conf_max_above_site_max(self, session):
-        log_models = self._create_event_logs(2000)
-        session.add_all(log_models)
-        session.commit()
-
-        response = self.client.get("/api/v1/eventLogs?limit=1500")
-        assert response.status_code == 200
-        self.assertEqual(len(response.json['event_logs']), 1000)
-
     def _create_event_logs(self, count):
         return [
             Log(

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -194,20 +194,3 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
         response = self.client.get("/api/v1/importErrors?limit=180")
         assert response.status_code == 200
         self.assertEqual(len(response.json['import_errors']), 150)
-
-    @provide_session
-    @conf_vars({("api", "maximum_page_limit"): "1500"})
-    def test_should_return_site_max_if_conf_max_above_site_max(self, session):
-        import_errors = [
-            ImportError(
-                filename=f"/tmp/file_{i}.py",
-                stacktrace="Lorem ipsum",
-                timestamp=timezone.parse(self.timestamp, timezone="UTC"),
-            )
-            for i in range(2000)
-        ]
-        session.add_all(import_errors)
-        session.commit()
-        response = self.client.get("/api/v1/importErrors?limit=1500")
-        assert response.status_code == 200
-        self.assertEqual(len(response.json['import_errors']), 1000)

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -132,7 +132,7 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
         [
             # Limit test data
             ("/api/v1/importErrors?limit=1", ["/tmp/file_1.py"]),
-            ("/api/v1/importErrors?limit=110", [f"/tmp/file_{i}.py" for i in range(1, 101)]),
+            ("/api/v1/importErrors?limit=100", [f"/tmp/file_{i}.py" for i in range(1, 101)]),
             # Offset test data
             ("/api/v1/importErrors?offset=1", [f"/tmp/file_{i}.py" for i in range(2, 102)]),
             ("/api/v1/importErrors?offset=3", [f"/tmp/file_{i}.py" for i in range(4, 104)]),
@@ -160,3 +160,48 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
             pool["filename"] for pool in response.json["import_errors"]
         ]
         self.assertEqual(import_ids, expected_import_error_ids)
+
+    @provide_session
+    def test_should_respect_default_page_limit(self, session):
+        import_errors = [
+            ImportError(
+                filename=f"/tmp/file_{i}.py",
+                stacktrace="Lorem ipsum",
+                timestamp=timezone.parse(self.timestamp, timezone="UTC"),
+            )
+            for i in range(1, 110)
+        ]
+        session.add_all(import_errors)
+        session.commit()
+        response = self.client.get("/api/v1/importErrors")
+        assert response.status_code == 200
+        self.assertEqual(len(response.json['import_errors']), 100)
+
+    @provide_session
+    def test_should_raise_when_page_size_limit_exceeded(self, session):
+        import_errors = [
+            ImportError(
+                filename=f"/tmp/file_{i}.py",
+                stacktrace="Lorem ipsum",
+                timestamp=timezone.parse(self.timestamp, timezone="UTC"),
+            )
+            for i in range(1, 110)
+        ]
+        session.add_all(import_errors)
+        session.commit()
+        response = self.client.get("/api/v1/importErrors?limit=150")
+        assert response.status_code == 400
+        self.assertEqual(
+            response.json,
+            {
+                'detail': "150 is greater than the maximum of 100\n"
+                          "\nFailed validating 'maximum' in schema:\n    "
+                          "{'default': 100, 'maximum': 100, "
+                          "'minimum': 1, 'type': 'integer'}\n"
+                          "\nOn instance:\n    150",
+                'status': 400,
+                'title': 'Bad Request',
+                'type': 'about:blank'
+            }
+
+        )

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from unittest import mock
 
 from parameterized import parameterized
 
@@ -162,7 +163,7 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
         self.assertEqual(import_ids, expected_import_error_ids)
 
     @provide_session
-    def test_should_respect_default_page_limit(self, session):
+    def test_should_respect_page_size_limit_default(self, session):
         import_errors = [
             ImportError(
                 filename=f"/tmp/file_{i}.py",
@@ -178,7 +179,9 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
         self.assertEqual(len(response.json['import_errors']), 100)
 
     @provide_session
-    def test_should_raise_when_page_size_limit_exceeded(self, session):
+    @mock.patch("airflow.api_connexion.parameters.conf.get")
+    def test_should_raise_when_page_size_limit_exceeded(self, mock_get, session):
+        mock_get.return_value = 100
         import_errors = [
             ImportError(
                 filename=f"/tmp/file_{i}.py",

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from unittest import mock
 
 from parameterized import parameterized
 
@@ -109,7 +110,7 @@ class TestGetPoolsPagination(TestBasePoolEndpoints):
         self.assertEqual(pool_ids, expected_pool_ids)
 
     @provide_session
-    def test_should_respect_default_page_limit(self, session):
+    def test_should_respect_page_size_limit_default(self, session):
         pools = [Pool(pool=f"test_pool{i}", slots=1) for i in range(1, 121)]
         session.add_all(pools)
         session.commit()
@@ -120,7 +121,9 @@ class TestGetPoolsPagination(TestBasePoolEndpoints):
         self.assertEqual(len(response.json['pools']), 100)
 
     @provide_session
-    def test_should_raise_when_page_size_limit_exceeded(self, session):
+    @mock.patch("airflow.api_connexion.parameters.conf.get")
+    def test_should_raise_when_page_size_limit_exceeded(self, mock_get, session):
+        mock_get.return_value = 100
         pools = [Pool(pool=f"test_pool{i}", slots=1) for i in range(1, 121)]
         session.add_all(pools)
         session.commit()

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -132,18 +132,6 @@ class TestGetPoolsPagination(TestBasePoolEndpoints):
         assert response.status_code == 200
         self.assertEqual(len(response.json['pools']), 150)
 
-    @provide_session
-    @conf_vars({("api", "maximum_page_limit"): "1500"})
-    def test_should_return_site_max_if_conf_max_above_site_max(self, session):
-        pools = [Pool(pool=f"test_pool{i}", slots=1) for i in range(1, 2000)]
-        session.add_all(pools)
-        session.commit()
-        result = session.query(Pool).count()
-        self.assertEqual(result, 2000)
-        response = self.client.get("/api/v1/pools?limit=1500")
-        assert response.status_code == 200
-        self.assertEqual(len(response.json['pools']), 1000)
-
 
 class TestGetPool(TestBasePoolEndpoints):
     @provide_session

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -118,9 +118,6 @@ class TestGetVariables(TestVariableEndpoint):
         assert response.status_code == 200
         self.assertEqual(len(response.json['variables']), 150)
 
-    # Takes a lot of time for variable to get added. so no test
-    # for test_should_return_site_max_if_conf_max_above_site_max
-
 
 class TestPatchVariable(TestVariableEndpoint):
     def test_should_update_variable(self):

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -110,22 +110,16 @@ class TestGetVariables(TestVariableEndpoint):
         assert response.json["total_entries"] == 101
         assert len(response.json["variables"]) == 100
 
-    @conf_vars({("api", "maximum_page_limit"): "100"})
-    def test_should_raise_when_page_size_limit_exceeded(self):
+    @conf_vars({("api", "maximum_page_limit"): "150"})
+    def test_should_return_conf_max_if_req_max_above_conf(self):
         for i in range(200):
             Variable.set(f"var{i}", i)
-        response = self.client.get("/api/v1/variables?limit=150")
-        assert response.status_code == 400
-        self.assertEqual(
-            response.json,
-            {
-                'detail': "150 is greater than the maximum limit of 100",
-                'status': 400,
-                'title': 'Bad Request',
-                'type': 'about:blank'
-            }
+        response = self.client.get("/api/v1/variables?limit=180")
+        assert response.status_code == 200
+        self.assertEqual(len(response.json['variables']), 150)
 
-        )
+    # Takes a lot of time for variable to get added. so no test
+    # for test_should_return_site_max_if_conf_max_above_site_max
 
 
 class TestPatchVariable(TestVariableEndpoint):

--- a/tests/api_connexion/test_parameters.py
+++ b/tests/api_connexion/test_parameters.py
@@ -18,37 +18,9 @@
 import unittest
 from unittest import mock
 
-from pendulum import DateTime
-from pendulum.tz.timezone import Timezone
-
 from airflow.api_connexion.exceptions import BadRequest
-from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters
-from airflow.utils import timezone
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from tests.test_utils.config import conf_vars
-
-
-class TestDateTimeParser(unittest.TestCase):
-
-    def setUp(self) -> None:
-        self.default_time = '2020-06-13T22:44:00+00:00'
-        self.default_time_2 = '2020-06-13T22:44:00Z'
-
-    def test_works_with_datestring_ending_00_00(self):
-        datetime = format_datetime(self.default_time)
-        datetime2 = timezone.parse(self.default_time)
-        assert datetime == datetime2
-        assert datetime.isoformat() == self.default_time
-
-    def test_works_with_datestring_ending_with_zed(self):
-        datetime = format_datetime(self.default_time_2)
-        datetime2 = timezone.parse(self.default_time_2)
-        assert datetime == datetime2
-        assert datetime.isoformat() == self.default_time  # python uses +00:00 instead of Z
-
-    def test_raises_400_for_invalid_arg(self):
-        invalid_datetime = '2020-06-13T22:44:00P'
-        with self.assertRaises(BadRequest):
-            format_datetime(invalid_datetime)
 
 
 class TestMaximumPagelimit(unittest.TestCase):
@@ -80,22 +52,6 @@ class TestMaximumPagelimit(unittest.TestCase):
 
 
 class TestFormatParameters(unittest.TestCase):
-
-    def test_should_works_with_datetime_formatter(self):
-        decorator = format_parameters({"param_a": format_datetime})
-        endpoint = mock.MagicMock()
-        decorated_endpoint = decorator(endpoint)
-
-        decorated_endpoint(param_a='2020-01-01T0:0:00+00:00')
-
-        endpoint.assert_called_once_with(param_a=DateTime(2020, 1, 1, 0, tzinfo=Timezone('UTC')))
-
-    def test_should_propagate_exceptions(self):
-        decorator = format_parameters({"param_a": format_datetime})
-        endpoint = mock.MagicMock()
-        decorated_endpoint = decorator(endpoint)
-        with self.assertRaises(BadRequest):
-            decorated_endpoint(param_a='XXXXX')
 
     @conf_vars({("api", "maximum_page_limit"): "100"})
     def test_should_work_with_limit(self):

--- a/tests/api_connexion/test_parameters.py
+++ b/tests/api_connexion/test_parameters.py
@@ -18,9 +18,37 @@
 import unittest
 from unittest import mock
 
+from pendulum import DateTime
+from pendulum.tz.timezone import Timezone
+
 from airflow.api_connexion.exceptions import BadRequest
-from airflow.api_connexion.parameters import check_limit, format_parameters
+from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters
+from airflow.utils import timezone
 from tests.test_utils.config import conf_vars
+
+
+class TestDateTimeParser(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.default_time = '2020-06-13T22:44:00+00:00'
+        self.default_time_2 = '2020-06-13T22:44:00Z'
+
+    def test_works_with_datestring_ending_00_00(self):
+        datetime = format_datetime(self.default_time)
+        datetime2 = timezone.parse(self.default_time)
+        assert datetime == datetime2
+        assert datetime.isoformat() == self.default_time
+
+    def test_works_with_datestring_ending_with_zed(self):
+        datetime = format_datetime(self.default_time_2)
+        datetime2 = timezone.parse(self.default_time_2)
+        assert datetime == datetime2
+        assert datetime.isoformat() == self.default_time  # python uses +00:00 instead of Z
+
+    def test_raises_400_for_invalid_arg(self):
+        invalid_datetime = '2020-06-13T22:44:00P'
+        with self.assertRaises(BadRequest):
+            format_datetime(invalid_datetime)
 
 
 class TestMaximumPagelimit(unittest.TestCase):
@@ -52,6 +80,22 @@ class TestMaximumPagelimit(unittest.TestCase):
 
 
 class TestFormatParameters(unittest.TestCase):
+
+    def test_should_works_with_datetime_formatter(self):
+        decorator = format_parameters({"param_a": format_datetime})
+        endpoint = mock.MagicMock()
+        decorated_endpoint = decorator(endpoint)
+
+        decorated_endpoint(param_a='2020-01-01T0:0:00+00:00')
+
+        endpoint.assert_called_once_with(param_a=DateTime(2020, 1, 1, 0, tzinfo=Timezone('UTC')))
+
+    def test_should_propagate_exceptions(self):
+        decorator = format_parameters({"param_a": format_datetime})
+        endpoint = mock.MagicMock()
+        decorated_endpoint = decorator(endpoint)
+        with self.assertRaises(BadRequest):
+            decorated_endpoint(param_a='XXXXX')
 
     @conf_vars({("api", "maximum_page_limit"): "100"})
     def test_should_work_with_limit(self):

--- a/tests/api_connexion/test_parameters.py
+++ b/tests/api_connexion/test_parameters.py
@@ -63,15 +63,20 @@ class TestMaximumPagelimit(unittest.TestCase):
         limit = check_limit(350)
         self.assertEqual(limit, 320)
 
-    @conf_vars({("api", "maximum_page_limit"): "1500"})
-    def test_limit_returns_site_max_if_current_app_max_is_above_site_max(self):
+    @conf_vars({("api", "maximum_page_limit"): "1000"})
+    def test_limit_returns_set_max_if_give_limit_is_exceeded(self):
         limit = check_limit(1500)
         self.assertEqual(limit, 1000)
 
-    @conf_vars({("api", "maximum_page_limit"): "200"})
+    @conf_vars({("api", "fallback_page_limit"): "100"})
     def test_limit_of_zero_returns_default(self):
         limit = check_limit(0)
         self.assertEqual(limit, 100)
+
+    @conf_vars({("api", "maximum_page_limit"): "1500"})
+    def test_negative_limit_raises(self):
+        with self.assertRaises(BadRequest):
+            check_limit(-1)
 
 
 class TestFormatParameters(unittest.TestCase):

--- a/tests/api_connexion/test_parameters.py
+++ b/tests/api_connexion/test_parameters.py
@@ -24,6 +24,7 @@ from pendulum.tz.timezone import Timezone
 from airflow.api_connexion.exceptions import BadRequest
 from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters
 from airflow.utils import timezone
+from tests.test_utils.config import conf_vars
 
 
 class TestDateTimeParser(unittest.TestCase):
@@ -52,15 +53,13 @@ class TestDateTimeParser(unittest.TestCase):
 
 class TestMaximumPagelimit(unittest.TestCase):
 
-    @mock.patch("airflow.api_connexion.parameters.conf.get")
-    def test_maximum_limit_return_val(self, mock_get):
-        mock_get.return_value = 320  # maximum limit
+    @conf_vars({("api", "maximum_page_limit"): "320"})
+    def test_maximum_limit_return_val(self):
         limit = check_limit(300)
         self.assertEqual(limit, 300)
 
-    @mock.patch("airflow.api_connexion.parameters.conf.get")
-    def test_maximum_limit_raises_on_limit_exceeding(self, mock_get):
-        mock_get.return_value = 320  # maximum limit
+    @conf_vars({("api", "maximum_page_limit"): "320"})
+    def test_maximum_limit_raises_on_limit_exceeding(self):
         with self.assertRaises(BadRequest):
             check_limit(350)
 
@@ -83,18 +82,16 @@ class TestFormatParameters(unittest.TestCase):
         with self.assertRaises(BadRequest):
             decorated_endpoint(param_a='XXXXX')
 
-    @mock.patch("airflow.api_connexion.parameters.conf.get")
-    def test_should_work_with_limit(self, mock_get):
-        mock_get.return_value = 100
+    @conf_vars({("api", "maximum_page_limit"): "100"})
+    def test_should_work_with_limit(self):
         decorator = format_parameters({"limit": check_limit})
         endpoint = mock.MagicMock()
         decorated_endpoint = decorator(endpoint)
         decorated_endpoint(limit=89)
         endpoint.assert_called_once_with(limit=89)
 
-    @mock.patch("airflow.api_connexion.parameters.conf.get")
-    def test_should_raise_exception_for_max_val_exceeded(self, mock_get):
-        mock_get.return_value = 100
+    @conf_vars({("api", "maximum_page_limit"): "100"})
+    def test_should_raise_exception_for_max_val_exceeded(self):
         decorator = format_parameters({"limit": check_limit})
         endpoint = mock.MagicMock()
         decorated_endpoint = decorator(endpoint)


### PR DESCRIPTION
---
The limit and offset parameters are being parsed manually but it can be handled by connexion, giving a better error messages in the case of limit exceeding.

This change also makes  `maximum` page limit configurable 

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
