### PR TITLE
Update local_task_job.py to remove an off color joke

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -159,7 +159,7 @@ class LocalTaskJob(BaseJob):
         ):
             self.log.warning(
                 "State of this instance has been externally set to %s. "
-                "Taking the poison pill.",
+                "Terminating instance.",
                 ti.state
             )
             if ti.state == State.FAILED and ti.task.on_failure_callback:


### PR DESCRIPTION
Removing the suicide joke from local_task_job as it doesn't have a place in a professional setting.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
