### PR TITLE
point go client mod path to new repo

### DIFF
--- a/clients/gen/go.sh
+++ b/clients/gen/go.sh
@@ -52,7 +52,7 @@ SPEC_PATH="${SPEC_PATH}" \
 OUTPUT_DIR="${OUTPUT_DIR}" \
     gen_client go \
     --package-name airflow \
-    --git-repo-id airflow/clients/go/airflow \
+    --git-repo-id airflow-client-go/airflow \
     --additional-properties "${go_config[*]}"
 
 # patch generated client to support problem HTTP API


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Forgot to update client repo path in the original PR, this fixes it and point it to the new go client repo.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
