### PR TITLE
Improve docstring note about GKEStartPodOperator on KubernetesPodOperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -46,7 +46,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
 
     .. note::
         If you use `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/>`__
-        and Airflow is not deployed in the same cluster, consider using 
+        and Airflow is not running in the same cluster, consider using 
         :class:`~airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator`, which
         simplifies the authorization process.
 

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -46,7 +46,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
 
     .. note::
         If you use `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/>`__
-        and Airflow is not running in the same cluster, consider using 
+        and Airflow is not running in the same cluster, consider using
         :class:`~airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator`, which
         simplifies the authorization process.
 

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -45,7 +45,8 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         :ref:`howto/operator:KubernetesPodOperator`
 
     .. note::
-        If you use `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/>`__, use
+        If you use `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/>`__
+        and Airflow is not deployed in the same cluster, consider using 
         :class:`~airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator`, which
         simplifies the authorization process.
 


### PR DESCRIPTION
Closes: #10048 

This PR clarifies the recommendation for using `GKEStartPodOperator`. If Airflow is running on Google Kubernetes Engine and the target cluster is the same cluster, the simpler choice would still be using `KubernetesPodOperator` with `in_cluster=True`.


