### PR TITLE
Backfill reset_dagruns set DagRun to NONE state

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1137,6 +1137,7 @@ class DAG(BaseDag, LoggingMixin):
                 self.set_dag_runs_state(session=session,
                                         start_date=start_date,
                                         end_date=end_date,
+                                        state=State.NONE,
                                         )
         else:
             count = 0


### PR DESCRIPTION
Currently when we backfill with `--reset_dagruns`, airflow would set the DagRuns within the backfill range to `RUNNING` state and that could cause the DAG to reach max active runs limitation before backfill execution actually starts.

Thus setting the DagRun to `NONE` state so that it could pass the max active runs checks [here](https://github.com/apache/airflow/blob/533b14341c774329d8184e6e559528ae8ed34b3a/airflow/jobs/backfill_job.py#L313) and then airflow would change the state to `RUNNING` state [here](https://github.com/apache/airflow/blob/533b14341c774329d8184e6e559528ae8ed34b3a/airflow/jobs/backfill_job.py#L329).

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
