### PR TITLE
Fix CI: Fetch target only when source repo != target repo

### DIFF
--- a/scripts/ci/openapi/client_codegen_diff.sh
+++ b/scripts/ci/openapi/client_codegen_diff.sh
@@ -23,15 +23,17 @@ SCRIPTS_CI_DIR=$(dirname "${BASH_SOURCE[0]}")
 get_environment_for_builds_on_ci
 
 set -e
-if [ "${CI_TARGET_REPO}" != "${CI_SOURCE_BRANCH}" ]; then
+TARGET_REMOTE=origin
+if [ "${CI_TARGET_REPO}" != "${CI_SOURCE_REPO}" ]; then
+    TARGET_REMOTE=target
     git remote add target "https://github.com/${CI_TARGET_REPO}"
-    git fetch target "${CI_TARGET_BRANCH}:${CI_TARGET_BRANCH}" --depth=1
+    git fetch target "${CI_TARGET_BRANCH}" --depth=1
 fi
 
-echo "Diffing openapi spec against ${CI_TARGET_BRANCH}..."
+echo "Diffing openapi spec against ${TARGET_REMOTE}/${CI_TARGET_BRANCH}..."
 
 SPEC_FILE=airflow/api_connexion/openapi/v1.yaml
-if ! git diff --name-only "${CI_TARGET_BRANCH}" HEAD | grep "${SPEC_FILE}\|clients/gen" ; then
+if ! git diff --name-only "${TARGET_REMOTE}/${CI_TARGET_BRANCH}" HEAD | grep "${SPEC_FILE}\|clients/gen" ; then
     echo "No openapi spec change detected, going to skip client code gen validation."
     exit 0
 fi
@@ -43,7 +45,7 @@ mkdir -p ./clients/go/airflow
 ./clients/gen/go.sh ./airflow/api_connexion/openapi/v1.yaml ./clients/go/airflow
 # generate client for target patch
 mkdir -p ./clients/go_target_branch/airflow
-git reset --hard "${CI_TARGET_BRANCH}"
+git reset --hard "${TARGET_REMOTE}/${CI_TARGET_BRANCH}"
 ./clients/gen/go.sh ./airflow/api_connexion/openapi/v1.yaml ./clients/go_target_branch/airflow
 
 diff ./clients/go_target_branch/airflow ./clients/go/airflow || true


### PR DESCRIPTION
A continuation of #9961

This fix should be able to cover all cases:
- PR: user:nonmaster -> apache:master
- PR: user:master -> apache:master
- PR: user:nonmaster -> user:master
- PR: apache:nonmaster -> apache:master
- CI build: apache:master

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
