### PR TITLE
Fix dag.clear usages after change from #9824

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -979,7 +979,8 @@ It will run a backfill job:
 .. code-block:: python
 
   if __name__ == '__main__':
-    dag.clear(reset_dag_runs=True)
+    from airflow.utils.state import State
+    dag.clear(dag_run_state=State.NONE)
     dag.run()
 
 

--- a/docs/executor/debug.rst
+++ b/docs/executor/debug.rst
@@ -43,7 +43,8 @@ It will run a backfill job:
 .. code-block:: python
 
   if __name__ == '__main__':
-    dag.clear(reset_dag_runs=True)
+    from airflow.utils.state import State
+    dag.clear(dag_run_state=State.NONE)
     dag.run()
 
 

--- a/tests/test_utils/system_tests_class.py
+++ b/tests/test_utils/system_tests_class.py
@@ -26,6 +26,7 @@ from airflow.exceptions import AirflowException
 from airflow.models.dagbag import DagBag
 from airflow.utils.file import mkdirs
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.state import State
 from tests.test_utils import AIRFLOW_MAIN_FOLDER
 from tests.utils.logging_command_executor import get_executor
 
@@ -149,7 +150,7 @@ class SystemTest(TestCase, LoggingMixin):
             )
 
         self.log.info("Attempting to run DAG: %s", dag_id)
-        dag.clear(reset_dag_runs=True)
+        dag.clear(dag_run_state=State.NONE)
         try:
             dag.run(ignore_first_depends_on_past=True, verbose=True)
         except Exception:


### PR DESCRIPTION
#9824 introduced changes in signature of `dag.clear(...)` but not all occurrences of invocation were adjusted. 

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
