### PR TITLE
Relax requirement to allow latest version of flask-login

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -698,7 +698,7 @@ INSTALL_REQUIREMENTS = [
     'flask>=1.1.0, <2.0',
     'flask-appbuilder>2.3.4,~=3.0',
     'flask-caching>=1.3.3, <2.0.0',
-    'flask-login>=0.3, <0.5',
+    'flask-login>=0.3, <1.0',
     'flask-swagger==0.2.13',
     'flask-wtf>=0.14.2, <0.15',
     'funcsigs>=1.0.0, <2.0.0',


### PR DESCRIPTION
The current latest available version is 0.5.0 (https://pypi.org/project/Flask-Login/0.5.0/)

Version 0.5.0 drops support for Python 2.6, 3.3, 3.4 and we don't use those versions in Airflow Master

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
