### PR TITLE
Fix failing test in test_webserver_command

### DIFF
--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -297,7 +297,8 @@ class TestCliWebServer(unittest.TestCase):
         proc.wait()
 
     # Patch for causing webserver timeout
-    @mock.patch("airflow.cli.commands.webserver_command.get_num_workers_running", return_value=0)
+    @mock.patch("airflow.cli.commands.webserver_command.GunicornMonitor._get_num_workers_running",
+                return_value=0)
     def test_cli_webserver_shutdown_when_gunicorn_master_is_killed(self, _):
         # Shorten timeout so that this test doesn't take too long time
         args = self.parser.parse_args(['webserver'])


### PR DESCRIPTION
Test was failing (this was in Quarantined test):

```
FAILED tests/cli/commands/test_webserver_command.py::TestCliWebServer::test_cli_webserver_shutdown_when_gunicorn_master_is_killed
```

```

        if not self.create and original is DEFAULT:
            raise AttributeError(
>               "{} does not have the attribute {!r}".format(target, name)
            )
E           AttributeError: <module 'airflow.bin.cli' from '/opt/airflow/airflow/bin/cli.py'> does not have the attribute 'get_num_workers_running'

/usr/local/lib/python3.5/site-packages/mock/mock.py:1368: AttributeError
```

This error occurred after Webserver / gunicorn refactor in https://github.com/apache/airflow/pull/899

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
