### PR TITLE
Update Serialized DAGs in Webserver when DAGs are Updated

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -330,6 +330,14 @@
       type: string
       example: ~
       default: "30"
+    - name: min_serialized_dag_fetch_interval
+      description: |
+        Fetching serialized DAG can not be faster than a minimum interval to reduce database
+        read rate. This config controls when your DAGs are updated in the Webserver
+      version_added: ~
+      type: string
+      example: ~
+      default: "10"
     - name: store_dag_code
       description: |
         Whether to persist DAG files code in DB.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -191,6 +191,10 @@ store_serialized_dags = False
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.
 min_serialized_dag_update_interval = 30
 
+# Fetching serialized DAG can not be faster than a minimum interval to reduce database
+# read rate. This config controls when your DAGs are updated in the Webserver
+min_serialized_dag_fetch_interval = 10
+
 # Whether to persist DAG files code in DB.
 # If set to True, Webserver reads file contents from DB instead of
 # trying to access files in a DAG folder. Defaults to same as the

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -151,10 +151,10 @@ class DagBag(BaseDagBag, LoggingMixin):
                 # Load from DB if not (yet) in the bag
                 self._add_dag_from_db(dag_id=dag_id)
 
-            min_serialized_dag_update_secs = timedelta(seconds=settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL)
+            min_serialized_dag_fetch_secs = timedelta(seconds=settings.MIN_SERIALIZED_DAG_FETCH_INTERVAL)
             if (
                 dag_id in self.dags_last_changed and
-                timezone.utcnow() > self.dags_last_changed[dag_id] + min_serialized_dag_update_secs
+                timezone.utcnow() > self.dags_last_changed[dag_id] + min_serialized_dag_fetch_secs
             ):
                 sd_last_updated_date = SerializedDagModel.get_last_updated_date(dag_id=dag_id)
                 if sd_last_updated_date > self.dags_last_changed[dag_id]:

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -19,7 +19,7 @@
 """Serialized DAG table in database."""
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 import sqlalchemy_jsonfield
@@ -231,3 +231,18 @@ class SerializedDagModel(Base):
                     min_update_interval=MIN_SERIALIZED_DAG_UPDATE_INTERVAL,
                     session=session
                 )
+
+    @classmethod
+    @provide_session
+    def get_last_updated_date(cls, dag_id: str, session: Session = None) -> datetime:
+        """
+        Get the date when the Serialized DAG associated to DAG was last updated
+        in serialized_dag table
+
+        :param dag_id: DAG ID
+        :type dag_id: str
+        :param session: ORM Session
+        :type session: Session
+        """
+        result = session.query(cls.last_updated).filter(cls.dag_id == dag_id).one()
+        return result.last_updated

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -234,7 +234,7 @@ class SerializedDagModel(Base):
 
     @classmethod
     @provide_session
-    def get_last_updated_date(cls, dag_id: str, session: Session = None) -> datetime:
+    def get_last_updated_datetime(cls, dag_id: str, session: Session = None) -> datetime:
         """
         Get the date when the Serialized DAG associated to DAG was last updated
         in serialized_dag table
@@ -244,5 +244,4 @@ class SerializedDagModel(Base):
         :param session: ORM Session
         :type session: Session
         """
-        result = session.query(cls.last_updated).filter(cls.dag_id == dag_id).one()
-        return result.last_updated
+        return session.query(cls.last_updated).filter(cls.dag_id == dag_id).scalar()

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -350,6 +350,11 @@ STORE_SERIALIZED_DAGS = conf.getboolean('core', 'store_serialized_dags', fallbac
 MIN_SERIALIZED_DAG_UPDATE_INTERVAL = conf.getint(
     'core', 'min_serialized_dag_update_interval', fallback=30)
 
+# Fetching serialized DAG can not be faster than a minimum interval to reduce database
+# read rate. This config controls when your DAGs are updated in the Webserver
+MIN_SERIALIZED_DAG_FETCH_INTERVAL = conf.getint(
+    'core', 'min_serialized_dag_fetch_interval', fallback=10)
+
 # Whether to persist DAG files code in DB. If set to True, Webserver reads file contents
 # from DB instead of trying to access files in a DAG folder.
 # Defaults to same as the store_serialized_dags setting.

--- a/docs/dag-serialization.rst
+++ b/docs/dag-serialization.rst
@@ -57,19 +57,21 @@ Add the following settings in ``airflow.cfg``:
 
     [core]
     store_serialized_dags = True
+    store_dag_code = True
+
+    # You can also update the following default configurations based on your needs
     min_serialized_dag_update_interval = 30
     min_serialized_dag_fetch_interval = 10
-    store_dag_code = True
 
 *   ``store_serialized_dags``: This flag decides whether to serialise DAGs and persist them in DB.
     If set to True, Webserver reads from DB instead of parsing DAG files
-*   ``min_serialized_dag_update_interval``: This flag sets the minimum interval (in seconds) after which
-    the serialized DAG in DB should be updated. This helps in reducing database write rate.
-*   ``min_serialized_dag_fetch_interval``: This flag sets the minimum interval (in seconds) after which
-    the serialized DAG will be fetched from DB from the Webserver. This helps in reducing database read rate.
-    This config controls when your DAGs are updated in the Webserver.
 *   ``store_dag_code``: This flag decides whether to persist DAG files code in DB.
     If set to True, Webserver reads file contents from DB instead of trying to access files in a DAG folder.
+*   ``min_serialized_dag_update_interval``: This flag sets the minimum interval (in seconds) after which
+    the serialized DAG in DB should be updated. This helps in reducing database write rate.
+*   ``min_serialized_dag_fetch_interval``: This flag controls how often a SerializedDAG will be re-fetched
+    from the DB when it's already loaded in the DagBag in the Webserver. Setting this higher will reduce
+    load on the DB, but at the expense of displaying a possibly stale cached version of the DAG.
 
 If you are updating Airflow from <1.10.7, please do not forget to run ``airflow db upgrade``.
 

--- a/docs/dag-serialization.rst
+++ b/docs/dag-serialization.rst
@@ -58,11 +58,16 @@ Add the following settings in ``airflow.cfg``:
     [core]
     store_serialized_dags = True
     min_serialized_dag_update_interval = 30
+    min_serialized_dag_fetch_interval = 10
+    store_dag_code = True
 
 *   ``store_serialized_dags``: This flag decides whether to serialise DAGs and persist them in DB.
     If set to True, Webserver reads from DB instead of parsing DAG files
 *   ``min_serialized_dag_update_interval``: This flag sets the minimum interval (in seconds) after which
     the serialized DAG in DB should be updated. This helps in reducing database write rate.
+*   ``min_serialized_dag_fetch_interval``: This flag sets the minimum interval (in seconds) after which
+    the serialized DAG will be fetched from DB from the Webserver. This helps in reducing database read rate.
+    This config controls when your DAGs are updated in the Webserver.
 *   ``store_dag_code``: This flag decides whether to persist DAG files code in DB.
     If set to True, Webserver reads file contents from DB instead of trying to access files in a DAG folder.
 

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -24,12 +24,14 @@ from datetime import datetime, timezone
 from tempfile import NamedTemporaryFile, mkdtemp
 from unittest.mock import patch
 
+from freezegun import freeze_time
 from sqlalchemy import func
 
 import airflow.example_dags
 from airflow import models
 from airflow.models import DagBag, DagModel
 from airflow.models.serialized_dag import SerializedDagModel
+from airflow.utils.dates import timezone as tz
 from airflow.utils.session import create_session
 from tests.models import TEST_DAGS_FOLDER
 from tests.test_utils import db
@@ -657,3 +659,35 @@ class TestDagBag(unittest.TestCase):
 
             new_serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
             self.assertEqual(new_serialized_dags_count, 1)
+
+    @patch("airflow.models.dagbag.settings.STORE_SERIALIZED_DAGS", True)
+    @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)
+    def test_get_dag_with_dag_serialization(self):
+        """
+        Test that Serialized DAG is updated in DagBag when it is updated in
+        Serialized DAG table after MIN_SERIALIZED_DAG_UPDATE_INTERVAL seconds are passed.
+        """
+
+        with freeze_time(tz.datetime(2020, 1, 5, 0, 0, 0)):
+            example_bash_op_dag = DagBag(include_examples=True).dags.get("example_bash_operator")
+            SerializedDagModel.write_dag(dag=example_bash_op_dag)
+
+        dag_bag = DagBag(read_dags_from_db=True)
+        ser_dag_1 = dag_bag.get_dag("example_bash_operator")
+        ser_dag_1_update_time = dag_bag.dags_last_changed["example_bash_operator"]
+        self.assertEqual(example_bash_op_dag.tags, ser_dag_1.tags)
+        self.assertEqual(ser_dag_1_update_time, tz.datetime(2020, 1, 5, 0, 0, 0))
+
+        with freeze_time(tz.datetime(2020, 1, 5, 0, 0, 6)):
+            example_bash_op_dag.tags += ["new_tag"]
+            SerializedDagModel.write_dag(dag=example_bash_op_dag)
+
+        with freeze_time(tz.datetime(2020, 1, 5, 0, 0, 4)):
+            self.assertEqual(dag_bag.get_dag("example_bash_operator").tags, ["example"])
+
+        with freeze_time(tz.datetime(2020, 1, 5, 0, 0, 8)):
+            updated_ser_dag_1 = dag_bag.get_dag("example_bash_operator")
+            updated_ser_dag_1_update_time = dag_bag.dags_last_changed["example_bash_operator"]
+
+        self.assertCountEqual(updated_ser_dag_1.tags, ["example", "new_tag"])
+        self.assertGreater(updated_ser_dag_1_update_time, ser_dag_1_update_time)


### PR DESCRIPTION
Depends on https://github.com/apache/airflow/pull/9850

Before this change, if DAG Serialization was enabled the Webserver would not update the DAGs once they are fetched from DB. The default worker_refresh_interval was `30` so whenever the gunicorn workers were restarted, they used to pull the updated DAGs when needed.

This change will allow us to have a large `worker_refresh_interval` (e.g 30 mins or even 1 day)

Please only review the last commit

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
