### PR TITLE
Add airflow config get-value command

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1222,8 +1222,8 @@ has been renamed to `request_filter`.
 
 The Airflow CLI has been organized so that related commands are grouped
 together as subcommands. The `airflow list_dags` command is now `airflow
-dags list`, `airflow pause` is `airflow dags pause`, etc. For a complete
-list of updated CLI commands, see https://airflow.apache.org/cli.html.
+dags list`, `airflow pause` is `airflow dags pause`, `airflow config` is `airflow config list`, etc.
+For a complete list of updated CLI commands, see https://airflow.apache.org/cli.html.
 
 ### Removal of Mesos Executor
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -730,6 +730,17 @@ ARG_FILE_IO = Arg(
     action='store_true'
 )
 
+# config
+ARG_SECTION = Arg(
+    ("section",),
+    help="The section name",
+)
+ARG_OPTION = Arg(
+    ("option",),
+    help="The option name",
+)
+
+
 ALTERNATIVE_CONN_SPECS_ARGS = [
     ARG_CONN_TYPE, ARG_CONN_HOST, ARG_CONN_LOGIN, ARG_CONN_PASSWORD, ARG_CONN_SCHEMA, ARG_CONN_PORT
 ]
@@ -1184,6 +1195,21 @@ CELERY_COMMANDS = (
     )
 )
 
+CONFIG_COMMANDS = (
+    ActionCommand(
+        name='get-value',
+        help='Print the value of the configuration',
+        func=lazy_load_command('airflow.cli.commands.config_command.get_value'),
+        args=(ARG_SECTION, ARG_OPTION, ),
+    ),
+    ActionCommand(
+        name='list',
+        help='List options for the configuration.',
+        func=lazy_load_command('airflow.cli.commands.config_command.show_config'),
+        args=(ARG_COLOR, ),
+    ),
+)
+
 airflow_commands: List[CLICommand] = [
     GroupCommand(
         name='dags',
@@ -1273,11 +1299,10 @@ airflow_commands: List[CLICommand] = [
         ),
         args=(),
     ),
-    ActionCommand(
-        name='config',
-        help='Show current application configuration',
-        func=lazy_load_command('airflow.cli.commands.config_command.show_config'),
-        args=(ARG_COLOR, ),
+    GroupCommand(
+        name="config",
+        help='View the configuration options.',
+        subcommands=CONFIG_COMMANDS
     ),
     ActionCommand(
         name='info',

--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -16,6 +16,7 @@
 # under the License.
 """Config sub-commands"""
 import io
+import sys
 
 import pygments
 from pygments.formatters.terminal import TerminalFormatter
@@ -35,3 +36,17 @@ def show_config(args):
                 code=code, formatter=TerminalFormatter(), lexer=IniLexer()
             )
         print(code)
+
+
+def get_value(args):
+    """Get one value from configuration"""
+    if not conf.has_section(args.section):
+        print(f'section [{args.section}] not found in config.', file=sys.stderr)
+        sys.exit(1)
+
+    if not conf.has_option(args.section, args.option):
+        print(f'option [{args.section}/{args.option}] not found in config.', file=sys.stderr)
+        sys.exit(1)
+
+    value = conf.get(args.section, args.option)
+    print(value)

--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -41,11 +41,11 @@ def show_config(args):
 def get_value(args):
     """Get one value from configuration"""
     if not conf.has_section(args.section):
-        print(f'section [{args.section}] not found in config.', file=sys.stderr)
+        print(f'The section [{args.section}] not found in config.', file=sys.stderr)
         sys.exit(1)
 
     if not conf.has_option(args.section, args.option):
-        print(f'option [{args.section}/{args.option}] not found in config.', file=sys.stderr)
+        print(f'The option [{args.section}/{args.option}] not found in config.', file=sys.stderr)
         sys.exit(1)
 
     value = conf.get(args.section, args.option)

--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -41,11 +41,11 @@ def show_config(args):
 def get_value(args):
     """Get one value from configuration"""
     if not conf.has_section(args.section):
-        print(f'The section [{args.section}] not found in config.', file=sys.stderr)
+        print(f'The section [{args.section}] is not found in config.', file=sys.stderr)
         sys.exit(1)
 
     if not conf.has_option(args.section, args.option):
-        print(f'The option [{args.section}/{args.option}] not found in config.', file=sys.stderr)
+        print(f'The option [{args.section}/{args.option}] is not found in config.', file=sys.stderr)
         sys.exit(1)
 
     value = conf.get(args.section, args.option)

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -89,7 +89,7 @@ class HttpHook(BaseHook):
         return session
 
     def run(self,
-            endpoint: str,
+            endpoint: Optional[str],
             data: Optional[Union[Dict[str, Any], str]] = None,
             headers: Optional[Dict[str, Any]] = None,
             extra_options: Optional[Dict[str, Any]] = None,

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -89,7 +89,7 @@ class HttpHook(BaseHook):
         return session
 
     def run(self,
-            endpoint: Optional[str],
+            endpoint: str,
             data: Optional[Union[Dict[str, Any], str]] = None,
             headers: Optional[Dict[str, Any]] = None,
             extra_options: Optional[Dict[str, Any]] = None,

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -69,7 +69,9 @@ class TestCliConfigGetValue(unittest.TestCase):
                 ['config', 'get-value', 'missing-section', 'dags_folder']
             ))
         self.assertEqual(1, cm.exception.code)
-        self.assertEqual("The section [missing-section] not found in config.", temp_stderr.getvalue().strip())
+        self.assertEqual(
+            "The section [missing-section] is not found in config.", temp_stderr.getvalue().strip()
+        )
 
     @mock.patch("airflow.cli.commands.config_command.conf")
     def test_should_raise_exception_when_option_is_missing(self, mock_conf):
@@ -82,5 +84,5 @@ class TestCliConfigGetValue(unittest.TestCase):
             ))
         self.assertEqual(1, cm.exception.code)
         self.assertEqual(
-            "The option [missing-section/dags_folder] not found in config.", temp_stderr.getvalue().strip()
+            "The option [missing-section/dags_folder] is not found in config.", temp_stderr.getvalue().strip()
         )

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -69,7 +69,7 @@ class TestCliConfigGetValue(unittest.TestCase):
                 ['config', 'get-value', 'missing-section', 'dags_folder']
             ))
         self.assertEqual(1, cm.exception.code)
-        self.assertEqual("section [missing-section] not found in config.", temp_stderr.getvalue().strip())
+        self.assertEqual("The section [missing-section] not found in config.", temp_stderr.getvalue().strip())
 
     @mock.patch("airflow.cli.commands.config_command.conf")
     def test_should_raise_exception_when_option_is_missing(self, mock_conf):
@@ -82,5 +82,5 @@ class TestCliConfigGetValue(unittest.TestCase):
             ))
         self.assertEqual(1, cm.exception.code)
         self.assertEqual(
-            "option [missing-section/dags_folder] not found in config.", temp_stderr.getvalue().strip()
+            "The option [missing-section/dags_folder] not found in config.", temp_stderr.getvalue().strip()
         )

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -24,7 +24,7 @@ from airflow.cli.commands import config_command
 from tests.test_utils.config import conf_vars
 
 
-class TestCliConfig(unittest.TestCase):
+class TestCliConfigList(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser = cli_parser.get_parser()
@@ -32,7 +32,7 @@ class TestCliConfig(unittest.TestCase):
     @mock.patch("airflow.cli.commands.config_command.io.StringIO")
     @mock.patch("airflow.cli.commands.config_command.conf")
     def test_cli_show_config_should_write_data(self, mock_conf, mock_stringio):
-        config_command.show_config(self.parser.parse_args(['config', '--color', 'off']))
+        config_command.show_config(self.parser.parse_args(['config', 'list', '--color', 'off']))
         mock_conf.write.assert_called_once_with(mock_stringio.return_value.__enter__.return_value)
 
     @conf_vars({
@@ -40,6 +40,47 @@ class TestCliConfig(unittest.TestCase):
     })
     def test_cli_show_config_should_display_key(self):
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
-            config_command.show_config(self.parser.parse_args(['config', '--color', 'off']))
+            config_command.show_config(self.parser.parse_args(['config', 'list', '--color', 'off']))
         self.assertIn('[core]', temp_stdout.getvalue())
         self.assertIn('testkey = test_value', temp_stdout.getvalue())
+
+
+class TestCliConfigGetValue(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @conf_vars({
+        ('core', 'test_key'): 'test_value'
+    })
+    def test_should_display_value(self):
+        with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+            config_command.get_value(self.parser.parse_args(['config', 'get-value', 'core', 'test_key']))
+
+        self.assertEqual("test_value", temp_stdout.getvalue().strip())
+
+    @mock.patch("airflow.cli.commands.config_command.conf")
+    def test_should_raise_exception_when_section_is_missing(self, mock_conf):
+        mock_conf.has_section.return_value = False
+        mock_conf.has_option.return_value = True
+
+        with contextlib.redirect_stderr(io.StringIO()) as temp_stderr, self.assertRaises(SystemExit) as cm:
+            config_command.get_value(self.parser.parse_args(
+                ['config', 'get-value', 'missing-section', 'dags_folder']
+            ))
+        self.assertEqual(1, cm.exception.code)
+        self.assertEqual("section [missing-section] not found in config.", temp_stderr.getvalue().strip())
+
+    @mock.patch("airflow.cli.commands.config_command.conf")
+    def test_should_raise_exception_when_option_is_missing(self, mock_conf):
+        mock_conf.has_section.return_value = True
+        mock_conf.has_option.return_value = False
+
+        with contextlib.redirect_stderr(io.StringIO()) as temp_stderr, self.assertRaises(SystemExit) as cm:
+            config_command.get_value(self.parser.parse_args(
+                ['config', 'get-value', 'missing-section', 'dags_folder']
+            ))
+        self.assertEqual(1, cm.exception.code)
+        self.assertEqual(
+            "option [missing-section/dags_folder] not found in config.", temp_stderr.getvalue().strip()
+        )


### PR DESCRIPTION
This command is useful for writing various scripts that integrate with Airflow. This can be helpful when writing in Helm chart also.

To obtain dags folder, run the following command:
```bash
airflow config get-value core dags_folder
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
