### PR TITLE
Add XCom.get_one() method back

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -729,10 +729,6 @@ with redirect_stdout(StreamLogWriter(logger, logging.INFO)), \
     print("I Love Airflow")
 ```
 
-### Removal of XCom.get_one()
-
-This one is superseded by `XCom.get_many().first()` which will return the same result.
-
 ### Changes to SQLSensor
 
 SQLSensor now consistent with python `bool()` function and the `allow_null` parameter has been removed.

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -120,6 +120,45 @@ class BaseXCom(Base, LoggingMixin):
 
     @classmethod
     @provide_session
+    def get_one(cls,
+                execution_date: pendulum.DateTime,
+                key: Optional[str] = None,
+                task_id: Optional[Union[str, Iterable[str]]] = None,
+                dag_id: Optional[Union[str, Iterable[str]]] = None,
+                include_prior_dates: bool = False,
+                session: Session = None):
+        """
+        Retrieve an XCom value, optionally meeting certain criteria.
+
+        :param execution_date: Execution date for the task
+        :type execution_date: pendulum.datetime
+        :param key: A key for the XCom. If provided, only XComs with matching
+            keys will be returned. To remove the filter, pass key=None.
+        :type key: str
+        :param task_id: Only XComs from task with matching id will be
+            pulled. Can pass None to remove the filter.
+        :type task_id: str
+        :param dag_id: If provided, only pulls XCom from this DAG.
+            If None (default), the DAG of the calling task is used.
+        :type dag_id: str
+        :param include_prior_dates: If False, only XCom from the current
+            execution_date are returned. If True, XCom from previous dates
+            are returned as well.
+        :type include_prior_dates: bool
+        :param session: database session
+        :type session: sqlalchemy.orm.session.Session
+        """
+        result = cls.get_many(execution_date=execution_date,
+                              key=key,
+                              task_ids=task_id,
+                              dag_ids=dag_id,
+                              include_prior_dates=include_prior_dates,
+                              session=session).first()
+        if result:
+            return result.value
+
+    @classmethod
+    @provide_session
     def get_many(cls,
                  execution_date: pendulum.DateTime,
                  key: Optional[str] = None,

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -126,9 +126,10 @@ class BaseXCom(Base, LoggingMixin):
                 task_id: Optional[Union[str, Iterable[str]]] = None,
                 dag_id: Optional[Union[str, Iterable[str]]] = None,
                 include_prior_dates: bool = False,
-                session: Session = None):
+                session: Session = None) -> Optional[Any]:
         """
-        Retrieve an XCom value, optionally meeting certain criteria.
+        Retrieve an XCom value, optionally meeting certain criteria. Returns None
+        of there are no results.
 
         :param execution_date: Execution date for the task
         :type execution_date: pendulum.datetime
@@ -156,6 +157,7 @@ class BaseXCom(Base, LoggingMixin):
                               session=session).first()
         if result:
             return result.value
+        return None
 
     @classmethod
     @provide_session

--- a/tests/models/test_cleartasks.py
+++ b/tests/models/test_cleartasks.py
@@ -265,6 +265,34 @@ class TestClearTasks(unittest.TestCase):
 
         self.assertEqual(ret_value, json_obj)
 
+    @conf_vars({("core", "enable_xcom_pickling"): "False"})
+    def test_xcom_get_one_disable_pickle_type(self):
+        json_obj = {"key": "value"}
+        execution_date = timezone.utcnow()
+        key = "xcom_test1"
+        dag_id = "test_dag1"
+        task_id = "test_task1"
+        XCom.set(key=key,
+                 value=json_obj,
+                 dag_id=dag_id,
+                 task_id=task_id,
+                 execution_date=execution_date)
+
+        ret_value = XCom.get_one(key=key,
+                                 dag_id=dag_id,
+                                 task_id=task_id,
+                                 execution_date=execution_date)
+
+        self.assertEqual(ret_value, json_obj)
+
+        session = settings.Session()
+        ret_value = session.query(XCom).filter(XCom.key == key, XCom.dag_id == dag_id,
+                                               XCom.task_id == task_id,
+                                               XCom.execution_date == execution_date
+                                               ).first().value
+
+        self.assertEqual(ret_value, json_obj)
+
     @conf_vars({("core", "enable_xcom_pickling"): "True"})
     def test_xcom_enable_pickle_type(self):
         json_obj = {"key": "value"}
@@ -282,6 +310,34 @@ class TestClearTasks(unittest.TestCase):
                                   dag_ids=dag_id,
                                   task_ids=task_id,
                                   execution_date=execution_date).first().value
+
+        self.assertEqual(ret_value, json_obj)
+
+        session = settings.Session()
+        ret_value = session.query(XCom).filter(XCom.key == key, XCom.dag_id == dag_id,
+                                               XCom.task_id == task_id,
+                                               XCom.execution_date == execution_date
+                                               ).first().value
+
+        self.assertEqual(ret_value, json_obj)
+
+    @conf_vars({("core", "enable_xcom_pickling"): "True"})
+    def test_xcom_get_one_enable_pickle_type(self):
+        json_obj = {"key": "value"}
+        execution_date = timezone.utcnow()
+        key = "xcom_test3"
+        dag_id = "test_dag"
+        task_id = "test_task3"
+        XCom.set(key=key,
+                 value=json_obj,
+                 dag_id=dag_id,
+                 task_id=task_id,
+                 execution_date=execution_date)
+
+        ret_value = XCom.get_one(key=key,
+                                 dag_id=dag_id,
+                                 task_id=task_id,
+                                 execution_date=execution_date)
 
         self.assertEqual(ret_value, json_obj)
 


### PR DESCRIPTION
It is a handy function to handle and many times we just need a single Xcom value and `Xcom.get_one()` can be a good candidate for that.

This was removed in https://github.com/apache/airflow/pull/6461 . xcom_pull will continue using batch operation but we should have a function just to retrieve a single value without worrying about Sqlalchmy query function like `.first` 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
