### PR TITLE
use the correct name in the webserver & configmap when using an existing volume claim

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -268,7 +268,7 @@ log_connections = {{ .Values.pgbouncer.logConnections }}
 {{- end -}}
 
 {{ define "airflow_dags_volume_claim" -}}
-{{- if and .Values.dags.persistence.enabled .Values.dags.persistence.existingClaim -}}
+{{- if .Values.dags.persistence.existingClaim -}}
 {{ .Values.dags.persistence.existingClaim }}
 {{- else -}}
 {{ .Release.Name }}-dags

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -101,7 +101,7 @@ data:
     git_dags_folder_mount_point = {{ include "airflow_dags_mount_path" . }}
     dags_volume_mount_point = {{ include "airflow_dags_mount_path" . }}
     {{- if .Values.dags.persistence.enabled }}
-    dags_volume_claim = {{ .Release.Name }}-dags
+    dags_volume_claim = {{ include "airflow_dags_volume_claim" . }}
     dags_volume_subpath = {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
     {{- else }}
     git_repo = {{ .Values.dags.gitSync.repo }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -145,7 +145,7 @@ spec:
         {{- if .Values.dags.persistence.enabled }}
         - name: dags
           persistentVolumeClaim:
-            claimName: {{ .Release.Name }}-dags
+            claimName: {{ template "airflow_dags_volume_claim" . }}
         {{- else if .Values.dags.gitSync.enabled }}
         - name: dags
           emptyDir: {}

--- a/chart/tests/git-sync-scheduler_test.yaml
+++ b/chart/tests/git-sync-scheduler_test.yaml
@@ -133,3 +133,16 @@ tests:
               secretKeyRef:
                 name: user-pass-secret
                 key: GIT_SYNC_PASSWORD
+  - it: should set the volume claim correctly when using an existing claim
+    set:
+      dags:
+        persistence:
+          enabled: true
+          existingClaim: test-claim
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dags
+            persistentVolumeClaim:
+              claimName: test-claim


### PR DESCRIPTION
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.

Use the correct name of the PVC in the webserver and the configmap