### PR TITLE
Get Airflow configs with sensitive data from Secret Backends

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -119,7 +119,7 @@ class AirflowConfigParser(ConfigParser):
     # is to not store password on boxes in text files.
     # These configs can also be fetched from Secrets backend
     # following the "{section}__{name}__secret" pattern
-    configs_with_secret = {
+    senstive_config_values = {
         ('core', 'sql_alchemy_conn'),
         ('core', 'fernet_key'),
         ('celery', 'broker_url'),
@@ -271,13 +271,13 @@ class AirflowConfigParser(ConfigParser):
         env_var_cmd = env_var + '_CMD'
         if env_var_cmd in os.environ:
             # if this is a valid command key...
-            if (section, key) in self.configs_with_secret:
+            if (section, key) in self.senstive_config_values:
                 return run_command(os.environ[env_var_cmd])
 
     def _get_cmd_option(self, section, key):
         fallback_key = key + '_cmd'
         # if this is a valid command key...
-        if (section, key) in self.configs_with_secret:
+        if (section, key) in self.senstive_config_values:
             if super().has_option(section, fallback_key):
                 command = super().get(section, fallback_key)
                 return run_command(command)
@@ -309,10 +309,10 @@ class AirflowConfigParser(ConfigParser):
             return None
         fallback_key = key + '_secret'
         # if this is a valid secret key...
-        if (section, key) in self.configs_with_secret:
+        if (section, key) in self.senstive_config_values:
             if super().has_option(section, fallback_key):
                 secrets_path = super().get(section, fallback_key)
-                return secrets_client.get_configuration(secrets_path)
+                return secrets_client.get_config(secrets_path)
 
     def get(self, section, key, **kwargs):
         section = str(section).lower()
@@ -590,7 +590,7 @@ class AirflowConfigParser(ConfigParser):
 
         # add bash commands
         if include_cmds:
-            for (section, key) in self.configs_with_secret:
+            for (section, key) in self.senstive_config_values:
                 opt = self._get_cmd_option(section, key)
                 if opt:
                     if not display_sensitive:
@@ -604,7 +604,7 @@ class AirflowConfigParser(ConfigParser):
 
         # add config from secret backends
         if include_secret:
-            for (section, key) in self.configs_with_secret:
+            for (section, key) in self.senstive_config_values:
                 opt = self._get_secret_option(section, key)
                 if opt:
                     if not display_sensitive:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -281,11 +281,11 @@ class AirflowConfigParser(ConfigParser):
             if (section, key) in self.sensitive_config_values:
                 return run_command(os.environ[env_var_cmd])
         # alternatively AIRFLOW__{SECTION}__{KEY}_SECRET (to get from Secrets Backend)
-        env_var_cmd = env_var + '_SECRET'
-        if env_var_cmd in os.environ:
-            # if this is a valid command key...
+        env_var_secret_path = env_var + '_SECRET'
+        if env_var_secret_path in os.environ:
+            # if this is a valid secret path...
             if (section, key) in self.sensitive_config_values:
-                return _get_config_value_from_secret_backend(os.environ[env_var_cmd])
+                return _get_config_value_from_secret_backend(os.environ[env_var_secret_path])
 
     def _get_cmd_option(self, section, key):
         fallback_key = key + '_cmd'

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -31,7 +31,6 @@ from base64 import b64encode
 from collections import OrderedDict
 # Ignored Mypy on configparser because it thinks the configparser module has no _UNSET attribute
 from configparser import _UNSET, ConfigParser, NoOptionError, NoSectionError  # type: ignore
-from json import JSONDecodeError
 from typing import Dict, Optional, Tuple, Union
 
 import yaml
@@ -298,7 +297,7 @@ class AirflowConfigParser(ConfigParser):
                 alternative_secrets_config_dict = json.loads(
                     super().get('secrets', 'backend_kwargs', fallback='{}')
                 )
-            except JSONDecodeError:
+            except json.JSONDecodeError:
                 alternative_secrets_config_dict = {}
             return secrets_backend(**alternative_secrets_config_dict)
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -119,7 +119,7 @@ class AirflowConfigParser(ConfigParser):
     # is to not store password on boxes in text files.
     # These configs can also be fetched from Secrets backend
     # following the "{section}__{name}__secret" pattern
-    senstive_config_values = {
+    sensitive_config_values = {
         ('core', 'sql_alchemy_conn'),
         ('core', 'fernet_key'),
         ('celery', 'broker_url'),
@@ -271,13 +271,13 @@ class AirflowConfigParser(ConfigParser):
         env_var_cmd = env_var + '_CMD'
         if env_var_cmd in os.environ:
             # if this is a valid command key...
-            if (section, key) in self.senstive_config_values:
+            if (section, key) in self.sensitive_config_values:
                 return run_command(os.environ[env_var_cmd])
 
     def _get_cmd_option(self, section, key):
         fallback_key = key + '_cmd'
         # if this is a valid command key...
-        if (section, key) in self.senstive_config_values:
+        if (section, key) in self.sensitive_config_values:
             if super().has_option(section, fallback_key):
                 command = super().get(section, fallback_key)
                 return run_command(command)
@@ -309,7 +309,7 @@ class AirflowConfigParser(ConfigParser):
             return None
         fallback_key = key + '_secret'
         # if this is a valid secret key...
-        if (section, key) in self.senstive_config_values:
+        if (section, key) in self.sensitive_config_values:
             if super().has_option(section, fallback_key):
                 secrets_path = super().get(section, fallback_key)
                 return secrets_client.get_config(secrets_path)
@@ -590,7 +590,7 @@ class AirflowConfigParser(ConfigParser):
 
         # add bash commands
         if include_cmds:
-            for (section, key) in self.senstive_config_values:
+            for (section, key) in self.sensitive_config_values:
                 opt = self._get_cmd_option(section, key)
                 if opt:
                     if not display_sensitive:
@@ -604,7 +604,7 @@ class AirflowConfigParser(ConfigParser):
 
         # add config from secret backends
         if include_secret:
-            for (section, key) in self.senstive_config_values:
+            for (section, key) in self.sensitive_config_values:
                 opt = self._get_secret_option(section, key)
                 if opt:
                     if not display_sensitive:

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -44,8 +44,8 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     if you provide ``{"connections_prefix": "airflow/connections"}`` and request conn_id ``smtp_default``.
     If variables prefix is ``airflow/variables/hello``, this would be accessible
     if you provide ``{"variables_prefix": "airflow/variables"}`` and request variable key ``hello``.
-    And if configurations_prefix is ``airflow/configurations/sql_alchemy_conn``, this would be accessible
-    if you provide ``{"configurations_prefix": "airflow/configurations"}`` and request variable
+    And if configs_prefix is ``airflow/configs/sql_alchemy_conn``, this would be accessible
+    if you provide ``{"configs_prefix": "airflow/configs"}`` and request variable
     key ``sql_alchemy_conn``.
 
     You can also pass additional keyword arguments like ``aws_secret_access_key``, ``aws_access_key_id``
@@ -55,8 +55,8 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     :type connections_prefix: str
     :param variables_prefix: Specifies the prefix of the secret to read to get Variables.
     :type variables_prefix: str
-    :param configurations_prefix: Specifies the prefix of the secret to read to get Variables.
-    :type configurations_prefix: str
+    :param configs_prefix: Specifies the prefix of the secret to read to get Variables.
+    :type configs_prefix: str
     :param profile_name: The name of a profile to use. If not given, then the default profile is used.
     :type profile_name: str
     :param sep: separator used to concatenate secret_prefix and secret_id. Default: "/"
@@ -67,7 +67,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         self,
         connections_prefix: str = 'airflow/connections',
         variables_prefix: str = 'airflow/variables',
-        configurations_prefix: str = 'airflow/configuration',
+        configs_prefix: str = 'airflow/configs',
         profile_name: Optional[str] = None,
         sep: str = "/",
         **kwargs
@@ -75,7 +75,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         super().__init__()
         self.connections_prefix = connections_prefix.rstrip("/")
         self.variables_prefix = variables_prefix.rstrip('/')
-        self.configurations_prefix = configurations_prefix.rstrip('/')
+        self.configs_prefix = configs_prefix.rstrip('/')
         self.profile_name = profile_name
         self.sep = sep
         self.kwargs = kwargs
@@ -108,14 +108,14 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         """
         return self._get_secret(self.variables_prefix, key)
 
-    def get_configuration(self, key: str) -> Optional[str]:
+    def get_config(self, key: str) -> Optional[str]:
         """
         Get Airflow Configuration
 
         :param key: Configuration Option Key
         :return: Configuration Option Value
         """
-        return self._get_secret(self.configurations_prefix, key)
+        return self._get_secret(self.configs_prefix, key)
 
     def _get_secret(self, path_prefix: str, secret_id: str) -> Optional[str]:
         """

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -45,7 +45,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     If variables prefix is ``airflow/variables/hello``, this would be accessible
     if you provide ``{"variables_prefix": "airflow/variables"}`` and request variable key ``hello``.
     And if config_prefix is ``airflow/config/sql_alchemy_conn``, this would be accessible
-    if you provide ``{"config_prefix": "airflow/config"}`` and request variable
+    if you provide ``{"config_prefix": "airflow/config"}`` and request config
     key ``sql_alchemy_conn``.
 
     You can also pass additional keyword arguments like ``aws_secret_access_key``, ``aws_access_key_id``

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -44,8 +44,8 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     if you provide ``{"connections_prefix": "airflow/connections"}`` and request conn_id ``smtp_default``.
     If variables prefix is ``airflow/variables/hello``, this would be accessible
     if you provide ``{"variables_prefix": "airflow/variables"}`` and request variable key ``hello``.
-    And if configs_prefix is ``airflow/configs/sql_alchemy_conn``, this would be accessible
-    if you provide ``{"configs_prefix": "airflow/configs"}`` and request variable
+    And if config_prefix is ``airflow/config/sql_alchemy_conn``, this would be accessible
+    if you provide ``{"config_prefix": "airflow/config"}`` and request variable
     key ``sql_alchemy_conn``.
 
     You can also pass additional keyword arguments like ``aws_secret_access_key``, ``aws_access_key_id``
@@ -55,8 +55,8 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     :type connections_prefix: str
     :param variables_prefix: Specifies the prefix of the secret to read to get Variables.
     :type variables_prefix: str
-    :param configs_prefix: Specifies the prefix of the secret to read to get Variables.
-    :type configs_prefix: str
+    :param config_prefix: Specifies the prefix of the secret to read to get Variables.
+    :type config_prefix: str
     :param profile_name: The name of a profile to use. If not given, then the default profile is used.
     :type profile_name: str
     :param sep: separator used to concatenate secret_prefix and secret_id. Default: "/"
@@ -67,7 +67,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         self,
         connections_prefix: str = 'airflow/connections',
         variables_prefix: str = 'airflow/variables',
-        configs_prefix: str = 'airflow/configs',
+        config_prefix: str = 'airflow/config',
         profile_name: Optional[str] = None,
         sep: str = "/",
         **kwargs
@@ -75,7 +75,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         super().__init__()
         self.connections_prefix = connections_prefix.rstrip("/")
         self.variables_prefix = variables_prefix.rstrip('/')
-        self.configs_prefix = configs_prefix.rstrip('/')
+        self.config_prefix = config_prefix.rstrip('/')
         self.profile_name = profile_name
         self.sep = sep
         self.kwargs = kwargs
@@ -115,7 +115,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param key: Configuration Option Key
         :return: Configuration Option Value
         """
-        return self._get_secret(self.configs_prefix, key)
+        return self._get_secret(self.config_prefix, key)
 
     def _get_secret(self, path_prefix: str, secret_id: str) -> Optional[str]:
         """

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -42,8 +42,11 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
     For example, if secrets prefix is ``airflow/connections/smtp_default``, this would be accessible
     if you provide ``{"connections_prefix": "airflow/connections"}`` and request conn_id ``smtp_default``.
-    And if variables prefix is ``airflow/variables/hello``, this would be accessible
+    If variables prefix is ``airflow/variables/hello``, this would be accessible
     if you provide ``{"variables_prefix": "airflow/variables"}`` and request variable key ``hello``.
+    And if configurations_prefix is ``airflow/configurations/sql_alchemy_conn``, this would be accessible
+    if you provide ``{"configurations_prefix": "airflow/configurations"}`` and request variable
+    key ``sql_alchemy_conn``.
 
     You can also pass additional keyword arguments like ``aws_secret_access_key``, ``aws_access_key_id``
     or ``region_name`` to this class and they would be passed on to Boto3 client.
@@ -52,6 +55,8 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     :type connections_prefix: str
     :param variables_prefix: Specifies the prefix of the secret to read to get Variables.
     :type variables_prefix: str
+    :param configurations_prefix: Specifies the prefix of the secret to read to get Variables.
+    :type configurations_prefix: str
     :param profile_name: The name of a profile to use. If not given, then the default profile is used.
     :type profile_name: str
     :param sep: separator used to concatenate secret_prefix and secret_id. Default: "/"
@@ -62,6 +67,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         self,
         connections_prefix: str = 'airflow/connections',
         variables_prefix: str = 'airflow/variables',
+        configurations_prefix: str = 'airflow/configuration',
         profile_name: Optional[str] = None,
         sep: str = "/",
         **kwargs
@@ -69,6 +75,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         super().__init__()
         self.connections_prefix = connections_prefix.rstrip("/")
         self.variables_prefix = variables_prefix.rstrip('/')
+        self.configurations_prefix = configurations_prefix.rstrip('/')
         self.profile_name = profile_name
         self.sep = sep
         self.kwargs = kwargs
@@ -94,12 +101,21 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
     def get_variable(self, key: str) -> Optional[str]:
         """
-        Get Airflow Variable from Environment Variable
+        Get Airflow Variable
 
         :param key: Variable Key
         :return: Variable Value
         """
         return self._get_secret(self.variables_prefix, key)
+
+    def get_configuration(self, key: str) -> Optional[str]:
+        """
+        Get Airflow Configuration
+
+        :param key: Configuration Option Key
+        :return: Configuration Option Value
+        """
+        return self._get_secret(self.configurations_prefix, key)
 
     def _get_secret(self, path_prefix: str, secret_id: str) -> Optional[str]:
         """

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -52,6 +52,9 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     :param variables_path: Specifies the path of the secret to read to get Variables
         (default: 'variables').
     :type variables_path: str
+    :param configurations_path: Specifies the path of the secret to read Airflow Configurations
+        (default: 'configurations').
+    :type configurations_path: str
     :param url: Base URL for the Vault instance being addressed.
     :type url: str
     :param auth_type: Authentication Type for Vault. Default is ``token``. Available values are:
@@ -111,6 +114,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         self,
         connections_path: str = 'connections',
         variables_path: str = 'variables',
+        configurations_path: str = 'configurations',
         url: Optional[str] = None,
         auth_type: str = 'token',
         auth_mount_point: Optional[str] = None,
@@ -135,9 +139,10 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         radius_port: Optional[int] = None,
         **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__()
         self.connections_path = connections_path.rstrip('/')
         self.variables_path = variables_path.rstrip('/')
+        self.configurations_path = configurations_path.rstrip('/')
         self.mount_point = mount_point
         self.kv_engine_version = kv_engine_version
         self.vault_client = _VaultClient(
@@ -181,7 +186,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
 
     def get_variable(self, key: str) -> Optional[str]:
         """
-        Get Airflow Variable from Environment Variable
+        Get Airflow Variable
 
         :param key: Variable Key
         :type key: str
@@ -189,5 +194,18 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :return: Variable Value retrieved from the vault
         """
         secret_path = self.build_path(self.variables_path, key)
+        response = self.vault_client.get_secret(secret_path=secret_path)
+        return response.get("value") if response else None
+
+    def get_configuration(self, key: str) -> Optional[str]:
+        """
+        Get Airflow Configuration
+
+        :param key: Configuration Option Key
+        :type key: str
+        :rtype: str
+        :return: Configuration Option Value retrieved from the vault
+        """
+        secret_path = self.build_path(self.configurations_path, key)
         response = self.vault_client.get_secret(secret_path=secret_path)
         return response.get("value") if response else None

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -52,9 +52,9 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     :param variables_path: Specifies the path of the secret to read to get Variables
         (default: 'variables').
     :type variables_path: str
-    :param configurations_path: Specifies the path of the secret to read Airflow Configurations
-        (default: 'configurations').
-    :type configurations_path: str
+    :param configs_path: Specifies the path of the secret to read Airflow Configurations
+        (default: 'configs').
+    :type configs_path: str
     :param url: Base URL for the Vault instance being addressed.
     :type url: str
     :param auth_type: Authentication Type for Vault. Default is ``token``. Available values are:
@@ -114,7 +114,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         self,
         connections_path: str = 'connections',
         variables_path: str = 'variables',
-        configurations_path: str = 'configurations',
+        configs_path: str = 'configs',
         url: Optional[str] = None,
         auth_type: str = 'token',
         auth_mount_point: Optional[str] = None,
@@ -142,7 +142,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         super().__init__()
         self.connections_path = connections_path.rstrip('/')
         self.variables_path = variables_path.rstrip('/')
-        self.configurations_path = configurations_path.rstrip('/')
+        self.configs_path = configs_path.rstrip('/')
         self.mount_point = mount_point
         self.kv_engine_version = kv_engine_version
         self.vault_client = _VaultClient(
@@ -197,7 +197,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         response = self.vault_client.get_secret(secret_path=secret_path)
         return response.get("value") if response else None
 
-    def get_configuration(self, key: str) -> Optional[str]:
+    def get_config(self, key: str) -> Optional[str]:
         """
         Get Airflow Configuration
 
@@ -206,6 +206,6 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :rtype: str
         :return: Configuration Option Value retrieved from the vault
         """
-        secret_path = self.build_path(self.configurations_path, key)
+        secret_path = self.build_path(self.configs_path, key)
         response = self.vault_client.get_secret(secret_path=secret_path)
         return response.get("value") if response else None

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -52,9 +52,9 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     :param variables_path: Specifies the path of the secret to read to get Variables
         (default: 'variables').
     :type variables_path: str
-    :param configs_path: Specifies the path of the secret to read Airflow Configurations
+    :param config_path: Specifies the path of the secret to read Airflow Configurations
         (default: 'configs').
-    :type configs_path: str
+    :type config_path: str
     :param url: Base URL for the Vault instance being addressed.
     :type url: str
     :param auth_type: Authentication Type for Vault. Default is ``token``. Available values are:
@@ -114,7 +114,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         self,
         connections_path: str = 'connections',
         variables_path: str = 'variables',
-        configs_path: str = 'configs',
+        config_path: str = 'config',
         url: Optional[str] = None,
         auth_type: str = 'token',
         auth_mount_point: Optional[str] = None,
@@ -142,7 +142,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         super().__init__()
         self.connections_path = connections_path.rstrip('/')
         self.variables_path = variables_path.rstrip('/')
-        self.configs_path = configs_path.rstrip('/')
+        self.config_path = config_path.rstrip('/')
         self.mount_point = mount_point
         self.kv_engine_version = kv_engine_version
         self.vault_client = _VaultClient(
@@ -206,6 +206,6 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :rtype: str
         :return: Configuration Option Value retrieved from the vault
         """
-        secret_path = self.build_path(self.configs_path, key)
+        secret_path = self.build_path(self.config_path, key)
         response = self.vault_client.get_secret(secret_path=secret_path)
         return response.get("value") if response else None

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -16,9 +16,10 @@
 # under the License.
 
 from abc import ABC
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from airflow.models.connection import Connection
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
 
 
 class BaseSecretsBackend(ABC):
@@ -52,13 +53,14 @@ class BaseSecretsBackend(ABC):
         """
         raise NotImplementedError()
 
-    def get_connections(self, conn_id: str) -> List[Connection]:
+    def get_connections(self, conn_id: str) -> List['Connection']:
         """
         Return connection object with a given ``conn_id``.
 
         :param conn_id: connection id
         :type conn_id: str
         """
+        from airflow.models.connection import Connection
         conn_uri = self.get_conn_uri(conn_id=conn_id)
         if not conn_uri:
             return []

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -74,11 +74,11 @@ class BaseSecretsBackend(ABC):
         """
         raise NotImplementedError()
 
-    def get_configuration(self, key: str) -> Optional[str]:
+    def get_config(self, key: str) -> Optional[str]:    # pylint: disable=unused-argument
         """
         Return value for Airflow Config Key
 
         :param key: Config Key
         :return: Config Value
         """
-        raise NotImplementedError()
+        return None

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -73,3 +73,12 @@ class BaseSecretsBackend(ABC):
         :return: Variable Value
         """
         raise NotImplementedError()
+
+    def get_configuration(self, key: str) -> Optional[str]:
+        """
+        Return value for Airflow Config Key
+
+        :param key: Config Key
+        :return: Config Value
+        """
+        raise NotImplementedError()

--- a/airflow/secrets/metastore.py
+++ b/airflow/secrets/metastore.py
@@ -19,11 +19,13 @@
 Objects relating to sourcing connections from metastore database
 """
 
-from typing import List
+from typing import TYPE_CHECKING, List
 
-from airflow.models.connection import Connection
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.session import provide_session
+
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
 
 
 class MetastoreBackend(BaseSecretsBackend):
@@ -33,7 +35,8 @@ class MetastoreBackend(BaseSecretsBackend):
 
     # pylint: disable=missing-docstring
     @provide_session
-    def get_connections(self, conn_id, session=None) -> List[Connection]:
+    def get_connections(self, conn_id, session=None) -> List['Connection']:
+        from airflow.models.connection import Connection
         conn_list = session.query(Connection).filter(Connection.conn_id == conn_id).all()
         session.expunge_all()
         return conn_list

--- a/docs/howto/set-config.rst
+++ b/docs/howto/set-config.rst
@@ -46,7 +46,18 @@ the key like this:
     [core]
     sql_alchemy_conn_cmd = bash_command_to_run
 
-The following config options support this ``_cmd`` version:
+You can also derive the connection string at run time by appending ``_secret`` to
+the key like this:
+
+.. code-block:: ini
+
+    [core]
+    sql_alchemy_conn_secret = sql_alchemy_conn
+
+This will retrieve config option from Secret Backends e.g Hashicorp Vault. See
+:ref:`Secrets Backends<secrets_backend_configuration>` for more details.
+
+The following config options support this ``_cmd`` and ``_secret`` version:
 
 * ``sql_alchemy_conn`` in ``[core]`` section
 * ``fernet_key`` in ``[core]`` section
@@ -65,6 +76,13 @@ the same way the usual config options can. For example:
 
     export AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD=bash_command_to_run
 
+Similarly, ``_secret`` config options can also be set using a corresponding environment variable.
+For example:
+
+.. code-block:: bash
+
+    export AIRFLOW__CORE__SQL_ALCHEMY_CONN_SECRET=sql_alchemy_conn
+
 The idea behind this is to not store passwords on boxes in plain text files.
 
 The universal order of precedence for all configuration options is as follows:
@@ -73,6 +91,7 @@ The universal order of precedence for all configuration options is as follows:
 #. set as a command environment variable
 #. set in ``airflow.cfg``
 #. command in ``airflow.cfg``
+#. secret key in ``airflow.cfg``
 #. Airflow's built in defaults
 
 .. note::

--- a/docs/howto/set-config.rst
+++ b/docs/howto/set-config.rst
@@ -53,6 +53,9 @@ the key like this:
 
     [core]
     sql_alchemy_conn_secret = sql_alchemy_conn
+    # You can also add a nested path
+    # example:
+    # sql_alchemy_conn_secret = core/sql_alchemy_conn
 
 This will retrieve config option from Secret Backends e.g Hashicorp Vault. See
 :ref:`Secrets Backends<secrets_backend_configuration>` for more details.
@@ -87,8 +90,9 @@ The idea behind this is to not store passwords on boxes in plain text files.
 
 The universal order of precedence for all configuration options is as follows:
 
-#. set as an environment variable
-#. set as a command environment variable
+#. set as an environment variable (``AIRFLOW__CORE__SQL_ALCHEMY_CONN``)
+#. set as a command environment variable (``AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD``)
+#. set as a secret environment variable (``AIRFLOW__CORE__SQL_ALCHEMY_CONN_SECRET``)
 #. set in ``airflow.cfg``
 #. command in ``airflow.cfg``
 #. secret key in ``airflow.cfg``

--- a/tests/providers/hashicorp/secrets/test_vault.py
+++ b/tests/providers/hashicorp/secrets/test_vault.py
@@ -281,7 +281,7 @@ class TestVaultSecrets(TestCase):
         }
 
         kwargs = {
-            "configurations_path": "configurations",
+            "configs_path": "configurations",
             "mount_point": "secret",
             "auth_type": "token",
             "url": "http://127.0.0.1:8200",
@@ -289,5 +289,5 @@ class TestVaultSecrets(TestCase):
         }
 
         test_client = VaultBackend(**kwargs)
-        returned_uri = test_client.get_configuration("sql_alchemy_conn")
+        returned_uri = test_client.get_config("sql_alchemy_conn")
         self.assertEqual('sqlite:////Users/airflow/airflow/airflow.db', returned_uri)

--- a/tests/providers/hashicorp/secrets/test_vault.py
+++ b/tests/providers/hashicorp/secrets/test_vault.py
@@ -260,3 +260,34 @@ class TestVaultSecrets(TestCase):
 
         with self.assertRaisesRegex(FileNotFoundError, path):
             VaultBackend(**kwargs).get_connections(conn_id='test')
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_config_value(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {
+            'request_id': '2d48a2ad-6bcb-e5b6-429d-da35fdf31f56',
+            'lease_id': '',
+            'renewable': False,
+            'lease_duration': 0,
+            'data': {'data': {'value': 'sqlite:////Users/airflow/airflow/airflow.db'},
+                     'metadata': {'created_time': '2020-03-28T02:10:54.301784Z',
+                                  'deletion_time': '',
+                                  'destroyed': False,
+                                  'version': 1}},
+            'wrap_info': None,
+            'warnings': None,
+            'auth': None
+        }
+
+        kwargs = {
+            "configurations_path": "configurations",
+            "mount_point": "secret",
+            "auth_type": "token",
+            "url": "http://127.0.0.1:8200",
+            "token": "s.FnL7qg0YnHZDpf4zKKuFy0UK"
+        }
+
+        test_client = VaultBackend(**kwargs)
+        returned_uri = test_client.get_configuration("sql_alchemy_conn")
+        self.assertEqual('sqlite:////Users/airflow/airflow/airflow.db', returned_uri)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -169,7 +169,7 @@ key6 = value6
         test_conf = AirflowConfigParser(
             default_config=parameterized_config(test_config_default))
         test_conf.read_string(test_config)
-        test_conf.configs_with_secret = test_conf.configs_with_secret | {
+        test_conf.as_command_stdout = test_conf.as_command_stdout | {
             ('test', 'key2'),
             ('test', 'key4'),
         }
@@ -228,7 +228,7 @@ sql_alchemy_conn_secret = sql_alchemy_conn
 
 [secrets]
 backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
-backend_kwargs = {"configurations_path": "configurations","url": "http://127.0.0.1:8200", "token": "token"}
+backend_kwargs = {"configs_path": "configurations","url": "http://127.0.0.1:8200", "token": "token"}
 '''
         test_config_default = '''[test]
 sql_alchemy_conn = airflow
@@ -236,7 +236,7 @@ sql_alchemy_conn = airflow
 
         test_conf = AirflowConfigParser(default_config=parameterized_config(test_config_default))
         test_conf.read_string(test_config)
-        test_conf.configs_with_secret = test_conf.configs_with_secret | {
+        test_conf.as_command_stdout = test_conf.as_command_stdout | {
             ('test', 'sql_alchemy_conn'),
         }
 
@@ -474,7 +474,7 @@ AIRFLOW_HOME = /root/airflow
         # Guarantee we have a deprecated setting, so we test the deprecation
         # lookup even if we remove this explicit fallback
         conf.deprecated_options[('celery', "result_backend")] = ('celery', 'celery_result_backend')
-        conf.configs_with_secret.add(('celery', 'celery_result_backend'))
+        conf.as_command_stdout.add(('celery', 'celery_result_backend'))
 
         conf.remove_option('celery', 'result_backend')
         with conf_vars({('celery', 'celery_result_backend_cmd'): '/bin/echo 99'}):
@@ -551,13 +551,13 @@ notacommand = OK
 '''
         test_cmdenv_conf = AirflowConfigParser()
         test_cmdenv_conf.read_string(test_cmdenv_config)
-        test_cmdenv_conf.configs_with_secret.add(('testcmdenv', 'itsacommand'))
+        test_cmdenv_conf.as_command_stdout.add(('testcmdenv', 'itsacommand'))
         with unittest.mock.patch.dict('os.environ'):
             # AIRFLOW__TESTCMDENV__ITSACOMMAND_CMD maps to ('testcmdenv', 'itsacommand') in
-            # configs_with_secret and therefore should return 'OK' from the environment variable's
+            # as_command_stdout and therefore should return 'OK' from the environment variable's
             # echo command, and must not return 'NOT OK' from the configuration
             self.assertEqual(test_cmdenv_conf.get('testcmdenv', 'itsacommand'), 'OK')
-            # AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD maps to no entry in configs_with_secret and therefore
+            # AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD maps to no entry in as_command_stdout and therefore
             # the option should return 'OK' from the configuration, and must not return 'NOT OK' from
             # the environement variable's echo command
             self.assertEqual(test_cmdenv_conf.get('testcmdenv', 'notacommand'), 'OK')

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -169,7 +169,7 @@ key6 = value6
         test_conf = AirflowConfigParser(
             default_config=parameterized_config(test_config_default))
         test_conf.read_string(test_config)
-        test_conf.as_command_stdout = test_conf.as_command_stdout | {
+        test_conf.configs_with_secret = test_conf.configs_with_secret | {
             ('test', 'key2'),
             ('test', 'key4'),
         }
@@ -202,6 +202,46 @@ key6 = value6
         cfg_dict = test_conf.as_dict(include_cmds=False, display_sensitive=True)
         self.assertNotIn('key4', cfg_dict['test'])
         self.assertEqual('printf key4_result', cfg_dict['test']['key4_cmd'])
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_config_from_secret_backend(self, mock_hvac):
+        """Get Config Value from a Secret Backend"""
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {
+            'request_id': '2d48a2ad-6bcb-e5b6-429d-da35fdf31f56',
+            'lease_id': '',
+            'renewable': False,
+            'lease_duration': 0,
+            'data': {'data': {'value': 'sqlite:////Users/airflow/airflow/airflow.db'},
+                     'metadata': {'created_time': '2020-03-28T02:10:54.301784Z',
+                                  'deletion_time': '',
+                                  'destroyed': False,
+                                  'version': 1}},
+            'wrap_info': None,
+            'warnings': None,
+            'auth': None
+        }
+
+        test_config = '''[test]
+sql_alchemy_conn_secret = sql_alchemy_conn
+
+[secrets]
+backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
+backend_kwargs = {"configurations_path": "configurations","url": "http://127.0.0.1:8200", "token": "token"}
+'''
+        test_config_default = '''[test]
+sql_alchemy_conn = airflow
+'''
+
+        test_conf = AirflowConfigParser(default_config=parameterized_config(test_config_default))
+        test_conf.read_string(test_config)
+        test_conf.configs_with_secret = test_conf.configs_with_secret | {
+            ('test', 'sql_alchemy_conn'),
+        }
+
+        self.assertEqual(
+            'sqlite:////Users/airflow/airflow/airflow.db', test_conf.get('test', 'sql_alchemy_conn'))
 
     def test_getboolean(self):
         """Test AirflowConfigParser.getboolean"""
@@ -434,7 +474,7 @@ AIRFLOW_HOME = /root/airflow
         # Guarantee we have a deprecated setting, so we test the deprecation
         # lookup even if we remove this explicit fallback
         conf.deprecated_options[('celery', "result_backend")] = ('celery', 'celery_result_backend')
-        conf.as_command_stdout.add(('celery', 'celery_result_backend'))
+        conf.configs_with_secret.add(('celery', 'celery_result_backend'))
 
         conf.remove_option('celery', 'result_backend')
         with conf_vars({('celery', 'celery_result_backend_cmd'): '/bin/echo 99'}):
@@ -511,13 +551,13 @@ notacommand = OK
 '''
         test_cmdenv_conf = AirflowConfigParser()
         test_cmdenv_conf.read_string(test_cmdenv_config)
-        test_cmdenv_conf.as_command_stdout.add(('testcmdenv', 'itsacommand'))
+        test_cmdenv_conf.configs_with_secret.add(('testcmdenv', 'itsacommand'))
         with unittest.mock.patch.dict('os.environ'):
             # AIRFLOW__TESTCMDENV__ITSACOMMAND_CMD maps to ('testcmdenv', 'itsacommand') in
-            # as_command_stdout and therefore should return 'OK' from the environment variable's
+            # configs_with_secret and therefore should return 'OK' from the environment variable's
             # echo command, and must not return 'NOT OK' from the configuration
             self.assertEqual(test_cmdenv_conf.get('testcmdenv', 'itsacommand'), 'OK')
-            # AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD maps to no entry in as_command_stdout and therefore
+            # AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD maps to no entry in configs_with_secret and therefore
             # the option should return 'OK' from the configuration, and must not return 'NOT OK' from
             # the environement variable's echo command
             self.assertEqual(test_cmdenv_conf.get('testcmdenv', 'notacommand'), 'OK')

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -169,7 +169,7 @@ key6 = value6
         test_conf = AirflowConfigParser(
             default_config=parameterized_config(test_config_default))
         test_conf.read_string(test_config)
-        test_conf.as_command_stdout = test_conf.as_command_stdout | {
+        test_conf.sensitive_config_values = test_conf.sensitive_config_values | {
             ('test', 'key2'),
             ('test', 'key4'),
         }
@@ -228,7 +228,7 @@ sql_alchemy_conn_secret = sql_alchemy_conn
 
 [secrets]
 backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
-backend_kwargs = {"configs_path": "configurations","url": "http://127.0.0.1:8200", "token": "token"}
+backend_kwargs = {"configs_path": "configs","url": "http://127.0.0.1:8200", "token": "token"}
 '''
         test_config_default = '''[test]
 sql_alchemy_conn = airflow
@@ -236,7 +236,7 @@ sql_alchemy_conn = airflow
 
         test_conf = AirflowConfigParser(default_config=parameterized_config(test_config_default))
         test_conf.read_string(test_config)
-        test_conf.as_command_stdout = test_conf.as_command_stdout | {
+        test_conf.sensitive_config_values = test_conf.sensitive_config_values | {
             ('test', 'sql_alchemy_conn'),
         }
 
@@ -474,7 +474,7 @@ AIRFLOW_HOME = /root/airflow
         # Guarantee we have a deprecated setting, so we test the deprecation
         # lookup even if we remove this explicit fallback
         conf.deprecated_options[('celery', "result_backend")] = ('celery', 'celery_result_backend')
-        conf.as_command_stdout.add(('celery', 'celery_result_backend'))
+        conf.sensitive_config_values.add(('celery', 'celery_result_backend'))
 
         conf.remove_option('celery', 'result_backend')
         with conf_vars({('celery', 'celery_result_backend_cmd'): '/bin/echo 99'}):
@@ -551,13 +551,13 @@ notacommand = OK
 '''
         test_cmdenv_conf = AirflowConfigParser()
         test_cmdenv_conf.read_string(test_cmdenv_config)
-        test_cmdenv_conf.as_command_stdout.add(('testcmdenv', 'itsacommand'))
+        test_cmdenv_conf.sensitive_config_values.add(('testcmdenv', 'itsacommand'))
         with unittest.mock.patch.dict('os.environ'):
             # AIRFLOW__TESTCMDENV__ITSACOMMAND_CMD maps to ('testcmdenv', 'itsacommand') in
-            # as_command_stdout and therefore should return 'OK' from the environment variable's
+            # sensitive_config_values and therefore should return 'OK' from the environment variable's
             # echo command, and must not return 'NOT OK' from the configuration
             self.assertEqual(test_cmdenv_conf.get('testcmdenv', 'itsacommand'), 'OK')
-            # AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD maps to no entry in as_command_stdout and therefore
+            # AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD maps to no entry in sensitive_config_values and therefore
             # the option should return 'OK' from the configuration, and must not return 'NOT OK' from
             # the environement variable's echo command
             self.assertEqual(test_cmdenv_conf.get('testcmdenv', 'notacommand'), 'OK')

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -204,6 +204,10 @@ key6 = value6
         self.assertEqual('printf key4_result', cfg_dict['test']['key4_cmd'])
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    @conf_vars({
+        ("secrets", "backend"): "airflow.providers.hashicorp.secrets.vault.VaultBackend",
+        ("secrets", "backend_kwargs"): '{"url": "http://127.0.0.1:8200", "token": "token"}',
+    })
     def test_config_from_secret_backend(self, mock_hvac):
         """Get Config Value from a Secret Backend"""
         mock_client = mock.MagicMock()
@@ -225,10 +229,6 @@ key6 = value6
 
         test_config = '''[test]
 sql_alchemy_conn_secret = sql_alchemy_conn
-
-[secrets]
-backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
-backend_kwargs = {"configs_path": "configs","url": "http://127.0.0.1:8200", "token": "token"}
 '''
         test_config_default = '''[test]
 sql_alchemy_conn = airflow


### PR DESCRIPTION
We should be able to get the followings config containing passwords and other sensitive data from Secret Backends:

```
        ('core', 'sql_alchemy_conn'),
        ('core', 'fernet_key'),
        ('celery', 'broker_url'),
        ('celery', 'flower_basic_auth'),
        ('celery', 'result_backend'),
        ('atlas', 'password'),
        ('smtp', 'smtp_password'),
        ('ldap', 'bind_password'),
        ('kubernetes', 'git_password'),
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
