### PR TITLE
[AIRFLOW-XXXX] Remove unnecessary docstring in AWSAthenaOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -26,10 +26,7 @@ from airflow.utils.decorators import apply_defaults
 
 class AWSAthenaOperator(BaseOperator):
     """
-    An operator that submit presto query to athena.
-
-    If ``do_xcom_push`` is True, the QueryExecutionID assigned to the
-    query will be pushed to an XCom when it successfuly completes.
+    An operator that submits a presto query to athena.
 
     :param query: Presto to be run on athena. (templated)
     :type query: str


### PR DESCRIPTION
**EDIT - here is the updated PR description:** `query_execution_id` is returned by `execute`, which means that the default behavior is that it will be `xcom_push`ed. While this can be overridden since this is a subclass of `BaseOperator` [and this is an argument that is accepted](https://github.com/apache/airflow/blob/eb403beea2d1035635b7bea24c49b6b964313e51/airflow/models/baseoperator.py#L359), it need not be mentioned in the docstring here since it is referring to default behavior.

Old PR description for transparency:
~Since query_execution_id is now returned by execute, it will be xcom
pushed by default, meaning `do_xcom_push` is no longer needed and should
not be mentioned in the docstring.~

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
