### PR TITLE
Dump Pod as YAML in logs for KubernetesPodOperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -18,6 +18,7 @@
 import re
 from typing import Dict, List, Optional, Tuple
 
+import yaml
 from kubernetes.client import models as k8s
 
 from airflow.exceptions import AirflowException
@@ -378,7 +379,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         )
 
         self.pod = pod
-        self.log.info("Starting pod %s", pod)
+        self.log.info("Starting pod:\n%s", yaml.safe_dump(pod.to_dict()))
         try:
             launcher.start_pod(
                 pod,

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -379,7 +379,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         )
 
         self.pod = pod
-        self.log.info("Starting pod:\n%s", yaml.safe_dump(pod.to_dict()))
+        self.log.debug("Starting pod:\n%s", yaml.safe_dump(pod.to_dict()))
         try:
             launcher.start_pod(
                 pod,

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -743,7 +743,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         with self.assertLogs(k.log) as cm:
             k.execute(context)
             expected_line = textwrap.dedent("""\
-            INFO:airflow.task.operators:Starting pod:
+            DEBUG:airflow.task.operators:Starting pod:
             api_version: v1
             kind: Pod
             metadata:

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -18,6 +18,7 @@
 import json
 import os
 import shutil
+import textwrap
 import unittest
 from unittest import mock
 from unittest.mock import ANY
@@ -739,7 +740,20 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         )
         monitor_mock.return_value = (State.SUCCESS, None)
         context = create_context(k)
-        k.execute(context)
+        with self.assertLogs(k.log) as cm:
+            k.execute(context)
+            expected_line = textwrap.dedent("""\
+            INFO:airflow.task.operators:Starting pod:
+            api_version: v1
+            kind: Pod
+            metadata:
+              annotations: null
+              cluster_name: null
+              creation_timestamp: null
+              deletion_grace_period_seconds: null\
+            """).strip()
+            self.assertTrue(any(line.startswith(expected_line) for line in cm.output))
+
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
         self.assertEqual({
             'apiVersion': 'v1',

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
+import logging
 import os
 import shutil
 import textwrap
@@ -740,7 +741,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         )
         monitor_mock.return_value = (State.SUCCESS, None)
         context = create_context(k)
-        with self.assertLogs(k.log) as cm:
+        with self.assertLogs(k.log, level=logging.DEBUG) as cm:
             k.execute(context)
             expected_line = textwrap.dedent("""\
             DEBUG:airflow.task.operators:Starting pod:


### PR DESCRIPTION
CC: @kuromt 

The YAML format is the more common representation for k8s objects.

---
Make sure to mark the boxes below before creating PR: [x]

- [X] Description above provides context of the change
- [X] Unit tests coverage for changes (not needed for documentation changes)
- [X] Target Github ISSUE in description if exists
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [X] Relevant documentation is updated including usage instructions.
- [X] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
