### PR TITLE
Add additional Cloud Datastore operators

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_datastore.py
+++ b/airflow/providers/google/cloud/example_dags/example_datastore.py
@@ -23,10 +23,13 @@ This example requires that your project contains Datastore instance.
 """
 
 import os
+from typing import Any, Dict
 
 from airflow import models
 from airflow.providers.google.cloud.operators.datastore import (
+    CloudDatastoreAllocateIdsOperator, CloudDatastoreBeginTransactionOperator, CloudDatastoreCommitOperator,
     CloudDatastoreExportEntitiesOperator, CloudDatastoreImportEntitiesOperator,
+    CloudDatastoreRollbackOperator, CloudDatastoreRunQueryOperator,
 )
 from airflow.utils import dates
 
@@ -37,20 +40,118 @@ with models.DAG(
     "example_gcp_datastore",
     schedule_interval=None,  # Override to match your needs
     start_date=dates.days_ago(1),
-    tags=['example'],
+    tags=["example"],
 ) as dag:
+    # [START how_to_export_task]
     export_task = CloudDatastoreExportEntitiesOperator(
         task_id="export_task",
         bucket=BUCKET,
         project_id=GCP_PROJECT_ID,
         overwrite_existing=True,
     )
+    # [END how_to_export_task]
 
+    # [START how_to_import_task]
     import_task = CloudDatastoreImportEntitiesOperator(
         task_id="import_task",
         bucket="{{ task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[2] }}",
         file="{{ '/'.join(task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[3:]) }}",
-        project_id=GCP_PROJECT_ID
+        project_id=GCP_PROJECT_ID,
     )
+    # [END how_to_import_task]
 
     export_task >> import_task
+
+# [START how_to_keys_def]
+KEYS = [
+    {
+        "partitionId": {"projectId": GCP_PROJECT_ID, "namespaceId": ""},
+        "path": {"kind": "airflow"},
+    }
+]
+# [END how_to_keys_def]
+
+# [START how_to_transaction_def]
+TRANSACTION_OPTIONS: Dict[str, Any] = {"readWrite": {}}
+# [END how_to_transaction_def]
+
+# [START how_to_commit_def]
+COMMIT_BODY = {
+    "mode": "TRANSACTIONAL",
+    "mutations": [
+        {
+            "insert": {
+                "key": KEYS[0],
+                "properties": {"string": {"stringValue": "airflow is awesome!"}},
+            }
+        }
+    ],
+    "transaction": "{{ task_instance.xcom_pull('begin_transaction_commit') }}",
+}
+# [END how_to_commit_def]
+
+# [START how_to_query_def]
+QUERY = {
+    "partitionId": {"projectId": GCP_PROJECT_ID, "namespaceId": ""},
+    "readOptions": {
+        "transaction": "{{ task_instance.xcom_pull('begin_transaction_query') }}"
+    },
+    "query": {},
+}
+# [END how_to_query_def]
+
+with models.DAG(
+    "example_gcp_datastore_operations",
+    start_date=dates.days_ago(1),
+    schedule_interval=None,  # Override to match your needs
+    tags=["example"],
+) as dag2:
+    # [START how_to_allocate_ids]
+    allocate_ids = CloudDatastoreAllocateIdsOperator(
+        task_id="allocate_ids", partial_keys=KEYS, project_id=GCP_PROJECT_ID
+    )
+    # [END how_to_allocate_ids]
+
+    # [START how_to_begin_transaction]
+    begin_transaction_commit = CloudDatastoreBeginTransactionOperator(
+        task_id="begin_transaction_commit",
+        transaction_options=TRANSACTION_OPTIONS,
+        project_id=GCP_PROJECT_ID,
+    )
+    # [END how_to_begin_transaction]
+
+    # [START how_to_commit_task]
+    commit_task = CloudDatastoreCommitOperator(
+        task_id="commit_task", body=COMMIT_BODY, project_id=GCP_PROJECT_ID
+    )
+    # [END how_to_commit_task]
+
+    allocate_ids >> begin_transaction_commit >> commit_task
+
+    begin_transaction_query = CloudDatastoreBeginTransactionOperator(
+        task_id="begin_transaction_query",
+        transaction_options=TRANSACTION_OPTIONS,
+        project_id=GCP_PROJECT_ID,
+    )
+
+    # [START how_to_run_query]
+    run_query = CloudDatastoreRunQueryOperator(
+        task_id="run_query", body=QUERY, project_id=GCP_PROJECT_ID
+    )
+    # [END how_to_run_query]
+
+    allocate_ids >> begin_transaction_query >> run_query
+
+    begin_transaction_to_rollback = CloudDatastoreBeginTransactionOperator(
+        task_id="begin_transaction_to_rollback",
+        transaction_options=TRANSACTION_OPTIONS,
+        project_id=GCP_PROJECT_ID,
+    )
+
+    # [START how_to_rollback_transaction]
+    rollback_transaction = CloudDatastoreRollbackOperator(
+        task_id="rollback_transaction",
+        transaction="{{ task_instance.xcom_pull('begin_transaction_to_rollback') }}",
+    )
+    begin_transaction_to_rollback >> rollback_transaction
+    # [END how_to_rollback_transaction]

--- a/airflow/providers/google/cloud/hooks/datastore.py
+++ b/airflow/providers/google/cloud/hooks/datastore.py
@@ -100,7 +100,7 @@ class DatastoreHook(GoogleBaseHook):
         return resp['keys']
 
     @GoogleBaseHook.fallback_to_default_project_id
-    def begin_transaction(self, project_id: str) -> str:
+    def begin_transaction(self, project_id: str, transaction_options: Dict[str, Any]) -> str:
         """
         Begins a new transaction.
 
@@ -109,6 +109,8 @@ class DatastoreHook(GoogleBaseHook):
 
         :param project_id: Google Cloud Platform project ID against which to make the request.
         :type project_id: str
+        :param transaction_options: Options for a new transaction.
+        :type transaction_options: Dict[str, Any]
         :return: a transaction handle.
         :rtype: str
         """
@@ -116,7 +118,7 @@ class DatastoreHook(GoogleBaseHook):
 
         resp = (conn  # pylint: disable=no-member
                 .projects()
-                .beginTransaction(projectId=project_id, body={})
+                .beginTransaction(projectId=project_id, body={"transactionOptions": transaction_options})
                 .execute(num_retries=self.num_retries))
 
         return resp['transaction']

--- a/docs/build
+++ b/docs/build
@@ -355,7 +355,6 @@ MISSING_GOOGLLE_DOC_GUIDES = {
     'bigquery_to_mysql',
     'cassandra_to_gcs',
     'dataflow',
-    'datastore',
     'dlp',
     'gcs_to_bigquery',
     'mssql_to_gcs',

--- a/docs/howto/operator/google/cloud/datastore.rst
+++ b/docs/howto/operator/google/cloud/datastore.rst
@@ -1,0 +1,173 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Google Cloud Datastore Operators
+================================
+
+Firestore in Datastore mode is a NoSQL document database built for automatic scaling,
+high performance, and ease of application development.
+
+For more information about the service visit
+`Datastore product documentation <https://cloud.google.com/datastore/docs>`__
+
+.. contents::
+  :depth: 1
+  :local:
+
+Prerequisite Tasks
+------------------
+
+.. include:: /howto/operator/google/_partials/prerequisite_tasks.rst
+
+
+.. _howto/operator:CloudDatastoreExportEntitiesOperator:
+
+Export Entities
+---------------
+
+To export entities from Google Cloud Datastore to Cloud Storage use
+:class:`~airflow.providers.google.cloud.operators.datastore.CloudDatastoreExportEntitiesOperator`
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_export_task]
+    :end-before: [END how_to_export_task]
+
+.. _howto/operator:CloudDatastoreImportEntitiesOperator:
+
+Import Entities
+---------------
+
+To import entities from Cloud Storage to Google Cloud Datastore use
+:class:`~airflow.providers.google.cloud.operators.datastore.CloudDatastoreImportEntitiesOperator`
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_import_task]
+    :end-before: [END how_to_import_task]
+
+.. _howto/operator:CloudDatastoreAllocateIdsOperator:
+
+Allocate Ids
+------------
+
+To allocate IDs for incomplete keys use
+:class:`~airflow.providers.google.cloud.operators.datastore.CloudDatastoreAllocateIdsOperator`
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_allocate_ids]
+    :end-before: [END how_to_allocate_ids]
+
+An example of a partial keys required by the operator:
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 0
+    :start-after: [START how_to_keys_def]
+    :end-before: [END how_to_keys_def]
+
+.. _howto/operator:CloudDatastoreBeginTransactionOperator:
+
+Begin transaction
+-----------------
+
+To begin a new transaction use
+:class:`~airflow.providers.google.cloud.operators.datastore.CloudDatastoreBeginTransactionOperator`
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_begin_transaction]
+    :end-before: [END how_to_begin_transaction]
+
+An example of a transaction options required by the operator:
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 0
+    :start-after: [START how_to_transaction_def]
+    :end-before: [END how_to_transaction_def]
+
+.. _howto/operator:CloudDatastoreCommitOperator:
+
+Commit transaction
+------------------
+
+To commit a transaction, optionally creating, deleting or modifying some entities
+use :class:`~airflow.providers.google.cloud.operators.datastore.CloudDatastoreCommitOperator`
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_commit_task]
+    :end-before: [END how_to_commit_task]
+
+An example of a commit information required by the operator:
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 0
+    :start-after: [START how_to_commit_def]
+    :end-before: [END how_to_commit_def]
+
+.. _howto/operator:CloudDatastoreRunQueryOperator:
+
+Run query
+---------
+
+To run a query for entities use
+:class:`~airflow.providers.google.cloud.operators.datastore.CloudDatastoreRunQueryOperator`
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_run_query]
+    :end-before: [END how_to_run_query]
+
+An example of a query required by the operator:
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 0
+    :start-after: [START how_to_query_def]
+    :end-before: [END how_to_query_def]
+
+.. _howto/operator:CloudDatastoreRollbackOperator:
+
+Roll back transaction
+---------------------
+
+To roll back a transaction
+use :class:`~airflow.providers.google.cloud.operators.datastore.CloudDatastoreRollbackOperator`
+
+.. exampleinclude:: /../airflow/providers/google/cloud/example_dags/example_datastore.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_rollback_transaction]
+    :end-before: [END how_to_rollback_transaction]
+
+
+References
+^^^^^^^^^^
+For further information, take a look at:
+
+* `Datastore API documentation <https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects>`__
+* `Product documentation <https://cloud.google.com/datastore/docs>`__

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -726,7 +726,7 @@ These integrations allow you to perform various operations within the Google Clo
      -
 
    * - `Datastore <https://cloud.google.com/datastore/>`__
-     -
+     - :doc:`How to use <howto/operator/google/cloud/datastore>`
      - :mod:`airflow.providers.google.cloud.hooks.datastore`
      - :mod:`airflow.providers.google.cloud.operators.datastore`
      -

--- a/tests/providers/google/cloud/hooks/test_datastore.py
+++ b/tests/providers/google/cloud/hooks/test_datastore.py
@@ -86,12 +86,17 @@ class TestDatastoreHook(unittest.TestCase):
     def test_begin_transaction(self, mock_get_conn):
         self.datastore_hook.connection = mock_get_conn.return_value
 
-        transaction = self.datastore_hook.begin_transaction(project_id=GCP_PROJECT_ID)
+        transaction = self.datastore_hook.begin_transaction(
+            project_id=GCP_PROJECT_ID,
+            transaction_options={},
+        )
 
         projects = self.datastore_hook.connection.projects
         projects.assert_called_once_with()
         begin_transaction = projects.return_value.beginTransaction
-        begin_transaction.assert_called_once_with(projectId=GCP_PROJECT_ID, body={})
+        begin_transaction.assert_called_once_with(
+            projectId=GCP_PROJECT_ID, body={'transactionOptions': {}}
+        )
         execute = begin_transaction.return_value.execute
         execute.assert_called_once_with(num_retries=mock.ANY)
         self.assertEqual(transaction, execute.return_value['transaction'])

--- a/tests/providers/google/cloud/operators/test_datastore.py
+++ b/tests/providers/google/cloud/operators/test_datastore.py
@@ -1,0 +1,206 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+from airflow.providers.google.cloud.operators.datastore import (
+    CloudDatastoreAllocateIdsOperator, CloudDatastoreBeginTransactionOperator, CloudDatastoreCommitOperator,
+    CloudDatastoreDeleteOperationOperator, CloudDatastoreExportEntitiesOperator,
+    CloudDatastoreGetOperationOperator, CloudDatastoreImportEntitiesOperator, CloudDatastoreRollbackOperator,
+    CloudDatastoreRunQueryOperator,
+)
+
+HOOK_PATH = "airflow.providers.google.cloud.operators.datastore.DatastoreHook"
+PROJECT_ID = "test-project"
+CONN_ID = "test-gcp-conn-id"
+BODY = {"key", "value"}
+TRANSACTION = "transaction-name"
+BUCKET = "gs://test-bucket"
+FILE = "filename"
+OPERATION_ID = "1234"
+
+
+class TestCloudDatastoreExportEntitiesOperator:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        mock_hook.return_value.export_to_storage_bucket.return_value = {
+            "name": OPERATION_ID
+        }
+        mock_hook.return_value.poll_operation_until_done.return_value = {
+            "metadata": {"common": {"state": "SUCCESSFUL"}}
+        }
+
+        op = CloudDatastoreExportEntitiesOperator(
+            task_id="test_task",
+            datastore_conn_id=CONN_ID,
+            project_id=PROJECT_ID,
+            bucket=BUCKET,
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(CONN_ID, None)
+        mock_hook.return_value.export_to_storage_bucket.assert_called_once_with(
+            project_id=PROJECT_ID,
+            bucket=BUCKET,
+            entity_filter=None,
+            labels=None,
+            namespace=None,
+        )
+
+        mock_hook.return_value.poll_operation_until_done.assert_called_once_with(
+            OPERATION_ID, 10
+        )
+
+
+class TestCloudDatastoreImportEntitiesOperator:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        mock_hook.return_value.import_from_storage_bucket.return_value = {
+            "name": OPERATION_ID
+        }
+        mock_hook.return_value.poll_operation_until_done.return_value = {
+            "metadata": {"common": {"state": "SUCCESSFUL"}}
+        }
+
+        op = CloudDatastoreImportEntitiesOperator(
+            task_id="test_task",
+            datastore_conn_id=CONN_ID,
+            project_id=PROJECT_ID,
+            bucket=BUCKET,
+            file=FILE,
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(CONN_ID, None)
+        mock_hook.return_value.import_from_storage_bucket.assert_called_once_with(
+            project_id=PROJECT_ID,
+            bucket=BUCKET,
+            file=FILE,
+            entity_filter=None,
+            labels=None,
+            namespace=None,
+        )
+
+        mock_hook.return_value.export_to_storage_bucketassert_called_once_with(
+            OPERATION_ID, 10
+        )
+
+
+class TestCloudDatastoreAllocateIds:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        partial_keys = [1, 2, 3]
+        op = CloudDatastoreAllocateIdsOperator(
+            task_id="test_task",
+            gcp_conn_id=CONN_ID,
+            project_id=PROJECT_ID,
+            partial_keys=partial_keys,
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.return_value.allocate_ids.assert_called_once_with(
+            project_id=PROJECT_ID, partial_keys=partial_keys
+        )
+
+
+class TestCloudDatastoreBeginTransaction:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        op = CloudDatastoreBeginTransactionOperator(
+            task_id="test_task",
+            gcp_conn_id=CONN_ID,
+            project_id=PROJECT_ID,
+            transaction_options=BODY,
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.return_value.begin_transaction.assert_called_once_with(
+            project_id=PROJECT_ID, transaction_options=BODY
+        )
+
+
+class TestCloudDatastoreCommit:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        op = CloudDatastoreCommitOperator(
+            task_id="test_task", gcp_conn_id=CONN_ID, project_id=PROJECT_ID, body=BODY
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.return_value.commit.assert_called_once_with(
+            project_id=PROJECT_ID, body=BODY
+        )
+
+
+class TestCloudDatastoreDeleteOperation:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        op = CloudDatastoreDeleteOperationOperator(
+            task_id="test_task", gcp_conn_id=CONN_ID, name=TRANSACTION
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.return_value.delete_operation.assert_called_once_with(
+            name=TRANSACTION
+        )
+
+
+class TestCloudDatastoreGetOperation:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        op = CloudDatastoreGetOperationOperator(
+            task_id="test_task", gcp_conn_id=CONN_ID, name=TRANSACTION
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.return_value.get_operation.assert_called_once_with(name=TRANSACTION)
+
+
+class TestCloudDatastoreRollback:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        op = CloudDatastoreRollbackOperator(
+            task_id="test_task",
+            gcp_conn_id=CONN_ID,
+            project_id=PROJECT_ID,
+            transaction=TRANSACTION,
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.return_value.rollback.assert_called_once_with(
+            project_id=PROJECT_ID, transaction=TRANSACTION
+        )
+
+
+class TestCloudDatastoreRunQuery:
+    @mock.patch(HOOK_PATH)
+    def test_execute(self, mock_hook):
+        op = CloudDatastoreRunQueryOperator(
+            task_id="test_task", gcp_conn_id=CONN_ID, project_id=PROJECT_ID, body=BODY
+        )
+        op.execute({})
+
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.return_value.run_query.assert_called_once_with(
+            project_id=PROJECT_ID, body=BODY
+        )

--- a/tests/providers/google/cloud/operators/test_datastore_system.py
+++ b/tests/providers/google/cloud/operators/test_datastore_system.py
@@ -42,3 +42,7 @@ class GcpDatastoreSystemTest(GoogleSystemTest):
     @provide_gcp_context(GCP_DATASTORE_KEY)
     def test_run_example_dag(self):
         self.run_dag('example_gcp_datastore', CLOUD_DAG_FOLDER)
+
+    @provide_gcp_context(GCP_DATASTORE_KEY)
+    def test_run_example_dag_operations(self):
+        self.run_dag('example_gcp_datastore_operations', CLOUD_DAG_FOLDER)

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -29,7 +29,6 @@ ROOT_FOLDER = os.path.realpath(
 
 MISSING_TEST_FILES = {
     'tests/providers/google/cloud/log/test_gcs_task_handler.py',
-    'tests/providers/google/cloud/operators/test_datastore.py',
     'tests/providers/microsoft/azure/sensors/test_azure_cosmos.py',
     'tests/providers/microsoft/azure/log/test_wasb_task_handler.py',
 }


### PR DESCRIPTION
This PR adds more operators for Google Cloud Datastore
service. It also adds missing tests and how-to guides.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
