### PR TITLE
Allow setting Hashicorp Vault token from File

### DIFF
--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -89,6 +89,9 @@ class VaultHook(BaseHook):
     :param kubernetes_jwt_path: Path for kubernetes jwt token (for ``kubernetes`` auth_type, default:
         ``/var/run/secrets/kubernetes.io/serviceaccount/token``)
     :type kubernetes_jwt_path: str
+    :param token_path: path to file containing authentication token to include in requests sent to Vault
+        (for ``token`` and ``github`` auth_type).
+    :type token_path: str
     :param gcp_key_path: Path to GCP Credential JSON file (for ``gcp`` auth_type)
            Mutually exclusive with gcp_keyfile_dict
     :type gcp_key_path: str
@@ -114,6 +117,7 @@ class VaultHook(BaseHook):
         role_id: Optional[str] = None,
         kubernetes_role: Optional[str] = None,
         kubernetes_jwt_path: Optional[str] = None,
+        token_path: Optional[str] = None,
         gcp_key_path: Optional[str] = None,
         gcp_scopes: Optional[str] = None,
         azure_tenant_id: Optional[str] = None,
@@ -178,6 +182,7 @@ class VaultHook(BaseHook):
             mount_point=mount_point,
             kv_engine_version=kv_engine_version,
             token=self.connection.password,
+            token_path=token_path,
             username=self.connection.login,
             password=self.connection.password,
             key_id=self.connection.login,

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -69,6 +69,9 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     :param token: Authentication token to include in requests sent to Vault.
         (for ``token`` and ``github`` auth_type)
     :type token: str
+    :param token_path: path to file containing authentication token to include in requests sent to Vault
+        (for ``token`` and ``github`` auth_type).
+    :type token_path: str
     :param username: Username for Authentication (for ``ldap`` and ``userpass`` auth_type).
     :type username: str
     :param password: Password for Authentication (for ``ldap`` and ``userpass`` auth_type).
@@ -114,6 +117,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         mount_point: str = 'secret',
         kv_engine_version: int = 2,
         token: Optional[str] = None,
+        token_path: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
         key_id: Optional[str] = None,
@@ -143,6 +147,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
             mount_point=mount_point,
             kv_engine_version=kv_engine_version,
             token=token,
+            token_path=token_path,
             username=username,
             password=password,
             key_id=key_id,

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -479,6 +479,21 @@ class TestVaultClient(TestCase):
         self.assertEqual("secret", vault_client.mount_point)
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_token_path(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+        with open('/tmp/test_token.txt', 'w+') as the_file:
+            the_file.write('s.7AU0I51yv1Q1lxOIg1F3ZRAS')
+        vault_client = _VaultClient(auth_type="token",
+                                    token_path="/tmp/test_token.txt", url="http://localhost:8180")
+        client = vault_client.client
+        mock_hvac.Client.assert_called_with(url='http://localhost:8180')
+        client.is_authenticated.assert_called_with()
+        self.assertEqual("s.7AU0I51yv1Q1lxOIg1F3ZRAS", client.token)
+        self.assertEqual(2, vault_client.kv_engine_version)
+        self.assertEqual("secret", vault_client.mount_point)
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_default_auth_type(self, mock_hvac):
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client


### PR DESCRIPTION
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

Add `token_path` parameter to the vault client, hook and secret backend so that we can supply the file containing the token instead of explicitly providing the token value