### PR TITLE
Fix function name in airflow/stats.py

### DIFF
--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -89,7 +89,7 @@ def stat_name_default_handler(stat_name, max_length=250) -> str:
     return stat_name
 
 
-def get_current_handle_stat_name_func() -> Callable[[str], str]:
+def get_current_handler_stat_name_func() -> Callable[[str], str]:
     """Get Stat Name Handler from airflow.cfg"""
     return conf.getimport('scheduler', 'stat_name_handler') or stat_name_default_handler
 
@@ -101,8 +101,8 @@ def validate_stat(fn):
     @wraps(fn)
     def wrapper(_self, stat, *args, **kwargs):
         try:
-            handle_stat_name_func = get_current_handle_stat_name_func()
-            stat_name = handle_stat_name_func(stat)
+            handler_stat_name_func = get_current_handler_stat_name_func()
+            stat_name = handler_stat_name_func(stat)
             return fn(_self, stat_name, *args, **kwargs)
         except InvalidStatsNameException:
             log.error('Invalid stat name: %s.', stat, exc_info=True)


### PR DESCRIPTION
`get_current_handle_stat_name_func()` didn't made to any release yet so should be fine to rename it without warnings or note in UPDATING.md

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
