### PR TITLE
Fix tests: Add Default Conns back only when needed

### DIFF
--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -34,7 +34,7 @@ class TestConnectionEndpoint(unittest.TestCase):
     def setUp(self) -> None:
         self.client = self.app.test_client()  # type:ignore
         # we want only the connection created here for this test
-        clear_db_connections()
+        clear_db_connections(False)
 
     def tearDown(self) -> None:
         clear_db_connections()

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -59,10 +59,11 @@ def clear_db_pools():
         add_default_pool_if_not_exists(session)
 
 
-def clear_db_connections():
+def clear_db_connections(add_default_connections_back=True):
     with create_session() as session:
         session.query(Connection).delete()
-        create_default_connections(session)
+        if add_default_connections_back:
+            create_default_connections(session)
 
 
 def clear_db_variables():


### PR DESCRIPTION
https://github.com/apache/airflow/pull/9675 failed some tests because default connections were added back. 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
