### PR TITLE
Add reference to the ASF CoC for First Time Contributors

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -177,6 +177,9 @@ firstPRWelcomeComment: >
   - Be patient and persistent. It might take some time to get a review or get the final approval from
   Committers.
 
+  - Please follow [ASF Code of Conduct](<https://www.apache.org/foundation/policies/conduct) for all
+  communication including (but not limited to) comments on Pull Requests, Mailing list and Slack.
+
   - Be sure to read the [Airflow Coding style](
   https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#coding-style-and-best-practices).
 

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -177,7 +177,7 @@ firstPRWelcomeComment: >
   - Be patient and persistent. It might take some time to get a review or get the final approval from
   Committers.
 
-  - Please follow [ASF Code of Conduct](<https://www.apache.org/foundation/policies/conduct) for all
+  - Please follow [ASF Code of Conduct](https://www.apache.org/foundation/policies/conduct) for all
   communication including (but not limited to) comments on Pull Requests, Mailing list and Slack.
 
   - Be sure to read the [Airflow Coding style](


### PR DESCRIPTION
Similar to https://github.com/apache/airflow/issues/9453 but this would inform all the "First Time Contributors"

Currently, we show the following when someone creates a PR to Airflow for the first time:

![image](https://user-images.githubusercontent.com/8811558/85211213-cef92480-b33e-11ea-8fba-8d42a26065d3.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
