### PR TITLE
Add support for remote logging to be injected into the airflow.cfg configmap in helm chart 

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -39,7 +39,7 @@ data:
     load_examples = False
     colored_console_log = False
     executor = {{ .Values.executor }}
-{{- if .Values.elasticsearch.enabled }}
+{{- if or .Values.elasticsearch.enabled .Values.logging.remoteLogging.enabled }}
     remote_logging = True
 {{- end }}
 
@@ -47,7 +47,13 @@ data:
     auth_backend = {{ .Values.api.authBackend }}
 
     [logging]
-    logging_level = DEBUG
+    logging_level = {{ .Values.logging.level }}
+{{- if .Values.logging.remoteLogging.enabled }}
+    remote_base_log_folder = {{ .Values.logging.remoteLogging.baseLogFolder }}
+    remote_log_conn_id = {{ .Values.logging.remoteLogging.logConnId }}
+    encrypt_s3_logs = False
+{{- end}}
+
     [webserver]
     enable_proxy_fix = True
     expose_config = True

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -384,6 +384,15 @@ elasticsearch:
     # host: ~
     # port: ~
 
+logging:
+  remoteLogging:
+    enabled: false
+    logConnId: ~
+    baseLogFolder: ~
+
+  level: DEBUG
+
+
 # All ports used by chart
 ports:
   flowerUI: 5555


### PR DESCRIPTION
Added support to inject the remote logging configuration into the `airflow.cfg` configmap. I kept it backwards compatible with the current version of the chart by not dropping the `elasticsearch.enabled` value. 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
