### PR TITLE
Bump mysqlclient to 2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -336,7 +336,7 @@ mssql = [
 ]
 mysql = [
     'mysql-connector-python>=8.0.11, <=8.0.18',
-    'mysqlclient>=1.3.6,<1.4',
+    'mysqlclient~=2.0.1',
 ]
 odbc = [
     'pyodbc',


### PR DESCRIPTION
mysqlclient was pinned as the functionality of Connection object of MySQL had changed and that it dropped python2.

mysqlclient has added context manager interface to Connection which closes the connection on `__exit__` in 2.0.0 and Airflow Master no longer uses Python 2

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
