### PR TITLE
Fix failing get_logs on AzureContainerInstanceHook

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -161,7 +161,7 @@ class AzureContainerInstanceHook(BaseHook):
         :return: A list of log messages
         :rtype: list[str]
         """
-        logs = self.connection.container.list_logs(resource_group, name, name, tail=tail)
+        logs = self.connection.containers.list_logs(resource_group, name, name, tail=tail)
         return logs.content.splitlines(True)
 
     def delete(self, resource_group, name):


### PR DESCRIPTION
Tried to fetch ContainerInstanceManagementClient.container but it's not a valid attribute, .containers is

---
Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
