### PR TITLE
Pre-create Celery db result tables before running Celery worker

### DIFF
--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 import daemon
 import psutil
+import sqlalchemy.exc
 from celery import maybe_patch_concurrency
 from celery.bin import worker as worker_bin
 from daemon.pidfile import TimeoutPIDLockFile
@@ -111,6 +112,22 @@ def worker(args):
         stderr=args.stderr,
         log=args.log_file,
     )
+
+    if hasattr(celery_app.backend, 'ResultSession'):
+        # Pre-create the database tables now, otherwise SQLA via Celery has a
+        # race condition where it one of the subprocesses can die with "Table
+        # already exists" error, because SQLA checks for which tables exist,
+        # then issues a CREATE TABLE, rather than doing CREATE TABLE IF NOT
+        # EXISTS
+        try:
+            session = celery_app.backend.ResultSession()
+            session.close()
+        except sqlalchemy.exc.IntegrityError:
+            # At least on postgres, trying to create a table that already exist
+            # gives a unique constraint violation or the
+            # "pg_type_typname_nsp_index" table. If this happens we can ignore
+            # it, we raced to create the tables and lost.
+            pass
 
     # Setup Celery worker
     worker_instance = worker_bin.worker(app=celery_app)

--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -115,7 +115,7 @@ def worker(args):
 
     if hasattr(celery_app.backend, 'ResultSession'):
         # Pre-create the database tables now, otherwise SQLA via Celery has a
-        # race condition where it one of the subprocesses can die with "Table
+        # race condition where one of the subprocesses can die with "Table
         # already exists" error, because SQLA checks for which tables exist,
         # then issues a CREATE TABLE, rather than doing CREATE TABLE IF NOT
         # EXISTS

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -62,6 +62,7 @@ class TestWorkerPrecheck(unittest.TestCase):
 
 @pytest.mark.integration("redis")
 @pytest.mark.integration("rabbitmq")
+@pytest.mark.backend("mysql", "postgres")
 class TestWorkerServeLogs(unittest.TestCase):
 
     @classmethod

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -92,6 +92,7 @@ class TestWorkerServeLogs(unittest.TestCase):
                 mock_popen.assert_not_called()
 
 
+@pytest.mark.backend("mysql", "postgres")
 class TestCeleryStopCommand(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -145,6 +146,7 @@ class TestCeleryStopCommand(unittest.TestCase):
         mock_read_pid_from_pidfile.assert_called_once_with(pid_file)
 
 
+@pytest.mark.backend("mysql", "postgres")
 class TestWorkerStart(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Otherwise at large scale this can end up with some tasks failing as they
try to create the result table at the same time.

This was always possible before, just exceedingly rare, but in large
scale performance testing where I create a lot of tasks quickly
(especially in my HA testing) I hit this a few times.

This is also only a problem for fresh installs/clean DBs, as once these
tables exist the possible race goes away.

This is the same fix from #8909, just for runtime, not test time.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.