### PR TITLE
Add log of affected sql rows with Cursor.rowcount

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -181,12 +181,13 @@ class DbApiHook(BaseHook):
 
             with closing(conn.cursor()) as cur:
                 for sql_statement in sql:
-                    if parameters is not None:
-                        self.log.info("%s with parameters %s", sql_statement, parameters)
-                        cur.execute(sql_statement, parameters)
-                    else:
-                        self.log.info(sql_statement)
-                        cur.execute(sql_statement)
+                    logstr = "Running statement: {}".format(sql_statement)
+                    if parameters:
+                        logstr += " with parameters {}".format(parameters)
+                    self.log.info(logstr)
+                    cur.execute(sql_statement, parameters)
+                    if hasattr(cur, 'rowcount'):
+                        self.log.info("Rows affected: %s", cur.rowcount)
 
             # If autocommit was set to False for db that supports autocommit,
             # or if db does not supports autocommit, we do a manual commit.

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -181,10 +181,8 @@ class DbApiHook(BaseHook):
 
             with closing(conn.cursor()) as cur:
                 for sql_statement in sql:
-                    logstr = "Running statement: {}".format(sql_statement)
-                    if parameters:
-                        logstr += " with parameters {}".format(parameters)
-                    self.log.info(logstr)
+
+                    self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
                     cur.execute(sql_statement, parameters)
                     if hasattr(cur, 'rowcount'):
                         self.log.info("Rows affected: %s", cur.rowcount)

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -183,7 +183,10 @@ class DbApiHook(BaseHook):
                 for sql_statement in sql:
 
                     self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
-                    cur.execute(sql_statement, parameters)
+                    if parameters:
+                        cur.execute(sql_statement, parameters)
+                    else:
+                        cur.execute(sql_statement)
                     if hasattr(cur, 'rowcount'):
                         self.log.info("Rows affected: %s", cur.rowcount)
 

--- a/tests/hooks/test_dbapi_hook.py
+++ b/tests/hooks/test_dbapi_hook.py
@@ -36,6 +36,7 @@ class TestDbApiHook(unittest.TestCase):
 
         class UnitTestDbApiHook(DbApiHook):
             conn_name_attr = 'test_conn_id'
+            log = mock.MagicMock()
 
             def get_conn(self):
                 return conn
@@ -171,3 +172,8 @@ class TestDbApiHook(unittest.TestCase):
             port=1
         ))
         self.assertEqual("conn_type://login:password@host:1/", self.db_hook.get_uri())
+
+    def test_run_log(self):
+        statement = 'SQL'
+        self.db_hook.run(statement)
+        assert self.db_hook.log.info.call_count == 2

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -258,3 +258,16 @@ class TestPostgresHook(unittest.TestCase):
                 (2, "world",)]
         fields = ("id", "value")
         self.db_hook.insert_rows(table, rows, fields, replace=True)
+
+    @pytest.mark.backend("postgres")
+    def test_rowcount(self):
+        hook = PostgresHook()
+        input_data = ["foo", "bar", "baz"]
+
+        with hook.get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("CREATE TABLE {} (c VARCHAR)".format(self.table))
+                values = ",".join("('{}')".format(data) for data in input_data)
+                cur.execute("INSERT INTO {} VALUES {}".format(self.table, values))
+                conn.commit()
+                self.assertEqual(cur.rowcount, len(input_data))

--- a/tests/providers/sqlite/hooks/test_sqlite.py
+++ b/tests/providers/sqlite/hooks/test_sqlite.py
@@ -55,6 +55,7 @@ class TestSqliteHook(unittest.TestCase):
 
         class UnitTestSqliteHook(SqliteHook):
             conn_name_attr = 'test_conn_id'
+            log = mock.MagicMock()
 
             def get_conn(self):
                 return conn
@@ -95,3 +96,8 @@ class TestSqliteHook(unittest.TestCase):
         self.assertEqual(result_sets[1][0], df.values.tolist()[1][0])
 
         self.cur.execute.assert_called_once_with(statement)
+
+    def test_run_log(self):
+        statement = 'SQL'
+        self.db_hook.run(statement)
+        assert self.db_hook.log.info.call_count == 2


### PR DESCRIPTION
Issue: https://github.com/apache/airflow/issues/9834

This change improves logging for `DbApiHook.run` and the operators/hooks using it (e.g. `PostgresHook`).
It logs the row count of each executed statement, only if the cursor object has the `rowcount` attribute.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
