### PR TITLE
Remove unnecessary environment variable from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         env:
           WORKFLOW: ci
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
       - name: Cancel workflow ${{ github.workflow }}
         uses: styfle/cancel-workflow-action@0.3.2
         with:
@@ -542,7 +541,6 @@ jobs:
         env:
           WORKFLOW: openapi
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
       - name: Cancel workflow ${{ github.workflow }}
         uses: styfle/cancel-workflow-action@0.3.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           WORKFLOW: ci
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repositoru }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
       - name: Cancel workflow ${{ github.workflow }}
         uses: styfle/cancel-workflow-action@0.3.2
         with:
@@ -542,7 +542,7 @@ jobs:
         env:
           WORKFLOW: openapi
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repositoru }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
       - name: Cancel workflow ${{ github.workflow }}
         uses: styfle/cancel-workflow-action@0.3.2
         with:


### PR DESCRIPTION
I found there is typo in setting environment `GITHUB_REPOSITORY` variable for two jobs, however jobs work fine anyway.
After short investigation i found info [here](https://github.community/t/override-repository-env-var/18440/2) which says that:

> The " GITHUB_REPOSITORY" is a default environment variable set by GitHub. When you try using the " env" key or the " set-env" command to change the value of a default environment variable, GitHub will prevent the value from being changed on the system, but this environment variable will be added into the  env context with the new value.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
