### PR TITLE
Use update instead of merge in _run_raw_task

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1112,7 +1112,14 @@ class TaskInstance(Base, LoggingMixin):
         self.set_duration()
         if not test_mode:
             session.add(Log(self.state, self))
-            session.merge(self)
+            session.query(TaskInstance).filter(
+                TaskInstance.dag_id == self.dag_id,
+                TaskInstance.task_id == self.task_id,
+                TaskInstance.execution_date == self.execution_date
+            ).update(
+                values={TaskInstance.state: self.state, TaskInstance.end_date: self.end_date},
+                synchronize_session=False,
+            )
         session.commit()
 
     @provide_session

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1115,9 +1115,13 @@ class TaskInstance(Base, LoggingMixin):
             session.query(TaskInstance).filter(
                 TaskInstance.dag_id == self.dag_id,
                 TaskInstance.task_id == self.task_id,
-                TaskInstance.execution_date == self.execution_date
+                TaskInstance.execution_date == self.execution_date,
             ).update(
-                values={TaskInstance.state: self.state, TaskInstance.end_date: self.end_date},
+                values={
+                    TaskInstance.state: self.state,
+                    TaskInstance.end_date: self.end_date,
+                    TaskInstance.duration: self.duration,
+                },
                 synchronize_session=False,
             )
         session.commit()

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1727,8 +1727,8 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
 
     @parameterized.expand([
         # Expected queries, mark_success
-        (7, False),
-        (5, True),
+        (6, False),
+        (4, True),
     ])
     def test_execute_queries_count(self, expected_query_count, mark_success):
         with create_session() as session:
@@ -1749,7 +1749,7 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
             ti.state = State.RUNNING
             session.merge(ti)
 
-        with assert_queries_count(10), patch(
+        with assert_queries_count(9), patch(
             "airflow.models.taskinstance.STORE_SERIALIZED_DAGS", True
         ):
             ti._run_raw_task()


### PR DESCRIPTION
Before:
```
[2020-06-26 15:00:26,228] {asserts.py:61} INFO - INSERT INTO rendered_task_instance_fields (dag_id, task_id, execution_date, rendered_fields) VALUES (%(dag_id)s, %(task_id)s, %(execution_date)s, %(rendered_fields)s)

[2020-06-26 15:00:26,232] {asserts.py:61} INFO - SELECT task_instance.try_number AS task_instance_try_number, task_instance.task_id AS task_instance_task_id, task_instance.dag_id AS task_instance_dag_id, task_instance.execution_date AS task_instance_execution_date, task_instance.start_date AS task_instance_start_date, task_instance.end_date AS task_instance_end_date, task_instance.duration AS task_instance_duration, task_instance.state AS task_instance_state, task_instance.max_tries AS task_instance_max_tries, task_instance.hostname AS task_instance_hostname, task_instance.unixname AS task_instance_unixname, task_instance.job_id AS task_instance_job_id, task_instance.pool AS task_instance_pool, task_instance.pool_slots AS task_instance_pool_slots, task_instance.queue AS task_instance_queue, task_instance.priority_weight AS task_instance_priority_weight, task_instance.operator AS task_instance_operator, task_instance.queued_dttm AS task_instance_queued_dttm, task_instance.pid AS task_instance_pid, task_instance.executor_config AS task_instance_executor_config
FROM task_instance
WHERE task_instance.task_id = %(param_1)s AND task_instance.dag_id = %(param_2)s AND task_instance.execution_date = %(param_3)s

[2020-06-26 15:00:26,235] {asserts.py:61} INFO - UPDATE task_instance SET end_date=%(end_date)s, state=%(state)s WHERE task_instance.task_id = %(task_instance_task_id)s AND task_instance.dag_id = %(task_instance_dag_id)s AND task_instance.execution_date = %(task_instance_execution_date)s

[2020-06-26 15:00:26,238] {asserts.py:61} INFO - INSERT INTO log (dttm, dag_id, task_id, event, execution_date, owner, extra) VALUES (%(dttm)s, %(dag_id)s, %(task_id)s, %(event)s, %(execution_date)s, %(owner)s, %(extra)s) RETURNING log.id
```
After:
```
[2020-06-26 15:00:57,858] {asserts.py:61} INFO - INSERT INTO rendered_task_instance_fields (dag_id, task_id, execution_date, rendered_fields) VALUES (%(dag_id)s, %(task_id)s, %(execution_date)s, %(rendered_fields)s)

[2020-06-26 15:00:57,863] {asserts.py:61} INFO - UPDATE task_instance SET end_date=%(end_date)s, state=%(state)s WHERE task_instance.dag_id = %(dag_id_1)s AND task_instance.task_id = %(task_id_1)s AND task_instance.execution_date = %(execution_date_1)s

[2020-06-26 15:00:57,865] {asserts.py:61} INFO - INSERT INTO log (dttm, dag_id, task_id, event, execution_date, owner, extra) VALUES (%(dttm)s, %(dag_id)s, %(task_id)s, %(event)s, %(execution_date)s, %(owner)s, %(extra)s) RETURNING log.id
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
