### PR TITLE
Replace deprecated SQL operators

### DIFF
--- a/airflow/providers/apache/druid/operators/druid_check.py
+++ b/airflow/providers/apache/druid/operators/druid_check.py
@@ -17,12 +17,12 @@
 # under the License.
 
 from airflow.exceptions import AirflowException
-from airflow.operators.check_operator import CheckOperator
+from airflow.operators.sql import SQLCheckOperator
 from airflow.providers.apache.druid.hooks.druid import DruidDbApiHook
 from airflow.utils.decorators import apply_defaults
 
 
-class DruidCheckOperator(CheckOperator):
+class DruidCheckOperator(SQLCheckOperator):
     """
     Performs checks against Druid. The ``DruidCheckOperator`` expects
     a sql query that will return a single row. Each value on that

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -34,7 +34,7 @@ from google.cloud.bigquery import TableReference
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.models.taskinstance import TaskInstance
-from airflow.operators.check_operator import CheckOperator, IntervalCheckOperator, ValueCheckOperator
+from airflow.operators.sql import SQLCheckOperator, SQLIntervalCheckOperator, SQLValueCheckOperator
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook, _parse_gcs_url
 from airflow.utils.decorators import apply_defaults
@@ -88,7 +88,7 @@ class BigQueryConsoleIndexableLink(BaseOperatorLink):
         return BIGQUERY_JOB_DETAILS_LINK_FMT.format(job_id=job_id)
 
 
-class BigQueryCheckOperator(CheckOperator):
+class BigQueryCheckOperator(SQLCheckOperator):
     """
     Performs checks against BigQuery. The ``BigQueryCheckOperator`` expects
     a sql query that will return a single row. Each value on that
@@ -168,7 +168,7 @@ class BigQueryCheckOperator(CheckOperator):
         )
 
 
-class BigQueryValueCheckOperator(ValueCheckOperator):
+class BigQueryValueCheckOperator(SQLValueCheckOperator):
     """
     Performs a simple value check using sql code.
 
@@ -231,7 +231,7 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
         )
 
 
-class BigQueryIntervalCheckOperator(IntervalCheckOperator):
+class BigQueryIntervalCheckOperator(SQLIntervalCheckOperator):
     """
     Checks that the values of metrics given as SQL expressions are within
     a certain tolerance of the ones from days_back before.

--- a/airflow/providers/qubole/operators/qubole_check.py
+++ b/airflow/providers/qubole/operators/qubole_check.py
@@ -17,13 +17,13 @@
 # under the License.
 #
 from airflow.exceptions import AirflowException
-from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
+from airflow.operators.sql import SQLCheckOperator, SQLValueCheckOperator
 from airflow.providers.qubole.hooks.qubole_check import QuboleCheckHook
 from airflow.providers.qubole.operators.qubole import QuboleOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class QuboleCheckOperator(CheckOperator, QuboleOperator):
+class QuboleCheckOperator(SQLCheckOperator, QuboleOperator):
     """
     Performs checks against Qubole Commands. ``QuboleCheckOperator`` expects
     a command that will be executed on QDS.
@@ -72,7 +72,7 @@ class QuboleCheckOperator(CheckOperator, QuboleOperator):
 
     """
 
-    template_fields = QuboleOperator.template_fields + CheckOperator.template_fields
+    template_fields = QuboleOperator.template_fields + SQLCheckOperator.template_fields
     template_ext = QuboleOperator.template_ext
     ui_fgcolor = '#000'
 
@@ -115,7 +115,7 @@ class QuboleCheckOperator(CheckOperator, QuboleOperator):
             object.__setattr__(self, name, value)
 
 
-class QuboleValueCheckOperator(ValueCheckOperator, QuboleOperator):
+class QuboleValueCheckOperator(SQLValueCheckOperator, QuboleOperator):
     """
     Performs a simple value check using Qubole command.
     By default, each value on the first row of this
@@ -153,7 +153,7 @@ class QuboleValueCheckOperator(ValueCheckOperator, QuboleOperator):
             QuboleOperator and ValueCheckOperator are template-supported.
     """
 
-    template_fields = QuboleOperator.template_fields + ValueCheckOperator.template_fields
+    template_fields = QuboleOperator.template_fields + SQLValueCheckOperator.template_fields
     template_ext = QuboleOperator.template_ext
     ui_fgcolor = '#000'
 


### PR DESCRIPTION
Operators in `from airflow.operators.check_operator import *` are deprecated

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
