### PR TITLE
Change worker_refresh_interval fallback to default of 30

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -401,7 +401,7 @@ def webserver(args):
                 gunicorn_master_proc=gunicorn_master_proc,
                 num_workers_expected=num_workers,
                 master_timeout=conf.getint('webserver', 'web_server_master_timeout'),
-                worker_refresh_interval=conf.getint('webserver', 'worker_refresh_interval', fallback=10),
+                worker_refresh_interval=conf.getint('webserver', 'worker_refresh_interval', fallback=30),
                 worker_refresh_batch_size=conf.getint('webserver', 'worker_refresh_batch_size', fallback=1),
                 reload_on_plugin_change=conf.getboolean(
                     'webserver', 'reload_on_plugin_change', fallback=False


### PR DESCRIPTION
The default value for `worker_refresh_interval` is 30 (https://airflow.readthedocs.io/en/latest/configurations-ref.html#worker-refresh-interval), so we should align the fallback to 30 too

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
