### PR TITLE
Import ABC from collections.abc

### DIFF
--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import collections
+import collections.abc
 import logging
 import os
 import smtplib


### PR DESCRIPTION
`collections.abc` should be used while using ABC. `collections` is used which is incorrect. One of the other dependencies like logging import `collections.abc` and thus shadows this error. Relevant line : https://github.com/apache/airflow/blob/5e4b801b32eeda79b59ff3cc8a3a503f57f5a509/airflow/utils/email.py#L132

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
