### PR TITLE
boolean values in environment variables

### DIFF
--- a/docs/howto/set-config.rst
+++ b/docs/howto/set-config.rst
@@ -37,6 +37,12 @@ or by creating a corresponding environment variable:
 .. code-block:: bash
 
     export AIRFLOW__CORE__SQL_ALCHEMY_CONN=my_conn_string
+    
+For setting boolean configuration values use ``true``/``false``:
+
+.. code-block:: bask
+
+    export AIRFLOW__CORE__REMOTE_LOGGING=true
 
 You can also derive the connection string at run time by appending ``_cmd`` to
 the key like this:


### PR DESCRIPTION
Some configuration variables are boolean and it was not clear to me how to set those bools from environmental variables which are all strings. Eventually, I found the mapping in [the code](https://github.com/apache/airflow/blob/master/airflow/configuration.py#L329-L341).

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
