### PR TITLE
Deprecate experimental API

### DIFF
--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -15,19 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.utils.docs import get_docs_url
+from typing import Optional
+
+from airflow import version
 
 
-def init_appbuilder_links(app):
-    """Add links to Docs menu in navbar"""
-    appbuilder = app.appbuilder
-
-    appbuilder.add_link(
-        "Website", href='https://airflow.apache.org', category="Docs", category_icon="fa-globe"
-    )
-    appbuilder.add_link("Documentation", href=get_docs_url(), category="Docs", category_icon="fa-cube")
-    appbuilder.add_link("GitHub", href='https://github.com/apache/airflow', category="Docs")
-    appbuilder.add_link(
-        "REST API Reference (Swagger UI)", href='/api/v1./api/v1_swagger_ui_index', category="Docs"
-    )
-    appbuilder.add_link("REST API Reference (Redoc)", href="RedocView.redoc", category='Docs')
+def get_docs_url(page: Optional[str] = None) -> str:
+    """Prepare link to Airflow documentation."""
+    if "dev" in version.version:
+        result = "https://airflow.readthedocs.io/en/latest/"
+    else:
+        result = 'https://airflow.apache.org/docs/{}/'.format(version.version)
+    if page:
+        result = result + page
+    return result

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,8 +95,8 @@ Content
     kubernetes
     lineage
     dag-serialization
-    Using the REST API <stable-rest-api/index.rst>
-    REST API Migration Guide <stable-rest-api/migration.rst>
+    Using the REST API <stable-rest-api/index>
+    REST API Migration Guide <stable-rest-api/migration>
     changelog
     best-practices
     faq

--- a/docs/rest-api-ref.rst
+++ b/docs/rest-api-ref.rst
@@ -21,7 +21,7 @@ Experimental REST API Reference
 Airflow exposes an REST API. It is available through the webserver. Endpoints are
 available at ``/api/experimental/``.
 
-.. warning::
+.. deprecated::
 
   This REST API is deprecated. Please consider using :doc:`the stable REST API <stable-rest-api/redoc>`.
   For more information on migration, see: :doc:`stable-rest-api/migration`.

--- a/docs/rest-api-ref.rst
+++ b/docs/rest-api-ref.rst
@@ -21,7 +21,7 @@ Experimental REST API Reference
 Airflow exposes an REST API. It is available through the webserver. Endpoints are
 available at ``/api/experimental/``.
 
-.. deprecated::
+.. deprecated:: 2.0
 
   This REST API is deprecated. Please consider using :doc:`the stable REST API <stable-rest-api/redoc>`.
   For more information on migration, see: :doc:`stable-rest-api/migration`.

--- a/docs/rest-api-ref.rst
+++ b/docs/rest-api-ref.rst
@@ -23,7 +23,8 @@ available at ``/api/experimental/``.
 
 .. warning::
 
-  The API structure is not stable. We expect the endpoint definitions to change.
+  This REST API is deprecated. Please consider using :doc:`the stable REST API <stable-rest-api/redoc>`.
+  For more information on migration, see: :doc:`stable-rest-api/migration`.
 
 Endpoints
 ---------

--- a/tests/utils/test_docs.py
+++ b/tests/utils/test_docs.py
@@ -15,19 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
 from airflow.utils.docs import get_docs_url
 
 
-def init_appbuilder_links(app):
-    """Add links to Docs menu in navbar"""
-    appbuilder = app.appbuilder
-
-    appbuilder.add_link(
-        "Website", href='https://airflow.apache.org', category="Docs", category_icon="fa-globe"
-    )
-    appbuilder.add_link("Documentation", href=get_docs_url(), category="Docs", category_icon="fa-cube")
-    appbuilder.add_link("GitHub", href='https://github.com/apache/airflow', category="Docs")
-    appbuilder.add_link(
-        "REST API Reference (Swagger UI)", href='/api/v1./api/v1_swagger_ui_index', category="Docs"
-    )
-    appbuilder.add_link("REST API Reference (Redoc)", href="RedocView.redoc", category='Docs')
+class TestGetDocsUrl(unittest.TestCase):
+    @parameterized.expand([
+        ('2.0.0.dev0', None, 'https://airflow.readthedocs.io/en/latest/'),
+        ('2.0.0.dev0', 'migration.html', 'https://airflow.readthedocs.io/en/latest/migration.html'),
+        ('1.10.0', None, 'https://airflow.apache.org/docs/1.10.0/'),
+        ('1.10.0', 'migration.html', 'https://airflow.apache.org/docs/1.10.0/migration.html'),
+    ])
+    def test_should_return_link(self, version, page, expected_urk):
+        with mock.patch('airflow.version.version', version):
+            self.assertEqual(expected_urk, get_docs_url(page))


### PR DESCRIPTION
I used [Deprecation HTTP Header Field](https://tools.ietf.org/id/draft-dalal-deprecation-header-03.html) to notify users about changes in API.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
