### PR TITLE
 Fix DockerOperator xcom

### DIFF
--- a/airflow/providers/docker/example_dags/example_docker_xcom.py
+++ b/airflow/providers/docker/example_dags/example_docker_xcom.py
@@ -34,7 +34,11 @@ with DAG(
     start_date=days_ago(5),
     catchup=True,
     max_active_runs=2,
-    default_args={"owner": "airflow", "retries": 2, "retry_delay": timedelta(minutes=5),},
+    default_args={
+        "owner": "airflow",
+        "retries": 2,
+        "retry_delay": timedelta(minutes=5),
+    },
 ) as dag:
 
     write_xcom_last = DockerOperator(

--- a/airflow/providers/docker/example_dags/example_docker_xcom.py
+++ b/airflow/providers/docker/example_dags/example_docker_xcom.py
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-function-docstring
+"""
+This sample writes and pull from xcom using DockerOperator.
+The following operators are being used: DockerOperator &
+BashOperator.
+"""
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.docker_operator import DockerOperator
+from airflow.utils.dates import days_ago
+
+with DAG(
+    dag_id="example_docker_xcom",
+    schedule_interval="@daily",
+    catchup=True,
+    max_active_runs=2,
+    default_args={
+        "owner": "airflow",
+        "start_date": days_ago(5),
+        "retries": 2,
+        "retry_delay": timedelta(minutes=5),
+    },
+) as dag:
+
+    write_xcom_last = DockerOperator(
+        task_id="write_xcom_last",
+        image="python:3-slim",
+        api_version="auto",
+        command="""python -c "import logging;[
+            print(i) for i in range(10)];logging.warning('this is a warning')" """,
+        do_xcom_push=True,
+        xcom_all=False,
+        auto_remove=True,
+        network_mode="bridge",
+    )
+
+    write_xcom_all = DockerOperator(
+        task_id="write_xcom_all",
+        image="python:3-slim",
+        api_version="auto",
+        command="""python -c "import logging;[
+            print(i) for i in range(10)];logging.warning('this is a warning')" """,
+        do_xcom_push=True,
+        xcom_all=True,
+        auto_remove=True,
+        network_mode="bridge",
+    )
+
+    pull_xcom_last = DockerOperator(
+        task_id="pull_xcom",
+        image="ubuntu:20.04",
+        api_version="auto",
+        command="""echo {{ ti.xcom_pull(task_ids="write_xcom_last") }}""",
+        do_xcom_push=True,
+        xcom_all=False,
+        auto_remove=True,
+        network_mode="bridge",
+    )
+
+    pull_xcom_all = BashOperator(
+        task_id="pull_xcom_all",
+        bash_command="""echo '{{ ti.xcom_pull(task_ids="write_xcom_all") }}' """,
+        do_xcom_push=True,
+    )
+
+    write_xcom_last >> pull_xcom_last
+    write_xcom_all >> pull_xcom_all

--- a/airflow/providers/docker/example_dags/example_docker_xcom.py
+++ b/airflow/providers/docker/example_dags/example_docker_xcom.py
@@ -31,14 +31,10 @@ from airflow.utils.dates import days_ago
 with DAG(
     dag_id="example_docker_xcom",
     schedule_interval="@daily",
+    start_date=days_ago(5),
     catchup=True,
     max_active_runs=2,
-    default_args={
-        "owner": "airflow",
-        "start_date": days_ago(5),
-        "retries": 2,
-        "retry_delay": timedelta(minutes=5),
-    },
+    default_args={"owner": "airflow", "retries": 2, "retry_delay": timedelta(minutes=5),},
 ) as dag:
 
     write_xcom_last = DockerOperator(


### PR DESCRIPTION
This PR solves the issue https://github.com/apache/airflow/issues/9164
This PR continues the discussion of https://github.com/apache/airflow/pull/9165

**Files changed**: 
`airflow/providers/docker/operators/docker.py`
`airflow/providers/docker/example_dags/example_docker_xcom.py`

**Problems**

* **Issue 1**: When `xcom_push=True` is enabled (and `xcom_push_all=False`), the output **sometimes is null** OR captured wrongly.
* **Issue 2**: When `xcom_push_all=True` a bytes string (`b'...'`) is stored as xcom, It's harder to use the output on following operators and is not compliant with other operators.
* **Issue 3**: `Stderr` and `stdout` are written to the same output xcom. In practice, we don't want warnings and errors messing up with the code to be parsed on following operators (But we need to capture the output on airflow logs). Sending `stderr` to xcom can lead to undefined/non-deterministic behavior.

**Solutions**:

* **Issue 1**:  Refactored the generator, using logs

```python
            def gen_output(stdout=False, stderr=False):
                return (
                    templ.decode("utf-8").strip()
                    if hasattr(templ, "decode")
                    else str(templ)
                    for templ in self.cli.logs(
                        self.container["Id"], stream=True, stdout=stdout, stderr=stderr
                    )
                )

            for line in gen_output(stdout=True, stderr=True):
                self.log.info(line)
```

* **Issue 2**:  I just added:
```python
...
                    templ.decode("utf-8").strip()
                    if hasattr(templ, "decode")
                    else str(templ)
...
```

* **Issue 3**:  I store `stdout` into xcom:
```python
           return_value = None
            if self.do_xcom_push:
                lines = gen_output(stdout=True)
                if self.xcom_all:
                    return_value = "\n".join(lines)
                else:
                    line_deque = deque(lines, maxlen=1)
                    return_value = line_deque.pop()
```
In the end, only logs are send to xcom and if any error is raised, the DAG run fail after finishing:
```python
            result = self.cli.wait(self.container["Id"])
            if result["StatusCode"] != 0:
                raise AirflowException("docker container failed: " + repr(result))
```

**Sample Output**

* **Issue 1**:
  * Captured correctly:
![image](https://user-images.githubusercontent.com/11466701/85225181-db928100-b401-11ea-92a7-5a10d8f30ad6.png)

`We would expect only the last line '9'`
* **Issue 2**:
  * Easier to pull outputs and use on other operators
![image](https://user-images.githubusercontent.com/11466701/85225198-07156b80-b402-11ea-91eb-5e63ab874871.png)


* **Issue 3**:
  * `Stderr` do not mess up with the output and has deterministic behavior
![image](https://user-images.githubusercontent.com/11466701/85225301-c0744100-b402-11ea-9393-0ec0bd75a9fa.png)

---

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes) `unnecessary`
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions. `unnecessary`
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
