### PR TITLE
YAML file supporting extra json parameters for LocalFileSystemBackend

### DIFF
--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -25,6 +25,7 @@ from collections import defaultdict
 from inspect import signature
 from json import JSONDecodeError
 from typing import Any, Dict, List, Optional, Set, Tuple
+
 import yaml
 
 from airflow.exceptions import AirflowException, AirflowFileParseException, FileSyntaxError

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -101,8 +101,8 @@ def _parse_yaml_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyn
         return {}, [FileSyntaxError(line_no=1, message="The file is empty.")]
     try:
         secrets = yaml.safe_load(content)
-    except yaml.YAMLError as e:
-        return {}, [FileSyntaxError(line_no=1, message=str(e))]
+    except yaml.MarkedYAMLError as e:
+        return {}, [FileSyntaxError(line_no=e.problem_mark.line, message=str(e))]
     if not isinstance(secrets, dict):
         return {}, [FileSyntaxError(line_no=1, message="The file should contain the object.")]
 

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -101,6 +101,11 @@ def _parse_yaml_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyn
         return {}, [FileSyntaxError(line_no=1, message="The file is empty.")]
     try:
         secrets = yaml.safe_load(content)
+        for key in list(secrets.keys()):
+            secret_values = secrets[key]
+            if(isinstance(secret_values, dict) and 'extra' in secret_values.keys()):
+                secrets[key]['extra'] = json.dumps(secrets[key]['extra'])
+
     except yaml.MarkedYAMLError as e:
         return {}, [FileSyntaxError(line_no=e.problem_mark.line, message=str(e))]
     if not isinstance(secrets, dict):

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -19,13 +19,13 @@
 Objects relating to retrieving connections and variables from local file
 """
 import json
-import yaml
 import logging
 import os
 from collections import defaultdict
 from inspect import signature
 from json import JSONDecodeError
 from typing import Any, Dict, List, Optional, Set, Tuple
+import yaml
 
 from airflow.exceptions import AirflowException, AirflowFileParseException, FileSyntaxError
 from airflow.secrets.base_secrets import BaseSecretsBackend

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -101,7 +101,7 @@ def _parse_yaml_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyn
     try:
         secrets = yaml.safe_load(content)
     except yaml.YAMLError as e:
-        return {}, [FileSyntaxError(line_no=int(e.lineno), message=e.msg)]
+        return {}, [FileSyntaxError(line_no=1, message=str(e))]
     if not isinstance(secrets, dict):
         return {}, [FileSyntaxError(line_no=1, message="The file should contain the object.")]
 

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -19,6 +19,7 @@
 Objects relating to retrieving connections and variables from local file
 """
 import json
+import yaml
 import logging
 import os
 from collections import defaultdict
@@ -84,6 +85,29 @@ def _parse_env_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSynt
     return secrets, errors
 
 
+def _parse_yaml_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyntaxError]]:
+    """
+    Parse a file in the YAML format.
+
+    :param file_path: The location of the file that will be processed.
+    :type file_path: str
+    :return: Tuple with mapping of key and list of values and list of syntax errors
+    """
+    with open(file_path) as f:
+        content = f.read()
+
+    if not content:
+        return {}, [FileSyntaxError(line_no=1, message="The file is empty.")]
+    try:
+        secrets = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        return {}, [FileSyntaxError(line_no=int(e.lineno), message=e.msg)]
+    if not isinstance(secrets, dict):
+        return {}, [FileSyntaxError(line_no=1, message="The file should contain the object.")]
+
+    return secrets, []
+
+
 def _parse_json_file(file_path: str) -> Tuple[Dict[str, Any], List[FileSyntaxError]]:
     """
     Parse a file in the JSON format.
@@ -110,6 +134,7 @@ def _parse_json_file(file_path: str) -> Tuple[Dict[str, Any], List[FileSyntaxErr
 FILE_PARSERS = {
     "env": _parse_env_file,
     "json": _parse_json_file,
+    "yaml": _parse_yaml_file,
 }
 
 

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -129,7 +129,7 @@ The following is a sample YAML file.
     CONN_B:
       - 'mysq://host_a'
       - 'mysq://host_b'
-    
+
     CONN_C:
       conn_type: scheme
       host: host
@@ -167,9 +167,9 @@ the variable value. The following is a sample JSON file.
 
 The YAML file structure is similar to that of JSON, with key containing the variable key and the value containing
 the variable value. The following is a sample YAML file.
-  
+
   .. code-block:: yaml
-  
+
     VAR_A: some_value
     VAR_B: different_value
 

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -117,7 +117,7 @@ The following is a sample JSON file.
     }
 
 The YAML file structure is similar to that of a JSON. The key-value pair of connection ID and the definitions of one or more connections.
-The connection can be defined as a URI (string) or JSON object.
+The connection can be defined as a URI (string) or JSON object. Any extra json parameters can be provided with the key extra.
 For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 The following is a sample YAML file.
@@ -137,6 +137,10 @@ The following is a sample YAML file.
       login: Login
       password: None
       port: 1234
+      extra:
+        a: b
+        nestedblock_dict:
+          x: y
 
 You can also define connections using a ``.env`` file. Then the key is the connection ID, and
 the value should describe the connection using the URI. If the connection ID is repeated, all values will

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -81,7 +81,7 @@ Here is a sample configuration:
     backend = airflow.secrets.local_filesystem.LocalFilesystemBackend
     backend_kwargs = {"variables_file_path": "/files/var.json", "connections_file_path": "/files/conn.json"}
 
-Both ``JSON`` and ``.env`` files are supported. All parameters are optional. If the file path is not passed,
+``JSON``, ``YAML`` and ``.env`` files are supported. All parameters are optional. If the file path is not passed,
 the backend returns an empty collection.
 
 Storing and Retrieving Connections
@@ -90,7 +90,7 @@ Storing and Retrieving Connections
 If you have set ``connections_file_path`` as ``/files/my_conn.json``, then the backend will read the
 file ``/files/my_conn.json`` when it looks for connections.
 
-The file can be defined in ``JSON`` or ``env`` format.
+The file can be defined in ``JSON``, ``YAML`` or ``env`` format.
 
 The JSON file must contain an object where the key contains the connection ID and the value contains
 the definitions of one or more connections. The connection can be defined as a URI (string) or JSON object.
@@ -116,6 +116,28 @@ The following is a sample JSON file.
         }
     }
 
+The YAML file structure is similar to that of a JSON. The key-value pair of connection ID and the definitions of one or more connections.
+The connection can be defined as a URI (string) or JSON object.
+For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
+For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
+The following is a sample YAML file.
+
+.. code-block:: yaml
+
+    CONN_A: 'mysq://host_a'
+
+    CONN_B:
+      - 'mysq://host_a'
+      - 'mysq://host_b'
+    
+    CONN_C:
+      conn_type: scheme
+      host: host
+      schema: lschema
+      login: Login
+      password: None
+      port: 1234
+
 You can also define connections using a ``.env`` file. Then the key is the connection ID, and
 the value should describe the connection using the URI. If the connection ID is repeated, all values will
 be returned. The following is a sample file.
@@ -131,7 +153,7 @@ Storing and Retrieving Variables
 If you have set ``variables_file_path`` as ``/files/my_var.json``, then the backend will read the
 file ``/files/my_var.json`` when it looks for variables.
 
-The file can be defined in ``JSON`` or ``env`` format.
+The file can be defined in ``JSON``, ``YAML`` or ``env`` format.
 
 The JSON file must contain an object where the key contains the variable key and the value contains
 the variable value. The following is a sample JSON file.
@@ -142,6 +164,14 @@ the variable value. The following is a sample JSON file.
         "VAR_A": "some_value",
         "var_b": "differnet_value"
     }
+
+The YAML file structure is similar to that of JSON, with key containing the variable key and the value containing
+the variable value. The following is a sample YAML file.
+  
+  .. code-block:: yaml
+  
+    VAR_A: some_value
+    VAR_B: different_value
 
 You can also define variable using a ``.env`` file. Then the key is the variable key, and variable should
 describe the variable value. The following is a sample file.

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import json
+import yaml
 import re
 import unittest
 from contextlib import contextmanager
@@ -105,6 +106,20 @@ class TestLoadVariables(unittest.TestCase):
             local_filesystem.load_variables("a.json")
 
 
+    @parameterized.expand(
+        (
+            ({}, {}),
+            ({"KEY": "AAA"}, {"KEY": "AAA"}),
+            ({"KEY_A": "AAA", "KEY_B": "BBB"}, {"KEY_A": "AAA", "KEY_B": "BBB"}),
+            ({"KEY_A": "AAA", "KEY_B": "BBB"}, {"KEY_A": "AAA", "KEY_B": "BBB"}),
+        )
+    )
+    def test_yaml_file_should_load_variables(self, file_content, expected_variables):
+        with mock_local_file(yaml.dump(yaml.load(json.dumps(file_content)), default_flow_style=False)):
+            variables = local_filesystem.load_variables('a.yaml')
+            self.assertEqual(expected_variables, variables)
+
+
 class TestLoadConnection(unittest.TestCase):
     @parameterized.expand(
         (
@@ -192,6 +207,32 @@ class TestLoadConnection(unittest.TestCase):
             re.escape("File a.json was not found. Check the configuration of your Secrets backend."),
         ):
             local_filesystem.load_connections("a.json")
+
+    @parameterized.expand(
+        (
+            ({"CONN_ID": "mysql://host_1"}, {"CONN_ID": ["mysql://host_1"]}),
+            ({"CONN_ID": ["mysql://host_1"]}, {"CONN_ID": ["mysql://host_1"]}),
+            (
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+            ),
+            ({"CONN_ID": {"uri": "mysql://host_1"}}, {"CONN_ID": ["mysql://host_1"]}),
+            ({"CONN_ID": [{"uri": "mysql://host_1"}]}, {"CONN_ID": ["mysql://host_1"]}),
+            (
+                {"CONN_ID": [{"uri": "mysql://host_1"}, {"uri": "mysql://host_2"}]},
+                {"CONN_ID": ["mysql://host_1", "mysql://host_2"]},
+            ),
+        )
+    )
+    def test_yaml_file_should_load_connection(self, file_content, expected_connection_uris):
+        with mock_local_file(yaml.dump(yaml.load(json.dumps(file_content)), default_flow_style=False)):
+            connections_by_conn_id = local_filesystem.load_connections("a.yaml")
+            connection_uris_by_conn_id = {
+                conn_id: [connection.get_uri() for connection in connections]
+                for conn_id, connections in connections_by_conn_id.items()
+            }
+
+            self.assertEqual(expected_connection_uris, connection_uris_by_conn_id)
 
 
 class TestLocalFileBackend(unittest.TestCase):

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -226,9 +226,15 @@ class TestLoadConnection(unittest.TestCase):
                schema: lschema
                login: Login
                password: None
-               port: 1234""",
+               port: 1234
+               extra:
+                 extra__google_cloud_platform__keyfile_dict:
+                   a: b
+                 extra__google_cloud_platform__keyfile_path: asaa""",
                 {"conn_a": ["mysql://hosta"], "conn_b": ["mysql://hostb", "mysql://hostc"],
-                    "conn_c": ["scheme://Login:None@host:1234/lschema"]}),
+                    "conn_c": [''.join("""scheme://Login:None@host:1234/lschema?
+                        extra__google_cloud_platform__keyfile_dict=%7B%27a%27%3A+%27b%27%7D
+                        &extra__google_cloud_platform__keyfile_path=asaa""".split())]}),
         )
     )
     def test_yaml_file_should_load_connection(self, file_content, expected_connection_uris):
@@ -240,6 +246,44 @@ class TestLoadConnection(unittest.TestCase):
             }
 
             self.assertEqual(expected_connection_uris, connection_uris_by_conn_id)
+
+    @parameterized.expand(
+        (
+            ("""conn_c:
+               conn_type: scheme
+               host: host
+               schema: lschema
+               login: Login
+               password: None
+               port: 1234
+               extra:
+                 aws_conn_id: bbb
+                 region_name: ccc
+                 """, {"conn_c": [{"aws_conn_id": "bbb", "region_name": "ccc"}]}),
+            ("""conn_d:
+               conn_type: scheme
+               host: host
+               schema: lschema
+               login: Login
+               password: None
+               port: 1234
+               extra:
+                 extra__google_cloud_platform__keyfile_dict:
+                   a: b
+                 extra__google_cloud_platform__key_path: xxx
+                 """, {"conn_d": [{"extra__google_cloud_platform__keyfile_dict": {"a": "b"},
+                                   "extra__google_cloud_platform__key_path": "xxx"}]}),
+
+        )
+    )
+    def test_yaml_file_should_load_connection_extras(self, file_content, expected_extras):
+        with mock_local_file(file_content):
+            connections_by_conn_id = local_filesystem.load_connections("a.yaml")
+            connection_uris_by_conn_id = {
+                conn_id: [connection.extra_dejson for connection in connections]
+                for conn_id, connections in connections_by_conn_id.items()
+            }
+            self.assertEqual(expected_extras, connection_uris_by_conn_id)
 
 
 class TestLocalFileBackend(unittest.TestCase):

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -21,8 +21,8 @@ import unittest
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from unittest import mock
-import yaml
 
+import yaml
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException, AirflowFileParseException
@@ -104,7 +104,6 @@ class TestLoadVariables(unittest.TestCase):
             re.escape("File a.json was not found. Check the configuration of your Secrets backend."),
         ):
             local_filesystem.load_variables("a.json")
-
 
     @parameterized.expand(
         (

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -16,12 +16,12 @@
 # under the License.
 
 import json
-import yaml
 import re
 import unittest
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from unittest import mock
+import yaml
 
 from parameterized import parameterized
 


### PR DESCRIPTION



LocalFileSystemBackend supports YAML files to add connections and the extra parameters ( like in [here](https://airflow.readthedocs.io/en/latest/howto/connection/gcp.html) ) would have to be provided as raw JSON instead of default YAML. The PR is to resolve this issue and provide extra parameters as nested key pairs 

Relevant to #9477 
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
