### PR TITLE
local job heartbeat callback should use session from provide_session

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -135,7 +135,11 @@ class LocalTaskJob(BaseJob):
             self.task_runner.terminate()
             return
 
-        self.task_instance.refresh_from_db()
+        if session is None:
+            self.task_instance.refresh_from_db()
+        else:
+            self.task_instance.refresh_from_db(session=session)
+
         ti = self.task_instance
 
         if ti.state == State.RUNNING:

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -113,7 +113,8 @@ class TestLocalTaskJob(unittest.TestCase):
         job1 = LocalTaskJob(task_instance=ti,
                             ignore_ti_state=True,
                             executor=SequentialExecutor())
-        self.assertRaises(AirflowException, job1.heartbeat_callback)
+        with self.assertRaises(AirflowException):
+            job1.heartbeat_callback(session=None)
 
         mock_pid.return_value = 1
         ti.state = State.RUNNING
@@ -125,7 +126,8 @@ class TestLocalTaskJob(unittest.TestCase):
         job1.heartbeat_callback(session=None)
 
         mock_pid.return_value = 2
-        self.assertRaises(AirflowException, job1.heartbeat_callback)
+        with self.assertRaises(AirflowException):
+            job1.heartbeat_callback(session=None)
 
     @patch('os.getpid')
     def test_heartbeat_failed_fast(self, mock_getpid):


### PR DESCRIPTION
so that the `refresh_from_db` will not check out a new db connection.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.


@KevinYang21 