### PR TITLE
Fix _process_executor_events method to use in-memory try_number

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1486,7 +1486,7 @@ class SchedulerJob(BaseJob):
         """
         Respond to executor events.
         """
-        ti_key_to_try_number_map = {}
+        ti_primary_key_to_try_number_map = {}
         event_buffer = self.executor.get_event_buffer(simple_dag_bag.dag_ids)
         tis_with_right_state: List[TaskInstanceKeyType] = []
 
@@ -1495,7 +1495,7 @@ class SchedulerJob(BaseJob):
             state, info = value
             dag_id, task_id, execution_date, try_number = key
             # We create map (dag_id, task_id, execution_date) -> in-memory try_number
-            ti_key_to_try_number_map[key[:-1]] = try_number
+            ti_primary_key_to_try_number_map[key[:-1]] = try_number
             self.log.info(
                 "Executor reports execution of %s.%s execution_date=%s "
                 "exited with status %s for try_number %s",
@@ -1514,7 +1514,7 @@ class SchedulerJob(BaseJob):
         for ti in tis:
             # Recreate ti_key (dag_id, task_id, execution_date, try_number) using in-memory try_number
             dag_id, task_id, execution_date, _ = ti.key
-            try_number = ti_key_to_try_number_map[(dag_id, task_id, execution_date)]
+            try_number = ti_primary_key_to_try_number_map[(dag_id, task_id, execution_date)]
             buffer_key = (dag_id, task_id, execution_date, try_number)
             state, info = event_buffer.pop(buffer_key)
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1513,8 +1513,9 @@ class SchedulerJob(BaseJob):
         tis = session.query(TI).filter(filter_for_tis).all()
         for ti in tis:
             # Recreate ti_key (dag_id, task_id, execution_date, try_number) using in-memory try_number
-            buffer_key = (*ti.key[:-1], ti_key_to_try_number_map[ti.key[:-1]])
-            dag_id, task_id, execution_date, try_number = buffer_key
+            dag_id, task_id, execution_date, _ = ti.key
+            try_number = ti_key_to_try_number_map[(dag_id, task_id, execution_date)]
+            buffer_key = (dag_id, task_id, execution_date, try_number)
             state, info = event_buffer.pop(buffer_key)
 
             # TODO: should we fail RUNNING as well, as we do in Backfills?

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1489,6 +1489,36 @@ class TestSchedulerJob(unittest.TestCase):
 
         mock_stats_incr.assert_called_once_with('scheduler.tasks.killed_externally')
 
+    def test_process_executor_events_uses_inmemory_try_numer(self):
+        execution_date = DEFAULT_DATE
+        dag_id = "dag_id"
+        task_id = "task_id"
+        try_number = 42
+
+        scheduler = SchedulerJob()
+        executor = MagicMock()
+        event_buffer = {
+            (dag_id, task_id, execution_date, try_number): (State.SUCCESS, None)
+        }
+        executor.get_event_buffer.return_value = event_buffer
+        scheduler.executor = executor
+
+        processor_agent = MagicMock()
+        scheduler.processor_agent = processor_agent
+
+        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
+        task = DummyOperator(dag=dag, task_id=task_id)
+
+        with create_session() as session:
+            ti = TaskInstance(task, DEFAULT_DATE)
+            ti.state = State.SUCCESS
+            session.merge(ti)
+
+        scheduler._process_executor_events(simple_dag_bag=MagicMock())
+        # Assert that the even_buffer is empty so the task was popped using right
+        # task instance key
+        self.assertEqual(event_buffer, {})
+
     def test_execute_task_instances_is_paused_wont_execute(self):
         dag_id = 'SchedulerJobTest.test_execute_task_instances_is_paused_wont_execute'
         task_id_1 = 'dummy_task'

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1489,7 +1489,7 @@ class TestSchedulerJob(unittest.TestCase):
 
         mock_stats_incr.assert_called_once_with('scheduler.tasks.killed_externally')
 
-    def test_process_executor_events_uses_inmemory_try_numer(self):
+    def test_process_executor_events_uses_inmemory_try_number(self):
         execution_date = DEFAULT_DATE
         dag_id = "dag_id"
         task_id = "task_id"


### PR DESCRIPTION
In #9488 I introduced a bug that is related to the difference between task instance `try_numer` in memory (executor) and in the database. This PR fixes this issue. 

Closes: #9689

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
