### PR TITLE
Move S3TaskHandler to the provider package

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -61,6 +61,10 @@ More tips can be found in the guide:
 https://developers.google.com/style/inclusive-documentation
 
 -->
+### S3TaskHandler has been moved
+The `S3TaskHandler` class from `airflow.utils.log.s3_task_handler` has been moved to
+`airflow.providers.amazon.aws.log.s3_task_handler`. This is because it has items specific to `aws`
+
 ### SendGrid emailer has been moved
 Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
 package was supported by the community. The project was passed to the Apache community and currently the

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -170,7 +170,7 @@ if REMOTE_LOGGING:
     if REMOTE_BASE_LOG_FOLDER.startswith('s3://'):
         S3_REMOTE_HANDLERS: Dict[str, Dict[str, str]] = {
             'task': {
-                'class': 'airflow.utils.log.s3_task_handler.S3TaskHandler',
+                'class': 'airflow.providers.amazon.aws.log.s3_task_handler.S3TaskHandler',
                 'formatter': 'airflow',
                 'base_log_folder': str(os.path.expanduser(BASE_LOG_FOLDER)),
                 's3_log_folder': REMOTE_BASE_LOG_FOLDER,

--- a/airflow/providers/amazon/aws/log/__init__.py
+++ b/airflow/providers/amazon/aws/log/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,15 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-This module is deprecated. Please use `airflow.providers.amazon.aws.log.s3_task_handler`.
-"""
-import warnings
-
-# pylint: disable=unused-import
-from airflow.providers.amazon.aws.log.s3_task_handler import S3TaskHandler  # noqa
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.amazon.aws.log.s3_task_handler`.",
-    DeprecationWarning, stacklevel=2
-)

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -1,0 +1,182 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+
+from cached_property import cached_property
+
+from airflow.configuration import conf
+from airflow.utils.log.file_task_handler import FileTaskHandler
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+class S3TaskHandler(FileTaskHandler, LoggingMixin):
+    """
+    S3TaskHandler is a python log handler that handles and reads
+    task instance logs. It extends airflow FileTaskHandler and
+    uploads to and reads from S3 remote storage.
+    """
+    def __init__(self, base_log_folder, s3_log_folder, filename_template):
+        super().__init__(base_log_folder, filename_template)
+        self.remote_base = s3_log_folder
+        self.log_relative_path = ''
+        self._hook = None
+        self.closed = False
+        self.upload_on_close = True
+
+    @cached_property
+    def hook(self):
+        """
+        Returns S3Hook.
+        """
+        remote_conn_id = conf.get('logging', 'REMOTE_LOG_CONN_ID')
+        try:
+            from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+            return S3Hook(remote_conn_id)
+        except Exception:  # pylint: disable=broad-except
+            self.log.exception(
+                'Could not create an S3Hook with connection id "%s". '
+                'Please make sure that airflow[aws] is installed and '
+                'the S3 connection exists.', remote_conn_id
+            )
+
+    def set_context(self, ti):
+        super().set_context(ti)
+        # Local location and remote location is needed to open and
+        # upload local log file to S3 remote storage.
+        self.log_relative_path = self._render_filename(ti, ti.try_number)
+        self.upload_on_close = not ti.raw
+
+        # Clear the file first so that duplicate data is not uploaded
+        # when re-using the same path (e.g. with rescheduled sensors)
+        if self.upload_on_close:
+            with open(self.handler.baseFilename, 'w'):
+                pass
+
+    def close(self):
+        """
+        Close and upload local log file to remote storage S3.
+        """
+        # When application exit, system shuts down all handlers by
+        # calling close method. Here we check if logger is already
+        # closed to prevent uploading the log to remote storage multiple
+        # times when `logging.shutdown` is called.
+        if self.closed:
+            return
+
+        super().close()
+
+        if not self.upload_on_close:
+            return
+
+        local_loc = os.path.join(self.local_base, self.log_relative_path)
+        remote_loc = os.path.join(self.remote_base, self.log_relative_path)
+        if os.path.exists(local_loc):
+            # read log and remove old logs to get just the latest additions
+            with open(local_loc, 'r') as logfile:
+                log = logfile.read()
+            self.s3_write(log, remote_loc)
+
+        # Mark closed so we don't double write if close is called twice
+        self.closed = True
+
+    def _read(self, ti, try_number, metadata=None):
+        """
+        Read logs of given task instance and try_number from S3 remote storage.
+        If failed, read the log from task instance host machine.
+
+        :param ti: task instance object
+        :param try_number: task instance try_number to read logs from
+        :param metadata: log metadata,
+                         can be used for steaming log reading and auto-tailing.
+        """
+        # Explicitly getting log relative path is necessary as the given
+        # task instance might be different than task instance passed in
+        # in set_context method.
+        log_relative_path = self._render_filename(ti, try_number)
+        remote_loc = os.path.join(self.remote_base, log_relative_path)
+
+        if self.s3_log_exists(remote_loc):
+            # If S3 remote file exists, we do not fetch logs from task instance
+            # local machine even if there are errors reading remote logs, as
+            # returned remote_log will contain error messages.
+            remote_log = self.s3_read(remote_loc, return_error=True)
+            log = '*** Reading remote log from {}.\n{}\n'.format(
+                remote_loc, remote_log)
+            return log, {'end_of_log': True}
+        else:
+            return super()._read(ti, try_number)
+
+    def s3_log_exists(self, remote_log_location):
+        """
+        Check if remote_log_location exists in remote storage
+
+        :param remote_log_location: log's location in remote storage
+        :return: True if location exists else False
+        """
+        try:
+            return self.hook.get_key(remote_log_location) is not None
+        except Exception:  # pylint: disable=broad-except
+            pass
+        return False
+
+    def s3_read(self, remote_log_location, return_error=False):
+        """
+        Returns the log found at the remote_log_location. Returns '' if no
+        logs are found or there is an error.
+
+        :param remote_log_location: the log's location in remote storage
+        :type remote_log_location: str (path)
+        :param return_error: if True, returns a string error message if an
+            error occurs. Otherwise returns '' when an error occurs.
+        :type return_error: bool
+        """
+        try:
+            return self.hook.read_key(remote_log_location)
+        except Exception:  # pylint: disable=broad-except
+            msg = 'Could not read logs from {}'.format(remote_log_location)
+            self.log.exception(msg)
+            # return error if needed
+            if return_error:
+                return msg
+
+    def s3_write(self, log, remote_log_location, append=True):
+        """
+        Writes the log to the remote_log_location. Fails silently if no hook
+        was created.
+
+        :param log: the log to write to the remote_log_location
+        :type log: str
+        :param remote_log_location: the log's location in remote storage
+        :type remote_log_location: str (path)
+        :param append: if False, any existing log file is overwritten. If True,
+            the new log is appended to any existing logs.
+        :type append: bool
+        """
+        if append and self.s3_log_exists(remote_log_location):
+            old_log = self.s3_read(remote_log_location)
+            log = '\n'.join([old_log, log]) if old_log else log
+
+        try:
+            self.hook.load_string(
+                log,
+                key=remote_log_location,
+                replace=True,
+                encrypt=conf.getboolean('logging', 'ENCRYPT_S3_LOGS'),
+            )
+        except Exception:  # pylint: disable=broad-except
+            self.log.exception('Could not write logs to %s', remote_log_location)

--- a/docs/autoapi_templates/index.rst
+++ b/docs/autoapi_templates/index.rst
@@ -408,3 +408,17 @@ All secrets backends derive from :class:`~airflow.secrets.BaseSecretsBackend`.
   airflow/providers/amazon/aws/secrets/index
   airflow/providers/hashicorp/secrets/index
   airflow/providers/google/cloud/secrets/index
+
+Task Log Handlers
+-----------------
+Task log handlers are python log handlers that handles and reads task instance logs.
+All task log handlers are derived from :class:`~airflow.utils.log.file_task_handler.FileTaskHandler`.
+
+.. toctree::
+  :includehidden:
+  :glob:
+  :maxdepth: 1
+
+  airflow/utils/log/index
+
+  airflow/providers/amazon/aws/log/index

--- a/docs/autoapi_templates/index.rst
+++ b/docs/autoapi_templates/index.rst
@@ -419,6 +419,5 @@ All task log handlers are derived from :class:`~airflow.utils.log.file_task_hand
   :glob:
   :maxdepth: 1
 
-  airflow/utils/log/index
 
   airflow/providers/amazon/aws/log/index

--- a/tests/providers/amazon/aws/log/__init__.py
+++ b/tests/providers/amazon/aws/log/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,15 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-This module is deprecated. Please use `airflow.providers.amazon.aws.log.s3_task_handler`.
-"""
-import warnings
-
-# pylint: disable=unused-import
-from airflow.providers.amazon.aws.log.s3_task_handler import S3TaskHandler  # noqa
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.amazon.aws.log.s3_task_handler`.",
-    DeprecationWarning, stacklevel=2
-)

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -23,7 +23,7 @@ from unittest import mock
 from airflow.models import DAG, TaskInstance
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.utils.log.s3_task_handler import S3TaskHandler
+from airflow.providers.amazon.aws.log.s3_task_handler import S3TaskHandler
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from tests.test_utils.config import conf_vars
@@ -119,7 +119,7 @@ class TestS3TaskHandler(unittest.TestCase):
     def test_set_context_raw(self):
         self.ti.raw = True
         mock_open = mock.mock_open()
-        with mock.patch('airflow.utils.log.s3_task_handler.open', mock_open):
+        with mock.patch('airflow.providers.amazon.aws.log.s3_task_handler.open', mock_open):
             self.s3_task_handler.set_context(self.ti)
 
         self.assertFalse(self.s3_task_handler.upload_on_close)
@@ -127,7 +127,7 @@ class TestS3TaskHandler(unittest.TestCase):
 
     def test_set_context_not_raw(self):
         mock_open = mock.mock_open()
-        with mock.patch('airflow.utils.log.s3_task_handler.open', mock_open):
+        with mock.patch('airflow.providers.amazon.aws.log.s3_task_handler.open', mock_open):
             self.s3_task_handler.set_context(self.ti)
 
         self.assertTrue(self.s3_task_handler.upload_on_close)


### PR DESCRIPTION
---
This PR fixes one of the issues listed in #9386

The `S3TaskHandler` class from `airflow.utils.log.s3_task_handler` was moved to
`airflow.providers.amazon.aws.log.s3_task_handler`.

Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
