### PR TITLE
Add missing precommit-hook ids to breeze-complete

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1321,15 +1321,16 @@ This is the current syntax for  `./breeze <./breeze>`_:
         you would like to run or 'all' to run all checks. One of:
 
                  all all-but-pylint airflow-config-yaml base-operator bat-tests build
-                 build-providers-dependencies check-apache-license check-executables-have-shebangs
-                 check-hooks-apply check-integrations check-merge-conflict check-xml
-                 consistent-pylint daysago-import-check debug-statements detect-private-key doctoc
-                 end-of-file-fixer fix-encoding-pragma flake8 forbid-tabs
-                 incorrect-use-of-LoggingMixin insert-license isort language-matters lint-dockerfile
-                 mixed-line-ending mypy provide-create-sessions pydevd pydocstyle pylint pylint-tests
-                 python-no-log-warn rst-backticks setup-order shellcheck stylelint
-                 trailing-whitespace update-breeze-file update-extras update-local-yml-file
-                 update-setup-cfg-file yamllint
+                 build-providers-dependencies check-apache-license check-builtin-literals
+                 check-executables-have-shebangs check-hooks-apply check-integrations
+                 check-merge-conflict check-xml consistent-pylint daysago-import-check
+                 debug-statements detect-private-key doctoc dont-use-safe-filter end-of-file-fixer
+                 fix-encoding-pragma flake8 forbid-tabs incorrect-use-of-LoggingMixin insert-license
+                 isort language-matters lint-dockerfile lint-openapi mixed-line-ending mypy
+                 provide-create-sessions pydevd pydocstyle pylint pylint-tests python-no-log-warn
+                 rst-backticks setup-order shellcheck stylelint trailing-whitespace
+                 update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
+                 yamllint
 
         You can pass extra arguments including options to to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/breeze-complete
+++ b/breeze-complete
@@ -50,6 +50,7 @@ bat-tests
 build
 build-providers-dependencies
 check-apache-license
+check-builtin-literals
 check-executables-have-shebangs
 check-hooks-apply
 check-integrations
@@ -60,6 +61,7 @@ daysago-import-check
 debug-statements
 detect-private-key
 doctoc
+dont-use-safe-filter
 end-of-file-fixer
 fix-encoding-pragma
 flake8
@@ -69,6 +71,7 @@ insert-license
 isort
 language-matters
 lint-dockerfile
+lint-openapi
 mixed-line-ending
 mypy
 provide-create-sessions


### PR DESCRIPTION
Add missing precommit-hook ids to breeze-complete

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
