### PR TITLE
apply_default keeps the function signature for mypy

### DIFF
--- a/airflow/contrib/operators/qubole_check_operator.py
+++ b/airflow/contrib/operators/qubole_check_operator.py
@@ -21,7 +21,7 @@ import warnings
 
 # pylint: disable=unused-import
 from airflow.providers.qubole.operators.qubole_check import (  # noqa
-    QuboleCheckOperator, QuboleValueCheckOperator, ValueCheckOperator,
+    QuboleCheckOperator, QuboleValueCheckOperator,
 )
 
 warnings.warn(

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -81,10 +81,9 @@ class PythonOperator(BaseOperator):
         op_kwargs: Optional[Dict] = None,
         templates_dict: Optional[Dict] = None,
         templates_exts: Optional[List[str]] = None,
-        *args,
         **kwargs
     ) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         if not callable(python_callable):
             raise AirflowException('`python_callable` param must be callable')
         self.python_callable = python_callable
@@ -404,12 +403,11 @@ class PythonVirtualenvOperator(PythonOperator):
         python_version: Optional[str] = None,
         use_dill: bool = False,
         system_site_packages: bool = True,
-        op_args: Optional[Iterable] = None,
+        op_args: Optional[List] = None,
         op_kwargs: Optional[Dict] = None,
         string_args: Optional[Iterable[str]] = None,
         templates_dict: Optional[Dict] = None,
-        templates_exts: Optional[Iterable[str]] = None,
-        *args,
+        templates_exts: Optional[List[str]] = None,
         **kwargs
     ):
         super().__init__(
@@ -418,7 +416,6 @@ class PythonVirtualenvOperator(PythonOperator):
             op_kwargs=op_kwargs,
             templates_dict=templates_dict,
             templates_exts=templates_exts,
-            *args,
             **kwargs)
         self.requirements = requirements or []
         self.string_args = string_args or []

--- a/airflow/operators/sql.py
+++ b/airflow/operators/sql.py
@@ -74,11 +74,8 @@ class SQLCheckOperator(BaseOperator):
     :type sql: str
     """
 
-    template_fields = ("sql",)  # type: Iterable[str]
-    template_ext = (
-        ".hql",
-        ".sql",
-    )  # type: Iterable[str]
+    template_fields: Iterable[str] = ("sql",)
+    template_ext: Iterable[str] = (".hql", ".sql",)
     ui_color = "#fff7e6"
 
     @apply_defaults
@@ -264,11 +261,8 @@ class SQLIntervalCheckOperator(BaseOperator):
     """
 
     __mapper_args__ = {"polymorphic_identity": "SQLIntervalCheckOperator"}
-    template_fields = ("sql1", "sql2")  # type: Iterable[str]
-    template_ext = (
-        ".hql",
-        ".sql",
-    )  # type: Iterable[str]
+    template_fields: Iterable[str] = ("sql1", "sql2")
+    template_ext: Iterable[str] = (".hql", ".sql",)
     ui_color = "#fff7e6"
 
     ratio_formulas = {
@@ -415,7 +409,7 @@ class SQLThresholdCheckOperator(BaseOperator):
     :type max_threshold: numeric or str
     """
 
-    template_fields = ("sql", "min_threshold", "max_threshold")  # type: Iterable[str]
+    template_fields = ("sql", "min_threshold", "max_threshold")
     template_ext = (
         ".hql",
         ".sql",

--- a/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
@@ -29,7 +29,7 @@ from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.utils.dates import days_ago
 
 # [START howto_operator_s3_to_redshift_env_variables]
-S3_BUCKET = getenv("S3_BUCKET")
+S3_BUCKET = getenv("S3_BUCKET", "test-bucket")
 S3_KEY = getenv("S3_KEY", "key")
 REDSHIFT_TABLE = getenv("REDSHIFT_TABLE", "test_table")
 # [END howto_operator_s3_to_redshift_env_variables]

--- a/airflow/providers/amazon/aws/operators/s3_list.py
+++ b/airflow/providers/amazon/aws/operators/s3_list.py
@@ -65,7 +65,7 @@ class S3ListOperator(BaseOperator):
                 aws_conn_id='aws_customers_conn'
             )
     """
-    template_fields = ('bucket', 'prefix', 'delimiter')  # type: Iterable[str]
+    template_fields: Iterable[str] = ('bucket', 'prefix', 'delimiter')
     ui_color = '#ffd700'
 
     @apply_defaults

--- a/airflow/providers/amazon/aws/operators/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_training.py
@@ -65,8 +65,8 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
                  check_interval=30,
                  max_ingestion_time=None,
                  action_if_job_exists: str = "increment",  # TODO use typing.Literal for this in Python 3.8
-                 *args, **kwargs):
-        super().__init__(config=config, *args, **kwargs)
+                 **kwargs):
+        super().__init__(config=config, **kwargs)
 
         self.wait_for_completion = wait_for_completion
         self.print_log = print_log

--- a/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -19,6 +19,7 @@
 This module contains Google Cloud Storage to S3 operator.
 """
 import warnings
+from typing import Iterable
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
@@ -73,7 +74,7 @@ class GCSToS3Operator(GCSListObjectsOperator):
         in the destination bucket.
     :type replace: bool
     """
-    template_fields = ('bucket', 'prefix', 'delimiter', 'dest_s3_key')
+    template_fields: Iterable[str] = ('bucket', 'prefix', 'delimiter', 'dest_s3_key')
     ui_color = '#f0eee4'
 
     @apply_defaults

--- a/airflow/providers/apache/cassandra/sensors/record.py
+++ b/airflow/providers/apache/cassandra/sensors/record.py
@@ -20,7 +20,7 @@ This module contains sensor that check the existence
 of a record in a Cassandra cluster.
 """
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -56,9 +56,8 @@ class CassandraRecordSensor(BaseSensorOperator):
     template_fields = ('table', 'keys')
 
     @apply_defaults
-    def __init__(self, table: str, keys: Dict[str, str], cassandra_conn_id: str,
-                 *args: Tuple[Any, ...], **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, table: str, keys: Dict[str, str], cassandra_conn_id: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         self.cassandra_conn_id = cassandra_conn_id
         self.table = table
         self.keys = keys

--- a/airflow/providers/apache/cassandra/sensors/table.py
+++ b/airflow/providers/apache/cassandra/sensors/table.py
@@ -21,7 +21,7 @@ This module contains sensor that check the existence
 of a table in a Cassandra cluster.
 """
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -54,9 +54,8 @@ class CassandraTableSensor(BaseSensorOperator):
     template_fields = ('table',)
 
     @apply_defaults
-    def __init__(self, table: str, cassandra_conn_id: str, *args: Tuple[Any, ...],
-                 **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, table: str, cassandra_conn_id: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         self.cassandra_conn_id = cassandra_conn_id
         self.table = table
 

--- a/airflow/providers/apache/druid/operators/druid.py
+++ b/airflow/providers/apache/druid/operators/druid.py
@@ -41,8 +41,8 @@ class DruidOperator(BaseOperator):
     def __init__(self, json_index_file: str,
                  druid_ingest_conn_id: str = 'druid_ingest_default',
                  max_ingestion_time: Optional[int] = None,
-                 *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+                 **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         self.json_index_file = json_index_file
         self.conn_id = druid_ingest_conn_id
         self.max_ingestion_time = max_ingestion_time

--- a/airflow/providers/apache/druid/operators/druid_check.py
+++ b/airflow/providers/apache/druid/operators/druid_check.py
@@ -61,9 +61,9 @@ class DruidCheckOperator(CheckOperator):
         self,
         sql: str,
         druid_broker_conn_id: str = 'druid_broker_default',
-        *args: Any, **kwargs: Any
+        **kwargs: Any
     ) -> None:
-        super().__init__(sql=sql, *args, **kwargs)
+        super().__init__(sql=sql, **kwargs)
         self.druid_broker_conn_id = druid_broker_conn_id
         self.sql = sql
 

--- a/airflow/providers/apache/druid/transfers/hive_to_druid.py
+++ b/airflow/providers/apache/druid/transfers/hive_to_druid.py
@@ -100,10 +100,9 @@ class HiveToDruidOperator(BaseOperator):
         segment_granularity: str = "DAY",
         hive_tblproperties: Optional[Dict[Any, Any]] = None,
         job_properties: Optional[Dict[Any, Any]] = None,
-        *args: Any,
         **kwargs: Any
     ) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.sql = sql
         self.druid_datasource = druid_datasource
         self.ts_dim = ts_dim

--- a/airflow/providers/apache/hdfs/sensors/hdfs.py
+++ b/airflow/providers/apache/hdfs/sensors/hdfs.py
@@ -43,9 +43,8 @@ class HdfsSensor(BaseSensorOperator):
                  ignore_copying: bool = True,
                  file_size: Optional[int] = None,
                  hook: Type[HDFSHook] = HDFSHook,
-                 *args: Any,
                  **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         if ignored_ext is None:
             ignored_ext = ['_COPYING_']
         self.filepath = filepath

--- a/airflow/providers/apache/hdfs/sensors/web_hdfs.py
+++ b/airflow/providers/apache/hdfs/sensors/web_hdfs.py
@@ -31,9 +31,8 @@ class WebHdfsSensor(BaseSensorOperator):
     def __init__(self,
                  filepath: str,
                  webhdfs_conn_id: str = 'webhdfs_default',
-                 *args: Any,
                  **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.filepath = filepath
         self.webhdfs_conn_id = webhdfs_conn_id
 

--- a/airflow/providers/apache/hive/operators/hive.py
+++ b/airflow/providers/apache/hive/operators/hive.py
@@ -17,7 +17,7 @@
 # under the License.
 import os
 import re
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 from airflow.configuration import conf
 from airflow.models import BaseOperator
@@ -81,11 +81,9 @@ class HiveOperator(BaseOperator):
             mapred_queue: Optional[str] = None,
             mapred_queue_priority: Optional[str] = None,
             mapred_job_name: Optional[str] = None,
-            *args: Tuple[Any, ...],
             **kwargs: Any
     ) -> None:
-
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.hql = hql
         self.hive_cli_conn_id = hive_cli_conn_id
         self.schema = schema

--- a/airflow/providers/apache/hive/operators/hive_stats.py
+++ b/airflow/providers/apache/hive/operators/hive_stats.py
@@ -18,7 +18,7 @@
 import json
 import warnings
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -72,7 +72,6 @@ class HiveStatsCollectionOperator(BaseOperator):
                  metastore_conn_id: str = 'metastore_default',
                  presto_conn_id: str = 'presto_default',
                  mysql_conn_id: str = 'airflow_db',
-                 *args: Tuple[Any, ...],
                  **kwargs: Any
                  ) -> None:
         if 'col_blacklist' in kwargs:
@@ -84,7 +83,7 @@ class HiveStatsCollectionOperator(BaseOperator):
                 stacklevel=2
             )
             excluded_columns = kwargs.pop('col_blacklist')
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.table = table
         self.partition = partition
         self.extra_exprs = extra_exprs or {}

--- a/airflow/providers/apache/hive/sensors/hive_partition.py
+++ b/airflow/providers/apache/hive/sensors/hive_partition.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -52,10 +52,9 @@ class HivePartitionSensor(BaseSensorOperator):
                  metastore_conn_id: str = 'metastore_default',
                  schema: str = 'default',
                  poke_interval: int = 60 * 3,
-                 *args: Tuple[Any, ...],
                  **kwargs: Any):
         super().__init__(
-            poke_interval=poke_interval, *args, **kwargs)
+            poke_interval=poke_interval, **kwargs)
         if not partition:
             partition = "ds='{{ ds }}'"
         self.metastore_conn_id = metastore_conn_id

--- a/airflow/providers/apache/hive/sensors/metastore_partition.py
+++ b/airflow/providers/apache/hive/sensors/metastore_partition.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 from airflow.sensors.sql_sensor import SqlSensor
 from airflow.utils.decorators import apply_defaults
@@ -50,7 +50,6 @@ class MetastorePartitionSensor(SqlSensor):
                  partition_name: str,
                  schema: str = "default",
                  mysql_conn_id: str = "metastore_mysql",
-                 *args: Tuple[Any, ...],
                  **kwargs: Any):
 
         self.partition_name = partition_name
@@ -63,7 +62,7 @@ class MetastorePartitionSensor(SqlSensor):
         # The inheritance model needs to be reworked in order to support overriding args/
         # kwargs with arguments here, then 'conn_id' and 'sql' can be passed into the
         # constructor below and apply_defaults will no longer throw an exception.
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def poke(self, context: Dict[str, Any]) -> Any:
         if self.first_poke:

--- a/airflow/providers/apache/hive/sensors/named_hive_partition.py
+++ b/airflow/providers/apache/hive/sensors/named_hive_partition.py
@@ -47,10 +47,9 @@ class NamedHivePartitionSensor(BaseSensorOperator):
                  metastore_conn_id: str = 'metastore_default',
                  poke_interval: int = 60 * 3,
                  hook: Any = None,
-                 *args: Tuple[Any, ...],
                  **kwargs: Any):
         super().__init__(
-            poke_interval=poke_interval, *args, **kwargs)
+            poke_interval=poke_interval, **kwargs)
 
         self.next_index_to_poke = 0
         if isinstance(partition_names, str):

--- a/airflow/providers/apache/hive/transfers/hive_to_mysql.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_mysql.py
@@ -76,8 +76,8 @@ class HiveToMySqlOperator(BaseOperator):
                  mysql_postoperator: Optional[str] = None,
                  bulk_load: bool = False,
                  hive_conf: Optional[Dict] = None,
-                 *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
         self.sql = sql
         self.mysql_table = mysql_table
         self.mysql_conn_id = mysql_conn_id

--- a/airflow/providers/apache/hive/transfers/hive_to_samba.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_samba.py
@@ -53,8 +53,8 @@ class HiveToSambaOperator(BaseOperator):
                  destination_filepath: str,
                  samba_conn_id: str = 'samba_default',
                  hiveserver2_conn_id: str = 'hiveserver2_default',
-                 *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
         self.hiveserver2_conn_id = hiveserver2_conn_id
         self.samba_conn_id = samba_conn_id
         self.destination_filepath = destination_filepath

--- a/airflow/providers/apache/hive/transfers/mssql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mssql_to_hive.py
@@ -86,8 +86,8 @@ class MsSqlToHiveOperator(BaseOperator):
                  mssql_conn_id: str = 'mssql_default',
                  hive_cli_conn_id: str = 'hive_cli_default',
                  tblproperties: Optional[Dict] = None,
-                 *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
         self.sql = sql
         self.hive_table = hive_table
         self.partition = partition

--- a/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -98,8 +98,8 @@ class MySqlToHiveOperator(BaseOperator):
             mysql_conn_id: str = 'mysql_default',
             hive_cli_conn_id: str = 'hive_cli_default',
             tblproperties: Optional[Dict] = None,
-            *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+            **kwargs) -> None:
+        super().__init__(**kwargs)
         self.sql = sql
         self.hive_table = hive_table
         self.partition = partition

--- a/airflow/providers/apache/hive/transfers/s3_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/s3_to_hive.py
@@ -124,8 +124,8 @@ class S3ToHiveOperator(BaseOperator):  # pylint: disable=too-many-instance-attri
             input_compressed: bool = False,
             tblproperties: Optional[Dict] = None,
             select_expression: Optional[str] = None,
-            *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+            **kwargs) -> None:
+        super().__init__(**kwargs)
         self.s3_key = s3_key
         self.field_dict = field_dict
         self.hive_table = hive_table

--- a/airflow/providers/apache/hive/transfers/vertica_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/vertica_to_hive.py
@@ -82,8 +82,8 @@ class VerticaToHiveOperator(BaseOperator):
             delimiter=chr(1),
             vertica_conn_id='vertica_default',
             hive_cli_conn_id='hive_cli_default',
-            *args, **kwargs):
-        super().__init__(*args, **kwargs)
+            **kwargs):
+        super().__init__(**kwargs)
         self.sql = sql
         self.hive_table = hive_table
         self.partition = partition

--- a/airflow/providers/apache/kylin/operators/kylin_cube.py
+++ b/airflow/providers/apache/kylin/operators/kylin_cube.py
@@ -111,9 +111,8 @@ class KylinCubeOperator(BaseOperator):
                  interval: int = 60,
                  timeout: int = 60 * 60 * 24,
                  eager_error_status=tuple(["ERROR", "DISCARDED", "KILLED", "SUICIDAL", "STOPPED"]),
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.kylin_conn_id = kylin_conn_id
         self.project = project
         self.cube = cube

--- a/airflow/providers/apache/livy/sensors/livy.py
+++ b/airflow/providers/apache/livy/sensors/livy.py
@@ -42,10 +42,9 @@ class LivySensor(BaseSensorOperator):
         self,
         batch_id: Union[int, str],
         livy_conn_id: str = 'livy_default',
-        *vargs: Any,
         **kwargs: Any
     ) -> None:
-        super().__init__(*vargs, **kwargs)
+        super().__init__(**kwargs)
         self._livy_conn_id = livy_conn_id
         self._batch_id = batch_id
         self._livy_hook: Optional[LivyHook] = None

--- a/airflow/providers/apache/pig/operators/pig.py
+++ b/airflow/providers/apache/pig/operators/pig.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import re
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.apache.pig.hooks.pig import PigCliHook
@@ -52,10 +52,9 @@ class PigOperator(BaseOperator):
             pig_cli_conn_id: str = 'pig_cli_default',
             pigparams_jinja_translate: bool = False,
             pig_opts: Optional[str] = None,
-            *args: Tuple[Any, ...],
             **kwargs: Any) -> None:
 
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.pigparams_jinja_translate = pigparams_jinja_translate
         self.pig = pig
         self.pig_cli_conn_id = pig_cli_conn_id

--- a/airflow/providers/apache/spark/operators/spark_jdbc.py
+++ b/airflow/providers/apache/spark/operators/spark_jdbc.py
@@ -149,9 +149,8 @@ class SparkJDBCOperator(SparkSubmitOperator):
                  lower_bound: Optional[str] = None,
                  upper_bound: Optional[str] = None,
                  create_table_column_types: Optional[str] = None,
-                 *args: Any,
                  **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self._spark_app_name = spark_app_name
         self._spark_conn_id = spark_conn_id
         self._spark_conf = spark_conf

--- a/airflow/providers/apache/spark/operators/spark_sql.py
+++ b/airflow/providers/apache/spark/operators/spark_sql.py
@@ -78,9 +78,8 @@ class SparkSqlOperator(BaseOperator):
                  num_executors: Optional[int] = None,
                  verbose: bool = True,
                  yarn_queue: str = 'default',
-                 *args: Any,
                  **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self._sql = sql
         self._conf = conf
         self._conn_id = conn_id

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -129,9 +129,8 @@ class SparkSubmitOperator(BaseOperator):
                  env_vars: Optional[Dict[str, Any]] = None,
                  verbose: bool = False,
                  spark_binary: Optional[str] = None,
-                 *args: Any,
                  **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self._application = application
         self._conf = conf
         self._files = files

--- a/airflow/providers/apache/sqoop/operators/sqoop.py
+++ b/airflow/providers/apache/sqoop/operators/sqoop.py
@@ -22,7 +22,7 @@ This module contains a sqoop 1 operator
 """
 import os
 import signal
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -128,10 +128,9 @@ class SqoopOperator(BaseOperator):
                  create_hcatalog_table: bool = False,
                  extra_import_options: Optional[Dict[str, Any]] = None,
                  extra_export_options: Optional[Dict[str, Any]] = None,
-                 *args: Tuple[str, Any],
                  **kwargs: Any
                  ) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.conn_id = conn_id
         self.cmd_type = cmd_type
         self.table = table

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -16,7 +16,7 @@
 # under the License.
 """Executes task in a Kubernetes POD"""
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import yaml
 from kubernetes.client import models as k8s
@@ -146,7 +146,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     :param priority_class_name: priority class name for the launched Pod
     :type priority_class_name: str
     """
-    template_fields = ('cmds', 'arguments', 'env_vars', 'config_file', 'pod_template_file')
+    template_fields: Iterable[str] = ('cmds', 'arguments', 'env_vars', 'config_file', 'pod_template_file')
 
     @apply_defaults
     def __init__(self,  # pylint: disable=too-many-arguments,too-many-locals
@@ -188,11 +188,10 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  do_xcom_push: bool = False,
                  pod_template_file: Optional[str] = None,
                  priority_class_name: Optional[str] = None,
-                 *args,
                  **kwargs):
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'do_xcom_push' instead")
-        super().__init__(*args, resources=None, **kwargs)
+        super().__init__(resources=None, **kwargs)
 
         self.pod = None
         self.do_xcom_push = do_xcom_push

--- a/airflow/providers/discord/operators/discord_webhook.py
+++ b/airflow/providers/discord/operators/discord_webhook.py
@@ -65,11 +65,11 @@ class DiscordWebhookOperator(SimpleHttpOperator):
                  avatar_url: Optional[str] = None,
                  tts: bool = False,
                  proxy: Optional[str] = None,
-                 *args,
                  **kwargs) -> None:
-        super().__init__(endpoint=webhook_endpoint,
-                         *args,
-                         **kwargs)
+        super().__init__(
+            endpoint=webhook_endpoint,
+            **kwargs
+        )
 
         if not http_conn_id:
             raise AirflowException('No valid Discord http_conn_id supplied.')

--- a/airflow/providers/google/cloud/example_dags/example_bigtable.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigtable.py
@@ -89,7 +89,7 @@ with models.DAG(
         instance_type=int(CBT_INSTANCE_TYPE),
         instance_labels=json.loads(CBT_INSTANCE_LABELS),
         cluster_nodes=int(CBT_CLUSTER_NODES),
-        cluster_storage_type=int(CBT_CLUSTER_STORAGE_TYPE),
+        cluster_storage_type=CBT_CLUSTER_STORAGE_TYPE,
         task_id='create_instance_task',
     )
     create_instance_task2 = BigtableCreateInstanceOperator(

--- a/airflow/providers/google/cloud/example_dags/example_functions.py
+++ b/airflow/providers/google/cloud/example_dags/example_functions.py
@@ -65,7 +65,7 @@ GCF_SOURCE_REPOSITORY = os.environ.get(
 GCF_ZIP_PATH = os.environ.get('GCF_ZIP_PATH', '')
 GCF_ENTRYPOINT = os.environ.get('GCF_ENTRYPOINT', 'helloWorld')
 GCF_RUNTIME = 'nodejs6'
-GCP_VALIDATE_BODY = os.environ.get('GCP_VALIDATE_BODY', True)
+GCP_VALIDATE_BODY = os.environ.get('GCP_VALIDATE_BODY', "True") == "True"
 
 # [START howto_operator_gcf_deploy_body]
 body = {

--- a/airflow/providers/google/cloud/example_dags/example_pubsub.py
+++ b/airflow/providers/google/cloud/example_dags/example_pubsub.py
@@ -126,7 +126,7 @@ with models.DAG(
     # [START howto_operator_gcp_pubsub_pull_message_with_operator]
     subscription = "{{ task_instance.xcom_pull('subscribe_task') }}"
 
-    pull_messages = PubSubPullOperator(
+    pull_messages_operaator = PubSubPullOperator(
         task_id="pull_messages",
         ack_messages=True,
         project_id=GCP_PROJECT_ID,
@@ -165,5 +165,5 @@ with models.DAG(
 
     (
         create_topic >> subscribe_task >> publish_task
-        >> pull_messages >> pull_messages_result >> unsubscribe_task >> delete_topic
+        >> pull_messages_operaator >> pull_messages_result >> unsubscribe_task >> delete_topic
     )

--- a/airflow/providers/google/cloud/operators/bigtable.py
+++ b/airflow/providers/google/cloud/operators/bigtable.py
@@ -18,11 +18,11 @@
 """
 This module contains Google Cloud Bigtable operators.
 """
-from enum import IntEnum
 from typing import Dict, Iterable, List, Optional
 
 import google.api_core.exceptions
 from google.cloud.bigtable.column_family import GarbageCollectionRule
+from google.cloud.bigtable_admin_v2 import enums
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -90,10 +90,8 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
     :type gcp_conn_id: str
     """
 
-    REQUIRED_ATTRIBUTES = ('instance_id', 'main_cluster_id',
-                           'main_cluster_zone')  # type: Iterable[str]
-    template_fields = ['project_id', 'instance_id', 'main_cluster_id',
-                       'main_cluster_zone']  # type: Iterable[str]
+    REQUIRED_ATTRIBUTES: Iterable[str] = ('instance_id', 'main_cluster_id', 'main_cluster_zone')
+    template_fields: Iterable[str] = ['project_id', 'instance_id', 'main_cluster_id', 'main_cluster_zone']
 
     @apply_defaults
     def __init__(self,  # pylint: disable=too-many-arguments
@@ -104,10 +102,10 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
                  replica_cluster_id: Optional[str] = None,
                  replica_cluster_zone: Optional[str] = None,
                  instance_display_name: Optional[str] = None,
-                 instance_type: Optional[IntEnum] = None,
-                 instance_labels: Optional[int] = None,
+                 instance_type: Optional[enums.Instance.Type] = None,
+                 instance_labels: Optional[Dict] = None,
                  cluster_nodes: Optional[int] = None,
-                 cluster_storage_type: Optional[IntEnum] = None,
+                 cluster_storage_type: Optional[enums.StorageType] = None,
                  timeout: Optional[float] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  *args, **kwargs) -> None:
@@ -401,7 +399,7 @@ class BigtableUpdateClusterOperator(BaseOperator, BigtableValidationMixin):
     def __init__(self,
                  instance_id: str,
                  cluster_id: str,
-                 nodes: str,
+                 nodes: int,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  *args, **kwargs) -> None:

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -19,7 +19,7 @@
 import json
 import re
 from copy import deepcopy
-from typing import Any, Dict, Iterable, Optional, Union
+from typing import Any, Dict, Optional, Union
 from urllib.parse import unquote, urlparse
 
 import yaml
@@ -180,7 +180,7 @@ class CloudBuildCreateBuildOperator(BaseOperator):
     :type api_version: str
     """
 
-    template_fields = ("body", "gcp_conn_id", "api_version")  # type: Iterable[str]
+    template_fields = ("body", "gcp_conn_id", "api_version")
     template_ext = ['.yml', '.yaml', '.json']
 
     @apply_defaults

--- a/airflow/providers/google/cloud/operators/cloud_sql.py
+++ b/airflow/providers/google/cloud/operators/cloud_sql.py
@@ -159,13 +159,13 @@ class CloudSQLBaseOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.project_id = project_id
         self.instance = instance
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self._validate_inputs()
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def _validate_inputs(self):
         if self.project_id == '':
@@ -243,12 +243,12 @@ class CloudSQLCreateInstanceOperator(CloudSQLBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
                  validate_body: bool = True,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.body = body
         self.validate_body = validate_body
         super().__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
-            api_version=api_version, *args, **kwargs)
+            api_version=api_version, **kwargs)
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -323,11 +323,11 @@ class CloudSQLInstancePatchOperator(CloudSQLBaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.body = body
         super().__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
-            api_version=api_version, *args, **kwargs)
+            api_version=api_version, **kwargs)
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -378,10 +378,10 @@ class CloudSQLDeleteInstanceOperator(CloudSQLBaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         super().__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
-            api_version=api_version, *args, **kwargs)
+            api_version=api_version, **kwargs)
 
     def execute(self, context):
         hook = CloudSQLHook(
@@ -433,12 +433,12 @@ class CloudSQLCreateInstanceDatabaseOperator(CloudSQLBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
                  validate_body: bool = True,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.body = body
         self.validate_body = validate_body
         super().__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
-            api_version=api_version, *args, **kwargs)
+            api_version=api_version, **kwargs)
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -513,13 +513,13 @@ class CloudSQLPatchInstanceDatabaseOperator(CloudSQLBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
                  validate_body: bool = True,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.database = database
         self.body = body
         self.validate_body = validate_body
         super().__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
-            api_version=api_version, *args, **kwargs)
+            api_version=api_version, **kwargs)
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -584,11 +584,11 @@ class CloudSQLDeleteInstanceDatabaseOperator(CloudSQLBaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.database = database
         super().__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
-            api_version=api_version, *args, **kwargs)
+            api_version=api_version, **kwargs)
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -651,12 +651,12 @@ class CloudSQLExportInstanceOperator(CloudSQLBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
                  validate_body: bool = True,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.body = body
         self.validate_body = validate_body
         super().__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
-            api_version=api_version, *args, **kwargs)
+            api_version=api_version, **kwargs)
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -731,12 +731,12 @@ class CloudSQLImportInstanceOperator(CloudSQLBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1beta4',
                  validate_body: bool = True,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.body = body
         self.validate_body = validate_body
         super().__init__(
             project_id=project_id, instance=instance, gcp_conn_id=gcp_conn_id,
-            api_version=api_version, *args, **kwargs)
+            api_version=api_version, **kwargs)
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -801,8 +801,8 @@ class CloudSQLExecuteQueryOperator(BaseOperator):
                  parameters: Optional[Union[Dict, Iterable]] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  gcp_cloudsql_conn_id: str = 'google_cloud_sql_default',
-                 *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
         self.sql = sql
         self.gcp_conn_id = gcp_conn_id
         self.gcp_cloudsql_conn_id = gcp_cloudsql_conn_id

--- a/airflow/providers/google/cloud/operators/compute.py
+++ b/airflow/providers/google/cloud/operators/compute.py
@@ -45,14 +45,14 @@ class ComputeEngineBaseOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.project_id = project_id
         self.zone = zone
         self.resource_id = resource_id
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self._validate_inputs()
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def _validate_inputs(self):
         if self.project_id == '':
@@ -102,10 +102,10 @@ class ComputeEngineStartInstanceOperator(ComputeEngineBaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         super().__init__(
             project_id=project_id, zone=zone, resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, *args, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
 
     def execute(self, context):
         hook = ComputeEngineHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
@@ -150,10 +150,10 @@ class ComputeEngineStopInstanceOperator(ComputeEngineBaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         super().__init__(
             project_id=project_id, zone=zone, resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, *args, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
 
     def execute(self, context):
         hook = ComputeEngineHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
@@ -210,7 +210,7 @@ class ComputeEngineSetMachineTypeOperator(ComputeEngineBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
                  validate_body: bool = True,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.body = body
         self._field_validator = None  # type: Optional[GcpBodyFieldValidator]
         if validate_body:
@@ -218,7 +218,7 @@ class ComputeEngineSetMachineTypeOperator(ComputeEngineBaseOperator):
                 SET_MACHINE_TYPE_VALIDATION_SPECIFICATION, api_version=api_version)
         super().__init__(
             project_id=project_id, zone=zone, resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, *args, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
 
     def _validate_all_body_fields(self):
         if self._field_validator:
@@ -332,7 +332,7 @@ class ComputeEngineCopyInstanceTemplateOperator(ComputeEngineBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
                  validate_body: bool = True,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.body_patch = body_patch
         self.request_id = request_id
         self._field_validator = None  # Optional[GcpBodyFieldValidator]
@@ -347,7 +347,7 @@ class ComputeEngineCopyInstanceTemplateOperator(ComputeEngineBaseOperator):
             GCE_INSTANCE_TEMPLATE_FIELDS_TO_SANITIZE)
         super().__init__(
             project_id=project_id, zone='global', resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, *args, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
 
     def _validate_all_body_fields(self):
         if self._field_validator:
@@ -444,7 +444,7 @@ class ComputeEngineInstanceGroupUpdateManagerTemplateOperator(ComputeEngineBaseO
                  request_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version='beta',
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         self.zone = zone
         self.source_template = source_template
         self.destination_template = destination_template
@@ -457,7 +457,7 @@ class ComputeEngineInstanceGroupUpdateManagerTemplateOperator(ComputeEngineBaseO
                                    " api version or above")
         super().__init__(
             project_id=project_id, zone=self.zone, resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, *args, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
 
     def _possibly_replace_template(self, dictionary: Dict) -> None:
         if dictionary.get('instanceTemplate') == self.source_template:

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -183,7 +183,7 @@ class GCSListObjectsOperator(BaseOperator):
                 gcp_conn_id=google_cloud_conn_id
             )
     """
-    template_fields = ('bucket', 'prefix', 'delimiter')  # type: Iterable[str]
+    template_fields: Iterable[str] = ('bucket', 'prefix', 'delimiter')
 
     ui_color = '#f0eee4'
 

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -222,8 +222,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
         users to specify a service account.
     :type gcp_conn_id: str
     """
-    template_fields = ('project_id', 'location',
-                       'cluster_name') + KubernetesPodOperator.template_fields
+    template_fields = {'project_id', 'location', 'cluster_name'} | set(KubernetesPodOperator.template_fields)
 
     @apply_defaults
     def __init__(self,
@@ -232,9 +231,8 @@ class GKEStartPodOperator(KubernetesPodOperator):
                  use_internal_ip: bool = False,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
-                 *args,
                  **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.project_id = project_id
         self.location = location
         self.cluster_name = cluster_name

--- a/airflow/providers/google/cloud/operators/life_sciences.py
+++ b/airflow/providers/google/cloud/operators/life_sciences.py
@@ -17,7 +17,7 @@
 # under the License.
 """Operators that interact with Google Cloud Life Sciences service."""
 
-from typing import Iterable, Optional
+from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -46,7 +46,7 @@ class LifeSciencesRunPipelineOperator(BaseOperator):
     :type api_version: str
     """
 
-    template_fields = ("body", "gcp_conn_id", "api_version")  # type: Iterable[str]
+    template_fields = ("body", "gcp_conn_id", "api_version")
 
     @apply_defaults
     def __init__(self,

--- a/airflow/providers/google/cloud/operators/spanner.py
+++ b/airflow/providers/google/cloud/operators/spanner.py
@@ -61,9 +61,9 @@ class SpannerDeployInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 instance_id: int,
+                 instance_id: str,
                  configuration_name: str,
-                 node_count: str,
+                 node_count: int,
                  display_name: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -122,7 +122,7 @@ class SpannerDeleteInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 instance_id: int,
+                 instance_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  *args, **kwargs) -> None:
@@ -178,7 +178,7 @@ class SpannerQueryDatabaseInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 instance_id: int,
+                 instance_id: str,
                  database_id: str,
                  query: Union[str, List[str]],
                  project_id: Optional[str] = None,
@@ -261,7 +261,7 @@ class SpannerDeployDatabaseInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 instance_id: int,
+                 instance_id: str,
                  database_id: str,
                  ddl_statements: List[str],
                  project_id: Optional[str] = None,
@@ -335,7 +335,7 @@ class SpannerUpdateDatabaseInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 instance_id: int,
+                 instance_id: str,
                  database_id: str,
                  ddl_statements: List[str],
                  project_id: Optional[str] = None,
@@ -407,7 +407,7 @@ class SpannerDeleteDatabaseInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 instance_id: int,
+                 instance_id: str,
                  database_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',

--- a/airflow/providers/google/cloud/operators/translate.py
+++ b/airflow/providers/google/cloud/operators/translate.py
@@ -18,7 +18,7 @@
 """
 This module contains Google Translate operators.
 """
-from typing import List, Union
+from typing import List, Optional, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -83,7 +83,7 @@ class CloudTranslateTextOperator(BaseOperator):
         values: Union[List[str], str],
         target_language: str,
         format_: str,
-        source_language: str,
+        source_language: Optional[str],
         model: str,
         gcp_conn_id: str = 'google_cloud_default',
         *args,

--- a/airflow/providers/google/cloud/operators/translate_speech.py
+++ b/airflow/providers/google/cloud/operators/translate_speech.py
@@ -108,7 +108,7 @@ class CloudTranslateSpeechOperator(BaseOperator):
         config: RecognitionConfig,
         target_language: str,
         format_: str,
-        source_language: str,
+        source_language: Optional[str],
         model: str,
         project_id: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',

--- a/airflow/providers/google/cloud/operators/vision.py
+++ b/airflow/providers/google/cloud/operators/vision.py
@@ -790,7 +790,7 @@ class CloudVisionCreateReferenceImageOperator(BaseOperator):
         reference_image_id: Optional[str] = None,
         project_id: Optional[str] = None,
         retry: Optional[Retry] = None,
-        timeout: Optional[str] = None,
+        timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
         *args,

--- a/airflow/providers/google/cloud/transfers/adls_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/adls_to_gcs.py
@@ -22,7 +22,7 @@ Google Cloud Storage operator.
 import os
 import warnings
 from tempfile import NamedTemporaryFile
-from typing import Optional
+from typing import Optional, Sequence
 
 from airflow.providers.google.cloud.hooks.gcs import GCSHook, _parse_gcs_url
 from airflow.providers.microsoft.azure.hooks.azure_data_lake import AzureDataLakeHook
@@ -94,7 +94,7 @@ class ADLSToGCSOperator(AzureDataLakeStorageListOperator):
                 gcp_conn_id='google_cloud_default'
             )
     """
-    template_fields = ('src_adls', 'dest_gcs')
+    template_fields: Sequence[str] = ('src_adls', 'dest_gcs')
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -107,13 +107,11 @@ class ADLSToGCSOperator(AzureDataLakeStorageListOperator):
                  delegate_to: Optional[str] = None,
                  replace: bool = False,
                  gzip: bool = False,
-                 *args,
                  **kwargs) -> None:
 
         super().__init__(
             path=src_adls,
             azure_data_lake_conn_id=azure_data_lake_conn_id,
-            *args,
             **kwargs
         )
 

--- a/airflow/providers/google/cloud/transfers/s3_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/s3_to_gcs.py
@@ -17,6 +17,7 @@
 # under the License.
 import warnings
 from tempfile import NamedTemporaryFile
+from typing import Iterable
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -87,7 +88,7 @@ class S3ToGCSOperator(S3ListOperator):
     templated, so you can use variables in them if you wish.
     """
 
-    template_fields = ('bucket', 'prefix', 'delimiter', 'dest_gcs')
+    template_fields: Iterable[str] = ('bucket', 'prefix', 'delimiter', 'dest_gcs')
     ui_color = '#e09411'
 
     # pylint: disable=too-many-arguments

--- a/airflow/providers/google/firebase/example_dags/example_firestore.py
+++ b/airflow/providers/google/firebase/example_dags/example_firestore.py
@@ -65,6 +65,8 @@ EXPORT_COLLECTION_ID = os.environ.get("GCP_FIRESTORE_COLLECTION_ID", "firestore_
 DATASET_NAME = os.environ.get("GCP_FIRESTORE_DATASET_NAME", "test_firestore_export")
 DATASET_LOCATION = os.environ.get("GCP_FIRESTORE_DATASET_LOCATION", "EU")
 
+if BUCKET_NAME is None:
+    raise ValueError("Bucket name is required. Please set GCP_FIRESTORE_ARCHIVE_URL env variable.")
 
 with models.DAG(
     "example_google_firestore",

--- a/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py
@@ -34,9 +34,9 @@ from airflow.utils import dates
 from airflow.utils.state import State
 
 PROFILE_ID = os.environ.get("MARKETING_PROFILE_ID", "123456789")
-FLOODLIGHT_ACTIVITY_ID = os.environ.get("FLOODLIGHT_ACTIVITY_ID", 12345)
-FLOODLIGHT_CONFIGURATION_ID = os.environ.get("FLOODLIGHT_CONFIGURATION_ID", 12345)
-ENCRYPTION_ENTITY_ID = os.environ.get("ENCRYPTION_ENTITY_ID", 12345)
+FLOODLIGHT_ACTIVITY_ID = int(os.environ.get("FLOODLIGHT_ACTIVITY_ID", 12345))
+FLOODLIGHT_CONFIGURATION_ID = int(os.environ.get("FLOODLIGHT_CONFIGURATION_ID", 12345))
+ENCRYPTION_ENTITY_ID = int(os.environ.get("ENCRYPTION_ENTITY_ID", 12345))
 DEVICE_ID = os.environ.get("DEVICE_ID", "12345")
 BUCKET = os.environ.get("MARKETING_BUCKET", "test-cm-bucket")
 REPORT_NAME = "test-report"

--- a/airflow/providers/google/marketing_platform/sensors/search_ads.py
+++ b/airflow/providers/google/marketing_platform/sensors/search_ads.py
@@ -59,10 +59,9 @@ class GoogleSearchAdsReportSensor(BaseSensorOperator):
         delegate_to: Optional[str] = None,
         mode: str = "reschedule",
         poke_interval: int = 5 * 60,
-        *args,
         **kwargs
     ):
-        super().__init__(mode=mode, poke_interval=poke_interval, *args, **kwargs)
+        super().__init__(mode=mode, poke_interval=poke_interval, **kwargs)
         self.report_id = report_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -89,7 +89,7 @@ class HttpHook(BaseHook):
         return session
 
     def run(self,
-            endpoint: str,
+            endpoint: Optional[str],
             data: Optional[Union[Dict[str, Any], str]] = None,
             headers: Optional[Dict[str, Any]] = None,
             extra_options: Optional[Dict[str, Any]] = None,

--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -60,7 +60,7 @@ class SimpleHttpOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 endpoint: str,
+                 endpoint: Optional[str] = None,
                  method: str = 'POST',
                  data: Any = None,
                  headers: Optional[Dict[str, str]] = None,

--- a/airflow/providers/microsoft/azure/operators/adls_list.py
+++ b/airflow/providers/microsoft/azure/operators/adls_list.py
@@ -15,8 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, List, Sequence
 
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.azure.hooks.azure_data_lake import AzureDataLakeHook
@@ -47,7 +46,7 @@ class AzureDataLakeStorageListOperator(BaseOperator):
                 azure_data_lake_conn_id='azure_data_lake_default'
             )
     """
-    template_fields = ('path',)  # type: Iterable[str]
+    template_fields: Sequence[str] = ('path',)
     ui_color = '#901dd2'
 
     @apply_defaults

--- a/airflow/providers/qubole/example_dags/example_qubole.py
+++ b/airflow/providers/qubole/example_dags/example_qubole.py
@@ -55,7 +55,7 @@ with DAG(
         """
     )
 
-    def compare_result(**kwargs):
+    def compare_result_fn(**kwargs):
         """
         Compares the results of two QuboleOperator tasks.
 
@@ -65,11 +65,11 @@ with DAG(
         :rtype: bool
         """
         ti = kwargs['ti']
-        qubole_result_1 = t1.get_results(ti)
-        qubole_result_2 = t2.get_results(ti)
+        qubole_result_1 = hive_show_table.get_results(ti)
+        qubole_result_2 = hive_s3_location.get_results(ti)
         return filecmp.cmp(qubole_result_1, qubole_result_2)
 
-    t1 = QuboleOperator(
+    hive_show_table = QuboleOperator(
         task_id='hive_show_table',
         command_type='hivecmd',
         query='show tables',
@@ -86,7 +86,7 @@ with DAG(
         }
     )
 
-    t2 = QuboleOperator(
+    hive_s3_location = QuboleOperator(
         task_id='hive_s3_location',
         command_type="hivecmd",
         script_location="s3n://public-qubole/qbol-library/scripts/show_table.hql",
@@ -97,13 +97,13 @@ with DAG(
         trigger_rule="all_done"
     )
 
-    t3 = PythonOperator(
+    compare_result = PythonOperator(
         task_id='compare_result',
-        python_callable=compare_result,
+        python_callable=compare_result_fn,
         trigger_rule="all_done"
     )
 
-    t3 << [t1, t2]
+    compare_result << [hive_show_table, hive_s3_location]
 
     options = ['hadoop_jar_cmd', 'presto_cmd', 'db_query', 'spark_cmd']
 
@@ -112,14 +112,14 @@ with DAG(
         python_callable=lambda: random.choice(options)
     )
 
-    branching << t3
+    branching << compare_result
 
     join = DummyOperator(
         task_id='join',
         trigger_rule='one_success'
     )
 
-    t4 = QuboleOperator(
+    hadoop_jar_cmd = QuboleOperator(
         task_id='hadoop_jar_cmd',
         command_type='hadoopcmd',
         sub_command='jar s3://paid-qubole/HadoopAPIExamples/'
@@ -135,7 +135,7 @@ with DAG(
         }
     )
 
-    t5 = QuboleOperator(
+    pig_cmd = QuboleOperator(
         task_id='pig_cmd',
         command_type="pigcmd",
         script_location="s3://public-qubole/qbol-library/scripts/script1-hadoop-s3-small.pig",
@@ -143,16 +143,16 @@ with DAG(
         trigger_rule="all_done"
     )
 
-    t5 << t4 << branching
-    t5 >> join
+    pig_cmd << hadoop_jar_cmd << branching
+    pig_cmd >> join
 
-    t6 = QuboleOperator(
+    presto_cmd = QuboleOperator(
         task_id='presto_cmd',
         command_type='prestocmd',
         query='show tables'
     )
 
-    t7 = QuboleOperator(
+    shell_cmd = QuboleOperator(
         task_id='shell_cmd',
         command_type="shellcmd",
         script_location="s3://public-qubole/qbol-library/scripts/shellx.sh",
@@ -160,17 +160,17 @@ with DAG(
         trigger_rule="all_done"
     )
 
-    t7 << t6 << branching
-    t7 >> join
+    shell_cmd << presto_cmd << branching
+    shell_cmd >> join
 
-    t8 = QuboleOperator(
+    db_query = QuboleOperator(
         task_id='db_query',
         command_type='dbtapquerycmd',
         query='show tables',
         db_tap_id=2064
     )
 
-    t9 = QuboleOperator(
+    db_export = QuboleOperator(
         task_id='db_export',
         command_type='dbexportcmd',
         mode=1,
@@ -181,10 +181,10 @@ with DAG(
         trigger_rule="all_done"
     )
 
-    t9 << t8 << branching
-    t9 >> join
+    db_export << db_query << branching
+    db_export >> join
 
-    t10 = QuboleOperator(
+    db_import = QuboleOperator(
         task_id='db_import',
         command_type='dbimportcmd',
         mode=1,
@@ -220,7 +220,7 @@ with DAG(
 
     '''
 
-    t11 = QuboleOperator(
+    spark_cmd = QuboleOperator(
         task_id='spark_cmd',
         command_type="sparkcmd",
         program=prog,
@@ -229,8 +229,8 @@ with DAG(
         tags='airflow_example_run'
     )
 
-    t11 << t10 << branching
-    t11 >> join
+    spark_cmd << db_import << branching
+    spark_cmd >> join
 
 with DAG(
     dag_id='example_qubole_sensor',
@@ -252,7 +252,7 @@ with DAG(
         """
     )
 
-    t1 = QuboleFileSensor(
+    check_s3_file = QuboleFileSensor(
         task_id='check_s3_file',
         qubole_conn_id='qubole_default',
         poke_interval=60,
@@ -266,7 +266,7 @@ with DAG(
         }
     )
 
-    t2 = QubolePartitionSensor(
+    check_hive_partition = QubolePartitionSensor(
         task_id='check_hive_partition',
         poke_interval=10,
         timeout=60,
@@ -281,4 +281,4 @@ with DAG(
               }
     )
 
-    t1 >> t2
+    check_s3_file >> check_hive_partition

--- a/airflow/providers/qubole/operators/qubole.py
+++ b/airflow/providers/qubole/operators/qubole.py
@@ -165,14 +165,16 @@ class QuboleOperator(BaseOperator):
         handler in task definition.
     """
 
-    template_fields = ('query', 'script_location', 'sub_command', 'script', 'files',
-                       'archives', 'program', 'cmdline', 'sql', 'where_clause', 'tags',
-                       'extract_query', 'boundary_query', 'macros', 'name', 'parameters',
-                       'dbtap_id', 'hive_table', 'db_table', 'split_column', 'note_id',
-                       'db_update_keys', 'export_dir', 'partition_spec', 'qubole_conn_id',
-                       'arguments', 'user_program_arguments', 'cluster_label')  # type: Iterable[str]
+    template_fields: Iterable[str] = (
+        'query', 'script_location', 'sub_command', 'script', 'files',
+        'archives', 'program', 'cmdline', 'sql', 'where_clause', 'tags',
+        'extract_query', 'boundary_query', 'macros', 'name', 'parameters',
+        'dbtap_id', 'hive_table', 'db_table', 'split_column', 'note_id',
+        'db_update_keys', 'export_dir', 'partition_spec', 'qubole_conn_id',
+        'arguments', 'user_program_arguments', 'cluster_label'
+    )
 
-    template_ext = ('.txt',)  # type: Iterable[str]
+    template_ext: Iterable[str] = ('.txt',)
     ui_color = '#3064A1'
     ui_fgcolor = '#fff'
     qubole_hook_allowed_args_list = ['command_type', 'qubole_conn_id', 'fetch_logs']

--- a/airflow/providers/qubole/operators/qubole_check.py
+++ b/airflow/providers/qubole/operators/qubole_check.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from typing import Iterable
+
 from airflow.exceptions import AirflowException
 from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
 from airflow.providers.qubole.hooks.qubole_check import QuboleCheckHook
@@ -72,7 +74,9 @@ class QuboleCheckOperator(CheckOperator, QuboleOperator):
 
     """
 
-    template_fields = QuboleOperator.template_fields + CheckOperator.template_fields
+    template_fields: Iterable[str] = (
+        set(QuboleOperator.template_fields) | set(CheckOperator.template_fields)
+    )
     template_ext = QuboleOperator.template_ext
     ui_fgcolor = '#000'
 
@@ -153,7 +157,7 @@ class QuboleValueCheckOperator(ValueCheckOperator, QuboleOperator):
             QuboleOperator and ValueCheckOperator are template-supported.
     """
 
-    template_fields = QuboleOperator.template_fields + ValueCheckOperator.template_fields
+    template_fields = set(QuboleOperator.template_fields) | set(ValueCheckOperator.template_fields)
     template_ext = QuboleOperator.template_ext
     ui_fgcolor = '#000'
 

--- a/airflow/providers/singularity/operators/singularity.py
+++ b/airflow/providers/singularity/operators/singularity.py
@@ -67,7 +67,7 @@ class SingularityOperator(BaseOperator):
     def __init__(  # pylint: disable=too-many-arguments
             self,
             image: str,
-            command: Union[int, List[str]],
+            command: Union[str, List[str]],
             start_command: Optional[Union[str, List[str]]] = None,
             environment: Optional[Dict[str, Any]] = None,
             pull_folder: Optional[str] = None,

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -49,8 +49,8 @@ class SlackAPIOperator(BaseOperator):
                  token: Optional[str] = None,
                  method: Optional[str] = None,
                  api_params: Optional[Dict] = None,
-                 *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
 
         self.token = token  # type: Optional[str]
         self.slack_conn_id = slack_conn_id  # type: Optional[str]
@@ -130,7 +130,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
                                  'airflow/master/airflow/www/static/pin_100.png',
                  attachments: Optional[List] = None,
                  blocks: Optional[List] = None,
-                 *args, **kwargs):
+                 **kwargs):
         self.method = 'chat.postMessage'
         self.channel = channel
         self.username = username
@@ -138,8 +138,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
         self.icon_url = icon_url
         self.attachments = attachments or []
         self.blocks = blocks or []
-        super().__init__(method=self.method,
-                         *args, **kwargs)
+        super().__init__(method=self.method, **kwargs)
 
     def construct_api_call_params(self):
         self.api_params = {
@@ -193,14 +192,14 @@ class SlackAPIFileOperator(SlackAPIOperator):
                  filename: str = 'default_name.csv',
                  filetype: str = 'csv',
                  content: str = 'default,content,csv,file',
-                 *args, **kwargs):
+                 **kwargs):
         self.method = 'files.upload'
         self.channel = channel
         self.initial_comment = initial_comment
         self.filename = filename
         self.filetype = filetype
         self.content = content
-        super(SlackAPIFileOperator, self).__init__(method=self.method, *args, **kwargs)
+        super(SlackAPIFileOperator, self).__init__(method=self.method, **kwargs)
 
     def construct_api_call_params(self):
         self.api_params = {

--- a/airflow/sensors/sql_sensor.py
+++ b/airflow/sensors/sql_sensor.py
@@ -51,8 +51,8 @@ class SqlSensor(BaseSensorOperator):
     :type: fail_on_empty: bool
     """
 
-    template_fields = ('sql',)  # type: Iterable[str]
-    template_ext = ('.hql', '.sql',)  # type: Iterable[str]
+    template_fields: Iterable[str] = ('sql',)
+    template_ext: Iterable[str] = ('.hql', '.sql',)
     ui_color = '#7c7287'
 
     @apply_defaults

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -21,7 +21,7 @@ import inspect
 import os
 from copy import copy
 from functools import wraps
-from typing import Any, Callable, TypeVar, cast, Dict
+from typing import Any, Callable, Dict, TypeVar, cast
 
 from airflow.exceptions import AirflowException
 

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -21,14 +21,16 @@ import inspect
 import os
 from copy import copy
 from functools import wraps
-from typing import Any, Callable, Dict
+from typing import Any, Callable, TypeVar, cast, Dict
 
 from airflow.exceptions import AirflowException
 
 signature = inspect.signature
 
+T = TypeVar('T', bound=Callable)  # pylint: disable=invalid-name
 
-def apply_defaults(func: Callable[..., Any]) -> Any:
+
+def apply_defaults(func: T) -> T:
     """
     Function decorator that Looks for an argument named "default_args", and
     fills the unspecified arguments from it.
@@ -90,8 +92,7 @@ def apply_defaults(func: Callable[..., Any]) -> Any:
 
         result = func(*args, **kwargs)
         return result
-
-    return wrapper
+    return cast(T, wrapper)
 
 
 if 'BUILDING_AIRFLOW_DOCS' in os.environ:

--- a/tests/dags/test_issue_1225.py
+++ b/tests/dags/test_issue_1225.py
@@ -118,7 +118,7 @@ dag9_task1 = DummyOperator(
     task_id='current',
     dag=dag9,
 )
-dag8_task2 = DummyOperator(
+dag9_task2 = DummyOperator(
     task_id='future',
     dag=dag9,
     start_date=DEFAULT_DATE + timedelta(days=1),


### PR DESCRIPTION
apply default cleared all information about constructor parameter types. I fixed it by using generic. This revealed some type inaccuracies that were previously hidden.

In addition, there was a problem with "multiple values for keyword argument"
https://github.com/python/mypy/issues/6799
so I deleted the args parameter in several places to suit mypy. We probably should do it for all operators, but I would prefer to do it in a separate ticket.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
