### PR TITLE
Add type hinting for mongo provider

### DIFF
--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -20,10 +20,8 @@ from ssl import CERT_NONE
 from types import TracebackType
 from typing import List, Optional, Type
 
-from pymongo import (
-    BulkWriteResult, Collation, Collection, CommandCursor, Cursor, DeleteResult, InsertManyResult,
-    InsertOneResult, MongoClient, ReplaceOne, UpdateResult,
-)
+import pymongo
+from pymongo import MongoClient, ReplaceOne
 
 from airflow.hooks.base_hook import BaseHook
 
@@ -100,7 +98,9 @@ class MongoHook(BaseHook):
             client.close()
             self.client = None
 
-    def get_collection(self, mongo_collection: str, mongo_db: Optional[str] = None) -> Collection:
+    def get_collection(self,
+                       mongo_collection: str,
+                       mongo_db: Optional[str] = None) -> pymongo.collection.Collection:
         """
         Fetches a mongo collection object for querying.
 
@@ -115,7 +115,7 @@ class MongoHook(BaseHook):
                   mongo_collection: str,
                   aggregate_query: list,
                   mongo_db: Optional[str] = None,
-                  **kwargs) -> CommandCursor:
+                  **kwargs) -> pymongo.command_cursor.CommandCursor:
         """
         Runs an aggregation pipeline and returns the results
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.aggregate
@@ -130,7 +130,7 @@ class MongoHook(BaseHook):
              query: dict,
              find_one: bool = False,
              mongo_db: Optional[str] = None,
-             **kwargs) -> Cursor:
+             **kwargs) -> pymongo.cursor.Cursor:
         """
         Runs a mongo find query and returns the results
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.find
@@ -146,7 +146,7 @@ class MongoHook(BaseHook):
                    mongo_collection: str,
                    doc: dict,
                    mongo_db: Optional[str] = None,
-                   **kwargs) -> InsertOneResult:
+                   **kwargs) -> pymongo.results.InsertOneResult:
         """
         Inserts a single document into a mongo collection
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.insert_one
@@ -159,7 +159,7 @@ class MongoHook(BaseHook):
                     mongo_collection: str,
                     docs: dict,
                     mongo_db: Optional[str] = None,
-                    **kwargs) -> InsertManyResult:
+                    **kwargs) -> pymongo.results.InsertManyResult:
         """
         Inserts many docs into a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.insert_many
@@ -173,7 +173,7 @@ class MongoHook(BaseHook):
                    filter_doc: dict,
                    update_doc: dict,
                    mongo_db: Optional[str] = None,
-                   **kwargs) -> UpdateResult:
+                   **kwargs) -> pymongo.results.UpdateResult:
         """
         Updates a single document in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.update_one
@@ -198,7 +198,7 @@ class MongoHook(BaseHook):
                     filter_doc: dict,
                     update_doc: dict,
                     mongo_db: Optional[str] = None,
-                    **kwargs) -> UpdateResult:
+                    **kwargs) -> pymongo.results.UpdateResult:
         """
         Updates one or more documents in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.update_many
@@ -223,7 +223,7 @@ class MongoHook(BaseHook):
                     doc: dict,
                     filter_doc: Optional[dict] = None,
                     mongo_db: Optional[str] = None,
-                    **kwargs) -> UpdateResult:
+                    **kwargs) -> pymongo.results.UpdateResult:
         """
         Replaces a single document in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.replace_one
@@ -256,8 +256,8 @@ class MongoHook(BaseHook):
                      filter_docs: Optional[List[dict]] = None,
                      mongo_db: Optional[str] = None,
                      upsert: bool = False,
-                     collation: Optional[Collation] = None,
-                     **kwargs) -> BulkWriteResult:
+                     collation: Optional[pymongo.collation.Collation] = None,
+                     **kwargs) -> pymongo.results.BulkWriteResult:
         """
         Replaces many documents in a mongo collection.
 
@@ -308,7 +308,7 @@ class MongoHook(BaseHook):
                    mongo_collection: str,
                    filter_doc: dict,
                    mongo_db: Optional[str] = None,
-                   **kwargs) -> DeleteResult:
+                   **kwargs) -> pymongo.results.DeleteResult:
         """
         Deletes a single document in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.delete_one
@@ -330,7 +330,7 @@ class MongoHook(BaseHook):
                     mongo_collection: str,
                     filter_doc: dict,
                     mongo_db: Optional[str] = None,
-                    **kwargs) -> DeleteResult:
+                    **kwargs) -> pymongo.results.DeleteResult:
         """
         Deletes one or more documents in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.delete_many

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -17,8 +17,13 @@
 # under the License.
 """Hook for Mongo DB"""
 from ssl import CERT_NONE
+from types import TracebackType
+from typing import List, Optional, Type
 
-from pymongo import MongoClient, ReplaceOne
+from pymongo import (
+    BulkWriteResult, Collation, Collection, CommandCursor, Cursor, DeleteResult, InsertManyResult,
+    InsertOneResult, MongoClient, ReplaceOne, UpdateResult,
+)
 
 from airflow.hooks.base_hook import BaseHook
 
@@ -38,7 +43,7 @@ class MongoHook(BaseHook):
     """
     conn_type = 'mongo'
 
-    def __init__(self, conn_id='mongo_default', *args, **kwargs):
+    def __init__(self, conn_id: str = 'mongo_default', *args, **kwargs) -> None:
 
         super().__init__()
         self.mongo_conn_id = conn_id
@@ -63,11 +68,14 @@ class MongoHook(BaseHook):
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> None:
         if self.client is not None:
             self.close_conn()
 
-    def get_conn(self):
+    def get_conn(self) -> MongoClient:
         """
         Fetches PyMongo Client
         """
@@ -92,18 +100,22 @@ class MongoHook(BaseHook):
             client.close()
             self.client = None
 
-    def get_collection(self, mongo_collection, mongo_db=None):
+    def get_collection(self, mongo_collection: str, mongo_db: Optional[str] = None) -> Collection:
         """
         Fetches a mongo collection object for querying.
 
         Uses connection schema as DB unless specified.
         """
         mongo_db = mongo_db if mongo_db is not None else self.connection.schema
-        mongo_conn = self.get_conn()
+        mongo_conn: MongoClient = self.get_conn()
 
         return mongo_conn.get_database(mongo_db).get_collection(mongo_collection)
 
-    def aggregate(self, mongo_collection, aggregate_query, mongo_db=None, **kwargs):
+    def aggregate(self,
+                  mongo_collection: str,
+                  aggregate_query: list,
+                  mongo_db: Optional[str] = None,
+                  **kwargs) -> CommandCursor:
         """
         Runs an aggregation pipeline and returns the results
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.aggregate
@@ -113,7 +125,12 @@ class MongoHook(BaseHook):
 
         return collection.aggregate(aggregate_query, **kwargs)
 
-    def find(self, mongo_collection, query, find_one=False, mongo_db=None, **kwargs):
+    def find(self,
+             mongo_collection: str,
+             query: dict,
+             find_one: bool = False,
+             mongo_db: Optional[str] = None,
+             **kwargs) -> Cursor:
         """
         Runs a mongo find query and returns the results
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.find
@@ -125,7 +142,11 @@ class MongoHook(BaseHook):
         else:
             return collection.find(query, **kwargs)
 
-    def insert_one(self, mongo_collection, doc, mongo_db=None, **kwargs):
+    def insert_one(self,
+                   mongo_collection: str,
+                   doc: dict,
+                   mongo_db: Optional[str] = None,
+                   **kwargs) -> InsertOneResult:
         """
         Inserts a single document into a mongo collection
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.insert_one
@@ -134,7 +155,11 @@ class MongoHook(BaseHook):
 
         return collection.insert_one(doc, **kwargs)
 
-    def insert_many(self, mongo_collection, docs, mongo_db=None, **kwargs):
+    def insert_many(self,
+                    mongo_collection: str,
+                    docs: dict,
+                    mongo_db: Optional[str] = None,
+                    **kwargs) -> InsertManyResult:
         """
         Inserts many docs into a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.insert_many
@@ -143,8 +168,12 @@ class MongoHook(BaseHook):
 
         return collection.insert_many(docs, **kwargs)
 
-    def update_one(self, mongo_collection, filter_doc, update_doc,
-                   mongo_db=None, **kwargs):
+    def update_one(self,
+                   mongo_collection: str,
+                   filter_doc: dict,
+                   update_doc: dict,
+                   mongo_db: Optional[str] = None,
+                   **kwargs) -> UpdateResult:
         """
         Updates a single document in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.update_one
@@ -164,8 +193,12 @@ class MongoHook(BaseHook):
 
         return collection.update_one(filter_doc, update_doc, **kwargs)
 
-    def update_many(self, mongo_collection, filter_doc, update_doc,
-                    mongo_db=None, **kwargs):
+    def update_many(self,
+                    mongo_collection: str,
+                    filter_doc: dict,
+                    update_doc: dict,
+                    mongo_db: Optional[str] = None,
+                    **kwargs) -> UpdateResult:
         """
         Updates one or more documents in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.update_many
@@ -185,8 +218,12 @@ class MongoHook(BaseHook):
 
         return collection.update_many(filter_doc, update_doc, **kwargs)
 
-    def replace_one(self, mongo_collection, doc, filter_doc=None,
-                    mongo_db=None, **kwargs):
+    def replace_one(self,
+                    mongo_collection: str,
+                    doc: dict,
+                    filter_doc: Optional[dict] = None,
+                    mongo_db: Optional[str] = None,
+                    **kwargs) -> UpdateResult:
         """
         Replaces a single document in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.replace_one
@@ -213,9 +250,14 @@ class MongoHook(BaseHook):
 
         return collection.replace_one(filter_doc, doc, **kwargs)
 
-    def replace_many(self, mongo_collection, docs,
-                     filter_docs=None, mongo_db=None, upsert=False, collation=None,
-                     **kwargs):
+    def replace_many(self,
+                     mongo_collection: str,
+                     docs: List[dict],
+                     filter_docs: Optional[List[dict]] = None,
+                     mongo_db: Optional[str] = None,
+                     upsert: bool = False,
+                     collation: Optional[Collation] = None,
+                     **kwargs) -> BulkWriteResult:
         """
         Replaces many documents in a mongo collection.
 
@@ -262,7 +304,11 @@ class MongoHook(BaseHook):
 
         return collection.bulk_write(requests, **kwargs)
 
-    def delete_one(self, mongo_collection, filter_doc, mongo_db=None, **kwargs):
+    def delete_one(self,
+                   mongo_collection: str,
+                   filter_doc: dict,
+                   mongo_db: Optional[str] = None,
+                   **kwargs) -> DeleteResult:
         """
         Deletes a single document in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.delete_one
@@ -280,7 +326,11 @@ class MongoHook(BaseHook):
 
         return collection.delete_one(filter_doc, **kwargs)
 
-    def delete_many(self, mongo_collection, filter_doc, mongo_db=None, **kwargs):
+    def delete_many(self,
+                    mongo_collection: str,
+                    filter_doc: dict,
+                    mongo_db: Optional[str] = None,
+                    **kwargs) -> DeleteResult:
         """
         Deletes one or more documents in a mongo collection.
         https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.delete_many

--- a/airflow/providers/mongo/sensors/mongo.py
+++ b/airflow/providers/mongo/sensors/mongo.py
@@ -54,7 +54,7 @@ class MongoSensor(BaseSensorOperator):
         self.collection = collection
         self.query = query
 
-    def poke(self, context: Optional[dict]) -> bool:
+    def poke(self, context: dict) -> bool:
         self.log.info("Sensor check existence of the document "
                       "that matches the following query: %s", self.query)
         hook = MongoHook(self.mongo_conn_id)

--- a/airflow/providers/mongo/sensors/mongo.py
+++ b/airflow/providers/mongo/sensors/mongo.py
@@ -43,7 +43,12 @@ class MongoSensor(BaseSensorOperator):
     template_fields = ('collection', 'query')
 
     @apply_defaults
-    def __init__(self, collection: str, query: dict, mongo_conn_id: str = "mongo_default", *args, **kwargs) -> None:
+    def __init__(self,
+                 collection: str,
+                 query: dict,
+                 mongo_conn_id: str = "mongo_default",
+                 *args,
+                 **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.mongo_conn_id = mongo_conn_id
         self.collection = collection

--- a/airflow/providers/mongo/sensors/mongo.py
+++ b/airflow/providers/mongo/sensors/mongo.py
@@ -15,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
+
 from airflow.providers.mongo.hooks.mongo import MongoHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
@@ -41,13 +43,13 @@ class MongoSensor(BaseSensorOperator):
     template_fields = ('collection', 'query')
 
     @apply_defaults
-    def __init__(self, collection, query, mongo_conn_id="mongo_default", *args, **kwargs):
+    def __init__(self, collection: str, query: dict, mongo_conn_id: str = "mongo_default", *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.mongo_conn_id = mongo_conn_id
         self.collection = collection
         self.query = query
 
-    def poke(self, context):
+    def poke(self, context: Optional[dict]) -> bool:
         self.log.info("Sensor check existence of the document "
                       "that matches the following query: %s", self.query)
         hook = MongoHook(self.mongo_conn_id)

--- a/airflow/providers/mongo/sensors/mongo.py
+++ b/airflow/providers/mongo/sensors/mongo.py
@@ -15,8 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional
-
 from airflow.providers.mongo.hooks.mongo import MongoHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults


### PR DESCRIPTION
This PR adds type hinting for methods in the mongo provider per #9708
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
