### PR TITLE
Add airflow upgrade-check command (MVP) (v1-10-test)

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -2285,7 +2285,7 @@ def upgrade_check(args):
         formatter = ConsoleFormatter()
     all_problems = check_upgrade(formatter)
     if all_problems:
-        exit(1)
+        sys.exit(1)
 
 
 class Arg(object):

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -2457,16 +2457,16 @@ class CLIFactory(object):
         # show_dag
         'save': Arg(
             ("-s", "--save"),
-            "Saves the result to the indicated file.\n"
+            "Saves the result to the indicated file. The file format is determined by the file extension.\n"
             "\n"
-            "The file format is determined by the file extension. For more information about supported "
-            "format, see: https://www.graphviz.org/doc/info/output.html\n"
+            "To see more information about supported format for show_dags command, see: "
+            "https://www.graphviz.org/doc/info/output.html\n"
             "\n"
             "If you want to create a PNG file then you should execute the following command:\n"
-            "airflow dags show <DAG_ID> --save output.png\n"
+            "airflow show_dag <DAG_ID> --save output.png\n"
             "\n"
             "If you want to create a DOT file then you should execute the following command:\n"
-            "airflow dags show <DAG_ID> --save output.dot\n"
+            "airflow show_dag <DAG_ID> --save output.dot\n"
         ),
         'imgcat': Arg(
             ("--imgcat", ),

--- a/airflow/upgrade/__init__.py
+++ b/airflow/upgrade/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+from typing import List
+
+from airflow.upgrade.formatters import BaseFormatter
+from airflow.upgrade.problem import RuleStatus
+from airflow.upgrade.rules.base_rule import BaseRule
+from airflow.upgrade.rules.conn_type_is_not_nullable import ConnTypeIsNotNullableRule
+
+# TODO: Add auto-discoverable for rules
+ALL_RULES = [
+    ConnTypeIsNotNullableRule()
+]  # type: List[BaseRule]
+
+
+def check_upgrade(formatter):
+    # type: (BaseFormatter) -> List[RuleStatus]
+    formatter.start_checking(ALL_RULES)
+    all_rule_statuses = []  # List[RuleStatus]
+    for rule in ALL_RULES:
+        messages = rule.check()
+        rule_status = RuleStatus(rule=rule, messages=list(messages))
+        all_rule_statuses.append(rule_status)
+        formatter.on_next_rule_status(rule_status)
+    formatter.end_checking(all_rule_statuses)
+    return all_rule_statuses

--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -20,13 +20,9 @@ from typing import List
 
 from airflow.upgrade.formatters import BaseFormatter
 from airflow.upgrade.problem import RuleStatus
-from airflow.upgrade.rules.base_rule import BaseRule
-from airflow.upgrade.rules.conn_type_is_not_nullable import ConnTypeIsNotNullableRule
+from airflow.upgrade.rules.base_rule import BaseRule, RULES
 
-# TODO: Add auto-discoverable for rules
-ALL_RULES = [
-    ConnTypeIsNotNullableRule()
-]  # type: List[BaseRule]
+ALL_RULES = [cls() for cls in RULES]  # type: List[BaseRule]
 
 
 def check_upgrade(formatter):
@@ -34,8 +30,7 @@ def check_upgrade(formatter):
     formatter.start_checking(ALL_RULES)
     all_rule_statuses = []  # List[RuleStatus]
     for rule in ALL_RULES:
-        messages = rule.check()
-        rule_status = RuleStatus(rule=rule, messages=list(messages))
+        rule_status = RuleStatus.from_rule(rule)
         all_rule_statuses.append(rule_status)
         formatter.on_next_rule_status(rule_status)
     formatter.end_checking(all_rule_statuses)

--- a/airflow/upgrade/formatters.py
+++ b/airflow/upgrade/formatters.py
@@ -99,11 +99,16 @@ class JSONFormatter(BaseFormatter):
     def start_checking(self, all_rules):
         print("Start looking for problems.")
 
-    def end_checking(self, all_problems):
-        formatted_results = [
-            {"rule": type(problem.rule).__name__, "message": problem.message}
-            for problem in all_problems
-        ]
-        with open(self.filename, "w") as output_file:
+    @staticmethod
+    def _info_from_rule_status(rule_status):
+        return {
+            "rule": type(rule_status.rule).__name__,
+            "title": rule_status.rule.title,
+            "messages": rule_status.messages,
+        }
+
+    def end_checking(self, rule_statuses):
+        formatted_results = [self._info_from_rule_status(rs) for rs in rule_statuses]
+        with open(self.filename, "w+") as output_file:
             json.dump(formatted_results, output_file, indent=2)
         print("Saved result to: {}".format(self.filename))

--- a/airflow/upgrade/formatters.py
+++ b/airflow/upgrade/formatters.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABCMeta
+from typing import List
+import json
+
+from airflow.upgrade.problem import RuleStatus
+from airflow.upgrade.rules.base_rule import BaseRule
+from airflow.utils.cli import header, get_terminal_size
+
+
+class BaseFormatter(object):
+    __metaclass__ = ABCMeta
+
+    def start_checking(self, all_rules):
+        # type: (List[BaseRule]) -> None
+        pass
+
+    def end_checking(self, rule_statuses):
+        # type: (List[RuleStatus]) -> None
+
+        pass
+
+    def on_next_rule_status(self, rule_status):
+        # type: (RuleStatus) -> None
+        pass
+
+
+class ConsoleFormatter(BaseFormatter):
+    def start_checking(self, all_rules):
+        print()
+        header("STATUS", "=")
+        print()
+
+    def end_checking(self, rule_statuses):
+        if rule_statuses:
+            messages_count = sum(
+                len(rule_status.messages)
+                for rule_status in rule_statuses
+            )
+            if messages_count == 1:
+                print("Found {} problem.".format(messages_count))
+            else:
+                print("Found {} problems.".format(messages_count))
+            print
+            header("RECOMMENDATIONS", "=")
+            print
+
+            self.display_recommendations(rule_statuses)
+        else:
+            print("Not found any problems. World is beautiful. ")
+            print("You can safely update Airflow to the new version.")
+
+    @staticmethod
+    def display_recommendations(rule_statuses):
+
+        for rule_status in rule_statuses:
+            rule = rule_status.rule
+            print(rule.title)
+            print("-" * len(rule.title))
+            print(rule.description)
+            print("")
+            print("Problems:")
+            for message_no, message in enumerate(rule_status.messages, 1):
+                print('{:>3}.  {}'.format(message_no, message))
+
+    def on_next_rule_status(self, rule_status):
+        status = "SUCCESS" if rule_status.is_success else "FAIL"
+        status_line_fmt = self.prepare_status_line_format()
+        print(status_line_fmt.format(rule_status.rule.title, status))
+
+    @staticmethod
+    def prepare_status_line_format():
+        _, terminal_width = get_terminal_size()
+
+        return "{:.<" + str(terminal_width - 10) + "}{:.>10}"
+
+
+class JSONFormatter(BaseFormatter):
+    def __init__(self, output_path):
+        self.filename = output_path
+
+    def start_checking(self, all_rules):
+        print("Start looking for problems.")
+
+    def end_checking(self, all_problems):
+        formatted_results = [
+            {"rule": type(problem.rule).__name__, "message": problem.message}
+            for problem in all_problems
+        ]
+        with open(self.filename, "w") as output_file:
+            json.dump(formatted_results, output_file, indent=2)
+        print("Saved result to: {}".format(self.filename))

--- a/airflow/upgrade/formatters.py
+++ b/airflow/upgrade/formatters.py
@@ -57,9 +57,9 @@ class ConsoleFormatter(BaseFormatter):
                 print("Found {} problem.".format(messages_count))
             else:
                 print("Found {} problems.".format(messages_count))
-            print
+            print()
             header("RECOMMENDATIONS", "=")
-            print
+            print()
 
             self.display_recommendations(rule_statuses)
         else:
@@ -75,9 +75,10 @@ class ConsoleFormatter(BaseFormatter):
             print("-" * len(rule.title))
             print(rule.description)
             print("")
-            print("Problems:")
-            for message_no, message in enumerate(rule_status.messages, 1):
-                print('{:>3}.  {}'.format(message_no, message))
+            if rule_status.messages:
+                print("Problems:")
+                for message_no, message in enumerate(rule_status.messages, 1):
+                    print('{:>3}.  {}'.format(message_no, message))
 
     def on_next_rule_status(self, rule_status):
         status = "SUCCESS" if rule_status.is_success else "FAIL"

--- a/airflow/upgrade/problem.py
+++ b/airflow/upgrade/problem.py
@@ -32,3 +32,9 @@ class RuleStatus(NamedTuple(
     @property
     def is_success(self):
         return bool(self.messages)
+
+    @classmethod
+    def from_rule(cls, rule):
+        # type: (BaseRule) -> RuleStatus
+        messages = rule.check()
+        return cls(rule=rule, messages=list(messages))

--- a/airflow/upgrade/problem.py
+++ b/airflow/upgrade/problem.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+from typing import NamedTuple, List
+
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class RuleStatus(NamedTuple(
+    'RuleStatus',
+    [
+        ('rule', BaseRule),
+        ('messages', List[str])
+    ]
+)):
+
+    @property
+    def is_success(self):
+        return bool(self.messages)

--- a/airflow/upgrade/rules/__init__.py
+++ b/airflow/upgrade/rules/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/upgrade/rules/base_rule.py
+++ b/airflow/upgrade/rules/base_rule.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABCMeta, abstractmethod
+
+
+class BaseRule(object):
+    __metaclass__ = ABCMeta
+
+    @property
+    @abstractmethod
+    def title(self):
+        """Short one-line summary"""
+        pass
+
+    @property
+    @abstractmethod
+    def description(self):
+        """A long description explaining the problem in detail. This can be an entry from UPDATING.md file."""
+        pass
+
+    def check(self):
+        pass

--- a/airflow/upgrade/rules/base_rule.py
+++ b/airflow/upgrade/rules/base_rule.py
@@ -17,19 +17,33 @@
 
 from abc import ABCMeta, abstractmethod
 
+from six import add_metaclass
 
+RULES = []
+
+
+class BaseRuleMeta(ABCMeta):
+    def __new__(cls, clsname, bases, attrs):
+        clazz = super(BaseRuleMeta, cls).__new__(cls, clsname, bases, attrs)
+        if clsname != "BaseRule":
+            RULES.append(clazz)
+        return clazz
+
+
+@add_metaclass(BaseRuleMeta)
 class BaseRule(object):
-    __metaclass__ = ABCMeta
 
     @property
     @abstractmethod
     def title(self):
+        # type: () -> str
         """Short one-line summary"""
         pass
 
     @property
     @abstractmethod
     def description(self):
+        # type: () -> str
         """A long description explaining the problem in detail. This can be an entry from UPDATING.md file."""
         pass
 

--- a/airflow/upgrade/rules/conn_type_is_not_nullable.py
+++ b/airflow/upgrade/rules/conn_type_is_not_nullable.py
@@ -35,8 +35,7 @@ If you made any modifications to the table directly, make sure you don't have nu
 
     @provide_session
     def check(self, session=None):
-        # invalid_connections = session.query(Connection).filter(Connection.conn_type.is_(None))
-        invalid_connections = [Connection(conn_id="AA")]
+        invalid_connections = session.query(Connection).filter(Connection.conn_type.is_(None))
         return (
             'Connection<id={}", conn_id={}> have empty conn_type field.'.format(conn.id, conn.conn_id)
             for conn in invalid_connections

--- a/airflow/upgrade/rules/conn_type_is_not_nullable.py
+++ b/airflow/upgrade/rules/conn_type_is_not_nullable.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.models import Connection
+from airflow.upgrade.rules.base_rule import BaseRule
+from airflow.utils.db import provide_session
+
+
+class ConnTypeIsNotNullableRule(BaseRule):
+
+    title = "Connection.conn_type is not nullable"
+
+    description = """\
+The `conn_type` column in the `connection` table must contain content. Previously, this rule was \
+enforced by application logic, but was not enforced by the database schema.
+
+If you made any modifications to the table directly, make sure you don't have null in the conn_type column.\
+"""
+
+    @provide_session
+    def check(self, session=None):
+        # invalid_connections = session.query(Connection).filter(Connection.conn_type.is_(None))
+        invalid_connections = [Connection(conn_id="AA")]
+        return (
+            'Connection<id={}", conn_id={}> have empty conn_type field.'.format(conn.id, conn.conn_id)
+            for conn in invalid_connections
+        )

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -26,9 +26,13 @@ import functools
 import getpass
 import json
 import socket
+import struct
 import sys
 from argparse import Namespace
 from datetime import datetime
+from fcntl import ioctl
+from os import environ
+from termios import TIOCGWINSZ
 
 from airflow.models import Log
 from airflow.utils import cli_action_loggers
@@ -137,3 +141,22 @@ def should_use_colors(args):
     if args.color == ColorMode.OFF:
         return False
     return is_terminal_support_colors()
+
+
+def get_terminal_size(fallback=(80, 20)):
+    """Return a tuple of (terminal height, terminal width)."""
+    try:
+        return struct.unpack('hhhh', ioctl(sys.__stdout__, TIOCGWINSZ, '\000' * 8))[0:2]
+    except IOError:
+        # when the output stream or init descriptor is not a tty, such
+        # as when when stdout is piped to another program
+        pass
+    try:
+        return int(environ.get('LINES')), int(environ.get('COLUMNS'))
+    except TypeError:
+        return fallback
+
+
+def header(text, fillchar):
+    rows, columns = get_terminal_size()
+    print(" {} ".format(text).center(columns, fillchar))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -216,6 +216,7 @@ exclude_patterns = [
     '_api/airflow/typing_compat',
     '_api/airflow/kubernetes',
     '_api/airflow/ti_deps',
+    '_api/airflow/upgrade',
     '_api/airflow/utils',
     '_api/airflow/version',
     '_api/airflow/www',

--- a/tests/upgrade/__init__.py
+++ b/tests/upgrade/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/upgrade/rules/__init__.py
+++ b/tests/upgrade/rules/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/upgrade/rules/test_base_rule.py
+++ b/tests/upgrade/rules/test_base_rule.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.upgrade.rules.base_rule import BaseRule, RULES
+
+
+class TestBaseRule:
+    def test_if_custom_rule_is_registered(self):
+        class CustomRule(BaseRule):
+            pass
+
+        assert CustomRule in list(RULES)

--- a/tests/upgrade/rules/test_conn_type_is_not_nullable.py
+++ b/tests/upgrade/rules/test_conn_type_is_not_nullable.py
@@ -34,8 +34,7 @@ class TestConnTypeIsNotNullableRule:
         with create_session() as session:
             conn = Connection(conn_id="TestConnTypeIsNotNullableRule")
             session.merge(conn)
-            session.commit()
-            msgs = rule.check(session=session)
 
+        msgs = rule.check(session=session)
         assert [m for m in msgs if "TestConnTypeIsNotNullableRule" in m], \
             "TestConnTypeIsNotNullableRule not in warning messages"

--- a/tests/upgrade/rules/test_conn_type_is_not_nullable.py
+++ b/tests/upgrade/rules/test_conn_type_is_not_nullable.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.models import Connection
+from airflow.upgrade.rules.conn_type_is_not_nullable import ConnTypeIsNotNullableRule
+from airflow.utils.db import create_session
+from tests.test_utils.db import clear_db_connections
+
+
+class TestConnTypeIsNotNullableRule:
+    def tearDown(self):
+        clear_db_connections()
+
+    def test_check(self):
+        rule = ConnTypeIsNotNullableRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        with create_session() as session:
+            conn = Connection(conn_id="TestConnTypeIsNotNullableRule")
+            session.merge(conn)
+            session.commit()
+            msgs = rule.check(session=session)
+
+        assert [m for m in msgs if "TestConnTypeIsNotNullableRule" in m], \
+            "TestConnTypeIsNotNullableRule not in warning messages"

--- a/tests/upgrade/test_formattes.py
+++ b/tests/upgrade/test_formattes.py
@@ -17,7 +17,7 @@
 
 import json
 from tempfile import NamedTemporaryFile
-from unittest import mock
+from tests.compat import mock
 
 import pytest
 

--- a/tests/upgrade/test_formattes.py
+++ b/tests/upgrade/test_formattes.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+import pytest
+
+from airflow.bin import cli
+from airflow.upgrade.rules.base_rule import BaseRule
+
+MESSAGES = ["msg1", "msg2"]
+
+
+class MockRule(BaseRule):
+    title = "title"
+    description = "description"
+
+    def check(self):
+        return MESSAGES
+
+
+class TestJSONFormatter:
+    @mock.patch("airflow.upgrade.checker.ALL_RULES", [MockRule()])
+    def test_output(self):
+        expected = [
+            {
+                "rule": MockRule.__name__,
+                "title": MockRule.title,
+                "messages": MESSAGES,
+            }
+        ]
+        parser = cli.CLIFactory.get_parser()
+        with NamedTemporaryFile("w+") as temp:
+            with pytest.raises(SystemExit):
+                cli.upgrade_check(parser.parse_args(['upgrade_check', '-s', temp.name]))
+            content = temp.read()
+
+        assert json.loads(content) == expected

--- a/tests/upgrade/test_problem.py
+++ b/tests/upgrade/test_problem.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+from airflow.upgrade.problem import RuleStatus
+
+
+class TestRuleStatus:
+    def test_is_success(self):
+        assert RuleStatus(rule=mock.MagicMock(), messages=[]).is_success is False
+        assert RuleStatus(rule=mock.MagicMock(), messages=["aaa"]).is_success is True
+
+    def test_rule_status_from_rule(self):
+        msgs = ["An interesting problem to solve"]
+        rule = mock.MagicMock()
+        rule.check.return_value = msgs
+
+        result = RuleStatus.from_rule(rule)
+        rule.check.assert_called_once()
+        assert result == RuleStatus(rule, msgs)

--- a/tests/upgrade/test_problem.py
+++ b/tests/upgrade/test_problem.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from unittest import mock
+from tests.compat import mock
 
 from airflow.upgrade.problem import RuleStatus
 

--- a/tests/upgrade/test_problem.py
+++ b/tests/upgrade/test_problem.py
@@ -31,5 +31,5 @@ class TestRuleStatus:
         rule.check.return_value = msgs
 
         result = RuleStatus.from_rule(rule)
-        rule.check.assert_called_once()
+        rule.check.assert_called_once_with()
         assert result == RuleStatus(rule, msgs)


### PR DESCRIPTION
This is a DRAFT and I still have to complete the missing documentation and unit tests.

I wanted to prepare a minimal valuable product for the upgrade_check command. Only one rule is implemented, but I think that's enough to show the feature. In the next steps, we can think about what rules we need to create, create tickets, and then work on the next rules by the whole community. 

Recently, we have a lot of new beginner contributors and I think we can try to engage them for this task. Most rules will be small and independent, so they will be great candidates for good-first-issue.

An example of the result of this command is presented in the termianlshot below
<img width="479" alt="Screenshot 2020-06-13 at 12 58 38" src="https://user-images.githubusercontent.com/12058428/84566968-a63cc200-ad75-11ea-870b-60d07d0c44fa.png">

Example JSON:
```
[
  {
    "rule": "ConnTypeIsNotNullableRule",
    "message": "Connection<id=''\", conn_id=AA> have empty conn_type field."
  }
]
```

Part of: https://github.com/apache/airflow/issues/8765
Continuation of the change, but for 1.10: https://github.com/apache/airflow/pull/9276
---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [XI will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
