### PR TITLE
Implement passing a list into get_records

### DIFF
--- a/tests/hooks/test_dbapi_hook.py
+++ b/tests/hooks/test_dbapi_hook.py
@@ -70,6 +70,42 @@ class TestDbApiHook(unittest.TestCase):
         assert self.cur.close.call_count == 1
         self.cur.execute.assert_called_once_with(statement, parameters)
 
+    def test_get_records_list(self):
+        statement = ["SQL", "SQL"]
+        rows = [[("hello",),
+                ("world",)],
+                [("hello",),
+                 ("world2",)]
+                ]
+
+        self.cur.fetchall.return_value = rows
+
+        self.assertEqual(rows, self.db_hook.get_records(statement))
+
+        assert self.conn.close.call_count == 1
+        assert self.cur.close.call_count == 1
+        assert self.cur.execute.call_count == 2
+        for query in statement:
+            self.cur.execute.assert_called_with(query)
+
+    def test_get_records_parameters_list(self):
+        statement = ["SQL", "SQL"]
+        parameters = ["X", "Y", "Z"]
+        rows = [[("hello",),
+                ("world",)],
+                [("hello",),
+                 ("world2",)]
+                ]
+
+        self.cur.fetchall.return_value = rows
+
+        self.assertEqual(rows, self.db_hook.get_records(statement, parameters))
+
+        assert self.conn.close.call_count == 1
+        assert self.cur.close.call_count == 1
+        for query in statement:
+            self.cur.execute.assert_called_with(query, parameters)
+
     def test_get_records_exception(self):
         statement = "SQL"
         self.cur.fetchall.side_effect = RuntimeError('Great Problems')


### PR DESCRIPTION
closes: #9957

Implements ability to pass a list of queries to the `get_records` dbapi_hook. This is functionality that is listed in the docstring but was not implemented

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
