### PR TITLE
Mask other forms of password arguments in SparkSubmitOperator

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -237,8 +237,23 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         # Mask any password related fields in application args with key value pair
         # where key contains password (case insensitive), e.g. HivePassword='abc'
         connection_cmd_masked = re.sub(
-            r"(\S*?(?:secret|password)\S*?\s*=\s*')[^']*(?=')",
-            r'\1******', ' '.join(connection_cmd), flags=re.I)
+            r"("
+            r"\S*?"                 # Match all non-whitespace characters before...
+            r"(?:secret|password)"  # ...literally a "secret" or "password"
+                                    # word (not capturing them).
+            r"\S*?"                 # All non-whitespace characters before either...
+            r"(?:=|\s+)"            # ...an equal sign or whitespace characters
+                                    # (not capturing them).
+            r"(['\"]?)"             # An optional single or double quote.
+            r")"                    # This is the end of the first capturing group.
+            r"(?:(?!\2\s).)*"       # All characters between optional quotes
+                                    # (matched above); if the value is quoted,
+                                    # it may contain whitespace.
+            r"(\2)",                # Optional matching quote.
+            r'\1******\3',
+            ' '.join(connection_cmd),
+            flags=re.I,
+        )
 
         return connection_cmd_masked
 

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -754,42 +754,38 @@ class TestSparkSubmitHook(unittest.TestCase):
     @parameterized.expand(
         (
             (
-                ("spark-submit", "foo", "--bar", "baz", "--password='secret'"),
-                "spark-submit foo --bar baz --password='******'",
-            ),
-            (
-                ("spark-submit", "foo", "--bar", "baz", "--secret='secret'"),
-                "spark-submit foo --bar baz --secret='******'",
-            ),
-            (
-                ("spark-submit", "foo", "--bar", "baz", "--foo.password='secret'"),
-                "spark-submit foo --bar baz --foo.password='******'",
-            ),
-            (
-                ("spark-submit", "foo", "--bar", "baz", "--foo.password='secret'"),
-                "spark-submit foo --bar baz --foo.password='******'",
-            ),
-            (
                 ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "--foo", "bar"),
                 "spark-submit foo --bar baz --password='******' --foo bar",
             ),
             (
-                ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "--foo=bar"),
-                "spark-submit foo --bar baz --password='******' --foo=bar",
+                ("spark-submit", "foo", "--bar", "baz", "--password='secret'"),
+                "spark-submit foo --bar baz --password='******'",
             ),
             (
-                ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "--foo='bar'"),
-                "spark-submit foo --bar baz --password='******' --foo='bar'",
+                ("spark-submit", "foo", "--bar", "baz", '--password="secret"'),
+                'spark-submit foo --bar baz --password="******"',
             ),
             (
-                ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "bar"),
-                "spark-submit foo --bar baz --password='******' bar",
+                ("spark-submit", "foo", "--bar", "baz", '--password=secret'),
+                'spark-submit foo --bar baz --password=******',
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--password 'secret'"),
+                "spark-submit foo --bar baz --password '******'",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--password='sec\"ret'"),
+                "spark-submit foo --bar baz --password='******'",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", '--password="sec\'ret"'),
+                'spark-submit foo --bar baz --password="******"',
             ),
             (
                 ("spark-submit",),
                 "spark-submit",
             ),
-        ),
+        )
     )
     def test_masks_passwords(self, command: str, expected: str) -> None:
         # Given

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -20,6 +20,8 @@ import io
 import unittest
 from unittest.mock import call, patch
 
+from parameterized import parameterized
+
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.apache.spark.hooks.spark_submit import SparkSubmitHook
@@ -748,3 +750,53 @@ class TestSparkSubmitHook(unittest.TestCase):
         client.delete_namespaced_pod.assert_called_once_with(
             'spark-pi-edf2ace37be7353a958b38733a12f8e6-driver',
             'mynamespace', **kwargs)
+
+    @parameterized.expand(
+        (
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--password='secret'"),
+                "spark-submit foo --bar baz --password='******'",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--secret='secret'"),
+                "spark-submit foo --bar baz --secret='******'",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--foo.password='secret'"),
+                "spark-submit foo --bar baz --foo.password='******'",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--foo.password='secret'"),
+                "spark-submit foo --bar baz --foo.password='******'",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "--foo", "bar"),
+                "spark-submit foo --bar baz --password='******' --foo bar",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "--foo=bar"),
+                "spark-submit foo --bar baz --password='******' --foo=bar",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "--foo='bar'"),
+                "spark-submit foo --bar baz --password='******' --foo='bar'",
+            ),
+            (
+                ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "bar"),
+                "spark-submit foo --bar baz --password='******' bar",
+            ),
+            (
+                ("spark-submit",),
+                "spark-submit",
+            ),
+        ),
+    )
+    def test_masks_passwords(self, command: str, expected: str) -> None:
+        # Given
+        hook = SparkSubmitHook()
+
+        # When
+        command_masked = hook._mask_cmd(command)
+
+        # Then
+        assert command_masked == expected


### PR DESCRIPTION
This is a follow-up to #6917. Related: #9595.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).
