### PR TITLE
Add placement_strategy option

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -86,6 +86,9 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
     :param placement_constraints: an array of placement constraint objects to use for
         the task
     :type placement_constraints: list
+    :param placement_strategy: an array of placement strategy objects to use for
+        the task
+    :type placement_strategy: list
     :param platform_version: the platform version on which your task is running
     :type platform_version: str
     :param network_configuration: the network configuration for the task
@@ -124,6 +127,7 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
         launch_type='EC2',
         group=None,
         placement_constraints=None,
+        placement_strategy=None,
         platform_version='LATEST',
         network_configuration=None,
         tags=None,
@@ -143,6 +147,7 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
         self.launch_type = launch_type
         self.group = group
         self.placement_constraints = placement_constraints
+        self.placement_strategy = placement_strategy
         self.platform_version = platform_version
         self.network_configuration = network_configuration
 
@@ -180,6 +185,8 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
             run_opts['group'] = self.group
         if self.placement_constraints is not None:
             run_opts['placementConstraints'] = self.placement_constraints
+        if self.placement_strategy is not None:
+            run_opts['placementStrategy'] = self.placement_strategy
         if self.network_configuration is not None:
             run_opts['networkConfiguration'] = self.network_configuration
         if self.tags is not None:

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -67,6 +67,7 @@ class TestECSOperator(unittest.TestCase):
             'placement_constraints': [
                 {'expression': 'attribute:ecs.instance-type =~ t2.*', 'type': 'memberOf'}
             ],
+            'placement_strategy': [{'field': 'memory', 'type': 'binpack'}],
             'network_configuration': {
                 'awsvpcConfiguration': {'securityGroups': ['sg-123abc'], 'subnets': ['subnet-123456ab']}
             },
@@ -125,6 +126,7 @@ class TestECSOperator(unittest.TestCase):
             taskDefinition='t',
             group='group',
             placementConstraints=[{'expression': 'attribute:ecs.instance-type =~ t2.*', 'type': 'memberOf'}],
+            placementStrategy=[{'field': 'memory', 'type': 'binpack'}],
             networkConfiguration={
                 'awsvpcConfiguration': {'securityGroups': ['sg-123abc'], 'subnets': ['subnet-123456ab']}
             },
@@ -156,6 +158,7 @@ class TestECSOperator(unittest.TestCase):
             taskDefinition='t',
             group='group',
             placementConstraints=[{'expression': 'attribute:ecs.instance-type =~ t2.*', 'type': 'memberOf'}],
+            placementStrategy=[{'field': 'memory', 'type': 'binpack'}],
             networkConfiguration={
                 'awsvpcConfiguration': {'securityGroups': ['sg-123abc'], 'subnets': ['subnet-123456ab'],}
             },


### PR DESCRIPTION
Enable ECSOperator to specify a placement strategy.

The pinback strategy makes it easier to leave free EC2 instances. This makes it easier for you to successfully execute ECS Tasks that require a large amount of space.

More info:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
