### PR TITLE
Add link to ADC docs in use-alternative-secret-backend.rst

### DIFF
--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -387,17 +387,14 @@ and if you want to retrieve both Variables and connections use the following sam
     backend_kwargs = {"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables", "sep": "-"}
 
 
-When ``gcp_key_path`` is not provided, it will use the Application Default Credentials in the current environment. You can set up the credentials with:
+When ``gcp_key_path`` is not provided, it will use the Application Default Credentials (ADC) to obtain credentials.
 
-.. code-block:: ini
+.. note::
 
-    # 1. GOOGLE_APPLICATION_CREDENTIALS environment variable
-    export GOOGLE_APPLICATION_CREDENTIALS=path/to/key-file.json
+    For more information about the Application Default Credentials (ADC), see:
 
-    # 2. Set with SDK
-    gcloud auth application-default login
-    # If the Cloud SDK has an active project, the project ID is returned. The active project can be set using:
-    gcloud config set project
+      * `google.auth.default <https://google-auth.readthedocs.io/en/latest/reference/google.auth.html#google.auth.default>`__
+      * `Setting Up Authentication for Server to Server Production Applications <https://cloud.google.com/docs/authentication/production>`__
 
 The value of the Secrets Manager secret id must be the :ref:`connection URI representation <generating_connection_uri>`
 of the connection object.


### PR DESCRIPTION
The ADC is very complex and a thorough description of this process is beyond the scope of our documentation, so it adds links to Google documentation. Unfortunately, Google also doesn't have one good public documentation that fully describes the ADC, so I have to add two links.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
