### PR TITLE
Fix calling `get_client` in BigQueryHook.table_exists

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -211,7 +211,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         """
         table_reference = TableReference(DatasetReference(project_id, dataset_id), table_id)
         try:
-            self.get_client().get_table(table_reference)
+            self.get_client(project_id=project_id).get_table(table_reference)
             return True
         except NotFound:
             return False

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -100,18 +100,19 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         with self.assertRaises(NotImplementedError):
             self.hook.insert_rows(table="table", rows=[1, 2])
 
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
     def test_bigquery_table_exists_true(self, mock_client):
         result = self.hook.table_exists(project_id=PROJECT_ID, dataset_id=DATASET_ID, table_id=TABLE_ID)
         mock_client.return_value.get_table.assert_called_once_with(TABLE_REFERENCE)
+        mock_client.assert_called_once_with(project_id=PROJECT_ID)
         assert result is True
 
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
     def test_bigquery_table_exists_false(self, mock_client):
         mock_client.return_value.get_table.side_effect = NotFound("Dataset not found")
-
         result = self.hook.table_exists(project_id=PROJECT_ID, dataset_id=DATASET_ID, table_id=TABLE_ID)
         mock_client.return_value.get_table.assert_called_once_with(TABLE_REFERENCE)
+        mock_client.assert_called_once_with(project_id=PROJECT_ID)
         assert result is False
 
     @mock.patch('airflow.providers.google.cloud.hooks.bigquery.read_gbq')


### PR DESCRIPTION
Calling the get_client method in hook.table_exists should specify the PROJECT_ID.

Closes: #9900

Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "How to write a good git commit message"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in Contribution Workflow Example.
