### PR TITLE
Fix Experimental API Client

### DIFF
--- a/airflow/api/auth/backend/default.py
+++ b/airflow/api/auth/backend/default.py
@@ -17,10 +17,9 @@
 # under the License.
 """Default authentication backend - everything is allowed"""
 from functools import wraps
-from typing import Callable, TypeVar, cast, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, TypeVar, Union, cast
 
 from requests.auth import AuthBase
-
 
 CLIENT_AUTH: Optional[Union[Tuple[str, str], AuthBase]] = None
 

--- a/airflow/api/auth/backend/default.py
+++ b/airflow/api/auth/backend/default.py
@@ -17,20 +17,12 @@
 # under the License.
 """Default authentication backend - everything is allowed"""
 from functools import wraps
-from typing import Callable, TypeVar, cast
+from typing import Callable, TypeVar, cast, Optional, Tuple, Union
 
-from airflow.typing_compat import Protocol
+from requests.auth import AuthBase
 
 
-class ClientAuthProtocol(Protocol):
-    """
-    Protocol type for CLIENT_AUTH
-    """
-    def handle_response(self, _):
-        """
-        CLIENT_AUTH.handle_response method
-        """
-        ...
+CLIENT_AUTH: Optional[Union[Tuple[str, str], AuthBase]] = None
 
 
 def init_app(_):

--- a/airflow/api/auth/backend/deny_all.py
+++ b/airflow/api/auth/backend/deny_all.py
@@ -17,11 +17,10 @@
 # under the License.
 """Authentication backend that denies all requests"""
 from functools import wraps
-from typing import Callable, Optional, TypeVar, cast, Tuple, Union
+from typing import Callable, Optional, Tuple, TypeVar, Union, cast
 
 from flask import Response
 from requests.auth import AuthBase
-
 
 CLIENT_AUTH: Optional[Union[Tuple[str, str], AuthBase]] = None
 

--- a/airflow/api/auth/backend/deny_all.py
+++ b/airflow/api/auth/backend/deny_all.py
@@ -17,13 +17,13 @@
 # under the License.
 """Authentication backend that denies all requests"""
 from functools import wraps
-from typing import Callable, Optional, TypeVar, cast
+from typing import Callable, Optional, TypeVar, cast, Tuple, Union
 
 from flask import Response
+from requests.auth import AuthBase
 
-from airflow.api.auth.backend.default import ClientAuthProtocol
 
-CLIENT_AUTH = None  # type: Optional[ClientAuthProtocol]
+CLIENT_AUTH: Optional[Union[Tuple[str, str], AuthBase]] = None
 
 
 def init_app(_):

--- a/airflow/api/auth/backend/kerberos_auth.py
+++ b/airflow/api/auth/backend/kerberos_auth.py
@@ -44,11 +44,12 @@ import logging
 import os
 from functools import wraps
 from socket import getfqdn
-from typing import Callable, TypeVar, cast
+from typing import Callable, TypeVar, cast, Optional, Tuple, Union
 
 import kerberos
 # noinspection PyProtectedMember
 from flask import Response, _request_ctx_stack as stack, g, make_response, request  # type: ignore
+from requests.auth import AuthBase
 from requests_kerberos import HTTPKerberosAuth
 
 from airflow.configuration import conf
@@ -56,7 +57,7 @@ from airflow.configuration import conf
 log = logging.getLogger(__name__)
 
 # pylint: disable=c-extension-no-member
-CLIENT_AUTH = HTTPKerberosAuth(service='airflow')
+CLIENT_AUTH: Optional[Union[Tuple[str, str], AuthBase]] = HTTPKerberosAuth(service='airflow')
 
 
 class KerberosService:  # pylint: disable=too-few-public-methods

--- a/airflow/api/auth/backend/kerberos_auth.py
+++ b/airflow/api/auth/backend/kerberos_auth.py
@@ -44,7 +44,7 @@ import logging
 import os
 from functools import wraps
 from socket import getfqdn
-from typing import Callable, TypeVar, cast, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, TypeVar, Union, cast
 
 import kerberos
 # noinspection PyProtectedMember

--- a/airflow/api/client/__init__.py
+++ b/airflow/api/client/__init__.py
@@ -33,6 +33,6 @@ def get_current_api_client() -> Client:
     api_module = import_module(conf.get('cli', 'api_client'))  # type: Any
     api_client = api_module.Client(
         api_base_url=conf.get('cli', 'endpoint_url'),
-        auth=api.load_auth()
+        auth=api.load_auth().CLIENT_AUTH
     )
     return api_client

--- a/tests/api/auth/__init__.py
+++ b/tests/api/auth/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-

--- a/tests/api/auth/__init__.py
+++ b/tests/api/auth/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+

--- a/tests/api/auth/test_client.py
+++ b/tests/api/auth/test_client.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest import mock
+
+from airflow.api.client import get_current_api_client
+from test_utils.config import conf_vars
+
+
+class TestGetCurrentApiClient(unittest.TestCase):
+
+    @mock.patch("airflow.api.client.json_client.Client")
+    @mock.patch("airflow.api.auth.backend.default.CLIENT_AUTH", "CLIENT_AUTH")
+    @conf_vars({
+        ("api", 'auth_backend'): 'airflow.api.auth.backend.default',
+        ("cli", 'api_client'): 'airflow.api.client.json_client',
+        ("cli", 'endpoint_url'): 'http://localhost:1234',
+    })
+    def test_should_create_cllient(self, mock_client):
+        result = get_current_api_client()
+
+        mock_client.assert_called_once_with(
+            api_base_url='http://localhost:1234', auth='CLIENT_AUTH'
+        )
+        self.assertEqual(mock_client.return_value, result)
+

--- a/tests/api/auth/test_client.py
+++ b/tests/api/auth/test_client.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import unittest
 from unittest import mock
 

--- a/tests/api/auth/test_client.py
+++ b/tests/api/auth/test_client.py
@@ -19,7 +19,7 @@ import unittest
 from unittest import mock
 
 from airflow.api.client import get_current_api_client
-from test_utils.config import conf_vars
+from tests.test_utils.config import conf_vars
 
 
 class TestGetCurrentApiClient(unittest.TestCase):
@@ -38,4 +38,3 @@ class TestGetCurrentApiClient(unittest.TestCase):
             api_base_url='http://localhost:1234', auth='CLIENT_AUTH'
         )
         self.assertEqual(mock_client.return_value, result)
-


### PR DESCRIPTION
Yesterday I broke it and today I fix it. The client does not initialize properly, because we should pass only one attribute, not the entire module.
Related PR:  https://github.com/apache/airflow/pull/9833

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
