### PR TITLE
Fixes failing formatting of DAG file containing {} in docstring

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -321,8 +321,8 @@ def wrapped_markdown(s, css_class=None):
         return None
 
     return Markup(
-        '<div class="rich_doc {css_class}" >' + markdown.markdown(s) + "</div>"
-    ).format(css_class=css_class)
+        '<div class="rich_doc {css_class}" >'.format(css_class=css_class) + markdown.markdown(s) + "</div>"
+    )
 
 
 def get_attr_renderer():

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -24,6 +24,7 @@ from bs4 import BeautifulSoup
 from parameterized import parameterized
 
 from airflow.www import utils
+from airflow.www.utils import wrapped_markdown
 from tests.test_utils.config import conf_vars
 
 
@@ -229,3 +230,16 @@ class TestAttrRenderer(unittest.TestCase):
     def test_markdown_none(self):
         rendered = self.attr_renderer["python_callable"](None)
         self.assertEqual("", rendered)
+
+
+class TestWrappedMarkdown(unittest.TestCase):
+
+    def test_wrapped_markdown_with_docstring_curly_braces(self):
+        rendered = wrapped_markdown("{braces}", css_class="a_class")
+        self.assertEqual('<div class="rich_doc a_class" ><p>{braces}</p></div>', rendered)
+
+    def test_wrapped_markdown_with_some_markdown(self):
+        rendered = wrapped_markdown("*italic*\n**bold**\n", css_class="a_class")
+        self.assertEqual(
+            '''<div class="rich_doc a_class" ><p><em>italic</em>
+<strong>bold</strong></p></div>''', rendered)


### PR DESCRIPTION
Fixes #9753

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
