### PR TITLE
Fix warning about incompatible plugins

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -273,7 +273,7 @@ def initialize_web_ui_plugins():
             'blueprint': bp
         } for bp in plugin.flask_blueprints])
 
-        if (admin_views and not flask_appbuilder_views) or (menu_links and flask_appbuilder_menu_links):
+        if (admin_views and not flask_appbuilder_views) or (menu_links and not flask_appbuilder_menu_links):
             log.warning(
                 "Plugin \'%s\' may not be compatible with the current Airflow version. "
                 "Please contact the author of the plugin.",

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -173,27 +173,6 @@ class TestPluginsManager(unittest.TestCase):
             with self.assertRaises(AssertionError), self.assertLogs(plugins_manager.log):
                 plugins_manager.initialize_web_ui_plugins()
 
-    def test_should_not_warning_about_fab_plugins(self):
-        class AirflowAdminViewsPlugin(AirflowPlugin):
-            name = "test_admin_views_plugin"
-
-            appbuilder_views = [mock.MagicMock()]
-
-        class AirflowAdminMenuLinksPlugin(AirflowPlugin):
-            name = "test_menu_links_plugin"
-
-            appbuilder_menu_items = [mock.MagicMock()]
-
-        with mock_plugin_manager(plugins=[
-            AirflowAdminViewsPlugin(),
-            AirflowAdminMenuLinksPlugin()
-        ]):
-            from airflow import plugins_manager
-
-            # assert not logs
-            with self.assertRaises(AssertionError), self.assertLogs(plugins_manager.log):
-                plugins_manager.initialize_web_ui_plugins()
-
     def test_should_not_warning_about_fab_and_flask_admin_plugins(self):
         class AirflowAdminViewsPlugin(AirflowPlugin):
             name = "test_admin_views_plugin"

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -121,7 +121,6 @@ class TestPluginsManager(unittest.TestCase):
             self.assertIn('PluginPropertyOperator', str(plugins_manager.operators_modules[0].__dict__))
             self.assertIn("TestNonPropertyHook", str(plugins_manager.hooks_modules[0].__dict__))
 
-    @mock_plugin_manager(plugins=[])
     def test_should_warning_about_incompatible_plugins(self):
         class AirflowAdminViewsPlugin(AirflowPlugin):
             name = "test_admin_views_plugin"

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -21,6 +21,7 @@ from unittest import mock
 from airflow.hooks.base_hook import BaseHook
 from airflow.plugins_manager import AirflowPlugin
 from airflow.www import app as application
+from tests.test_utils.mock_plugins import mock_plugin_manager
 
 
 class TestPluginsRBAC(unittest.TestCase):
@@ -94,59 +95,53 @@ class TestPluginsRBAC(unittest.TestCase):
 
 
 class TestPluginsManager(unittest.TestCase):
-    class AirflowTestPropertyPlugin(AirflowPlugin):
-        name = "test_property_plugin"
+    def test_should_load_plugins_from_property(self):
+        class AirflowTestPropertyPlugin(AirflowPlugin):
+            name = "test_property_plugin"
 
-        @property
-        def operators(self):
-            from airflow.models.baseoperator import BaseOperator
+            @property
+            def operators(self):
+                from airflow.models.baseoperator import BaseOperator
 
-            class PluginPropertyOperator(BaseOperator):
+                class PluginPropertyOperator(BaseOperator):
+                    pass
+
+                return [PluginPropertyOperator]
+
+            class TestNonPropertyHook(BaseHook):
                 pass
 
-            return [PluginPropertyOperator]
+            hooks = [TestNonPropertyHook]
 
-        class TestNonPropertyHook(BaseHook):
-            pass
+        with mock_plugin_manager(plugins=[AirflowTestPropertyPlugin()]):
+            from airflow import plugins_manager
+            plugins_manager.integrate_dag_plugins()
 
-        hooks = [TestNonPropertyHook]
+            self.assertIn('AirflowTestPropertyPlugin', str(plugins_manager.plugins))
+            self.assertIn('PluginPropertyOperator', str(plugins_manager.operators_modules[0].__dict__))
+            self.assertIn("TestNonPropertyHook", str(plugins_manager.hooks_modules[0].__dict__))
 
-    @mock.patch('airflow.plugins_manager.plugins', [AirflowTestPropertyPlugin()])
-    @mock.patch('airflow.plugins_manager.operators_modules', None)
-    @mock.patch('airflow.plugins_manager.sensors_modules', None)
-    @mock.patch('airflow.plugins_manager.hooks_modules', None)
-    @mock.patch('airflow.plugins_manager.macros_modules', None)
-    def test_should_load_plugins_from_property(self):
-        from airflow import plugins_manager
-        plugins_manager.integrate_dag_plugins()
-        self.assertIn('TestPluginsManager.AirflowTestPropertyPlugin', str(plugins_manager.plugins))
-        self.assertIn('PluginPropertyOperator', str(plugins_manager.operators_modules[0].__dict__))
-        self.assertIn("TestNonPropertyHook", str(plugins_manager.hooks_modules[0].__dict__))
-
-    @mock.patch('airflow.plugins_manager.plugins', [])
-    @mock.patch('airflow.plugins_manager.admin_views', None)
-    @mock.patch('airflow.plugins_manager.flask_blueprints', None)
-    @mock.patch('airflow.plugins_manager.menu_links', None)
-    @mock.patch('airflow.plugins_manager.flask_appbuilder_views', None)
-    @mock.patch('airflow.plugins_manager.flask_appbuilder_menu_links', None)
+    @mock_plugin_manager(plugins=[])
     def test_should_warning_about_incompatible_plugins(self):
-        class AirflowDeprecatedAdminViewsPlugin(AirflowPlugin):
+        class AirflowAdminViewsPlugin(AirflowPlugin):
             name = "test_admin_views_plugin"
 
             admin_views = [mock.MagicMock()]
 
-        class AirflowDeprecatedAdminMenuLinksPlugin(AirflowPlugin):
+        class AirflowAdminMenuLinksPlugin(AirflowPlugin):
             name = "test_menu_links_plugin"
 
             menu_links = [mock.MagicMock()]
 
-        from airflow import plugins_manager
-        plugins_manager.plugins = [
-            AirflowDeprecatedAdminViewsPlugin(),
-            AirflowDeprecatedAdminMenuLinksPlugin()
-        ]
-        with self.assertLogs(plugins_manager.log) as cm:
-            plugins_manager.initialize_web_ui_plugins()
+        with mock_plugin_manager(plugins=[
+            AirflowAdminViewsPlugin(),
+            AirflowAdminMenuLinksPlugin()
+        ]):
+            from airflow import plugins_manager
+
+            # assert not logs
+            with self.assertLogs(plugins_manager.log) as cm:
+                plugins_manager.initialize_web_ui_plugins()
 
         self.assertEqual(cm.output, [
             'WARNING:airflow.plugins_manager:Plugin \'test_admin_views_plugin\' may not be '
@@ -156,3 +151,68 @@ class TestPluginsManager(unittest.TestCase):
             'compatible with the current Airflow version. Please contact the author of '
             'the plugin.'
         ])
+
+    def test_should_not_warning_about_compatible_plugins(self):
+        class AirflowAdminViewsPlugin(AirflowPlugin):
+            name = "test_admin_views_plugin"
+
+            appbuilder_views = [mock.MagicMock()]
+
+        class AirflowAdminMenuLinksPlugin(AirflowPlugin):
+            name = "test_menu_links_plugin"
+
+            appbuilder_menu_items = [mock.MagicMock()]
+
+        with mock_plugin_manager(plugins=[
+            AirflowAdminViewsPlugin(),
+            AirflowAdminMenuLinksPlugin()
+        ]):
+            from airflow import plugins_manager
+
+            # assert not logs
+            with self.assertRaises(AssertionError), self.assertLogs(plugins_manager.log):
+                plugins_manager.initialize_web_ui_plugins()
+
+    def test_should_not_warning_about_fab_plugins(self):
+        class AirflowAdminViewsPlugin(AirflowPlugin):
+            name = "test_admin_views_plugin"
+
+            appbuilder_views = [mock.MagicMock()]
+
+        class AirflowAdminMenuLinksPlugin(AirflowPlugin):
+            name = "test_menu_links_plugin"
+
+            appbuilder_menu_items = [mock.MagicMock()]
+
+        with mock_plugin_manager(plugins=[
+            AirflowAdminViewsPlugin(),
+            AirflowAdminMenuLinksPlugin()
+        ]):
+            from airflow import plugins_manager
+
+            # assert not logs
+            with self.assertRaises(AssertionError), self.assertLogs(plugins_manager.log):
+                plugins_manager.initialize_web_ui_plugins()
+
+    def test_should_not_warning_about_fab_and_flask_admin_plugins(self):
+        class AirflowAdminViewsPlugin(AirflowPlugin):
+            name = "test_admin_views_plugin"
+
+            admin_views = [mock.MagicMock()]
+            appbuilder_views = [mock.MagicMock()]
+
+        class AirflowAdminMenuLinksPlugin(AirflowPlugin):
+            name = "test_menu_links_plugin"
+
+            menu_links = [mock.MagicMock()]
+            appbuilder_menu_items = [mock.MagicMock()]
+
+        with mock_plugin_manager(plugins=[
+            AirflowAdminViewsPlugin(),
+            AirflowAdminMenuLinksPlugin()
+        ]):
+            from airflow import plugins_manager
+
+            # assert not logs
+            with self.assertRaises(AssertionError), self.assertLogs(plugins_manager.log):
+                plugins_manager.initialize_web_ui_plugins()

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -152,7 +152,7 @@ class TestPluginsManager(unittest.TestCase):
             'the plugin.'
         ])
 
-    def test_should_not_warning_about_compatible_plugins(self):
+    def test_should_not_warning_about_fab_plugins(self):
         class AirflowAdminViewsPlugin(AirflowPlugin):
             name = "test_admin_views_plugin"
 


### PR DESCRIPTION
One condition was bad and warns when the plugin is for admin and FAB flask.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
