### PR TITLE
"build-essential" are needed for proper install on Linux

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,6 +36,17 @@ requirements are per major/minor python version (3.6/3.7). You can use them as c
 files when installing Airflow from PyPI. Note that you have to specify correct Airflow version
 and python versions in the URL.
 
+
+  **Prerequisites**
+
+  On Debian based Linux OS:
+
+  .. code-block:: bash
+
+      sudo apt-get update
+      sudo apt-get install build-essential
+
+
 1. Installing just airflow
 
 .. code-block:: bash


### PR DESCRIPTION
On a fresh install of Windows Subsystem for Linux (Ubuntu 20.04), created a conda environment and tried to follow the above guide  to install airflow but was getting gcc errors. Installing build-essential solved the issue.  

On Windows 10, with a clean conda environment, setproctitle fails to install with error "Microsoft Visual C++ 14.0 is required". Suggests to install "Microsoft Visual C++ Build Tools".  I got this both on Python version 3.8.3 and 3.5.6.
Installed some versions of C++ build tools from Visual Studio community edition installer and tried installing airflow again but getting a new error now - "cannot open include file: 'basetsd.h'".

May be add some prerequisites about Windows and Python versions?

---
Make sure to mark the boxes below before creating PR: [x]

- [ x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [ x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ x] Relevant documentation is updated including usage instructions.
- [x ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
