### PR TITLE
Adds separate scheduled-only workflow to cancel duplicates

### DIFF
--- a/.github/workflows/cancel_duplicate_workflows.yml
+++ b/.github/workflows/cancel_duplicate_workflows.yml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: Cancel duplicate workflows
+on:
+  schedule:
+    - cron: '/5 * * * *'
+
+  cancel-duplicate-workflows:
+    if: github.repository == 'apache/airflow'
+    timeout-minutes: 10
+    name: "Cancel duplicate workflows"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ci.yml


### PR DESCRIPTION
Unfortunately cancelling workflows does not work from the workflows
executed by forks because their tokens do not allow doing that
(they are read only). So we have to run a separate cron-triggered
action (in the context of apache/airflow repository to cancel
all duplicate workflows. This action stops all the workflows
running from the same fork/branch except the last one.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
