### PR TITLE
Add type hinting for discord provider

### DIFF
--- a/airflow/providers/discord/hooks/discord_webhook.py
+++ b/airflow/providers/discord/hooks/discord_webhook.py
@@ -18,6 +18,7 @@
 #
 import json
 import re
+from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpHook
@@ -54,15 +55,15 @@ class DiscordWebhookHook(HttpHook):
     """
 
     def __init__(self,
-                 http_conn_id=None,
-                 webhook_endpoint=None,
-                 message="",
-                 username=None,
-                 avatar_url=None,
-                 tts=False,
-                 proxy=None,
+                 http_conn_id: Optional[str] = None,
+                 webhook_endpoint: Optional[str] = None,
+                 message: str = "",
+                 username: Optional[str] = None,
+                 avatar_url: Optional[str] = None,
+                 tts: bool = False,
+                 proxy: Optional[str] = None,
                  *args,
-                 **kwargs):
+                 **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.http_conn_id = http_conn_id
         self.webhook_endpoint = self._get_webhook_endpoint(http_conn_id, webhook_endpoint)
@@ -72,7 +73,7 @@ class DiscordWebhookHook(HttpHook):
         self.tts = tts
         self.proxy = proxy
 
-    def _get_webhook_endpoint(self, http_conn_id, webhook_endpoint):
+    def _get_webhook_endpoint(self, http_conn_id: Optional[str], webhook_endpoint: Optional[str]) -> str:
         """
         Given a Discord http_conn_id, return the default webhook endpoint or override if a
         webhook_endpoint is manually supplied.
@@ -98,7 +99,7 @@ class DiscordWebhookHook(HttpHook):
 
         return endpoint
 
-    def _build_discord_payload(self):
+    def _build_discord_payload(self) -> str:
         """
         Construct the Discord JSON payload. All relevant parameters are combined here
         to a valid Discord JSON payload.
@@ -122,7 +123,7 @@ class DiscordWebhookHook(HttpHook):
 
         return json.dumps(payload)
 
-    def execute(self):
+    def execute(self) -> None:
         """
         Execute the Discord webhook call
         """

--- a/airflow/providers/discord/hooks/discord_webhook.py
+++ b/airflow/providers/discord/hooks/discord_webhook.py
@@ -18,7 +18,7 @@
 #
 import json
 import re
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpHook
@@ -106,7 +106,7 @@ class DiscordWebhookHook(HttpHook):
 
         :return: Discord payload (str) to send
         """
-        payload = {}
+        payload: Dict[str, Any] = {}
 
         if self.username:
             payload['username'] = self.username

--- a/airflow/providers/discord/operators/discord_webhook.py
+++ b/airflow/providers/discord/operators/discord_webhook.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from typing import Any, Dict, Optional
+
 from airflow.exceptions import AirflowException
 from airflow.providers.discord.hooks.discord_webhook import DiscordWebhookHook
 from airflow.providers.http.operators.http import SimpleHttpOperator
@@ -56,15 +58,15 @@ class DiscordWebhookOperator(SimpleHttpOperator):
 
     @apply_defaults
     def __init__(self,
-                 http_conn_id=None,
-                 webhook_endpoint=None,
-                 message="",
-                 username=None,
-                 avatar_url=None,
-                 tts=False,
-                 proxy=None,
+                 http_conn_id: Optional[str] = None,
+                 webhook_endpoint: Optional[str] = None,
+                 message: str = "",
+                 username: Optional[str] = None,
+                 avatar_url: Optional[str] = None,
+                 tts: bool = False,
+                 proxy: Optional[str] = None,
                  *args,
-                 **kwargs):
+                 **kwargs) -> None:
         super().__init__(endpoint=webhook_endpoint,
                          *args,
                          **kwargs)
@@ -81,7 +83,7 @@ class DiscordWebhookOperator(SimpleHttpOperator):
         self.proxy = proxy
         self.hook = None
 
-    def execute(self, context):
+    def execute(self, context: Dict[Any, Any]) -> None:
         """
         Call the DiscordWebhookHook to post message
         """

--- a/airflow/providers/discord/operators/discord_webhook.py
+++ b/airflow/providers/discord/operators/discord_webhook.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Any, Dict, Optional
+from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.discord.hooks.discord_webhook import DiscordWebhookHook
@@ -83,7 +83,7 @@ class DiscordWebhookOperator(SimpleHttpOperator):
         self.proxy = proxy
         self.hook = None
 
-    def execute(self, context: Dict[Any, Any]) -> None:
+    def execute(self, context: dict) -> None:
         """
         Call the DiscordWebhookHook to post message
         """

--- a/airflow/providers/discord/operators/discord_webhook.py
+++ b/airflow/providers/discord/operators/discord_webhook.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Optional
+from typing import Dict, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.discord.hooks.discord_webhook import DiscordWebhookHook
@@ -83,7 +83,7 @@ class DiscordWebhookOperator(SimpleHttpOperator):
         self.proxy = proxy
         self.hook = None
 
-    def execute(self, context: dict) -> None:
+    def execute(self, context: Dict) -> None:
         """
         Call the DiscordWebhookHook to post message
         """

--- a/airflow/providers/discord/operators/discord_webhook.py
+++ b/airflow/providers/discord/operators/discord_webhook.py
@@ -81,7 +81,7 @@ class DiscordWebhookOperator(SimpleHttpOperator):
         self.avatar_url = avatar_url
         self.tts = tts
         self.proxy = proxy
-        self.hook = None
+        self.hook: Optional[DiscordWebhookHook] = None
 
     def execute(self, context: Dict) -> None:
         """


### PR DESCRIPTION
This PR adds type hinting for methods in the discord provider per #9708
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.