### PR TITLE
Revert "Bump mysqlclient to 2.0.1 (#9987)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -336,7 +336,7 @@ mssql = [
 ]
 mysql = [
     'mysql-connector-python>=8.0.11, <=8.0.18',
-    'mysqlclient~=2.0.1',
+    'mysqlclient>=1.3.6,<1.4',
 ]
 odbc = [
     'pyodbc',


### PR DESCRIPTION
This reverts commit c4388127f1c47e1abe512e1ef104c9835a150a04.

Seems that mysql upgrade caused a problem with missing _mysql_exceptions. Let's revert before we investigate and fix.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
