### PR TITLE
Fix CI: Don't add & fetch remote if source branch == target branch

### DIFF
--- a/scripts/ci/openapi/client_codegen_diff.sh
+++ b/scripts/ci/openapi/client_codegen_diff.sh
@@ -23,9 +23,10 @@ SCRIPTS_CI_DIR=$(dirname "${BASH_SOURCE[0]}")
 get_environment_for_builds_on_ci
 
 set -e
-
-git remote add target "https://github.com/${CI_TARGET_REPO}"
-git fetch target "${CI_TARGET_BRANCH}:${CI_TARGET_BRANCH}" --depth=1
+if [ "${CI_TARGET_REPO}" != "${CI_SOURCE_BRANCH}" ]; then
+    git remote add target "https://github.com/${CI_TARGET_REPO}"
+    git fetch target "${CI_TARGET_BRANCH}:${CI_TARGET_BRANCH}" --depth=1
+fi
 
 echo "Diffing openapi spec against ${CI_TARGET_BRANCH}..."
 


### PR DESCRIPTION
CI has been failing on Master since last 2 days after https://github.com/apache/airflow/pull/9922 was merged that added `set -e` which causes CI job to fail immediately if anything in that script fails. 

![image](https://user-images.githubusercontent.com/8811558/88337311-6f6fa980-cd2e-11ea-837f-5893c55964d7.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
