### PR TITLE
Add response_filter to SimpleHttpOperator

### DIFF
--- a/airflow/providers/http/example_dags/example_http.py
+++ b/airflow/providers/http/example_dags/example_http.py
@@ -71,6 +71,15 @@ task_get_op = SimpleHttpOperator(
     dag=dag,
 )
 # [END howto_operator_http_task_get_op]
+# [START howto_operator_http_task_get_op_response_filter]
+task_get_op = SimpleHttpOperator(
+    task_id='get_op_response_filter',
+    method='GET',
+    endpoint='get',
+    response_filter=lambda response: response.json()['nested']['property'],
+    dag=dag,
+)
+# [END howto_operator_http_task_get_op_response_filter]
 # [START howto_operator_http_task_put_op]
 task_put_op = SimpleHttpOperator(
     task_id='put_op',

--- a/docs/howto/operator/http.rst
+++ b/docs/howto/operator/http.rst
@@ -59,6 +59,21 @@ Here we are calling a ``GET`` request and pass params to it. The task will succe
     :start-after: [START howto_operator_http_task_get_op]
     :end-before: [END howto_operator_http_task_get_op]
 
+SimpleHttpOperator returns the response body as text by default. If you want to modify the response before passing
+it on the next task downstream use ``response_filter``. This is useful if:
+
+- the API you are consuming returns a large JSON payload and you're interested in a subset of the data
+- the API returns data in xml or csv and you want to convert it to JSON
+- you're interested in the headers of the response instead of the body
+
+Below is an example of retrieving data from a REST API and only returning a nested property instead of the full
+response body.
+
+.. exampleinclude:: /../airflow/providers/http/example_dags/example_http.py
+    :language: python
+    :start-after: [START howto_operator_http_task_get_op_response_filter]
+    :end-before: [END howto_operator_http_task_get_op_response_filter]
+
 In the third example we are performing a ``PUT`` operation to put / set data according to the data that is being
 provided to the request.
 

--- a/tests/providers/http/operators/test_http.py
+++ b/tests/providers/http/operators/test_http.py
@@ -79,3 +79,16 @@ class TestSimpleHttpOp(unittest.TestCase):
                 mock.call('invalid response')
             ]
             mock_info.assert_has_calls(calls, any_order=True)
+
+    @requests_mock.mock()
+    def test_filters_response(self, m):
+        m.get('http://www.example.com', json={'value': 5})
+        operator = SimpleHttpOperator(
+            task_id='test_HTTP_op',
+            method='GET',
+            endpoint='/',
+            http_conn_id='HTTP_EXAMPLE',
+            response_filter=lambda response: response.json()
+        )
+        result = operator.execute(None)
+        assert result == {'value': 5}


### PR DESCRIPTION
Allows users to manipulate SimpleHttpOperator responses and chose what
part of the response they want to pass to downstream tasks.

Use case 1:

I want to use the SimpleHttpOperator to retrieve API data and pass it to
another operator via xcom. The API I'm retrieving data from is returning
JSON in megabytes. I don't want to save megabytes to the metadata
database. Instead I want to filter and manipulate the response data to
only contain the subset of data I'm interested in.

Use case 2:

I want to pass JSON parsed data (as a python dictionary) from the
SimpleHttpOperator to other tasks instead of raw text.

Use case 3:

I'm not interested in the response HTTP body and instead want to
retrieve HTTP headers or status codes and pass it to my downstream
tasks.