### PR TITLE
DbApiHook: Support kwargs in get_pandas_df

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -106,7 +106,7 @@ class DbApiHook(BaseHook):
             engine_kwargs = {}
         return create_engine(self.get_uri(), **engine_kwargs)
 
-    def get_pandas_df(self, sql, parameters=None):
+    def get_pandas_df(self, sql, parameters=None, **kwargs):
         """
         Executes the sql and returns a pandas dataframe
 
@@ -119,7 +119,7 @@ class DbApiHook(BaseHook):
         from pandas.io import sql as psql
 
         with closing(self.get_conn()) as conn:
-            return psql.read_sql(sql, con=conn, params=parameters)
+            return psql.read_sql(sql, con=conn, params=parameters, **kwargs)
 
     def get_records(self, sql, parameters=None):
         """

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -115,6 +115,8 @@ class DbApiHook(BaseHook):
         :type sql: str or list
         :param parameters: The parameters to render the SQL query with.
         :type parameters: dict or iterable
+        :param kwargs: (optional) passed into pandas.io.sql.read_sql method
+        :type kwargs: dict
         """
         from pandas.io import sql as psql
 

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -1058,6 +1058,8 @@ class HiveServer2Hook(DbApiHook):
         :type schema: str
         :param hive_conf: hive_conf to execute alone with the hql.
         :type hive_conf: dict
+        :param kwargs: (optional) passed into pandas.DataFrame constructor
+        :type kwargs: dict
         :return: result of hive execution
         :rtype: DataFrame
 

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -1044,9 +1044,10 @@ class HiveServer2Hook(DbApiHook):
         """
         return self.get_results(hql, schema=schema, hive_conf=hive_conf)['data']
 
-    def get_pandas_df(self, hql: Union[str, Text],
+    def get_pandas_df(self, hql: Union[str, Text],  # type: ignore
                       schema: str = 'default',
-                      hive_conf: Optional[Dict[Any, Any]] = None
+                      hive_conf: Optional[Dict[Any, Any]] = None,
+                      **kwargs
                       ) -> pandas.DataFrame:
         """
         Get a pandas dataframe from a Hive query
@@ -1069,6 +1070,6 @@ class HiveServer2Hook(DbApiHook):
         :return: pandas.DateFrame
         """
         res = self.get_results(hql, schema=schema, hive_conf=hive_conf)
-        df = pandas.DataFrame(res['data'])
+        df = pandas.DataFrame(res['data'], **kwargs)
         df.columns = [c[0] for c in res['header']]
         return df

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -58,7 +58,7 @@ class ExasolHook(DbApiHook):
         conn = pyexasol.connect(**conn_args)
         return conn
 
-    def get_pandas_df(self, sql, parameters=None):
+    def get_pandas_df(self, sql, parameters=None, **kwargs):
         """
         Executes the sql and returns a pandas dataframe
 
@@ -69,7 +69,7 @@ class ExasolHook(DbApiHook):
         :type parameters: dict or iterable
         """
         with closing(self.get_conn()) as conn:
-            conn.export_to_pandas(sql, query_params=parameters)
+            conn.export_to_pandas(sql, query_params=parameters, **kwargs)
 
     def get_records(self, sql, parameters=None):
         """

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -67,6 +67,8 @@ class ExasolHook(DbApiHook):
         :type sql: str or list
         :param parameters: The parameters to render the SQL query with.
         :type parameters: dict or iterable
+        :param kwargs: (optional) passed into pyexasol.ExaConnection.export_to_pandas method
+        :type kwargs: dict
         """
         with closing(self.get_conn()) as conn:
             conn.export_to_pandas(sql, query_params=parameters, **kwargs)

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -168,7 +168,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         raise NotImplementedError()
 
     def get_pandas_df(
-        self, sql: str, parameters: Optional[Union[Iterable, Mapping]] = None, dialect: Optional[str] = None
+        self, sql: str, parameters: Optional[Union[Iterable, Mapping]] = None, dialect: Optional[str] = None,
+        **kwargs
     ) -> DataFrame:
         """
         Returns a Pandas DataFrame for the results produced by a BigQuery
@@ -196,7 +197,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                         project_id=project_id,
                         dialect=dialect,
                         verbose=False,
-                        credentials=credentials)
+                        credentials=credentials,
+                        **kwargs)
 
     @GoogleBaseHook.fallback_to_default_project_id
     def table_exists(self, dataset_id: str, table_id: str, project_id: str) -> bool:

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -187,6 +187,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param dialect: Dialect of BigQuery SQL – legacy SQL or standard SQL
             defaults to use `self.use_legacy_sql` if not specified
         :type dialect: str in {'legacy', 'standard'}
+        :param kwargs: (optional) passed into pandas_gbq.read_gbq method
+        :type kwargs: dict
         """
         if dialect is None:
             dialect = 'legacy' if self.use_legacy_sql else 'standard'

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -89,7 +89,7 @@ class PrestoHook(DbApiHook):
         except DatabaseError as e:
             raise PrestoException(e)
 
-    def get_pandas_df(self, hql, parameters=None):
+    def get_pandas_df(self, hql, parameters=None, **kwargs):
         """
         Get a pandas dataframe from a sql query.
         """
@@ -102,10 +102,10 @@ class PrestoHook(DbApiHook):
             raise PrestoException(e)
         column_descriptions = cursor.description
         if data:
-            df = pandas.DataFrame(data)
+            df = pandas.DataFrame(data, **kwargs)
             df.columns = [c[0] for c in column_descriptions]
         else:
-            df = pandas.DataFrame()
+            df = pandas.DataFrame(**kwargs)
         return df
 
     def run(self, hql, parameters=None):


### PR DESCRIPTION
Support all parameters that are supported by pandas `read_sql` function: https://github.com/pandas-dev/pandas/blob/1.0.x/pandas/io/sql.py#L336-L345

Closes #8468

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
