### PR TITLE
Fix Writing Serialized Dags to DB

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -125,10 +125,10 @@ class TestDagFileProcessor(unittest.TestCase):
         return dag
 
     @classmethod
+    @patch("airflow.models.dagbag.settings.STORE_SERIALIZED_DAGS", True)
     def setUpClass(cls):
         # Ensure the DAGs we are looking at from the DB are up-to-date
         non_serialized_dagbag = DagBag(store_serialized_dags=False, include_examples=False)
-        non_serialized_dagbag.store_serialized_dags = True
         non_serialized_dagbag.sync_to_db()
         cls.dagbag = DagBag(store_serialized_dags=True)
 
@@ -1370,10 +1370,10 @@ class TestSchedulerJob(unittest.TestCase):
         self.null_exec = MockExecutor()
 
     @classmethod
+    @patch("airflow.models.dagbag.settings.STORE_SERIALIZED_DAGS", True)
     def setUpClass(cls):
         # Ensure the DAGs we are looking at from the DB are up-to-date
         non_serialized_dagbag = DagBag(store_serialized_dags=False, include_examples=False)
-        non_serialized_dagbag.store_serialized_dags = True
         non_serialized_dagbag.sync_to_db()
         cls.dagbag = DagBag(store_serialized_dags=True)
 

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -24,13 +24,16 @@ from datetime import datetime, timezone
 from tempfile import NamedTemporaryFile, mkdtemp
 from unittest.mock import patch
 
+from sqlalchemy import func
+
 import airflow.example_dags
 from airflow import models
 from airflow.models import DagBag, DagModel
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils.session import create_session
 from tests.models import TEST_DAGS_FOLDER
+from tests.test_utils import db
 from tests.test_utils.config import conf_vars
-from tests.test_utils.db import clear_db_dags
 
 
 class TestDagBag(unittest.TestCase):
@@ -43,10 +46,12 @@ class TestDagBag(unittest.TestCase):
         shutil.rmtree(cls.empty_dir)
 
     def setUp(self) -> None:
-        clear_db_dags()
+        db.clear_db_dags()
+        db.clear_db_serialized_dags()
 
     def tearDown(self) -> None:
-        clear_db_dags()
+        db.clear_db_dags()
+        db.clear_db_serialized_dags()
 
     def test_get_existing_dag(self):
         """
@@ -632,3 +637,23 @@ class TestDagBag(unittest.TestCase):
         # clean up
         with create_session() as session:
             session.query(DagModel).filter(DagModel.dag_id == 'test_deactivate_unknown_dags').delete()
+
+    @patch("airflow.models.dagbag.settings.STORE_SERIALIZED_DAGS", True)
+    def test_serialized_dags_are_written_to_db_on_sync(self):
+        """
+        Test that when dagbag.sync_to_db is called the DAGs are Serialized and written to DB
+        even when dagbag.store_serialized_dags is False
+        """
+        with create_session() as session:
+            serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
+            self.assertEqual(serialized_dags_count, 0)
+
+            dagbag = DagBag(
+                dag_folder=os.path.join(TEST_DAGS_FOLDER, "test_example_bash_operator.py"),
+                include_examples=False)
+            dagbag.sync_to_db()
+
+            self.assertFalse(dagbag.store_serialized_dags)
+
+            new_serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
+            self.assertEqual(new_serialized_dags_count, 1)


### PR DESCRIPTION
While working on a different PR I found that the Serialized DAGs weren't written to the DB.

https://github.com/apache/airflow/pull/8739 - We changed that logic here which caused that

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
