### PR TITLE
YAML file supports extra json parameters

### DIFF
--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -101,10 +101,6 @@ def _parse_yaml_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyn
         return {}, [FileSyntaxError(line_no=1, message="The file is empty.")]
     try:
         secrets = yaml.safe_load(content)
-        for key in list(secrets.keys()):
-            secret_values = secrets[key]
-            if(isinstance(secret_values, dict) and 'extra' in secret_values.keys()):
-                secrets[key]['extra'] = json.dumps(secrets[key]['extra'])
 
     except yaml.MarkedYAMLError as e:
         return {}, [FileSyntaxError(line_no=e.problem_mark.line, message=str(e))]
@@ -185,7 +181,7 @@ def _create_connection(conn_id: str, value: Any):
     if isinstance(value, str):
         return Connection(conn_id=conn_id, uri=value)
     if isinstance(value, dict):
-        connection_parameter_names = get_connection_parameter_names()
+        connection_parameter_names = get_connection_parameter_names() | {"extra_dejson"}
         current_keys = set(value.keys())
         if not current_keys.issubset(connection_parameter_names):
             illegal_keys = current_keys - connection_parameter_names
@@ -194,6 +190,14 @@ def _create_connection(conn_id: str, value: Any):
                 f"The object have illegal keys: {illegal_keys_list}. "
                 f"The dictionary can only contain the following keys: {connection_parameter_names}"
             )
+        if "extra" in value and "extra_dejson" in value:
+            raise AirflowException(
+                "The extra and extra_dejson parameters are mutually exclusive. "
+                "Please provide only one parameter."
+            )
+        if "extra_dejson" in value:
+            value["extra"] = json.dumps(value["extra_dejson"])
+            del value["extra_dejson"]
 
         if "conn_id" in current_keys and conn_id != value["conn_id"]:
             raise AirflowException(

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -101,6 +101,11 @@ def _parse_yaml_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyn
         return {}, [FileSyntaxError(line_no=1, message="The file is empty.")]
     try:
         secrets = yaml.safe_load(content)
+        for key in list(secrets.keys()):
+            secret_values = secrets[key]
+            if(isinstance(secret_values, dict) and 'extra' in secret_values.keys()):
+                secrets[key]['extra'] = json.dumps(secrets[key]['extra'])
+
     except yaml.MarkedYAMLError as e:
         return {}, [FileSyntaxError(line_no=e.problem_mark.line, message=str(e))]
     if not isinstance(secrets, dict):

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -117,7 +117,7 @@ The following is a sample JSON file.
     }
 
 The YAML file structure is similar to that of a JSON. The key-value pair of connection ID and the definitions of one or more connections.
-The connection can be defined as a URI (string) or JSON object.
+The connection can be defined as a URI (string) or JSON object. Any extra json parameters can be provided with the key extra.
 For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 The following is a sample YAML file.
@@ -137,6 +137,10 @@ The following is a sample YAML file.
       login: Login
       password: None
       port: 1234
+      extra:
+        a: b
+        nestedblock_dict:
+          x: y
 
 You can also define connections using a ``.env`` file. Then the key is the connection ID, and
 the value should describe the connection using the URI. If the connection ID is repeated, all values will

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -117,7 +117,7 @@ The following is a sample JSON file.
     }
 
 The YAML file structure is similar to that of a JSON. The key-value pair of connection ID and the definitions of one or more connections.
-The connection can be defined as a URI (string) or JSON object. Any extra json parameters can be provided with the key extra.
+The connection can be defined as a URI (string) or JSON object. Any extra json parameters can be provided with the key extra_dejson (Keys extra and extra_dejson are mutually exclusive).
 For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 The following is a sample YAML file.
@@ -137,7 +137,7 @@ The following is a sample YAML file.
       login: Login
       password: None
       port: 1234
-      extra:
+      extra_dejson:
         a: b
         nestedblock_dict:
           x: y

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -93,7 +93,7 @@ Storing and Retrieving Connections
 If you have set ``connections_file_path`` as ``/files/my_conn.json``, then the backend will read the
 file ``/files/my_conn.json`` when it looks for connections.
 
-The file can be defined in ``JSON``, ``YAML`` or ``env`` format.
+The file can be defined in ``JSON``, ``YAML`` or ``env`` format. Depending on the format, the data should be saved as a URL or as a connection object.  For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.	 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 
 Any extra json parameters can be provided using keys like ``extra_dejson`` and ``extra``.
 The key ``extra_dejson`` can be used to provide parameters as JSON object where as the key ``extra`` can be used in case of a JSON string.

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -94,6 +94,7 @@ The file can be defined in ``JSON``, ``YAML`` or ``env`` format.
 
 The JSON file must contain an object where the key contains the connection ID and the value contains
 the definitions of one or more connections. The connection can be defined as a URI (string) or JSON object.
+
 For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 The following is a sample JSON file.
@@ -117,7 +118,10 @@ The following is a sample JSON file.
     }
 
 The YAML file structure is similar to that of a JSON. The key-value pair of connection ID and the definitions of one or more connections.
-The connection can be defined as a URI (string) or JSON object. Any extra json parameters can be provided with the key extra_dejson (Keys extra and extra_dejson are mutually exclusive).
+The connection can be defined as a URI (string) or JSON object. Any extra json parameters can be provided using keys like ``extra_dejson`` and ``extra``.
+The key ``extra_dejson`` can be used to provide parameters as JSON object where as the key ``extra`` can be used in case of a JSON string.
+The keys ``extra`` and ``extra_dejson`` are mutually exclusive.
+
 For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 The following is a sample YAML file.

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -68,6 +68,9 @@ This backend is especially useful in the following use cases:
 To use variable and connection from local file, specify :py:class:`~airflow.secrets.local_filesystem.LocalFilesystemBackend`
 as the ``backend`` in  ``[secrets]`` section of ``airflow.cfg``.
 
+For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
+For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
+
 Available parameters to ``backend_kwargs``:
 
 * ``variables_file_path``: File location with variables data.
@@ -98,9 +101,6 @@ The keys ``extra`` and ``extra_dejson`` are mutually exclusive.
 
 The JSON file must contain an object where the key contains the connection ID and the value contains
 the definitions of one or more connections. The connection can be defined as a URI (string) or JSON object.
-
-For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
-For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
 The following is a sample JSON file.
 
 .. code-block:: json
@@ -123,10 +123,6 @@ The following is a sample JSON file.
 
 The YAML file structure is similar to that of a JSON. The key-value pair of connection ID and the definitions of one or more connections.
 The connection can be defined as a URI (string) or JSON object.
-
-For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
-For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
-The following is a sample YAML file.
 
 .. code-block:: yaml
 

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -100,7 +100,7 @@ The key ``extra_dejson`` can be used to provide parameters as JSON object where 
 The keys ``extra`` and ``extra_dejson`` are mutually exclusive.
 
 The JSON file must contain an object where the key contains the connection ID and the value contains
-the definitions of one or more connections. The connection can be defined as a URI (string) or JSON object.
+the definitions of one or more connections. In this format, the connection can be defined as a URI (string) or JSON object.
 The following is a sample JSON file.
 
 .. code-block:: json

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -68,9 +68,6 @@ This backend is especially useful in the following use cases:
 To use variable and connection from local file, specify :py:class:`~airflow.secrets.local_filesystem.LocalFilesystemBackend`
 as the ``backend`` in  ``[secrets]`` section of ``airflow.cfg``.
 
-For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
-For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
-
 Available parameters to ``backend_kwargs``:
 
 * ``variables_file_path``: File location with variables data.
@@ -93,8 +90,7 @@ Storing and Retrieving Connections
 If you have set ``connections_file_path`` as ``/files/my_conn.json``, then the backend will read the
 file ``/files/my_conn.json`` when it looks for connections.
 
-The file can be defined in ``JSON``, ``YAML`` or ``env`` format. Depending on the format, the data should be saved as a URL or as a connection object.  For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.	 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.
-
+The file can be defined in ``JSON``, ``YAML`` or ``env`` format. Depending on the format, the data should be saved as a URL or as a connection object.
 Any extra json parameters can be provided using keys like ``extra_dejson`` and ``extra``.
 The key ``extra_dejson`` can be used to provide parameters as JSON object where as the key ``extra`` can be used in case of a JSON string.
 The keys ``extra`` and ``extra_dejson`` are mutually exclusive.

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -92,6 +92,10 @@ file ``/files/my_conn.json`` when it looks for connections.
 
 The file can be defined in ``JSON``, ``YAML`` or ``env`` format.
 
+Any extra json parameters can be provided using keys like ``extra_dejson`` and ``extra``.
+The key ``extra_dejson`` can be used to provide parameters as JSON object where as the key ``extra`` can be used in case of a JSON string.
+The keys ``extra`` and ``extra_dejson`` are mutually exclusive.
+
 The JSON file must contain an object where the key contains the connection ID and the value contains
 the definitions of one or more connections. The connection can be defined as a URI (string) or JSON object.
 
@@ -118,9 +122,7 @@ The following is a sample JSON file.
     }
 
 The YAML file structure is similar to that of a JSON. The key-value pair of connection ID and the definitions of one or more connections.
-The connection can be defined as a URI (string) or JSON object. Any extra json parameters can be provided using keys like ``extra_dejson`` and ``extra``.
-The key ``extra_dejson`` can be used to provide parameters as JSON object where as the key ``extra`` can be used in case of a JSON string.
-The keys ``extra`` and ``extra_dejson`` are mutually exclusive.
+The connection can be defined as a URI (string) or JSON object.
 
 For a guide about defining a connection as a URI, see:: :ref:`generating_connection_uri`.
 For a description of the connection object parameters see :class:`~airflow.models.connection.Connection`.

--- a/docs/howto/use-alternative-secrets-backend.rst
+++ b/docs/howto/use-alternative-secrets-backend.rst
@@ -122,7 +122,7 @@ The following is a sample JSON file.
     }
 
 The YAML file structure is similar to that of a JSON. The key-value pair of connection ID and the definitions of one or more connections.
-The connection can be defined as a URI (string) or JSON object.
+In this format, the connection can be defined as a URI (string) or JSON object.
 
 .. code-block:: yaml
 

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -226,9 +226,15 @@ class TestLoadConnection(unittest.TestCase):
                schema: lschema
                login: Login
                password: None
-               port: 1234""",
+               port: 1234
+               extra:
+                 extra__google_cloud_platform__keyfile_dict:
+                   a: b
+                 extra__google_cloud_platform__keyfile_path: asaa""",
                 {"conn_a": ["mysql://hosta"], "conn_b": ["mysql://hostb", "mysql://hostc"],
-                    "conn_c": ["scheme://Login:None@host:1234/lschema"]}),
+                    "conn_c": [''.join("""scheme://Login:None@host:1234/lschema?
+                        extra__google_cloud_platform__keyfile_dict=%7B%27a%27%3A+%27b%27%7D
+                        &extra__google_cloud_platform__keyfile_path=asaa""".split())]}),
         )
     )
     def test_yaml_file_should_load_connection(self, file_content, expected_connection_uris):
@@ -240,6 +246,44 @@ class TestLoadConnection(unittest.TestCase):
             }
 
             self.assertEqual(expected_connection_uris, connection_uris_by_conn_id)
+
+    @parameterized.expand(
+        (
+            ("""conn_c:
+               conn_type: scheme
+               host: host
+               schema: lschema
+               login: Login
+               password: None
+               port: 1234
+               extra:
+                 aws_conn_id: bbb
+                 region_name: ccc
+                 """, {"conn_c": [{"aws_conn_id": "bbb", "region_name": "ccc"}]}),
+            ("""conn_d:
+               conn_type: scheme
+               host: host
+               schema: lschema
+               login: Login
+               password: None
+               port: 1234
+               extra:
+                 extra__google_cloud_platform__keyfile_dict:
+                   a: b
+                 extra__google_cloud_platform__key_path: xxx
+                 """, {"conn_d": [{"extra__google_cloud_platform__keyfile_dict": {"a": "b"},
+                                   "extra__google_cloud_platform__key_path": "xxx"}]}),
+
+        )
+    )
+    def test_yaml_file_should_load_connection_extras(self, file_content, expected_extras):
+        with mock_local_file(file_content):
+            connections_by_conn_id = local_filesystem.load_connections("a.yaml")
+            connection_uris_by_conn_id = {
+                conn_id: [connection.extra_dejson for connection in connections]
+                for conn_id, connections in connections_by_conn_id.items()
+            }
+            self.assertEqual(expected_extras, connection_uris_by_conn_id)
 
 
 class TestLocalFileBackend(unittest.TestCase):

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -227,7 +227,7 @@ class TestLoadConnection(unittest.TestCase):
                login: Login
                password: None
                port: 1234
-               extra:
+               extra_dejson:
                  extra__google_cloud_platform__keyfile_dict:
                    a: b
                  extra__google_cloud_platform__keyfile_path: asaa""",
@@ -256,7 +256,7 @@ class TestLoadConnection(unittest.TestCase):
                login: Login
                password: None
                port: 1234
-               extra:
+               extra_dejson:
                  aws_conn_id: bbb
                  region_name: ccc
                  """, {"conn_c": [{"aws_conn_id": "bbb", "region_name": "ccc"}]}),
@@ -267,7 +267,7 @@ class TestLoadConnection(unittest.TestCase):
                login: Login
                password: None
                port: 1234
-               extra:
+               extra_dejson:
                  extra__google_cloud_platform__keyfile_dict:
                    a: b
                  extra__google_cloud_platform__key_path: xxx
@@ -284,6 +284,28 @@ class TestLoadConnection(unittest.TestCase):
                 for conn_id, connections in connections_by_conn_id.items()
             }
             self.assertEqual(expected_extras, connection_uris_by_conn_id)
+
+    @parameterized.expand(
+        (
+            ("""conn_c:
+               conn_type: scheme
+               host: host
+               schema: lschema
+               login: Login
+               password: None
+               port: 1234
+               extra:
+                 abc: xyz
+               extra_dejson:
+                 aws_conn_id: bbb
+                 region_name: ccc
+                 """, "The extra and extra_dejson parameters are mutually exclusive."),
+        )
+    )
+    def test_yaml_invalid_extra(self, file_content, expected_message):
+        with mock_local_file(file_content):
+            with self.assertRaisesRegex(AirflowException, re.escape(expected_message)):
+                local_filesystem.load_connections("a.yaml")
 
 
 class TestLocalFileBackend(unittest.TestCase):

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -273,6 +273,15 @@ class TestLoadConnection(unittest.TestCase):
                  extra__google_cloud_platform__key_path: xxx
                  """, {"conn_d": [{"extra__google_cloud_platform__keyfile_dict": {"a": "b"},
                                    "extra__google_cloud_platform__key_path": "xxx"}]}),
+            ("""conn_d:
+               conn_type: scheme
+               host: host
+               schema: lschema
+               login: Login
+               password: None
+               port: 1234
+               extra: '{\"extra__google_cloud_platform__keyfile_dict\": {\"a\": \"b\"}}'""", {"conn_d": [
+                {"extra__google_cloud_platform__keyfile_dict": {"a": "b"}}]})
 
         )
     )


### PR DESCRIPTION
---
LocalFileSystemBackend supports YAML files to add connections and the extra parameters ( like in here ) would have to be provided as raw JSON instead of default YAML. The PR is to resolve this issue and provide extra parameters as nested key pairs

Relevant to #9477
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
