### PR TITLE
provide_session keep return type

### DIFF
--- a/airflow/api_connexion/schemas/pool_schema.py
+++ b/airflow/api_connexion/schemas/pool_schema.py
@@ -59,7 +59,7 @@ class PoolSchema(SQLAlchemySchema):
         return obj.queued_slots()
 
     @staticmethod
-    def get_open_slots(obj: Pool) -> int:
+    def get_open_slots(obj: Pool) -> float:
         """
         Returns the open slots of the pool.
         """

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -20,7 +20,7 @@
 import time
 from collections import OrderedDict
 from datetime import datetime
-from typing import Set
+from typing import Optional, Set
 
 from sqlalchemy.orm.session import Session, make_transient
 from tabulate import tabulate
@@ -295,12 +295,14 @@ class BackfillJob(BaseJob):
 
         # check if we are scheduling on top of a already existing dag_run
         # we could find a "scheduled" run instead of a "backfill"
-        run = DagRun.find(dag_id=dag.dag_id,
-                          execution_date=run_date,
-                          session=session)
-
-        if run is not None and len(run) > 0:
-            run = run[0]
+        runs = DagRun.find(
+            dag_id=dag.dag_id,
+            execution_date=run_date,
+            session=session
+        )
+        run: Optional[DagRun]
+        if runs:
+            run = runs[0]
             if run.state == State.RUNNING:
                 respect_dag_max_active_limit = False
         else:

--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -17,6 +17,7 @@
 
 import contextlib
 from functools import wraps
+from typing import Callable, TypeVar
 
 from airflow import settings
 
@@ -37,7 +38,10 @@ def create_session():
         session.close()
 
 
-def provide_session(func):
+RT = TypeVar("RT")  # pylint: disable=invalid-name
+
+
+def provide_session(func: Callable[..., RT]) -> Callable[..., RT]:
     """
     Function decorator that provides a session if it isn't provided.
     If you want to reuse a session or run the function as part of a
@@ -45,7 +49,7 @@ def provide_session(func):
     will create one and close it for you.
     """
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args, **kwargs) -> RT:
         arg_session = 'session'
 
         func_params = func.__code__.co_varnames


### PR DESCRIPTION
Currently, the decorator provide_session causes the function's result type to be ignored. Unfortunately, we cannot keep the full signature, because the parameter session has a dual character. Depending on the context, it is required and optional at the same time. It is possible that we can try to write some complex mypy plugin that will detect these situations and handle it correctly, but for now proposes a partial solution.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
