### PR TITLE
Update usages of airflow db upgrade/init in best practices docs

### DIFF
--- a/docs/best-practices.rst
+++ b/docs/best-practices.rst
@@ -263,13 +263,13 @@ Once that is done, you can run -
 
 .. code-block::
 
- airflow db upgrade
+ airflow upgradedb
 
-``upgrade`` keeps track of migrations already applies, so it's safe to run as often as you need.
+``upgradedb`` keeps track of migrations already applies, so it's safe to run as often as you need.
 
 .. note::
 
- Do not use ``airflow db init`` as it can create a lot of default connections, charts, etc. which are not required in production DB.
+ Do not use ``airflow initdb`` as it can create a lot of default connections, charts, etc. which are not required in production DB.
 
 
 Multi-Node Cluster


### PR DESCRIPTION
On version 1.10.10 `db` is not a valid command, some previous version must have migrated all db commands to their own specific commands such as `upgradedb`, `initdb`. This PR updates the outdated best-practices documentation to use the new commands.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
