### PR TITLE
Fix bug in executor_config when defining resources

### DIFF
--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -33,7 +33,7 @@ class Resources(K8SModel):
     :type request_memory: str
     :param request_cpu: requested CPU number
     :type request_cpu: float | str
-    :param request_ephemeral_storage: requested ephermeral storage
+    :param request_ephemeral_storage: requested ephemeral storage
     :type request_ephemeral_storage: str
     :param limit_memory: limit for memory usage
     :type limit_memory: str
@@ -41,7 +41,7 @@ class Resources(K8SModel):
     :type limit_cpu: float | str
     :param limit_gpu: Limits for GPU used
     :type limit_gpu: int
-    :param limit_ephemeral_storage: Limit for ephermeral storage
+    :param limit_ephemeral_storage: Limit for ephemeral storage
     :type limit_ephemeral_storage: float | str
     """
     def __init__(

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -360,7 +360,8 @@ class PodGenerator(object):
                 return namespaced, resources_obj
 
             namespaced, requests = extract('request_cpu', 'request_memory', 'request_ephemeral_storage')
-            namespaced, limits = extract('limit_cpu', 'limit_memory', 'limit_ephemeral_storage', limit_gpu='limit_gpu')
+            namespaced, limits = extract('limit_cpu', 'limit_memory', 'limit_ephemeral_storage',
+                                         limit_gpu='limit_gpu')
 
             if requests is None and limits is None:
                 resources = None

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -345,7 +345,6 @@ class PodGenerator(object):
 
         if resources is None:
             def extract(cpu, memory):
-                nonlocal namespaced
                 resources_obj = {
                     'cpu': namespaced.pop(cpu, None),
                     'memory': namespaced.pop(memory, None),
@@ -355,11 +354,11 @@ class PodGenerator(object):
 
                 if all(r is None for r in resources_obj):
                     resources_obj = None
-                return resources_obj
+                return namespaced, resources_obj
 
             ephemeral_storage = namespaced.pop('ephemeral-storage', None)
-            requests = extract('request_cpu', 'request_memory')
-            limits = extract('limit_cpu', 'limit_memory')
+            namespaced, requests = extract('request_cpu', 'request_memory')
+            namespaced, limits = extract('limit_cpu', 'limit_memory')
             if requests is None and limits is None:
                 resources = None
             else:

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -288,6 +288,135 @@ class TestPodGenerator(unittest.TestCase):
         }, result)
 
     @mock.patch('uuid.uuid4')
+    def test_from_obj_with_resources(self, mock_uuid):
+        self.maxDiff = None
+
+        mock_uuid.return_value = self.static_uuid
+        result = PodGenerator.from_obj({
+            "KubernetesExecutor": {
+                "annotations": {"test": "annotation"},
+                "volumes": [
+                    {
+                        "name": "example-kubernetes-test-volume",
+                        "hostPath": {"path": "/tmp/"},
+                    },
+                ],
+                "volume_mounts": [
+                    {
+                        "mountPath": "/foo/",
+                        "name": "example-kubernetes-test-volume",
+                    },
+                ],
+                'request_cpu': "200m",
+                'limit_cpu': "200m",
+                'request_memory': "500Mi",
+                'limit_memory': "500Mi",
+                'ephemeral-storage': '2Gi',
+            }
+        })
+        result = self.k8s_client.sanitize_for_serialization(result)
+
+        self.assertEqual({
+            'apiVersion': 'v1',
+            'kind': 'Pod',
+            'metadata': {
+                'annotations': {'test': 'annotation'},
+            },
+            'spec': {
+                'containers': [{
+                    'args': [],
+                    'command': [],
+                    'env': [],
+                    'envFrom': [],
+                    'name': 'base',
+                    'ports': [],
+                    'resources': {
+                        'limits': {
+                            'cpu': '200m',
+                            'ephemeral-storage': '2Gi',
+                            'memory': '500Mi',
+                        },
+                        'requests': {
+                            'cpu': '200m',
+                            'ephemeral-storage': '2Gi',
+                            'memory': '500Mi',
+                        },
+                    },
+                    'volumeMounts': [{
+                        'mountPath': '/foo/',
+                        'name': 'example-kubernetes-test-volume'
+                    }],
+                }],
+                'hostNetwork': False,
+                'imagePullSecrets': [],
+                'volumes': [{
+                    'hostPath': {'path': '/tmp/'},
+                    'name': 'example-kubernetes-test-volume'
+                }],
+            }
+        }, result)
+
+    @mock.patch('uuid.uuid4')
+    def test_from_obj_with_only_request_resources(self, mock_uuid):
+        self.maxDiff = None
+
+        mock_uuid.return_value = self.static_uuid
+        result = PodGenerator.from_obj({
+            "KubernetesExecutor": {
+                "annotations": {"test": "annotation"},
+                "volumes": [
+                    {
+                        "name": "example-kubernetes-test-volume",
+                        "hostPath": {"path": "/tmp/"},
+                    },
+                ],
+                "volume_mounts": [
+                    {
+                        "mountPath": "/foo/",
+                        "name": "example-kubernetes-test-volume",
+                    },
+                ],
+                'request_cpu': "200m",
+                'request_memory': "500Mi",
+            }
+        })
+        result = self.k8s_client.sanitize_for_serialization(result)
+
+        self.assertEqual({
+            'apiVersion': 'v1',
+            'kind': 'Pod',
+            'metadata': {
+                'annotations': {'test': 'annotation'},
+            },
+            'spec': {
+                'containers': [{
+                    'args': [],
+                    'command': [],
+                    'env': [],
+                    'envFrom': [],
+                    'name': 'base',
+                    'ports': [],
+                    'resources': {
+                        'requests': {
+                            'cpu': '200m',
+                            'memory': '500Mi',
+                        },
+                    },
+                    'volumeMounts': [{
+                        'mountPath': '/foo/',
+                        'name': 'example-kubernetes-test-volume'
+                    }],
+                }],
+                'hostNetwork': False,
+                'imagePullSecrets': [],
+                'volumes': [{
+                    'hostPath': {'path': '/tmp/'},
+                    'name': 'example-kubernetes-test-volume'
+                }],
+            }
+        }, result)
+
+    @mock.patch('uuid.uuid4')
     def test_reconcile_pods_empty_mutator_pod(self, mock_uuid):
         mock_uuid.return_value = self.static_uuid
         base_pod = PodGenerator(

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -308,10 +308,12 @@ class TestPodGenerator(unittest.TestCase):
                     },
                 ],
                 'request_cpu': "200m",
-                'limit_cpu': "200m",
+                'limit_cpu': "400m",
                 'request_memory': "500Mi",
-                'limit_memory': "500Mi",
-                'ephemeral-storage': '2Gi',
+                'limit_memory': "1000Mi",
+                'limit_gpu': "2",
+                'request_ephemeral_storage': '2Gi',
+                'limit_ephemeral_storage': '4Gi',
             }
         })
         result = self.k8s_client.sanitize_for_serialization(result)
@@ -332,9 +334,10 @@ class TestPodGenerator(unittest.TestCase):
                     'ports': [],
                     'resources': {
                         'limits': {
-                            'cpu': '200m',
-                            'ephemeral-storage': '2Gi',
-                            'memory': '500Mi',
+                            'cpu': '400m',
+                            'ephemeral-storage': '4Gi',
+                            'memory': '1000Mi',
+                            'nvidia.com/gpu': "2",
                         },
                         'requests': {
                             'cpu': '200m',


### PR DESCRIPTION
Fixes a bug in 1.10.11 where the executor_config errors out when resources are specified.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
