### PR TITLE
Update docs about the change to default auth for experimental API

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -77,8 +77,7 @@ deny all requests:
     posed security risks for if the Webserver is publicly accessible.
 
 If you wish to have the experimental API work, and aware of the risks of enabling this without authentication
-(or if you have your own authentication layer in front of Airflow) you can get
-the previous behaviour on a new install by setting this in your airflow.cfg:
+(or if you have your own authentication layer in front of Airflow) you can set the following in ``airflow.cfg``:
 
 .. code-block:: ini
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -80,10 +80,10 @@ If you wish to have the experimental API work, and aware of the risks of enablin
 (or if you have your own authentication layer in front of Airflow) you can get
 the previous behaviour on a new install by setting this in your airflow.cfg:
 
-```
-[api]
-auth_backend = airflow.api.auth.backend.default
-```
+.. code-block:: ini
+
+    [api]
+    auth_backend = airflow.api.auth.backend.default
 
 Kerberos authentication is currently supported for the API.
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -63,14 +63,27 @@ OAuth, OpenID, LDAP, REMOTE_USER. You can configure in ``webserver_config.py``. 
 API Authentication
 ------------------
 
-Authentication for the API is handled separately to the Web Authentication. The default is to not
-require any authentication on the API i.e. wide open by default. This is not recommended if your
-Airflow webserver is publicly accessible, and you should probably use the ``deny all`` backend:
+Authentication for the API is handled separately to the Web Authentication. The default is to
+deny all requests:
 
 .. code-block:: ini
 
     [api]
     auth_backend = airflow.api.auth.backend.deny_all
+
+.. versionchanged:: 1.10.11
+
+    In Airflow <1.10.11, the default setting was to allow all API requests without authentication, but this
+    posed security risks for if the Webserver is publicly accessible.
+
+If you wish to have the experimental API work, and aware of the risks of enabling this without authentication
+(or if you have your own authentication layer in front of Airflow) you can get
+the previous behaviour on a new install by setting this in your airflow.cfg:
+
+```
+[api]
+auth_backend = airflow.api.auth.backend.default
+```
 
 Kerberos authentication is currently supported for the API.
 


### PR DESCRIPTION
https://github.com/apache/airflow/issues/9611 updated the default but we missed to change our docs

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
