### PR TITLE
Fix is_terminal_support_colors functtion

### DIFF
--- a/airflow/utils/platform.py
+++ b/airflow/utils/platform.py
@@ -41,7 +41,7 @@ def is_terminal_support_colors() -> bool:
     """
     if sys.platform == "win32":
         return False
-    if is_tty():
+    if not is_tty():
         return False
     if "COLORTERM" in os.environ:
         return True


### PR DESCRIPTION
This function does not return a valid value.
To check the behavior, you can run the following command:
```bash
airflow config | cat # Output without colors
airflow config # Output with colors
```
This is code that depends on your operating system, so it is very difficult to test using automated testing. :-/ 

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
