### PR TITLE
Support for set in XCom serialization (fix #8703)

### DIFF
--- a/airflow/serialization/json.py
+++ b/airflow/serialization/json.py
@@ -58,6 +58,7 @@ def serialize(value):
        ``{TYPE: 'foo', VAR: 'bar'}``
     """
     serialization_function_by_type = {
+        type(None): _return_primitive,
         int: _return_primitive,
         bool: _return_primitive,
         float: _return_primitive,
@@ -111,6 +112,7 @@ def deserialize(value):
     """
 
     deserialization_function_by_type = {
+        type(None): _return_primitive,
         int: _return_primitive,
         bool: _return_primitive,
         float: _return_primitive,

--- a/airflow/serialization/json.py
+++ b/airflow/serialization/json.py
@@ -1,12 +1,28 @@
-import enum
-import json
-from typing import Any, Union
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any
 
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 
 
-def encode(value: Any, type_: Any) -> [Encoding, Any]:
-    "Encode value and type into a JSON dict."
+def encode(value: Any, type_: Any) -> dict:
+    """Encode value and type into a JSON-friendly dict."""
     return {Encoding.VAR: value, Encoding.TYPE: type_}
 
 
@@ -18,31 +34,29 @@ def _serialize_list(list_: list) -> list:
 
 
 def _serialize_dict(dict_: dict) -> dict:
-    value = {k: serialize(v) for k,v in dict_.items()}
-    return encode( 
-        value=value,
-        type_=DAT.DICT
-    )
+    value = {k: serialize(v) for k, v in dict_.items()}
+    return encode(value=value, type_=DAT.DICT)
 
 
 def _serialize_set(set_: set) -> dict:
     value = [serialize(item) for item in set_]
-    return encode(
-        value=value,
-        type_=DAT.SET
-    )
+    return encode(value=value, type_=DAT.SET)
 
 
-def _serialize_tuple(tupe_: tuple) -> dict:
+def _serialize_tuple(tuple_: tuple) -> dict:
     value = [serialize(item) for item in tuple_]
-    return encode(
-        value=value,
-        type_=DAT.TUPLE
-    )
+    return encode(value=value, type_=DAT.TUPLE)
 
 
-def serialize(value: Any) -> Any:
-    "Serialize a value so it can be stored as JSON."
+def serialize(value):
+    """Serialize a value so it can be stored as JSON.
+
+    The serialization protocol is:
+
+    (1) keep JSON supported types: primitives, dict, list;
+    (2) encode other types such as tuples and sets as
+       ``{TYPE: 'foo', VAR: 'bar'}``
+    """
     serialization_function_by_type = {
         int: _return_primitive,
         bool: _return_primitive,
@@ -53,7 +67,7 @@ def serialize(value: Any) -> Any:
         set: _serialize_set,
         tuple: _serialize_tuple
     }
-    try: 
+    try:
         function = serialization_function_by_type[type(value)]
     except KeyError:
         raise TypeError(f"Unable to serialize {type(value)}")
@@ -68,26 +82,34 @@ def _deserialize_dict(dict_: dict) -> dict:
     type_ = dict_[Encoding.TYPE]
     value = dict_[Encoding.VAR]
     if type_ == DAT.DICT:
-        value = {k: deserialize(v) for k,v in value.items()}
+        value = {k: deserialize(v) for k, v in value.items()}
     elif type_ == DAT.SET:
         value = _deserialize_set(value)
     elif type_ == DAT.TUPLE:
-        value = _deserialize_tuple()
+        value = _deserialize_tuple(value)
     else:
         raise TypeError(f"Unable to deserialize dict of {Encoding.TYPE}: {type_}")
     return value
 
 
 def _deserialize_set(set_: set) -> set:
-    return set([deserialize(item) for item in set_])
+    return {deserialize(item) for item in set_}
 
 
 def _deserialize_tuple(tuple_: tuple) -> tuple:
     return tuple(deserialize(item) for item in tuple_)
 
 
-def deserialize(value: Any) -> Any:
-    "Deserialize a JSON-compatible value into its original value."
+def deserialize(value):
+    """Deserialize a JSON-compatible value into its original value.
+
+    The deserialization protocol is:
+
+    (1) keep JSON supported types: primitives, lists
+    (2) decode other types which might have been encoded in dicts using
+       ``{TYPE: 'foo', VAR: 'bar'}``
+    """
+
     deserialization_function_by_type = {
         int: _return_primitive,
         bool: _return_primitive,
@@ -96,7 +118,7 @@ def deserialize(value: Any) -> Any:
         list: _deserialize_list,
         dict: _deserialize_dict
     }
-    try: 
+    try:
         function = deserialization_function_by_type[type(value)]
     except KeyError:
         raise ValueError(f"Unable to deserialize {type(value)}")

--- a/airflow/serialization/json.py
+++ b/airflow/serialization/json.py
@@ -1,0 +1,103 @@
+import enum
+import json
+from typing import Any, Union
+
+from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
+
+
+def encode(value: Any, type_: Any) -> [Encoding, Any]:
+    "Encode value and type into a JSON dict."
+    return {Encoding.VAR: value, Encoding.TYPE: type_}
+
+
+_return_primitive = lambda value: value
+
+
+def _serialize_list(list_: list) -> list:
+    return [serialize(item) for item in list_]
+
+
+def _serialize_dict(dict_: dict) -> dict:
+    value = {k: serialize(v) for k,v in dict_.items()}
+    return encode( 
+        value=value,
+        type_=DAT.DICT
+    )
+
+
+def _serialize_set(set_: set) -> dict:
+    value = [serialize(item) for item in set_]
+    return encode(
+        value=value,
+        type_=DAT.SET
+    )
+
+
+def _serialize_tuple(tupe_: tuple) -> dict:
+    value = [serialize(item) for item in tuple_]
+    return encode(
+        value=value,
+        type_=DAT.TUPLE
+    )
+
+
+def serialize(value: Any) -> Any:
+    "Serialize a value so it can be stored as JSON."
+    serialization_function_by_type = {
+        int: _return_primitive,
+        bool: _return_primitive,
+        float: _return_primitive,
+        str: _return_primitive,
+        list: _serialize_list,
+        dict: _serialize_dict,
+        set: _serialize_set,
+        tuple: _serialize_tuple
+    }
+    try: 
+        function = serialization_function_by_type[type(value)]
+    except KeyError:
+        raise TypeError(f"Unable to serialize {type(value)}")
+    return function(value)
+
+
+def _deserialize_list(list_: list) -> list:
+    return [deserialize(item) for item in list_]
+
+
+def _deserialize_dict(dict_: dict) -> dict:
+    type_ = dict_[Encoding.TYPE]
+    value = dict_[Encoding.VAR]
+    if type_ == DAT.DICT:
+        value = {k: deserialize(v) for k,v in value.items()}
+    elif type_ == DAT.SET:
+        value = _deserialize_set(value)
+    elif type_ == DAT.TUPLE:
+        value = _deserialize_tuple()
+    else:
+        raise TypeError(f"Unable to deserialize dict of {Encoding.TYPE}: {type_}")
+    return value
+
+
+def _deserialize_set(set_: set) -> set:
+    return set([deserialize(item) for item in set_])
+
+
+def _deserialize_tuple(tuple_: tuple) -> tuple:
+    return tuple(deserialize(item) for item in tuple_)
+
+
+def deserialize(value: Any) -> Any:
+    "Deserialize a JSON-compatible value into its original value."
+    deserialization_function_by_type = {
+        int: _return_primitive,
+        bool: _return_primitive,
+        float: _return_primitive,
+        str: _return_primitive,
+        list: _deserialize_list,
+        dict: _deserialize_dict
+    }
+    try: 
+        function = deserialization_function_by_type[type(value)]
+    except KeyError:
+        raise ValueError(f"Unable to deserialize {type(value)}")
+    return function(value)

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -212,3 +212,31 @@ class TestXCom(unittest.TestCase):
 
         for result in results:
             self.assertEqual(result.value, json_obj)
+
+    @conf_vars({("core", "xcom_enable_pickling"): "False"})
+    def test_xcom_enable_set_type(self):
+        set_obj = {"set-value1", "set-value2"}
+        execution_date = timezone.utcnow()
+        key = "xcom_test5"
+        dag_id = "test_dag5"
+        task_id = "test_task5"
+        XCom.set(key=key,
+                 value=set_obj,
+                 dag_id=dag_id,
+                 task_id=task_id,
+                 execution_date=execution_date)
+
+        ret_value = XCom.get_one(key=key,
+                                 dag_id=dag_id,
+                                 task_id=task_id,
+                                 execution_date=execution_date)
+
+        self.assertEqual(ret_value, set_obj)
+
+        session = settings.Session()
+        ret_value = session.query(XCom).filter(XCom.key == key, XCom.dag_id == dag_id,
+                                               XCom.task_id == task_id,
+                                               XCom.execution_date == execution_date
+                                               ).first().value
+
+        self.assertEqual(ret_value, set_obj)

--- a/tests/serialization/test_json.py
+++ b/tests/serialization/test_json.py
@@ -1,4 +1,21 @@
-import enum
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import unittest
 
 import pytest
@@ -14,8 +31,8 @@ class TestSerialize(unittest.TestCase):
         assert serialize(300) == 300
 
     def test_boolean(self):
-        assert serialize(True) == True
-        assert serialize(False) == False
+        assert serialize(True)
+        assert not serialize(False)
 
     def test_string(self):
         assert serialize("string") == "string"
@@ -24,7 +41,7 @@ class TestSerialize(unittest.TestCase):
         assert serialize(0.1) == 0.1
 
     def test_list_of_primitives(self):
-        assert serialize([1,"a",True]) == [1,"a", True]
+        assert serialize([1, "a", True]) == [1, "a", True]
 
     def test_list_of_sets(self):
         values = [
@@ -83,6 +100,14 @@ class TestSerialize(unittest.TestCase):
         }
         assert serialize(value) == expected_serialization
 
+    def test_tuple(self):
+        value = (1, 2, 3)
+        expected_serialization = {
+            Encoding.VAR: [1, 2, 3],
+            Encoding.TYPE: DAT.TUPLE
+        }
+        assert serialize(value) == expected_serialization
+
     def test_enum_raises_exception(self):
         value = Encoding.VAR
         with pytest.raises(TypeError) as err:
@@ -97,8 +122,8 @@ class TestDeserialize(unittest.TestCase):
         assert deserialize(300) == 300
 
     def test_boolean(self):
-        assert deserialize(True) == True
-        assert deserialize(False) == False
+        assert deserialize(True)
+        assert not deserialize(False)
 
     def test_string(self):
         assert deserialize("string") == "string"
@@ -107,7 +132,7 @@ class TestDeserialize(unittest.TestCase):
         assert deserialize(0.1) == 0.1
 
     def test_list_of_primitives(self):
-        assert deserialize([1,"a",True]) == [1,"a", True]
+        assert deserialize([1, "a", True]) == [1, "a", True]
 
     def test_list_of_sets(self):
         values = [
@@ -132,7 +157,7 @@ class TestDeserialize(unittest.TestCase):
             Encoding.TYPE: DAT.DICT
         }
         expected_deserialization = {"key": "value"}
-        
+
         assert deserialize(value) == expected_deserialization
 
     def test_dictionary_of_list_of_sets(self):
@@ -164,14 +189,22 @@ class TestDeserialize(unittest.TestCase):
             Encoding.VAR: [1, 2, 3],
             Encoding.TYPE: DAT.SET
         }
-        expected_deserialization = {1, 2, 3} 
+        expected_deserialization = {1, 2, 3}
+        assert deserialize(value) == expected_deserialization
+
+    def test_tuple(self):
+        value = {
+            Encoding.VAR: [1, 2, 3],
+            Encoding.TYPE: DAT.TUPLE
+        }
+        expected_deserialization = (1, 2, 3)
         assert deserialize(value) == expected_deserialization
 
     def test_unsupported_value(self):
         value = Encoding.VAR
         with pytest.raises(ValueError) as err:
             deserialize(value)
-        assert err.value.args[0] == "Unable to deserialize <enum 'Encoding'>" 
+        assert err.value.args[0] == "Unable to deserialize <enum 'Encoding'>"
 
     def test_unsupported_dict_type(self):
         value = {
@@ -180,4 +213,4 @@ class TestDeserialize(unittest.TestCase):
         }
         with pytest.raises(TypeError) as err:
             deserialize(value)
-        assert err.value.args[0] == "Unable to deserialize dict of __type: dag" 
+        assert err.value.args[0] == "Unable to deserialize dict of __type: dag"

--- a/tests/serialization/test_json.py
+++ b/tests/serialization/test_json.py
@@ -1,0 +1,183 @@
+import enum
+import unittest
+
+import pytest
+
+from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
+from airflow.serialization.json import deserialize, serialize
+
+
+class TestSerialize(unittest.TestCase):
+
+    def test_integer(self):
+        assert serialize(1) == 1
+        assert serialize(300) == 300
+
+    def test_boolean(self):
+        assert serialize(True) == True
+        assert serialize(False) == False
+
+    def test_string(self):
+        assert serialize("string") == "string"
+
+    def test_float(self):
+        assert serialize(0.1) == 0.1
+
+    def test_list_of_primitives(self):
+        assert serialize([1,"a",True]) == [1,"a", True]
+
+    def test_list_of_sets(self):
+        values = [
+            {1},
+            {2}
+        ]
+        expected_serialization = [
+            {
+                Encoding.VAR: [1],
+                Encoding.TYPE: DAT.SET
+            },
+            {
+                Encoding.VAR: [2],
+                Encoding.TYPE: DAT.SET
+            },
+        ]
+        assert serialize(values) == expected_serialization
+
+    def test_dictionary_of_primitives(self):
+        value = {"key": "value"}
+        expected_serialization = {
+            Encoding.VAR: {"key": "value"},
+            Encoding.TYPE: DAT.DICT
+        }
+        assert serialize(value) == expected_serialization
+
+    def test_dictionary_of_list_of_sets(self):
+        value = {
+            "key_to_list": [
+                set(["a"]),
+                set(["b"])
+            ]
+        }
+        expected_serialization = {
+            Encoding.VAR: {
+                "key_to_list": [
+                    {
+                        Encoding.VAR: ["a"],
+                        Encoding.TYPE: DAT.SET
+                    },
+                    {
+                        Encoding.VAR: ["b"],
+                        Encoding.TYPE: DAT.SET
+                    }
+                ]
+            },
+            Encoding.TYPE: DAT.DICT
+        }
+        assert serialize(value) == expected_serialization
+
+    def test_set(self):
+        value = {1, 2, 3}
+        expected_serialization = {
+            Encoding.VAR: [1, 2, 3],
+            Encoding.TYPE: DAT.SET
+        }
+        assert serialize(value) == expected_serialization
+
+    def test_enum_raises_exception(self):
+        value = Encoding.VAR
+        with pytest.raises(TypeError) as err:
+            serialize(value)
+        assert err.value.args[0] == "Unable to serialize <enum 'Encoding'>"
+
+
+class TestDeserialize(unittest.TestCase):
+
+    def test_integer(self):
+        assert deserialize(1) == 1
+        assert deserialize(300) == 300
+
+    def test_boolean(self):
+        assert deserialize(True) == True
+        assert deserialize(False) == False
+
+    def test_string(self):
+        assert deserialize("string") == "string"
+
+    def test_float(self):
+        assert deserialize(0.1) == 0.1
+
+    def test_list_of_primitives(self):
+        assert deserialize([1,"a",True]) == [1,"a", True]
+
+    def test_list_of_sets(self):
+        values = [
+            {
+                Encoding.VAR: [1],
+                Encoding.TYPE: DAT.SET
+            },
+            {
+                Encoding.VAR: [2],
+                Encoding.TYPE: DAT.SET
+            }
+        ]
+        expected_deserialization = [
+            {1},
+            {2}
+        ]
+        assert deserialize(values) == expected_deserialization
+
+    def test_dictionary_of_primitives(self):
+        value = {
+            Encoding.VAR: {"key": "value"},
+            Encoding.TYPE: DAT.DICT
+        }
+        expected_deserialization = {"key": "value"}
+        
+        assert deserialize(value) == expected_deserialization
+
+    def test_dictionary_of_list_of_sets(self):
+        value = {
+            Encoding.VAR: {
+                "key_to_list": [
+                    {
+                        Encoding.VAR: ["a"],
+                        Encoding.TYPE: DAT.SET
+                    },
+                    {
+                        Encoding.VAR: ["b"],
+                        Encoding.TYPE: DAT.SET
+                    }
+                ]
+            },
+            Encoding.TYPE: DAT.DICT
+        }
+        expected_deserialization = {
+            "key_to_list": [
+                set(["a"]),
+                set(["b"])
+            ]
+        }
+        assert deserialize(value) == expected_deserialization
+
+    def test_set(self):
+        value = {
+            Encoding.VAR: [1, 2, 3],
+            Encoding.TYPE: DAT.SET
+        }
+        expected_deserialization = {1, 2, 3} 
+        assert deserialize(value) == expected_deserialization
+
+    def test_unsupported_value(self):
+        value = Encoding.VAR
+        with pytest.raises(ValueError) as err:
+            deserialize(value)
+        assert err.value.args[0] == "Unable to deserialize <enum 'Encoding'>" 
+
+    def test_unsupported_dict_type(self):
+        value = {
+            Encoding.VAR: [1, 2, 3],
+            Encoding.TYPE: DAT.DAG
+        }
+        with pytest.raises(TypeError) as err:
+            deserialize(value)
+        assert err.value.args[0] == "Unable to deserialize dict of __type: dag" 

--- a/tests/serialization/test_json.py
+++ b/tests/serialization/test_json.py
@@ -26,6 +26,9 @@ from airflow.serialization.json import deserialize, serialize
 
 class TestSerialize(unittest.TestCase):
 
+    def test_none(self):
+        assert serialize(None) is None
+
     def test_integer(self):
         assert serialize(1) == 1
         assert serialize(300) == 300
@@ -116,6 +119,9 @@ class TestSerialize(unittest.TestCase):
 
 
 class TestDeserialize(unittest.TestCase):
+
+    def test_none(self):
+        assert deserialize(None) is None
 
     def test_integer(self):
         assert deserialize(1) == 1


### PR DESCRIPTION
Closes #8703. Any feedback is very welcome!

There are some standing questions:

1) What are your thoughts on isolating the JSON serialization logic in a separate "lightweight" module? My initial attempt was to use the existing `serialized_objects.py` module, without duplicating any code, following the suggestion from https://github.com/apache/airflow/issues/8703#issuecomment-623385925:
```
# Module: xcom.py

from airflow.serialization.serialized_objects import BaseSerialization
(...)
# within the function `serialize_value`
            dict_ = BaseSerialization.serialize_to_json(value)
            return json.dumps(dict_).encode('UTF-8')
(...)
# within the function `deserialize_value`
            dict_ = json.loads(result.value.decode('UTF-8'))
            return BaseSerialization.from_dict(dict_)
```
However, this seems to have resulted in a circular dependency, which could be observed when running `pytest tests/models/test_xcom.py`:
```
______________________ ERROR collecting tests/models/test_xcom.py ______________________
/usr/local/lib/python3.6/logging/config.py:390: in resolve
    found = getattr(found, frag)
E   AttributeError: module 'airflow.utils.log' has no attribute 'file_task_handler'

During handling of the above exception, another exception occurred:
/usr/local/lib/python3.6/logging/config.py:392: in resolve
    self.importer(used)
airflow/utils/log/file_task_handler.py:26: in <module>
    from airflow.models import TaskInstance
airflow/models/__init__.py:20: in <module>
    from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
airflow/models/baseoperator.py:45: in <module>
    from airflow.models.taskinstance import TaskInstance, clear_task_instances
airflow/models/taskinstance.py:50: in <module>
    from airflow.models.xcom import XCOM_RETURN_KEY, XCom
airflow/models/xcom.py:37: in <module>
    from airflow.serialization.serialized_objects import BaseSerialization
airflow/serialization/serialized_objects.py:31: in <module>
    from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
E   ImportError: cannot import name 'BaseOperator'

The above exception was the direct cause of the following exception:
/usr/local/lib/python3.6/logging/config.py:565: in configure
    handler = self.configure_handler(handlers[name])
/usr/local/lib/python3.6/logging/config.py:715: in configure_handler
    klass = self.resolve(cname)
/usr/local/lib/python3.6/logging/config.py:399: in resolve
    raise v
/usr/local/lib/python3.6/logging/config.py:392: in resolve
    self.importer(used)
airflow/utils/log/file_task_handler.py:26: in <module>
    from airflow.models import TaskInstance
airflow/models/__init__.py:20: in <module>
    from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
airflow/models/baseoperator.py:45: in <module>
    from airflow.models.taskinstance import TaskInstance, clear_task_instances
airflow/models/taskinstance.py:50: in <module>
    from airflow.models.xcom import XCOM_RETURN_KEY, XCom
airflow/models/xcom.py:37: in <module>
    from airflow.serialization.serialized_objects import BaseSerialization
airflow/serialization/serialized_objects.py:31: in <module>
    from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
E   ValueError: Cannot resolve 'airflow.utils.log.file_task_handler.FileTaskHandler': cannot import name 'BaseOperator'

During handling of the above exception, another exception occurred:
/usr/local/lib/python3.6/site-packages/py/_path/local.py:704: in pyimport
    __import__(modname)
tests/models/__init__.py:21: in <module>
    from airflow.utils import timezone
airflow/__init__.py:41: in <module>
    settings.initialize()
airflow/settings.py:326: in initialize
    LOGGING_CLASS_PATH = configure_logging()
airflow/logging_config.py:69: in configure_logging
    raise e
airflow/logging_config.py:64: in configure_logging
    dictConfig(logging_config)
/usr/local/lib/python3.6/logging/config.py:802: in dictConfig
    dictConfigClass(config).configure()
/usr/local/lib/python3.6/logging/config.py:573: in configure
    '%r: %s' % (name, e))
E   ValueError: Unable to configure handler 'task': Cannot resolve 'airflow.utils.log.file_task_handler.FileTaskHandler': cannot import name 'BaseOperator'
```

2) Assuming there is an agreement with (1), I can refactor the class `serialization/serialized_objects.py::BaseSerialization` to use the module so we avoid duplicating the logic.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides a context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in the description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In the case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In the case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards-incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
