### PR TITLE
Restrict editing DagRun State in the old UI

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -71,8 +71,7 @@ Now use NULL as default value for dag.description in dag table
 Before 1.10.11 it was possible to edit DagRun State in the `/admin/dagrun/` page
  to any text.
 
-From Airflow 1.10.11, you would still be able to set from dropdown to a pre-defined option
- but would not allow setting it to any text.
+In Airflow 1.10.11+, the user can only choose the states from the list.
 
 ## Airflow 1.10.10
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -66,6 +66,14 @@ https://developers.google.com/style/inclusive-documentation
 
 Now use NULL as default value for dag.description in dag table
 
+### Restrict editing DagRun State in the old UI (Flask-admin based UI)
+
+Before 1.10.11 it was possible to edit DagRun State in the `/admin/dagrun/` page
+ to any text.
+
+From Airflow 1.10.11, you would still be able to set from dropdown to a pre-defined option
+ but would not allow setting it to any text.
+
 ## Airflow 1.10.10
 
 ### Setting Empty string to a Airflow Variable will return an empty string

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2818,7 +2818,6 @@ class DagRunModelView(ModelViewOnly):
     verbose_name_plural = "DAG Runs"
     can_edit = True
     can_create = True
-    column_editable_list = ('state',)
     verbose_name = "dag run"
     column_default_sort = ('execution_date', True)
     form_choices = {


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/8717

Restrict editing DagRun State in the old UI after clicking on the state itself. We can still click on the checkbox and update the state from dropdown

**Before**:

![image](https://user-images.githubusercontent.com/8811558/86262058-4dfc2180-bbb7-11ea-9cb0-158218cb4c21.png)


**After**:

![image](https://user-images.githubusercontent.com/8811558/86261288-4425ee80-bbb6-11ea-96c4-928e3ecf60b9.png)


---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
