### PR TITLE
Don't Update Serialized DAGs in DB if DAG didn't change

### DIFF
--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -98,13 +98,8 @@ class SerializedDagModel(Base):
             ).scalar():
                 return
 
-        log.debug("Checking if DAG (%s) is updated or same", dag.dag_id)
-        serialized_dag_from_db: SerializedDagModel = (
-            session
-            .query(cls)
-            .filter(cls.dag_id == dag.dag_id)
-            .one_or_none()
-        )
+        log.debug("Checking if DAG (%s) changed", dag.dag_id)
+        serialized_dag_from_db: SerializedDagModel = session.query(cls).get(dag.dag_id)
         new_serialized_dag = cls(dag)
         if serialized_dag_from_db and (serialized_dag_from_db.data == new_serialized_dag.data):
             log.debug("Serialized DAG (%s) is unchanged. Skipping writing to DB", dag.dag_id)

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Serialzed DAG table in database."""
+"""Serialized DAG table in database."""
 
 import logging
 from datetime import timedelta
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 import sqlalchemy_jsonfield
 from sqlalchemy import BigInteger, Column, Index, String, and_
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import exists
 
 from airflow.models.base import ID_LEN, Base
@@ -78,8 +79,10 @@ class SerializedDagModel(Base):
 
     @classmethod
     @provide_session
-    def write_dag(cls, dag: DAG, min_update_interval: Optional[int] = None, session=None):
+    def write_dag(cls, dag: DAG, min_update_interval: Optional[int] = None, session: Session = None):
         """Serializes a DAG and writes it into database.
+        If the record already exists, it checks if the Serialized DAG changed or not. If it is
+        changed, it updates the record, ignores otherwise.
 
         :param dag: a DAG to be written into database
         :param min_update_interval: minimal interval in seconds to update serialized DAG
@@ -94,13 +97,26 @@ class SerializedDagModel(Base):
                      (timezone.utcnow() - timedelta(seconds=min_update_interval)) < cls.last_updated))
             ).scalar():
                 return
-        log.debug("Writing DAG: %s to the DB", dag.dag_id)
-        session.merge(cls(dag))
+
+        log.debug("Checking if DAG (%s) is updated or same", dag.dag_id)
+        serialized_dag_from_db: SerializedDagModel = (
+            session
+            .query(cls)
+            .filter(cls.dag_id == dag.dag_id)
+            .one_or_none()
+        )
+        new_serialized_dag = cls(dag)
+        if serialized_dag_from_db and (serialized_dag_from_db.data == new_serialized_dag.data):
+            log.debug("Serialized DAG (%s) is unchanged. Skipping writing to DB", dag.dag_id)
+            return
+
+        log.debug("Writing Serialized DAG: %s to the DB", dag.dag_id)
+        session.merge(new_serialized_dag)
         log.debug("DAG: %s written to the DB", dag.dag_id)
 
     @classmethod
     @provide_session
-    def read_all_dags(cls, session=None) -> Dict[str, 'SerializedDAG']:
+    def read_all_dags(cls, session: Session = None) -> Dict[str, 'SerializedDAG']:
         """Reads all DAGs in serialized_dag table.
 
         :param session: ORM Session
@@ -134,7 +150,7 @@ class SerializedDagModel(Base):
 
     @classmethod
     @provide_session
-    def remove_dag(cls, dag_id: str, session=None):
+    def remove_dag(cls, dag_id: str, session: Session = None):
         """Deletes a DAG with given dag_id.
 
         :param dag_id: dag_id to be deleted
@@ -145,7 +161,7 @@ class SerializedDagModel(Base):
 
     @classmethod
     @provide_session
-    def remove_stale_dags(cls, expiration_date, session=None):
+    def remove_stale_dags(cls, expiration_date, session: Session = None):
         """
         Deletes Serialized DAGs that were last touched by the scheduler before
         the expiration date. These DAGs were likely deleted.
@@ -153,6 +169,8 @@ class SerializedDagModel(Base):
         :param expiration_date: set inactive DAGs that were touched before this
             time
         :type expiration_date: datetime
+        :param session: ORM Session
+        :type session: Session
         :return: None
         """
         log.debug("Deleting Serialized DAGs that haven't been touched by the "
@@ -165,7 +183,7 @@ class SerializedDagModel(Base):
 
     @classmethod
     @provide_session
-    def has_dag(cls, dag_id: str, session=None) -> bool:
+    def has_dag(cls, dag_id: str, session: Session = None) -> bool:
         """Checks a DAG exist in serialized_dag table.
 
         :param dag_id: the DAG to check
@@ -175,7 +193,7 @@ class SerializedDagModel(Base):
 
     @classmethod
     @provide_session
-    def get(cls, dag_id: str, session=None) -> Optional['SerializedDagModel']:
+    def get(cls, dag_id: str, session: Session = None) -> Optional['SerializedDagModel']:
         """
         Get the SerializedDAG for the given dag ID.
         It will cope with being passed the ID of a subdag by looking up the
@@ -197,12 +215,15 @@ class SerializedDagModel(Base):
 
     @staticmethod
     @provide_session
-    def bulk_sync_to_db(dags: List[DAG], session=None):
+    def bulk_sync_to_db(dags: List[DAG], session: Session = None):
         """
-        Saves DAGs as Seralized DAG objects in the database. Each DAG is saved in a separate database query.
+        Saves DAGs as Serialized DAG objects in the database. Each
+        DAG is saved in a separate database query.
 
         :param dags: the DAG objects to save to the DB
         :type dags: List[airflow.models.dag.DAG]
+        :param session: ORM Session
+        :type session: Session
         :return: None
         """
         for dag in dags:


### PR DESCRIPTION
We should not update the "last_updated" column unnecessarily. This is first of  few optimizations to DAG Serialization that would also aid in DAG Versioning

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
