### PR TITLE
Adding new SageMaker operator for ProcessingJobs

### DIFF
--- a/airflow/providers/amazon/aws/hooks/sagemaker.py
+++ b/airflow/providers/amazon/aws/hooks/sagemaker.py
@@ -123,7 +123,7 @@ def secondary_training_status_message(job_description, prev_description):
     return '\n'.join(status_strs)
 
 
-class SageMakerHook(AwsBaseHook):
+class SageMakerHook(AwsBaseHook):   # pylint: disable=too-many-public-methods
     """
     Interact with Amazon SageMaker.
 
@@ -400,6 +400,34 @@ class SageMakerHook(AwsBaseHook):
                               )
         return response
 
+    def create_processing_job(self, config, wait_for_completion=True,
+                              check_interval=30, max_ingestion_time=None):
+        """
+        Create a processing job
+
+        :param config: the config for processing job
+        :type config: dict
+        :param wait_for_completion: if the program should keep running until job finishes
+        :type wait_for_completion: bool
+        :param check_interval: the time interval in seconds which the operator
+            will check the status of any SageMaker job
+        :type check_interval: int
+        :param max_ingestion_time: the maximum ingestion time in seconds. Any
+            SageMaker jobs that run longer than this will fail. Setting this to
+            None implies no timeout for any SageMaker job.
+        :type max_ingestion_time: int
+        :return: A response to transform job creation
+        """
+
+        response = self.get_conn().create_processing_job(**config)
+        if wait_for_completion:
+            self.check_status(config['ProcessingJobName'],
+                              'ProcessingJobStatus',
+                              self.describe_processing_job,
+                              check_interval, max_ingestion_time
+                              )
+        return response
+
     def create_model(self, config):
         """
         Create a model job
@@ -578,6 +606,17 @@ class SageMakerHook(AwsBaseHook):
         """
 
         return self.get_conn().describe_transform_job(TransformJobName=name)
+
+    def describe_processing_job(self, name):
+        """
+        Return the processing job info associated with the name
+
+        :param name: the name of the processing job
+        :type name: str
+        :return: A dict contains all the processing job info
+        """
+
+        return self.get_conn().describe_processing_job(ProcessingJobName=name)
 
     def describe_endpoint_config(self, name):
         """
@@ -783,6 +822,28 @@ class SageMakerHook(AwsBaseHook):
         list_training_jobs_request = partial(self.get_conn().list_training_jobs, **config)
         results = self._list_request(
             list_training_jobs_request, "TrainingJobSummaries", max_results=max_results
+        )
+        return results
+
+    def list_processing_jobs(self, **kwargs) -> List[Dict]:  # noqa: D402
+        """
+        This method wraps boto3's list_processing_jobs(). All arguments should be provided via kwargs.
+        Note boto3 expects these in CamelCase format, for example:
+
+        .. code-block:: python
+
+            list_processing_jobs(NameContains="myjob", StatusEquals="Failed")
+
+        .. seealso::
+            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.list_processing_jobs
+
+        :param kwargs: (optional) kwargs to boto3's list_training_jobs method
+        :return: results of the list_processing_jobs request
+        """
+
+        list_processing_jobs_request = partial(self.get_conn().list_processing_jobs, **kwargs)
+        results = self._list_request(
+            list_processing_jobs_request, "ProcessingJobSummaries", max_results=kwargs.get("MaxResults")
         )
         return results
 

--- a/airflow/providers/amazon/aws/operators/sagemaker_processing.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_processing.py
@@ -1,0 +1,125 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.amazon.aws.operators.sagemaker_base import SageMakerBaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class SageMakerProcessingOperator(SageMakerBaseOperator):
+    """
+    Initiate a SageMaker processing job.
+
+    This operator returns The ARN of the processing job created in Amazon SageMaker.
+
+    :param config: The configuration necessary to start a processing job (templated).
+
+        For details of the configuration parameter see :py:meth:`SageMaker.Client.create_processing_job`
+    :type config: dict
+    :param aws_conn_id: The AWS connection ID to use.
+    :type aws_conn_id: str
+    :param wait_for_completion: If wait is set to True, the time interval, in seconds,
+        that the operation waits to check the status of the processing job.
+    :type wait_for_completion: bool
+    :param print_log: if the operator should print the cloudwatch log during processing
+    :type print_log: bool
+    :param check_interval: if wait is set to be true, this is the time interval
+        in seconds which the operator will check the status of the processing job
+    :type check_interval: int
+    :param max_ingestion_time: If wait is set to True, the operation fails if the processing job
+        doesn't finish within max_ingestion_time seconds. If you set this parameter to None,
+        the operation does not timeout.
+    :type max_ingestion_time: int
+    :param action_if_job_exists: Behaviour if the job name already exists. Possible options are "increment"
+        (default) and "fail".
+    :type action_if_job_exists: str
+    """
+
+    @apply_defaults
+    def __init__(self,
+                 config,
+                 aws_conn_id,
+                 wait_for_completion=True,
+                 print_log=True,
+                 check_interval=30,
+                 max_ingestion_time=None,
+                 action_if_job_exists: str = "increment",  # TODO use typing.Literal for this in Python 3.8
+                 **kwargs):
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
+
+        if action_if_job_exists not in ("increment", "fail"):
+            raise AirflowException(
+                "Argument action_if_job_exists accepts only 'increment' and 'fail'. "
+                f"Provided value: '{action_if_job_exists}'."
+            )
+        self.action_if_job_exists = action_if_job_exists
+        self.wait_for_completion = wait_for_completion
+        self.print_log = print_log
+        self.check_interval = check_interval
+        self.max_ingestion_time = max_ingestion_time
+        self._create_integer_fields()
+
+    def _create_integer_fields(self):
+        """Set fields which should be casted to integers."""
+        self.integer_fields = [
+            ['ProcessingResources', 'ClusterConfig', 'InstanceCount'],
+            ['ProcessingResources', 'ClusterConfig', 'VolumeSizeInGB']
+        ]
+        if 'StoppingCondition' in self.config:
+            self.integer_fields += [
+                ['StoppingCondition', 'MaxRuntimeInSeconds']
+            ]
+
+    def expand_role(self):
+        if 'RoleArn' in self.config:
+            hook = AwsBaseHook(self.aws_conn_id, client_type='iam')
+            self.config['RoleArn'] = hook.expand_role(self.config['RoleArn'])
+
+    def execute(self, context):
+        self.preprocess_config()
+
+        processing_job_name = self.config["ProcessingJobName"]
+        processing_jobs = self.hook.list_processing_jobs(NameContains=processing_job_name)
+
+        # Check if given ProcessingJobName already exists
+        if processing_job_name in [pj["ProcessingJobName"] for pj in processing_jobs]:
+            if self.action_if_job_exists == "fail":
+                raise AirflowException(
+                    f"A SageMaker processing job with name {processing_job_name} already exists."
+                )
+            if self.action_if_job_exists == "increment":
+                self.log.info("Found existing processing job with name '%s'.", processing_job_name)
+                new_processing_job_name = f"{processing_job_name}-{len(processing_jobs) + 1}"
+                self.config["ProcessingJobName"] = new_processing_job_name
+                self.log.info("Incremented processing job name to '%s'.", new_processing_job_name)
+
+        self.log.info("Creating SageMaker processing job %s.", self.config["ProcessingJobName"])
+        response = self.hook.create_processing_job(
+            self.config,
+            wait_for_completion=self.wait_for_completion,
+            check_interval=self.check_interval,
+            max_ingestion_time=self.max_ingestion_time
+        )
+        if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+            raise AirflowException('Sagemaker Processing Job creation failed: %s' % response)
+        return {
+            'Processing': self.hook.describe_processing_job(
+                self.config['ProcessingJobName']
+            )
+        }

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -472,9 +472,10 @@ These integrations allow you to perform various operations within the Amazon Web
        :mod:`airflow.providers.amazon.aws.operators.sagemaker_endpoint_config`,
        :mod:`airflow.providers.amazon.aws.operators.sagemaker_endpoint`,
        :mod:`airflow.providers.amazon.aws.operators.sagemaker_model`,
+       :mod:`airflow.providers.amazon.aws.operators.sagemaker_processing`,
        :mod:`airflow.providers.amazon.aws.operators.sagemaker_training`,
        :mod:`airflow.providers.amazon.aws.operators.sagemaker_transform`,
-       :mod:`airflow.providers.amazon.aws.operators.sagemaker_tuning`
+       :mod:`airflow.providers.amazon.aws.operators.sagemaker_tuning`,
      - :mod:`airflow.providers.amazon.aws.sensors.sagemaker_base`,
        :mod:`airflow.providers.amazon.aws.sensors.sagemaker_endpoint`,
        :mod:`airflow.providers.amazon.aws.sensors.sagemaker_training`,

--- a/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
@@ -1,0 +1,167 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import mock
+from parameterized import parameterized
+
+from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
+from airflow.providers.amazon.aws.operators.sagemaker_processing import SageMakerProcessingOperator
+
+job_name = 'test-job-name'
+
+create_processing_params = {
+    "AppSpecification": {
+        "ContainerArguments": ["container_arg"],
+        "ContainerEntrypoint": ["container_entrypoint"],
+        "ImageUri": "{{ image_uri }}",
+    },
+    "Environment": {"{{ key }}": "{{ value }}"},
+    "ExperimentConfig": {
+        "ExperimentName": "ExperimentName",
+        "TrialComponentDisplayName": "TrialComponentDisplayName",
+        "TrialName": "TrialName",
+    },
+    "ProcessingInputs": [
+        {
+            "InputName": "AnalyticsInputName",
+            "S3Input": {
+                "LocalPath": "{{ Local Path }}",
+                "S3CompressionType": "None",
+                "S3DataDistributionType": "FullyReplicated",
+                "S3DataType": "S3Prefix",
+                "S3InputMode": "File",
+                "S3Uri": "{{ S3Uri }}",
+            },
+        }
+    ],
+    "ProcessingJobName": job_name,
+    "ProcessingOutputConfig": {
+        "KmsKeyId": "KmsKeyID",
+        "Outputs": [
+            {
+                "OutputName": "AnalyticsOutputName",
+                "S3Output": {
+                    "LocalPath": "{{ Local Path }}",
+                    "S3UploadMode": "EndOfJob",
+                    "S3Uri": "{{ S3Uri }}",
+                },
+            }
+        ],
+    },
+    "ProcessingResources": {
+        "ClusterConfig": {
+            "InstanceCount": 2,
+            "InstanceType": "ml.p2.xlarge",
+            "VolumeSizeInGB": 30,
+            "VolumeKmsKeyId": "{{ kms_key }}",
+        }
+    },
+    "RoleArn": "arn:aws:iam::0122345678910:role/SageMakerPowerUser",
+    "Tags": [{"{{ key }}": "{{ value }}"}],
+}
+
+create_processing_params_with_stopping_condition = create_processing_params.copy()
+create_processing_params_with_stopping_condition.update(StoppingCondition={"MaxRuntimeInSeconds": 3600})
+
+
+class TestSageMakerProcessingOperator(unittest.TestCase):
+
+    def setUp(self):
+        self.processing_config_kwargs = dict(task_id='test_sagemaker_operator',
+                                             aws_conn_id='sagemaker_test_id',
+                                             wait_for_completion=False,
+                                             check_interval=5)
+
+    @parameterized.expand([
+        (create_processing_params, [['ProcessingResources', 'ClusterConfig', 'InstanceCount'],
+                                    ['ProcessingResources', 'ClusterConfig', 'VolumeSizeInGB']]),
+        (create_processing_params_with_stopping_condition, [
+            ['ProcessingResources', 'ClusterConfig', 'InstanceCount'],
+            ['ProcessingResources', 'ClusterConfig', 'VolumeSizeInGB'],
+            ['StoppingCondition', 'MaxRuntimeInSeconds']])])
+    def test_integer_fields_are_set(self, config, expected_fields):
+        sagemaker = SageMakerProcessingOperator(**self.processing_config_kwargs, config=config)
+        assert sagemaker.integer_fields == expected_fields
+
+    @mock.patch.object(SageMakerHook, 'get_conn')
+    @mock.patch.object(SageMakerHook, 'create_processing_job',
+                       return_value={'ProcessingJobArn': 'testarn',
+                                     'ResponseMetadata': {'HTTPStatusCode': 200}})
+    def test_execute(self, mock_processing, mock_client):
+        sagemaker = SageMakerProcessingOperator(**self.processing_config_kwargs,
+                                                config=create_processing_params)
+        sagemaker.execute(None)
+        mock_processing.assert_called_once_with(create_processing_params,
+                                                wait_for_completion=False,
+                                                check_interval=5,
+                                                max_ingestion_time=None
+                                                )
+
+    @mock.patch.object(SageMakerHook, 'get_conn')
+    @mock.patch.object(SageMakerHook, 'create_processing_job',
+                       return_value={'ProcessingJobArn': 'testarn',
+                                     'ResponseMetadata': {'HTTPStatusCode': 404}})
+    def test_execute_with_failure(self, mock_processing, mock_client):
+        sagemaker = SageMakerProcessingOperator(**self.processing_config_kwargs,
+                                                config=create_processing_params)
+        self.assertRaises(AirflowException, sagemaker.execute, None)
+
+    @mock.patch.object(SageMakerHook, "get_conn")
+    @mock.patch.object(SageMakerHook, "list_processing_jobs",
+                       return_value=[{"ProcessingJobName": job_name}])
+    @mock.patch.object(SageMakerHook, "create_processing_job",
+                       return_value={"ResponseMetadata": {"HTTPStatusCode": 200}})
+    def test_execute_with_existing_job_increment(
+        self, mock_create_processing_job, mock_list_processing_jobs, mock_client
+    ):
+        sagemaker = SageMakerProcessingOperator(**self.processing_config_kwargs,
+                                                config=create_processing_params)
+        sagemaker.action_if_job_exists = "increment"
+        sagemaker.execute(None)
+
+        expected_config = create_processing_params.copy()
+        # Expect to see ProcessingJobName suffixed with "-2" because we return one existing job
+        expected_config["ProcessingJobName"] = f"{job_name}-2"
+        mock_create_processing_job.assert_called_once_with(
+            expected_config,
+            wait_for_completion=False,
+            check_interval=5,
+            max_ingestion_time=None,
+        )
+
+    @mock.patch.object(SageMakerHook, "get_conn")
+    @mock.patch.object(SageMakerHook, "list_processing_jobs",
+                       return_value=[{"ProcessingJobName": job_name}])
+    @mock.patch.object(SageMakerHook, "create_processing_job",
+                       return_value={"ResponseMetadata": {"HTTPStatusCode": 200}})
+    def test_execute_with_existing_job_fail(
+        self, mock_create_processing_job, mock_list_processing_jobs, mock_client
+    ):
+        sagemaker = SageMakerProcessingOperator(**self.processing_config_kwargs,
+                                                config=create_processing_params)
+        sagemaker.action_if_job_exists = "fail"
+        self.assertRaises(AirflowException, sagemaker.execute, None)
+
+    @mock.patch.object(SageMakerHook, "get_conn")
+    def test_action_if_job_exists_validation(self, mock_client):
+        sagemaker = SageMakerProcessingOperator(**self.processing_config_kwargs,
+                                                config=create_processing_params)
+        self.assertRaises(AirflowException, sagemaker.__init__,
+                          action_if_job_exists="not_fail_or_increment")


### PR DESCRIPTION
**Description of Changes**
Added new SageMaker operator for [ProcessingJobs](https://docs.aws.amazon.com/cli/latest/reference/sagemaker/create-processing-job.html)

**Testing**
Added unit testing for the new ProcessingJobs Operator. Also tested this with local changes to the SageMaker PythonSDK and was able to create/run a DAG for ProcessingJobs. See [relevant PR](https://github.com/aws/sagemaker-python-sdk/pull/1620) for SageMaker PythonSDK.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
