### PR TITLE
Pass conf to subdags

### DIFF
--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -19,7 +19,7 @@
 The module which provides a way to nest your DAGs and so your levels of complexity.
 """
 from enum import Enum
-from typing import Optional
+from typing import Dict, Optional
 
 from sqlalchemy.orm.session import Session
 
@@ -55,6 +55,8 @@ class SubDagOperator(BaseSensorOperator):
 
     :param subdag: the DAG object to run as a subdag of the current DAG.
     :param session: sqlalchemy session
+    :param conf: Configuration for the subdag
+    :type conf: dict
     :param propagate_skipped_state: by setting this argument you can define
         whether the skipped state of leaf task(s) should be propagated to the parent dag's downstream task.
     """
@@ -67,10 +69,12 @@ class SubDagOperator(BaseSensorOperator):
     def __init__(self,
                  subdag: DAG,
                  session: Optional[Session] = None,
+                 conf: Optional[Dict] = None,
                  propagate_skipped_state: Optional[SkippedStatePropagationOptions] = None,
                  *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.subdag = subdag
+        self.conf = conf
         self.propagate_skipped_state = propagate_skipped_state
 
         self._validate_dag(kwargs)
@@ -150,6 +154,7 @@ class SubDagOperator(BaseSensorOperator):
                 run_type=DagRunType.SCHEDULED,
                 execution_date=execution_date,
                 state=State.RUNNING,
+                conf=self.conf,
                 external_trigger=True,
             )
             self.log.info("Created DagRun: %s", dag_run.run_id)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
This PR allows the SubdagOperator to pass a conf dict to the DAG it triggers. This makes it easier to call DAGs that were designed to be standalone without having to modify them.

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
