### PR TITLE
Restrict changing XCom values from the Webserver

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -293,10 +293,10 @@ plugins =
   airflow.mypy.plugin.decorators
 ```
 
-### Xcom Values can no longer be edited in the UI
+### XCom Values can no longer be changed from the Webserver
 
-Since XCom values can contain pickled data, we would no longer allow editing
-Xcom values from the UI.
+Since XCom values can contain pickled data, we would no longer allow changing
+XCom values from the UI.
 
 ### Use project_id argument consistently across GCP hooks and operators
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -293,6 +293,11 @@ plugins =
   airflow.mypy.plugin.decorators
 ```
 
+### Xcom Values can no longer be edited in the UI
+
+Since XCom values can contain pickled data, we would no longer allow editing
+Xcom values from the UI.
+
 ### Use project_id argument consistently across GCP hooks and operators
 
 - Changed order of arguments in DataflowHook.start_python_dataflow. Uses

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -293,10 +293,10 @@ plugins =
   airflow.mypy.plugin.decorators
 ```
 
-### XCom Values can no longer be changed from the Webserver
+### XCom Values can no longer be added or changed from the Webserver
 
-Since XCom values can contain pickled data, we would no longer allow changing
-XCom values from the UI.
+Since XCom values can contain pickled data, we would no longer allow adding or
+changing XCom values from the UI.
 
 ### Use project_id argument consistently across GCP hooks and operators
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2192,12 +2192,11 @@ class XComModelView(AirflowModelView):
 
     datamodel = AirflowModelView.CustomSQLAInterface(XCom)
 
-    base_permissions = ['can_add', 'can_list', 'can_edit', 'can_delete']
+    base_permissions = ['can_add', 'can_list', 'can_delete']
 
     search_columns = ['key', 'value', 'timestamp', 'execution_date', 'task_id', 'dag_id']
     list_columns = ['key', 'value', 'timestamp', 'execution_date', 'task_id', 'dag_id']
     add_columns = ['key', 'value', 'execution_date', 'task_id', 'dag_id']
-    edit_columns = ['key', 'value', 'execution_date', 'task_id', 'dag_id']
     base_order = ('execution_date', 'desc')
 
     base_filters = [['dag_id', DagFilter, lambda: []]]

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2192,11 +2192,10 @@ class XComModelView(AirflowModelView):
 
     datamodel = AirflowModelView.CustomSQLAInterface(XCom)
 
-    base_permissions = ['can_add', 'can_list', 'can_delete']
+    base_permissions = ['can_list', 'can_delete']
 
     search_columns = ['key', 'value', 'timestamp', 'execution_date', 'task_id', 'dag_id']
     list_columns = ['key', 'value', 'timestamp', 'execution_date', 'task_id', 'dag_id']
-    add_columns = ['key', 'value', 'execution_date', 'task_id', 'dag_id']
     base_order = ('execution_date', 'desc')
 
     base_filters = [['dag_id', DagFilter, lambda: []]]


### PR DESCRIPTION
Since XCom values can contain pickled data, we would no longer allow editing Xcom values from the UI.

We don't allow changing DAG files from the UI, so this brings XComs in line with that

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
