### PR TITLE
Make boolean comparison more cross-platform compatible

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -33,7 +33,7 @@ import jinja2
 import pendulum
 from croniter import croniter
 from dateutil.relativedelta import relativedelta
-from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, String, Text, func, or_
+from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, String, Text, func, or_, true
 from sqlalchemy.orm import backref, joinedload, relationship
 from sqlalchemy.orm.session import Session
 
@@ -1805,7 +1805,7 @@ class DagModel(Base):
         """
         paused_dag_ids = (
             session.query(DagModel.dag_id)
-            .filter(DagModel.is_paused.is_(True))
+            .filter(DagModel.is_paused == true())
             .filter(DagModel.dag_id.in_(dag_ids))
             .all()
         )


### PR DESCRIPTION
This changes the boolean comparison in DagModel.get_paused_dag_ids to be more cross-platform compatible between various RDBMs. Using the equals operator and SQLAlchemy's true() should render the statement correctly for various platforms (eg. "is_paused = 1" for SQL Server, "is_paused IS True" for Postgres).


This addresses the issue #9926.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
