### PR TITLE
Fixes PodMutationHook for backwards compatibility

### DIFF
--- a/airflow/kubernetes/k8s_model.py
+++ b/airflow/kubernetes/k8s_model.py
@@ -29,7 +29,7 @@ else:
 
 
 class K8SModel(ABC):
-    __slots__ = []
+    __slots__ = []  # type: list
     """
     These Airflow Kubernetes models are here for backwards compatibility
     reasons only. Ideally clients should use the kubernetes api

--- a/airflow/kubernetes/k8s_model.py
+++ b/airflow/kubernetes/k8s_model.py
@@ -29,7 +29,7 @@ else:
 
 
 class K8SModel(ABC):
-    __slots__ = []  # type: list
+
     """
     These Airflow Kubernetes models are here for backwards compatibility
     reasons only. Ideally clients should use the kubernetes api

--- a/airflow/kubernetes/k8s_model.py
+++ b/airflow/kubernetes/k8s_model.py
@@ -47,6 +47,12 @@ class K8SModel(ABC):
         :return: The pod with the object attached
         """
 
+    def as_dict(self):
+        res ={}
+        for s in self.__slots__:
+            if hasattr(self, s):
+                res[s] = getattr(self, s)
+        return res
 
 def append_to_pod(pod, k8s_objects):
     """
@@ -60,3 +66,4 @@ def append_to_pod(pod, k8s_objects):
         return pod
     new_pod = reduce(lambda p, o: o.attach_to_pod(p), k8s_objects, pod)
     return new_pod
+

--- a/airflow/kubernetes/k8s_model.py
+++ b/airflow/kubernetes/k8s_model.py
@@ -51,12 +51,15 @@ class K8SModel(ABC):
 
     def as_dict(self):
         res = {}
-        for s in self.__slots__:
-            if hasattr(self, s):
-                res[s] = getattr(self, s)
-        res_dict = self.__dict__.copy()
-        res_dict.update(res)
-        return res_dict
+        if hasattr(self, "__slots__"):
+            for s in self.__slots__:
+                if hasattr(self, s):
+                    res[s] = getattr(self, s)
+        if hasattr(self, "__dict__"):
+            res_dict = self.__dict__.copy()
+            res_dict.update(res)
+            return res_dict
+        return res
 
 
 def append_to_pod(pod, k8s_objects):

--- a/airflow/kubernetes/k8s_model.py
+++ b/airflow/kubernetes/k8s_model.py
@@ -40,6 +40,7 @@ class K8SModel(ABC):
     can be avoided. All of these models implement the
     `attach_to_pod` method so that they integrate with the kubernetes client.
     """
+
     @abc.abstractmethod
     def attach_to_pod(self, pod):
         """
@@ -49,7 +50,7 @@ class K8SModel(ABC):
         """
 
     def as_dict(self):
-        res ={}
+        res = {}
         for s in self.__slots__:
             if hasattr(self, s):
                 res[s] = getattr(self, s)
@@ -57,8 +58,11 @@ class K8SModel(ABC):
         res_dict.update(res)
         return res_dict
 
+
 def append_to_pod(pod, k8s_objects):
     """
+    Attach Kubernetes objects to the given POD
+
     :param pod: A pod to attach a list of Kubernetes objects to
     :type pod: kubernetes.client.models.V1Pod
     :param k8s_objects: a potential None list of K8SModels
@@ -69,4 +73,3 @@ def append_to_pod(pod, k8s_objects):
         return pod
     new_pod = reduce(lambda p, o: o.attach_to_pod(p), k8s_objects, pod)
     return new_pod
-

--- a/airflow/kubernetes/k8s_model.py
+++ b/airflow/kubernetes/k8s_model.py
@@ -29,6 +29,7 @@ else:
 
 
 class K8SModel(ABC):
+    __slots__ = []
     """
     These Airflow Kubernetes models are here for backwards compatibility
     reasons only. Ideally clients should use the kubernetes api
@@ -52,7 +53,9 @@ class K8SModel(ABC):
         for s in self.__slots__:
             if hasattr(self, s):
                 res[s] = getattr(self, s)
-        return res
+        res_dict = self.__dict__.copy()
+        res_dict.update(res)
+        return res_dict
 
 def append_to_pod(pod, k8s_objects):
     """

--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -24,6 +24,7 @@ import kubernetes.client.models as k8s
 
 from airflow.kubernetes.k8s_model import K8SModel
 
+
 class Resources(K8SModel):
     __slots__ = ('request_memory',
                  'request_cpu',

--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -128,4 +128,3 @@ class Port(K8SModel):
         cp_pod.spec.containers[0].ports = cp_pod.spec.containers[0].ports or []
         cp_pod.spec.containers[0].ports.append(port)
         return cp_pod
-

--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -25,7 +25,13 @@ import kubernetes.client.models as k8s
 from airflow.kubernetes.k8s_model import K8SModel
 
 class Resources(K8SModel):
-    __slots__ = ('request_memory', 'request_cpu', 'limit_memory', 'limit_cpu', 'limit_gpu')
+    __slots__ = ('request_memory',
+                 'request_cpu',
+                 'limit_memory',
+                 'limit_cpu',
+                 'limit_gpu',
+                 'request_ephemeral_storage',
+                 'limit_ephemeral_storage')
 
     """
     :param request_memory: requested memory

--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -24,7 +24,6 @@ import kubernetes.client.models as k8s
 
 from airflow.kubernetes.k8s_model import K8SModel
 
-
 class Resources(K8SModel):
     __slots__ = ('request_memory', 'request_cpu', 'limit_memory', 'limit_cpu', 'limit_gpu')
 
@@ -44,15 +43,17 @@ class Resources(K8SModel):
     :param limit_ephemeral_storage: Limit for ephemeral storage
     :type limit_ephemeral_storage: float | str
     """
+
     def __init__(
-            self,
-            request_memory=None,
-            request_cpu=None,
-            request_ephemeral_storage=None,
-            limit_memory=None,
-            limit_cpu=None,
-            limit_gpu=None,
-            limit_ephemeral_storage=None):
+        self,
+        request_memory=None,
+        request_cpu=None,
+        request_ephemeral_storage=None,
+        limit_memory=None,
+        limit_cpu=None,
+        limit_gpu=None,
+        limit_ephemeral_storage=None
+    ):
         self.request_memory = request_memory
         self.request_cpu = request_cpu
         self.request_ephemeral_storage = request_ephemeral_storage
@@ -104,9 +105,10 @@ class Port(K8SModel):
     __slots__ = ('name', 'container_port')
 
     def __init__(
-            self,
-            name=None,
-            container_port=None):
+        self,
+        name=None,
+        container_port=None
+    ):
         """Creates port"""
         self.name = name
         self.container_port = container_port
@@ -120,3 +122,4 @@ class Port(K8SModel):
         cp_pod.spec.containers[0].ports = cp_pod.spec.containers[0].ports or []
         cp_pod.spec.containers[0].ports.append(port)
         return cp_pod
+

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -69,6 +69,8 @@ class PodLauncher(LoggingMixin):
         :type pod: k8s.V1Pod
         """
         try:
+            # attempts to run pod_mutation_hook using old pod, if this
+            # fails we attempt to run with k8s official pod
             from airflow.kubernetes_deprecated.pod import Pod
             from airflow.kubernetes.pod_generator import PodGenerator
             dummy_pod = Pod(image=pod.spec.containers[0]['image'], envs={}, cmds=[])
@@ -77,7 +79,6 @@ class PodLauncher(LoggingMixin):
             PodGenerator.reconcile_pods(pod, dummy_pod)
         except AttributeError:
             pod_mutation_hook(pod)
-
 
         sanitized_pod = self._client.api_client.sanitize_for_serialization(pod)
         json_pod = json.dumps(sanitized_pod, indent=2)

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -96,8 +96,8 @@ class PodLauncher(LoggingMixin):
             dummy_pod = convert_to_airflow_pod(pod)
             pod_mutation_hook(dummy_pod)
             dummy_pod = dummy_pod.to_v1_kubernetes_pod()
-            # pod = PodGenerator.reconcile_pods(pod, dummy_pod)
-        return dummy_pod
+            return dummy_pod
+        return pod
 
     def delete_pod(self, pod):
         """Deletes POD"""

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -66,7 +66,7 @@ class PodLauncher(LoggingMixin):
     def run_pod_async(self, pod, **kwargs):
         """Runs POD asynchronously
 
-        :param pod:
+        :param pod: Pod to run
         :type pod: k8s.V1Pod
         """
         pod = self._mutate_pod_backcompat(pod)

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -28,7 +28,7 @@ from requests.exceptions import BaseHTTPError
 from airflow import AirflowException
 from airflow.kubernetes.pod_launcher_helper import convert_to_airflow_pod
 from airflow.kubernetes.pod_generator import PodDefaults
-from airflow.settings import pod_mutation_hook
+from airflow import settings
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
 import kubernetes.client.models as k8s  # noqa
@@ -89,12 +89,12 @@ class PodLauncher(LoggingMixin):
     def _mutate_pod_backcompat(pod):
         """Backwards compatible Pod Mutation Hook"""
         try:
-            pod_mutation_hook(pod)
+            settings.pod_mutation_hook(pod)
             # attempts to run pod_mutation_hook using k8s.V1Pod, if this
             # fails we attempt to run by converting pod to Old Pod
         except AttributeError:
             dummy_pod = convert_to_airflow_pod(pod)
-            pod_mutation_hook(dummy_pod)
+            settings.pod_mutation_hook(dummy_pod)
             dummy_pod = dummy_pod.to_v1_kubernetes_pod()
             return dummy_pod
         return pod

--- a/airflow/kubernetes/pod_launcher_helper.py
+++ b/airflow/kubernetes/pod_launcher_helper.py
@@ -21,7 +21,6 @@ from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.kubernetes.pod import Port
 from airflow.kubernetes_deprecated.pod import Pod
-from airflow.kubernetes.pod_generator import PodGenerator
 import kubernetes.client.models as k8s  # noqa
 
 
@@ -40,6 +39,7 @@ def convert_to_airflow_pod(pod):
                     ports=_extract_ports(base_container.ports)
                     )
     return dummy_pod
+
 
 def _extract_env_vars(env_vars):
     """

--- a/airflow/kubernetes/pod_launcher_helper.py
+++ b/airflow/kubernetes/pod_launcher_helper.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import List, Union
 
 import kubernetes.client.models as k8s  # noqa
 
@@ -26,17 +27,18 @@ from airflow.kubernetes_deprecated.pod import Pod
 def convert_to_airflow_pod(pod):
     base_container = pod.spec.containers[0]  # type: k8s.V1Container
 
-    dummy_pod = Pod(image=base_container.image,
-                    envs=_extract_env_vars(base_container.env),
-                    volumes=_extract_volumes(pod.spec.volumes),
-                    volume_mounts=_extract_volume_mounts(base_container.volume_mounts),
-                    labels=pod.metadata.labels,
-                    name=pod.metadata.name,
-                    namespace=pod.metadata.namespace,
-                    image_pull_policy=base_container.image_pull_policy or 'IfNotPresent',
-                    cmds=[],
-                    ports=_extract_ports(base_container.ports)
-                    )
+    dummy_pod = Pod(
+        image=base_container.image,
+        envs=_extract_env_vars(base_container.env),
+        volumes=_extract_volumes(pod.spec.volumes),
+        volume_mounts=_extract_volume_mounts(base_container.volume_mounts),
+        labels=pod.metadata.labels,
+        name=pod.metadata.name,
+        namespace=pod.metadata.namespace,
+        image_pull_policy=base_container.image_pull_policy or 'IfNotPresent',
+        cmds=[],
+        ports=_extract_ports(base_container.ports)
+    )
     return dummy_pod
 
 
@@ -49,10 +51,9 @@ def _extract_env_vars(env_vars):
     :rtype: dict
     """
     result = {}
-    env_vars = env_vars or []
-    for e in env_vars:
-        env_var = e  # type: k8s.V1EnvVar
-        if not isinstance(env_var, dict):
+    env_vars = env_vars or []  # type: List[Union[k8s.V1EnvVar, dict]]
+    for env_var in env_vars:
+        if isinstance(env_var, k8s.V1EnvVar):
             env_var.to_dict()
         result[env_var.get("name")] = env_var.get("value")
     return result
@@ -60,36 +61,36 @@ def _extract_env_vars(env_vars):
 
 def _extract_volumes(volumes):
     result = []
-    volumes = volumes or []
-    for v in volumes:
-        volume = v  # type: k8s.V1Volume
-        if not isinstance(volume, dict):
-            volume.to_dict()
+    volumes = volumes or []  # type: List[Union[k8s.V1Volume, dict]]
+    for volume in volumes:
+        if isinstance(volume, k8s.V1Volume):
+            volume = volume.to_dict()
         result.append(Volume(name=volume.get("name"), configs=volume))
     return result
 
 
 def _extract_volume_mounts(volume_mounts):
     result = []
-    volume_mounts = volume_mounts or []
-    for v in volume_mounts:
-        volume_mount = v  # type: k8s.V1VolumeMount
-        if not isinstance(volume_mount, dict):
-            volume_mount.to_dict()
-        result.append(VolumeMount(name=volume_mount.get("name"),
-                                  mount_path=volume_mount.get("mount_path"),
-                                  sub_path=volume_mount.get("sub_path"),
-                                  read_only=volume_mount.get("read_only")))
+    volume_mounts = volume_mounts or []  # type: List[Union[k8s.V1VolumeMount, dict]]
+    for volume_mount in volume_mounts:
+        if isinstance(volume_mount, k8s.V1VolumeMount):
+            volume_mount = volume_mount.to_dict()
+        result.append(
+            VolumeMount(
+                name=volume_mount.get("name"),
+                mount_path=volume_mount.get("mount_path"),
+                sub_path=volume_mount.get("sub_path"),
+                read_only=volume_mount.get("read_only"))
+        )
 
     return result
 
 
 def _extract_ports(ports):
     result = []
-    ports = ports or []
-    for p in ports:
-        port = p  # type: k8s.V1ContainerPort
-        if not isinstance(port, dict):
-            port.to_dict()
+    ports = ports or []  # type: List[Union[k8s.V1ContainerPort, dict]]
+    for port in ports:
+        if isinstance(port, k8s.V1ContainerPort):
+            port = port.to_dict()
         result.append(Port(name=port.get("name"), container_port=port.get("container_port")))
     return result

--- a/airflow/kubernetes/pod_launcher_helper.py
+++ b/airflow/kubernetes/pod_launcher_helper.py
@@ -1,0 +1,47 @@
+import kubernetes.client.models as k8s  # noqa
+
+from airflow.kubernetes.volume import Volume
+from airflow.kubernetes.volume_mount import VolumeMount
+from airflow.kubernetes.pod import Port
+
+
+def extract_env_vars(env_vars):
+    """
+
+    @param env_vars:
+    @type env_vars: list
+    @return: result
+    @rtype: dict
+    """
+    result = {}
+    for e in env_vars:
+        env_var = e  # type: k8s.V1EnvVar
+        result[env_var.name] = env_var.value
+    return result
+
+
+def extract_volumes(volumes):
+    result = []
+    for v in volumes:
+        volume = v  # type: k8s.V1Volume
+        result.append(Volume(name=volume.name, configs=volume.__dict__))
+    return result
+
+
+def extract_volume_mounts(volume_mounts):
+    result = []
+    for v in volume_mounts:
+        volume = v  # type: k8s.V1VolumeMount
+        result.append(VolumeMount(name=volume.name,
+                                  mount_path=volume.mount_path,
+                                  sub_path=volume.sub_path,
+                                  read_only=volume.read_only))
+
+    return result
+
+def extract_ports(ports):
+    result = []
+    for p in ports:
+        port = p  # type: k8s.V1ContainerPort
+        result.append(Port(name=port.name, container_port=port.container_port))
+    return result

--- a/airflow/kubernetes/pod_launcher_helper.py
+++ b/airflow/kubernetes/pod_launcher_helper.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import kubernetes.client.models as k8s  # noqa
 
 from airflow.kubernetes.volume import Volume

--- a/airflow/kubernetes/pod_launcher_helper.py
+++ b/airflow/kubernetes/pod_launcher_helper.py
@@ -44,10 +44,10 @@ def convert_to_airflow_pod(pod):
 def _extract_env_vars(env_vars):
     """
 
-    @param env_vars:
-    @type env_vars: list
-    @return: result
-    @rtype: dict
+    :param env_vars:
+    :type env_vars: list
+    :return: result
+    :rtype: dict
     """
     result = {}
     env_vars = env_vars or []

--- a/airflow/kubernetes/volume_mount.py
+++ b/airflow/kubernetes/volume_mount.py
@@ -24,6 +24,10 @@ from airflow.kubernetes.k8s_model import K8SModel
 
 
 class VolumeMount(K8SModel):
+    __slots__ = ('name',
+                 'mount_path',
+                 'sub_path',
+                 'read_only')
     """
     Initialize a Kubernetes Volume Mount. Used to mount pod level volumes to
     running container.

--- a/airflow/kubernetes/volume_mount.py
+++ b/airflow/kubernetes/volume_mount.py
@@ -24,10 +24,7 @@ from airflow.kubernetes.k8s_model import K8SModel
 
 
 class VolumeMount(K8SModel):
-    __slots__ = ('name',
-                 'mount_path',
-                 'sub_path',
-                 'read_only')
+    __slots__ = ('name', 'mount_path', 'sub_path', 'read_only')
     """
     Initialize a Kubernetes Volume Mount. Used to mount pod level volumes to
     running container.

--- a/airflow/kubernetes_deprecated/__init__.py
+++ b/airflow/kubernetes_deprecated/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/kubernetes_deprecated/pod.py
+++ b/airflow/kubernetes_deprecated/pod.py
@@ -163,20 +163,8 @@ class Pod(object):
     def as_dict(self):
         res = self.__dict__
         res['resources'] = res['resources'].as_dict()
+        res['ports'] = [port.as_dict() for port in res['ports']]
+        res['volume_mounts'] = [volume_mount.as_dict() for volume_mount in res['volume_mounts']]
+        res['volumes'] = [volume.as_dict() for volume in res['volumes']]
 
-        new_ports = []
-        for port in res['ports']:
-            new_ports.append(port.as_dict())
-        res['ports'] = new_ports
-
-        volume_mounts = []
-        for volume_mount in res['volume_mounts']:
-            volume_mounts.append(volume_mount.as_dict())
-        res['volume_mounts'] = volume_mounts
-
-        volumes = []
-        for volume in res['volumes']:
-            volumes.append(volume.as_dict())
-        res['volumes'] = volumes
         return res
-

--- a/airflow/kubernetes_deprecated/pod.py
+++ b/airflow/kubernetes_deprecated/pod.py
@@ -19,16 +19,7 @@ import kubernetes.client.models as k8s
 from airflow.kubernetes.pod import Resources
 
 
-class Port:
-    def __init__(
-            self,
-            name=None,
-            container_port=None):
-        self.name = name
-        self.container_port = container_port
-
-
-class Pod:
+class Pod(object):
     """
     Represents a kubernetes pod and manages execution of a single pod.
     :param image: The docker image
@@ -168,3 +159,19 @@ class Pod:
             pod = runtime_info.attach_to_pod(pod)
         pod = self.resources.attach_to_pod(pod)
         return pod
+
+    def as_dict(self):
+        res = self.__dict__
+        res['resources'] = res['resources'].as_dict()
+
+        new_ports = []
+        for port in res['ports']:
+            new_ports.append(port.as_dict())
+        res['ports'] = new_ports
+
+        volume_mounts = []
+        for volume_mount in res['volume_mounts']:
+            volume_mounts.append(volume_mount.as_dict())
+        res['volume_mounts'] = volume_mounts
+        return res
+

--- a/airflow/kubernetes_deprecated/pod.py
+++ b/airflow/kubernetes_deprecated/pod.py
@@ -117,7 +117,7 @@ class Pod(object):
         """
         Convert to support k8s V1Pod
 
-        @return: k8s.V1Pod
+        :return: k8s.V1Pod
         """
         meta = k8s.V1ObjectMeta(
             labels=self.labels,
@@ -131,7 +131,7 @@ class Pod(object):
                     image=self.image,
                     command=self.cmds,
                     name="base",
-                    env=self.envs,
+                    env=[k8s.V1EnvVar(name=key, value=val) for key, val in self.envs.items()],
                     args=self.args,
                     image_pull_policy=self.image_pull_policy,
                 )

--- a/airflow/kubernetes_deprecated/pod.py
+++ b/airflow/kubernetes_deprecated/pod.py
@@ -1,0 +1,170 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import kubernetes.client.models as k8s
+from airflow.kubernetes.pod import Resources
+
+
+class Port:
+    def __init__(
+            self,
+            name=None,
+            container_port=None):
+        self.name = name
+        self.container_port = container_port
+
+
+class Pod:
+    """
+    Represents a kubernetes pod and manages execution of a single pod.
+    :param image: The docker image
+    :type image: str
+    :param envs: A dict containing the environment variables
+    :type envs: dict
+    :param cmds: The command to be run on the pod
+    :type cmds: list[str]
+    :param secrets: Secrets to be launched to the pod
+    :type secrets: list[airflow.contrib.kubernetes.secret.Secret]
+    :param result: The result that will be returned to the operator after
+        successful execution of the pod
+    :type result: any
+    :param image_pull_policy: Specify a policy to cache or always pull an image
+    :type image_pull_policy: str
+    :param image_pull_secrets: Any image pull secrets to be given to the pod.
+        If more than one secret is required, provide a comma separated list:
+        secret_a,secret_b
+    :type image_pull_secrets: str
+    :param affinity: A dict containing a group of affinity scheduling rules
+    :type affinity: dict
+    :param hostnetwork: If True enable host networking on the pod
+    :type hostnetwork: bool
+    :param tolerations: A list of kubernetes tolerations
+    :type tolerations: list
+    :param security_context: A dict containing the security context for the pod
+    :type security_context: dict
+    :param configmaps: A list containing names of configmaps object
+        mounting env variables to the pod
+    :type configmaps: list[str]
+    :param pod_runtime_info_envs: environment variables about
+                                  pod runtime information (ip, namespace, nodeName, podName)
+    :type pod_runtime_info_envs: list[PodRuntimeEnv]
+    :param dnspolicy: Specify a dnspolicy for the pod
+    :type dnspolicy: str
+    """
+    def __init__(
+            self,
+            image,
+            envs,
+            cmds,
+            args=None,
+            secrets=None,
+            labels=None,
+            node_selectors=None,
+            name=None,
+            ports=None,
+            volumes=None,
+            volume_mounts=None,
+            namespace='default',
+            result=None,
+            image_pull_policy='IfNotPresent',
+            image_pull_secrets=None,
+            init_containers=None,
+            service_account_name=None,
+            resources=None,
+            annotations=None,
+            affinity=None,
+            hostnetwork=False,
+            tolerations=None,
+            security_context=None,
+            configmaps=None,
+            pod_runtime_info_envs=None,
+            dnspolicy=None
+    ):
+        self.image = image
+        self.envs = envs or {}
+        self.cmds = cmds
+        self.args = args or []
+        self.secrets = secrets or []
+        self.result = result
+        self.labels = labels or {}
+        self.name = name
+        self.ports = ports or []
+        self.volumes = volumes or []
+        self.volume_mounts = volume_mounts or []
+        self.node_selectors = node_selectors or {}
+        self.namespace = namespace
+        self.image_pull_policy = image_pull_policy
+        self.image_pull_secrets = image_pull_secrets
+        self.init_containers = init_containers
+        self.service_account_name = service_account_name
+        self.resources = resources or Resources()
+        self.annotations = annotations or {}
+        self.affinity = affinity or {}
+        self.hostnetwork = hostnetwork or False
+        self.tolerations = tolerations or []
+        self.security_context = security_context
+        self.configmaps = configmaps or []
+        self.pod_runtime_info_envs = pod_runtime_info_envs or []
+        self.dnspolicy = dnspolicy
+
+    def to_v1_kubernetes_pod(self):
+        """
+        Convert to support k8s V1Pod
+
+        @return: k8s.V1Pod
+        """
+        meta = k8s.V1ObjectMeta(
+            labels=self.labels,
+            name=self.name,
+            namespace=self.namespace,
+        )
+        spec = k8s.V1PodSpec(
+            init_containers=self.init_containers,
+            containers=[
+                k8s.V1Container(
+                    image=self.image,
+                    command=self.cmds,
+                    name="base",
+                    env=self.envs,
+                    args=self.args,
+                    image_pull_policy=self.image_pull_policy,
+                )
+            ],
+            image_pull_secrets=self.image_pull_secrets,
+            service_account_name=self.service_account_name,
+            dns_policy=self.dnspolicy,
+            host_network=self.hostnetwork,
+            tolerations=self.tolerations,
+            security_context=self.security_context,
+        )
+
+        pod = k8s.V1Pod(
+            spec=spec,
+            metadata=meta,
+        )
+        for port in self.ports:
+            pod = port.attach_to_pod(pod)
+        for volume in self.volumes:
+            pod = volume.attach_to_pod(pod)
+        for volume_mount in self.volume_mounts:
+            pod = volume_mount.attach_to_pod(pod)
+        for secret in self.secrets:
+            pod = secret.attach_to_pod(pod)
+        for runtime_info in self.pod_runtime_info_envs:
+            pod = runtime_info.attach_to_pod(pod)
+        pod = self.resources.attach_to_pod(pod)
+        return pod

--- a/airflow/kubernetes_deprecated/pod.py
+++ b/airflow/kubernetes_deprecated/pod.py
@@ -22,6 +22,7 @@ from airflow.kubernetes.pod import Resources
 class Pod(object):
     """
     Represents a kubernetes pod and manages execution of a single pod.
+
     :param image: The docker image
     :type image: str
     :param envs: A dict containing the environment variables

--- a/airflow/kubernetes_deprecated/pod.py
+++ b/airflow/kubernetes_deprecated/pod.py
@@ -173,5 +173,10 @@ class Pod(object):
         for volume_mount in res['volume_mounts']:
             volume_mounts.append(volume_mount.as_dict())
         res['volume_mounts'] = volume_mounts
+
+        volumes = []
+        for volume in res['volumes']:
+            volumes.append(volume.as_dict())
+        res['volumes'] = volumes
         return res
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -201,6 +201,7 @@ exclude_patterns = [
     '_api/airflow/example_dags',
     '_api/airflow/index.rst',
     '_api/airflow/jobs',
+    '_api/airflow/kubernetes_deprecated',
     '_api/airflow/lineage',
     '_api/airflow/logging_config',
     '_api/airflow/macros',

--- a/tests/kubernetes/models/test_pod.py
+++ b/tests/kubernetes/models/test_pod.py
@@ -80,14 +80,13 @@ class TestPod(unittest.TestCase):
         from airflow.kubernetes.volume import Volume
         from airflow.kubernetes.volume_mount import VolumeMount
         from airflow.kubernetes.pod import Resources
-        # from airflow.kubernetes.pod import Pod
 
         pod = DeprecatedPod(
             image="foo",
             name="bar",
             namespace="baz",
             image_pull_policy="Never",
-            envs=[],
+            envs={"test_key": "test_value"},
             cmds=["airflow"],
             resources=Resources(
                 request_memory="1G",
@@ -102,7 +101,6 @@ class TestPod(unittest.TestCase):
 
         result = pod.to_v1_kubernetes_pod()
         result = k8s_client.sanitize_for_serialization(result)
-        print(result['spec']['containers'][0]['resources'])
 
         expected = \
             {
@@ -118,7 +116,7 @@ class TestPod(unittest.TestCase):
                             {
                                 'args': [],
                                 'command': ['airflow'],
-                                'env': {},
+                                'env': [{'name': 'test_key', 'value': 'test_value'}],
                                 'image': 'foo',
                                 'imagePullPolicy': 'Never',
                                 'name': 'base',
@@ -155,4 +153,5 @@ class TestPod(unittest.TestCase):
                         ]
                      }
             }
+        self.maxDiff = None
         self.assertEquals(expected, result)

--- a/tests/kubernetes/models/test_pod.py
+++ b/tests/kubernetes/models/test_pod.py
@@ -74,3 +74,85 @@ class TestPod(unittest.TestCase):
                 'volumes': []
             }
         }, result)
+
+    def test_to_v1_pod(self):
+        from airflow.kubernetes_deprecated.pod import Pod as DeprecatedPod
+        from airflow.kubernetes.volume import Volume
+        from airflow.kubernetes.volume_mount import VolumeMount
+        from airflow.kubernetes.pod import Resources
+        # from airflow.kubernetes.pod import Pod
+
+        pod = DeprecatedPod(
+            image="foo",
+            name="bar",
+            namespace="baz",
+            image_pull_policy="Never",
+            envs=[],
+            cmds=["airflow"],
+            resources=Resources(
+                request_memory="1G",
+                request_cpu="100Mi",
+                limit_gpu="100G"
+            ),
+            volumes=[Volume(name="foo", configs={})],
+            volume_mounts=[VolumeMount(name="foo", mount_path="/mnt", sub_path="/", read_only=True)]
+        )
+
+        k8s_client = ApiClient()
+
+        result = pod.to_v1_kubernetes_pod()
+        result = k8s_client.sanitize_for_serialization(result)
+        print(result['spec']['containers'][0]['resources'])
+
+        expected = \
+            {
+                'metadata':
+                    {
+                        'labels': {},
+                        'name': 'bar',
+                        'namespace': 'baz'
+                    },
+                'spec':
+                    {'containers':
+                        [
+                            {
+                                'args': [],
+                                'command': ['airflow'],
+                                'env': {},
+                                'image': 'foo',
+                                'imagePullPolicy': 'Never',
+                                'name': 'base',
+                                'volumeMounts':
+                                    [
+                                        {
+                                            'mountPath': '/mnt',
+                                            'name': 'foo',
+                                            'readOnly': True, 'subPath': '/'
+                                        }
+                                    ],  # noqa
+                                'resources':
+                                    {
+                                        'limits':
+                                            {
+                                                'cpu': None,
+                                                'memory': None,
+                                                'nvidia.com/gpu': '100G',
+                                                'ephemeral-storage': None
+                                            },
+                                        'requests':
+                                            {
+                                                'cpu': '100Mi',
+                                                'memory': '1G',
+                                                'ephemeral-storage': None
+                                            }
+                                }
+                            }
+                        ],
+                        'hostNetwork': False,
+                        'tolerations': [],
+                        'volumes': [
+                            {'name': 'foo'}
+                        ]
+                     }
+            }
+        self.assertEquals(expected, result)

--- a/tests/kubernetes/test_pod_launcher_helper.py
+++ b/tests/kubernetes/test_pod_launcher_helper.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+import mock
+
+from requests.exceptions import BaseHTTPError
+
+from airflow import AirflowException
+from airflow.kubernetes.pod_launcher import PodLauncher
+from airflow.kubernetes.pod import Port,Resources
+from airflow.kubernetes.volume_mount import VolumeMount
+from airflow.kubernetes.pod_launcher_helper import convert_to_airflow_pod
+from airflow.kubernetes_deprecated.pod import Pod
+import kubernetes.client.models as k8s
+
+
+class TestPodLauncherHelper(unittest.TestCase):
+    def test_convert_to_airflow_pod(self):
+        input_pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(
+              name="foo",
+              namespace="bar"
+            ),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="base",
+                        command="foo",
+                        image="myimage",
+                        ports=[
+                            k8s.V1ContainerPort(
+                                name="myport",
+                                container_port=8080,
+                            )
+                        ],
+                        volume_mounts=[k8s.V1VolumeMount(
+                            name="mymount",
+                            mount_path="/tmp/mount",
+                            read_only="True"
+                        )]
+                    )
+                ]
+            )
+        )
+        result_pod = convert_to_airflow_pod(input_pod)
+
+        expected = Pod(
+            name="foo",
+            namespace="bar",
+            envs={},
+            cmds=[],
+            image="myimage",
+            ports=[
+                Port(name="myport", container_port=8080)
+            ],
+            volume_mounts= [VolumeMount(
+                name="mymount",
+                mount_path="/tmp/mount",
+                sub_path=None,
+                read_only="True"
+            )]
+        )
+        expected_dict = expected.as_dict()
+        result_dict = result_pod.as_dict()
+        self.maxDiff = None
+
+        self.assertDictEqual(expected_dict, result_dict)

--- a/tests/kubernetes/test_pod_launcher_helper.py
+++ b/tests/kubernetes/test_pod_launcher_helper.py
@@ -15,13 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
-import mock
 
-from requests.exceptions import BaseHTTPError
-
-from airflow import AirflowException
-from airflow.kubernetes.pod_launcher import PodLauncher
-from airflow.kubernetes.pod import Port,Resources
+from airflow.kubernetes.pod import Port
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.pod_launcher_helper import convert_to_airflow_pod
@@ -33,8 +28,8 @@ class TestPodLauncherHelper(unittest.TestCase):
     def test_convert_to_airflow_pod(self):
         input_pod = k8s.V1Pod(
             metadata=k8s.V1ObjectMeta(
-              name="foo",
-              namespace="bar"
+                name="foo",
+                namespace="bar"
             ),
             spec=k8s.V1PodSpec(
                 containers=[
@@ -73,7 +68,7 @@ class TestPodLauncherHelper(unittest.TestCase):
             ports=[
                 Port(name="myport", container_port=8080)
             ],
-            volume_mounts= [VolumeMount(
+            volume_mounts=[VolumeMount(
                 name="mymount",
                 mount_path="/tmp/mount",
                 sub_path=None,

--- a/tests/kubernetes/test_pod_launcher_helper.py
+++ b/tests/kubernetes/test_pod_launcher_helper.py
@@ -74,7 +74,7 @@ class TestPodLauncherHelper(unittest.TestCase):
                 sub_path=None,
                 read_only="True"
             )],
-            volumes=[Volume(name="myvolume", configs={})]
+            volumes=[Volume(name="myvolume", configs={'name': 'myvolume'})]
         )
         expected_dict = expected.as_dict()
         result_dict = result_pod.as_dict()

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -22,7 +22,6 @@ import sys
 import tempfile
 import unittest
 from kubernetes.client import ApiClient
-import kubernetes.client.models as k8s #noqa
 from tests.compat import MagicMock, Mock, call, patch
 
 
@@ -76,6 +75,7 @@ def pod_mutation_hook(v1pod):
     @return:
     """
     v1pod.spec.containers[0].image = "test-image"
+
 
 class SettingsContext:
     def __init__(self, content, module_name):
@@ -294,8 +294,9 @@ class LocalSettingsTest(unittest.TestCase):
                 volume_mounts=[VolumeMount(name="foo", mount_path="/mnt", sub_path="/", read_only=True)]
             )
 
-            with self.assertRaises(AttributeError) as context:
+            with self.assertRaises(AttributeError):
                 self.assertRaises(settings.pod_mutation_hook(pod))
+
 
 class TestStatsWithAllowList(unittest.TestCase):
 

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -22,7 +22,6 @@ import sys
 import tempfile
 import unittest
 from airflow.kubernetes import pod_generator
-from airflow.kubernetes.pod_launcher import PodLauncher
 from tests.compat import MagicMock, Mock, call, patch
 
 
@@ -188,6 +187,7 @@ class LocalSettingsTest(unittest.TestCase):
         with SettingsContext(SETTINGS_FILE_POD_MUTATION_HOOK, "airflow_local_settings"):
             from airflow import settings
             settings.import_local_settings()  # pylint: ignore
+            from airflow.kubernetes.pod_launcher import PodLauncher
 
             self.mock_kube_client = Mock()
             self.pod_launcher = PodLauncher(kube_client=self.mock_kube_client)
@@ -203,18 +203,6 @@ class LocalSettingsTest(unittest.TestCase):
                 volumes=[{"name": "foo"}]
             ).gen_pod()
 
-            """
-            def pod_mutation_hook(pod):
-                pod.namespace = 'airflow-tests'
-                pod.image = 'my_image'
-                pod.volumes.append(Volume(name="bar", configs={}))
-                pod.ports = [Port(container_port=8080)]
-                pod.resources = Resources(
-                                request_memory="2G",
-                                request_cpu="200Mi",
-                                limit_gpu="200G"
-                            )
-            """
             self.assertEqual(pod.metadata.namespace, "baz")
             self.assertEqual(pod.spec.containers[0].image, "foo")
             self.assertEqual(pod.spec.volumes, [{'name': 'foo'}])
@@ -253,6 +241,7 @@ class LocalSettingsTest(unittest.TestCase):
         with SettingsContext(SETTINGS_FILE_POD_MUTATION_HOOK_V1_POD, "airflow_local_settings"):
             from airflow import settings
             settings.import_local_settings()  # pylint: ignore
+            from airflow.kubernetes.pod_launcher import PodLauncher
 
             self.mock_kube_client = Mock()
             self.pod_launcher = PodLauncher(kube_client=self.mock_kube_client)

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -180,10 +180,11 @@ class LocalSettingsTest(unittest.TestCase):
             settings.import_local_settings()  # pylint: ignore
 
             pod = MagicMock()
+            pod.volumes = []
             settings.pod_mutation_hook(pod)
 
             assert pod.namespace == 'airflow-tests'
-            self.assertEqual(pod.volumes[0].name, "foo")
+            self.assertEqual(pod.volumes[0].name, "bar")
 
     def test_pod_mutation_to_k8s_pod(self):
         with SettingsContext(SETTINGS_FILE_POD_MUTATION_HOOK, "airflow_local_settings"):
@@ -198,7 +199,7 @@ class LocalSettingsTest(unittest.TestCase):
                 name="bar",
                 namespace="baz",
                 image_pull_policy="Never",
-                envs=[],
+                envs={},
                 cmds=["airflow"],
                 resources=Resources(
                     request_memory="1G",
@@ -229,7 +230,7 @@ class LocalSettingsTest(unittest.TestCase):
                                 {
                                     'args': [],
                                     'command': ['airflow'],
-                                    'env': {},
+                                    'env': [],
                                     'image': 'my_image',
                                     'imagePullPolicy': 'Never',
                                     'ports': [{'containerPort': 8080}],

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -64,16 +64,6 @@ def pod_mutation_hook(pod):
 """
 
 
-def pod_mutation_hook(v1pod):
-    """
-
-    @param v1pod:
-    :type v1pod: k8s.V1Pod
-    @return:
-    """
-    v1pod.spec.containers[0].image = "test-image"
-
-
 class SettingsContext:
     def __init__(self, content, module_name):
         self.content = content


### PR DESCRIPTION
Users were unable to use the traditional pod_mutation_hook due to breaking changes in 1.10.11. This fix allows both new and old forms
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
