### PR TITLE
Set pytest version to be < 6.0.0 due to breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -462,7 +462,7 @@ devel = [
     'pre-commit',
     'pylint==2.5.3',
     'pysftp',
-    'pytest',
+    'pytest<6.0.0',  # FIXME: pylint complaining for pytest.mark.* on v6.0
     'pytest-cov',
     'pytest-instafail',
     'pytest-rerunfailures',


### PR DESCRIPTION
The latest pytest version 6.0.0 released yesterday (2020-07-28) does not work in conjunction with the version of pylint (2.4.3) we are using.

To fix this issue I set pytest to < 6.0.0.

related: https://github.com/pytest-dev/pytest/issues/7558

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
