### PR TITLE
Fix use of returned GCP credentials

### DIFF
--- a/airflow/utils/log/stackdriver_task_handler.py
+++ b/airflow/utils/log/stackdriver_task_handler.py
@@ -104,7 +104,7 @@ class StackdriverTaskHandler(logging.Handler):
     @cached_property
     def _client(self) -> gcp_logging.Client:
         """Google Cloud Library API client"""
-        credentials = get_credentials_and_project_id(
+        credentials, _ = get_credentials_and_project_id(
             key_path=self.gcp_key_path,
             scopes=self.scopes,
         )

--- a/tests/utils/log/test_stackdriver_task_handler.py
+++ b/tests/utils/log/test_stackdriver_task_handler.py
@@ -39,6 +39,8 @@ class TestStackdriverLoggingHandlerStandalone(unittest.TestCase):
     @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch('airflow.utils.log.stackdriver_task_handler.gcp_logging.Client')
     def test_should_pass_message_to_client(self, mock_client, mock_get_creds_and_project_id):
+        mock_get_creds_and_project_id.return_value = ('creds', 'project_id')
+
         transport_type = mock.MagicMock()
         stackdriver_task_handler = StackdriverTaskHandler(
             transport=transport_type,
@@ -55,7 +57,7 @@ class TestStackdriverLoggingHandlerStandalone(unittest.TestCase):
             mock.ANY, 'test-message', labels={"key": 'value'}, resource=Resource(type='global', labels={})
         )
         mock_client.assert_called_once_with(
-            credentials=mock_get_creds_and_project_id.return_value,
+            credentials='creds',
             client_info=mock.ANY
         )
 
@@ -76,9 +78,8 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
         self.ti.state = State.RUNNING
         self.addCleanup(self.dag.clear)
 
-    @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch('airflow.utils.log.stackdriver_task_handler.gcp_logging.Client')
-    def test_should_set_labels(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_set_labels(self, mock_client):
         self.stackdriver_task_handler.set_context(self.ti)
         self.logger.addHandler(self.stackdriver_task_handler)
 
@@ -96,9 +97,8 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
             mock.ANY, 'test-message', labels=labels, resource=resource
         )
 
-    @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch('airflow.utils.log.stackdriver_task_handler.gcp_logging.Client')
-    def test_should_append_labels(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_append_labels(self, mock_client):
         self.stackdriver_task_handler = StackdriverTaskHandler(
             transport=self.transport_mock,
             labels={"product.googleapis.com/task_id": "test-value"}
@@ -121,12 +121,11 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
             mock.ANY, 'test-message', labels=labels, resource=resource
         )
 
-    @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch(
         'airflow.utils.log.stackdriver_task_handler.gcp_logging.Client',
         **{'return_value.project': 'asf-project'}  # type: ignore
     )
-    def test_should_read_logs_for_all_try(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_read_logs_for_all_try(self, mock_client):
         mock_client.return_value.list_entries.return_value = _create_list_response(["MSG1", "MSG2"], None)
 
         logs, metadata = self.stackdriver_task_handler.read(self.ti)
@@ -141,12 +140,11 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
         self.assertEqual(['MSG1\nMSG2'], logs)
         self.assertEqual([{'end_of_log': True}], metadata)
 
-    @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch(  # type: ignore
         'airflow.utils.log.stackdriver_task_handler.gcp_logging.Client',
         **{'return_value.project': 'asf-project'}  # type: ignore
     )
-    def test_should_read_logs_for_task_with_quote(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_read_logs_for_task_with_quote(self, mock_client):
         mock_client.return_value.list_entries.return_value = _create_list_response(["MSG1", "MSG2"], None)
         self.ti.task_id = "K\"OT"
         logs, metadata = self.stackdriver_task_handler.read(self.ti)
@@ -161,12 +159,11 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
         self.assertEqual(['MSG1\nMSG2'], logs)
         self.assertEqual([{'end_of_log': True}], metadata)
 
-    @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch(
         'airflow.utils.log.stackdriver_task_handler.gcp_logging.Client',
         **{'return_value.project': 'asf-project'}  # type: ignore
     )
-    def test_should_read_logs_for_single_try(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_read_logs_for_single_try(self, mock_client):
         mock_client.return_value.list_entries.return_value = _create_list_response(["MSG1", "MSG2"], None)
 
         logs, metadata = self.stackdriver_task_handler.read(self.ti, 3)
@@ -182,9 +179,8 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
         self.assertEqual(['MSG1\nMSG2'], logs)
         self.assertEqual([{'end_of_log': True}], metadata)
 
-    @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch('airflow.utils.log.stackdriver_task_handler.gcp_logging.Client')
-    def test_should_read_logs_with_pagination(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_read_logs_with_pagination(self, mock_client):
         mock_client.return_value.list_entries.side_effect = [
             _create_list_response(["MSG1", "MSG2"], "TOKEN1"),
             _create_list_response(["MSG3", "MSG4"], None),
@@ -204,9 +200,8 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
         self.assertEqual(['MSG3\nMSG4'], logs)
         self.assertEqual([{'end_of_log': True}], metadata2)
 
-    @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch('airflow.utils.log.stackdriver_task_handler.gcp_logging.Client')
-    def test_should_read_logs_with_download(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_read_logs_with_download(self, mock_client):
         mock_client.return_value.list_entries.side_effect = [
             _create_list_response(["MSG1", "MSG2"], "TOKEN1"),
             _create_list_response(["MSG3", "MSG4"], None),
@@ -217,12 +212,11 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
         self.assertEqual(['MSG1\nMSG2\nMSG3\nMSG4'], logs)
         self.assertEqual([{'end_of_log': True}], metadata1)
 
-    @mock.patch('airflow.utils.log.stackdriver_task_handler.get_credentials_and_project_id')
     @mock.patch(
         'airflow.utils.log.stackdriver_task_handler.gcp_logging.Client',
         **{'return_value.project': 'asf-project'}  # type: ignore
     )
-    def test_should_read_logs_with_custom_resources(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_read_logs_with_custom_resources(self, mock_client):
         resource = Resource(
             type="cloud_composer_environment",
             labels={
@@ -263,6 +257,8 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
             gcp_key_path="KEY_PATH",
         )
 
+        mock_get_creds_and_project_id.return_value = ('creds', 'project_id')
+
         client = stackdriver_task_handler._client
 
         mock_get_creds_and_project_id.assert_called_once_with(
@@ -275,7 +271,7 @@ class TestStackdriverLoggingHandlerTask(unittest.TestCase):
             )
         )
         mock_client.assert_called_once_with(
-            credentials=mock_get_creds_and_project_id.return_value,
+            credentials='creds',
             client_info=mock.ANY
         )
         self.assertEqual(mock_client.return_value, client)


### PR DESCRIPTION
The code in `StackdriverTaskHandler` was handling the return of `get_credentials_and_project_id` as single value when it in fact is a tuple.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
