### PR TITLE
Improve idempotency of BigQueryInsertJobOperator

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -49,6 +49,8 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = logging.getLogger(__name__)
 
+BigQueryJob = Union[CopyJob, QueryJob, LoadJob, ExtractJob]
+
 
 # pylint: disable=too-many-public-methods
 class BigQueryHook(GoogleBaseHook, DbApiHook):
@@ -1435,7 +1437,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         job_id: Optional[str] = None,
         project_id: Optional[str] = None,
         location: Optional[str] = None,
-    ) -> Union[CopyJob, QueryJob, LoadJob, ExtractJob]:
+    ) -> BigQueryJob:
         """
         Executes a BigQuery job. Waits for the job to complete and returns job id.
         See here:

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1768,6 +1768,7 @@ class BigQueryInsertJobOperator(BaseOperator):
                 raise AirflowException(
                     f"Job with id: {job_id} already exists and is in {job.state} state. If you "
                     f"want to force rerun it consider setting `force_rerun=True`."
+                    f"Or, if you want to reattach in this scenario add {job.state} to `reattach_states`"
                 )
 
         return job.job_id

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -21,22 +21,22 @@
 This module contains Google BigQuery operators.
 """
 import enum
+import hashlib
 import json
 import re
+import uuid
 import warnings
-from time import sleep, time
-from typing import Any, Dict, Iterable, List, Optional, SupportsAbs, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, SupportsAbs, Union
 
 import attr
 from google.api_core.exceptions import Conflict
-from google.api_core.retry import exponential_sleep_generator
 from google.cloud.bigquery import TableReference
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.models.taskinstance import TaskInstance
 from airflow.operators.check_operator import CheckOperator, IntervalCheckOperator, ValueCheckOperator
-from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, BigQueryJob
 from airflow.providers.google.cloud.hooks.gcs import GCSHook, _parse_gcs_url
 from airflow.utils.decorators import apply_defaults
 
@@ -1632,7 +1632,18 @@ class BigQueryUpsertTableOperator(BaseOperator):
 class BigQueryInsertJobOperator(BaseOperator):
     """
     Executes a BigQuery job. Waits for the job to complete and returns job id.
-    See here:
+    This operator work in the following way:
+
+    - it calculates a unique hash of the job using job's configuration or uuid if ``force_rerun`` is True
+    - creates ``job_id`` in form of
+        ``[provided_job_id | airflow_{dag_id}_{task_id}_{exec_date}]_{uniqueness_suffix}``
+    - submits a BigQuery job using the ``job_id``
+    - if job with given id already exists then it tries to reattach to the job if its not done and its
+        state is in ``reattach_states``. If the job is done the operator will raise ``AirflowException``.
+
+    Using ``force_rerun`` will submit a new job everytime without attaching to already existing ones.
+
+    For job definition see here:
 
         https://cloud.google.com/bigquery/docs/reference/v2/jobs
 
@@ -1645,15 +1656,21 @@ class BigQueryInsertJobOperator(BaseOperator):
         configuration field in the job  object. For more details see
         https://cloud.google.com/bigquery/docs/reference/v2/jobs
     :type configuration: Dict[str, Any]
-    :param job_id: The ID of the job. The ID must contain only letters (a-z, A-Z),
-        numbers (0-9), underscores (_), or dashes (-). The maximum length is 1,024
-        characters. If not provided then uuid will be generated.
+    :param job_id: The ID of the job. It will be suffixed with hash of job configuration
+        unless ``force_rerun`` is True.
+        The ID must contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or
+        dashes (-). The maximum length is 1,024 characters. If not provided then uuid will
+        be generated.
     :type job_id: str
+    :param force_rerun: If True then operator will use hash of uuid as job id suffix
+    :type force_rerun: bool
+    :param reattach_states: Set of BigQuery job's states in case of which we should reattach
+        to the job. Should be other than final states.
     :param project_id: Google Cloud Project where the job is running
     :type project_id: str
     :param location: location the job is running
     :type location: str
-    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     """
 
@@ -1667,6 +1684,8 @@ class BigQueryInsertJobOperator(BaseOperator):
         project_id: Optional[str] = None,
         location: Optional[str] = None,
         job_id: Optional[str] = None,
+        force_rerun: bool = False,
+        reattach_states: Optional[Set[str]] = None,
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
         **kwargs,
@@ -1678,6 +1697,8 @@ class BigQueryInsertJobOperator(BaseOperator):
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.force_rerun = force_rerun
+        self.reattach_states: Set[str] = reattach_states or set()
 
     def prepare_template(self) -> None:
         # If .json is passed then we have to read the file
@@ -1685,7 +1706,11 @@ class BigQueryInsertJobOperator(BaseOperator):
             with open(self.configuration, 'r') as file:
                 self.configuration = json.loads(file.read())
 
-    def _submit_job(self, hook: BigQueryHook, job_id: str):
+    def _submit_job(
+        self,
+        hook: BigQueryHook,
+        job_id: str,
+    ) -> BigQueryJob:
         # Submit a new job
         job = hook.insert_job(
             configuration=self.configuration,
@@ -1697,18 +1722,36 @@ class BigQueryInsertJobOperator(BaseOperator):
         job.result()
         return job
 
+    @staticmethod
+    def _handle_job_error(job: BigQueryJob) -> None:
+        if job.error_result:
+            raise AirflowException(f"BigQuery job {job.job_id} failed: {job.error_result}")
+
+    def _job_id(self, context):
+        if self.force_rerun:
+            hash_base = str(uuid.uuid4())
+        else:
+            hash_base = json.dumps(self.configuration, sort_keys=True)
+
+        uniqueness_suffix = hashlib.md5(hash_base.encode()).hexdigest()
+
+        if self.job_id:
+            return f"{self.job_id}_{uniqueness_suffix}"
+
+        exec_date = re.sub(r"\:|-|\+", "_", context['execution_date'].isoformat())
+        return f"airflow_{self.dag_id}_{self.task_id}_{exec_date}_{uniqueness_suffix}"
+
     def execute(self, context: Any):
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
         )
 
-        exec_date = re.sub("\:|\-|\+", "_", context['execution_date'].isoformat())
-        job_id = self.job_id or f"airflow_{self.dag_id}_{self.task_id}_{exec_date}_"
+        job_id = self._job_id(context)
 
         try:
-            # Submit a new job
             job = self._submit_job(hook, job_id)
+            self._handle_job_error(job)
         except Conflict:
             # If the job already exists retrieve it
             job = hook.get_job(
@@ -1716,17 +1759,15 @@ class BigQueryInsertJobOperator(BaseOperator):
                 location=self.location,
                 job_id=job_id,
             )
-
-            if job.done() and job.error_result:
-                # The job exists and finished with an error and we are probably reruning it
-                # So we have to make a new job_id because it has to be unique
-                job_id = f"{self.job_id}_{int(time())}"
-                job = self._submit_job(hook, job_id)
-            elif not job.done():
+            if job.state in self.reattach_states and not job.done():
                 # The job is still running so wait for it to be ready
                 job.result()
-
-        if job.error_result:
-            raise AirflowException(f"BigQuery job {job_id} failed: {job.error_result}")
+                self._handle_job_error(job)
+            elif job.done():
+                # Same job configuration so we need force_rerun
+                raise AirflowException(
+                    f"Job with id: {job_id} already exists and is in {job.state} state. If you "
+                    f"want to force rerun it consider setting `force_rerun=True`."
+                )
 
         return job.job_id

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1759,11 +1759,11 @@ class BigQueryInsertJobOperator(BaseOperator):
                 location=self.location,
                 job_id=job_id,
             )
-            if job.state in self.reattach_states and not job.done():
-                # The job is still running so wait for it to be ready
+            if job.state in self.reattach_states:
+                # We are reattaching to a job
                 job.result()
                 self._handle_job_error(job)
-            elif job.done():
+            else:
                 # Same job configuration so we need force_rerun
                 raise AirflowException(
                     f"Job with id: {job_id} already exists and is in {job.state} state. If you "

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1684,7 +1684,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         project_id: Optional[str] = None,
         location: Optional[str] = None,
         job_id: Optional[str] = None,
-        force_rerun: bool = False,
+        force_rerun: bool = True,
         reattach_states: Optional[Set[str]] = None,
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,


### PR DESCRIPTION
Closes #8903 

This operator work in the following way:
- it calculates unique hash of the job using job's configuration or uuid if ``force_rerun`` is True
- creates ``job_id`` in form of 
``[provide_job_id | airflow_{dag_id}_{task_id}_{exec_date}]_{uniqueness_suffix}``
- submits a BigQuery job using the ``job_id``
- if job with given id already exists then it tries to reattach to the job if its not done and its
state is in ``reattach_states``. If the job is done the operator will raise ``AirflowException``.

Using ``force_rerun`` will submit a new job everytime wihtout attaching to already existing ones.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
