### PR TITLE
Pin github checkout action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     name: "Cancel previous workflow run"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Get ci workflow id
         run: "scripts/ci/cancel/get_workflow_id.sh"
         env:
@@ -69,7 +69,7 @@ jobs:
     env:
       MOUNT_SOURCE_DIR_FOR_STATIC_CHECKS: "true"
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
@@ -96,7 +96,7 @@ jobs:
     needs:
       - cancel-previous-workflow-run
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: "Build CI image ${{ matrix.python-version }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Build docs"
@@ -115,7 +115,7 @@ jobs:
       INSTALL_AIRFLOW_VERSION: "1.10.10"
       PYTHON_MAJOR_MINOR_VERSION: 3.6
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
@@ -138,7 +138,7 @@ jobs:
     outputs:
       run-tests: ${{ steps.trigger-tests.outputs.run-tests }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: "Check if tests should be run"
         run: "./scripts/ci/tools/ci_check_if_tests_should_be_run.sh"
         id: trigger-tests
@@ -173,7 +173,7 @@ jobs:
       HELM_VERSION: "${{ matrix.helm-version }}"
     if: needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
@@ -223,7 +223,7 @@ jobs:
       TEST_TYPE: ${{ matrix.test-type }}
     if: needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
@@ -253,7 +253,7 @@ jobs:
       TEST_TYPE: ${{ matrix.test-type }}
     if: needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
@@ -281,7 +281,7 @@ jobs:
       RUN_TESTS: "true"
     if: needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
@@ -312,7 +312,7 @@ jobs:
       TEST_TYPE: ${{ matrix.test-type }}
     if: needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
@@ -330,7 +330,7 @@ jobs:
     needs:
       - cancel-previous-workflow-run
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: "Helm Tests"
         run: ./scripts/ci/kubernetes/ci_run_helm_testing.sh
       - name: "Cancel workflow on helm-tests failure"
@@ -349,7 +349,7 @@ jobs:
     env:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: "Build PROD image ${{ matrix.python-version }}"
         run: ./scripts/ci/images/ci_prepare_prod_image_on_ci.sh
       - name: "Cancel workflow on build prod image failure"
@@ -376,7 +376,7 @@ jobs:
     env:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Build PROD images ${{ matrix.python-version }}"
@@ -404,7 +404,7 @@ jobs:
       PULL_PYTHON_BASE_IMAGES_FROM_CACHE: "false"
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Build CI image"
@@ -432,7 +432,7 @@ jobs:
       (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' ) &&
       github.event_name != 'pull'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
@@ -514,7 +514,7 @@ jobs:
       - docs
     if: github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Tag commit"
@@ -536,7 +536,7 @@ jobs:
     needs:
       - cancel-previous-workflow-run
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Get workflow id
         run: "scripts/ci/cancel/get_workflow_id.sh"
         env:


### PR DESCRIPTION
Github checkout action stopped using master - and we should pin it anyway

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
