### PR TITLE
Fix various typos in airflow/cli/commands

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -43,7 +43,7 @@ from airflow.utils.state import State
 
 
 def _tabulate_dag_runs(dag_runs: List[DagRun], tablefmt: str = "fancy_grid") -> str:
-    tabulat_data = (
+    tabulate_data = (
         {
             'ID': dag_run.id,
             'Run ID': dag_run.run_id,
@@ -55,13 +55,13 @@ def _tabulate_dag_runs(dag_runs: List[DagRun], tablefmt: str = "fancy_grid") -> 
         } for dag_run in dag_runs
     )
     return tabulate(
-        tabular_data=tabulat_data,
+        tabular_data=tabulate_data,
         tablefmt=tablefmt
     )
 
 
 def _tabulate_dags(dags: List[DAG], tablefmt: str = "fancy_grid") -> str:
-    tabulat_data = (
+    tabulate_data = (
         {
             'DAG ID': dag.dag_id,
             'Filepath': dag.filepath,
@@ -69,7 +69,7 @@ def _tabulate_dags(dags: List[DAG], tablefmt: str = "fancy_grid") -> str:
         } for dag in sorted(dags, key=lambda d: d.dag_id)
     )
     return tabulate(
-        tabular_data=tabulat_data,
+        tabular_data=tabulate_data,
         tablefmt=tablefmt,
         headers='keys'
     )
@@ -261,10 +261,10 @@ def dag_state(args):
         dag = get_dag_by_file_location(args.dag_id)
     dr = DagRun.find(dag.dag_id, execution_date=args.execution_date)
     out = dr[0].state if dr else None
-    confout = ''
+    conf_out = ''
     if out and dr[0].conf:
-        confout = ', ' + json.dumps(dr[0].conf)
-    print(str(out) + confout)
+        conf_out = ', ' + json.dumps(dr[0].conf)
+    print(str(out) + conf_out)
 
 
 @cli_utils.action_logging

--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -43,7 +43,7 @@ class Anonymizer(Protocol):
         """Remove pii from paths"""
 
     def process_username(self, value):
-        """Remove pii from ussername"""
+        """Remove pii from username"""
 
     def process_url(self, value):
         """Remove pii from URL"""
@@ -247,7 +247,7 @@ class SystemInfo:
 
 
 class PathsInfo:
-    """Path informaation"""
+    """Path information"""
 
     def __init__(self, anonymizer: Anonymizer):
         system_path = os.environ.get("PATH", "").split(os.pathsep)

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -75,7 +75,7 @@ class GunicornMonitor(LoggingMixin):
     :param worker_refresh_batch_size: Number of workers to refresh at a time. When set to 0, worker
         refresh is disabled. When nonzero, airflow periodically refreshes webserver workers by
         bringing up new ones and killing old ones.
-    :param reload_on_plugin_change: If set to True, Airflow will track files in plugins_follder directory.
+    :param reload_on_plugin_change: If set to True, Airflow will track files in plugins_folder directory.
         When it detects changes, then reload the gunicorn.
     """
     def __init__(


### PR DESCRIPTION
e.g `tabulat_data` -> `tabulate_data`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
