### PR TITLE
Added get_blobs_list method to WasbHook

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -88,6 +88,23 @@ class WasbHook(BaseHook):
                                              num_results=1, **kwargs)
         return len(list(matches)) > 0
 
+    def get_blobs_list(self, container_name, prefix, **kwargs):
+        """
+        Return a list of blobs from path defined in prefix param 
+
+        :param container_name: Name of the container.
+        :type container_name: str
+        :param prefix: Prefix of the blob.
+        :type prefix: str
+        :param kwargs: Optional keyword arguments that
+            `BlockBlobService.list_blobs()` takes (num_results, include,
+            delimiter, marker, timeout)
+        :type kwargs: object
+        :return: List of blobs.
+        :rtype: list(azure.storage.common.models.ListGenerator)
+        """
+        return self.connection.list_blobs(container_name, prefix, **kwargs)
+    
     def load_file(self, file_path, container_name, blob_name, **kwargs):
         """
         Upload a file to Azure Blob Storage.

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -88,7 +88,7 @@ class WasbHook(BaseHook):
                                              num_results=1, **kwargs)
         return len(list(matches)) > 0
 
-    def get_blobs_list(self, container_name, prefix, **kwargs):
+    def get_blobs_list(self, container_name: str, prefix: str, **kwargs):
         """
         Return a list of blobs from path defined in prefix param 
 

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -90,7 +90,7 @@ class WasbHook(BaseHook):
 
     def get_blobs_list(self, container_name: str, prefix: str, **kwargs):
         """
-        Return a list of blobs from path defined in prefix param 
+        Return a list of blobs from path defined in prefix param
 
         :param container_name: Name of the container.
         :type container_name: str

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -104,6 +104,7 @@ class WasbHook(BaseHook):
         :rtype: list(azure.storage.common.models.ListGenerator)
         """
         return self.connection.list_blobs(container_name, prefix, **kwargs)
+
     def load_file(self, file_path, container_name, blob_name, **kwargs):
         """
         Upload a file to Azure Blob Storage.

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -104,7 +104,6 @@ class WasbHook(BaseHook):
         :rtype: list(azure.storage.common.models.ListGenerator)
         """
         return self.connection.list_blobs(container_name, prefix, **kwargs)
-    
     def load_file(self, file_path, container_name, blob_name, **kwargs):
         """
         Upload a file to Azure Blob Storage.

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -188,3 +188,13 @@ class TestWasbHook(unittest.TestCase):
                 is_prefix=True, ignore_if_missing=False
             )
         self.assertIsInstance(context.exception, AirflowException)
+
+    @mock.patch('airflow.providers.microsoft.azure.hooks.wasb.BlockBlobService',
+                autospec=True)
+    def test_get_blobs_list(self, mock_service):
+        mock_instance = mock_service.return_value
+        hook = WasbHook(wasb_conn_id='wasb_test_sas_token')
+        hook.get_blobs_list('container', 'prefix', num_results=1, timeout=3)
+        mock_instance.list_blobs.assert_called_once_with(
+            'container', 'prefix', num_results=1, timeout=3
+        )


### PR DESCRIPTION
The function returns list with blobs. Also it provides possibility to pass on any parameters for list_blobs() function using **kwargs

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
