### PR TITLE
Add new committers: Ry Walker & Leah Cole to project.rst

### DIFF
--- a/docs/project.rst
+++ b/docs/project.rst
@@ -67,6 +67,8 @@ Committers
 - @turbaszek (Tomasz Urbaszek)
 - @zhongjiajie (Jiajie Zhong)
 - @houqp (Qingping Hou)
+- @ryw (Ry Walker)
+- @leahecole (Leah Cole)
 
 For the full list of contributors, take a look at `Airflow's Github
 Contributor page:


### PR DESCRIPTION
They were announced last Friday during Airflow Summit. I will officially send emails to mailing lists today and on Twitter

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
