### PR TITLE
Add try clause to DataFusionHook.wait_for_pipeline_state

### DIFF
--- a/airflow/providers/google/cloud/hooks/datafusion.py
+++ b/airflow/providers/google/cloud/hooks/datafusion.py
@@ -112,13 +112,15 @@ class DataFusionHook(GoogleBaseHook):
         start_time = monotonic()
         current_state = None
         while monotonic() - start_time < timeout:
-            current_state = self._get_workflow_state(
-                pipeline_name=pipeline_name,
-                pipeline_id=pipeline_id,
-                instance_url=instance_url,
-                namespace=namespace,
-            )
-
+            try:
+                current_state = self._get_workflow_state(
+                    pipeline_name=pipeline_name,
+                    pipeline_id=pipeline_id,
+                    instance_url=instance_url,
+                    namespace=namespace,
+                )
+            except AirflowException:
+                pass  # Because the pipeline may not be visible in system yet
             if current_state in success_states:
                 return
             if current_state in failure_states:


### PR DESCRIPTION
Sometimes it may happen that the pipeline is not visible instantly in
DataFusion so retrieving it will result in 404

closes: #10030

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
