### PR TITLE
Check deprecation messages in airflow.contrib

### DIFF
--- a/airflow/contrib/utils/log/__init__.py
+++ b/airflow/contrib/utils/log/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-This module is deprecated. Please use `airflow.utils.log`.
+This package is deprecated. Please use `airflow.utils.log`.
 """
 
 import warnings

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -54,14 +54,13 @@ class TestProjectStructure(unittest.TestCase):
             self.assert_file_not_contains(filename, "providers")
 
     def test_deprecated_packages(self):
-        for directory in ["hooks", "operators", "secrets", "sensors", "task_runner"]:
-            path_pattern = f"{ROOT_FOLDER}/airflow/contrib/{directory}/*.py"
+        path_pattern = f"{ROOT_FOLDER}/airflow/contrib/**/*.py"
 
-            for filename in glob.glob(path_pattern, recursive=True):
-                if filename.endswith("/__init__.py"):
-                    self.assert_file_contains(filename, "This package is deprecated.")
-                else:
-                    self.assert_file_contains(filename, "This module is deprecated.")
+        for filename in glob.glob(path_pattern, recursive=True):
+            if filename.endswith("/__init__.py"):
+                self.assert_file_contains(filename, "This package is deprecated.")
+            else:
+                self.assert_file_contains(filename, "This module is deprecated.")
 
     def assert_file_not_contains(self, filename: str, pattern: str):
         with open(filename, 'rb', 0) as file, mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as content:


### PR DESCRIPTION
This change will protect us from adding a new module or package by mistake.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
