### PR TITLE
Add metric for scheduling delay between first run task & expected start time

### DIFF
--- a/docs/logging-monitoring/metrics.rst
+++ b/docs/logging-monitoring/metrics.rst
@@ -133,16 +133,17 @@ Name                                                Description
 Timers
 ------
 
-=========================================== =================================================================
-Name                                        Description
-=========================================== =================================================================
-``dagrun.dependency-check.<dag_id>``        Milliseconds taken to check DAG dependencies
-``dag.<dag_id>.<task_id>.duration``         Milliseconds taken to finish a task
-``dag_processing.last_duration.<dag_file>`` Milliseconds taken to load the given DAG file
-``dagrun.duration.success.<dag_id>``        Milliseconds taken for a DagRun to reach success state
-``dagrun.duration.failed.<dag_id>``         Milliseconds taken for a DagRun to reach failed state
-``dagrun.schedule_delay.<dag_id>``          Milliseconds of delay between the scheduled DagRun start date and
-                                            the actual DagRun start date
-``scheduler.critical_section_duration``     Milliseconds spent in the critical section of scheduler loop --
-                                            only a single scheduler can enter this loop at a time
-=========================================== =================================================================
+=================================================== ========================================================================
+Name                                                Description
+=================================================== ========================================================================
+``dagrun.dependency-check.<dag_id>``                Milliseconds taken to check DAG dependencies
+``dag.<dag_id>.<task_id>.duration``                 Milliseconds taken to finish a task
+``dag_processing.last_duration.<dag_file>``         Milliseconds taken to load the given DAG file
+``dagrun.duration.success.<dag_id>``                Milliseconds taken for a DagRun to reach success state
+``dagrun.duration.failed.<dag_id>``                 Milliseconds taken for a DagRun to reach failed state
+``dagrun.schedule_delay.<dag_id>``                  Milliseconds of delay between the scheduled DagRun
+                                                    start date and the actual DagRun start date
+``scheduler.critical_section_duration``             Milliseconds spent in the critical section of scheduler loop --
+                                                    only a single scheduler can enter this loop at a time
+``dagrun.<dag_id>.first_task_scheduling_delay``     Seconds elapsed between first task start_date and dagrun expected start
+=================================================== ========================================================================


### PR DESCRIPTION
        This is to emit the true scheduling delay stats, which is defined as the time when the first
        task in DAG starts minus the expected DAG run datetime. This method will be used in the update_state method
        when the state of the DagRun is updated to a completed status (either success or failure).
        The method will find the first started task within the DAG and calculate the expected DagRun start time (
        based on dag.execution_date & dag.schedule_interval), and minus these two to get the delay.

        The emitted data may contains outlier (e.g. when the first task was cleared, so the second task's start_date
        will be used), but we can get ride of the the outliers on the stats side through the dashboards.

        Note, the stat will only be emitted if the DagRun is a scheduler triggered one (i.e. external_trigger is False).


This is all useful when you want to even measure executor delays, considerations for adding more capacity, adding more scheduling processes, etc. Measuring just the delay in the dagrun from its start time to expected time is just one of the measurement, but measuring from the dag run to its first real running job is important as well.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
