### PR TITLE
Relax requirement to allow latest version of flask-caching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -702,7 +702,7 @@ INSTALL_REQUIREMENTS = [
     'dill>=0.2.2, <0.4',
     'flask>=1.1.0, <2.0',
     'flask-appbuilder>2.3.4,~=3.0',
-    'flask-caching>=1.3.3, <1.4.0',
+    'flask-caching>=1.3.3, <2.0.0',
     'flask-login>=0.3, <0.5',
     'flask-swagger==0.2.13',
     'flask-wtf>=0.14.2, <0.15',


### PR DESCRIPTION
Current available version is 1.9.0 (https://pypi.org/project/Flask-Caching/1.9.0/)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
