### PR TITLE
Use supports_read instead of is_supported in log endpoint 

### DIFF
--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -50,7 +50,7 @@ def get_log(session, dag_id, dag_run_id, task_id, task_try_number,
         metadata['download_logs'] = False
 
     task_log_reader = TaskLogReader()
-    if not task_log_reader.is_supported:
+    if not task_log_reader.supports_read:
         raise BadRequest("Task log handler does not support read logs.")
 
     query = session.query(DagRun).filter(DagRun.dag_id == dag_id)

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -219,7 +219,7 @@ class TestGetLog(unittest.TestCase):
 
     @mock.patch("airflow.api_connexion.endpoints.log_endpoint.TaskLogReader")
     def test_get_logs_for_handler_without_read_method(self, mock_log_reader):
-        type(mock_log_reader.return_value).is_supported = PropertyMock(return_value=False)
+        type(mock_log_reader.return_value).supports_read = PropertyMock(return_value=False)
 
         key = self.app.config["SECRET_KEY"]
         serializer = URLSafeSerializer(key)


### PR DESCRIPTION
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

`is_supported` was renamed to `supports_read` in https://github.com/apache/airflow/pull/9354 , renaming the missed ones as well 