### PR TITLE
JSON serialize Log extras

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -18,6 +18,7 @@
 
 import functools
 import gzip
+import json
 from io import BytesIO as IO
 
 import pendulum
@@ -44,7 +45,7 @@ def action_logging(f):
                 event=f.__name__,
                 task_instance=None,
                 owner=user,
-                extra=str(list(request.values.items())),
+                extra=json.dumps(request.values),
                 task_id=request.values.get('task_id'),
                 dag_id=request.values.get('dag_id'))
 


### PR DESCRIPTION
It would be very useful to be able to query the the logged extras, to determine if a trigger has a configuration, or a clear operation is confirmed.

---
Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
