### PR TITLE
Specify simple_salesforce version requirements in 1.10.x

### DIFF
--- a/airflow/contrib/hooks/salesforce_hook.py
+++ b/airflow/contrib/hooks/salesforce_hook.py
@@ -23,7 +23,7 @@ which allows you to connect to your Salesforce instance,
 retrieve data from it, and write that data to a file
 for other uses.
 
-NOTE:   this hook also relies on the simple_salesforce package:
+NOTE:   this hook also relies on the simple_salesforce package, version <= 0.75.3:
         https://github.com/simple-salesforce/simple-salesforce
 """
 import json


### PR DESCRIPTION
The saleforce hook found in contrib.hooks.salesforce_hook passes the
`sandbox` kwarg to the `simple_salesforce.Salesforce` constructor, which was deprecated
starting in version 1.0 of simple_salesforce and so this hook is
unusable with any version greater than 0.75.3 of simple_salesforce.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
