### PR TITLE
Use absolute paths in howto guides

### DIFF
--- a/docs/howto/operator/gcp/_partials/prerequisite_tasks.rst
+++ b/docs/howto/operator/gcp/_partials/prerequisite_tasks.rst
@@ -28,6 +28,6 @@ To use these operators, you must do a few things:
 
       pip install 'apache-airflow[google]'
 
-    Detailed information is available for :doc:`../../../../installation`.
+    Detailed information is available for :doc:`/installation`.
 
-  * :doc:`Setup a GCP Connection <../../connection/gcp>`.
+  * :doc:`Setup a GCP Connection </howto/connection/gcp>`.

--- a/docs/howto/operator/gcp/ads.rst
+++ b/docs/howto/operator/gcp/ads.rst
@@ -27,7 +27,7 @@ businesses to advertise on Google Search, YouTube and other sites across the web
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleAdsToGcsOperator:
 

--- a/docs/howto/operator/gcp/analytics.rst
+++ b/docs/howto/operator/gcp/analytics.rst
@@ -30,7 +30,7 @@ For more information about the Google Analytics 360 API check
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleAnalyticsListAccountsOperator:
 

--- a/docs/howto/operator/gcp/automl.rst
+++ b/docs/howto/operator/gcp/automl.rst
@@ -31,7 +31,7 @@ and then integrate those models into your applications and web sites.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudAutoMLDocuments:

--- a/docs/howto/operator/gcp/bigquery.rst
+++ b/docs/howto/operator/gcp/bigquery.rst
@@ -33,7 +33,7 @@ data.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 Manage datasets
 ^^^^^^^^^^^^^^^

--- a/docs/howto/operator/gcp/bigquery_dts.rst
+++ b/docs/howto/operator/gcp/bigquery_dts.rst
@@ -33,7 +33,7 @@ gain access to data connectors that allow you to easily transfer data from Terad
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:BigQueryDTSDocuments:

--- a/docs/howto/operator/gcp/bigtable.rst
+++ b/docs/howto/operator/gcp/bigtable.rst
@@ -27,7 +27,7 @@ Google Cloud Bigtable Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:BigtableCreateInstanceOperator:

--- a/docs/howto/operator/gcp/campaign_manager.rst
+++ b/docs/howto/operator/gcp/campaign_manager.rst
@@ -30,7 +30,7 @@ reports. For more information about the Campaign Manager API check
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleCampaignManagerDeleteReportOperator:
 

--- a/docs/howto/operator/gcp/cloud_build.rst
+++ b/docs/howto/operator/gcp/cloud_build.rst
@@ -33,7 +33,7 @@ artifacts such as Docker containers or Java archives.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudBuildBuild:
 

--- a/docs/howto/operator/gcp/cloud_memorystore.rst
+++ b/docs/howto/operator/gcp/cloud_memorystore.rst
@@ -32,7 +32,7 @@ of managing complex Redis deployments.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudMemorystoreInstance:

--- a/docs/howto/operator/gcp/cloud_sql.rst
+++ b/docs/howto/operator/gcp/cloud_sql.rst
@@ -27,7 +27,7 @@ Google Cloud SQL Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudSQLCreateInstanceDatabaseOperator:
 

--- a/docs/howto/operator/gcp/cloud_storage_transfer_service.rst
+++ b/docs/howto/operator/gcp/cloud_storage_transfer_service.rst
@@ -27,7 +27,7 @@ Google Cloud Transfer Service Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudDataTransferServiceCreateJobOperator:
 

--- a/docs/howto/operator/gcp/compute.rst
+++ b/docs/howto/operator/gcp/compute.rst
@@ -27,7 +27,7 @@ Google Compute Engine Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:ComputeEngineStartInstanceOperator:
 

--- a/docs/howto/operator/gcp/datacatalog.rst
+++ b/docs/howto/operator/gcp/datacatalog.rst
@@ -36,7 +36,7 @@ Google Cloud. It offers:
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudDataCatalogEntryOperators:

--- a/docs/howto/operator/gcp/datafusion.rst
+++ b/docs/howto/operator/gcp/datafusion.rst
@@ -33,7 +33,7 @@ and action.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudDataFusionRestartInstanceOperator:

--- a/docs/howto/operator/gcp/dataproc.rst
+++ b/docs/howto/operator/gcp/dataproc.rst
@@ -32,7 +32,7 @@ For more information about the service visit `Dataproc production documentation 
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:DataprocCreateClusterOperator:

--- a/docs/howto/operator/gcp/display_video.rst
+++ b/docs/howto/operator/gcp/display_video.rst
@@ -27,7 +27,7 @@ campaign management features you need.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleDisplayVideo360CreateReportOperator:
 

--- a/docs/howto/operator/gcp/facebook_ads_to_gcs.rst
+++ b/docs/howto/operator/gcp/facebook_ads_to_gcs.rst
@@ -27,7 +27,7 @@ Facebook Ads To GCS Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:FacebookAdsReportToGcsOperator:
 

--- a/docs/howto/operator/gcp/firestore.rst
+++ b/docs/howto/operator/gcp/firestore.rst
@@ -34,7 +34,7 @@ Cloud Functions.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudFirestoreExportDatabaseOperator:

--- a/docs/howto/operator/gcp/functions.rst
+++ b/docs/howto/operator/gcp/functions.rst
@@ -27,7 +27,7 @@ Google Cloud Functions Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudFunctionDeleteFunctionOperator:
 

--- a/docs/howto/operator/gcp/gcs.rst
+++ b/docs/howto/operator/gcp/gcs.rst
@@ -27,7 +27,7 @@ Google Cloud Storage Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToBigQueryOperator:
 

--- a/docs/howto/operator/gcp/gcs_to_gcs.rst
+++ b/docs/howto/operator/gcp/gcs_to_gcs.rst
@@ -61,7 +61,7 @@ In the next section they will be described.
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 Operators

--- a/docs/howto/operator/gcp/gcs_to_gdrive.rst
+++ b/docs/howto/operator/gcp/gcs_to_gdrive.rst
@@ -33,7 +33,7 @@ document editor, file sharing mechanisms.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToGoogleDriveOperator:
 

--- a/docs/howto/operator/gcp/gcs_to_local.rst
+++ b/docs/howto/operator/gcp/gcs_to_local.rst
@@ -29,7 +29,7 @@ This page shows how to download data from GCS to local filesystem.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToLocalFilesystemOperator:
 

--- a/docs/howto/operator/gcp/gcs_to_sftp.rst
+++ b/docs/howto/operator/gcp/gcs_to_sftp.rst
@@ -32,7 +32,7 @@ It runs over the SSH protocol. It supports the full security and authentication 
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToSFTPOperator:
 

--- a/docs/howto/operator/gcp/gcs_to_sheets.rst
+++ b/docs/howto/operator/gcp/gcs_to_sheets.rst
@@ -32,7 +32,7 @@ common spreadsheet tasks.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToGoogleSheets:
 

--- a/docs/howto/operator/gcp/kubernetes_engine.rst
+++ b/docs/howto/operator/gcp/kubernetes_engine.rst
@@ -31,7 +31,7 @@ consists of multiple machines (specifically, Compute Engine instances) grouped t
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 Manage GKE cluster
 ^^^^^^^^^^^^^^^^^^

--- a/docs/howto/operator/gcp/life_sciences.rst
+++ b/docs/howto/operator/gcp/life_sciences.rst
@@ -31,7 +31,7 @@ and biomedical data at scale.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 Pipeline Configuration

--- a/docs/howto/operator/gcp/local_to_gcs.rst
+++ b/docs/howto/operator/gcp/local_to_gcs.rst
@@ -29,7 +29,7 @@ This page shows how to upload data from local filesystem to GCS.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:LocalFilesystemToGCSOperator:
 

--- a/docs/howto/operator/gcp/natural_language.rst
+++ b/docs/howto/operator/gcp/natural_language.rst
@@ -35,7 +35,7 @@ messaging app.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudNaturalLanguageDocuments:

--- a/docs/howto/operator/gcp/pubsub.rst
+++ b/docs/howto/operator/gcp/pubsub.rst
@@ -35,7 +35,7 @@ By decoupling senders and receivers Google Cloud PubSub allows developers to com
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:PubSubCreateTopicOperator:
 

--- a/docs/howto/operator/gcp/search_ads.rst
+++ b/docs/howto/operator/gcp/search_ads.rst
@@ -28,7 +28,7 @@ For more information check `Google Search Ads <https://developers.google.com/sea
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleSearchAdsInsertReportOperator:
 

--- a/docs/howto/operator/gcp/sftp_to_gcs.rst
+++ b/docs/howto/operator/gcp/sftp_to_gcs.rst
@@ -32,7 +32,7 @@ It runs over the SSH protocol. It supports the full security and authentication 
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:SFTPToGCSOperator:
 

--- a/docs/howto/operator/gcp/sheets.rst
+++ b/docs/howto/operator/gcp/sheets.rst
@@ -39,7 +39,7 @@ For more information check `official documentation <https://developers.google.co
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleSheetsCreateSpreadsheetOperator:
 

--- a/docs/howto/operator/gcp/sheets_to_gcs.rst
+++ b/docs/howto/operator/gcp/sheets_to_gcs.rst
@@ -32,7 +32,7 @@ common spreadsheet tasks.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleSheetsToGCSOperator:
 

--- a/docs/howto/operator/gcp/spanner.rst
+++ b/docs/howto/operator/gcp/spanner.rst
@@ -27,7 +27,7 @@ Google Cloud Spanner Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:SpannerDeployInstanceOperator:
 

--- a/docs/howto/operator/gcp/speech_to_text.rst
+++ b/docs/howto/operator/gcp/speech_to_text.rst
@@ -22,7 +22,7 @@ Google Cloud Speech to Text Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudSpeechToTextRecognizeSpeechOperator:
 

--- a/docs/howto/operator/gcp/stackdriver.rst
+++ b/docs/howto/operator/gcp/stackdriver.rst
@@ -27,7 +27,7 @@ Google Cloud Stackdriver Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:StackdriverListAlertPoliciesOperator:

--- a/docs/howto/operator/gcp/text_to_speech.rst
+++ b/docs/howto/operator/gcp/text_to_speech.rst
@@ -22,7 +22,7 @@ Google Cloud Text to Speech Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudTextToSpeechSynthesizeOperator:
 

--- a/docs/howto/operator/gcp/translate.rst
+++ b/docs/howto/operator/gcp/translate.rst
@@ -27,7 +27,7 @@ Google Cloud Translate Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudTranslateTextOperator:
 

--- a/docs/howto/operator/gcp/translate_speech.rst
+++ b/docs/howto/operator/gcp/translate_speech.rst
@@ -25,7 +25,7 @@ Google Cloud Speech Translate Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudTranslateSpeechOperator:
 

--- a/docs/howto/operator/gcp/video_intelligence.rst
+++ b/docs/howto/operator/gcp/video_intelligence.rst
@@ -42,7 +42,7 @@ Google Cloud Video Intelligence Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudVideoIntelligenceDetectVideoLabelsOperator:
 

--- a/docs/howto/operator/gcp/vision.rst
+++ b/docs/howto/operator/gcp/vision.rst
@@ -27,7 +27,7 @@ Google Cloud Vision Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: _partials/prerequisite_tasks.rst
+.. include:: /howto/operator/gcp/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudVisionAddProductToProductSetOperator:
 


### PR DESCRIPTION
I propose this change for two reasons.
- include with links is relatively problematic because include causes links to be resolved from the context of the wrong file. This is resolved in the context of the parent file, not in the context of the current file. This limits the reuse of the file.
- The use of absolute paths will allow easier refactorization, because I would like to divide these sections into several smaller ones, e.g. transfer/service operators, and then grouping by the department.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
