### PR TITLE
Fix docstrings in exceptions.py

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -140,7 +140,7 @@ class BackfillUnfinished(AirflowException):
     Raises when not all tasks succeed in backfill.
 
     :param message: The human-readable description of the exception
-    :zparam ti_status: The information about all task statuses
+    :param ti_status: The information about all task statuses
     """
     def __init__(self, message, ti_status):
         super().__init__(message)


### PR DESCRIPTION
Fix incorrect docstrings

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
