### PR TITLE
Update gcp to google in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ pip install apache-airflow==1.10.11 \
  --constraint https://raw.githubusercontent.com/apache/airflow/1.10.11/requirements/requirements-python3.7.txt
 ```
 
-2. Installing with extras (for example postgres,gcp)
+2. Installing with extras (for example postgres,google)
 ```bash
-pip install apache-airflow[postgres,gcp]==1.10.11 \
+pip install apache-airflow[postgres,google]==1.10.11 \
  --constraint https://raw.githubusercontent.com/apache/airflow/1.10.11/requirements/requirements-python3.7.txt
 ```
 


### PR DESCRIPTION
Update occurrences of `gcp` in  README.md to `google`. This has been already updated in setup.py, so this is only a doc change. 

closes: https://github.com/apache/airflow/issues/8583

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
