### PR TITLE
Use pfromat instead of str to render arguments in WebUI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -41,7 +41,7 @@ from flask_appbuilder import BaseView, ModelView, expose, has_access, permission
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.filters import BaseFilter
 from flask_babel import lazy_gettext
-from jinja2.utils import htmlsafe_json_dumps  # type: ignore
+from jinja2.utils import htmlsafe_json_dumps, pformat  # type: ignore
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
 from sqlalchemy import and_, desc, func, or_, union_all
@@ -631,7 +631,7 @@ class Airflow(AirflowBaseView):  # noqa: D101
             if template_field in wwwutils.get_attr_renderer():
                 html_dict[template_field] = wwwutils.get_attr_renderer()[template_field](content)
             else:
-                html_dict[template_field] = Markup("<pre><code>{}</pre></code>").format(str(content))
+                html_dict[template_field] = Markup("<pre><code>{}</pre></code>").format(pformat(content))
 
         return self.render_template(
             'airflow/ti_code.html',


### PR DESCRIPTION
Large dictionaries that are part of operators input renders to hard to read form:
<img width="2533" alt="Screenshot 2020-06-30 at 11 20 04" src="https://user-images.githubusercontent.com/9528307/86109357-9686e280-bac4-11ea-8e32-46bdf250d1c6.png">

This PR proposes to use `pformat` instead of `str` to render the value:
<img width="963" alt="Screenshot 2020-06-30 at 11 19 25" src="https://user-images.githubusercontent.com/9528307/86109429-abfc0c80-bac4-11ea-8070-17b1bb13c920.png">


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
