### PR TITLE
Fix package installation when a AIRFLOW_INSTALL_VERSION is not empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,8 +204,8 @@ WORKDIR /opt/airflow
 
 ENV PATH=${PATH}:/root/.local/bin
 
-RUN pip install --user "${AIRFLOW_INSTALL_SOURCES}[${AIRFLOW_EXTRAS}]${AIRFLOW_INSTALL_VERSION}" \
-    --constraint "${AIRFLOW_CONSTRAINTS_URL}" && \
+RUN if [ -n "$AIRFLOW_INSTALL_VERSION" ]; then pip install --user "${AIRFLOW_INSTALL_SOURCES}[${AIRFLOW_EXTRAS}]" --constraint "${AIRFLOW_CONSTRAINTS_URL}" ; \
+		else pip install --user "${AIRFLOW_INSTALL_SOURCES}[${AIRFLOW_EXTRAS}]==${AIRFLOW_INSTALL_VERSION}" --constraint "${AIRFLOW_CONSTRAINTS_URL}" ; fi &&\
     if [ -n "${ADDITIONAL_PYTHON_DEPS}" ]; then pip install --user ${ADDITIONAL_PYTHON_DEPS} \
     --constraint "${AIRFLOW_CONSTRAINTS_URL}"; fi && \
     find /root/.local/ -name '*.pyc' -print0 | xargs -0 rm -r && \


### PR DESCRIPTION
This PR adds support for installation of different versions of Airflow by solving a small issue that occurs when the AIRFLOW_INSTALL_VERSION is provided

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
