### PR TITLE
Clean up tmp directory when exiting from breeze shell

### DIFF
--- a/breeze
+++ b/breeze
@@ -2124,6 +2124,7 @@ function run_breeze_command {
                 "${BUILD_CACHE_DIR}/${LAST_DC_PROD_FILE}" run --service-ports --rm airflow "${@}"
             else
                 "${BUILD_CACHE_DIR}/${LAST_DC_CI_FILE}" run --service-ports --rm airflow "${@}"
+                "${SCRIPTS_CI_DIR}/tools/ci_clear_tmp.sh"
             fi
             ;;
         run_exec)

--- a/scripts/ci/in_container/_in_container_utils.sh
+++ b/scripts/ci/in_container/_in_container_utils.sh
@@ -115,6 +115,16 @@ function in_container_fix_ownership() {
     fi
 }
 
+function in_container_clear_tmp() {
+    if [[ ${VERBOSE} == "true" ]]; then
+        echo "Cleaning ${AIRFLOW_SOURCES}/tmp from the container"
+    fi
+    rm -rf /tmp/*
+    if [[ ${VERBOSE} == "true" ]]; then
+        echo "Cleaned ${AIRFLOW_SOURCES}/tmp from the container"
+    fi
+}
+
 function in_container_go_to_airflow_sources() {
     pushd "${AIRFLOW_SOURCES}"  &>/dev/null || exit 1
 }

--- a/scripts/ci/in_container/run_clear_tmp.sh
+++ b/scripts/ci/in_container/run_clear_tmp.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# shellcheck source=scripts/ci/in_container/_in_container_script_init.sh
+. "$( dirname "${BASH_SOURCE[0]}" )/_in_container_script_init.sh"
+
+in_container_clear_tmp

--- a/scripts/ci/tools/ci_clear_tmp.sh
+++ b/scripts/ci/tools/ci_clear_tmp.sh
@@ -36,11 +36,9 @@ HOST_OS="$(uname -s)"
 export HOST_USER_ID
 export HOST_GROUP_ID
 export HOST_OS
-export BACKEND="sqlite"
 
 docker-compose \
     -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
     -f "${SCRIPTS_CI_DIR}/docker-compose/local.yml" \
-    -f "${SCRIPTS_CI_DIR}/docker-compose/forward-credentials.yml" \
-    run --entrypoint /bin/bash \
-    airflow -c /opt/airflow/scripts/ci/in_container/run_fix_ownership.sh
+   run --entrypoint /bin/bash \
+    airflow -c /opt/airflow/scripts/ci/in_container/run_clear_tmp.sh


### PR DESCRIPTION
Since we are mountign tmp dir now to inside container, some
of the remnants of what's going on inside remains after exit.
This is particularly bad if you are using tmux (some of the
directories remaining there prevent tmux from re-run)

This change cleans up /tmp directory on exit from Breeze command.
It does it from inside container so that we clean up all
root-owned files without sudo.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
