### PR TITLE
Fix the default value for store_dag_code

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -338,8 +338,8 @@
         ``store_serialized_dags`` setting.
       version_added: 1.10.10
       type: string
-      example: ~
-      default: "%(store_serialized_dags)s"
+      example: "False"
+      default: ~
     - name: max_num_rendered_ti_fields_per_task
       description: |
         Maximum number of Rendered Task Instance Fields (Template Fields) per task to store

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -195,7 +195,8 @@ min_serialized_dag_update_interval = 30
 # If set to True, Webserver reads file contents from DB instead of
 # trying to access files in a DAG folder. Defaults to same as the
 # ``store_serialized_dags`` setting.
-store_dag_code = %(store_serialized_dags)s
+# Example: store_dag_code = False
+# store_dag_code =
 
 # Maximum number of Rendered Task Instance Fields (Template Fields) per task to store
 # in the Database.

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1589,7 +1589,7 @@ class DAG(BaseDag, LoggingMixin):
                         orm_dag.tags.append(dag_tag_orm)
                         session.add(dag_tag_orm)
 
-        if conf.getboolean('core', 'store_dag_code', fallback=False):
+        if settings.STORE_DAG_CODE:
             DagCode.bulk_sync_to_db([dag.fileloc for dag in orm_dags])
 
         session.commit()

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -22,9 +22,9 @@ from typing import Iterable, Optional
 
 from sqlalchemy import BigInteger, Column, String, UnicodeText, and_, exists
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowException, DagCodeNotFound
 from airflow.models import Base
+from airflow.settings import STORE_DAG_CODE
 from airflow.utils import timezone
 from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
 from airflow.utils.session import provide_session
@@ -181,7 +181,7 @@ class DagCode(Base):
 
         :return: source code as string
         """
-        if conf.getboolean('core', 'store_dag_code', fallback=False):
+        if STORE_DAG_CODE:
             return cls._get_code_from_db(fileloc)
         else:
             return cls._get_code_from_file(fileloc)

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -340,6 +340,11 @@ STORE_SERIALIZED_DAGS = conf.getboolean('core', 'store_serialized_dags', fallbac
 MIN_SERIALIZED_DAG_UPDATE_INTERVAL = conf.getint(
     'core', 'min_serialized_dag_update_interval', fallback=30)
 
+# Whether to persist DAG files code in DB. If set to True, Webserver reads file contents
+# from DB instead of trying to access files in a DAG folder.
+# Defaults to same as the store_serialized_dags setting.
+STORE_DAG_CODE = conf.getboolean("core", "store_dag_code", fallback=STORE_SERIALIZED_DAGS)
+
 # If donot_modify_handlers=True, we do not modify logging handlers in task_run command
 # If the flag is set to False, we remove all handlers from the root logger
 # and add all handlers from 'airflow.task' logger to the root Logger. This is done

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -41,7 +41,7 @@ from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.exceptions import AirflowException
 from airflow.models import errors
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
-from airflow.settings import STORE_SERIALIZED_DAGS
+from airflow.settings import STORE_DAG_CODE, STORE_SERIALIZED_DAGS
 from airflow.stats import Stats
 from airflow.utils import timezone
 from airflow.utils.file import list_py_file_paths
@@ -631,7 +631,7 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
             conf.getint('scheduler', 'scheduler_zombie_task_threshold'))
 
         # Should store dag file source in a database?
-        self.store_dag_code = conf.getboolean('core', 'store_dag_code', fallback=False)
+        self.store_dag_code = STORE_DAG_CODE
         # Map from file path to the processor
         self._processors: Dict[str, AbstractDagFileProcessorProcess] = {}
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -22,10 +22,9 @@ import tempfile
 import unittest
 import warnings
 from collections import OrderedDict
-from importlib import reload
 from unittest import mock
 
-from airflow import configuration, settings
+from airflow import configuration
 from airflow.configuration import (
     DEFAULT_CONFIG, AirflowConfigException, AirflowConfigParser, conf, expand_env_var, get_airflow_config,
     get_airflow_home, parameterized_config, run_command,
@@ -41,9 +40,6 @@ from tests.test_utils.reset_warning_registry import reset_warning_registry
     'AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD': 'echo -n "NOT OK"'
 })
 class TestConf(unittest.TestCase):
-
-    def tearDown(self) -> None:
-        reload(settings)
 
     def test_airflow_home_default(self):
         with unittest.mock.patch.dict('os.environ'):
@@ -606,17 +602,19 @@ notacommand = OK
 
     @conf_vars({("core", "store_serialized_dags"): "True"})
     def test_store_dag_code_default_config(self):
-        reload(settings)
+        store_serialized_dags = conf.getboolean('core', 'store_serialized_dags', fallback=False)
+        store_dag_code = conf.getboolean("core", "store_dag_code", fallback=store_serialized_dags)
         self.assertFalse(conf.has_option("core", "store_dag_code"))
-        self.assertTrue(settings.STORE_SERIALIZED_DAGS)
-        self.assertTrue(settings.STORE_DAG_CODE)
+        self.assertTrue(store_serialized_dags)
+        self.assertTrue(store_dag_code)
 
     @conf_vars({
         ("core", "store_serialized_dags"): "True",
         ("core", "store_dag_code"): "False"
     })
     def test_store_dag_code_config_when_set(self):
-        reload(settings)
+        store_serialized_dags = conf.getboolean('core', 'store_serialized_dags', fallback=False)
+        store_dag_code = conf.getboolean("core", "store_dag_code", fallback=store_serialized_dags)
         self.assertTrue(conf.has_option("core", "store_dag_code"))
-        self.assertTrue(settings.STORE_SERIALIZED_DAGS)
-        self.assertFalse(settings.STORE_DAG_CODE)
+        self.assertTrue(store_serialized_dags)
+        self.assertFalse(store_dag_code)


### PR DESCRIPTION
related to #8255 (fixes the issue mentioned with `store_dag_code` but does not address Config interpolation)

The default value of `store_dag_code` should be same as `store_serialized_dags` setting.  But if the value is set it should use that value

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
