### PR TITLE
Updates the slack WebClient call to use the instance variable - token

### DIFF
--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -68,7 +68,7 @@ class SlackHook(BaseHook):
     ) -> None:
         super().__init__()
         self.token = self.__get_token(token, slack_conn_id)
-        self.client = WebClient(token, **client_args)
+        self.client = WebClient(self.token, **client_args)
 
     def __get_token(self, token, slack_conn_id):
         if token is not None:

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -41,8 +41,9 @@ class TestSlackHook(unittest.TestCase):
         expected = test_token
         self.assertEqual(output, expected)
 
+    @mock.patch('airflow.providers.slack.hooks.slack.WebClient')
     @mock.patch('airflow.providers.slack.hooks.slack.SlackHook.get_connection')
-    def test_get_token_with_valid_slack_conn_id_only(self, get_connection_mock):
+    def test_get_token_with_valid_slack_conn_id_only(self, get_connection_mock, mock_slack_client):
         """ tests `__get_token` method when only connection is provided """
         # Given
         test_token = None
@@ -59,6 +60,7 @@ class TestSlackHook(unittest.TestCase):
         output = hook.token
         expected = test_password
         self.assertEqual(output, expected)
+        mock_slack_client.assert_called_once_with(test_password)
 
     @mock.patch('airflow.providers.slack.hooks.slack.SlackHook.get_connection')
     def test_get_token_with_no_password_slack_conn_id_only(self, get_connection_mock):


### PR DESCRIPTION
Updates the SlackHook call of slack WebClient to use the instance variable token instead of token supplied during instantiation of SlackHook object.
