### PR TITLE
Replace deprecated wtforms HTMLString with markupsafe.MarkUp

### DIFF
--- a/airflow/www/widgets.py
+++ b/airflow/www/widgets.py
@@ -17,7 +17,8 @@
 # under the License.
 
 from flask_appbuilder.widgets import RenderTemplateWidget
-from wtforms.widgets import HTMLString, html_params
+from markupsafe import Markup
+from wtforms.widgets import html_params
 
 
 class AirflowModelListWidget(RenderTemplateWidget):
@@ -43,6 +44,6 @@ class AirflowDateTimePickerWidget:
             field.data = ""
         template = self.data_template
 
-        return HTMLString(
+        return Markup(
             template % {"text": html_params(type="text", value=field.data, **kwargs)}
         )

--- a/requirements/requirements-python3.6.txt
+++ b/requirements/requirements-python3.6.txt
@@ -72,9 +72,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.14.7
+boto3==1.14.8
 boto==2.49.0
-botocore==1.17.7
+botocore==1.17.8
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -101,7 +101,7 @@ cryptography==2.9.2
 curlify==2.2.1
 cx-Oracle==7.3.0
 dask==2.19.0
-datadog==0.36.0
+datadog==0.37.0
 decorator==4.4.2
 defusedxml==0.6.0
 dill==0.3.2
@@ -120,8 +120,8 @@ email-validator==1.1.1
 entrypoints==0.3
 eventlet==0.25.2
 execnet==1.7.1
-facebook-business==7.0.2
-fastavro==0.23.4
+facebook-business==7.0.3
+fastavro==0.23.5
 filelock==3.0.12
 fissix==20.5.1
 flake8-colors==0.1.6
@@ -180,7 +180,7 @@ hmsclient==0.1.1
 httplib2==0.18.1
 humanize==0.5.1
 hvac==0.10.4
-identify==1.4.19
+identify==1.4.20
 idna-ssl==1.1.0
 idna==2.9
 ijson==2.6.1
@@ -201,7 +201,7 @@ jira==2.0.0
 jmespath==0.10.0
 json-merge-patch==0.2
 jsondiff==1.1.2
-jsonpatch==1.25
+jsonpatch==1.26
 jsonpickle==1.4.1
 jsonpointer==2.0
 jsonschema==3.2.0
@@ -239,7 +239,7 @@ networkx==2.4
 nodeenv==1.4.0
 nteract-scrapbook==0.4.1
 ntlm-auth==1.5.0
-numpy==1.18.5
+numpy==1.19.0
 oauthlib==2.1.0
 openapi-spec-validator==0.2.8
 oscrypto==1.2.0
@@ -380,14 +380,14 @@ uritemplate==3.0.1
 urllib3==1.25.9
 vertica-python==0.10.4
 vine==1.3.0
-virtualenv==20.0.23
+virtualenv==20.0.24
 watchtower==0.7.3
 wcwidth==0.2.4
 websocket-client==0.57.0
 wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.23.0
-yandexcloud==0.41.0
+yandexcloud==0.42.0
 yarl==1.4.2
 zdesk==2.7.1
 zict==2.0.0

--- a/requirements/requirements-python3.7.txt
+++ b/requirements/requirements-python3.7.txt
@@ -72,9 +72,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.14.7
+boto3==1.14.8
 boto==2.49.0
-botocore==1.17.7
+botocore==1.17.8
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -100,7 +100,7 @@ cryptography==2.9.2
 curlify==2.2.1
 cx-Oracle==7.3.0
 dask==2.19.0
-datadog==0.36.0
+datadog==0.37.0
 decorator==4.4.2
 defusedxml==0.6.0
 dill==0.3.2
@@ -119,8 +119,8 @@ email-validator==1.1.1
 entrypoints==0.3
 eventlet==0.25.2
 execnet==1.7.1
-facebook-business==7.0.2
-fastavro==0.23.4
+facebook-business==7.0.3
+fastavro==0.23.5
 filelock==3.0.12
 fissix==20.5.1
 flake8-colors==0.1.6
@@ -179,7 +179,7 @@ hmsclient==0.1.1
 httplib2==0.18.1
 humanize==0.5.1
 hvac==0.10.4
-identify==1.4.19
+identify==1.4.20
 idna==2.9
 ijson==2.6.1
 imagesize==1.2.0
@@ -197,7 +197,7 @@ jira==2.0.0
 jmespath==0.10.0
 json-merge-patch==0.2
 jsondiff==1.1.2
-jsonpatch==1.25
+jsonpatch==1.26
 jsonpickle==1.4.1
 jsonpointer==2.0
 jsonschema==3.2.0
@@ -235,7 +235,7 @@ networkx==2.4
 nodeenv==1.4.0
 nteract-scrapbook==0.4.1
 ntlm-auth==1.5.0
-numpy==1.18.5
+numpy==1.19.0
 oauthlib==2.1.0
 openapi-spec-validator==0.2.8
 oscrypto==1.2.0
@@ -374,14 +374,14 @@ uritemplate==3.0.1
 urllib3==1.25.9
 vertica-python==0.10.4
 vine==1.3.0
-virtualenv==20.0.23
+virtualenv==20.0.24
 watchtower==0.7.3
 wcwidth==0.2.4
 websocket-client==0.57.0
 wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.23.0
-yandexcloud==0.41.0
+yandexcloud==0.42.0
 yarl==1.4.2
 zdesk==2.7.1
 zict==2.0.0

--- a/requirements/requirements-python3.8.txt
+++ b/requirements/requirements-python3.8.txt
@@ -45,7 +45,7 @@ apispec==1.3.3
 appdirs==1.4.4
 argcomplete==1.11.1
 asn1crypto==1.3.0
-astroid==2.3.3
+astroid==2.4.2
 async-generator==1.10
 async-timeout==3.0.1
 atlasclient==1.0.0
@@ -72,9 +72,9 @@ beautifulsoup4==4.7.1
 billiard==3.6.3.0
 black==19.10b0
 blinker==1.4
-boto3==1.14.7
+boto3==1.14.8
 boto==2.49.0
-botocore==1.17.7
+botocore==1.17.8
 bowler==0.8.0
 cached-property==1.5.1
 cachetools==4.1.0
@@ -100,7 +100,7 @@ cryptography==2.9.2
 curlify==2.2.1
 cx-Oracle==7.3.0
 dask==2.19.0
-datadog==0.36.0
+datadog==0.37.0
 decorator==4.4.2
 defusedxml==0.6.0
 dill==0.3.2
@@ -119,8 +119,8 @@ email-validator==1.1.1
 entrypoints==0.3
 eventlet==0.25.2
 execnet==1.7.1
-facebook-business==7.0.2
-fastavro==0.23.4
+facebook-business==7.0.3
+fastavro==0.23.5
 filelock==3.0.12
 fissix==20.5.1
 flake8-colors==0.1.6
@@ -179,7 +179,7 @@ hmsclient==0.1.1
 httplib2==0.18.1
 humanize==0.5.1
 hvac==0.10.4
-identify==1.4.19
+identify==1.4.20
 idna==2.9
 ijson==2.6.1
 imagesize==1.2.0
@@ -197,7 +197,7 @@ jira==2.0.0
 jmespath==0.10.0
 json-merge-patch==0.2
 jsondiff==1.1.2
-jsonpatch==1.25
+jsonpatch==1.26
 jsonpickle==1.4.1
 jsonpointer==2.0
 jsonschema==3.2.0
@@ -235,7 +235,7 @@ networkx==2.4
 nodeenv==1.4.0
 nteract-scrapbook==0.4.1
 ntlm-auth==1.5.0
-numpy==1.18.5
+numpy==1.19.0
 oauthlib==2.1.0
 openapi-spec-validator==0.2.8
 oscrypto==1.2.0
@@ -373,14 +373,14 @@ uritemplate==3.0.1
 urllib3==1.25.9
 vertica-python==0.10.4
 vine==1.3.0
-virtualenv==20.0.23
+virtualenv==20.0.24
 watchtower==0.7.3
 wcwidth==0.2.4
 websocket-client==0.57.0
-wrapt==1.11.2
+wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.23.0
-yandexcloud==0.41.0
+yandexcloud==0.42.0
 yarl==1.4.2
 zdesk==2.7.1
 zict==2.0.0

--- a/requirements/setup-3.6.md5
+++ b/requirements/setup-3.6.md5
@@ -1,1 +1,1 @@
-2aefe5ee0325c61727269fc63b030f61  /opt/airflow/setup.py
+58b2fa003085a21989e7c2cc68a10461  /opt/airflow/setup.py

--- a/requirements/setup-3.7.md5
+++ b/requirements/setup-3.7.md5
@@ -1,1 +1,1 @@
-2aefe5ee0325c61727269fc63b030f61  /opt/airflow/setup.py
+58b2fa003085a21989e7c2cc68a10461  /opt/airflow/setup.py

--- a/requirements/setup-3.8.md5
+++ b/requirements/setup-3.8.md5
@@ -1,1 +1,1 @@
-2aefe5ee0325c61727269fc63b030f61  /opt/airflow/setup.py
+58b2fa003085a21989e7c2cc68a10461  /opt/airflow/setup.py

--- a/setup.py
+++ b/setup.py
@@ -709,6 +709,7 @@ INSTALL_REQUIREMENTS = [
     'lazy_object_proxy~=1.3',
     'lockfile>=0.12.2',
     'markdown>=2.5.2, <3.0',
+    'markupsafe>=1.1.1, <2.0',
     'pandas>=0.17.1, <2.0',
     'pendulum~=2.0',
     'pep562~=1.0;python_version<"3.7"',


### PR DESCRIPTION
WTForms uses `MarkUp` to escape strings now and removed their internal class HTMLString in Master. Details: https://github.com/wtforms/wtforms/pull/400

That change previously broke Airflow for new users (in 2.3.0). However on users request they added `HTMLString` that just passes all args to `markupsafe.MarkUp` back for temporary Backward compatbility with deprecation warning in 2.3.1. Details: https://github.com/wtforms/wtforms/issues/581

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
