### PR TITLE
Cancel queued/running builds on second push to PR

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: Cancel
-on: [push]
+on: [push, pull_request]
 jobs:
   cancel:
     name: 'Cancel Previous Runs'


### PR DESCRIPTION
We need to Cancel builds to PR too.

https://github.com/apache/airflow/pull/9050 only cancels on push to Master branch

There are 4 workflows running for each push in our of my PRs:

![image](https://user-images.githubusercontent.com/8811558/85714159-0fabc180-b6e2-11ea-836b-445d9de37424.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
