### PR TITLE
Add invitation to #documentation channel when docs build fails

### DIFF
--- a/docs/build
+++ b/docs/build
@@ -492,10 +492,18 @@ check_guide_links_in_operators_and_hooks_ref()
 check_exampleinclude_for_example_dags()
 check_gcp_guides()
 
+CHANNEL_INVITATION = """\
+If you need help, write to #documentation channel on Airflow's Slack.
+Channel link: https://apache-airflow.slack.com/archives/CJ1LVREHX
+Invitation link: https://apache-airflow-slack.herokuapp.com/\
+"""
+
 if build_errors:
     display_errors_summary()
     print()
     print("The documentation has errors. Fix them to build documentation.")
+    print()
+    print(CHANNEL_INVITATION)
     sys.exit(1)
 
 build_sphinx_docs()
@@ -504,4 +512,6 @@ if build_errors:
     display_errors_summary()
     print()
     print("The documentation has errors.")
+    print()
+    print(CHANNEL_INVITATION)
     sys.exit(1)


### PR DESCRIPTION
The documentation building process causes various unexpected problems. New contributors may not know where to look for help.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
