### PR TITLE
Add impersonation to Google operators

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1038,6 +1038,12 @@ of this provider.
 This section describes the changes that have been made, and what you need to do to update your if
 you use operators or hooks which integrate with Google services (including Google Cloud Platform - GCP).
 
+#### Direct impersonation added to operators communicating with Google services
+[Directly impersonating a service account](https://cloud.google.com/iam/docs/understanding-service-accounts#directly_impersonating_a_service_account)
+has been made possible for operators communicating with Google services via new argument called `impersonation_chain`
+(`google_impersonation_chain` in case of operators that also communicate with services of other cloud providers).
+As a result, GCSToS3Operator no longer derivatives from GCSListObjectsOperator.
+
 #### Normalize gcp_conn_id for Google Cloud Platform
 
 Previously not all hooks and operators related to Google Cloud Platform use

--- a/airflow/providers/google/ads/operators/ads.py
+++ b/airflow/providers/google/ads/operators/ads.py
@@ -20,7 +20,7 @@ This module contains Google Ad to GCS operators.
 """
 import csv
 from tempfile import NamedTemporaryFile
-from typing import Dict
+from typing import Dict, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.google.ads.hooks.ads import GoogleAdsHook
@@ -57,9 +57,18 @@ class GoogleAdsListAccountsOperator(BaseOperator):
     :type page_size: int
     :param gzip: Option to compress local file or file data for upload
     :type gzip: bool
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("bucket", "object_name")
+    template_fields = ("bucket", "object_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -69,6 +78,7 @@ class GoogleAdsListAccountsOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         google_ads_conn_id: str = "google_ads_default",
         gzip: bool = False,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -77,6 +87,7 @@ class GoogleAdsListAccountsOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.google_ads_conn_id = google_ads_conn_id
         self.gzip = gzip
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         uri = f"gs://{self.bucket}/{self.object_name}"
@@ -86,8 +97,10 @@ class GoogleAdsListAccountsOperator(BaseOperator):
             google_ads_conn_id=self.google_ads_conn_id
         )
 
-        gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
-
+        gcs_hook = GCSHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         with NamedTemporaryFile("w+") as temp_file:
             # Download accounts
             accounts = ads_hook.list_accessible_customers()

--- a/airflow/providers/google/ads/transfers/ads_to_gcs.py
+++ b/airflow/providers/google/ads/transfers/ads_to_gcs.py
@@ -18,7 +18,7 @@
 import csv
 from operator import attrgetter
 from tempfile import NamedTemporaryFile
-from typing import Dict, List
+from typing import Dict, List, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.google.ads.hooks.ads import GoogleAdsHook
@@ -58,9 +58,18 @@ class GoogleAdsToGcsOperator(BaseOperator):
     :type page_size: int
     :param gzip: Option to compress local file or file data for upload
     :type gzip: bool
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("client_ids", "query", "attributes", "bucket", "obj")
+    template_fields = ("client_ids", "query", "attributes", "bucket", "obj", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -74,6 +83,7 @@ class GoogleAdsToGcsOperator(BaseOperator):
         google_ads_conn_id: str = "google_ads_default",
         page_size: int = 10000,
         gzip: bool = False,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -86,6 +96,7 @@ class GoogleAdsToGcsOperator(BaseOperator):
         self.google_ads_conn_id = google_ads_conn_id
         self.page_size = page_size
         self.gzip = gzip
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         service = GoogleAdsHook(
@@ -108,7 +119,10 @@ class GoogleAdsToGcsOperator(BaseOperator):
             writer.writerows(converted_rows)
             csvfile.flush()
 
-            hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
+            hook = GCSHook(
+                gcp_conn_id=self.gcp_conn_id,
+                impersonation_chain=self.impersonation_chain
+            )
             hook.upload(
                 bucket_name=self.bucket,
                 object_name=self.obj,

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -63,11 +63,11 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     def __init__(self,
                  gcp_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
-                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  use_legacy_sql: bool = True,
                  location: Optional[str] = None,
                  bigquery_conn_id: Optional[str] = None,
-                 api_resource_configs: Optional[Dict] = None) -> None:
+                 api_resource_configs: Optional[Dict] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,) -> None:
         # To preserve backward compatibility
         # TODO: remove one day
         if bigquery_conn_id:

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -416,8 +416,8 @@ class DataflowHook(GoogleBaseHook):
         self,
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        poll_sleep: int = 10,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
-        poll_sleep: int = 10
     ) -> None:
         self.poll_sleep = poll_sleep
         super().__init__(

--- a/airflow/providers/google/cloud/hooks/datastore.py
+++ b/airflow/providers/google/cloud/hooks/datastore.py
@@ -44,9 +44,9 @@ class DatastoreHook(GoogleBaseHook):
         self,
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
-        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         api_version: str = 'v1',
-        datastore_conn_id: Optional[str] = None
+        datastore_conn_id: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
     ) -> None:
         if datastore_conn_id:
             warnings.warn(

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -116,8 +116,8 @@ class GCSHook(GoogleBaseHook):
         self,
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        google_cloud_storage_conn_id: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
-        google_cloud_storage_conn_id: Optional[str] = None
     ) -> None:
         # To preserve backward compatibility
         # TODO: remove one day

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -51,8 +51,8 @@ class GKEHook(GoogleBaseHook):
         self,
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        location: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
-        location: Optional[str] = None
     ) -> None:
         super().__init__(
             gcp_conn_id=gcp_conn_id,

--- a/airflow/providers/google/cloud/operators/automl.py
+++ b/airflow/providers/google/cloud/operators/automl.py
@@ -58,9 +58,18 @@ class AutoMLTrainModelOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("model", "location", "project_id")
+    template_fields = ("model", "location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -72,6 +81,7 @@ class AutoMLTrainModelOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -83,9 +93,13 @@ class AutoMLTrainModelOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Creating model.")
         operation = hook.create_model(
             model=self.model,
@@ -132,9 +146,18 @@ class AutoMLPredictOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("model_id", "location", "project_id")
+    template_fields = ("model_id", "location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -148,6 +171,7 @@ class AutoMLPredictOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -161,9 +185,13 @@ class AutoMLPredictOperator(BaseOperator):
         self.retry = retry
         self.payload = payload
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         result = hook.predict(
             model_id=self.model_id,
             payload=self.payload,
@@ -218,6 +246,15 @@ class AutoMLBatchPredictOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -226,6 +263,7 @@ class AutoMLBatchPredictOperator(BaseOperator):
         "output_config",
         "location",
         "project_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -241,6 +279,7 @@ class AutoMLBatchPredictOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -253,11 +292,15 @@ class AutoMLBatchPredictOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
         self.input_config = input_config
         self.output_config = output_config
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Fetch batch prediction.")
         operation = hook.batch_predict(
             model_id=self.model_id,
@@ -303,9 +346,18 @@ class AutoMLCreateDatasetOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("dataset", "location", "project_id")
+    template_fields = ("dataset", "location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -317,6 +369,7 @@ class AutoMLCreateDatasetOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -328,9 +381,13 @@ class AutoMLCreateDatasetOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Creating dataset")
         result = hook.create_dataset(
             dataset=self.dataset,
@@ -378,9 +435,19 @@ class AutoMLImportDataOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("dataset_id", "input_config", "location", "project_id")
+    template_fields = ("dataset_id", "input_config", "location", "project_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -393,6 +460,7 @@ class AutoMLImportDataOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -405,9 +473,13 @@ class AutoMLImportDataOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Importing dataset")
         operation = hook.import_data(
             dataset_id=self.dataset_id,
@@ -461,6 +533,15 @@ class AutoMLTablesListColumnSpecsOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -470,6 +551,7 @@ class AutoMLTablesListColumnSpecsOperator(BaseOperator):
         "filter_",
         "location",
         "project_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -486,6 +568,7 @@ class AutoMLTablesListColumnSpecsOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -500,9 +583,13 @@ class AutoMLTablesListColumnSpecsOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Requesting column specs.")
         page_iterator = hook.list_column_specs(
             dataset_id=self.dataset_id,
@@ -550,9 +637,18 @@ class AutoMLTablesUpdateDatasetOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("dataset", "update_mask", "location")
+    template_fields = ("dataset", "update_mask", "location", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -564,6 +660,7 @@ class AutoMLTablesUpdateDatasetOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -575,9 +672,13 @@ class AutoMLTablesUpdateDatasetOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Updating AutoML dataset %s.", self.dataset["name"])
         result = hook.update_dataset(
             dataset=self.dataset,
@@ -617,9 +718,18 @@ class AutoMLGetModelOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("model_id", "location", "project_id")
+    template_fields = ("model_id", "location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -631,6 +741,7 @@ class AutoMLGetModelOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -642,9 +753,13 @@ class AutoMLGetModelOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         result = hook.get_model(
             model_id=self.model_id,
             location=self.location,
@@ -683,9 +798,18 @@ class AutoMLDeleteModelOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("model_id", "location", "project_id")
+    template_fields = ("model_id", "location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -697,6 +821,7 @@ class AutoMLDeleteModelOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -708,9 +833,13 @@ class AutoMLDeleteModelOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         operation = hook.delete_model(
             model_id=self.model_id,
             location=self.location,
@@ -759,9 +888,18 @@ class AutoMLDeployModelOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("model_id", "location", "project_id")
+    template_fields = ("model_id", "location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -774,6 +912,7 @@ class AutoMLDeployModelOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -786,9 +925,13 @@ class AutoMLDeployModelOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Deploying model_id %s", self.model_id)
 
         operation = hook.deploy_model(
@@ -838,9 +981,18 @@ class AutoMLTablesListTableSpecsOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("dataset_id", "filter_", "location", "project_id")
+    template_fields = ("dataset_id", "filter_", "location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -854,6 +1006,7 @@ class AutoMLTablesListTableSpecsOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -866,9 +1019,13 @@ class AutoMLTablesListTableSpecsOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Requesting table specs for %s.", self.dataset_id)
         page_iterator = hook.list_table_specs(
             dataset_id=self.dataset_id,
@@ -909,9 +1066,18 @@ class AutoMLListDatasetOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("location", "project_id")
+    template_fields = ("location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -922,6 +1088,7 @@ class AutoMLListDatasetOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -931,9 +1098,13 @@ class AutoMLListDatasetOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         self.log.info("Requesting datasets")
         page_iterator = hook.list_datasets(
             location=self.location,
@@ -979,9 +1150,18 @@ class AutoMLDeleteDatasetOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("dataset_id", "location", "project_id")
+    template_fields = ("dataset_id", "location", "project_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -993,6 +1173,7 @@ class AutoMLDeleteDatasetOperator(BaseOperator):
         timeout: Optional[float] = None,
         retry: Optional[Retry] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1004,6 +1185,7 @@ class AutoMLDeleteDatasetOperator(BaseOperator):
         self.timeout = timeout
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     @staticmethod
     def _parse_dataset_id(dataset_id: Union[str, List[str]]) -> List[str]:
@@ -1015,7 +1197,10 @@ class AutoMLDeleteDatasetOperator(BaseOperator):
             return dataset_id.split(",")
 
     def execute(self, context):
-        hook = CloudAutoMLHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudAutoMLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         dataset_id_list = self._parse_dataset_id(self.dataset_id)
         for dataset_id in dataset_id_list:
             self.log.info("Deleting dataset %s", dataset_id)

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -26,7 +26,7 @@ import json
 import re
 import uuid
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Set, SupportsAbs, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, SupportsAbs, Union
 
 import attr
 from google.api_core.exceptions import Conflict
@@ -134,9 +134,18 @@ class BigQueryCheckOperator(CheckOperator):
     :param location: The geographic location of the job. See details at:
         https://cloud.google.com/bigquery/docs/locations#specifying_your_location
     :type location: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('sql', 'gcp_conn_id',)
+    template_fields = ('sql', 'gcp_conn_id', 'impersonation_chain',)
     template_ext = ('.sql',)
     ui_color = BigQueryUIColors.CHECK.value
 
@@ -148,6 +157,7 @@ class BigQueryCheckOperator(CheckOperator):
         bigquery_conn_id: Optional[str] = None,
         use_legacy_sql: bool = True,
         location: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(sql=sql, **kwargs)
@@ -159,12 +169,14 @@ class BigQueryCheckOperator(CheckOperator):
         self.sql = sql
         self.use_legacy_sql = use_legacy_sql
         self.location = location
+        self.impersonation_chain = impersonation_chain
 
     def get_db_hook(self) -> BigQueryHook:
         return BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             use_legacy_sql=self.use_legacy_sql,
-            location=self.location
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
         )
 
 
@@ -189,9 +201,18 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
     :param location: The geographic location of the job. See details at:
         https://cloud.google.com/bigquery/docs/locations#specifying_your_location
     :type location: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('sql', 'gcp_conn_id', 'pass_value',)
+    template_fields = ('sql', 'gcp_conn_id', 'pass_value', 'impersonation_chain',)
     template_ext = ('.sql',)
     ui_color = BigQueryUIColors.CHECK.value
 
@@ -205,6 +226,7 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
         bigquery_conn_id: Optional[str] = None,
         use_legacy_sql: bool = True,
         location: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -221,12 +243,14 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
         self.location = location
         self.gcp_conn_id = gcp_conn_id
         self.use_legacy_sql = use_legacy_sql
+        self.impersonation_chain = impersonation_chain
 
     def get_db_hook(self) -> BigQueryHook:
         return BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             use_legacy_sql=self.use_legacy_sql,
-            location=self.location
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
         )
 
 
@@ -264,9 +288,18 @@ class BigQueryIntervalCheckOperator(IntervalCheckOperator):
     :param location: The geographic location of the job. See details at:
         https://cloud.google.com/bigquery/docs/locations#specifying_your_location
     :type location: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('table', 'gcp_conn_id', 'sql1', 'sql2')
+    template_fields = ('table', 'gcp_conn_id', 'sql1', 'sql2', 'impersonation_chain',)
     ui_color = BigQueryUIColors.CHECK.value
 
     @apply_defaults
@@ -280,6 +313,7 @@ class BigQueryIntervalCheckOperator(IntervalCheckOperator):
         bigquery_conn_id: Optional[str] = None,
         use_legacy_sql: bool = True,
         location: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -297,12 +331,14 @@ class BigQueryIntervalCheckOperator(IntervalCheckOperator):
         self.gcp_conn_id = gcp_conn_id
         self.use_legacy_sql = use_legacy_sql
         self.location = location
+        self.impersonation_chain = impersonation_chain
 
     def get_db_hook(self) -> BigQueryHook:
         return BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             use_legacy_sql=self.use_legacy_sql,
             location=self.location,
+            impersonation_chain=self.impersonation_chain,
         )
 
 
@@ -353,14 +389,24 @@ class BigQueryGetDataOperator(BaseOperator):
     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud Platform.
         This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type bigquery_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param location: The location used for the operation.
     :type location: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('dataset_id', 'table_id', 'max_results', 'selected_fields')
+    template_fields = ('dataset_id', 'table_id', 'max_results', 'selected_fields',
+                       'impersonation_chain',)
     ui_color = BigQueryUIColors.QUERY.value
 
     @apply_defaults
@@ -374,6 +420,7 @@ class BigQueryGetDataOperator(BaseOperator):
         bigquery_conn_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         location: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -391,6 +438,7 @@ class BigQueryGetDataOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.location = location
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         self.log.info('Fetching Data from %s.%s max results: %s',
@@ -398,7 +446,8 @@ class BigQueryGetDataOperator(BaseOperator):
 
         hook = BigQueryHook(
             bigquery_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         rows = hook.list_rows(
@@ -447,9 +496,9 @@ class BigQueryExecuteQueryOperator(BaseOperator):
     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud Platform.
         This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type bigquery_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param udf_config: The User Defined Function configuration for the query.
         See https://cloud.google.com/bigquery/user-defined-functions for details.
@@ -507,9 +556,19 @@ class BigQueryExecuteQueryOperator(BaseOperator):
                 "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key"
             }
     :type encryption_configuration: dict
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('sql', 'destination_dataset_table', 'labels', 'query_params')
+    template_fields = ('sql', 'destination_dataset_table', 'labels', 'query_params',
+                       'impersonation_chain',)
     template_ext = ('.sql', )
     ui_color = BigQueryUIColors.QUERY.value
 
@@ -552,6 +611,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
                  cluster_fields: Optional[List[str]] = None,
                  location: Optional[str] = None,
                  encryption_configuration: Optional[dict] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
 
@@ -588,6 +648,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
         self.location = location
         self.encryption_configuration = encryption_configuration
         self.hook = None  # type: Optional[BigQueryHook]
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         if self.hook is None:
@@ -597,6 +658,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
                 use_legacy_sql=self.use_legacy_sql,
                 delegate_to=self.delegate_to,
                 location=self.location,
+                impersonation_chain=self.impersonation_chain,
             )
         if isinstance(self.sql, str):
             job_id = self.hook.run_query(
@@ -702,9 +764,9 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
     :param google_cloud_storage_conn_id: [Optional] The connection ID used to connect to Google Cloud
         Platform and interact with the Google Cloud Storage service.
     :type google_cloud_storage_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to
-        work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param labels: a dictionary containing labels for the table, passed to BigQuery
 
@@ -770,6 +832,15 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
             .. seealso::
                 https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#clustering.fields
     :type cluster_fields: list
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     template_fields = (
         'dataset_id',
@@ -777,7 +848,8 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         'project_id',
         'gcs_schema_object',
         'labels',
-        'view'
+        'view',
+        'impersonation_chain',
     )
 
     ui_color = BigQueryUIColors.TABLE.value
@@ -801,6 +873,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         encryption_configuration: Optional[Dict] = None,
         location: Optional[str] = None,
         cluster_fields: Optional[List[str]] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -820,19 +893,23 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         self.location = location
         self.cluster_fields = cluster_fields
         self.table_resource = table_resource
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.bigquery_conn_id,
             delegate_to=self.delegate_to,
-            location=self.location
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
         )
 
         if not self.schema_fields and self.gcs_schema_object:
             gcs_bucket, gcs_object = _parse_gcs_url(self.gcs_schema_object)
             gcs_hook = GCSHook(
                 google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
-                delegate_to=self.delegate_to)
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
             schema_fields = json.loads(gcs_hook.download(
                 gcs_bucket,
                 gcs_object).decode("utf-8"))
@@ -933,9 +1010,9 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         Platform and interact with the Google Cloud Storage service.
         cloud storage hook.
     :type google_cloud_storage_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to
-        work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param src_fmt_configs: configure optional fields specific to the source format
     :type src_fmt_configs: dict
@@ -950,6 +1027,15 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
     :type encryption_configuration: dict
     :param location: The location used for the operation.
     :type location: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     template_fields = (
         'bucket',
@@ -958,6 +1044,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         'destination_project_dataset_table',
         'labels',
         'table_resource',
+        'impersonation_chain',
     )
     ui_color = BigQueryUIColors.TABLE.value
 
@@ -986,6 +1073,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         labels: Optional[Dict] = None,
         encryption_configuration: Optional[Dict] = None,
         location: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1043,18 +1131,22 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         self.labels = labels
         self.encryption_configuration = encryption_configuration
         self.location = location
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.bigquery_conn_id,
             delegate_to=self.delegate_to,
-            location=self.location
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
         )
 
         if not self.schema_fields and self.schema_object and self.source_format != 'DATASTORE_BACKUP':
             gcs_hook = GCSHook(
                 google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
-                delegate_to=self.delegate_to)
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
             schema_object = gcs_hook.download(self.bucket, self.schema_object)
             schema_fields = json.loads(schema_object.decode("utf-8"))
         else:
@@ -1115,6 +1207,19 @@ class BigQueryDeleteDatasetOperator(BaseOperator):
     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud Platform.
         This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type bigquery_conn_id: str
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
 
     **Example**: ::
 
@@ -1127,7 +1232,7 @@ class BigQueryDeleteDatasetOperator(BaseOperator):
             dag=dag)
     """
 
-    template_fields = ('dataset_id', 'project_id')
+    template_fields = ('dataset_id', 'project_id', 'impersonation_chain',)
     ui_color = BigQueryUIColors.DATASET.value
 
     @apply_defaults
@@ -1139,6 +1244,7 @@ class BigQueryDeleteDatasetOperator(BaseOperator):
         gcp_conn_id: str = 'google_cloud_default',
         bigquery_conn_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         if bigquery_conn_id:
@@ -1152,6 +1258,7 @@ class BigQueryDeleteDatasetOperator(BaseOperator):
         self.delete_contents = delete_contents
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
         super().__init__(**kwargs)
 
@@ -1160,7 +1267,8 @@ class BigQueryDeleteDatasetOperator(BaseOperator):
 
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         bq_hook.delete_dataset(
@@ -1194,6 +1302,19 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud Platform.
         This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type bigquery_conn_id: str
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
         **Example**: ::
 
             create_new_dataset = BigQueryCreateEmptyDatasetOperator(
@@ -1203,11 +1324,9 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
                 gcp_conn_id='_my_gcp_conn_',
                 task_id='newDatasetCreator',
                 dag=dag)
-    :param location: The location used for the operation.
-    :type location: str
     """
 
-    template_fields = ('dataset_id', 'project_id', 'dataset_reference')
+    template_fields = ('dataset_id', 'project_id', 'dataset_reference', 'impersonation_chain',)
     ui_color = BigQueryUIColors.DATASET.value
 
     @apply_defaults
@@ -1220,6 +1339,7 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  bigquery_conn_id: Optional[str] = None,
                  delegate_to: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
 
         if bigquery_conn_id:
@@ -1234,6 +1354,7 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.dataset_reference = dataset_reference if dataset_reference else {}
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
         super().__init__(**kwargs)
 
@@ -1241,7 +1362,8 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
-            location=self.location
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
         )
 
         try:
@@ -1273,11 +1395,25 @@ class BigQueryGetDatasetOperator(BaseOperator):
     :type project_id: str
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: dataset
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
     """
 
-    template_fields = ('dataset_id', 'project_id')
+    template_fields = ('dataset_id', 'project_id', 'impersonation_chain',)
     ui_color = BigQueryUIColors.DATASET.value
 
     @apply_defaults
@@ -1287,16 +1423,20 @@ class BigQueryGetDatasetOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
+
         self.dataset_id = dataset_id
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
         bq_hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id,
-                               delegate_to=self.delegate_to)
+                               delegate_to=self.delegate_to,
+                               impersonation_chain=self.impersonation_chain)
 
         self.log.info('Start getting dataset: %s:%s', self.project_id, self.dataset_id)
 
@@ -1323,12 +1463,21 @@ class BigQueryGetDatasetTablesOperator(BaseOperator):
     :type max_results: int
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('dataset_id', 'project_id')
+    template_fields = ('dataset_id', 'project_id', 'impersonation_chain',)
     ui_color = BigQueryUIColors.DATASET.value
 
     @apply_defaults
@@ -1339,6 +1488,7 @@ class BigQueryGetDatasetTablesOperator(BaseOperator):
         max_results: Optional[int] = None,
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         self.dataset_id = dataset_id
@@ -1346,12 +1496,14 @@ class BigQueryGetDatasetTablesOperator(BaseOperator):
         self.max_results = max_results
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         return bq_hook.get_dataset_tables(
@@ -1381,11 +1533,25 @@ class BigQueryPatchDatasetOperator(BaseOperator):
     :type project_id: str
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: dataset
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
     """
 
-    template_fields = ('dataset_id', 'project_id')
+    template_fields = ('dataset_id', 'project_id', 'impersonation_chain',)
     ui_color = BigQueryUIColors.DATASET.value
 
     @apply_defaults
@@ -1396,6 +1562,7 @@ class BigQueryPatchDatasetOperator(BaseOperator):
         project_id: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
 
@@ -1408,12 +1575,14 @@ class BigQueryPatchDatasetOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.dataset_resource = dataset_resource
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         return bq_hook.patch_dataset(
@@ -1448,11 +1617,25 @@ class BigQueryUpdateDatasetOperator(BaseOperator):
     :type project_id: str
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: dataset
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
     """
 
-    template_fields = ('dataset_id', 'project_id')
+    template_fields = ('dataset_id', 'project_id', 'impersonation_chain',)
     ui_color = BigQueryUIColors.DATASET.value
 
     @apply_defaults
@@ -1464,6 +1647,7 @@ class BigQueryUpdateDatasetOperator(BaseOperator):
         project_id: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         self.dataset_id = dataset_id
@@ -1472,12 +1656,14 @@ class BigQueryUpdateDatasetOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.dataset_resource = dataset_resource
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
         bq_hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
         fields = self.fields or list(self.dataset_resource.keys())
 
@@ -1507,17 +1693,26 @@ class BigQueryDeleteTableOperator(BaseOperator):
     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud Platform.
         This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type bigquery_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param ignore_if_missing: if True, then return success even if the
         requested table does not exist.
     :type ignore_if_missing: bool
     :param location: The location used for the operation.
     :type location: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('deletion_dataset_table',)
+    template_fields = ('deletion_dataset_table', 'impersonation_chain',)
     ui_color = BigQueryUIColors.TABLE.value
 
     @apply_defaults
@@ -1529,6 +1724,7 @@ class BigQueryDeleteTableOperator(BaseOperator):
         delegate_to: Optional[str] = None,
         ignore_if_missing: bool = False,
         location: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -1544,13 +1740,15 @@ class BigQueryDeleteTableOperator(BaseOperator):
         self.delegate_to = delegate_to
         self.ignore_if_missing = ignore_if_missing
         self.location = location
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         self.log.info('Deleting: %s', self.deletion_dataset_table)
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
-            location=self.location
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
         )
         hook.delete_table(
             table_id=self.deletion_dataset_table,
@@ -1587,8 +1785,17 @@ class BigQueryUpsertTableOperator(BaseOperator):
     :type delegate_to: str
     :param location: The location used for the operation.
     :type location: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('dataset_id', 'table_resource')
+    template_fields = ('dataset_id', 'table_resource', 'impersonation_chain',)
     ui_color = BigQueryUIColors.TABLE.value
 
     @apply_defaults
@@ -1601,6 +1808,7 @@ class BigQueryUpsertTableOperator(BaseOperator):
         bigquery_conn_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         location: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -1617,6 +1825,7 @@ class BigQueryUpsertTableOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.location = location
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         self.log.info('Upserting Dataset: %s with table_resource: %s', self.dataset_id, self.table_resource)
@@ -1624,6 +1833,7 @@ class BigQueryUpsertTableOperator(BaseOperator):
             bigquery_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             location=self.location,
+            impersonation_chain=self.impersonation_chain,
         )
         hook.run_table_upsert(
             dataset_id=self.dataset_id,
@@ -1675,9 +1885,22 @@ class BigQueryInsertJobOperator(BaseOperator):
     :type location: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("configuration", "job_id")
+    template_fields = ("configuration", "job_id", "impersonation_chain",)
     template_ext = (".json", )
     ui_color = BigQueryUIColors.QUERY.value
 
@@ -1691,6 +1914,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         reattach_states: Optional[Set[str]] = None,
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -1702,6 +1926,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         self.delegate_to = delegate_to
         self.force_rerun = force_rerun
         self.reattach_states: Set[str] = reattach_states or set()
+        self.impersonation_chain = impersonation_chain
 
     def prepare_template(self) -> None:
         # If .json is passed then we have to read the file
@@ -1748,6 +1973,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         job_id = self._job_id(context)

--- a/airflow/providers/google/cloud/operators/bigquery_dts.py
+++ b/airflow/providers/google/cloud/operators/bigquery_dts.py
@@ -18,7 +18,7 @@
 """
 This module contains Google BigQuery Data Transfer Service operators.
 """
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Sequence, Tuple, Union
 
 from google.api_core.retry import Retry
 from google.protobuf.json_format import MessageToDict
@@ -55,6 +55,15 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -62,6 +71,7 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
         "project_id",
         "authorization_code",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -74,6 +84,7 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id="google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -84,9 +95,13 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = BiqQueryDataTransferServiceHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BiqQueryDataTransferServiceHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         self.log.info("Creating DTS transfer config")
         response = hook.create_transfer_config(
             project_id=self.project_id,
@@ -126,9 +141,18 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("transfer_config_id", "project_id", "gcp_conn_id")
+    template_fields = ("transfer_config_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -139,6 +163,7 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id="google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -148,9 +173,13 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = BiqQueryDataTransferServiceHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BiqQueryDataTransferServiceHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.delete_transfer_config(
             transfer_config_id=self.transfer_config_id,
             project_id=self.project_id,
@@ -196,6 +225,15 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
     :type metadata: Optional[Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -204,6 +242,7 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
         "requested_time_range",
         "requested_run_time",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -217,6 +256,7 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id="google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -228,9 +268,13 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = BiqQueryDataTransferServiceHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BiqQueryDataTransferServiceHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         self.log.info('Submitting manual transfer for %s', self.transfer_config_id)
         response = hook.start_manual_transfer_runs(
             transfer_config_id=self.transfer_config_id,

--- a/airflow/providers/google/cloud/operators/bigtable.py
+++ b/airflow/providers/google/cloud/operators/bigtable.py
@@ -19,7 +19,7 @@
 This module contains Google Cloud Bigtable operators.
 """
 import enum
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Sequence, Union
 
 import google.api_core.exceptions
 from google.cloud.bigtable.column_family import GarbageCollectionRule
@@ -89,10 +89,20 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
                     If None is not specified, Operator will wait indefinitely.
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     REQUIRED_ATTRIBUTES: Iterable[str] = ('instance_id', 'main_cluster_id', 'main_cluster_zone')
-    template_fields: Iterable[str] = ['project_id', 'instance_id', 'main_cluster_id', 'main_cluster_zone']
+    template_fields: Iterable[str] = ['project_id', 'instance_id', 'main_cluster_id',
+                                      'main_cluster_zone', 'impersonation_chain', ]
 
     @apply_defaults
     def __init__(self, *,   # pylint: disable=too-many-arguments
@@ -109,6 +119,7 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
                  cluster_storage_type: Optional[enums.StorageType] = None,
                  timeout: Optional[float] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.project_id = project_id
         self.instance_id = instance_id
@@ -124,10 +135,14 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
         self.timeout = timeout
         self._validate_inputs()
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
-        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigtableHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         instance = hook.get_instance(project_id=self.project_id,
                                      instance_id=self.instance_id)
         if instance:
@@ -187,10 +202,19 @@ class BigtableUpdateInstanceOperator(BaseOperator, BigtableValidationMixin):
                     If None is not specified, Operator will wait indefinitely.
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     REQUIRED_ATTRIBUTES: Iterable[str] = ['instance_id']
-    template_fields: Iterable[str] = ['project_id', 'instance_id']
+    template_fields: Iterable[str] = ['project_id', 'instance_id', 'impersonation_chain', ]
 
     @apply_defaults
     def __init__(self, *,
@@ -201,6 +225,7 @@ class BigtableUpdateInstanceOperator(BaseOperator, BigtableValidationMixin):
                  instance_labels: Optional[Dict] = None,
                  timeout: Optional[float] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.project_id = project_id
         self.instance_id = instance_id
@@ -210,10 +235,14 @@ class BigtableUpdateInstanceOperator(BaseOperator, BigtableValidationMixin):
         self.timeout = timeout
         self._validate_inputs()
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
-        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigtableHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         instance = hook.get_instance(project_id=self.project_id,
                                      instance_id=self.instance_id)
         if not instance:
@@ -253,24 +282,38 @@ class BigtableDeleteInstanceOperator(BaseOperator, BigtableValidationMixin):
     :type project_id: str
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     REQUIRED_ATTRIBUTES = ('instance_id',)  # type: Iterable[str]
-    template_fields = ['project_id', 'instance_id']  # type: Iterable[str]
+    template_fields = ['project_id', 'instance_id', 'impersonation_chain', ]  # type: Iterable[str]
 
     @apply_defaults
     def __init__(self, *,
                  instance_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.project_id = project_id
         self.instance_id = instance_id
         self._validate_inputs()
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
-        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigtableHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             hook.delete_instance(project_id=self.project_id,
                                  instance_id=self.instance_id)
@@ -313,9 +356,19 @@ class BigtableCreateTableOperator(BaseOperator, BigtableValidationMixin):
                             :class:`google.cloud.bigtable.column_family.GarbageCollectionRule`
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     REQUIRED_ATTRIBUTES = ('instance_id', 'table_id')  # type: Iterable[str]
-    template_fields = ['project_id', 'instance_id', 'table_id']  # type: Iterable[str]
+    template_fields = ['project_id', 'instance_id', 'table_id',
+                       'impersonation_chain', ]  # type: Iterable[str]
 
     @apply_defaults
     def __init__(self, *,
@@ -325,6 +378,7 @@ class BigtableCreateTableOperator(BaseOperator, BigtableValidationMixin):
                  initial_split_keys: Optional[List] = None,
                  column_families: Optional[Dict[str, GarbageCollectionRule]] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.project_id = project_id
         self.instance_id = instance_id
@@ -333,6 +387,7 @@ class BigtableCreateTableOperator(BaseOperator, BigtableValidationMixin):
         self.column_families = column_families or {}
         self._validate_inputs()
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def _compare_column_families(self, hook, instance):
@@ -359,7 +414,10 @@ class BigtableCreateTableOperator(BaseOperator, BigtableValidationMixin):
         return True
 
     def execute(self, context):
-        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigtableHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         instance = hook.get_instance(project_id=self.project_id, instance_id=self.instance_id)
         if not instance:
             raise AirflowException(
@@ -403,9 +461,19 @@ class BigtableDeleteTableOperator(BaseOperator, BigtableValidationMixin):
     :param app_profile_id: Application profile.
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     REQUIRED_ATTRIBUTES = ('instance_id', 'table_id')  # type: Iterable[str]
-    template_fields = ['project_id', 'instance_id', 'table_id']  # type: Iterable[str]
+    template_fields = ['project_id', 'instance_id', 'table_id',
+                       'impersonation_chain', ]  # type: Iterable[str]
 
     @apply_defaults
     def __init__(self, *,
@@ -414,6 +482,7 @@ class BigtableDeleteTableOperator(BaseOperator, BigtableValidationMixin):
                  project_id: Optional[str] = None,
                  app_profile_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.project_id = project_id
         self.instance_id = instance_id
@@ -421,10 +490,14 @@ class BigtableDeleteTableOperator(BaseOperator, BigtableValidationMixin):
         self.app_profile_id = app_profile_id
         self._validate_inputs()
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
-        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigtableHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         instance = hook.get_instance(project_id=self.project_id,
                                      instance_id=self.instance_id)
         if not instance:
@@ -468,9 +541,19 @@ class BigtableUpdateClusterOperator(BaseOperator, BigtableValidationMixin):
     :param project_id: Optional, the ID of the GCP project.
     :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     REQUIRED_ATTRIBUTES = ('instance_id', 'cluster_id', 'nodes')  # type: Iterable[str]
-    template_fields = ['project_id', 'instance_id', 'cluster_id', 'nodes']  # type: Iterable[str]
+    template_fields = ['project_id', 'instance_id', 'cluster_id', 'nodes',
+                       'impersonation_chain', ]  # type: Iterable[str]
 
     @apply_defaults
     def __init__(self, *,
@@ -479,6 +562,7 @@ class BigtableUpdateClusterOperator(BaseOperator, BigtableValidationMixin):
                  nodes: int,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.project_id = project_id
         self.instance_id = instance_id
@@ -486,10 +570,14 @@ class BigtableUpdateClusterOperator(BaseOperator, BigtableValidationMixin):
         self.nodes = nodes
         self._validate_inputs()
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def execute(self, context):
-        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigtableHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         instance = hook.get_instance(project_id=self.project_id,
                                      instance_id=self.instance_id)
         if not instance:

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -19,7 +19,7 @@
 import json
 import re
 from copy import deepcopy
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Sequence, Union
 from urllib.parse import unquote, urlparse
 
 import yaml
@@ -178,9 +178,18 @@ class CloudBuildCreateBuildOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: API version used (for example v1 or v1beta1).
     :type api_version: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("body", "gcp_conn_id", "api_version")
+    template_fields = ("body", "gcp_conn_id", "api_version", "impersonation_chain",)
     template_ext = ['.yml', '.yaml', '.json']
 
     @apply_defaults
@@ -189,6 +198,7 @@ class CloudBuildCreateBuildOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = "google_cloud_default",
                  api_version: str = "v1",
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.body = body
@@ -198,6 +208,7 @@ class CloudBuildCreateBuildOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self._validate_inputs()
+        self.impersonation_chain = impersonation_chain
 
     def prepare_template(self) -> None:
         # if no file is specified, skip
@@ -214,6 +225,10 @@ class CloudBuildCreateBuildOperator(BaseOperator):
             raise AirflowException("The required parameter 'body' is missing")
 
     def execute(self, context):
-        hook = CloudBuildHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
+        hook = CloudBuildHook(
+            gcp_conn_id=self.gcp_conn_id,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain
+        )
         body = BuildProcessor(body=self.body).process_body()
         return hook.create_build(body=body, project_id=self.project_id)

--- a/airflow/providers/google/cloud/operators/cloud_memorystore.py
+++ b/airflow/providers/google/cloud/operators/cloud_memorystore.py
@@ -68,6 +68,15 @@ class CloudMemorystoreCreateInstanceOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -79,6 +88,7 @@ class CloudMemorystoreCreateInstanceOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -92,6 +102,7 @@ class CloudMemorystoreCreateInstanceOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -103,9 +114,13 @@ class CloudMemorystoreCreateInstanceOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.create_instance(
             location=self.location,
             instance_id=self.instance_id,
@@ -143,9 +158,19 @@ class CloudMemorystoreDeleteInstanceOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("location", "instance", "project_id", "retry", "timeout", "metadata", "gcp_conn_id")
+    template_fields = ("location", "instance", "project_id", "retry", "timeout", "metadata",
+                       "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -157,6 +182,7 @@ class CloudMemorystoreDeleteInstanceOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -167,9 +193,13 @@ class CloudMemorystoreDeleteInstanceOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.delete_instance(
             location=self.location,
             instance=self.instance,
@@ -211,6 +241,15 @@ class CloudMemorystoreExportInstanceOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -222,6 +261,7 @@ class CloudMemorystoreExportInstanceOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -235,6 +275,7 @@ class CloudMemorystoreExportInstanceOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -246,9 +287,13 @@ class CloudMemorystoreExportInstanceOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
 
         hook.export_instance(
             location=self.location,
@@ -289,6 +334,15 @@ class CloudMemorystoreFailoverInstanceOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -300,6 +354,7 @@ class CloudMemorystoreFailoverInstanceOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -313,6 +368,7 @@ class CloudMemorystoreFailoverInstanceOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -324,9 +380,13 @@ class CloudMemorystoreFailoverInstanceOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.failover_instance(
             location=self.location,
             instance=self.instance,
@@ -362,9 +422,19 @@ class CloudMemorystoreGetInstanceOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("location", "instance", "project_id", "retry", "timeout", "metadata", "gcp_conn_id")
+    template_fields = ("location", "instance", "project_id", "retry", "timeout", "metadata",
+                       "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -376,6 +446,7 @@ class CloudMemorystoreGetInstanceOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -386,9 +457,13 @@ class CloudMemorystoreGetInstanceOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.get_instance(
             location=self.location,
             instance=self.instance,
@@ -432,6 +507,15 @@ class CloudMemorystoreImportOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -443,6 +527,7 @@ class CloudMemorystoreImportOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -456,6 +541,7 @@ class CloudMemorystoreImportOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -467,9 +553,13 @@ class CloudMemorystoreImportOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.import_instance(
             location=self.location,
             instance=self.instance,
@@ -509,9 +599,19 @@ class CloudMemorystoreListInstancesOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("location", "page_size", "project_id", "retry", "timeout", "metadata", "gcp_conn_id")
+    template_fields = ("location", "page_size", "project_id", "retry", "timeout", "metadata",
+                       "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -523,6 +623,7 @@ class CloudMemorystoreListInstancesOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -533,9 +634,13 @@ class CloudMemorystoreListInstancesOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.list_instances(
             location=self.location,
             page_size=self.page_size,
@@ -590,6 +695,15 @@ class CloudMemorystoreUpdateInstanceOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -602,6 +716,7 @@ class CloudMemorystoreUpdateInstanceOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -616,6 +731,7 @@ class CloudMemorystoreUpdateInstanceOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -628,9 +744,13 @@ class CloudMemorystoreUpdateInstanceOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.update_instance(
             update_mask=self.update_mask,
             instance=self.instance,
@@ -670,6 +790,15 @@ class CloudMemorystoreScaleInstanceOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -681,6 +810,7 @@ class CloudMemorystoreScaleInstanceOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -694,6 +824,7 @@ class CloudMemorystoreScaleInstanceOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -705,9 +836,13 @@ class CloudMemorystoreScaleInstanceOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
 
         hook.update_instance(
             update_mask={"paths": ["memory_size_gb"]},
@@ -767,6 +902,15 @@ class CloudMemorystoreCreateInstanceAndImportOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -779,6 +923,7 @@ class CloudMemorystoreCreateInstanceAndImportOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -793,6 +938,7 @@ class CloudMemorystoreCreateInstanceAndImportOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -805,9 +951,13 @@ class CloudMemorystoreCreateInstanceAndImportOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
 
         hook.create_instance(
             location=self.location,
@@ -862,6 +1012,15 @@ class CloudMemorystoreExportAndDeleteInstanceOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -873,6 +1032,7 @@ class CloudMemorystoreExportAndDeleteInstanceOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -886,6 +1046,7 @@ class CloudMemorystoreExportAndDeleteInstanceOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -897,9 +1058,13 @@ class CloudMemorystoreExportAndDeleteInstanceOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudMemorystoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
 
         hook.export_instance(
             location=self.location,

--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -21,7 +21,7 @@ This module contains Google Cloud Transfer operators.
 """
 from copy import deepcopy
 from datetime import date, time
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -190,9 +190,18 @@ class CloudDataTransferServiceCreateJobOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1).
     :type api_version: str
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_transfer_job_create_template_fields]
-    template_fields = ('body', 'gcp_conn_id', 'aws_conn_id')
+    template_fields = ('body', 'gcp_conn_id', 'aws_conn_id', 'google_impersonation_chain',)
     # [END gcp_transfer_job_create_template_fields]
 
     @apply_defaults
@@ -202,6 +211,7 @@ class CloudDataTransferServiceCreateJobOperator(BaseOperator):
         aws_conn_id: str = 'aws_default',
         gcp_conn_id: str = 'google_cloud_default',
         api_version: str = 'v1',
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -209,6 +219,7 @@ class CloudDataTransferServiceCreateJobOperator(BaseOperator):
         self.aws_conn_id = aws_conn_id
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
+        self.google_impersonation_chain = google_impersonation_chain
         self._validate_inputs()
 
     def _validate_inputs(self):
@@ -216,7 +227,11 @@ class CloudDataTransferServiceCreateJobOperator(BaseOperator):
 
     def execute(self, context):
         TransferJobPreprocessor(body=self.body, aws_conn_id=self.aws_conn_id).process_body()
-        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         return hook.create_transfer_job(body=self.body)
 
 
@@ -248,9 +263,19 @@ class CloudDataTransferServiceUpdateJobOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1).
     :type api_version: str
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_transfer_job_update_template_fields]
-    template_fields = ('job_name', 'body', 'gcp_conn_id', 'aws_conn_id')
+    template_fields = ('job_name', 'body', 'gcp_conn_id', 'aws_conn_id',
+                       'google_impersonation_chain',)
     # [END gcp_transfer_job_update_template_fields]
 
     @apply_defaults
@@ -261,6 +286,7 @@ class CloudDataTransferServiceUpdateJobOperator(BaseOperator):
         aws_conn_id: str = 'aws_default',
         gcp_conn_id: str = 'google_cloud_default',
         api_version: str = 'v1',
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -269,6 +295,7 @@ class CloudDataTransferServiceUpdateJobOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self.aws_conn_id = aws_conn_id
+        self.google_impersonation_chain = google_impersonation_chain
         self._validate_inputs()
 
     def _validate_inputs(self):
@@ -278,7 +305,11 @@ class CloudDataTransferServiceUpdateJobOperator(BaseOperator):
 
     def execute(self, context):
         TransferJobPreprocessor(body=self.body, aws_conn_id=self.aws_conn_id).process_body()
-        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         return hook.update_transfer_job(job_name=self.job_name, body=self.body)
 
 
@@ -304,9 +335,19 @@ class CloudDataTransferServiceDeleteJobOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1).
     :type api_version: str
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_transfer_job_delete_template_fields]
-    template_fields = ('job_name', 'project_id', 'gcp_conn_id', 'api_version')
+    template_fields = ('job_name', 'project_id', 'gcp_conn_id', 'api_version',
+                       'google_impersonation_chain',)
     # [END gcp_transfer_job_delete_template_fields]
 
     @apply_defaults
@@ -316,6 +357,7 @@ class CloudDataTransferServiceDeleteJobOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
         project_id: Optional[str] = None,
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -323,6 +365,7 @@ class CloudDataTransferServiceDeleteJobOperator(BaseOperator):
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
+        self.google_impersonation_chain = google_impersonation_chain
         self._validate_inputs()
 
     def _validate_inputs(self):
@@ -331,7 +374,11 @@ class CloudDataTransferServiceDeleteJobOperator(BaseOperator):
 
     def execute(self, context):
         self._validate_inputs()
-        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         hook.delete_transfer_job(job_name=self.job_name, project_id=self.project_id)
 
 
@@ -351,9 +398,18 @@ class CloudDataTransferServiceGetOperationOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1).
     :type api_version: str
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_transfer_operation_get_template_fields]
-    template_fields = ('operation_name', 'gcp_conn_id')
+    template_fields = ('operation_name', 'gcp_conn_id', 'google_impersonation_chain',)
     # [END gcp_transfer_operation_get_template_fields]
 
     @apply_defaults
@@ -362,12 +418,14 @@ class CloudDataTransferServiceGetOperationOperator(BaseOperator):
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
         self.operation_name = operation_name
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
+        self.google_impersonation_chain = google_impersonation_chain
         self._validate_inputs()
 
     def _validate_inputs(self):
@@ -375,7 +433,11 @@ class CloudDataTransferServiceGetOperationOperator(BaseOperator):
             raise AirflowException("The required parameter 'operation_name' is empty or None")
 
     def execute(self, context):
-        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         operation = hook.get_transfer_operation(operation_name=self.operation_name)
         return operation
 
@@ -397,15 +459,25 @@ class CloudDataTransferServiceListOperationsOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1).
     :type api_version: str
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_transfer_operations_list_template_fields]
-    template_fields = ('filter', 'gcp_conn_id')
+    template_fields = ('filter', 'gcp_conn_id', 'google_impersonation_chain',)
     # [END gcp_transfer_operations_list_template_fields]
 
     def __init__(self,
                  request_filter: Optional[Dict] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
+                 google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         # To preserve backward compatibility
         # TODO: remove one day
@@ -420,6 +492,7 @@ class CloudDataTransferServiceListOperationsOperator(BaseOperator):
         self.filter = request_filter
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
+        self.google_impersonation_chain = google_impersonation_chain
         self._validate_inputs()
 
     def _validate_inputs(self):
@@ -427,7 +500,11 @@ class CloudDataTransferServiceListOperationsOperator(BaseOperator):
             raise AirflowException("The required parameter 'filter' is empty or None")
 
     def execute(self, context):
-        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         operations_list = hook.list_transfer_operations(request_filter=self.filter)
         self.log.info(operations_list)
         return operations_list
@@ -447,9 +524,19 @@ class CloudDataTransferServicePauseOperationOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version:  API version used (e.g. v1).
     :type api_version: str
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_transfer_operation_pause_template_fields]
-    template_fields = ('operation_name', 'gcp_conn_id', 'api_version')
+    template_fields = ('operation_name', 'gcp_conn_id', 'api_version',
+                       'google_impersonation_chain',)
     # [END gcp_transfer_operation_pause_template_fields]
 
     @apply_defaults
@@ -458,12 +545,14 @@ class CloudDataTransferServicePauseOperationOperator(BaseOperator):
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
         self.operation_name = operation_name
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
+        self.google_impersonation_chain = google_impersonation_chain
         self._validate_inputs()
 
     def _validate_inputs(self):
@@ -471,7 +560,11 @@ class CloudDataTransferServicePauseOperationOperator(BaseOperator):
             raise AirflowException("The required parameter 'operation_name' is empty or None")
 
     def execute(self, context):
-        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         hook.pause_transfer_operation(operation_name=self.operation_name)
 
 
@@ -489,9 +582,19 @@ class CloudDataTransferServiceResumeOperationOperator(BaseOperator):
     :param api_version: API version used (e.g. v1).
     :type api_version: str
     :type gcp_conn_id: str
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_transfer_operation_resume_template_fields]
-    template_fields = ('operation_name', 'gcp_conn_id', 'api_version')
+    template_fields = ('operation_name', 'gcp_conn_id', 'api_version',
+                       'google_impersonation_chain',)
     # [END gcp_transfer_operation_resume_template_fields]
 
     @apply_defaults
@@ -500,11 +603,13 @@ class CloudDataTransferServiceResumeOperationOperator(BaseOperator):
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         self.operation_name = operation_name
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
+        self.google_impersonation_chain = google_impersonation_chain
         self._validate_inputs()
         super().__init__(**kwargs)
 
@@ -513,7 +618,11 @@ class CloudDataTransferServiceResumeOperationOperator(BaseOperator):
             raise AirflowException("The required parameter 'operation_name' is empty or None")
 
     def execute(self, context):
-        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         hook.resume_transfer_operation(operation_name=self.operation_name)
 
 
@@ -532,9 +641,19 @@ class CloudDataTransferServiceCancelOperationOperator(BaseOperator):
     :param gcp_conn_id: The connection ID used to connect to Google
         Cloud Platform.
     :type gcp_conn_id: str
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_transfer_operation_cancel_template_fields]
-    template_fields = ('operation_name', 'gcp_conn_id', 'api_version')
+    template_fields = ('operation_name', 'gcp_conn_id', 'api_version',
+                       'google_impersonation_chain',)
     # [END gcp_transfer_operation_cancel_template_fields]
 
     @apply_defaults
@@ -543,12 +662,14 @@ class CloudDataTransferServiceCancelOperationOperator(BaseOperator):
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
         self.operation_name = operation_name
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
+        self.google_impersonation_chain = google_impersonation_chain
         self._validate_inputs()
 
     def _validate_inputs(self):
@@ -556,7 +677,11 @@ class CloudDataTransferServiceCancelOperationOperator(BaseOperator):
             raise AirflowException("The required parameter 'operation_name' is empty or None")
 
     def execute(self, context):
-        hook = CloudDataTransferServiceHook(api_version=self.api_version, gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataTransferServiceHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         hook.cancel_transfer_operation(operation_name=self.operation_name)
 
 
@@ -594,10 +719,9 @@ class CloudDataTransferServiceS3ToGCSOperator(BaseOperator):
     :param gcp_conn_id: The destination connection ID to use
         when connecting to Google Cloud Storage.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
-    :type delegate_to: str
     :param description: Optional transfer service job description
     :type description: str
     :param schedule: Optional transfer service schedule;
@@ -620,9 +744,19 @@ class CloudDataTransferServiceS3ToGCSOperator(BaseOperator):
     :type wait: bool
     :param timeout: Time to wait for the operation to end in seconds. Defaults to 60 seconds if not specified.
     :type timeout: Optional[Union[float, timedelta]]
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('gcp_conn_id', 's3_bucket', 'gcs_bucket', 'description', 'object_conditions')
+    template_fields = ('gcp_conn_id', 's3_bucket', 'gcs_bucket', 'description', 'object_conditions',
+                       'google_impersonation_chain',)
     ui_color = '#e09411'
 
     @apply_defaults
@@ -640,6 +774,7 @@ class CloudDataTransferServiceS3ToGCSOperator(BaseOperator):
         transfer_options: Optional[Dict] = None,
         wait: bool = True,
         timeout: Optional[float] = None,
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
 
@@ -656,9 +791,14 @@ class CloudDataTransferServiceS3ToGCSOperator(BaseOperator):
         self.transfer_options = transfer_options
         self.wait = wait
         self.timeout = timeout
+        self.google_impersonation_chain = google_impersonation_chain
 
     def execute(self, context):
-        hook = CloudDataTransferServiceHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        hook = CloudDataTransferServiceHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.google_impersonation_chain,
+        )
         body = self._create_body()
 
         TransferJobPreprocessor(body=body, aws_conn_id=self.aws_conn_id, default_schedule=True).process_body()
@@ -730,10 +870,9 @@ class CloudDataTransferServiceGCSToGCSOperator(BaseOperator):
     :param gcp_conn_id: Optional connection ID to use when connecting to Google Cloud
         Storage.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: Google account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
-    :type delegate_to: str
     :param description: Optional transfer service job description
     :type description: str
     :param schedule: Optional transfer service schedule;
@@ -756,6 +895,15 @@ class CloudDataTransferServiceGCSToGCSOperator(BaseOperator):
     :type wait: bool
     :param timeout: Time to wait for the operation to end in seconds. Defaults to 60 seconds if not specified.
     :type timeout: Optional[Union[float, timedelta]]
+    :param google_impersonation_chain: Optional Google service account to impersonate using
+        short-term credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type google_impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -764,6 +912,7 @@ class CloudDataTransferServiceGCSToGCSOperator(BaseOperator):
         'destination_bucket',
         'description',
         'object_conditions',
+        'google_impersonation_chain',
     )
     ui_color = '#e09411'
 
@@ -781,6 +930,7 @@ class CloudDataTransferServiceGCSToGCSOperator(BaseOperator):
         transfer_options: Optional[Dict] = None,
         wait: bool = True,
         timeout: Optional[float] = None,
+        google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
 
@@ -796,9 +946,14 @@ class CloudDataTransferServiceGCSToGCSOperator(BaseOperator):
         self.transfer_options = transfer_options
         self.wait = wait
         self.timeout = timeout
+        self.google_impersonation_chain = google_impersonation_chain
 
     def execute(self, context):
-        hook = CloudDataTransferServiceHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        hook = CloudDataTransferServiceHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.google_impersonation_chain,
+        )
 
         body = self._create_body()
 

--- a/airflow/providers/google/cloud/operators/compute.py
+++ b/airflow/providers/google/cloud/operators/compute.py
@@ -20,7 +20,7 @@ This module contains Google Compute Engine operators.
 """
 
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from googleapiclient.errors import HttpError
 from json_merge_patch import merge
@@ -45,12 +45,14 @@ class ComputeEngineBaseOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.project_id = project_id
         self.zone = zone
         self.resource_id = resource_id
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
+        self.impersonation_chain = impersonation_chain
         self._validate_inputs()
         super().__init__(**kwargs)
 
@@ -90,9 +92,19 @@ class ComputeEngineStartInstanceOperator(ComputeEngineBaseOperator):
     :type api_version: str
     :param validate_body: Optional, If set to False, body validation is not performed.
         Defaults to False.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gce_instance_start_template_fields]
-    template_fields = ('project_id', 'zone', 'resource_id', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'zone', 'resource_id', 'gcp_conn_id', 'api_version',
+                       'impersonation_chain',)
     # [END gce_instance_start_template_fields]
 
     @apply_defaults
@@ -102,13 +114,19 @@ class ComputeEngineStartInstanceOperator(ComputeEngineBaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(
             project_id=project_id, zone=zone, resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version,
+            impersonation_chain=impersonation_chain, **kwargs)
 
     def execute(self, context):
-        hook = ComputeEngineHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
+        hook = ComputeEngineHook(
+            gcp_conn_id=self.gcp_conn_id,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain
+        )
         return hook.start_instance(zone=self.zone,
                                    resource_id=self.resource_id,
                                    project_id=self.project_id)
@@ -138,9 +156,19 @@ class ComputeEngineStopInstanceOperator(ComputeEngineBaseOperator):
     :type api_version: str
     :param validate_body: Optional, If set to False, body validation is not performed.
         Defaults to False.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gce_instance_stop_template_fields]
-    template_fields = ('project_id', 'zone', 'resource_id', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'zone', 'resource_id', 'gcp_conn_id', 'api_version',
+                       'impersonation_chain',)
     # [END gce_instance_stop_template_fields]
 
     @apply_defaults
@@ -150,13 +178,19 @@ class ComputeEngineStopInstanceOperator(ComputeEngineBaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(
             project_id=project_id, zone=zone, resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version,
+            impersonation_chain=impersonation_chain, **kwargs)
 
     def execute(self, context):
-        hook = ComputeEngineHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
+        hook = ComputeEngineHook(
+            gcp_conn_id=self.gcp_conn_id,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.stop_instance(zone=self.zone,
                            resource_id=self.resource_id,
                            project_id=self.project_id)
@@ -196,9 +230,19 @@ class ComputeEngineSetMachineTypeOperator(ComputeEngineBaseOperator):
     :param validate_body: Optional, If set to False, body validation is not performed.
         Defaults to False.
     :type validate_body: bool
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gce_instance_set_machine_type_template_fields]
-    template_fields = ('project_id', 'zone', 'resource_id', 'body', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'zone', 'resource_id', 'body', 'gcp_conn_id', 'api_version',
+                       'impersonation_chain',)
     # [END gce_instance_set_machine_type_template_fields]
 
     @apply_defaults
@@ -210,6 +254,7 @@ class ComputeEngineSetMachineTypeOperator(ComputeEngineBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
                  validate_body: bool = True,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.body = body
         self._field_validator = None  # type: Optional[GcpBodyFieldValidator]
@@ -218,14 +263,19 @@ class ComputeEngineSetMachineTypeOperator(ComputeEngineBaseOperator):
                 SET_MACHINE_TYPE_VALIDATION_SPECIFICATION, api_version=api_version)
         super().__init__(
             project_id=project_id, zone=zone, resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version,
+            impersonation_chain=impersonation_chain, **kwargs)
 
     def _validate_all_body_fields(self):
         if self._field_validator:
             self._field_validator.validate(self.body)
 
     def execute(self, context):
-        hook = ComputeEngineHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
+        hook = ComputeEngineHook(
+            gcp_conn_id=self.gcp_conn_id,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain
+        )
         self._validate_all_body_fields()
         return hook.set_machine_type(zone=self.zone,
                                      resource_id=self.resource_id,
@@ -317,10 +367,19 @@ class ComputeEngineCopyInstanceTemplateOperator(ComputeEngineBaseOperator):
     :param validate_body: Optional, If set to False, body validation is not performed.
         Defaults to False.
     :type validate_body: bool
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gce_instance_template_copy_operator_template_fields]
     template_fields = ('project_id', 'resource_id', 'request_id',
-                       'gcp_conn_id', 'api_version')
+                       'gcp_conn_id', 'api_version', 'impersonation_chain',)
     # [END gce_instance_template_copy_operator_template_fields]
 
     @apply_defaults
@@ -332,6 +391,7 @@ class ComputeEngineCopyInstanceTemplateOperator(ComputeEngineBaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
                  validate_body: bool = True,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.body_patch = body_patch
         self.request_id = request_id
@@ -347,14 +407,19 @@ class ComputeEngineCopyInstanceTemplateOperator(ComputeEngineBaseOperator):
             GCE_INSTANCE_TEMPLATE_FIELDS_TO_SANITIZE)
         super().__init__(
             project_id=project_id, zone='global', resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version,
+            impersonation_chain=impersonation_chain, **kwargs)
 
     def _validate_all_body_fields(self):
         if self._field_validator:
             self._field_validator.validate(self.body_patch)
 
     def execute(self, context):
-        hook = ComputeEngineHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
+        hook = ComputeEngineHook(
+            gcp_conn_id=self.gcp_conn_id,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain
+        )
         self._validate_all_body_fields()
         try:
             # Idempotence check (sort of) - we want to check if the new template
@@ -426,11 +491,20 @@ class ComputeEngineInstanceGroupUpdateManagerTemplateOperator(ComputeEngineBaseO
     :param validate_body: Optional, If set to False, body validation is not performed.
         Defaults to False.
     :type validate_body: bool
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gce_igm_update_template_operator_template_fields]
     template_fields = ('project_id', 'resource_id', 'zone', 'request_id',
                        'source_template', 'destination_template',
-                       'gcp_conn_id', 'api_version')
+                       'gcp_conn_id', 'api_version', 'impersonation_chain',)
     # [END gce_igm_update_template_operator_template_fields]
 
     @apply_defaults
@@ -444,6 +518,7 @@ class ComputeEngineInstanceGroupUpdateManagerTemplateOperator(ComputeEngineBaseO
                  request_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version='beta',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.zone = zone
         self.source_template = source_template
@@ -457,7 +532,8 @@ class ComputeEngineInstanceGroupUpdateManagerTemplateOperator(ComputeEngineBaseO
                                    " api version or above")
         super().__init__(
             project_id=project_id, zone=self.zone, resource_id=resource_id,
-            gcp_conn_id=gcp_conn_id, api_version=api_version, **kwargs)
+            gcp_conn_id=gcp_conn_id, api_version=api_version,
+            impersonation_chain=impersonation_chain, **kwargs)
 
     def _possibly_replace_template(self, dictionary: Dict) -> None:
         if dictionary.get('instanceTemplate') == self.source_template:
@@ -465,7 +541,11 @@ class ComputeEngineInstanceGroupUpdateManagerTemplateOperator(ComputeEngineBaseO
             self._change_performed = True
 
     def execute(self, context):
-        hook = ComputeEngineHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
+        hook = ComputeEngineHook(
+            gcp_conn_id=self.gcp_conn_id,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain
+        )
         old_instance_group_manager = hook.get_instance_group_manager(
             zone=self.zone, resource_id=self.resource_id, project_id=self.project_id)
         patch_body = {}

--- a/airflow/providers/google/cloud/operators/datacatalog.py
+++ b/airflow/providers/google/cloud/operators/datacatalog.py
@@ -66,6 +66,15 @@ class CloudDataCatalogCreateEntryOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -78,6 +87,7 @@ class CloudDataCatalogCreateEntryOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -92,6 +102,7 @@ class CloudDataCatalogCreateEntryOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -104,9 +115,13 @@ class CloudDataCatalogCreateEntryOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             result = hook.create_entry(
                 location=self.location,
@@ -170,6 +185,15 @@ class CloudDataCatalogCreateEntryGroupOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -181,6 +205,7 @@ class CloudDataCatalogCreateEntryGroupOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -194,6 +219,7 @@ class CloudDataCatalogCreateEntryGroupOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -205,9 +231,13 @@ class CloudDataCatalogCreateEntryGroupOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             result = hook.create_entry_group(
                 location=self.location,
@@ -271,6 +301,15 @@ class CloudDataCatalogCreateTagOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -284,6 +323,7 @@ class CloudDataCatalogCreateTagOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -299,6 +339,7 @@ class CloudDataCatalogCreateTagOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -312,9 +353,13 @@ class CloudDataCatalogCreateTagOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             tag = hook.create_tag(
                 location=self.location,
@@ -389,6 +434,15 @@ class CloudDataCatalogCreateTagTemplateOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -400,6 +454,7 @@ class CloudDataCatalogCreateTagTemplateOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -413,6 +468,7 @@ class CloudDataCatalogCreateTagTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -424,9 +480,13 @@ class CloudDataCatalogCreateTagTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             result = hook.create_tag_template(
                 location=self.location,
@@ -491,6 +551,15 @@ class CloudDataCatalogCreateTagTemplateFieldOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -503,6 +572,7 @@ class CloudDataCatalogCreateTagTemplateFieldOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -517,6 +587,7 @@ class CloudDataCatalogCreateTagTemplateFieldOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -529,9 +600,13 @@ class CloudDataCatalogCreateTagTemplateFieldOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             result = hook.create_tag_template_field(
                 location=self.location,
@@ -588,6 +663,15 @@ class CloudDataCatalogDeleteEntryOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -599,6 +683,7 @@ class CloudDataCatalogDeleteEntryOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -612,6 +697,7 @@ class CloudDataCatalogDeleteEntryOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -623,9 +709,13 @@ class CloudDataCatalogDeleteEntryOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             hook.delete_entry(
                 location=self.location,
@@ -668,9 +758,19 @@ class CloudDataCatalogDeleteEntryGroupOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("location", "entry_group", "project_id", "retry", "timeout", "metadata", "gcp_conn_id")
+    template_fields = ("location", "entry_group", "project_id", "retry", "timeout", "metadata",
+                       "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -682,6 +782,7 @@ class CloudDataCatalogDeleteEntryGroupOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -692,9 +793,13 @@ class CloudDataCatalogDeleteEntryGroupOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             hook.delete_entry_group(
                 location=self.location,
@@ -738,6 +843,15 @@ class CloudDataCatalogDeleteTagOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -750,6 +864,7 @@ class CloudDataCatalogDeleteTagOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -764,6 +879,7 @@ class CloudDataCatalogDeleteTagOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -776,9 +892,13 @@ class CloudDataCatalogDeleteTagOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             hook.delete_tag(
                 location=self.location,
@@ -824,6 +944,15 @@ class CloudDataCatalogDeleteTagTemplateOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -835,6 +964,7 @@ class CloudDataCatalogDeleteTagTemplateOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -848,6 +978,7 @@ class CloudDataCatalogDeleteTagTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -859,9 +990,13 @@ class CloudDataCatalogDeleteTagTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             hook.delete_tag_template(
                 location=self.location,
@@ -906,6 +1041,15 @@ class CloudDataCatalogDeleteTagTemplateFieldOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -918,6 +1062,7 @@ class CloudDataCatalogDeleteTagTemplateFieldOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -932,6 +1077,7 @@ class CloudDataCatalogDeleteTagTemplateFieldOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -944,9 +1090,13 @@ class CloudDataCatalogDeleteTagTemplateFieldOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         try:
             hook.delete_tag_template_field(
                 location=self.location,
@@ -990,6 +1140,15 @@ class CloudDataCatalogGetEntryOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1001,6 +1160,7 @@ class CloudDataCatalogGetEntryOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1014,6 +1174,7 @@ class CloudDataCatalogGetEntryOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1025,9 +1186,13 @@ class CloudDataCatalogGetEntryOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.get_entry(
             location=self.location,
             entry_group=self.entry_group,
@@ -1071,6 +1236,15 @@ class CloudDataCatalogGetEntryGroupOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1082,6 +1256,7 @@ class CloudDataCatalogGetEntryGroupOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1095,6 +1270,7 @@ class CloudDataCatalogGetEntryGroupOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1106,9 +1282,13 @@ class CloudDataCatalogGetEntryGroupOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.get_entry_group(
             location=self.location,
             entry_group=self.entry_group,
@@ -1147,6 +1327,15 @@ class CloudDataCatalogGetTagTemplateOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1157,6 +1346,7 @@ class CloudDataCatalogGetTagTemplateOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1169,6 +1359,7 @@ class CloudDataCatalogGetTagTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1179,9 +1370,13 @@ class CloudDataCatalogGetTagTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.get_tag_template(
             location=self.location,
             tag_template=self.tag_template,
@@ -1225,6 +1420,15 @@ class CloudDataCatalogListTagsOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1237,6 +1441,7 @@ class CloudDataCatalogListTagsOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1251,6 +1456,7 @@ class CloudDataCatalogListTagsOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1263,9 +1469,13 @@ class CloudDataCatalogListTagsOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.list_tags(
             location=self.location,
             entry_group=self.entry_group,
@@ -1307,6 +1517,15 @@ class CloudDataCatalogLookupEntryOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1317,6 +1536,7 @@ class CloudDataCatalogLookupEntryOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1329,6 +1549,7 @@ class CloudDataCatalogLookupEntryOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1339,9 +1560,13 @@ class CloudDataCatalogLookupEntryOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.lookup_entry(
             linked_resource=self.linked_resource,
             sql_resource=self.sql_resource,
@@ -1384,6 +1609,15 @@ class CloudDataCatalogRenameTagTemplateFieldOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1396,6 +1630,7 @@ class CloudDataCatalogRenameTagTemplateFieldOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1410,6 +1645,7 @@ class CloudDataCatalogRenameTagTemplateFieldOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1422,9 +1658,13 @@ class CloudDataCatalogRenameTagTemplateFieldOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.rename_tag_template_field(
             location=self.location,
             tag_template=self.tag_template,
@@ -1492,6 +1732,15 @@ class CloudDataCatalogSearchCatalogOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1503,6 +1752,7 @@ class CloudDataCatalogSearchCatalogOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1516,6 +1766,7 @@ class CloudDataCatalogSearchCatalogOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1527,9 +1778,13 @@ class CloudDataCatalogSearchCatalogOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         result = hook.search_catalog(
             scope=self.scope,
             query=self.query,
@@ -1581,6 +1836,15 @@ class CloudDataCatalogUpdateEntryOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1594,6 +1858,7 @@ class CloudDataCatalogUpdateEntryOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1609,6 +1874,7 @@ class CloudDataCatalogUpdateEntryOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1622,9 +1888,13 @@ class CloudDataCatalogUpdateEntryOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.update_entry(
             entry=self.entry,
             update_mask=self.update_mask,
@@ -1677,6 +1947,15 @@ class CloudDataCatalogUpdateTagOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1691,6 +1970,7 @@ class CloudDataCatalogUpdateTagOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1707,6 +1987,7 @@ class CloudDataCatalogUpdateTagOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1721,9 +2002,13 @@ class CloudDataCatalogUpdateTagOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.update_tag(
             tag=self.tag,
             update_mask=self.update_mask,
@@ -1780,6 +2065,15 @@ class CloudDataCatalogUpdateTagTemplateOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1792,6 +2086,7 @@ class CloudDataCatalogUpdateTagTemplateOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1806,6 +2101,7 @@ class CloudDataCatalogUpdateTagTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1818,9 +2114,13 @@ class CloudDataCatalogUpdateTagTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.update_tag_template(
             tag_template=self.tag_template,
             update_mask=self.update_mask,
@@ -1881,6 +2181,15 @@ class CloudDataCatalogUpdateTagTemplateFieldOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to 'google_cloud_default'.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -1895,6 +2204,7 @@ class CloudDataCatalogUpdateTagTemplateFieldOperator(BaseOperator):
         "timeout",
         "metadata",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1911,6 +2221,7 @@ class CloudDataCatalogUpdateTagTemplateFieldOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1925,9 +2236,13 @@ class CloudDataCatalogUpdateTagTemplateFieldOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        hook = CloudDataCatalogHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDataCatalogHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain
+        )
         hook.update_tag_template_field(
             tag_template_field=self.tag_template_field,
             update_mask=self.update_mask,

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -19,7 +19,7 @@
 This module contains Google DataFusion operators.
 """
 from time import sleep
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from google.api_core.retry import exponential_sleep_generator
 from googleapiclient.errors import HttpError
@@ -48,12 +48,22 @@ class CloudDataFusionRestartInstanceOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name",)
+    template_fields = ("instance_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -64,6 +74,7 @@ class CloudDataFusionRestartInstanceOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -73,12 +84,14 @@ class CloudDataFusionRestartInstanceOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Restarting Data Fusion instance: %s", self.instance_name)
         operation = hook.restart_instance(
@@ -108,12 +121,22 @@ class CloudDataFusionDeleteInstanceOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name",)
+    template_fields = ("instance_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -124,6 +147,7 @@ class CloudDataFusionDeleteInstanceOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -133,12 +157,14 @@ class CloudDataFusionDeleteInstanceOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Deleting Data Fusion instance: %s", self.instance_name)
         operation = hook.delete_instance(
@@ -171,12 +197,22 @@ class CloudDataFusionCreateInstanceOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name", "instance")
+    template_fields = ("instance_name", "instance", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -188,6 +224,7 @@ class CloudDataFusionCreateInstanceOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -198,12 +235,14 @@ class CloudDataFusionCreateInstanceOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Creating Data Fusion instance: %s", self.instance_name)
         try:
@@ -261,12 +300,22 @@ class CloudDataFusionUpdateInstanceOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name", "instance")
+    template_fields = ("instance_name", "instance", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -279,6 +328,7 @@ class CloudDataFusionUpdateInstanceOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -290,12 +340,14 @@ class CloudDataFusionUpdateInstanceOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Updating Data Fusion instance: %s", self.instance_name)
         operation = hook.patch_instance(
@@ -327,12 +379,22 @@ class CloudDataFusionGetInstanceOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name",)
+    template_fields = ("instance_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -343,6 +405,7 @@ class CloudDataFusionGetInstanceOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -352,12 +415,14 @@ class CloudDataFusionGetInstanceOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Retrieving Data Fusion instance: %s", self.instance_name)
         instance = hook.get_instance(
@@ -393,12 +458,22 @@ class CloudDataFusionCreatePipelineOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name", "pipeline_name")
+    template_fields = ("instance_name", "pipeline_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -412,6 +487,7 @@ class CloudDataFusionCreatePipelineOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -424,12 +500,14 @@ class CloudDataFusionCreatePipelineOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Creating Data Fusion pipeline: %s", self.pipeline_name)
         instance = hook.get_instance(
@@ -471,12 +549,22 @@ class CloudDataFusionDeletePipelineOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name", "version_id", "pipeline_name")
+    template_fields = ("instance_name", "version_id", "pipeline_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -490,6 +578,7 @@ class CloudDataFusionDeletePipelineOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -502,12 +591,14 @@ class CloudDataFusionDeletePipelineOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Deleting Data Fusion pipeline: %s", self.pipeline_name)
         instance = hook.get_instance(
@@ -550,12 +641,22 @@ class CloudDataFusionListPipelinesOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name", "artifact_name", "artifact_version")
+    template_fields = ("instance_name", "artifact_name", "artifact_version", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -569,6 +670,7 @@ class CloudDataFusionListPipelinesOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -581,12 +683,14 @@ class CloudDataFusionListPipelinesOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Listing Data Fusion pipelines")
         instance = hook.get_instance(
@@ -635,12 +739,22 @@ class CloudDataFusionStartPipelineOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name", "pipeline_name", "runtime_args")
+    template_fields = ("instance_name", "pipeline_name", "runtime_args", "impersonation_chain",)
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
@@ -656,6 +770,7 @@ class CloudDataFusionStartPipelineOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -670,12 +785,14 @@ class CloudDataFusionStartPipelineOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Starting Data Fusion pipeline: %s", self.pipeline_name)
         instance = hook.get_instance(
@@ -725,12 +842,22 @@ class CloudDataFusionStopPipelineOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("instance_name", "pipeline_name")
+    template_fields = ("instance_name", "pipeline_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -743,6 +870,7 @@ class CloudDataFusionStopPipelineOperator(BaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -754,12 +882,14 @@ class CloudDataFusionStopPipelineOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Starting Data Fusion pipeline: %s", self.pipeline_name)
         instance = hook.get_instance(

--- a/airflow/providers/google/cloud/operators/datastore.py
+++ b/airflow/providers/google/cloud/operators/datastore.py
@@ -19,7 +19,7 @@
 """
 This module contains Google Datastore operators.
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -46,9 +46,9 @@ class CloudDatastoreExportEntitiesOperator(BaseOperator):
     :param cloud_storage_conn_id: the name of the cloud storage connection id to
         force-write backup
     :type cloud_storage_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param entity_filter: description of what data from the project is included in the
         export, refer to
@@ -62,8 +62,17 @@ class CloudDatastoreExportEntitiesOperator(BaseOperator):
     :param overwrite_existing: if the storage bucket + namespace is not empty, it will be
         emptied prior to exports. This enables overwriting existing backups.
     :type overwrite_existing: bool
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['bucket', 'namespace', 'entity_filter', 'labels']
+    template_fields = ['bucket', 'namespace', 'entity_filter', 'labels', 'impersonation_chain', ]
 
     @apply_defaults
     def __init__(self,  # pylint: disable=too-many-arguments
@@ -78,6 +87,7 @@ class CloudDatastoreExportEntitiesOperator(BaseOperator):
                  polling_interval_in_seconds: int = 10,
                  overwrite_existing: bool = False,
                  project_id: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.datastore_conn_id = datastore_conn_id
@@ -90,6 +100,7 @@ class CloudDatastoreExportEntitiesOperator(BaseOperator):
         self.polling_interval_in_seconds = polling_interval_in_seconds
         self.overwrite_existing = overwrite_existing
         self.project_id = project_id
+        self.impersonation_chain = impersonation_chain
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
@@ -97,12 +108,19 @@ class CloudDatastoreExportEntitiesOperator(BaseOperator):
         self.log.info('Exporting data to Cloud Storage bucket %s', self.bucket)
 
         if self.overwrite_existing and self.namespace:
-            gcs_hook = GCSHook(self.cloud_storage_conn_id)
+            gcs_hook = GCSHook(
+                self.cloud_storage_conn_id,
+                impersonation_chain=self.impersonation_chain
+            )
             objects = gcs_hook.list(self.bucket, prefix=self.namespace)
             for obj in objects:
                 gcs_hook.delete(self.bucket, obj)
 
-        ds_hook = DatastoreHook(self.datastore_conn_id, self.delegate_to)
+        ds_hook = DatastoreHook(
+            self.datastore_conn_id,
+            self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         result = ds_hook.export_to_storage_bucket(bucket=self.bucket,
                                                   namespace=self.namespace,
                                                   entity_filter=self.entity_filter,
@@ -143,16 +161,26 @@ class CloudDatastoreImportEntitiesOperator(BaseOperator):
     :type labels: dict
     :param datastore_conn_id: the name of the connection id to use
     :type datastore_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param polling_interval_in_seconds: number of seconds to wait before polling for
         execution status again
     :type polling_interval_in_seconds: float
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ['bucket', 'file', 'namespace', 'entity_filter', 'labels']
+    template_fields = ['bucket', 'file', 'namespace', 'entity_filter', 'labels',
+                       'impersonation_chain', ]
 
     @apply_defaults
     def __init__(self,
@@ -166,6 +194,7 @@ class CloudDatastoreImportEntitiesOperator(BaseOperator):
                  delegate_to: Optional[str] = None,
                  polling_interval_in_seconds: float = 10,
                  project_id: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.datastore_conn_id = datastore_conn_id
@@ -177,12 +206,17 @@ class CloudDatastoreImportEntitiesOperator(BaseOperator):
         self.labels = labels
         self.polling_interval_in_seconds = polling_interval_in_seconds
         self.project_id = project_id
+        self.impersonation_chain = impersonation_chain
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
     def execute(self, context):
         self.log.info('Importing data from Cloud Storage bucket %s', self.bucket)
-        ds_hook = DatastoreHook(self.datastore_conn_id, self.delegate_to)
+        ds_hook = DatastoreHook(
+            self.datastore_conn_id,
+            self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         result = ds_hook.import_from_storage_bucket(bucket=self.bucket,
                                                     file=self.file,
                                                     namespace=self.namespace,
@@ -216,14 +250,23 @@ class CloudDatastoreAllocateIdsOperator(BaseOperator):
     :type partial_keys: list
     :param project_id: Google Cloud Platform project ID against which to make the request.
     :type project_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ("partial_keys",)
+    template_fields = ("partial_keys", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -232,6 +275,7 @@ class CloudDatastoreAllocateIdsOperator(BaseOperator):
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -240,9 +284,13 @@ class CloudDatastoreAllocateIdsOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = DatastoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = DatastoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         keys = hook.allocate_ids(
             partial_keys=self.partial_keys,
             project_id=self.project_id,
@@ -265,14 +313,23 @@ class CloudDatastoreBeginTransactionOperator(BaseOperator):
     :type transaction_options: Dict[str, Any]
     :param project_id: Google Cloud Platform project ID against which to make the request.
     :type project_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ("transaction_options",)
+    template_fields = ("transaction_options", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -281,6 +338,7 @@ class CloudDatastoreBeginTransactionOperator(BaseOperator):
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -289,9 +347,13 @@ class CloudDatastoreBeginTransactionOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = DatastoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = DatastoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         handle = hook.begin_transaction(
             transaction_options=self.transaction_options,
             project_id=self.project_id,
@@ -314,14 +376,23 @@ class CloudDatastoreCommitOperator(BaseOperator):
     :type body: dict
     :param project_id: Google Cloud Platform project ID against which to make the request.
     :type project_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ("body",)
+    template_fields = ("body", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -330,6 +401,7 @@ class CloudDatastoreCommitOperator(BaseOperator):
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -338,9 +410,13 @@ class CloudDatastoreCommitOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = DatastoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = DatastoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         response = hook.commit(
             body=self.body,
             project_id=self.project_id,
@@ -363,14 +439,23 @@ class CloudDatastoreRollbackOperator(BaseOperator):
     :type transaction: str
     :param project_id: Google Cloud Platform project ID against which to make the request.
     :type project_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ("transaction",)
+    template_fields = ("transaction", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -379,6 +464,7 @@ class CloudDatastoreRollbackOperator(BaseOperator):
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -387,9 +473,13 @@ class CloudDatastoreRollbackOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = DatastoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = DatastoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook.rollback(
             transaction=self.transaction,
             project_id=self.project_id,
@@ -411,14 +501,23 @@ class CloudDatastoreRunQueryOperator(BaseOperator):
     :type body: dict
     :param project_id: Google Cloud Platform project ID against which to make the request.
     :type project_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ("body",)
+    template_fields = ("body", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -427,6 +526,7 @@ class CloudDatastoreRunQueryOperator(BaseOperator):
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -435,9 +535,13 @@ class CloudDatastoreRunQueryOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = DatastoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = DatastoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         response = hook.run_query(
             body=self.body,
             project_id=self.project_id,
@@ -454,14 +558,23 @@ class CloudDatastoreGetOperationOperator(BaseOperator):
 
     :param name: the name of the operation resource.
     :type name: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ("name",)
+    template_fields = ("name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -469,6 +582,7 @@ class CloudDatastoreGetOperationOperator(BaseOperator):
         name: str,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -476,9 +590,13 @@ class CloudDatastoreGetOperationOperator(BaseOperator):
         self.name = name
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = DatastoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = DatastoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         op = hook.get_operation(name=self.name)
         return op
 
@@ -492,14 +610,23 @@ class CloudDatastoreDeleteOperationOperator(BaseOperator):
 
     :param name: the name of the operation resource.
     :type name: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ("name",)
+    template_fields = ("name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -507,6 +634,7 @@ class CloudDatastoreDeleteOperationOperator(BaseOperator):
         name: str,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -514,7 +642,11 @@ class CloudDatastoreDeleteOperationOperator(BaseOperator):
         self.name = name
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = DatastoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook = DatastoreHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook.delete_operation(name=self.name)

--- a/airflow/providers/google/cloud/operators/dlp.py
+++ b/airflow/providers/google/cloud/operators/dlp.py
@@ -59,9 +59,18 @@ class CloudDLPCancelDLPJobOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("dlp_job_id", "project_id", "gcp_conn_id")
+    template_fields = ("dlp_job_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -72,6 +81,7 @@ class CloudDLPCancelDLPJobOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -81,9 +91,13 @@ class CloudDLPCancelDLPJobOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook.cancel_dlp_job(
             dlp_job_id=self.dlp_job_id,
             project_id=self.project_id,
@@ -120,6 +134,16 @@ class CloudDLPCreateDeidentifyTemplateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.DeidentifyTemplate
     """
 
@@ -129,6 +153,7 @@ class CloudDLPCreateDeidentifyTemplateOperator(BaseOperator):
         "deidentify_template",
         "template_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -142,6 +167,7 @@ class CloudDLPCreateDeidentifyTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -153,9 +179,13 @@ class CloudDLPCreateDeidentifyTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             template = hook.create_deidentify_template(
                 organization_id=self.organization_id,
@@ -207,10 +237,21 @@ class CloudDLPCreateDLPJobOperator(BaseOperator):
     :type wait_until_finished: bool
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.DlpJob
     """
 
-    template_fields = ("project_id", "inspect_job", "risk_job", "job_id", "gcp_conn_id")
+    template_fields = ("project_id", "inspect_job", "risk_job", "job_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -224,6 +265,7 @@ class CloudDLPCreateDLPJobOperator(BaseOperator):
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         wait_until_finished: bool = True,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -236,9 +278,13 @@ class CloudDLPCreateDLPJobOperator(BaseOperator):
         self.metadata = metadata
         self.wait_until_finished = wait_until_finished
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             job = hook.create_dlp_job(
                 project_id=self.project_id,
@@ -288,6 +334,16 @@ class CloudDLPCreateInspectTemplateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.InspectTemplate
     """
 
@@ -297,6 +353,7 @@ class CloudDLPCreateInspectTemplateOperator(BaseOperator):
         "inspect_template",
         "template_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -310,6 +367,7 @@ class CloudDLPCreateInspectTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -321,9 +379,13 @@ class CloudDLPCreateInspectTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             template = hook.create_inspect_template(
                 organization_id=self.organization_id,
@@ -370,10 +432,21 @@ class CloudDLPCreateJobTriggerOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.JobTrigger
     """
 
-    template_fields = ("project_id", "job_trigger", "trigger_id", "gcp_conn_id")
+    template_fields = ("project_id", "job_trigger", "trigger_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -385,6 +458,7 @@ class CloudDLPCreateJobTriggerOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -395,9 +469,13 @@ class CloudDLPCreateJobTriggerOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             trigger = hook.create_job_trigger(
                 project_id=self.project_id,
@@ -444,6 +522,16 @@ class CloudDLPCreateStoredInfoTypeOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.StoredInfoType
     """
 
@@ -453,6 +541,7 @@ class CloudDLPCreateStoredInfoTypeOperator(BaseOperator):
         "config",
         "stored_info_type_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -466,6 +555,7 @@ class CloudDLPCreateStoredInfoTypeOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -477,9 +567,13 @@ class CloudDLPCreateStoredInfoTypeOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             info = hook.create_stored_info_type(
                 organization_id=self.organization_id,
@@ -538,6 +632,16 @@ class CloudDLPDeidentifyContentOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.DeidentifyContentResponse
     """
 
@@ -549,6 +653,7 @@ class CloudDLPDeidentifyContentOperator(BaseOperator):
         "inspect_template_name",
         "deidentify_template_name",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -564,6 +669,7 @@ class CloudDLPDeidentifyContentOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -577,9 +683,13 @@ class CloudDLPDeidentifyContentOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         response = hook.deidentify_content(
             project_id=self.project_id,
             deidentify_config=self.deidentify_config,
@@ -618,9 +728,19 @@ class CloudDLPDeleteDeidentifyTemplateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("template_id", "organization_id", "project_id", "gcp_conn_id")
+    template_fields = ("template_id", "organization_id", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -632,6 +752,7 @@ class CloudDLPDeleteDeidentifyTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -642,9 +763,13 @@ class CloudDLPDeleteDeidentifyTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             hook.delete_deidentify_template(
                 template_id=self.template_id,
@@ -680,9 +805,18 @@ class CloudDLPDeleteDLPJobOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("dlp_job_id", "project_id", "gcp_conn_id")
+    template_fields = ("dlp_job_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -693,6 +827,7 @@ class CloudDLPDeleteDLPJobOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -702,9 +837,13 @@ class CloudDLPDeleteDLPJobOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             hook.delete_dlp_job(
                 dlp_job_id=self.dlp_job_id,
@@ -741,9 +880,19 @@ class CloudDLPDeleteInspectTemplateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("template_id", "organization_id", "project_id", "gcp_conn_id")
+    template_fields = ("template_id", "organization_id", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -755,6 +904,7 @@ class CloudDLPDeleteInspectTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -765,9 +915,13 @@ class CloudDLPDeleteInspectTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             hook.delete_inspect_template(
                 template_id=self.template_id,
@@ -802,9 +956,18 @@ class CloudDLPDeleteJobTriggerOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("job_trigger_id", "project_id", "gcp_conn_id")
+    template_fields = ("job_trigger_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -815,6 +978,7 @@ class CloudDLPDeleteJobTriggerOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -824,9 +988,13 @@ class CloudDLPDeleteJobTriggerOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             hook.delete_job_trigger(
                 job_trigger_id=self.job_trigger_id,
@@ -863,6 +1031,15 @@ class CloudDLPDeleteStoredInfoTypeOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -870,6 +1047,7 @@ class CloudDLPDeleteStoredInfoTypeOperator(BaseOperator):
         "organization_id",
         "project_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -882,6 +1060,7 @@ class CloudDLPDeleteStoredInfoTypeOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -892,9 +1071,13 @@ class CloudDLPDeleteStoredInfoTypeOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             hook.delete_stored_info_type(
                 stored_info_type_id=self.stored_info_type_id,
@@ -932,10 +1115,21 @@ class CloudDLPGetDeidentifyTemplateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.DeidentifyTemplate
     """
 
-    template_fields = ("template_id", "organization_id", "project_id", "gcp_conn_id")
+    template_fields = ("template_id", "organization_id", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -947,6 +1141,7 @@ class CloudDLPGetDeidentifyTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -957,9 +1152,13 @@ class CloudDLPGetDeidentifyTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         template = hook.get_deidentify_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -992,10 +1191,20 @@ class CloudDLPGetDLPJobOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.DlpJob
     """
 
-    template_fields = ("dlp_job_id", "project_id", "gcp_conn_id")
+    template_fields = ("dlp_job_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1006,6 +1215,7 @@ class CloudDLPGetDLPJobOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1015,9 +1225,13 @@ class CloudDLPGetDLPJobOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         job = hook.get_dlp_job(
             dlp_job_id=self.dlp_job_id,
             project_id=self.project_id,
@@ -1052,10 +1266,21 @@ class CloudDLPGetInspectTemplateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.InspectTemplate
     """
 
-    template_fields = ("template_id", "organization_id", "project_id", "gcp_conn_id")
+    template_fields = ("template_id", "organization_id", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1067,6 +1292,7 @@ class CloudDLPGetInspectTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1077,9 +1303,13 @@ class CloudDLPGetInspectTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         template = hook.get_inspect_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -1112,10 +1342,20 @@ class CloudDLPGetDLPJobTriggerOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.JobTrigger
     """
 
-    template_fields = ("job_trigger_id", "project_id", "gcp_conn_id")
+    template_fields = ("job_trigger_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1126,6 +1366,7 @@ class CloudDLPGetDLPJobTriggerOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1135,9 +1376,13 @@ class CloudDLPGetDLPJobTriggerOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         trigger = hook.get_job_trigger(
             job_trigger_id=self.job_trigger_id,
             project_id=self.project_id,
@@ -1172,6 +1417,16 @@ class CloudDLPGetStoredInfoTypeOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.StoredInfoType
     """
 
@@ -1180,6 +1435,7 @@ class CloudDLPGetStoredInfoTypeOperator(BaseOperator):
         "organization_id",
         "project_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1192,6 +1448,7 @@ class CloudDLPGetStoredInfoTypeOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1202,9 +1459,13 @@ class CloudDLPGetStoredInfoTypeOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         info = hook.get_stored_info_type(
             stored_info_type_id=self.stored_info_type_id,
             organization_id=self.organization_id,
@@ -1244,6 +1505,16 @@ class CloudDLPInspectContentOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.tasks_v2.types.InspectContentResponse
     """
 
@@ -1253,6 +1524,7 @@ class CloudDLPInspectContentOperator(BaseOperator):
         "item",
         "inspect_template_name",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1266,6 +1538,7 @@ class CloudDLPInspectContentOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1277,9 +1550,13 @@ class CloudDLPInspectContentOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         response = hook.inspect_content(
             project_id=self.project_id,
             inspect_config=self.inspect_config,
@@ -1320,10 +1597,20 @@ class CloudDLPListDeidentifyTemplatesOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.dlp_v2.types.DeidentifyTemplate]
     """
 
-    template_fields = ("organization_id", "project_id", "gcp_conn_id")
+    template_fields = ("organization_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1336,6 +1623,7 @@ class CloudDLPListDeidentifyTemplatesOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1347,9 +1635,13 @@ class CloudDLPListDeidentifyTemplatesOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         template = hook.list_deidentify_templates(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -1391,10 +1683,20 @@ class CloudDLPListDLPJobsOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.dlp_v2.types.DlpJob]
     """
 
-    template_fields = ("project_id", "gcp_conn_id")
+    template_fields = ("project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1408,6 +1710,7 @@ class CloudDLPListDLPJobsOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1420,9 +1723,13 @@ class CloudDLPListDLPJobsOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         job = hook.list_dlp_jobs(
             project_id=self.project_id,
             results_filter=self.results_filter,
@@ -1457,10 +1764,20 @@ class CloudDLPListInfoTypesOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: ListInfoTypesResponse
     """
 
-    template_fields = ("language_code", "gcp_conn_id")
+    template_fields = ("language_code", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1471,6 +1788,7 @@ class CloudDLPListInfoTypesOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1480,9 +1798,13 @@ class CloudDLPListInfoTypesOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         response = hook.list_info_types(
             language_code=self.language_code,
             results_filter=self.results_filter,
@@ -1521,10 +1843,20 @@ class CloudDLPListInspectTemplatesOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.dlp_v2.types.InspectTemplate]
     """
 
-    template_fields = ("organization_id", "project_id", "gcp_conn_id")
+    template_fields = ("organization_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1537,6 +1869,7 @@ class CloudDLPListInspectTemplatesOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1548,9 +1881,13 @@ class CloudDLPListInspectTemplatesOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         templates = hook.list_inspect_templates(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -1590,10 +1927,20 @@ class CloudDLPListJobTriggersOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.dlp_v2.types.JobTrigger]
     """
 
-    template_fields = ("project_id", "gcp_conn_id")
+    template_fields = ("project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1606,6 +1953,7 @@ class CloudDLPListJobTriggersOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1617,9 +1965,13 @@ class CloudDLPListJobTriggersOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         jobs = hook.list_job_triggers(
             project_id=self.project_id,
             page_size=self.page_size,
@@ -1660,10 +2012,20 @@ class CloudDLPListStoredInfoTypesOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.dlp_v2.types.StoredInfoType]
     """
 
-    template_fields = ("organization_id", "project_id", "gcp_conn_id")
+    template_fields = ("organization_id", "project_id", "gcp_conn_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -1676,6 +2038,7 @@ class CloudDLPListStoredInfoTypesOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1687,9 +2050,13 @@ class CloudDLPListStoredInfoTypesOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         infos = hook.list_stored_info_types(
             organization_id=self.organization_id,
             project_id=self.project_id,
@@ -1734,6 +2101,16 @@ class CloudDLPRedactImageOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.RedactImageResponse
     """
 
@@ -1744,6 +2121,7 @@ class CloudDLPRedactImageOperator(BaseOperator):
         "include_findings",
         "byte_item",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1758,6 +2136,7 @@ class CloudDLPRedactImageOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1770,9 +2149,13 @@ class CloudDLPRedactImageOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         response = hook.redact_image(
             project_id=self.project_id,
             inspect_config=self.inspect_config,
@@ -1819,6 +2202,16 @@ class CloudDLPReidentifyContentOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.ReidentifyContentResponse
     """
 
@@ -1830,6 +2223,7 @@ class CloudDLPReidentifyContentOperator(BaseOperator):
         "inspect_template_name",
         "reidentify_template_name",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1845,6 +2239,7 @@ class CloudDLPReidentifyContentOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1858,9 +2253,13 @@ class CloudDLPReidentifyContentOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         response = hook.reidentify_content(
             project_id=self.project_id,
             reidentify_config=self.reidentify_config,
@@ -1903,6 +2302,16 @@ class CloudDLPUpdateDeidentifyTemplateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.DeidentifyTemplate
     """
 
@@ -1913,6 +2322,7 @@ class CloudDLPUpdateDeidentifyTemplateOperator(BaseOperator):
         "deidentify_template",
         "update_mask",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -1927,6 +2337,7 @@ class CloudDLPUpdateDeidentifyTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1939,9 +2350,13 @@ class CloudDLPUpdateDeidentifyTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         template = hook.update_deidentify_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -1983,6 +2398,16 @@ class CloudDLPUpdateInspectTemplateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.InspectTemplate
     """
 
@@ -1993,6 +2418,7 @@ class CloudDLPUpdateInspectTemplateOperator(BaseOperator):
         "inspect_template",
         "update_mask",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -2007,6 +2433,7 @@ class CloudDLPUpdateInspectTemplateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -2019,9 +2446,13 @@ class CloudDLPUpdateInspectTemplateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         template = hook.update_inspect_template(
             template_id=self.template_id,
             organization_id=self.organization_id,
@@ -2060,6 +2491,16 @@ class CloudDLPUpdateJobTriggerOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.InspectTemplate
     """
 
@@ -2069,6 +2510,7 @@ class CloudDLPUpdateJobTriggerOperator(BaseOperator):
         "job_trigger",
         "update_mask",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -2082,6 +2524,7 @@ class CloudDLPUpdateJobTriggerOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -2093,9 +2536,13 @@ class CloudDLPUpdateJobTriggerOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         trigger = hook.update_job_trigger(
             job_trigger_id=self.job_trigger_id,
             project_id=self.project_id,
@@ -2137,6 +2584,16 @@ class CloudDLPUpdateStoredInfoTypeOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.dlp_v2.types.StoredInfoType
     """
 
@@ -2147,6 +2604,7 @@ class CloudDLPUpdateStoredInfoTypeOperator(BaseOperator):
         "config",
         "update_mask",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -2161,6 +2619,7 @@ class CloudDLPUpdateStoredInfoTypeOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -2173,9 +2632,13 @@ class CloudDLPUpdateStoredInfoTypeOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudDLPHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudDLPHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         info = hook.update_stored_info_type(
             stored_info_type_id=self.stored_info_type_id,
             organization_id=self.organization_id,

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -22,7 +22,7 @@ This module contains Google Kubernetes Engine operators.
 
 import os
 import tempfile
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Sequence, Union
 
 from google.cloud.container_v1.types import Cluster
 
@@ -69,8 +69,18 @@ class GKEDeleteClusterOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: The api version to use
     :type api_version: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['project_id', 'gcp_conn_id', 'name', 'location', 'api_version']
+    template_fields = ['project_id', 'gcp_conn_id', 'name', 'location', 'api_version',
+                       'impersonation_chain', ]
 
     @apply_defaults
     def __init__(self,
@@ -80,6 +90,7 @@ class GKEDeleteClusterOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v2',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
 
@@ -88,6 +99,7 @@ class GKEDeleteClusterOperator(BaseOperator):
         self.location = location
         self.api_version = api_version
         self.name = name
+        self.impersonation_chain = impersonation_chain
         self._check_input()
 
     def _check_input(self):
@@ -97,7 +109,11 @@ class GKEDeleteClusterOperator(BaseOperator):
             raise AirflowException('Operator has incorrect or missing input.')
 
     def execute(self, context):
-        hook = GKEHook(gcp_conn_id=self.gcp_conn_id, location=self.location)
+        hook = GKEHook(
+            gcp_conn_id=self.gcp_conn_id,
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
+        )
         delete_result = hook.delete_cluster(name=self.name, project_id=self.project_id)
         return delete_result
 
@@ -148,8 +164,18 @@ class GKECreateClusterOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: The api version to use
     :type api_version: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['project_id', 'gcp_conn_id', 'location', 'api_version', 'body']
+    template_fields = ['project_id', 'gcp_conn_id', 'location', 'api_version', 'body',
+                       'impersonation_chain', ]
 
     @apply_defaults
     def __init__(self,
@@ -159,6 +185,7 @@ class GKECreateClusterOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v2',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
 
@@ -167,6 +194,7 @@ class GKECreateClusterOperator(BaseOperator):
         self.location = location
         self.api_version = api_version
         self.body = body
+        self.impersonation_chain = impersonation_chain
         self._check_input()
 
     def _check_input(self):
@@ -181,7 +209,11 @@ class GKECreateClusterOperator(BaseOperator):
             raise AirflowException("Operator has incorrect or missing input.")
 
     def execute(self, context):
-        hook = GKEHook(gcp_conn_id=self.gcp_conn_id, location=self.location)
+        hook = GKEHook(
+            gcp_conn_id=self.gcp_conn_id,
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
+        )
         create_op = hook.create_cluster(cluster=self.body, project_id=self.project_id)
         return create_op
 

--- a/airflow/providers/google/cloud/operators/life_sciences.py
+++ b/airflow/providers/google/cloud/operators/life_sciences.py
@@ -17,7 +17,7 @@
 # under the License.
 """Operators that interact with Google Cloud Life Sciences service."""
 
-from typing import Optional
+from typing import Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -44,9 +44,18 @@ class LifeSciencesRunPipelineOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: API version used (for example v2beta).
     :type api_version: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("body", "gcp_conn_id", "api_version")
+    template_fields = ("body", "gcp_conn_id", "api_version", "impersonation_chain",)
 
     @apply_defaults
     def __init__(self,
@@ -56,6 +65,7 @@ class LifeSciencesRunPipelineOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = "google_cloud_default",
                  api_version: str = "v2beta",
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.body = body
@@ -64,6 +74,7 @@ class LifeSciencesRunPipelineOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self._validate_inputs()
+        self.impersonation_chain = impersonation_chain
 
     def _validate_inputs(self):
         if not self.body:
@@ -72,7 +83,11 @@ class LifeSciencesRunPipelineOperator(BaseOperator):
             raise AirflowException("The required parameter 'location' is missing")
 
     def execute(self, context):
-        hook = LifeSciencesHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
+        hook = LifeSciencesHook(
+            gcp_conn_id=self.gcp_conn_id,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         return hook.run_pipeline(body=self.body,
                                  location=self.location,

--- a/airflow/providers/google/cloud/operators/natural_language.py
+++ b/airflow/providers/google/cloud/operators/natural_language.py
@@ -55,9 +55,18 @@ class CloudNaturalLanguageAnalyzeEntitiesOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START natural_language_analyze_entities_template_fields]
-    template_fields = ("document", "gcp_conn_id")
+    template_fields = ("document", "gcp_conn_id", "impersonation_chain",)
     # [END natural_language_analyze_entities_template_fields]
 
     @apply_defaults
@@ -69,6 +78,7 @@ class CloudNaturalLanguageAnalyzeEntitiesOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -78,9 +88,13 @@ class CloudNaturalLanguageAnalyzeEntitiesOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudNaturalLanguageHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudNaturalLanguageHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Start analyzing entities")
         response = hook.analyze_entities(
@@ -114,10 +128,20 @@ class CloudNaturalLanguageAnalyzeEntitySentimentOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.language_v1.types.AnalyzeEntitiesResponse
     """
     # [START natural_language_analyze_entity_sentiment_template_fields]
-    template_fields = ("document", "gcp_conn_id")
+    template_fields = ("document", "gcp_conn_id", "impersonation_chain",)
     # [END natural_language_analyze_entity_sentiment_template_fields]
 
     @apply_defaults
@@ -129,6 +153,7 @@ class CloudNaturalLanguageAnalyzeEntitySentimentOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -138,9 +163,13 @@ class CloudNaturalLanguageAnalyzeEntitySentimentOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudNaturalLanguageHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudNaturalLanguageHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Start entity sentiment analyze")
         response = hook.analyze_entity_sentiment(
@@ -177,10 +206,20 @@ class CloudNaturalLanguageAnalyzeSentimentOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.language_v1.types.AnalyzeEntitiesResponse
     """
     # [START natural_language_analyze_sentiment_template_fields]
-    template_fields = ("document", "gcp_conn_id")
+    template_fields = ("document", "gcp_conn_id", "impersonation_chain",)
     # [END natural_language_analyze_sentiment_template_fields]
 
     @apply_defaults
@@ -192,6 +231,7 @@ class CloudNaturalLanguageAnalyzeSentimentOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -201,9 +241,13 @@ class CloudNaturalLanguageAnalyzeSentimentOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudNaturalLanguageHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudNaturalLanguageHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Start sentiment analyze")
         response = hook.analyze_sentiment(
@@ -234,9 +278,18 @@ class CloudNaturalLanguageClassifyTextOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START natural_language_classify_text_template_fields]
-    template_fields = ("document", "gcp_conn_id")
+    template_fields = ("document", "gcp_conn_id", "impersonation_chain",)
     # [END natural_language_classify_text_template_fields]
 
     @apply_defaults
@@ -247,6 +300,7 @@ class CloudNaturalLanguageClassifyTextOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -255,9 +309,13 @@ class CloudNaturalLanguageClassifyTextOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudNaturalLanguageHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudNaturalLanguageHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Start text classify")
         response = hook.classify_text(

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -76,9 +76,9 @@ class PubSubCreateTopicOperator(BaseOperator):
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud Platform.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request
-        must have domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param labels: Client-assigned labels; see
         https://cloud.google.com/pubsub/docs/labels
@@ -105,8 +105,17 @@ class PubSubCreateTopicOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]]
     :param project: (Deprecated) the GCP project ID where the topic will be created
     :type project: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['project_id', 'topic']
+    template_fields = ['project_id', 'topic', 'impersonation_chain', ]
     ui_color = '#0273d4'
 
     # pylint: disable=too-many-arguments
@@ -125,6 +134,7 @@ class PubSubCreateTopicOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         project: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         # To preserve backward compatibility
@@ -147,10 +157,14 @@ class PubSubCreateTopicOperator(BaseOperator):
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
-                          delegate_to=self.delegate_to)
+        hook = PubSubHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Creating topic %s", self.topic)
         hook.create_topic(
@@ -237,9 +251,9 @@ class PubSubCreateSubscriptionOperator(BaseOperator):
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud Platform.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request
-        must have domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param push_config: If push delivery is used with this subscription,
         this field is used to configure it. An empty ``pushConfig`` signifies
@@ -301,11 +315,21 @@ class PubSubCreateSubscriptionOperator(BaseOperator):
     :param subscription_project: (Deprecated) the GCP project ID where the subscription
         will be created. If empty, ``topic_project`` will be used.
     :type subscription_project: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['project_id', 'topic', 'subscription', 'subscription_project_id']
+    template_fields = ['project_id', 'topic', 'subscription', 'subscription_project_id',
+                       'impersonation_chain', ]
     ui_color = '#0273d4'
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-locals
     @apply_defaults
     def __init__(
         self, *,
@@ -331,6 +355,7 @@ class PubSubCreateSubscriptionOperator(BaseOperator):
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         topic_project: Optional[str] = None,
         subscription_project: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
 
@@ -368,10 +393,14 @@ class PubSubCreateSubscriptionOperator(BaseOperator):
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
-                          delegate_to=self.delegate_to)
+        hook = PubSubHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Creating subscription for topic %s", self.topic)
         result = hook.create_subscription(
@@ -441,9 +470,9 @@ class PubSubDeleteTopicOperator(BaseOperator):
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud Platform.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request
-        must have domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param retry: (Optional) A retry object used to retry requests.
         If None is specified, requests will not be retried.
@@ -456,8 +485,17 @@ class PubSubDeleteTopicOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]]
     :param project: (Deprecated) the GCP project ID where the topic will be created
     :type project: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['project_id', 'topic']
+    template_fields = ['project_id', 'topic', 'impersonation_chain', ]
     ui_color = '#cb4335'
 
     @apply_defaults
@@ -472,6 +510,7 @@ class PubSubDeleteTopicOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         project: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         # To preserve backward compatibility
@@ -491,10 +530,14 @@ class PubSubDeleteTopicOperator(BaseOperator):
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
-                          delegate_to=self.delegate_to)
+        hook = PubSubHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Deleting topic %s", self.topic)
         hook.delete_topic(
@@ -552,9 +595,9 @@ class PubSubDeleteSubscriptionOperator(BaseOperator):
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud Platform.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request
-        must have domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param retry: (Optional) A retry object used to retry requests.
         If None is specified, requests will not be retried.
@@ -567,8 +610,17 @@ class PubSubDeleteSubscriptionOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]]
     :param project: (Deprecated) the GCP project ID where the topic will be created
     :type project: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['project_id', 'subscription']
+    template_fields = ['project_id', 'subscription', 'impersonation_chain', ]
     ui_color = '#cb4335'
 
     @apply_defaults
@@ -583,6 +635,7 @@ class PubSubDeleteSubscriptionOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
         project: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         # To preserve backward compatibility
@@ -602,10 +655,14 @@ class PubSubDeleteSubscriptionOperator(BaseOperator):
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
-                          delegate_to=self.delegate_to)
+        hook = PubSubHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Deleting subscription %s", self.subscription)
         hook.delete_subscription(
@@ -665,14 +722,23 @@ class PubSubPublishMessageOperator(BaseOperator):
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud Platform.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request
-        must have domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param project: (Deprecated) the GCP project ID where the topic will be created
     :type project: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['project_id', 'topic', 'messages']
+    template_fields = ['project_id', 'topic', 'messages', 'impersonation_chain', ]
     ui_color = '#0273d4'
 
     @apply_defaults
@@ -684,6 +750,7 @@ class PubSubPublishMessageOperator(BaseOperator):
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
         project: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         # To preserve backward compatibility
@@ -700,10 +767,14 @@ class PubSubPublishMessageOperator(BaseOperator):
         self.messages = messages
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
-                          delegate_to=self.delegate_to)
+        hook = PubSubHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Publishing to topic %s", self.topic)
         hook.publish(project_id=self.project_id, topic=self.topic, messages=self.messages)
@@ -746,9 +817,9 @@ class PubSubPullOperator(BaseOperator):
     :param gcp_conn_id: The connection ID to use connecting to
         Google Cloud Platform.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request
-        must have domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param messages_callback: (Optional) Callback to process received messages.
         It's return value will be saved to XCom.
@@ -756,8 +827,17 @@ class PubSubPullOperator(BaseOperator):
         If not provided, the default implementation will convert `ReceivedMessage` objects
         into JSON-serializable dicts using `google.protobuf.json_format.MessageToDict` function.
     :type messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]]
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ['project_id', 'subscription']
+    template_fields = ['project_id', 'subscription', 'impersonation_chain', ]
 
     @apply_defaults
     def __init__(
@@ -769,6 +849,7 @@ class PubSubPullOperator(BaseOperator):
         messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]] = None,
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -779,11 +860,13 @@ class PubSubPullOperator(BaseOperator):
         self.max_messages = max_messages
         self.ack_messages = ack_messages
         self.messages_callback = messages_callback
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         hook = PubSubHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         pulled_messages = hook.pull(

--- a/airflow/providers/google/cloud/operators/spanner.py
+++ b/airflow/providers/google/cloud/operators/spanner.py
@@ -18,7 +18,7 @@
 """
 This module contains Google Spanner operators.
 """
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -53,10 +53,19 @@ class SpannerDeployInstanceOperator(BaseOperator):
     :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_spanner_deploy_template_fields]
     template_fields = ('project_id', 'instance_id', 'configuration_name', 'display_name',
-                       'gcp_conn_id')
+                       'gcp_conn_id', 'impersonation_chain', )
     # [END gcp_spanner_deploy_template_fields]
 
     @apply_defaults
@@ -67,6 +76,7 @@ class SpannerDeployInstanceOperator(BaseOperator):
                  display_name: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.instance_id = instance_id
         self.project_id = project_id
@@ -75,6 +85,7 @@ class SpannerDeployInstanceOperator(BaseOperator):
         self.display_name = display_name
         self.gcp_conn_id = gcp_conn_id
         self._validate_inputs()
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def _validate_inputs(self):
@@ -85,7 +96,10 @@ class SpannerDeployInstanceOperator(BaseOperator):
                                    "is empty or None")
 
     def execute(self, context):
-        hook = SpannerHook(gcp_conn_id=self.gcp_conn_id)
+        hook = SpannerHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         if not hook.get_instance(project_id=self.project_id, instance_id=self.instance_id):
             self.log.info("Creating Cloud Spanner instance '%s'", self.instance_id)
             func = hook.create_instance
@@ -115,9 +129,18 @@ class SpannerDeleteInstanceOperator(BaseOperator):
     :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_spanner_delete_template_fields]
-    template_fields = ('project_id', 'instance_id', 'gcp_conn_id')
+    template_fields = ('project_id', 'instance_id', 'gcp_conn_id', 'impersonation_chain',)
     # [END gcp_spanner_delete_template_fields]
 
     @apply_defaults
@@ -125,11 +148,13 @@ class SpannerDeleteInstanceOperator(BaseOperator):
                  instance_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.instance_id = instance_id
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self._validate_inputs()
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def _validate_inputs(self):
@@ -140,7 +165,10 @@ class SpannerDeleteInstanceOperator(BaseOperator):
                                    "is empty or None")
 
     def execute(self, context):
-        hook = SpannerHook(gcp_conn_id=self.gcp_conn_id)
+        hook = SpannerHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         if hook.get_instance(project_id=self.project_id, instance_id=self.instance_id):
             return hook.delete_instance(project_id=self.project_id,
                                         instance_id=self.instance_id)
@@ -170,9 +198,19 @@ class SpannerQueryDatabaseInstanceOperator(BaseOperator):
     :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_spanner_query_template_fields]
-    template_fields = ('project_id', 'instance_id', 'database_id', 'query', 'gcp_conn_id')
+    template_fields = ('project_id', 'instance_id', 'database_id', 'query', 'gcp_conn_id',
+                       'impersonation_chain',)
     template_ext = ('.sql',)
     # [END gcp_spanner_query_template_fields]
 
@@ -183,6 +221,7 @@ class SpannerQueryDatabaseInstanceOperator(BaseOperator):
                  query: Union[str, List[str]],
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.instance_id = instance_id
         self.project_id = project_id
@@ -190,6 +229,7 @@ class SpannerQueryDatabaseInstanceOperator(BaseOperator):
         self.query = query
         self.gcp_conn_id = gcp_conn_id
         self._validate_inputs()
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def _validate_inputs(self):
@@ -205,7 +245,10 @@ class SpannerQueryDatabaseInstanceOperator(BaseOperator):
             raise AirflowException("The required parameter 'query' is empty")
 
     def execute(self, context):
-        hook = SpannerHook(gcp_conn_id=self.gcp_conn_id)
+        hook = SpannerHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         queries = self.query
         if isinstance(self.query, str):
             queries = [x.strip() for x in self.query.split(';')]
@@ -252,10 +295,19 @@ class SpannerDeployDatabaseInstanceOperator(BaseOperator):
     :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_spanner_database_deploy_template_fields]
     template_fields = ('project_id', 'instance_id', 'database_id', 'ddl_statements',
-                       'gcp_conn_id')
+                       'gcp_conn_id', 'impersonation_chain',)
     template_ext = ('.sql', )
     # [END gcp_spanner_database_deploy_template_fields]
 
@@ -266,6 +318,7 @@ class SpannerDeployDatabaseInstanceOperator(BaseOperator):
                  ddl_statements: List[str],
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.instance_id = instance_id
         self.project_id = project_id
@@ -273,6 +326,7 @@ class SpannerDeployDatabaseInstanceOperator(BaseOperator):
         self.ddl_statements = ddl_statements
         self.gcp_conn_id = gcp_conn_id
         self._validate_inputs()
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def _validate_inputs(self):
@@ -286,7 +340,10 @@ class SpannerDeployDatabaseInstanceOperator(BaseOperator):
                                    " or None")
 
     def execute(self, context):
-        hook = SpannerHook(gcp_conn_id=self.gcp_conn_id)
+        hook = SpannerHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         if not hook.get_database(project_id=self.project_id,
                                  instance_id=self.instance_id,
                                  database_id=self.database_id):
@@ -326,10 +383,19 @@ class SpannerUpdateDatabaseInstanceOperator(BaseOperator):
     :type operation_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_spanner_database_update_template_fields]
     template_fields = ('project_id', 'instance_id', 'database_id', 'ddl_statements',
-                       'gcp_conn_id')
+                       'gcp_conn_id', 'impersonation_chain',)
     template_ext = ('.sql', )
     # [END gcp_spanner_database_update_template_fields]
 
@@ -341,6 +407,7 @@ class SpannerUpdateDatabaseInstanceOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  operation_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.instance_id = instance_id
         self.project_id = project_id
@@ -349,6 +416,7 @@ class SpannerUpdateDatabaseInstanceOperator(BaseOperator):
         self.operation_id = operation_id
         self.gcp_conn_id = gcp_conn_id
         self._validate_inputs()
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def _validate_inputs(self):
@@ -365,7 +433,10 @@ class SpannerUpdateDatabaseInstanceOperator(BaseOperator):
                                    " or None")
 
     def execute(self, context):
-        hook = SpannerHook(gcp_conn_id=self.gcp_conn_id)
+        hook = SpannerHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         if not hook.get_database(project_id=self.project_id,
                                  instance_id=self.instance_id,
                                  database_id=self.database_id):
@@ -399,10 +470,19 @@ class SpannerDeleteDatabaseInstanceOperator(BaseOperator):
     :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_spanner_database_delete_template_fields]
     template_fields = ('project_id', 'instance_id', 'database_id',
-                       'gcp_conn_id')
+                       'gcp_conn_id', 'impersonation_chain',)
     # [END gcp_spanner_database_delete_template_fields]
 
     @apply_defaults
@@ -411,12 +491,14 @@ class SpannerDeleteDatabaseInstanceOperator(BaseOperator):
                  database_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         self.instance_id = instance_id
         self.project_id = project_id
         self.database_id = database_id
         self.gcp_conn_id = gcp_conn_id
         self._validate_inputs()
+        self.impersonation_chain = impersonation_chain
         super().__init__(**kwargs)
 
     def _validate_inputs(self):
@@ -430,7 +512,10 @@ class SpannerDeleteDatabaseInstanceOperator(BaseOperator):
                                    " or None")
 
     def execute(self, context):
-        hook = SpannerHook(gcp_conn_id=self.gcp_conn_id)
+        hook = SpannerHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         database = hook.get_database(project_id=self.project_id,
                                      instance_id=self.instance_id,
                                      database_id=self.database_id)

--- a/airflow/providers/google/cloud/operators/stackdriver.py
+++ b/airflow/providers/google/cloud/operators/stackdriver.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Optional
+from typing import Optional, Sequence, Union
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -70,13 +70,22 @@ class StackdriverListAlertPoliciesOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project to fetch alerts from.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('filter_',)
+    template_fields = ('filter_', 'impersonation_chain',)
     ui_color = "#e5ffcc"
 
     # pylint: disable=too-many-arguments
@@ -93,6 +102,7 @@ class StackdriverListAlertPoliciesOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -106,13 +116,18 @@ class StackdriverListAlertPoliciesOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('List Alert Policies: Project id: %s Format: %s Filter: %s Order By: %s Page Size: %d',
                       self.project_id, self.format_, self.filter_, self.order_by, self.page_size)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
 
         return self.hook.list_alert_policies(
             project_id=self.project_id,
@@ -153,13 +168,22 @@ class StackdriverEnableAlertPoliciesOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project in which alert needs to be enabled.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     ui_color = "#e5ffcc"
-    template_fields = ('filter_',)
+    template_fields = ('filter_', 'impersonation_chain',)
 
     @apply_defaults
     def __init__(
@@ -171,6 +195,7 @@ class StackdriverEnableAlertPoliciesOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -181,12 +206,17 @@ class StackdriverEnableAlertPoliciesOperator(BaseOperator):
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('Enable Alert Policies: Project id: %s Filter: %s', self.project_id, self.filter_)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         self.hook.enable_alert_policies(
             filter_=self.filter_,
             project_id=self.project_id,
@@ -224,14 +254,23 @@ class StackdriverDisableAlertPoliciesOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project in which alert needs to be disabled.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     ui_color = "#e5ffcc"
-    template_fields = ('filter_',)
+    template_fields = ('filter_', 'impersonation_chain',)
 
     @apply_defaults
     def __init__(
@@ -243,6 +282,7 @@ class StackdriverDisableAlertPoliciesOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -253,12 +293,17 @@ class StackdriverDisableAlertPoliciesOperator(BaseOperator):
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('Disable Alert Policies: Project id: %s Filter: %s', self.project_id, self.filter_)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         self.hook.disable_alert_policies(
             filter_=self.filter_,
             project_id=self.project_id,
@@ -296,13 +341,22 @@ class StackdriverUpsertAlertOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project in which alert needs to be created/updated.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('alerts',)
+    template_fields = ('alerts', 'impersonation_chain',)
     template_ext = ('.json',)
 
     ui_color = "#e5ffcc"
@@ -317,6 +371,7 @@ class StackdriverUpsertAlertOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -327,12 +382,17 @@ class StackdriverUpsertAlertOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('Upsert Alert Policies: Alerts: %s Project id: %s', self.alerts, self.project_id)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         self.hook.upsert_alert(
             alerts=self.alerts,
             project_id=self.project_id,
@@ -367,13 +427,22 @@ class StackdriverDeleteAlertOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project from which alert needs to be deleted.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('name',)
+    template_fields = ('name', 'impersonation_chain',)
 
     ui_color = "#e5ffcc"
 
@@ -387,6 +456,7 @@ class StackdriverDeleteAlertOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -397,12 +467,17 @@ class StackdriverDeleteAlertOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('Delete Alert Policy: Project id: %s Name: %s', self.project_id, self.name)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         self.hook.delete_alert_policy(
             name=self.name,
             retry=self.retry,
@@ -456,13 +531,22 @@ class StackdriverListNotificationChannelsOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project to fetch notification channels from.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('filter_',)
+    template_fields = ('filter_', 'impersonation_chain',)
 
     ui_color = "#e5ffcc"
 
@@ -480,6 +564,7 @@ class StackdriverListNotificationChannelsOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -493,6 +578,7 @@ class StackdriverListNotificationChannelsOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
@@ -501,7 +587,11 @@ class StackdriverListNotificationChannelsOperator(BaseOperator):
             self.project_id, self.format_, self.filter_, self.order_by, self.page_size
         )
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         return self.hook.list_notification_channels(
             format_=self.format_,
             project_id=self.project_id,
@@ -541,13 +631,22 @@ class StackdriverEnableNotificationChannelsOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The location used for the operation.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('filter_',)
+    template_fields = ('filter_', 'impersonation_chain',)
 
     ui_color = "#e5ffcc"
 
@@ -561,6 +660,7 @@ class StackdriverEnableNotificationChannelsOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -571,13 +671,18 @@ class StackdriverEnableNotificationChannelsOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('Enable Notification Channels: Project id: %s Filter: %s',
                       self.project_id, self.filter_)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         self.hook.enable_notification_channels(
             filter_=self.filter_,
             project_id=self.project_id,
@@ -614,13 +719,22 @@ class StackdriverDisableNotificationChannelsOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project in which notification channels needs to be enabled.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('filter_',)
+    template_fields = ('filter_', 'impersonation_chain',)
 
     ui_color = "#e5ffcc"
 
@@ -634,6 +748,7 @@ class StackdriverDisableNotificationChannelsOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -644,13 +759,18 @@ class StackdriverDisableNotificationChannelsOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('Disable Notification Channels: Project id: %s Filter: %s',
                       self.project_id, self.filter_)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         self.hook.disable_notification_channels(
             filter_=self.filter_,
             project_id=self.project_id,
@@ -688,13 +808,22 @@ class StackdriverUpsertNotificationChannelOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project in which notification channels needs to be created/updated.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('channels',)
+    template_fields = ('channels', 'impersonation_chain',)
     template_ext = ('.json',)
 
     ui_color = "#e5ffcc"
@@ -709,6 +838,7 @@ class StackdriverUpsertNotificationChannelOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -719,13 +849,18 @@ class StackdriverUpsertNotificationChannelOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('Upsert Notification Channels: Channels: %s Project id: %s',
                       self.channels, self.project_id)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         self.hook.upsert_channel(
             channels=self.channels,
             project_id=self.project_id,
@@ -760,13 +895,22 @@ class StackdriverDeleteNotificationChannelOperator(BaseOperator):
     :type gcp_conn_id: str
     :param project_id: The project from which notification channel needs to be deleted.
     :type project_id: str
-    :param delegate_to: (Optional) The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('name',)
+    template_fields = ('name', 'impersonation_chain',)
 
     ui_color = "#e5ffcc"
 
@@ -780,6 +924,7 @@ class StackdriverDeleteNotificationChannelOperator(BaseOperator):
         gcp_conn_id: Optional[str] = 'google_cloud_default',
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -790,12 +935,17 @@ class StackdriverDeleteNotificationChannelOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.project_id = project_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def execute(self, context):
         self.log.info('Delete Notification Channel: Project id: %s Name: %s', self.project_id, self.name)
         if self.hook is None:
-            self.hook = StackdriverHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+            self.hook = StackdriverHook(
+                gcp_conn_id=self.gcp_conn_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
+            )
         self.hook.delete_notification_channel(
             name=self.name,
             retry=self.retry,

--- a/airflow/providers/google/cloud/operators/tasks.py
+++ b/airflow/providers/google/cloud/operators/tasks.py
@@ -63,6 +63,16 @@ class CloudTasksQueueCreateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.tasks_v2.types.Queue
     """
 
@@ -72,6 +82,7 @@ class CloudTasksQueueCreateOperator(BaseOperator):
         "location",
         "queue_name",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -85,6 +96,7 @@ class CloudTasksQueueCreateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -96,9 +108,13 @@ class CloudTasksQueueCreateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             queue = hook.create_queue(
                 location=self.location,
@@ -154,6 +170,16 @@ class CloudTasksQueueUpdateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.tasks_v2.types.Queue
     """
 
@@ -164,6 +190,7 @@ class CloudTasksQueueUpdateOperator(BaseOperator):
         "queue_name",
         "update_mask",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -178,6 +205,7 @@ class CloudTasksQueueUpdateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -190,9 +218,13 @@ class CloudTasksQueueUpdateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         queue = hook.update_queue(
             task_queue=self.task_queue,
             project_id=self.project_id,
@@ -228,10 +260,21 @@ class CloudTasksQueueGetOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.tasks_v2.types.Queue
     """
 
-    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id")
+    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -243,6 +286,7 @@ class CloudTasksQueueGetOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -253,9 +297,13 @@ class CloudTasksQueueGetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         queue = hook.get_queue(
             location=self.location,
             queue_name=self.queue_name,
@@ -292,10 +340,21 @@ class CloudTasksQueuesListOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.tasks_v2.types.Queue]
     """
 
-    template_fields = ("location", "project_id", "gcp_conn_id")
+    template_fields = ("location", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -308,6 +367,7 @@ class CloudTasksQueuesListOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -319,9 +379,13 @@ class CloudTasksQueuesListOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         queues = hook.list_queues(
             location=self.location,
             project_id=self.project_id,
@@ -356,9 +420,19 @@ class CloudTasksQueueDeleteOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id")
+    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -370,6 +444,7 @@ class CloudTasksQueueDeleteOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -380,9 +455,13 @@ class CloudTasksQueueDeleteOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook.delete_queue(
             location=self.location,
             queue_name=self.queue_name,
@@ -415,10 +494,21 @@ class CloudTasksQueuePurgeOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.tasks_v2.types.Queue]
     """
 
-    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id")
+    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -430,6 +520,7 @@ class CloudTasksQueuePurgeOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -440,9 +531,13 @@ class CloudTasksQueuePurgeOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         queue = hook.purge_queue(
             location=self.location,
             queue_name=self.queue_name,
@@ -476,10 +571,21 @@ class CloudTasksQueuePauseOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.tasks_v2.types.Queue]
     """
 
-    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id")
+    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -491,6 +597,7 @@ class CloudTasksQueuePauseOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -501,9 +608,13 @@ class CloudTasksQueuePauseOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         queues = hook.pause_queue(
             location=self.location,
             queue_name=self.queue_name,
@@ -537,10 +648,21 @@ class CloudTasksQueueResumeOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.tasks_v2.types.Queue]
     """
 
-    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id")
+    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -552,6 +674,7 @@ class CloudTasksQueueResumeOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -562,9 +685,13 @@ class CloudTasksQueueResumeOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         queue = hook.resume_queue(
             location=self.location,
             queue_name=self.queue_name,
@@ -607,6 +734,16 @@ class CloudTasksTaskCreateOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.tasks_v2.types.Task
     """
 
@@ -617,6 +754,7 @@ class CloudTasksTaskCreateOperator(BaseOperator):
         "queue_name",
         "task_name",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -632,6 +770,7 @@ class CloudTasksTaskCreateOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -645,9 +784,13 @@ class CloudTasksTaskCreateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         task = hook.create_task(
             location=self.location,
             queue_name=self.queue_name,
@@ -689,6 +832,16 @@ class CloudTasksTaskGetOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.tasks_v2.types.Task
     """
 
@@ -698,6 +851,7 @@ class CloudTasksTaskGetOperator(BaseOperator):
         "task_name",
         "project_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -712,6 +866,7 @@ class CloudTasksTaskGetOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -724,9 +879,13 @@ class CloudTasksTaskGetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         task = hook.get_task(
             location=self.location,
             queue_name=self.queue_name,
@@ -768,10 +927,21 @@ class CloudTasksTasksListOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: list[google.cloud.tasks_v2.types.Task]
     """
 
-    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id")
+    template_fields = ("location", "queue_name", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -785,6 +955,7 @@ class CloudTasksTasksListOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -797,9 +968,13 @@ class CloudTasksTasksListOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         tasks = hook.list_tasks(
             location=self.location,
             queue_name=self.queue_name,
@@ -837,6 +1012,15 @@ class CloudTasksTaskDeleteOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -845,6 +1029,7 @@ class CloudTasksTaskDeleteOperator(BaseOperator):
         "task_name",
         "project_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -858,6 +1043,7 @@ class CloudTasksTaskDeleteOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -869,9 +1055,13 @@ class CloudTasksTaskDeleteOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook.delete_task(
             location=self.location,
             queue_name=self.queue_name,
@@ -910,6 +1100,16 @@ class CloudTasksTaskRunOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :rtype: google.cloud.tasks_v2.types.Task
     """
 
@@ -919,6 +1119,7 @@ class CloudTasksTaskRunOperator(BaseOperator):
         "task_name",
         "project_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -933,6 +1134,7 @@ class CloudTasksTaskRunOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -945,9 +1147,13 @@ class CloudTasksTaskRunOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudTasksHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTasksHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         task = hook.run_task(
             location=self.location,
             queue_name=self.queue_name,

--- a/airflow/providers/google/cloud/operators/video_intelligence.py
+++ b/airflow/providers/google/cloud/operators/video_intelligence.py
@@ -18,7 +18,7 @@
 """
 This module contains Google Cloud Vision operators.
 """
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Sequence, Union
 
 from google.api_core.retry import Retry
 from google.cloud.videointelligence_v1 import enums
@@ -64,9 +64,18 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to ``google_cloud_default``.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_video_intelligence_detect_labels_template_fields]
-    template_fields = ("input_uri", "output_uri", "gcp_conn_id")
+    template_fields = ("input_uri", "output_uri", "gcp_conn_id", "impersonation_chain",)
     # [END gcp_video_intelligence_detect_labels_template_fields]
 
     @apply_defaults
@@ -80,6 +89,7 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -91,9 +101,13 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
         self.timeout = timeout
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVideoIntelligenceHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVideoIntelligenceHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         operation = hook.annotate_video(
             input_uri=self.input_uri,
             input_content=self.input_content,
@@ -143,9 +157,18 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to ``google_cloud_default``.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_video_intelligence_detect_explicit_content_template_fields]
-    template_fields = ("input_uri", "output_uri", "gcp_conn_id")
+    template_fields = ("input_uri", "output_uri", "gcp_conn_id", "impersonation_chain",)
     # [END gcp_video_intelligence_detect_explicit_content_template_fields]
 
     @apply_defaults
@@ -159,6 +182,7 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -170,9 +194,13 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
         self.timeout = timeout
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVideoIntelligenceHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVideoIntelligenceHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         operation = hook.annotate_video(
             input_uri=self.input_uri,
             input_content=self.input_content,
@@ -222,9 +250,18 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to ``google_cloud_default``.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START gcp_video_intelligence_detect_video_shots_template_fields]
-    template_fields = ("input_uri", "output_uri", "gcp_conn_id")
+    template_fields = ("input_uri", "output_uri", "gcp_conn_id", "impersonation_chain",)
     # [END gcp_video_intelligence_detect_video_shots_template_fields]
 
     @apply_defaults
@@ -238,6 +275,7 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -249,9 +287,13 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
         self.timeout = timeout
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVideoIntelligenceHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVideoIntelligenceHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         operation = hook.annotate_video(
             input_uri=self.input_uri,
             input_content=self.input_content,

--- a/airflow/providers/google/cloud/operators/vision.py
+++ b/airflow/providers/google/cloud/operators/vision.py
@@ -68,9 +68,19 @@ class CloudVisionCreateProductSetOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_productset_create_template_fields]
-    template_fields = ("location", "project_id", "product_set_id", "gcp_conn_id")
+    template_fields = ("location", "project_id", "product_set_id", "gcp_conn_id",
+                       "impersonation_chain",)
     # [END vision_productset_create_template_fields]
 
     @apply_defaults
@@ -84,6 +94,7 @@ class CloudVisionCreateProductSetOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -95,9 +106,13 @@ class CloudVisionCreateProductSetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             return hook.create_product_set(
                 location=self.location,
@@ -143,9 +158,19 @@ class CloudVisionGetProductSetOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_productset_get_template_fields]
-    template_fields = ('location', 'project_id', 'product_set_id', 'gcp_conn_id')
+    template_fields = ('location', 'project_id', 'product_set_id', 'gcp_conn_id',
+                       'impersonation_chain',)
     # [END vision_productset_get_template_fields]
 
     @apply_defaults
@@ -158,6 +183,7 @@ class CloudVisionGetProductSetOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -168,9 +194,13 @@ class CloudVisionGetProductSetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.get_product_set(
             location=self.location,
             product_set_id=self.product_set_id,
@@ -227,9 +257,19 @@ class CloudVisionUpdateProductSetOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_productset_update_template_fields]
-    template_fields = ('location', 'project_id', 'product_set_id', 'gcp_conn_id')
+    template_fields = ('location', 'project_id', 'product_set_id', 'gcp_conn_id',
+                       'impersonation_chain',)
     # [END vision_productset_update_template_fields]
 
     @apply_defaults
@@ -244,6 +284,7 @@ class CloudVisionUpdateProductSetOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -256,9 +297,13 @@ class CloudVisionUpdateProductSetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.update_product_set(
             location=self.location,
             product_set_id=self.product_set_id,
@@ -300,9 +345,19 @@ class CloudVisionDeleteProductSetOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_productset_delete_template_fields]
-    template_fields = ('location', 'project_id', 'product_set_id', 'gcp_conn_id')
+    template_fields = ('location', 'project_id', 'product_set_id', 'gcp_conn_id',
+                       'impersonation_chain',)
     # [END vision_productset_delete_template_fields]
 
     @apply_defaults
@@ -315,6 +370,7 @@ class CloudVisionDeleteProductSetOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -325,9 +381,13 @@ class CloudVisionDeleteProductSetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook.delete_product_set(
             location=self.location,
             product_set_id=self.product_set_id,
@@ -377,9 +437,19 @@ class CloudVisionCreateProductOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_product_create_template_fields]
-    template_fields = ('location', 'project_id', 'product_id', 'gcp_conn_id')
+    template_fields = ('location', 'project_id', 'product_id', 'gcp_conn_id',
+                       'impersonation_chain',)
     # [END vision_product_create_template_fields]
 
     @apply_defaults
@@ -393,6 +463,7 @@ class CloudVisionCreateProductOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -404,9 +475,13 @@ class CloudVisionCreateProductOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         try:
             return hook.create_product(
                 location=self.location,
@@ -455,9 +530,19 @@ class CloudVisionGetProductOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_product_get_template_fields]
-    template_fields = ('location', 'project_id', 'product_id', 'gcp_conn_id')
+    template_fields = ('location', 'project_id', 'product_id', 'gcp_conn_id',
+                       'impersonation_chain',)
     # [END vision_product_get_template_fields]
 
     @apply_defaults
@@ -470,6 +555,7 @@ class CloudVisionGetProductOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -480,9 +566,13 @@ class CloudVisionGetProductOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.get_product(
             location=self.location,
             product_id=self.product_id,
@@ -550,9 +640,19 @@ class CloudVisionUpdateProductOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_product_update_template_fields]
-    template_fields = ('location', 'project_id', 'product_id', 'gcp_conn_id')
+    template_fields = ('location', 'project_id', 'product_id', 'gcp_conn_id',
+                       'impersonation_chain',)
     # [END vision_product_update_template_fields]
 
     @apply_defaults
@@ -567,6 +667,7 @@ class CloudVisionUpdateProductOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -579,9 +680,13 @@ class CloudVisionUpdateProductOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.update_product(
             product=self.product,
             location=self.location,
@@ -628,9 +733,19 @@ class CloudVisionDeleteProductOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_product_delete_template_fields]
-    template_fields = ('location', 'project_id', 'product_id', 'gcp_conn_id')
+    template_fields = ('location', 'project_id', 'product_id', 'gcp_conn_id',
+                       'impersonation_chain',)
     # [END vision_product_delete_template_fields]
 
     @apply_defaults
@@ -643,6 +758,7 @@ class CloudVisionDeleteProductOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -653,9 +769,13 @@ class CloudVisionDeleteProductOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook.delete_product(
             location=self.location,
             product_id=self.product_id,
@@ -688,9 +808,18 @@ class CloudVisionImageAnnotateOperator(BaseOperator):
     :type timeout: float
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_annotate_image_template_fields]
-    template_fields = ('request', 'gcp_conn_id')
+    template_fields = ('request', 'gcp_conn_id', 'impersonation_chain',)
     # [END vision_annotate_image_template_fields]
 
     @apply_defaults
@@ -700,6 +829,7 @@ class CloudVisionImageAnnotateOperator(BaseOperator):
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -707,9 +837,13 @@ class CloudVisionImageAnnotateOperator(BaseOperator):
         self.retry = retry
         self.timeout = timeout
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         if not isinstance(self.request, list):
             response = hook.annotate_image(request=self.request, retry=self.retry, timeout=self.timeout)
@@ -760,6 +894,15 @@ class CloudVisionCreateReferenceImageOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_reference_image_create_template_fields]
     template_fields = (
@@ -769,6 +912,7 @@ class CloudVisionCreateReferenceImageOperator(BaseOperator):
         "reference_image_id",
         "project_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
     # [END vision_reference_image_create_template_fields]
 
@@ -784,6 +928,7 @@ class CloudVisionCreateReferenceImageOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -796,10 +941,14 @@ class CloudVisionCreateReferenceImageOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         try:
-            hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+            hook = CloudVisionHook(
+                gcp_conn_id=self.gcp_conn_id,
+                impersonation_chain=self.impersonation_chain,
+            )
             return hook.create_reference_image(
                 location=self.location,
                 product_id=self.product_id,
@@ -850,6 +999,15 @@ class CloudVisionDeleteReferenceImageOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_reference_image_create_template_fields]
     template_fields = (
@@ -858,6 +1016,7 @@ class CloudVisionDeleteReferenceImageOperator(BaseOperator):
         "reference_image_id",
         "project_id",
         "gcp_conn_id",
+        "impersonation_chain",
     )
     # [END vision_reference_image_create_template_fields]
 
@@ -872,6 +1031,7 @@ class CloudVisionDeleteReferenceImageOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -883,9 +1043,13 @@ class CloudVisionDeleteReferenceImageOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook.delete_reference_image(
             location=self.location,
             product_id=self.product_id,
@@ -932,9 +1096,19 @@ class CloudVisionAddProductToProductSetOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_add_product_to_product_set_template_fields]
-    template_fields = ("location", "product_set_id", "product_id", "project_id", "gcp_conn_id")
+    template_fields = ("location", "product_set_id", "product_id", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
     # [END vision_add_product_to_product_set_template_fields]
 
     @apply_defaults
@@ -948,6 +1122,7 @@ class CloudVisionAddProductToProductSetOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -959,9 +1134,13 @@ class CloudVisionAddProductToProductSetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.add_product_to_product_set(
             product_set_id=self.product_set_id,
             product_id=self.product_id,
@@ -1002,9 +1181,19 @@ class CloudVisionRemoveProductFromProductSetOperator(BaseOperator):
     :type metadata: sequence[tuple[str, str]]
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_remove_product_from_product_set_template_fields]
-    template_fields = ("location", "product_set_id", "product_id", "project_id", "gcp_conn_id")
+    template_fields = ("location", "product_set_id", "product_id", "project_id", "gcp_conn_id",
+                       "impersonation_chain",)
     # [END vision_remove_product_from_product_set_template_fields]
 
     @apply_defaults
@@ -1018,6 +1207,7 @@ class CloudVisionRemoveProductFromProductSetOperator(BaseOperator):
         timeout: Optional[float] = None,
         metadata: Optional[MetaData] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1029,9 +1219,13 @@ class CloudVisionRemoveProductFromProductSetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.remove_product_from_product_set(
             product_set_id=self.product_set_id,
             product_id=self.product_id,
@@ -1070,9 +1264,20 @@ class CloudVisionDetectTextOperator(BaseOperator):
     :param additional_properties: Additional properties to be set on the AnnotateImageRequest. See more:
         :class:`google.cloud.vision_v1.types.AnnotateImageRequest`
     :type additional_properties: dict
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_detect_text_set_template_fields]
-    template_fields = ("image", "max_results", "timeout", "gcp_conn_id")
+    template_fields = ("image", "max_results", "timeout", "gcp_conn_id", "impersonation_chain",)
     # [END vision_detect_text_set_template_fields]
 
     def __init__(
@@ -1085,6 +1290,7 @@ class CloudVisionDetectTextOperator(BaseOperator):
         web_detection_params: Optional[Dict] = None,
         additional_properties: Optional[Dict] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1099,9 +1305,13 @@ class CloudVisionDetectTextOperator(BaseOperator):
             language_hints=language_hints,
             web_detection_params=web_detection_params,
         )
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.text_detection(
             image=self.image,
             max_results=self.max_results,
@@ -1138,9 +1348,21 @@ class CloudVisionTextDetectOperator(BaseOperator):
     :param additional_properties: Additional properties to be set on the AnnotateImageRequest. See more:
         https://googleapis.github.io/google-cloud-python/latest/vision/gapic/v1/types.html#google.cloud.vision_v1.types.AnnotateImageRequest
     :type additional_properties: dict
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_document_detect_text_set_template_fields]
-    template_fields = ("image", "max_results", "timeout", "gcp_conn_id")  # Iterable[str]
+    template_fields = ("image", "max_results", "timeout", "gcp_conn_id",
+                       "impersonation_chain",)  # Iterable[str]
     # [END vision_document_detect_text_set_template_fields]
 
     def __init__(
@@ -1153,6 +1375,7 @@ class CloudVisionTextDetectOperator(BaseOperator):
         web_detection_params: Optional[Dict] = None,
         additional_properties: Optional[Dict] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1166,9 +1389,13 @@ class CloudVisionTextDetectOperator(BaseOperator):
             language_hints=language_hints,
             web_detection_params=web_detection_params,
         )
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.document_text_detection(
             image=self.image,
             max_results=self.max_results,
@@ -1199,9 +1426,20 @@ class CloudVisionDetectImageLabelsOperator(BaseOperator):
     :param additional_properties: Additional properties to be set on the AnnotateImageRequest. See more:
         https://googleapis.github.io/google-cloud-python/latest/vision/gapic/v1/types.html#google.cloud.vision_v1.types.AnnotateImageRequest
     :type additional_properties: dict
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_detect_labels_template_fields]
-    template_fields = ("image", "max_results", "timeout", "gcp_conn_id")
+    template_fields = ("image", "max_results", "timeout", "gcp_conn_id", "impersonation_chain",)
     # [END vision_detect_labels_template_fields]
 
     def __init__(
@@ -1212,6 +1450,7 @@ class CloudVisionDetectImageLabelsOperator(BaseOperator):
         timeout: Optional[float] = None,
         additional_properties: Optional[Dict] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1221,9 +1460,13 @@ class CloudVisionDetectImageLabelsOperator(BaseOperator):
         self.timeout = timeout
         self.gcp_conn_id = gcp_conn_id
         self.additional_properties = additional_properties
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.label_detection(
             image=self.image,
             max_results=self.max_results,
@@ -1254,9 +1497,20 @@ class CloudVisionDetectImageSafeSearchOperator(BaseOperator):
     :param additional_properties: Additional properties to be set on the AnnotateImageRequest. See more:
         https://googleapis.github.io/google-cloud-python/latest/vision/gapic/v1/types.html#google.cloud.vision_v1.types.AnnotateImageRequest
     :type additional_properties: dict
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
     # [START vision_detect_safe_search_template_fields]
-    template_fields = ("image", "max_results", "timeout", "gcp_conn_id")
+    template_fields = ("image", "max_results", "timeout", "gcp_conn_id", "impersonation_chain",)
     # [END vision_detect_safe_search_template_fields]
 
     def __init__(
@@ -1267,6 +1521,7 @@ class CloudVisionDetectImageSafeSearchOperator(BaseOperator):
         timeout: Optional[float] = None,
         additional_properties: Optional[Dict] = None,
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -1276,9 +1531,13 @@ class CloudVisionDetectImageSafeSearchOperator(BaseOperator):
         self.timeout = timeout
         self.gcp_conn_id = gcp_conn_id
         self.additional_properties = additional_properties
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudVisionHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.safe_search_detection(
             image=self.image,
             max_results=self.max_results,

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -18,7 +18,7 @@
 """
 This module contains a Google Bigquery sensor.
 """
-from typing import Optional
+from typing import Optional, Sequence, Union
 
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -41,12 +41,21 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
     :param bigquery_conn_id: The connection ID to use when connecting to
         Google BigQuery.
     :type bigquery_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must
-        have domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('project_id', 'dataset_id', 'table_id',)
+    template_fields = ('project_id', 'dataset_id', 'table_id', 'impersonation_chain',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -56,6 +65,7 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
                  table_id: str,
                  bigquery_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
 
         super().__init__(**kwargs)
@@ -64,13 +74,16 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
         self.table_id = table_id
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context):
         table_uri = '{0}:{1}.{2}'.format(self.project_id, self.dataset_id, self.table_id)
         self.log.info('Sensor checks existence of table: %s', table_uri)
         hook = BigQueryHook(
             bigquery_conn_id=self.bigquery_conn_id,
-            delegate_to=self.delegate_to)
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.table_exists(
             project_id=self.project_id,
             dataset_id=self.dataset_id,
@@ -99,8 +112,18 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         For this to work, the service account making the request must
         have domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('project_id', 'dataset_id', 'table_id', 'partition_id',)
+    template_fields = ('project_id', 'dataset_id', 'table_id', 'partition_id',
+                       'impersonation_chain',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -111,6 +134,7 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
                  partition_id: str,
                  bigquery_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
 
         super().__init__(**kwargs)
@@ -120,13 +144,16 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         self.partition_id = partition_id
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context):
         table_uri = '{0}:{1}.{2}'.format(self.project_id, self.dataset_id, self.table_id)
         self.log.info('Sensor checks existence of partition: "%s" in table: %s', self.partition_id, table_uri)
         hook = BigQueryHook(
             bigquery_conn_id=self.bigquery_conn_id,
-            delegate_to=self.delegate_to)
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.table_partition_exists(
             project_id=self.project_id,
             dataset_id=self.dataset_id,

--- a/airflow/providers/google/cloud/sensors/bigquery_dts.py
+++ b/airflow/providers/google/cloud/sensors/bigquery_dts.py
@@ -56,6 +56,16 @@ class BigQueryDataTransferServiceTransferRunSensor(BaseSensorOperator):
     :type request_timeout: Optional[float]
     :param metadata: Additional metadata that is provided to the method.
     :type metadata: Optional[Sequence[Tuple[str, str]]]
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
     :return: An ``google.cloud.bigquery_datatransfer_v1.types.TransferRun`` instance.
     """
 
@@ -64,6 +74,7 @@ class BigQueryDataTransferServiceTransferRunSensor(BaseSensorOperator):
         "transfer_config_id",
         "expected_statuses",
         "project_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -78,6 +89,7 @@ class BigQueryDataTransferServiceTransferRunSensor(BaseSensorOperator):
         retry: Optional[Retry] = None,
         request_timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -93,9 +105,13 @@ class BigQueryDataTransferServiceTransferRunSensor(BaseSensorOperator):
         )
         self.project_id = project_id
         self.gcp_cloud_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context):
-        hook = BiqQueryDataTransferServiceHook(gcp_conn_id=self.gcp_cloud_conn_id)
+        hook = BiqQueryDataTransferServiceHook(
+            gcp_conn_id=self.gcp_cloud_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         run = hook.get_transfer_run(
             run_id=self.run_id,
             transfer_config_id=self.transfer_config_id,

--- a/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py
@@ -18,7 +18,7 @@
 """
 This module contains a Google Cloud Transfer sensor.
 """
-from typing import Optional, Set, Union
+from typing import Optional, Sequence, Set, Union
 
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import CloudDataTransferServiceHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -47,10 +47,19 @@ class CloudDataTransferServiceJobStatusSensor(BaseSensorOperator):
     :param gcp_conn_id: The connection ID used to connect to Google Cloud
         Platform.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     # [START gcp_transfer_job_sensor_template_fields]
-    template_fields = ('job_name',)
+    template_fields = ('job_name', 'impersonation_chain',)
     # [END gcp_transfer_job_sensor_template_fields]
 
     @apply_defaults
@@ -60,6 +69,7 @@ class CloudDataTransferServiceJobStatusSensor(BaseSensorOperator):
         expected_statuses: Union[Set[str], str],
         project_id: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -69,9 +79,13 @@ class CloudDataTransferServiceJobStatusSensor(BaseSensorOperator):
         )
         self.project_id = project_id
         self.gcp_cloud_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context):
-        hook = CloudDataTransferServiceHook(gcp_conn_id=self.gcp_cloud_conn_id)
+        hook = CloudDataTransferServiceHook(
+            gcp_conn_id=self.gcp_cloud_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
         operations = hook.list_transfer_operations(
             request_filter={'project_id': self.project_id, 'job_names': [self.job_name]}
         )

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -21,7 +21,7 @@ This module contains Google Cloud Storage sensors.
 
 import os
 from datetime import datetime
-from typing import Callable, List, Optional, Set
+from typing import Callable, List, Optional, Sequence, Set, Union
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
@@ -41,12 +41,21 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
     :type google_cloud_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('bucket', 'object')
+    template_fields = ('bucket', 'object', 'impersonation_chain',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -55,6 +64,7 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
                  object: str,  # pylint: disable=redefined-builtin
                  google_cloud_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
 
         super().__init__(**kwargs)
@@ -62,12 +72,15 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
         self.object = object
         self.google_cloud_conn_id = google_cloud_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context):
         self.log.info('Sensor checks existence of : %s, %s', self.bucket, self.object)
         hook = GCSHook(
             google_cloud_storage_conn_id=self.google_cloud_conn_id,
-            delegate_to=self.delegate_to)
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.exists(self.bucket, self.object)
 
 
@@ -96,12 +109,21 @@ class GCSObjectUpdateSensor(BaseSensorOperator):
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
     :type google_cloud_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('bucket', 'object')
+    template_fields = ('bucket', 'object', 'impersonation_chain',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -111,6 +133,7 @@ class GCSObjectUpdateSensor(BaseSensorOperator):
                  ts_func: Callable = ts_function,
                  google_cloud_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
 
         super().__init__(**kwargs)
@@ -119,12 +142,15 @@ class GCSObjectUpdateSensor(BaseSensorOperator):
         self.ts_func = ts_func
         self.google_cloud_conn_id = google_cloud_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context):
         self.log.info('Sensor checks existence of : %s, %s', self.bucket, self.object)
         hook = GCSHook(
             google_cloud_storage_conn_id=self.google_cloud_conn_id,
-            delegate_to=self.delegate_to)
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         return hook.is_updated_after(self.bucket, self.object, self.ts_func(context))
 
 
@@ -144,12 +170,21 @@ class GCSObjectsWtihPrefixExistenceSensor(BaseSensorOperator):
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
     :type google_cloud_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
-    template_fields = ('bucket', 'prefix')
+    template_fields = ('bucket', 'prefix', 'impersonation_chain',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -158,6 +193,7 @@ class GCSObjectsWtihPrefixExistenceSensor(BaseSensorOperator):
                  prefix: str,
                  google_cloud_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.bucket = bucket
@@ -165,13 +201,16 @@ class GCSObjectsWtihPrefixExistenceSensor(BaseSensorOperator):
         self.google_cloud_conn_id = google_cloud_conn_id
         self.delegate_to = delegate_to
         self._matches = []  # type: List[str]
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context):
         self.log.info('Sensor checks existence of objects: %s, %s',
                       self.bucket, self.prefix)
         hook = GCSHook(
             google_cloud_storage_conn_id=self.google_cloud_conn_id,
-            delegate_to=self.delegate_to)
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         self._matches = hook.list(self.bucket, prefix=self.prefix)
         return bool(self._matches)
 
@@ -220,13 +259,22 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
     :param google_cloud_conn_id: The connection ID to use when connecting
         to Google Cloud Storage.
     :type google_cloud_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work,
-        the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ('bucket', 'prefix')
+    template_fields = ('bucket', 'prefix', 'impersonation_chain',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -239,6 +287,7 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
                  allow_delete: bool = True,
                  google_cloud_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
+                 impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
                  **kwargs) -> None:
 
         super().__init__(**kwargs)
@@ -255,6 +304,7 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
         self.google_cloud_conn_id = google_cloud_conn_id
         self.delegate_to = delegate_to
         self.last_activity_time = None
+        self.impersonation_chain = impersonation_chain
         self.hook = None
 
     def _get_gcs_hook(self):
@@ -262,6 +312,7 @@ class GCSUploadSessionCompleteSensor(BaseSensorOperator):
             self.hook = GCSHook(
                 gcp_conn_id=self.google_cloud_conn_id,
                 delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
             )
         return self.hook
 

--- a/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
@@ -20,7 +20,7 @@ This module contains Facebook Ad Reporting to GCS operators.
 """
 import csv
 import tempfile
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.facebook.ads.hooks.ads import FacebookAdsReportingHook
@@ -66,9 +66,18 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
     :type sleep_time: int
     :param gzip: Option to compress local file or file data for upload
     :type gzip: bool
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("facebook_conn_id", "bucket_name", "object_name")
+    template_fields = ("facebook_conn_id", "bucket_name", "object_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -81,6 +90,7 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
         api_version: str = "v6.0",
         gcp_conn_id: str = "google_cloud_default",
         facebook_conn_id: str = "facebook_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -92,6 +102,7 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
         self.fields = fields
         self.params = params
         self.gzip = gzip
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         service = FacebookAdsReportingHook(facebook_conn_id=self.facebook_conn_id,
@@ -109,7 +120,10 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
                 writer.writeheader()
                 writer.writerows(converted_rows)
                 csvfile.flush()
-                hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
+                hook = GCSHook(
+                    gcp_conn_id=self.gcp_conn_id,
+                    impersonation_chain=self.impersonation_chain,
+                )
                 hook.upload(
                     bucket_name=self.bucket_name,
                     object_name=self.object_name,

--- a/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_sftp.py
@@ -20,7 +20,7 @@ This module contains Google Cloud Storage to SFTP operator.
 """
 import os
 from tempfile import NamedTemporaryFile
-from typing import Optional
+from typing import Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -61,13 +61,22 @@ class GCSToSFTPOperator(BaseOperator):
     :param sftp_conn_id: The sftp connection id. The name or identifier for
         establishing a connection to the SFTP server.
     :type sftp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("source_bucket", "source_object", "destination_path")
+    template_fields = ("source_bucket", "source_object", "destination_path", "impersonation_chain",)
     ui_color = "#f0eee4"
 
     # pylint: disable=too-many-arguments
@@ -81,6 +90,7 @@ class GCSToSFTPOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         sftp_conn_id: str = "ssh_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -92,11 +102,14 @@ class GCSToSFTPOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.sftp_conn_id = sftp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
         self.sftp_dirs = None
 
     def execute(self, context):
         gcs_hook = GCSHook(
-            gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         sftp_hook = SFTPHook(self.sftp_conn_id)

--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -266,6 +266,8 @@ class _CredentialProvider(LoggingMixin):
                 target_scopes=self.scopes
             )
 
+            project_id = _get_project_id_from_service_account_email(self.target_principal)
+
         return credentials, project_id
 
     def _get_credentials_using_keyfile_dict(self):
@@ -358,3 +360,20 @@ def _get_target_principal_and_delegates(
         return impersonation_chain, None
 
     return impersonation_chain[-1], impersonation_chain[:-1]
+
+
+def _get_project_id_from_service_account_email(service_account_email: str) -> str:
+    """
+    Extracts project_id from service account's email address.
+
+    :param service_account_email: email of the service account.
+    :type service_account_email: str
+
+    :return: Returns the project_id of the provided service account.
+    :rtype: str
+    """
+    try:
+        return service_account_email.split('@')[1].split('.')[0]
+    except IndexError:
+        raise AirflowException(f"Could not extract project_id from service account's email: "
+                               f"{service_account_email}.")

--- a/airflow/providers/google/marketing_platform/operators/analytics.py
+++ b/airflow/providers/google/marketing_platform/operators/analytics.py
@@ -20,7 +20,7 @@ This module contains Google Analytics 360 operators.
 """
 import csv
 from tempfile import NamedTemporaryFile
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
@@ -46,11 +46,21 @@ class GoogleAnalyticsListAccountsOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
         "api_version",
         "gcp_conn_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -58,16 +68,20 @@ class GoogleAnalyticsListAccountsOperator(BaseOperator):
         self, *,
         api_version: str = "v3",
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
 
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         hook = GoogleAnalyticsHook(
-            api_version=self.api_version, gcp_conn_id=self.gcp_conn_id
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
         )
         result = hook.list_accounts()
         return result
@@ -91,6 +105,15 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
     :type web_property_ad_words_link_id: str
     :param web_property_id: Web property ID to retrieve the Google Ads link for.
     :type web_property_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -99,6 +122,7 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
         "account_id",
         "web_property_ad_words_link_id",
         "web_property_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -109,6 +133,7 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
         web_property_id: str,
         api_version: str = "v3",
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -118,10 +143,13 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
         self.web_property_id = web_property_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         hook = GoogleAnalyticsHook(
-            api_version=self.api_version, gcp_conn_id=self.gcp_conn_id
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
         )
         result = hook.get_ad_words_link(
             account_id=self.account_id,
@@ -147,6 +175,15 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
     :type account_id: str
     :param web_property_id: Web property UA-string to retrieve the Google Ads links for.
     :type web_property_id: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -154,6 +191,7 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
         "gcp_conn_id",
         "account_id",
         "web_property_id",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -163,6 +201,7 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
         web_property_id: str,
         api_version: str = "v3",
         gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -171,10 +210,13 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
         self.web_property_id = web_property_id
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         hook = GoogleAnalyticsHook(
-            api_version=self.api_version, gcp_conn_id=self.gcp_conn_id
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
         )
         result = hook.list_ad_words_links(
             account_id=self.account_id, web_property_id=self.web_property_id,
@@ -203,13 +245,24 @@ class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
     :type resumable_upload: bool
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param api_version: The version of the api that will be requested for example 'v3'.
     :type api_version: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("storage_bucket", "storage_name_object")
+    template_fields = ("storage_bucket", "storage_name_object", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -223,6 +276,7 @@ class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
         api_version: str = "v3",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -235,16 +289,20 @@ class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.api_version = api_version
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         gcs_hook = GCSHook(
-            gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         ga_hook = GoogleAnalyticsHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
 
         with NamedTemporaryFile("w+") as tmp_file:
@@ -280,11 +338,24 @@ class GoogleAnalyticsDeletePreviousDataUploadsOperator(BaseOperator):
     :type custom_data_source_id: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
     :param api_version: The version of the api that will be requested for example 'v3'.
     :type api_version: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
+
+    template_fields = ("impersonation_chain",)
 
     def __init__(
         self,
@@ -294,6 +365,7 @@ class GoogleAnalyticsDeletePreviousDataUploadsOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
         api_version: str = "v3",
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -304,10 +376,14 @@ class GoogleAnalyticsDeletePreviousDataUploadsOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.api_version = api_version
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
         ga_hook = GoogleAnalyticsHook(
-            gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to, api_version=self.api_version
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
 
         uploads = ga_hook.list_uploads(
@@ -346,11 +422,22 @@ class GoogleAnalyticsModifyFileHeadersDataImportOperator(BaseOperator):
           set by GA. Dictionary maps the current CSV header to GA ID which will
           be the new header for the CSV to upload to GA eg clientId : dimension1.
     :type custom_dimension_header_mapping: dict
-    :param delegate_to: The account to impersonate, if any.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("storage_bucket", "storage_name_object")
+    template_fields = ("storage_bucket", "storage_name_object", "impersonation_chain",)
 
     def __init__(
         self,
@@ -359,6 +446,7 @@ class GoogleAnalyticsModifyFileHeadersDataImportOperator(BaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
         custom_dimension_header_mapping: Optional[Dict[str, str]] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super(GoogleAnalyticsModifyFileHeadersDataImportOperator, self).__init__(
@@ -369,6 +457,7 @@ class GoogleAnalyticsModifyFileHeadersDataImportOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.custom_dimension_header_mapping = custom_dimension_header_mapping or {}
+        self.impersonation_chain = impersonation_chain
 
     def _modify_column_headers(
         self, tmp_file_location: str, custom_dimension_header_mapping: Dict[str, str]
@@ -404,7 +493,11 @@ class GoogleAnalyticsModifyFileHeadersDataImportOperator(BaseOperator):
             write_file.writelines(all_data)
 
     def execute(self, context):
-        gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        gcs_hook = GCSHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         with NamedTemporaryFile("w+") as tmp_file:
             # Download file from GCS
             self.log.info(

--- a/airflow/providers/google/marketing_platform/operators/campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/operators/campaign_manager.py
@@ -21,7 +21,7 @@ This module contains Google CampaignManager operators.
 import json
 import tempfile
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from googleapiclient import http
 
@@ -54,9 +54,19 @@ class GoogleCampaignManagerDeleteReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -66,6 +76,7 @@ class GoogleCampaignManagerDeleteReportOperator(BaseOperator):
         "api_version",
         "gcp_conn_id",
         "delegate_to",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -77,6 +88,7 @@ class GoogleCampaignManagerDeleteReportOperator(BaseOperator):
         api_version: str = "v3.3",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -93,12 +105,14 @@ class GoogleCampaignManagerDeleteReportOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = GoogleCampaignManagerHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         if self.report_name:
             reports = hook.list_reports(profile_id=self.profile_id)
@@ -144,9 +158,19 @@ class GoogleCampaignManagerDownloadReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -159,6 +183,7 @@ class GoogleCampaignManagerDownloadReportOperator(BaseOperator):
         "api_version",
         "gcp_conn_id",
         "delegate_to",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -174,6 +199,7 @@ class GoogleCampaignManagerDownloadReportOperator(BaseOperator):
         api_version: str = "v3.3",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -187,6 +213,7 @@ class GoogleCampaignManagerDownloadReportOperator(BaseOperator):
         self.report_name = report_name
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def _resolve_file_name(self, name: str) -> str:
         csv = ".csv"
@@ -207,9 +234,12 @@ class GoogleCampaignManagerDownloadReportOperator(BaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         gcs_hook = GCSHook(
-            google_cloud_storage_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to
+            google_cloud_storage_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
         # Get name of the report
         report = hook.get_report(
@@ -264,9 +294,19 @@ class GoogleCampaignManagerInsertReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -275,6 +315,7 @@ class GoogleCampaignManagerInsertReportOperator(BaseOperator):
         "api_version",
         "gcp_conn_id",
         "delegate_to",
+        "impersonation_chain",
     )
 
     template_ext = (".json",)
@@ -287,6 +328,7 @@ class GoogleCampaignManagerInsertReportOperator(BaseOperator):
         api_version: str = "v3.3",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -295,6 +337,7 @@ class GoogleCampaignManagerInsertReportOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def prepare_template(self) -> None:
         # If .json is passed then we have to read the file
@@ -307,6 +350,7 @@ class GoogleCampaignManagerInsertReportOperator(BaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Inserting Campaign Manager report.")
         response = hook.insert_report(
@@ -340,9 +384,19 @@ class GoogleCampaignManagerRunReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -352,6 +406,7 @@ class GoogleCampaignManagerRunReportOperator(BaseOperator):
         "api_version",
         "gcp_conn_id",
         "delegate_to",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -363,6 +418,7 @@ class GoogleCampaignManagerRunReportOperator(BaseOperator):
         api_version: str = "v3.3",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -372,12 +428,14 @@ class GoogleCampaignManagerRunReportOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = GoogleCampaignManagerHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Running report %s", self.report_id)
         response = hook.run_report(
@@ -423,9 +481,19 @@ class GoogleCampaignManagerBatchInsertConversionsOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
-    :type delegate_to: Optional[str]
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -434,6 +502,7 @@ class GoogleCampaignManagerBatchInsertConversionsOperator(BaseOperator):
         "encryption_entity_type",
         "encryption_entity_id",
         "encryption_source",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -448,6 +517,7 @@ class GoogleCampaignManagerBatchInsertConversionsOperator(BaseOperator):
         api_version: str = "v3.3",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -460,12 +530,14 @@ class GoogleCampaignManagerBatchInsertConversionsOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = GoogleCampaignManagerHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         response = hook.conversions_batch_insert(
             profile_id=self.profile_id,
@@ -510,9 +582,19 @@ class GoogleCampaignManagerBatchUpdateConversionsOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
-    :type delegate_to: Optional[str]
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = (
@@ -521,6 +603,7 @@ class GoogleCampaignManagerBatchUpdateConversionsOperator(BaseOperator):
         "encryption_entity_type",
         "encryption_entity_id",
         "encryption_source",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -535,6 +618,7 @@ class GoogleCampaignManagerBatchUpdateConversionsOperator(BaseOperator):
         api_version: str = "v3.3",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -547,12 +631,14 @@ class GoogleCampaignManagerBatchUpdateConversionsOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = GoogleCampaignManagerHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         response = hook.conversions_batch_update(
             profile_id=self.profile_id,

--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -23,7 +23,7 @@ import json
 import shutil
 import tempfile
 import urllib.request
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Union
 from urllib.parse import urlparse
 
 from airflow.exceptions import AirflowException
@@ -52,12 +52,22 @@ class GoogleDisplayVideo360CreateReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("body",)
+    template_fields = ("body", "impersonation_chain",)
     template_ext = (".json",)
 
     @apply_defaults
@@ -67,6 +77,7 @@ class GoogleDisplayVideo360CreateReportOperator(BaseOperator):
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -74,6 +85,7 @@ class GoogleDisplayVideo360CreateReportOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def prepare_template(self) -> None:
         # If .json is passed then we have to read the file
@@ -86,6 +98,7 @@ class GoogleDisplayVideo360CreateReportOperator(BaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Creating Display & Video 360 report.")
         response = hook.create_query(query=self.body)
@@ -115,12 +128,22 @@ class GoogleDisplayVideo360DeleteReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("report_id",)
+    template_fields = ("report_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -130,6 +153,7 @@ class GoogleDisplayVideo360DeleteReportOperator(BaseOperator):
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -138,6 +162,7 @@ class GoogleDisplayVideo360DeleteReportOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
         if report_name and report_id:
             raise AirflowException("Use only one value - `report_name` or `report_id`.")
@@ -152,6 +177,7 @@ class GoogleDisplayVideo360DeleteReportOperator(BaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         if self.report_id:
             reports_ids_to_delete = [self.report_id]
@@ -195,12 +221,22 @@ class GoogleDisplayVideo360DownloadReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("report_id", "bucket_name", "report_name")
+    template_fields = ("report_id", "bucket_name", "report_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -213,6 +249,7 @@ class GoogleDisplayVideo360DownloadReportOperator(BaseOperator):
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -224,6 +261,7 @@ class GoogleDisplayVideo360DownloadReportOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def _resolve_file_name(self, name: str) -> str:
         new_name = name if name.endswith(".csv") else f"{name}.csv"
@@ -240,9 +278,12 @@ class GoogleDisplayVideo360DownloadReportOperator(BaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         gcs_hook = GCSHook(
-            google_cloud_storage_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to
+            google_cloud_storage_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         resource = hook.get_query(query_id=self.report_id)
@@ -300,12 +341,22 @@ class GoogleDisplayVideo360RunReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service account making the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("report_id", "params")
+    template_fields = ("report_id", "params", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -315,6 +366,7 @@ class GoogleDisplayVideo360RunReportOperator(BaseOperator):
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -323,12 +375,14 @@ class GoogleDisplayVideo360RunReportOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = GoogleDisplayVideo360Hook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info(
             "Running report %s with the following params:\n %s",
@@ -356,7 +410,7 @@ class GoogleDisplayVideo360DownloadLineItemsOperator(BaseOperator):
     :type request_body: Dict[str, Any],
     """
 
-    template_fields = ("request_body", "bucket_name", "object_name")
+    template_fields = ("request_body", "bucket_name", "object_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -368,6 +422,7 @@ class GoogleDisplayVideo360DownloadLineItemsOperator(BaseOperator):
         api_version: str = "v1.1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -378,13 +433,19 @@ class GoogleDisplayVideo360DownloadLineItemsOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict) -> str:
-        gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        gcs_hook = GCSHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook = GoogleDisplayVideo360Hook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version,
             delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         self.log.info("Retrieving report...")
@@ -431,6 +492,7 @@ class GoogleDisplayVideo360UploadLineItemsOperator(BaseOperator):
     template_fields = (
         "bucket_name",
         "object_name",
+        "impersonation_chain",
     )
 
     @apply_defaults
@@ -441,6 +503,7 @@ class GoogleDisplayVideo360UploadLineItemsOperator(BaseOperator):
         api_version: str = "v1.1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -449,13 +512,19 @@ class GoogleDisplayVideo360UploadLineItemsOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
-        gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        gcs_hook = GCSHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         hook = GoogleDisplayVideo360Hook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
 
         self.log.info("Uploading file %s...")
@@ -497,12 +566,22 @@ class GoogleDisplayVideo360CreateSDFDownloadTaskOperator(BaseOperator):
     :type inventory_source_filter: Dict[str, Any]
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service account making the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("body_request", )
+    template_fields = ("body_request", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -511,6 +590,7 @@ class GoogleDisplayVideo360CreateSDFDownloadTaskOperator(BaseOperator):
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -518,12 +598,14 @@ class GoogleDisplayVideo360CreateSDFDownloadTaskOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = GoogleDisplayVideo360Hook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
 
         self.log.info("Creating operation for SDF download task...")
@@ -560,12 +642,22 @@ class GoogleDisplayVideo360SDFtoGCSOperator(BaseOperator):
     :type inventory_source_filter: Dict[str, Any]
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service account making the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("operation_name", "bucket_name", "object_name")
+    template_fields = ("operation_name", "bucket_name", "object_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -577,6 +669,7 @@ class GoogleDisplayVideo360SDFtoGCSOperator(BaseOperator):
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -587,14 +680,20 @@ class GoogleDisplayVideo360SDFtoGCSOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Dict):
         hook = GoogleDisplayVideo360Hook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
-        gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        gcs_hook = GCSHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.log.info("Retrieving operation...")
         operation = hook.get_sdf_download_operation(operation_name=self.operation_name)

--- a/airflow/providers/google/marketing_platform/operators/search_ads.py
+++ b/airflow/providers/google/marketing_platform/operators/search_ads.py
@@ -20,7 +20,7 @@ This module contains Google Search Ads operators.
 """
 import json
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -47,12 +47,22 @@ class GoogleSearchAdsInsertReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("report",)
+    template_fields = ("report", "impersonation_chain",)
     template_ext = (".json",)
 
     @apply_defaults
@@ -62,6 +72,7 @@ class GoogleSearchAdsInsertReportOperator(BaseOperator):
         api_version: str = "v2",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -69,6 +80,7 @@ class GoogleSearchAdsInsertReportOperator(BaseOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def prepare_template(self) -> None:
         # If .json is passed then we have to read the file
@@ -81,6 +93,7 @@ class GoogleSearchAdsInsertReportOperator(BaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info("Generating Search Ads report")
         response = hook.insert_report(report=self.report)
@@ -115,12 +128,22 @@ class GoogleSearchAdsDownloadReportOperator(BaseOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("report_name", "report_id", "bucket_name")
+    template_fields = ("report_name", "report_id", "bucket_name", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -133,6 +156,7 @@ class GoogleSearchAdsDownloadReportOperator(BaseOperator):
         api_version: str = "v2",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
@@ -145,6 +169,7 @@ class GoogleSearchAdsDownloadReportOperator(BaseOperator):
         self.gzip = gzip
         self.bucket_name = self._set_bucket_name(bucket_name)
         self.report_name = report_name
+        self.impersonation_chain = impersonation_chain
 
     def _resolve_file_name(self, name: str) -> str:
         csv = ".csv"
@@ -172,10 +197,13 @@ class GoogleSearchAdsDownloadReportOperator(BaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
 
         gcs_hook = GCSHook(
-            gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
 
         # Resolve file name of the report

--- a/airflow/providers/google/marketing_platform/sensors/display_video.py
+++ b/airflow/providers/google/marketing_platform/sensors/display_video.py
@@ -18,7 +18,7 @@
 """
 Sensor for detecting the completion of DV360 reports.
 """
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence, Union
 
 from airflow import AirflowException
 from airflow.providers.google.marketing_platform.hooks.display_video import GoogleDisplayVideo360Hook
@@ -39,12 +39,22 @@ class GoogleDisplayVideo360ReportSensor(BaseSensorOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service account making the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("report_id",)
+    template_fields = ("report_id", "impersonation_chain",)
 
     def __init__(
         self, *,
@@ -52,6 +62,7 @@ class GoogleDisplayVideo360ReportSensor(BaseSensorOperator):
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -60,12 +71,14 @@ class GoogleDisplayVideo360ReportSensor(BaseSensorOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context: Dict) -> bool:
         hook = GoogleDisplayVideo360Hook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
 
         response = hook.get_query(query_id=self.report_id)
@@ -88,13 +101,23 @@ class GoogleDisplayVideo360GetSDFDownloadOperationSensor(BaseSensorOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service account making the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
 
     """
 
-    template_fields = ("operation_name", )
+    template_fields = ("operation_name", "impersonation_chain",)
 
     def __init__(
         self,
@@ -104,6 +127,7 @@ class GoogleDisplayVideo360GetSDFDownloadOperationSensor(BaseSensorOperator):
         delegate_to: Optional[str] = None,
         mode: str = "reschedule",
         poke_interval: int = 60 * 5,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         *args,
         **kwargs
     ):
@@ -114,12 +138,14 @@ class GoogleDisplayVideo360GetSDFDownloadOperationSensor(BaseSensorOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context: Dict) -> bool:
         hook = GoogleDisplayVideo360Hook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         operation = hook.get_sdf_download_operation(operation_name=self.operation_name)
 

--- a/airflow/providers/google/marketing_platform/sensors/search_ads.py
+++ b/airflow/providers/google/marketing_platform/sensors/search_ads.py
@@ -18,7 +18,7 @@
 """
 This module contains Google Search Ads sensor.
 """
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence, Union
 
 from airflow.providers.google.marketing_platform.hooks.search_ads import GoogleSearchAdsHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -43,12 +43,22 @@ class GoogleSearchAdsReportSensor(BaseSensorOperator):
     :type api_version: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to work, the service accountmaking the
-        request must have  domain-wide delegation enabled.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ("report_id",)
+    template_fields = ("report_id", "impersonation_chain",)
 
     @apply_defaults
     def __init__(
@@ -59,6 +69,7 @@ class GoogleSearchAdsReportSensor(BaseSensorOperator):
         delegate_to: Optional[str] = None,
         mode: str = "reschedule",
         poke_interval: int = 5 * 60,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs
     ):
         super().__init__(mode=mode, poke_interval=poke_interval, **kwargs)
@@ -66,10 +77,14 @@ class GoogleSearchAdsReportSensor(BaseSensorOperator):
         self.api_version = api_version
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def poke(self, context: Dict):
         hook = GoogleSearchAdsHook(
-            gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to, api_version=self.api_version
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            api_version=self.api_version,
+            impersonation_chain=self.impersonation_chain,
         )
         self.log.info('Checking status of %s report.', self.report_id)
         response = hook.get(report_id=self.report_id)

--- a/airflow/providers/google/suite/operators/sheets.py
+++ b/airflow/providers/google/suite/operators/sheets.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.google.suite.hooks.sheets import GSheetsHook
@@ -35,11 +35,22 @@ class GoogleSheetsCreateSpreadsheetOperator(BaseOperator):
     :type spreadsheet: Dict[str, Any]
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = ["spreadsheet"]
+    template_fields = ["spreadsheet", "impersonation_chain", ]
 
     @apply_defaults
     def __init__(
@@ -47,15 +58,21 @@ class GoogleSheetsCreateSpreadsheetOperator(BaseOperator):
         spreadsheet: Dict[str, Any],
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.gcp_conn_id = gcp_conn_id
         self.spreadsheet = spreadsheet
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Any):
-        hook = GSheetsHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        hook = GSheetsHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         spreadsheet = hook.create_spreadsheet(spreadsheet=self.spreadsheet)
         self.xcom_push(context, "spreadsheet_id", spreadsheet["spreadsheetId"])
         self.xcom_push(context, "spreadsheet_url", spreadsheet["spreadsheetUrl"])

--- a/airflow/providers/google/suite/transfers/gcs_to_sheets.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_sheets.py
@@ -17,7 +17,7 @@
 
 import csv
 from tempfile import NamedTemporaryFile
-from typing import Any, Optional
+from typing import Any, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
@@ -43,8 +43,19 @@ class GCSToGoogleSheetsOperator(BaseOperator):
     :type spreadsheet_range: str
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: str
-    :param delegate_to: The account to impersonate, if any.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
     """
 
     template_fields = [
@@ -52,6 +63,7 @@ class GCSToGoogleSheetsOperator(BaseOperator):
         "bucket_name",
         "object_name",
         "spreadsheet_range",
+        "impersonation_chain",
     ]
 
     @apply_defaults
@@ -63,6 +75,7 @@ class GCSToGoogleSheetsOperator(BaseOperator):
         spreadsheet_range: str = "Sheet1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -73,12 +86,19 @@ class GCSToGoogleSheetsOperator(BaseOperator):
         self.bucket_name = bucket_name
         self.object_name = object_name
         self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Any):
         sheet_hook = GSheetsHook(
-            gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
-        gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id, delegate_to=self.delegate_to)
+        gcs_hook = GCSHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
         with NamedTemporaryFile("w+") as temp_file:
             # Download data
             gcs_hook.download(

--- a/tests/providers/google/ads/operators/test_ads.py
+++ b/tests/providers/google/ads/operators/test_ads.py
@@ -33,6 +33,7 @@ QUERY = """
     """
 
 FIELDS_TO_EXTRACT = ["segments.date.value", "customer.id.value"]
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 gcp_conn_id = "gcp_conn_id"
 google_ads_conn_id = "google_ads_conn_id"
@@ -56,13 +57,17 @@ class TestGoogleAdsListAccountsOperator:
             object_name=GCS_OBJ_PATH,
             bucket=BUCKET,
             task_id="run_operator",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute({})
 
         mock_ads_hook.assert_called_once_with(
             gcp_conn_id=gcp_conn_id, google_ads_conn_id=google_ads_conn_id
         )
-        mock_gcs_hook.assert_called_once_with(gcp_conn_id=gcp_conn_id)
+        mock_gcs_hook.assert_called_once_with(
+            gcp_conn_id=gcp_conn_id,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         mock_ads_hook.return_value.list_accessible_customers.assert_called_once_with()
         mocks_csv_writer.assert_called_once_with(file_object)

--- a/tests/providers/google/ads/transfers/test_ads_to_gcs.py
+++ b/tests/providers/google/ads/transfers/test_ads_to_gcs.py
@@ -19,7 +19,8 @@ from unittest import mock
 
 from airflow.providers.google.ads.transfers.ads_to_gcs import GoogleAdsToGcsOperator
 from tests.providers.google.ads.operators.test_ads import (
-    BUCKET, CLIENT_IDS, FIELDS_TO_EXTRACT, GCS_OBJ_PATH, QUERY, gcp_conn_id, google_ads_conn_id,
+    BUCKET, CLIENT_IDS, FIELDS_TO_EXTRACT, GCS_OBJ_PATH, IMPERSONATION_CHAIN, QUERY, gcp_conn_id,
+    google_ads_conn_id,
 )
 
 
@@ -36,6 +37,7 @@ class TestGoogleAdsToGcsOperator:
             obj=GCS_OBJ_PATH,
             bucket=BUCKET,
             task_id="run_operator",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute({})
         mock_ads_hook.assert_called_once_with(
@@ -44,7 +46,10 @@ class TestGoogleAdsToGcsOperator:
         mock_ads_hook.return_value.search.assert_called_once_with(
             client_ids=CLIENT_IDS, query=QUERY, page_size=10000
         )
-        mock_gcs_hook.assert_called_once_with(gcp_conn_id=gcp_conn_id)
+        mock_gcs_hook.assert_called_once_with(
+            gcp_conn_id=gcp_conn_id,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_gcs_hook.return_value.upload.assert_called_once_with(
             bucket_name=BUCKET, object_name=GCS_OBJ_PATH, filename=mock.ANY, gzip=False
         )

--- a/tests/providers/google/cloud/operators/test_bigtable.py
+++ b/tests/providers/google/cloud/operators/test_bigtable.py
@@ -37,6 +37,7 @@ INSTANCE_ID = 'test-instance-id'
 CLUSTER_ID = 'test-cluster-id'
 CLUSTER_ZONE = 'us-central1-f'
 GCP_CONN_ID = 'test-gcp-conn-id'
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 NODES = 5
 INSTANCE_DISPLAY_NAME = "test instance"
 INSTANCE_TYPE = enums.Instance.Type.PRODUCTION
@@ -79,11 +80,15 @@ class TestBigtableInstanceCreate(unittest.TestCase):
             main_cluster_id=CLUSTER_ID,
             main_cluster_zone=CLUSTER_ZONE,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_instance.assert_not_called()
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
@@ -95,11 +100,15 @@ class TestBigtableInstanceCreate(unittest.TestCase):
             main_cluster_id=CLUSTER_ID,
             main_cluster_zone=CLUSTER_ZONE,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_instance.assert_not_called()
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
@@ -111,7 +120,8 @@ class TestBigtableInstanceCreate(unittest.TestCase):
             main_cluster_id=CLUSTER_ID,
             main_cluster_zone=CLUSTER_ZONE,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         mock_hook.return_value.create_instance.side_effect = mock.Mock(
@@ -120,7 +130,10 @@ class TestBigtableInstanceCreate(unittest.TestCase):
         with self.assertRaises(google.api_core.exceptions.GoogleAPICallError):
             op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_instance.assert_called_once_with(
             cluster_nodes=None,
             cluster_storage_type=None,
@@ -147,10 +160,14 @@ class TestBigtableInstanceUpdate(unittest.TestCase):
             instance_type=INSTANCE_TYPE,
             instance_labels=INSTANCE_LABELS,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -168,10 +185,14 @@ class TestBigtableInstanceUpdate(unittest.TestCase):
             instance_type=INSTANCE_TYPE,
             instance_labels=INSTANCE_LABELS,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_instance.assert_called_once_with(
             project_id=None,
             instance_id=INSTANCE_ID,
@@ -211,7 +232,8 @@ class TestBigtableInstanceUpdate(unittest.TestCase):
                 instance_type=INSTANCE_TYPE,
                 instance_labels=INSTANCE_LABELS,
                 task_id="id",
-                gcp_conn_id=GCP_CONN_ID
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
             )
             op.execute(None)
 
@@ -219,7 +241,10 @@ class TestBigtableInstanceUpdate(unittest.TestCase):
         self.assertEqual(str(err), "Dependency: instance '{}' does not exist.".format(
             INSTANCE_ID))
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_instance.assert_not_called()
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
@@ -233,7 +258,8 @@ class TestBigtableInstanceUpdate(unittest.TestCase):
                 instance_type=INSTANCE_TYPE,
                 instance_labels=INSTANCE_LABELS,
                 task_id="id",
-                gcp_conn_id=GCP_CONN_ID
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
             )
             op.execute(None)
 
@@ -241,7 +267,10 @@ class TestBigtableInstanceUpdate(unittest.TestCase):
         self.assertEqual(str(err), "Dependency: instance '{}' does not exist.".format(
             INSTANCE_ID))
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_instance.assert_not_called()
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
@@ -253,7 +282,8 @@ class TestBigtableInstanceUpdate(unittest.TestCase):
             instance_type=INSTANCE_TYPE,
             instance_labels=INSTANCE_LABELS,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.update_instance.side_effect = mock.Mock(
             side_effect=google.api_core.exceptions.GoogleAPICallError('error'))
@@ -261,7 +291,10 @@ class TestBigtableInstanceUpdate(unittest.TestCase):
         with self.assertRaises(google.api_core.exceptions.GoogleAPICallError):
             op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -305,14 +338,18 @@ class TestBigtableClusterUpdate(unittest.TestCase):
                 cluster_id=CLUSTER_ID,
                 nodes=NODES,
                 task_id="id",
-                gcp_conn_id=GCP_CONN_ID
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
             )
             op.execute(None)
 
         err = e.exception
         self.assertEqual(str(err), "Dependency: instance '{}' does not exist.".format(
             INSTANCE_ID))
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_cluster.assert_not_called()
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
@@ -326,14 +363,18 @@ class TestBigtableClusterUpdate(unittest.TestCase):
                 cluster_id=CLUSTER_ID,
                 nodes=NODES,
                 task_id="id",
-                gcp_conn_id=GCP_CONN_ID
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
             )
             op.execute(None)
 
         err = e.exception
         self.assertEqual(str(err), "Dependency: instance '{}' does not exist.".format(
             INSTANCE_ID))
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_cluster.assert_not_called()
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
@@ -349,7 +390,8 @@ class TestBigtableClusterUpdate(unittest.TestCase):
                 cluster_id=CLUSTER_ID,
                 nodes=NODES,
                 task_id="id",
-                gcp_conn_id=GCP_CONN_ID
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
             )
             op.execute(None)
 
@@ -359,7 +401,10 @@ class TestBigtableClusterUpdate(unittest.TestCase):
             "Dependency: cluster '{}' does not exist for instance '{}'.".format(
                 CLUSTER_ID, INSTANCE_ID)
         )
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_cluster.assert_called_once_with(
             instance=instance, cluster_id=CLUSTER_ID, nodes=NODES)
 
@@ -375,7 +420,8 @@ class TestBigtableClusterUpdate(unittest.TestCase):
                 cluster_id=CLUSTER_ID,
                 nodes=NODES,
                 task_id="id",
-                gcp_conn_id=GCP_CONN_ID
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
             )
             op.execute(None)
 
@@ -385,7 +431,10 @@ class TestBigtableClusterUpdate(unittest.TestCase):
             "Dependency: cluster '{}' does not exist for instance '{}'.".format(
                 CLUSTER_ID, INSTANCE_ID)
         )
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_cluster.assert_called_once_with(
             instance=instance, cluster_id=CLUSTER_ID, nodes=NODES)
 
@@ -397,7 +446,8 @@ class TestBigtableClusterUpdate(unittest.TestCase):
             cluster_id=CLUSTER_ID,
             nodes=NODES,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         instance = mock_hook.return_value.get_instance.return_value = mock.Mock(Instance)
         mock_hook.return_value.update_cluster.side_effect = mock.Mock(
@@ -406,7 +456,10 @@ class TestBigtableClusterUpdate(unittest.TestCase):
         with self.assertRaises(google.api_core.exceptions.GoogleAPICallError):
             op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_cluster.assert_called_once_with(
             instance=instance, cluster_id=CLUSTER_ID, nodes=NODES)
 
@@ -418,10 +471,14 @@ class TestBigtableInstanceDelete(unittest.TestCase):
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID)
@@ -431,10 +488,14 @@ class TestBigtableInstanceDelete(unittest.TestCase):
         op = BigtableDeleteInstanceOperator(
             instance_id=INSTANCE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=None,
             instance_id=INSTANCE_ID)
@@ -460,12 +521,16 @@ class TestBigtableInstanceDelete(unittest.TestCase):
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.delete_instance.side_effect = mock.Mock(
             side_effect=google.api_core.exceptions.NotFound("Instance not found."))
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID)
@@ -475,12 +540,16 @@ class TestBigtableInstanceDelete(unittest.TestCase):
         op = BigtableDeleteInstanceOperator(
             instance_id=INSTANCE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.delete_instance.side_effect = mock.Mock(
             side_effect=google.api_core.exceptions.NotFound("Instance not found."))
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=None,
             instance_id=INSTANCE_ID)
@@ -491,7 +560,8 @@ class TestBigtableInstanceDelete(unittest.TestCase):
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.delete_instance.side_effect = mock.Mock(
             side_effect=google.api_core.exceptions.GoogleAPICallError('error'))
@@ -499,7 +569,10 @@ class TestBigtableInstanceDelete(unittest.TestCase):
         with self.assertRaises(google.api_core.exceptions.GoogleAPICallError):
             op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID)
@@ -513,10 +586,14 @@ class TestBigtableTableDelete(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_table.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -548,13 +625,17 @@ class TestBigtableTableDelete(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         mock_hook.return_value.delete_table.side_effect = mock.Mock(
             side_effect=google.api_core.exceptions.NotFound("Table not found."))
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_table.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -566,13 +647,17 @@ class TestBigtableTableDelete(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         mock_hook.return_value.delete_table.side_effect = mock.Mock(
             side_effect=google.api_core.exceptions.NotFound("Table not found."))
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_table.assert_called_once_with(
             project_id=None,
             instance_id=INSTANCE_ID,
@@ -585,7 +670,8 @@ class TestBigtableTableDelete(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         mock_hook.return_value.get_instance.return_value = None
@@ -594,7 +680,10 @@ class TestBigtableTableDelete(unittest.TestCase):
         err = e.exception
         self.assertEqual(str(err), "Dependency: instance '{}' does not exist.".format(
             INSTANCE_ID))
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_table.assert_not_called()
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
@@ -604,7 +693,8 @@ class TestBigtableTableDelete(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.delete_table.side_effect = mock.Mock(
             side_effect=google.api_core.exceptions.GoogleAPICallError('error'))
@@ -612,7 +702,10 @@ class TestBigtableTableDelete(unittest.TestCase):
         with self.assertRaises(google.api_core.exceptions.GoogleAPICallError):
             op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_table.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -629,11 +722,15 @@ class TestBigtableTableCreate(unittest.TestCase):
             initial_split_keys=INITIAL_SPLIT_KEYS,
             column_families=EMPTY_COLUMN_FAMILIES,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         instance = mock_hook.return_value.get_instance.return_value = mock.Mock(Instance)
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_table.assert_called_once_with(
             instance=instance,
             table_id=TABLE_ID,
@@ -668,7 +765,8 @@ class TestBigtableTableCreate(unittest.TestCase):
             initial_split_keys=INITIAL_SPLIT_KEYS,
             column_families=EMPTY_COLUMN_FAMILIES,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.get_instance.return_value = None
         with self.assertRaises(AirflowException) as e:
@@ -679,7 +777,10 @@ class TestBigtableTableCreate(unittest.TestCase):
             "Dependency: instance '{}' does not exist in project '{}'.".format(
                 INSTANCE_ID, PROJECT_ID)
         )
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
     def test_creating_table_that_exists(self, mock_hook):
@@ -690,7 +791,8 @@ class TestBigtableTableCreate(unittest.TestCase):
             initial_split_keys=INITIAL_SPLIT_KEYS,
             column_families=EMPTY_COLUMN_FAMILIES,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         mock_hook.return_value.get_column_families_for_table.return_value = \
@@ -700,7 +802,10 @@ class TestBigtableTableCreate(unittest.TestCase):
             side_effect=google.api_core.exceptions.AlreadyExists("Table already exists."))
         op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_table.assert_called_once_with(
             instance=instance,
             table_id=TABLE_ID,
@@ -715,7 +820,8 @@ class TestBigtableTableCreate(unittest.TestCase):
             initial_split_keys=INITIAL_SPLIT_KEYS,
             column_families=EMPTY_COLUMN_FAMILIES,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         mock_hook.return_value.get_column_families_for_table.return_value = \
@@ -725,7 +831,10 @@ class TestBigtableTableCreate(unittest.TestCase):
             side_effect=google.api_core.exceptions.AlreadyExists("Table already exists."))
         op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_table.assert_called_once_with(
             instance=instance,
             table_id=TABLE_ID,
@@ -742,7 +851,8 @@ class TestBigtableTableCreate(unittest.TestCase):
             initial_split_keys=INITIAL_SPLIT_KEYS,
             column_families=EMPTY_COLUMN_FAMILIES,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         mock_hook.return_value.get_column_families_for_table.return_value = {
@@ -757,7 +867,10 @@ class TestBigtableTableCreate(unittest.TestCase):
             str(err),
             "Table '{}' already exists with different Column Families.".format(TABLE_ID)
         )
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
     @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
     def test_creating_table_that_exists_with_different_column_families_gc_rule_in__table(
@@ -769,7 +882,8 @@ class TestBigtableTableCreate(unittest.TestCase):
             initial_split_keys=INITIAL_SPLIT_KEYS,
             column_families={"cf-id": MaxVersionsGCRule(1)},
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         cf_mock = mock.Mock()
@@ -788,4 +902,7 @@ class TestBigtableTableCreate(unittest.TestCase):
             str(err),
             "Table '{}' already exists with different Column Families.".format(TABLE_ID)
         )
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )

--- a/tests/providers/google/cloud/operators/test_cloud_memorystore.py
+++ b/tests/providers/google/cloud/operators/test_cloud_memorystore.py
@@ -31,6 +31,7 @@ from airflow.providers.google.cloud.operators.cloud_memorystore import (
 )
 
 TEST_GCP_CONN_ID = "test-gcp-conn-id"
+TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 TEST_TASK_ID = "task-id"
 TEST_LOCATION = "test-location"
 TEST_INSTANCE_ID = "test-instance-id"
@@ -63,9 +64,13 @@ class TestCloudMemorystoreCreateInstanceOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_instance.assert_called_once_with(
             location=TEST_LOCATION,
             instance_id=TEST_INSTANCE_ID,
@@ -89,9 +94,13 @@ class TestCloudMemorystoreDeleteInstanceOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             location=TEST_LOCATION,
             instance=TEST_INSTANCE_NAME,
@@ -115,9 +124,13 @@ class TestCloudMemorystoreExportInstanceOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.export_instance.assert_called_once_with(
             location=TEST_LOCATION,
             instance=TEST_INSTANCE_NAME,
@@ -142,9 +155,13 @@ class TestCloudMemorystoreFailoverInstanceOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.failover_instance.assert_called_once_with(
             location=TEST_LOCATION,
             instance=TEST_INSTANCE_NAME,
@@ -168,9 +185,13 @@ class TestCloudMemorystoreGetInstanceOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.get_instance.assert_called_once_with(
             location=TEST_LOCATION,
             instance=TEST_INSTANCE_NAME,
@@ -194,9 +215,13 @@ class TestCloudMemorystoreImportOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.import_instance.assert_called_once_with(
             location=TEST_LOCATION,
             instance=TEST_INSTANCE_NAME,
@@ -220,9 +245,13 @@ class TestCloudMemorystoreListInstancesOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.list_instances.assert_called_once_with(
             location=TEST_LOCATION,
             page_size=TEST_PAGE_SIZE,
@@ -247,9 +276,13 @@ class TestCloudMemorystoreUpdateInstanceOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_instance.assert_called_once_with(
             update_mask=TEST_UPDATE_MASK,
             instance=TEST_INSTANCE,
@@ -275,9 +308,13 @@ class TestCloudMemorystoreScaleInstanceOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_instance.assert_called_once_with(
             update_mask={"paths": ["memory_size_gb"]},
             instance={"memory_size_gb": 4},
@@ -304,11 +341,15 @@ class TestCloudMemorystoreCreateInstanceAndImportOperatorOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(mock.MagicMock())
         mock_hook.assert_has_calls(
             [
-                mock.call(gcp_conn_id=TEST_GCP_CONN_ID),
+                mock.call(
+                    gcp_conn_id=TEST_GCP_CONN_ID,
+                    impersonation_chain=TEST_IMPERSONATION_CHAIN,
+                ),
                 mock.call().create_instance(
                     location=TEST_LOCATION,
                     instance_id=TEST_INSTANCE_ID,

--- a/tests/providers/google/cloud/operators/test_cloud_sql.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql.py
@@ -178,7 +178,8 @@ class TestCloudSql(unittest.TestCase):
             'task_instance': mock.Mock()
         })
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.create_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             body=CREATE_BODY
@@ -200,7 +201,8 @@ class TestCloudSql(unittest.TestCase):
             'task_instance': mock.Mock()
         })
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.create_instance.assert_called_once_with(
             project_id=None,
             body=CREATE_BODY
@@ -223,7 +225,8 @@ class TestCloudSql(unittest.TestCase):
             'task_instance': mock.Mock()
         })
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.create_instance.assert_not_called()
         self.assertIsNone(result)
 
@@ -293,7 +296,8 @@ class TestCloudSql(unittest.TestCase):
         self.assertIn("The field 'settings.ipConfiguration.authorizedNetworks' "
                       "should be of list type according to the specification", str(err))
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
 
     @mock.patch("airflow.providers.google.cloud.operators.cloud_sql.CloudSQLHook")
     def test_create_should_validate_non_empty_fields(self, mock_hook):
@@ -316,7 +320,8 @@ class TestCloudSql(unittest.TestCase):
         self.assertIn("The body field 'settings.tier' can't be empty. "
                       "Please provide a value.", str(err))
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
 
     @mock.patch("airflow.providers.google.cloud.operators.cloud_sql.CloudSQLHook")
     def test_instance_patch(self, mock_hook):
@@ -329,7 +334,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             body=PATCH_BODY,
@@ -347,7 +353,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_instance.assert_called_once_with(
             project_id=None,
             body=PATCH_BODY,
@@ -372,7 +379,8 @@ class TestCloudSql(unittest.TestCase):
         err = cm.exception
         self.assertIn('specify another instance to patch', str(err))
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_instance.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.operators.cloud_sql"
@@ -388,7 +396,8 @@ class TestCloudSql(unittest.TestCase):
         result = op.execute(None)
         self.assertTrue(result)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME
@@ -406,7 +415,8 @@ class TestCloudSql(unittest.TestCase):
         result = op.execute(None)
         self.assertTrue(result)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=None,
             instance=INSTANCE_NAME
@@ -428,7 +438,8 @@ class TestCloudSql(unittest.TestCase):
         result = op.execute(None)
         self.assertTrue(result)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_instance.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.operators.cloud_sql"
@@ -444,7 +455,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.create_database.assert_called_once_with(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
@@ -464,7 +476,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.create_database.assert_called_once_with(
             project_id=None,
             instance=INSTANCE_NAME,
@@ -487,7 +500,8 @@ class TestCloudSql(unittest.TestCase):
         result = op.execute(None)
         self.assertTrue(result)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.create_database.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.operators.cloud_sql"
@@ -504,7 +518,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_database.assert_called_once_with(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
@@ -526,7 +541,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_database.assert_called_once_with(
             project_id=None,
             instance=INSTANCE_NAME,
@@ -554,7 +570,8 @@ class TestCloudSql(unittest.TestCase):
         self.assertIn("Cloud SQL instance with ID", str(err))
         self.assertIn("does not contain database", str(err))
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_database.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.operators.cloud_sql.CloudSQLHook")
@@ -587,7 +604,8 @@ class TestCloudSql(unittest.TestCase):
         result = op.execute(None)
         self.assertTrue(result)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_database.assert_called_once_with(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
@@ -607,7 +625,8 @@ class TestCloudSql(unittest.TestCase):
         result = op.execute(None)
         self.assertTrue(result)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_database.assert_called_once_with(
             project_id=None,
             instance=INSTANCE_NAME,
@@ -629,7 +648,8 @@ class TestCloudSql(unittest.TestCase):
         result = op.execute(None)
         self.assertTrue(result)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_database.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.operators.cloud_sql.CloudSQLHook")
@@ -643,7 +663,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.export_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
@@ -661,7 +682,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.export_instance.assert_called_once_with(
             project_id=None,
             instance=INSTANCE_NAME,
@@ -680,7 +702,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.import_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance=INSTANCE_NAME,
@@ -698,7 +721,8 @@ class TestCloudSql(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
-                                          gcp_conn_id="google_cloud_default")
+                                          gcp_conn_id="google_cloud_default",
+                                          impersonation_chain=None,)
         mock_hook.return_value.import_instance.assert_called_once_with(
             project_id=None,
             instance=INSTANCE_NAME,

--- a/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
@@ -50,6 +50,7 @@ except ImportError:  # pragma: no cover
 
 GCP_PROJECT_ID = 'project-id'
 TASK_ID = 'task-id'
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 JOB_NAME = "job-name"
 OPERATION_NAME = "operation-name"
@@ -234,10 +235,18 @@ class TestGcpStorageTransferJobCreateOperator(unittest.TestCase):
         mock_hook.return_value.create_transfer_job.return_value = VALID_TRANSFER_JOB_GCS_RAW
         body = deepcopy(VALID_TRANSFER_JOB_GCS)
         del body['name']
-        op = CloudDataTransferServiceCreateJobOperator(body=body, task_id=TASK_ID)
+        op = CloudDataTransferServiceCreateJobOperator(
+            body=body,
+            task_id=TASK_ID,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
         result = op.execute(None)
 
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         mock_hook.return_value.create_transfer_job.assert_called_once_with(body=VALID_TRANSFER_JOB_GCS_RAW)
 
@@ -254,11 +263,19 @@ class TestGcpStorageTransferJobCreateOperator(unittest.TestCase):
         )
         body = deepcopy(VALID_TRANSFER_JOB_AWS)
         del body['name']
-        op = CloudDataTransferServiceCreateJobOperator(body=body, task_id=TASK_ID)
+        op = CloudDataTransferServiceCreateJobOperator(
+            body=body,
+            task_id=TASK_ID,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         result = op.execute(None)
 
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         mock_hook.return_value.create_transfer_job.assert_called_once_with(body=VALID_TRANSFER_JOB_AWS_RAW)
 
@@ -315,10 +332,19 @@ class TestGcpStorageTransferJobUpdateOperator(unittest.TestCase):
         mock_hook.return_value.update_transfer_job.return_value = VALID_TRANSFER_JOB_GCS
         body = {'transferJob': {'description': 'example-name'}, 'updateTransferJobFieldMask': DESCRIPTION}
 
-        op = CloudDataTransferServiceUpdateJobOperator(job_name=JOB_NAME, body=body, task_id=TASK_ID)
+        op = CloudDataTransferServiceUpdateJobOperator(
+            job_name=JOB_NAME,
+            body=body,
+            task_id=TASK_ID,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
         result = op.execute(None)
 
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_transfer_job.assert_called_once_with(job_name=JOB_NAME, body=body)
         self.assertEqual(result, VALID_TRANSFER_JOB_GCS)
 
@@ -350,10 +376,17 @@ class TestGcpStorageTransferJobDeleteOperator(unittest.TestCase):
     )
     def test_job_delete(self, mock_hook):
         op = CloudDataTransferServiceDeleteJobOperator(
-            job_name=JOB_NAME, project_id=GCP_PROJECT_ID, task_id='task-id'
+            job_name=JOB_NAME,
+            project_id=GCP_PROJECT_ID,
+            task_id='task-id',
+            google_impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_transfer_job.assert_called_once_with(
             job_name=JOB_NAME, project_id=GCP_PROJECT_ID
         )
@@ -399,9 +432,17 @@ class TestGpcStorageTransferOperationsGetOperator(unittest.TestCase):
     )
     def test_operation_get(self, mock_hook):
         mock_hook.return_value.get_transfer_operation.return_value = VALID_OPERATION
-        op = CloudDataTransferServiceGetOperationOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
+        op = CloudDataTransferServiceGetOperationOperator(
+            operation_name=OPERATION_NAME,
+            task_id=TASK_ID,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.get_transfer_operation.assert_called_once_with(operation_name=OPERATION_NAME)
         self.assertEqual(result, VALID_OPERATION)
 
@@ -440,9 +481,17 @@ class TestGcpStorageTransferOperationListOperator(unittest.TestCase):
     )
     def test_operation_list(self, mock_hook):
         mock_hook.return_value.list_transfer_operations.return_value = [VALID_TRANSFER_JOB_GCS]
-        op = CloudDataTransferServiceListOperationsOperator(request_filter=TEST_FILTER, task_id=TASK_ID)
+        op = CloudDataTransferServiceListOperationsOperator(
+            request_filter=TEST_FILTER,
+            task_id=TASK_ID,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.list_transfer_operations.assert_called_once_with(request_filter=TEST_FILTER)
         self.assertEqual(result, [VALID_TRANSFER_JOB_GCS])
 
@@ -477,9 +526,17 @@ class TestGcpStorageTransferOperationsPauseOperator(unittest.TestCase):
         'airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook'
     )
     def test_operation_pause(self, mock_hook):
-        op = CloudDataTransferServicePauseOperationOperator(operation_name=OPERATION_NAME, task_id='task-id')
+        op = CloudDataTransferServicePauseOperationOperator(
+            operation_name=OPERATION_NAME,
+            task_id='task-id',
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
         op.execute(None)
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.pause_transfer_operation.assert_called_once_with(operation_name=OPERATION_NAME)
 
     # Setting all of the operator's input parameters as templated dag_ids
@@ -522,9 +579,17 @@ class TestGcpStorageTransferOperationsResumeOperator(unittest.TestCase):
         'airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook'
     )
     def test_operation_resume(self, mock_hook):
-        op = CloudDataTransferServiceResumeOperationOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
+        op = CloudDataTransferServiceResumeOperationOperator(
+            operation_name=OPERATION_NAME,
+            task_id=TASK_ID,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.resume_transfer_operation.assert_called_once_with(
             operation_name=OPERATION_NAME
         )
@@ -570,9 +635,17 @@ class TestGcpStorageTransferOperationsCancelOperator(unittest.TestCase):
         'airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook'
     )
     def test_operation_cancel(self, mock_hook):
-        op = CloudDataTransferServiceCancelOperationOperator(operation_name=OPERATION_NAME, task_id=TASK_ID)
+        op = CloudDataTransferServiceCancelOperationOperator(
+            operation_name=OPERATION_NAME,
+            task_id=TASK_ID,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(api_version='v1', gcp_conn_id='google_cloud_default')
+        mock_hook.assert_called_once_with(
+            api_version='v1',
+            gcp_conn_id='google_cloud_default',
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.cancel_transfer_operation.assert_called_once_with(
             operation_name=OPERATION_NAME
         )

--- a/tests/providers/google/cloud/operators/test_compute.py
+++ b/tests/providers/google/cloud/operators/test_compute.py
@@ -60,7 +60,8 @@ class TestGceInstanceStart(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.start_instance.assert_called_once_with(
             zone=GCE_ZONE, resource_id=RESOURCE_ID, project_id=GCP_PROJECT_ID
         )
@@ -155,7 +156,8 @@ class TestGceInstanceStop(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.stop_instance.assert_called_once_with(
             zone=GCE_ZONE, resource_id=RESOURCE_ID, project_id=GCP_PROJECT_ID
         )
@@ -209,7 +211,8 @@ class TestGceInstanceStop(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.stop_instance.assert_called_once_with(
             zone=GCE_ZONE, resource_id=RESOURCE_ID, project_id=None
         )
@@ -256,7 +259,8 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.set_machine_type.assert_called_once_with(
             zone=GCE_ZONE,
             resource_id=RESOURCE_ID,
@@ -316,7 +320,8 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.set_machine_type.assert_called_once_with(
             zone=GCE_ZONE,
             resource_id=RESOURCE_ID,
@@ -369,7 +374,8 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
         self.assertIn(
             "The required body field 'machineType' is missing. Please add it.", str(err))
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
 
     MOCK_OP_RESPONSE = "{'kind': 'compute#operation', 'id': '8529919847974922736', " \
                        "'name': " \
@@ -532,7 +538,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.insert_instance_template.assert_called_once_with(
             project_id=GCP_PROJECT_ID,
             body=GCE_INSTANCE_TEMPLATE_BODY_INSERT,
@@ -554,7 +561,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.insert_instance_template.assert_called_once_with(
             project_id=None,
             body=GCE_INSTANCE_TEMPLATE_BODY_INSERT,
@@ -575,7 +583,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.insert_instance_template.assert_not_called()
         self.assertEqual(GCE_INSTANCE_TEMPLATE_BODY_GET_NEW, result)
 
@@ -595,7 +604,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.insert_instance_template.assert_called_once_with(
             project_id=GCP_PROJECT_ID,
             body=GCE_INSTANCE_TEMPLATE_BODY_INSERT,
@@ -620,7 +630,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
 
         body_insert = deepcopy(GCE_INSTANCE_TEMPLATE_BODY_INSERT)
         body_insert["description"] = "New description"
@@ -650,7 +661,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         body_insert = deepcopy(GCE_INSTANCE_TEMPLATE_BODY_INSERT)
         body_insert["some_wrong_field"] = "test"
         body_insert["properties"]["some_other_wrong_field"] = "test"
@@ -681,7 +693,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         body_insert = deepcopy(GCE_INSTANCE_TEMPLATE_BODY_INSERT)
         body_insert["properties"]["machineType"] = "n1-standard-2"
         mock_hook.return_value.insert_instance_template.assert_called_once_with(
@@ -723,7 +736,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         body_insert = deepcopy(GCE_INSTANCE_TEMPLATE_BODY_INSERT)
         body_insert["properties"]["networkInterfaces"] = [
             {
@@ -779,7 +793,8 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
 
         body_insert = deepcopy(GCE_INSTANCE_TEMPLATE_BODY_INSERT)
         body_insert["properties"]["disks"] = [
@@ -942,7 +957,8 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='beta',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_instance_group_manager.assert_called_once_with(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
@@ -965,7 +981,8 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='beta',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_instance_group_manager.assert_called_once_with(
             project_id=None,
             zone=GCE_ZONE,
@@ -991,7 +1008,8 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='beta',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         expected_patch_no_instance_template = \
             deepcopy(GCE_INSTANCE_GROUP_MANAGER_EXPECTED_PATCH)
         del expected_patch_no_instance_template['instanceTemplate']
@@ -1020,7 +1038,8 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='beta',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         expected_patch_no_versions = \
             deepcopy(GCE_INSTANCE_GROUP_MANAGER_EXPECTED_PATCH)
         del expected_patch_no_versions['versions']
@@ -1048,7 +1067,8 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='beta',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         expected_patch_with_update_policy = \
             deepcopy(GCE_INSTANCE_GROUP_MANAGER_EXPECTED_PATCH)
         expected_patch_with_update_policy['updatePolicy'] = GCE_INSTANCE_GROUP_MANAGER_UPDATE_POLICY
@@ -1072,11 +1092,12 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
             task_id='id',
             source_template=GCE_INSTANCE_TEMPLATE_SOURCE_URL,
             request_id=GCE_INSTANCE_GROUP_MANAGER_REQUEST_ID,
-            destination_template=GCE_INSTANCE_TEMPLATE_DESTINATION_URL
+            destination_template=GCE_INSTANCE_TEMPLATE_DESTINATION_URL,
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='beta',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_instance_group_manager.assert_called_once_with(
             project_id=GCP_PROJECT_ID,
             zone=GCE_ZONE,
@@ -1115,6 +1136,7 @@ class TestGceInstanceGroupManagerUpdate(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='beta',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.patch_instance_group_manager.assert_not_called()
         self.assertTrue(result)

--- a/tests/providers/google/cloud/operators/test_datacatalog.py
+++ b/tests/providers/google/cloud/operators/test_datacatalog.py
@@ -44,6 +44,7 @@ TEST_RETRY: Retry = Retry()
 TEST_TIMEOUT: float = 0.5
 TEST_METADATA: Sequence[Tuple[str, str]] = []
 TEST_GCP_CONN_ID: str = "test-gcp-conn-id"
+TEST_IMPERSONATION_CHAIN: Sequence[str] = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 TEST_ENTRY_GROUP_ID: str = "test-entry-group-id"
 TEST_TAG_TEMPLATE_ID: str = "test-tag-template-id"
 TEST_TAG_TEMPLATE_FIELD_ID: str = "test-tag-template-field-id"
@@ -104,10 +105,14 @@ class TestCloudDataCatalogCreateEntryOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
         result = task.execute(context={"task_instance": ti})
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_entry.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -140,10 +145,14 @@ class TestCloudDataCatalogCreateEntryOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
         result = task.execute(context={"task_instance": ti})
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_entry.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -183,10 +192,14 @@ class TestCloudDataCatalogCreateEntryGroupOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
         result = task.execute(context={"task_instance": ti})
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_entry_group.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group_id=TEST_ENTRY_GROUP_ID,
@@ -218,10 +231,14 @@ class TestCloudDataCatalogCreateTagOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
         result = task.execute(context={"task_instance": ti})
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_tag.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -253,10 +270,14 @@ class TestCloudDataCatalogCreateTagTemplateOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
         result = task.execute(context={"task_instance": ti})
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_tag_template.assert_called_once_with(
             location=TEST_LOCATION,
             tag_template_id=TEST_TAG_TEMPLATE_ID,
@@ -287,10 +308,14 @@ class TestCloudDataCatalogCreateTagTemplateFieldOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
         result = task.execute(context={"task_instance": ti})
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_tag_template_field.assert_called_once_with(
             location=TEST_LOCATION,
             tag_template=TEST_TAG_TEMPLATE_ID,
@@ -318,9 +343,13 @@ class TestCloudDataCatalogDeleteEntryOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_entry.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -344,9 +373,13 @@ class TestCloudDataCatalogDeleteEntryGroupOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_entry_group.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -371,9 +404,13 @@ class TestCloudDataCatalogDeleteTagOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_tag.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -399,9 +436,13 @@ class TestCloudDataCatalogDeleteTagTemplateOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_tag_template.assert_called_once_with(
             location=TEST_LOCATION,
             tag_template=TEST_TAG_TEMPLATE_ID,
@@ -427,9 +468,13 @@ class TestCloudDataCatalogDeleteTagTemplateFieldOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_tag_template_field.assert_called_once_with(
             location=TEST_LOCATION,
             tag_template=TEST_TAG_TEMPLATE_ID,
@@ -455,9 +500,13 @@ class TestCloudDataCatalogGetEntryOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.get_entry.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -482,9 +531,13 @@ class TestCloudDataCatalogGetEntryGroupOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.get_entry_group.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -508,9 +561,13 @@ class TestCloudDataCatalogGetTagTemplateOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.get_tag_template.assert_called_once_with(
             location=TEST_LOCATION,
             tag_template=TEST_TAG_TEMPLATE_ID,
@@ -535,9 +592,13 @@ class TestCloudDataCatalogListTagsOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.list_tags.assert_called_once_with(
             location=TEST_LOCATION,
             entry_group=TEST_ENTRY_GROUP_ID,
@@ -561,9 +622,13 @@ class TestCloudDataCatalogLookupEntryOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.lookup_entry.assert_called_once_with(
             linked_resource=TEST_LINKED_RESOURCE,
             sql_resource=TEST_SQL_RESOURCE,
@@ -587,9 +652,13 @@ class TestCloudDataCatalogRenameTagTemplateFieldOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.rename_tag_template_field.assert_called_once_with(
             location=TEST_LOCATION,
             tag_template=TEST_TAG_TEMPLATE_ID,
@@ -615,9 +684,13 @@ class TestCloudDataCatalogSearchCatalogOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.search_catalog.assert_called_once_with(
             scope=TEST_SCOPE,
             query=TEST_QUERY,
@@ -644,9 +717,13 @@ class TestCloudDataCatalogUpdateEntryOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_entry.assert_called_once_with(
             entry=TEST_ENTRY,
             update_mask=TEST_UPDATE_MASK,
@@ -676,9 +753,13 @@ class TestCloudDataCatalogUpdateTagOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_tag.assert_called_once_with(
             tag=TEST_TAG_ID,
             update_mask=TEST_UPDATE_MASK,
@@ -707,9 +788,13 @@ class TestCloudDataCatalogUpdateTagTemplateOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_tag_template.assert_called_once_with(
             tag_template=TEST_TAG_TEMPLATE_ID,
             update_mask=TEST_UPDATE_MASK,
@@ -738,9 +823,13 @@ class TestCloudDataCatalogUpdateTagTemplateFieldOperator(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
             gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         task.execute(context=mock.MagicMock())
-        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_tag_template_field.assert_called_once_with(
             tag_template_field=TEST_TAG_TEMPLATE_FIELD,
             update_mask=TEST_UPDATE_MASK,

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -44,6 +44,7 @@ TASK_ID = "task-id"
 GCP_PROJECT = "test-project"
 GCP_LOCATION = "test-location"
 GCP_CONN_ID = "test-conn"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 CLUSTER_NAME = "cluster_name"
 CLUSTER = {
@@ -210,9 +211,13 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
             retry=RETRY,
             timeout=TIMEOUT,
             metadata=METADATA,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_cluster.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -237,9 +242,13 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
             timeout=TIMEOUT,
             metadata=METADATA,
             request_id=REQUEST_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_cluster.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -376,10 +385,14 @@ class TestDataprocClusterScaleOperator(unittest.TestCase):
             num_preemptible_workers=4,
             graceful_decommission_timeout="10m",
             gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_cluster.assert_called_once_with(
             project_id=GCP_PROJECT,
             location=GCP_LOCATION,
@@ -403,9 +416,13 @@ class TestDataprocClusterDeleteOperator(unittest.TestCase):
             retry=RETRY,
             timeout=TIMEOUT,
             metadata=METADATA,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_cluster.assert_called_once_with(
             region=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -436,10 +453,14 @@ class TestDataprocSubmitJobOperator(unittest.TestCase):
             timeout=TIMEOUT,
             metadata=METADATA,
             request_id=REQUEST_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.submit_job.assert_called_once_with(
             project_id=GCP_PROJECT,
             location=GCP_LOCATION,
@@ -470,9 +491,13 @@ class TestDataprocUpdateClusterOperator(unittest.TestCase):
             retry=RETRY,
             timeout=TIMEOUT,
             metadata=METADATA,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.update_cluster.assert_called_once_with(
             location=GCP_LOCATION,
             project_id=GCP_PROJECT,
@@ -506,9 +531,13 @@ class TestDataprocWorkflowTemplateInstantiateOperator(unittest.TestCase):
             timeout=TIMEOUT,
             metadata=METADATA,
             gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.instantiate_workflow_template.assert_called_once_with(
             template_name=template_id,
             location=GCP_LOCATION,
@@ -537,9 +566,13 @@ class TestDataprocWorkflowTemplateInstantiateInlineOperator(unittest.TestCase):
             timeout=TIMEOUT,
             metadata=METADATA,
             gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.instantiate_inline_workflow_template.assert_called_once_with(
             template=template,
             location=GCP_LOCATION,
@@ -589,9 +622,13 @@ class TestDataProcHiveOperator(unittest.TestCase):
             gcp_conn_id=GCP_CONN_ID,
             query=self.query,
             variables=self.variables,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.submit_job.assert_called_once_with(
             project_id=GCP_PROJECT, job=self.job, location=GCP_LOCATION
         )
@@ -654,9 +691,13 @@ class TestDataProcPigOperator(unittest.TestCase):
             gcp_conn_id=GCP_CONN_ID,
             query=self.query,
             variables=self.variables,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.submit_job.assert_called_once_with(
             project_id=GCP_PROJECT, job=self.job, location=GCP_LOCATION
         )
@@ -722,9 +763,13 @@ class TestDataProcSparkSqlOperator(unittest.TestCase):
             gcp_conn_id=GCP_CONN_ID,
             query=self.query,
             variables=self.variables,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context={})
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.submit_job.assert_called_once_with(
             project_id=GCP_PROJECT, job=self.job, location=GCP_LOCATION
         )

--- a/tests/providers/google/cloud/operators/test_datastore.py
+++ b/tests/providers/google/cloud/operators/test_datastore.py
@@ -52,7 +52,7 @@ class TestCloudDatastoreExportEntitiesOperator:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(CONN_ID, None)
+        mock_hook.assert_called_once_with(CONN_ID, None, impersonation_chain=None)
         mock_hook.return_value.export_to_storage_bucket.assert_called_once_with(
             project_id=PROJECT_ID,
             bucket=BUCKET,
@@ -85,7 +85,7 @@ class TestCloudDatastoreImportEntitiesOperator:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(CONN_ID, None)
+        mock_hook.assert_called_once_with(CONN_ID, None, impersonation_chain=None)
         mock_hook.return_value.import_from_storage_bucket.assert_called_once_with(
             project_id=PROJECT_ID,
             bucket=BUCKET,
@@ -112,7 +112,7 @@ class TestCloudDatastoreAllocateIds:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.allocate_ids.assert_called_once_with(
             project_id=PROJECT_ID, partial_keys=partial_keys
         )
@@ -129,7 +129,7 @@ class TestCloudDatastoreBeginTransaction:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.begin_transaction.assert_called_once_with(
             project_id=PROJECT_ID, transaction_options=BODY
         )
@@ -143,7 +143,7 @@ class TestCloudDatastoreCommit:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.commit.assert_called_once_with(
             project_id=PROJECT_ID, body=BODY
         )
@@ -157,7 +157,7 @@ class TestCloudDatastoreDeleteOperation:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.delete_operation.assert_called_once_with(
             name=TRANSACTION
         )
@@ -171,7 +171,7 @@ class TestCloudDatastoreGetOperation:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.get_operation.assert_called_once_with(name=TRANSACTION)
 
 
@@ -186,7 +186,7 @@ class TestCloudDatastoreRollback:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.rollback.assert_called_once_with(
             project_id=PROJECT_ID, transaction=TRANSACTION
         )
@@ -200,7 +200,7 @@ class TestCloudDatastoreRunQuery:
         )
         op.execute({})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID)
+        mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.run_query.assert_called_once_with(
             project_id=PROJECT_ID, body=BODY
         )

--- a/tests/providers/google/cloud/operators/test_dlp.py
+++ b/tests/providers/google/cloud/operators/test_dlp.py
@@ -55,7 +55,10 @@ class TestCloudDLPCancelDLPJobOperator(unittest.TestCase):
         mock_hook.return_value.cancel_dlp_job.return_value = mock.MagicMock()
         operator = CloudDLPCancelDLPJobOperator(dlp_job_id=DLP_JOB_ID, task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.cancel_dlp_job.assert_called_once_with(
             dlp_job_id=DLP_JOB_ID,
             project_id=None,
@@ -73,7 +76,10 @@ class TestCloudDLPCreateDeidentifyTemplateOperator(unittest.TestCase):
             organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_deidentify_template.assert_called_once_with(
             organization_id=ORGANIZATION_ID,
             project_id=None,
@@ -91,7 +97,10 @@ class TestCloudDLPCreateDLPJobOperator(unittest.TestCase):
         mock_hook.return_value.create_dlp_job.return_value = mock.MagicMock()
         operator = CloudDLPCreateDLPJobOperator(project_id=PROJECT_ID, task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_dlp_job.assert_called_once_with(
             project_id=PROJECT_ID,
             inspect_job=None,
@@ -112,7 +121,10 @@ class TestCloudDLPCreateInspectTemplateOperator(unittest.TestCase):
             organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_inspect_template.assert_called_once_with(
             organization_id=ORGANIZATION_ID,
             project_id=None,
@@ -130,7 +142,10 @@ class TestCloudDLPCreateJobTriggerOperator(unittest.TestCase):
         mock_hook.return_value.create_job_trigger.return_value = mock.MagicMock()
         operator = CloudDLPCreateJobTriggerOperator(project_id=PROJECT_ID, task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_job_trigger.assert_called_once_with(
             project_id=PROJECT_ID,
             job_trigger=None,
@@ -149,7 +164,10 @@ class TestCloudDLPCreateStoredInfoTypeOperator(unittest.TestCase):
             organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_stored_info_type.assert_called_once_with(
             organization_id=ORGANIZATION_ID,
             project_id=None,
@@ -169,7 +187,10 @@ class TestCloudDLPDeidentifyContentOperator(unittest.TestCase):
             project_id=PROJECT_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.deidentify_content.assert_called_once_with(
             project_id=PROJECT_ID,
             deidentify_config=None,
@@ -191,7 +212,10 @@ class TestCloudDLPDeleteDeidentifyTemplateOperator(unittest.TestCase):
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_deidentify_template.assert_called_once_with(
             template_id=TEMPLATE_ID,
             organization_id=ORGANIZATION_ID,
@@ -210,7 +234,10 @@ class TestCloudDLPDeleteDlpJobOperator(unittest.TestCase):
             dlp_job_id=DLP_JOB_ID, project_id=PROJECT_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_dlp_job.assert_called_once_with(
             dlp_job_id=DLP_JOB_ID,
             project_id=PROJECT_ID,
@@ -228,7 +255,10 @@ class TestCloudDLPDeleteInspectTemplateOperator(unittest.TestCase):
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_inspect_template.assert_called_once_with(
             template_id=TEMPLATE_ID,
             organization_id=ORGANIZATION_ID,
@@ -247,7 +277,10 @@ class TestCloudDLPDeleteJobTriggerOperator(unittest.TestCase):
             job_trigger_id=TRIGGER_ID, project_id=PROJECT_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_job_trigger.assert_called_once_with(
             job_trigger_id=TRIGGER_ID,
             project_id=PROJECT_ID,
@@ -267,7 +300,10 @@ class TestCloudDLPDeleteStoredInfoTypeOperator(unittest.TestCase):
             task_id="id",
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_stored_info_type.assert_called_once_with(
             stored_info_type_id=STORED_INFO_TYPE_ID,
             organization_id=ORGANIZATION_ID,
@@ -286,7 +322,10 @@ class TestCloudDLPGetDeidentifyTemplateOperator(unittest.TestCase):
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_deidentify_template.assert_called_once_with(
             template_id=TEMPLATE_ID,
             organization_id=ORGANIZATION_ID,
@@ -305,7 +344,10 @@ class TestCloudDLPGetDlpJobOperator(unittest.TestCase):
             dlp_job_id=DLP_JOB_ID, project_id=PROJECT_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_dlp_job.assert_called_once_with(
             dlp_job_id=DLP_JOB_ID,
             project_id=PROJECT_ID,
@@ -323,7 +365,10 @@ class TestCloudDLPGetInspectTemplateOperator(unittest.TestCase):
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_inspect_template.assert_called_once_with(
             template_id=TEMPLATE_ID,
             organization_id=ORGANIZATION_ID,
@@ -342,7 +387,10 @@ class TestCloudDLPGetJobTripperOperator(unittest.TestCase):
             job_trigger_id=TRIGGER_ID, project_id=PROJECT_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_job_trigger.assert_called_once_with(
             job_trigger_id=TRIGGER_ID,
             project_id=PROJECT_ID,
@@ -362,7 +410,10 @@ class TestCloudDLPGetStoredInfoTypeOperator(unittest.TestCase):
             task_id="id",
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_stored_info_type.assert_called_once_with(
             stored_info_type_id=STORED_INFO_TYPE_ID,
             organization_id=ORGANIZATION_ID,
@@ -379,7 +430,10 @@ class TestCloudDLPInspectContentOperator(unittest.TestCase):
         mock_hook.return_value.inspect_content.return_value = mock.MagicMock()
         operator = CloudDLPInspectContentOperator(project_id=PROJECT_ID, task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.inspect_content.assert_called_once_with(
             project_id=PROJECT_ID,
             inspect_config=None,
@@ -399,7 +453,10 @@ class TestCloudDLPListDeidentifyTemplatesOperator(unittest.TestCase):
             organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.list_deidentify_templates.assert_called_once_with(
             organization_id=ORGANIZATION_ID,
             project_id=None,
@@ -417,7 +474,10 @@ class TestCloudDLPListDlpJobsOperator(unittest.TestCase):
         mock_hook.return_value.list_dlp_jobs.return_value = mock.MagicMock()
         operator = CloudDLPListDLPJobsOperator(project_id=PROJECT_ID, task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.list_dlp_jobs.assert_called_once_with(
             project_id=PROJECT_ID,
             results_filter=None,
@@ -436,7 +496,10 @@ class TestCloudDLPListInfoTypesOperator(unittest.TestCase):
         mock_hook.return_value.list_info_types.return_value = mock.MagicMock()
         operator = CloudDLPListInfoTypesOperator(task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.list_info_types.assert_called_once_with(
             language_code=None,
             results_filter=None,
@@ -454,7 +517,10 @@ class TestCloudDLPListInspectTemplatesOperator(unittest.TestCase):
             organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.list_inspect_templates.assert_called_once_with(
             organization_id=ORGANIZATION_ID,
             project_id=None,
@@ -472,7 +538,10 @@ class TestCloudDLPListJobTriggersOperator(unittest.TestCase):
         mock_hook.return_value.list_job_triggers.return_value = mock.MagicMock()
         operator = CloudDLPListJobTriggersOperator(project_id=PROJECT_ID, task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.list_job_triggers.assert_called_once_with(
             project_id=PROJECT_ID,
             page_size=None,
@@ -492,7 +561,10 @@ class TestCloudDLPListStoredInfoTypesOperator(unittest.TestCase):
             organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.list_stored_info_types.assert_called_once_with(
             organization_id=ORGANIZATION_ID,
             project_id=None,
@@ -510,7 +582,10 @@ class TestCloudDLPRedactImageOperator(unittest.TestCase):
         mock_hook.return_value.redact_image.return_value = mock.MagicMock()
         operator = CloudDLPRedactImageOperator(project_id=PROJECT_ID, task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.redact_image.assert_called_once_with(
             project_id=PROJECT_ID,
             inspect_config=None,
@@ -531,7 +606,10 @@ class TestCloudDLPReidentifyContentOperator(unittest.TestCase):
             project_id=PROJECT_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.reidentify_content.assert_called_once_with(
             project_id=PROJECT_ID,
             reidentify_config=None,
@@ -553,7 +631,10 @@ class TestCloudDLPUpdateDeidentifyTemplateOperator(unittest.TestCase):
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_deidentify_template.assert_called_once_with(
             template_id=TEMPLATE_ID,
             organization_id=ORGANIZATION_ID,
@@ -574,7 +655,10 @@ class TestCloudDLPUpdateInspectTemplateOperator(unittest.TestCase):
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_inspect_template.assert_called_once_with(
             template_id=TEMPLATE_ID,
             organization_id=ORGANIZATION_ID,
@@ -595,7 +679,10 @@ class TestCloudDLPUpdateJobTriggerOperator(unittest.TestCase):
             job_trigger_id=TRIGGER_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_job_trigger.assert_called_once_with(
             job_trigger_id=TRIGGER_ID,
             project_id=None,
@@ -617,7 +704,10 @@ class TestCloudDLPUpdateStoredInfoTypeOperator(unittest.TestCase):
             task_id="id",
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_stored_info_type.assert_called_once_with(
             stored_info_type_id=STORED_INFO_TYPE_ID,
             organization_id=ORGANIZATION_ID,

--- a/tests/providers/google/cloud/operators/test_functions.py
+++ b/tests/providers/google/cloud/operators/test_functions.py
@@ -97,7 +97,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.get_function.assert_called_once_with(
             'projects/test_project_id/locations/test_region/functions/helloWorld'
         )
@@ -123,7 +124,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.get_function.assert_called_once_with(
             'projects/test_project_id/locations/test_region/functions/helloWorld'
         )
@@ -147,7 +149,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         operator.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         new_body = deepcopy(VALID_BODY)
         new_body['labels'] = {
             'airflow-version': 'v' + version.replace('.', '-').replace('+', '-')}
@@ -196,7 +199,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.reset_mock()
 
     @parameterized.expand([
@@ -220,7 +224,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.reset_mock()
 
     @parameterized.expand([
@@ -243,7 +248,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.reset_mock()
 
     @mock.patch('airflow.providers.google.cloud.operators.functions.CloudFunctionsHook')
@@ -262,7 +268,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.reset_mock()
 
     @mock.patch('airflow.providers.google.cloud.operators.functions.CloudFunctionsHook')
@@ -282,7 +289,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         self.assertIn("The body field 'name' of value '' does not match",
                       str(err))
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.reset_mock()
 
     @parameterized.expand([
@@ -317,7 +325,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         err = cm.exception
         self.assertIn(message, str(err))
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.reset_mock()
 
     @parameterized.expand([
@@ -414,7 +423,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
             )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         if zip_path:
             mock_hook.return_value.upload_function_zip.assert_called_once_with(
                 project_id=project_id,
@@ -468,7 +478,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         err = cm.exception
         self.assertIn(message, str(err))
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.reset_mock()
 
     @parameterized.expand([
@@ -504,7 +515,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.get_function.assert_called_once_with(
             'projects/test_project_id/locations/test_region/functions/helloWorld'
         )
@@ -528,7 +540,8 @@ class TestGcfFunctionDeploy(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.reset_mock()
 
 
@@ -558,7 +571,8 @@ class TestGcfFunctionDelete(unittest.TestCase):
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_function.assert_called_once_with(
             'projects/project_name/locations/project_location/functions/function_name'
         )
@@ -573,7 +587,8 @@ class TestGcfFunctionDelete(unittest.TestCase):
         )
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
 
     @mock.patch('airflow.providers.google.cloud.operators.functions.CloudFunctionsHook')
     def test_invalid_name(self, mock_hook):
@@ -611,7 +626,8 @@ class TestGcfFunctionDelete(unittest.TestCase):
             side_effect=HttpError(resp=MOCK_RESP_404, content=b'not found'))
         op.execute(None)
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_function.assert_called_once_with(
             'projects/project_name/locations/project_location/functions/function_name'
         )
@@ -630,7 +646,8 @@ class TestGcfFunctionDelete(unittest.TestCase):
             op.execute(None)
 
         mock_hook.assert_called_once_with(api_version='v1',
-                                          gcp_conn_id='google_cloud_default')
+                                          gcp_conn_id='google_cloud_default',
+                                          impersonation_chain=None,)
         mock_hook.return_value.delete_function.assert_called_once_with(
             'projects/project_name/locations/project_location/functions/function_name'
         )
@@ -647,6 +664,7 @@ class TestGcfFunctionInvokeOperator(unittest.TestCase):
         payload = {'key': 'value'}
         api_version = 'test'
         gcp_conn_id = 'test_conn'
+        impersonation_chain = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
         op = CloudFunctionInvokeFunctionOperator(
             task_id='test',
@@ -655,12 +673,14 @@ class TestGcfFunctionInvokeOperator(unittest.TestCase):
             location=GCP_LOCATION,
             project_id=GCP_PROJECT_ID,
             api_version=api_version,
-            gcp_conn_id=gcp_conn_id
+            gcp_conn_id=gcp_conn_id,
+            impersonation_chain=impersonation_chain,
         )
         op.execute(None)
         mock_gcf_hook.assert_called_once_with(
             api_version=api_version,
-            gcp_conn_id=gcp_conn_id
+            gcp_conn_id=gcp_conn_id,
+            impersonation_chain=impersonation_chain,
         )
 
         mock_gcf_hook.return_value.call_function.assert_called_once_with(

--- a/tests/providers/google/cloud/operators/test_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs.py
@@ -34,6 +34,7 @@ PREFIX = "TEST"
 MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
 TEST_OBJECT = "dir1/test-object"
 LOCAL_FILE_PATH = "/home/airflow/gcp/test-object"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestGoogleCloudStorageCreateBucket(unittest.TestCase):
@@ -242,11 +243,13 @@ class TestGoogleCloudStorageSync(unittest.TestCase):
             allow_overwrite=True,
             gcp_conn_id="GCP_CONN_ID",
             delegate_to="DELEGATE_TO",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute({})
         mock_hook.assert_called_once_with(
             google_cloud_storage_conn_id='GCP_CONN_ID',
-            delegate_to='DELEGATE_TO'
+            delegate_to='DELEGATE_TO',
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.sync.assert_called_once_with(
             source_bucket='SOURCE_BUCKET',

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -44,6 +44,7 @@ TEST_MODEL_NAME = "test-model-name"
 TEST_VERSION_NAME = "test-version"
 TEST_GCP_CONN_ID = "test-gcp-conn-id"
 TEST_DELEGATE_TO = "test-delegate-to"
+TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 TEST_MODEL = {
     'name': TEST_MODEL_NAME,
 }
@@ -123,7 +124,8 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)
 
-        mock_hook.assert_called_once_with('google_cloud_default', None)
+        mock_hook.assert_called_once_with('google_cloud_default', None,
+                                          impersonation_chain=None,)
         hook_instance.create_job.assert_called_once_with(
             project_id='test-project',
             job={
@@ -163,7 +165,8 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)
 
-        mock_hook.assert_called_once_with('google_cloud_default', None)
+        mock_hook.assert_called_once_with('google_cloud_default', None,
+                                          impersonation_chain=None,)
         hook_instance.create_job.assert_called_once_with(
             project_id='test-project',
             job={
@@ -200,7 +203,8 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)
 
-        mock_hook.assert_called_once_with('google_cloud_default', None)
+        mock_hook.assert_called_once_with('google_cloud_default', None,
+                                          impersonation_chain=None,)
         hook_instance.create_job.assert_called_once_with(
             project_id='test-project',
             job={
@@ -278,7 +282,8 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
                 task_id='test-prediction')
             prediction_task.execute(None)
 
-            mock_hook.assert_called_once_with('google_cloud_default', None)
+            mock_hook.assert_called_once_with('google_cloud_default', None,
+                                              impersonation_chain=None,)
             hook_instance.create_job.assert_called_once_with(
                 'test-project', {
                     'jobId': 'test_prediction',
@@ -343,7 +348,10 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
         training_op.execute(MagicMock())
 
         mock_hook.assert_called_once_with(
-            gcp_conn_id='google_cloud_default', delegate_to=None)
+            gcp_conn_id='google_cloud_default',
+            delegate_to=None,
+            impersonation_chain=None,
+        )
         # Make sure only 'create_job' is invoked on hook instance
         self.assertEqual(len(hook_instance.mock_calls), 1)
         hook_instance.create_job.assert_called_once_with(
@@ -368,7 +376,11 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
             **self.TRAINING_DEFAULT_ARGS)
         training_op.execute(MagicMock())
 
-        mock_hook.assert_called_once_with(gcp_conn_id='google_cloud_default', delegate_to=None)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id='google_cloud_default',
+            delegate_to=None,
+            impersonation_chain=None,
+        )
         # Make sure only 'create_job' is invoked on hook instance
         self.assertEqual(len(hook_instance.mock_calls), 1)
         hook_instance.create_job.assert_called_once_with(
@@ -390,7 +402,10 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
             training_op.execute(None)
 
         mock_hook.assert_called_once_with(
-            gcp_conn_id='google_cloud_default', delegate_to=None)
+            gcp_conn_id='google_cloud_default',
+            delegate_to=None,
+            impersonation_chain=None,
+        )
         # Make sure only 'create_job' is invoked on hook instance
         self.assertEqual(len(hook_instance.mock_calls), 1)
         hook_instance.create_job.assert_called_once_with(
@@ -411,7 +426,10 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
             training_op.execute(None)
 
         mock_hook.assert_called_once_with(
-            gcp_conn_id='google_cloud_default', delegate_to=None)
+            gcp_conn_id='google_cloud_default',
+            delegate_to=None,
+            impersonation_chain=None,
+        )
         # Make sure only 'create_job' is invoked on hook instance
         self.assertEqual(len(hook_instance.mock_calls), 1)
         hook_instance.create_job.assert_called_once_with(
@@ -505,7 +523,10 @@ class TestMLEngineTrainingCancelJobOperator(unittest.TestCase):
         cancel_training_op.execute(None)
 
         mock_hook.assert_called_once_with(
-            gcp_conn_id='google_cloud_default', delegate_to=None)
+            gcp_conn_id='google_cloud_default',
+            delegate_to=None,
+            impersonation_chain=None,
+        )
         # Make sure only 'cancel_job' is invoked on hook instance
         self.assertEqual(len(hook_instance.mock_calls), 1)
         hook_instance.cancel_job.assert_called_once_with(
@@ -527,7 +548,10 @@ class TestMLEngineTrainingCancelJobOperator(unittest.TestCase):
             cancel_training_op.execute(None)
 
         mock_hook.assert_called_once_with(
-            gcp_conn_id='google_cloud_default', delegate_to=None)
+            gcp_conn_id='google_cloud_default',
+            delegate_to=None,
+            impersonation_chain=None,
+        )
         # Make sure only 'create_job' is invoked on hook instance
         self.assertEqual(len(hook_instance.mock_calls), 1)
         hook_instance.cancel_job.assert_called_once_with(
@@ -545,12 +569,17 @@ class TestMLEngineModelOperator(unittest.TestCase):
             model=TEST_MODEL,
             operation="create",
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO
+            delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_model.assert_called_once_with(
             project_id=TEST_PROJECT_ID, model=TEST_MODEL
         )
@@ -563,12 +592,17 @@ class TestMLEngineModelOperator(unittest.TestCase):
             model=TEST_MODEL,
             operation="get",
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO
+            delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         result = task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.get_model.assert_called_once_with(
             project_id=TEST_PROJECT_ID, model_name=TEST_MODEL_NAME
         )
@@ -597,12 +631,17 @@ class TestMLEngineCreateModelOperator(unittest.TestCase):
             project_id=TEST_PROJECT_ID,
             model=TEST_MODEL,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO
+            delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_model.assert_called_once_with(
             project_id=TEST_PROJECT_ID, model=TEST_MODEL
         )
@@ -617,12 +656,17 @@ class TestMLEngineGetModelOperator(unittest.TestCase):
             project_id=TEST_PROJECT_ID,
             model_name=TEST_MODEL_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO
+            delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         result = task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.get_model.assert_called_once_with(
             project_id=TEST_PROJECT_ID, model_name=TEST_MODEL_NAME
         )
@@ -639,12 +683,17 @@ class TestMLEngineDeleteModelOperator(unittest.TestCase):
             model_name=TEST_MODEL_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
             delete_contents=True
         )
 
         task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_model.assert_called_once_with(
             project_id=TEST_PROJECT_ID, model_name=TEST_MODEL_NAME, delete_contents=True
         )
@@ -668,7 +717,11 @@ class TestMLEngineVersionOperator(unittest.TestCase):
             **self.VERSION_DEFAULT_ARGS)
         training_op.execute(None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id='google_cloud_default', delegate_to=None)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id='google_cloud_default',
+            delegate_to=None,
+            impersonation_chain=None,
+        )
         # Make sure only 'create_version' is invoked on hook instance
         self.assertEqual(len(hook_instance.mock_calls), 1)
         hook_instance.create_version.assert_called_once_with(
@@ -686,11 +739,16 @@ class TestMLEngineCreateVersion(unittest.TestCase):
             version=TEST_VERSION,
             gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.create_version.assert_called_once_with(
             project_id=TEST_PROJECT_ID,
             model_name=TEST_MODEL_NAME,
@@ -731,11 +789,16 @@ class TestMLEngineSetDefaultVersion(unittest.TestCase):
             version_name=TEST_VERSION_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.set_default_version.assert_called_once_with(
             project_id=TEST_PROJECT_ID,
             model_name=TEST_MODEL_NAME,
@@ -775,11 +838,16 @@ class TestMLEngineListVersions(unittest.TestCase):
             model_name=TEST_MODEL_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.list_versions.assert_called_once_with(
             project_id=TEST_PROJECT_ID,
             model_name=TEST_MODEL_NAME,
@@ -807,11 +875,16 @@ class TestMLEngineDeleteVersion(unittest.TestCase):
             version_name=TEST_VERSION_NAME,
             gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
 
         task.execute(None)
 
-        mock_hook.assert_called_once_with(delegate_to=TEST_DELEGATE_TO, gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            delegate_to=TEST_DELEGATE_TO,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.delete_version.assert_called_once_with(
             project_id=TEST_PROJECT_ID,
             model_name=TEST_MODEL_NAME,

--- a/tests/providers/google/cloud/operators/test_mlengine_utils.py
+++ b/tests/providers/google/cloud/operators/test_mlengine_utils.py
@@ -88,7 +88,8 @@ class TestCreateEvaluateOps(unittest.TestCase):
             hook_instance = mock_mlengine_hook.return_value
             hook_instance.create_job.return_value = success_message
             result = pred.execute(None)
-            mock_mlengine_hook.assert_called_once_with('google_cloud_default', None)
+            mock_mlengine_hook.assert_called_once_with('google_cloud_default', None,
+                                                       impersonation_chain=None,)
             hook_instance.create_job.assert_called_once_with(
                 project_id='test-project',
                 job={

--- a/tests/providers/google/cloud/operators/test_spanner.py
+++ b/tests/providers/google/cloud/operators/test_spanner.py
@@ -53,7 +53,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -75,7 +78,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_instance.assert_called_once_with(
             project_id=None,
             instance_id=INSTANCE_ID,
@@ -98,7 +104,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_instance.assert_called_once_with(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -120,7 +129,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_instance.assert_called_once_with(
             project_id=None,
             instance_id=INSTANCE_ID,
@@ -143,7 +155,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_instance.assert_not_called()
         self.assertIsNone(result)
 
@@ -176,7 +191,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID
         )
@@ -190,7 +208,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=None,
             instance_id=INSTANCE_ID
@@ -207,7 +228,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_instance.assert_not_called()
         self.assertTrue(result)
 
@@ -239,7 +263,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.execute_dml.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID,
             database_id=DB_ID,
@@ -257,7 +284,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)  # pylint: disable=assignment-from-no-return
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.execute_dml.assert_called_once_with(
             project_id=None, instance_id=INSTANCE_ID,
             database_id=DB_ID, queries=[INSERT_QUERY]
@@ -296,7 +326,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.execute_dml.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID, database_id=DB_ID, queries=[INSERT_QUERY]
         )
@@ -312,7 +345,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.execute_dml.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID,
             database_id=DB_ID, queries=[INSERT_QUERY, INSERT_QUERY_2]
@@ -329,7 +365,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_database.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID, database_id=DB_ID,
             ddl_statements=DDL_STATEMENTS
@@ -347,7 +386,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_database.assert_called_once_with(
             project_id=None, instance_id=INSTANCE_ID, database_id=DB_ID,
             ddl_statements=DDL_STATEMENTS
@@ -366,7 +408,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_database.assert_not_called()
         mock_hook.return_value.update_database.assert_not_called()
         self.assertTrue(result)
@@ -404,7 +449,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_database.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID, database_id=DB_ID,
             ddl_statements=DDL_STATEMENTS, operation_id=None
@@ -421,7 +469,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_database.assert_called_once_with(
             project_id=None, instance_id=INSTANCE_ID, database_id=DB_ID,
             ddl_statements=DDL_STATEMENTS, operation_id=None
@@ -464,7 +515,10 @@ class TestCloudSpanner(unittest.TestCase):
         err = cm.exception
         self.assertIn("The Cloud Spanner database 'db1' in project 'project-id' and "
                       "instance 'instance-id' is missing", str(err))
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
 
     @mock.patch("airflow.providers.google.cloud.operators.spanner.SpannerHook")
     def test_database_delete(self, mock_hook):
@@ -476,7 +530,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_database.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID, database_id=DB_ID
         )
@@ -491,7 +548,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_database.assert_called_once_with(
             project_id=None, instance_id=INSTANCE_ID, database_id=DB_ID
         )
@@ -508,7 +568,10 @@ class TestCloudSpanner(unittest.TestCase):
             task_id="id"
         )
         result = op.execute(None)
-        mock_hook.assert_called_once_with(gcp_conn_id="google_cloud_default")
+        mock_hook.assert_called_once_with(
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_database.assert_not_called()
         self.assertTrue(result)
 

--- a/tests/providers/google/cloud/operators/test_speech_to_text.py
+++ b/tests/providers/google/cloud/operators/test_speech_to_text.py
@@ -25,6 +25,7 @@ from airflow.providers.google.cloud.operators.speech_to_text import CloudSpeechT
 
 PROJECT_ID = "project-id"
 GCP_CONN_ID = "gcp-conn-id"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 CONFIG = {"encoding": "LINEAR16"}
 AUDIO = {"uri": "gs://bucket/object"}
 
@@ -35,10 +36,18 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.return_value.recognize_speech.return_value = MagicMock()
 
         CloudSpeechToTextRecognizeSpeechOperator(  # pylint: disable=no-value-for-parameter
-            project_id=PROJECT_ID, gcp_conn_id=GCP_CONN_ID, config=CONFIG, audio=AUDIO, task_id="id"
+            project_id=PROJECT_ID,
+            gcp_conn_id=GCP_CONN_ID,
+            config=CONFIG,
+            audio=AUDIO,
+            task_id="id",
+            impersonation_chain=IMPERSONATION_CHAIN,
         ).execute(context={"task_instance": Mock()})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.recognize_speech.assert_called_once_with(
             config=CONFIG, audio=AUDIO, retry=None, timeout=None
         )

--- a/tests/providers/google/cloud/operators/test_tasks.py
+++ b/tests/providers/google/cloud/operators/test_tasks.py
@@ -49,7 +49,10 @@ class TestCloudTasksQueueCreate(unittest.TestCase):
             location=LOCATION, task_queue=Queue(), task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_queue.assert_called_once_with(
             location=LOCATION,
             task_queue=Queue(),
@@ -69,7 +72,10 @@ class TestCloudTasksQueueUpdate(unittest.TestCase):
             task_queue=Queue(name=FULL_QUEUE_PATH), task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_queue.assert_called_once_with(
             task_queue=Queue(name=FULL_QUEUE_PATH),
             project_id=None,
@@ -90,7 +96,10 @@ class TestCloudTasksQueueGet(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_queue.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -107,7 +116,10 @@ class TestCloudTasksQueuesList(unittest.TestCase):
         mock_hook.return_value.list_queues.return_value = mock.MagicMock()
         operator = CloudTasksQueuesListOperator(location=LOCATION, task_id="id")
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.list_queues.assert_called_once_with(
             location=LOCATION,
             project_id=None,
@@ -127,7 +139,10 @@ class TestCloudTasksQueueDelete(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_queue.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -146,7 +161,10 @@ class TestCloudTasksQueuePurge(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.purge_queue.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -165,7 +183,10 @@ class TestCloudTasksQueuePause(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.pause_queue.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -184,7 +205,10 @@ class TestCloudTasksQueueResume(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.resume_queue.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -203,7 +227,10 @@ class TestCloudTasksTaskCreate(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task=Task(), task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_task.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -225,7 +252,10 @@ class TestCloudTasksTaskGet(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_name=TASK_NAME, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_task.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -246,7 +276,10 @@ class TestCloudTasksTasksList(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.list_tasks.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -267,7 +300,10 @@ class TestCloudTasksTaskDelete(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_name=TASK_NAME, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_task.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,
@@ -287,7 +323,10 @@ class TestCloudTasksTaskRun(unittest.TestCase):
             location=LOCATION, queue_name=QUEUE_ID, task_name=TASK_NAME, task_id="id"
         )
         operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.run_task.assert_called_once_with(
             location=LOCATION,
             queue_name=QUEUE_ID,

--- a/tests/providers/google/cloud/operators/test_text_to_speech.py
+++ b/tests/providers/google/cloud/operators/test_text_to_speech.py
@@ -26,6 +26,7 @@ from airflow.providers.google.cloud.operators.text_to_speech import CloudTextToS
 
 PROJECT_ID = "project-id"
 GCP_CONN_ID = "gcp-conn-id"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 INPUT = {"text": "text"}
 VOICE = {"language_code": "en-US"}
 AUDIO_CONFIG = {"audio_encoding": "MP3"}
@@ -52,10 +53,17 @@ class TestGcpTextToSpeech(unittest.TestCase):
             target_bucket_name=TARGET_BUCKET_NAME,
             target_filename=TARGET_FILENAME,
             task_id="id",
+            impersonation_chain=IMPERSONATION_CHAIN,
         ).execute(context={"task_instance": Mock()})
 
-        mock_text_to_speech_hook.assert_called_once_with(gcp_conn_id="gcp-conn-id")
-        mock_gcp_hook.assert_called_once_with(google_cloud_storage_conn_id="gcp-conn-id")
+        mock_text_to_speech_hook.assert_called_once_with(
+            gcp_conn_id="gcp-conn-id",
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        mock_gcp_hook.assert_called_once_with(
+            google_cloud_storage_conn_id="gcp-conn-id",
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_text_to_speech_hook.return_value.synthesize_speech.assert_called_once_with(
             input_data=INPUT, voice=VOICE, audio_config=AUDIO_CONFIG, retry=None, timeout=None
         )

--- a/tests/providers/google/cloud/operators/test_translate.py
+++ b/tests/providers/google/cloud/operators/test_translate.py
@@ -23,6 +23,7 @@ import mock
 from airflow.providers.google.cloud.operators.translate import CloudTranslateTextOperator
 
 GCP_CONN_ID = 'google_cloud_default'
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestCloudTranslate(unittest.TestCase):
@@ -44,9 +45,13 @@ class TestCloudTranslate(unittest.TestCase):
             model='base',
             gcp_conn_id=GCP_CONN_ID,
             task_id='id',
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         return_value = op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.translate.assert_called_once_with(
             values=['zażółć gęślą jaźń'],
             target_language='en',

--- a/tests/providers/google/cloud/operators/test_translate_speech.py
+++ b/tests/providers/google/cloud/operators/test_translate_speech.py
@@ -27,6 +27,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.translate_speech import CloudTranslateSpeechOperator
 
 GCP_CONN_ID = 'google_cloud_default'
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestCloudTranslateSpeech(unittest.TestCase):
@@ -58,11 +59,18 @@ class TestCloudTranslateSpeech(unittest.TestCase):
             model='base',
             gcp_conn_id=GCP_CONN_ID,
             task_id='id',
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         return_value = op.execute(context=None)
 
-        mock_speech_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
-        mock_translate_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_speech_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        mock_translate_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         mock_speech_hook.return_value.recognize_speech.assert_called_once_with(
             audio={"uri": "gs://bucket/object"},
@@ -109,8 +117,14 @@ class TestCloudTranslateSpeech(unittest.TestCase):
         err = cm.exception
         self.assertIn("it should contain 'alternatives' field", str(err))
 
-        mock_speech_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
-        mock_translate_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_speech_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
+        mock_translate_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
 
         mock_speech_hook.return_value.recognize_speech.assert_called_once_with(
             audio={"uri": "gs://bucket/object"},

--- a/tests/providers/google/cloud/operators/test_video_intelligence.py
+++ b/tests/providers/google/cloud/operators/test_video_intelligence.py
@@ -29,6 +29,7 @@ from airflow.providers.google.cloud.operators.video_intelligence import (
 
 PROJECT_ID = "project-id"
 GCP_CONN_ID = "gcp-conn-id"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 CONFIG = {"encoding": "LINEAR16"}
 AUDIO = {"uri": "gs://bucket/object"}
 
@@ -44,10 +45,16 @@ class TestCloudVideoIntelligenceOperators(unittest.TestCase):
         mock_hook.return_value.annotate_video.return_value = mocked_operation
 
         CloudVideoIntelligenceDetectVideoLabelsOperator(
-            input_uri=INPUT_URI, task_id="id", gcp_conn_id=GCP_CONN_ID
+            input_uri=INPUT_URI,
+            task_id="id",
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         ).execute(context={"task_instance": mock.Mock()})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.annotate_video.assert_called_once_with(
             input_uri=INPUT_URI,
             features=[enums.Feature.LABEL_DETECTION],
@@ -65,10 +72,16 @@ class TestCloudVideoIntelligenceOperators(unittest.TestCase):
         mock_hook.return_value.annotate_video.return_value = mocked_operation
 
         CloudVideoIntelligenceDetectVideoExplicitContentOperator(
-            input_uri=INPUT_URI, task_id="id", gcp_conn_id=GCP_CONN_ID
+            input_uri=INPUT_URI,
+            task_id="id",
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         ).execute(context={"task_instance": mock.Mock()})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.annotate_video.assert_called_once_with(
             input_uri=INPUT_URI,
             features=[enums.Feature.EXPLICIT_CONTENT_DETECTION],
@@ -86,10 +99,16 @@ class TestCloudVideoIntelligenceOperators(unittest.TestCase):
         mock_hook.return_value.annotate_video.return_value = mocked_operation
 
         CloudVideoIntelligenceDetectVideoShotsOperator(
-            input_uri=INPUT_URI, task_id="id", gcp_conn_id=GCP_CONN_ID
+            input_uri=INPUT_URI,
+            task_id="id",
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         ).execute(context={"task_instance": mock.Mock()})
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_hook.return_value.annotate_video.assert_called_once_with(
             input_uri=INPUT_URI,
             features=[enums.Feature.SHOT_CHANGE_DETECTION],

--- a/tests/providers/google/cloud/operators/test_vision.py
+++ b/tests/providers/google/cloud/operators/test_vision.py
@@ -57,7 +57,10 @@ class TestCloudVisionProductSetCreate(unittest.TestCase):
             location=LOCATION_TEST, product_set=PRODUCTSET_TEST, task_id='id'
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_product_set.assert_called_once_with(
             location=LOCATION_TEST,
             product_set=PRODUCTSET_TEST,
@@ -91,7 +94,10 @@ class TestCloudVisionProductSetUpdate(unittest.TestCase):
             location=LOCATION_TEST, product_set=PRODUCTSET_TEST, task_id='id'
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_product_set.assert_called_once_with(
             location=LOCATION_TEST,
             product_set=PRODUCTSET_TEST,
@@ -112,7 +118,10 @@ class TestCloudVisionProductSetGet(unittest.TestCase):
             location=LOCATION_TEST, product_set_id=PRODUCTSET_ID_TEST, task_id='id'
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_product_set.assert_called_once_with(
             location=LOCATION_TEST,
             product_set_id=PRODUCTSET_ID_TEST,
@@ -131,7 +140,10 @@ class TestCloudVisionProductSetDelete(unittest.TestCase):
             location=LOCATION_TEST, product_set_id=PRODUCTSET_ID_TEST, task_id='id'
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_product_set.assert_called_once_with(
             location=LOCATION_TEST,
             product_set_id=PRODUCTSET_ID_TEST,
@@ -148,7 +160,10 @@ class TestCloudVisionProductCreate(unittest.TestCase):
         mock_hook.return_value.create_product.return_value = {}
         op = CloudVisionCreateProductOperator(location=LOCATION_TEST, product=PRODUCT_TEST, task_id='id')
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_product.assert_called_once_with(
             location=LOCATION_TEST,
             product=PRODUCT_TEST,
@@ -180,7 +195,10 @@ class TestCloudVisionProductGet(unittest.TestCase):
         mock_hook.return_value.get_product.return_value = {}
         op = CloudVisionGetProductOperator(location=LOCATION_TEST, product_id=PRODUCT_ID_TEST, task_id='id')
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.get_product.assert_called_once_with(
             location=LOCATION_TEST,
             product_id=PRODUCT_ID_TEST,
@@ -197,7 +215,10 @@ class TestCloudVisionProductUpdate(unittest.TestCase):
         mock_hook.return_value.update_product.return_value = {}
         op = CloudVisionUpdateProductOperator(location=LOCATION_TEST, product=PRODUCT_TEST, task_id='id')
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.update_product.assert_called_once_with(
             location=LOCATION_TEST,
             product=PRODUCT_TEST,
@@ -218,7 +239,10 @@ class TestCloudVisionProductDelete(unittest.TestCase):
             location=LOCATION_TEST, product_id=PRODUCT_ID_TEST, task_id='id'
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_product.assert_called_once_with(
             location=LOCATION_TEST,
             product_id=PRODUCT_ID_TEST,
@@ -242,7 +266,10 @@ class TestCloudVisionReferenceImageCreate(unittest.TestCase):
             task_id='id',
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_reference_image.assert_called_once_with(
             location=LOCATION_TEST,
             product_id=PRODUCT_ID_TEST,
@@ -267,7 +294,10 @@ class TestCloudVisionReferenceImageCreate(unittest.TestCase):
             task_id='id',
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.create_reference_image.assert_called_once_with(
             location=LOCATION_TEST,
             product_id=PRODUCT_ID_TEST,
@@ -293,7 +323,10 @@ class TestCloudVisionReferenceImageDelete(unittest.TestCase):
             task_id='id',
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.delete_reference_image.assert_called_once_with(
             location=LOCATION_TEST,
             product_id=PRODUCT_ID_TEST,
@@ -315,7 +348,10 @@ class TestCloudVisionAddProductToProductSetOperator(unittest.TestCase):
             task_id='id',
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.add_product_to_product_set.assert_called_once_with(
             product_set_id=PRODUCTSET_ID_TEST,
             product_id=PRODUCT_ID_TEST,
@@ -337,7 +373,10 @@ class TestCloudVisionRemoveProductFromProductSetOperator(unittest.TestCase):
             task_id='id',
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.remove_product_from_product_set.assert_called_once_with(
             product_set_id=PRODUCTSET_ID_TEST,
             product_id=PRODUCT_ID_TEST,
@@ -354,7 +393,10 @@ class TestCloudVisionAnnotateImageOperator(unittest.TestCase):
     def test_minimal_green_path_for_one_image(self, mock_hook):
         op = CloudVisionImageAnnotateOperator(request=ANNOTATE_REQUEST_TEST, task_id='id')
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.annotate_image.assert_called_once_with(
             request=ANNOTATE_REQUEST_TEST, retry=None, timeout=None
         )
@@ -363,7 +405,10 @@ class TestCloudVisionAnnotateImageOperator(unittest.TestCase):
     def test_minimal_green_path_for_batch(self, mock_hook):
         op = CloudVisionImageAnnotateOperator(request=ANNOTATE_REQUEST_BATCH_TEST, task_id='id')
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.batch_annotate_images.assert_called_once_with(
             requests=ANNOTATE_REQUEST_BATCH_TEST, retry=None, timeout=None
         )
@@ -374,7 +419,10 @@ class TestCloudVisionDetectTextOperator(unittest.TestCase):
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionDetectTextOperator(image=DETECT_TEST_IMAGE, task_id="id")
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.text_detection.assert_called_once_with(
             image=DETECT_TEST_IMAGE, max_results=None, retry=None, timeout=None, additional_properties=None
         )
@@ -394,7 +442,10 @@ class TestCloudVisionDetectTextOperator(unittest.TestCase):
             }
         )
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.text_detection.assert_called_once_with(
             image=DETECT_TEST_IMAGE,
             max_results=None,
@@ -418,7 +469,10 @@ class TestCloudVisionDetectDocumentTextOperator(unittest.TestCase):
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionTextDetectOperator(image=DETECT_TEST_IMAGE, task_id="id")
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.document_text_detection.assert_called_once_with(
             image=DETECT_TEST_IMAGE, max_results=None, retry=None, timeout=None, additional_properties=None
         )
@@ -429,7 +483,10 @@ class TestCloudVisionDetectImageLabelsOperator(unittest.TestCase):
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionDetectImageLabelsOperator(image=DETECT_TEST_IMAGE, task_id="id")
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.label_detection.assert_called_once_with(
             image=DETECT_TEST_IMAGE, max_results=None, retry=None, timeout=None, additional_properties=None
         )
@@ -440,7 +497,10 @@ class TestCloudVisionDetectImageSafeSearchOperator(unittest.TestCase):
     def test_minimal_green_path(self, mock_hook):
         op = CloudVisionDetectImageSafeSearchOperator(image=DETECT_TEST_IMAGE, task_id="id")
         op.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+        )
         mock_hook.return_value.safe_search_detection.assert_called_once_with(
             image=DETECT_TEST_IMAGE, max_results=None, retry=None, timeout=None, additional_properties=None
         )

--- a/tests/providers/google/cloud/sensors/test_bigquery.py
+++ b/tests/providers/google/cloud/sensors/test_bigquery.py
@@ -27,6 +27,7 @@ TEST_TABLE_ID = 'test_table'
 TEST_DELEGATE_TO = "test_delegate_to"
 TEST_GCP_CONN_ID = 'test_gcp_conn_id'
 TEST_PARTITION_ID = "20200101"
+TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestBigqueryTableExistenceSensor(TestCase):
@@ -38,7 +39,8 @@ class TestBigqueryTableExistenceSensor(TestCase):
             dataset_id=TEST_DATASET_ID,
             table_id=TEST_TABLE_ID,
             bigquery_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO
+            delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.table_exists.return_value = True
         results = task.poke(mock.MagicMock())
@@ -47,7 +49,8 @@ class TestBigqueryTableExistenceSensor(TestCase):
 
         mock_hook.assert_called_once_with(
             bigquery_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO
+            delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.table_exists.assert_called_once_with(
             project_id=TEST_PROJECT_ID,
@@ -66,7 +69,8 @@ class TestBigqueryTablePartitionExistenceSensor(TestCase):
             table_id=TEST_TABLE_ID,
             partition_id=TEST_PARTITION_ID,
             bigquery_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO
+            delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.table_partition_exists.return_value = True
         results = task.poke(mock.MagicMock())
@@ -75,7 +79,8 @@ class TestBigqueryTablePartitionExistenceSensor(TestCase):
 
         mock_hook.assert_called_once_with(
             bigquery_conn_id=TEST_GCP_CONN_ID,
-            delegate_to=TEST_DELEGATE_TO
+            delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.table_partition_exists.assert_called_once_with(
             project_id=TEST_PROJECT_ID,

--- a/tests/providers/google/cloud/sensors/test_bigtable.py
+++ b/tests/providers/google/cloud/sensors/test_bigtable.py
@@ -31,6 +31,7 @@ PROJECT_ID = 'test_project_id'
 INSTANCE_ID = 'test-instance-id'
 GCP_CONN_ID = 'test-gcp-conn-id'
 TABLE_ID = 'test-table-id'
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class BigtableWaitForTableReplicationTest(unittest.TestCase):
@@ -47,7 +48,8 @@ class BigtableWaitForTableReplicationTest(unittest.TestCase):
                 instance_id=instance_id,
                 table_id=table_id,
                 task_id="id",
-                gcp_conn_id=GCP_CONN_ID
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
             )
         err = e.exception
         self.assertEqual(str(err), 'Empty parameter: {}'.format(missing_attribute))
@@ -62,10 +64,14 @@ class BigtableWaitForTableReplicationTest(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         self.assertFalse(op.poke(None))
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
     @mock.patch('airflow.providers.google.cloud.sensors.bigtable.BigtableHook')
     def test_wait_no_table(self, mock_hook):
@@ -78,10 +84,14 @@ class BigtableWaitForTableReplicationTest(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         self.assertFalse(op.poke(None))
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
     @mock.patch('airflow.providers.google.cloud.sensors.bigtable.BigtableHook')
     def test_wait_not_ready(self, mock_hook):
@@ -94,10 +104,14 @@ class BigtableWaitForTableReplicationTest(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         self.assertFalse(op.poke(None))
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
     @mock.patch('airflow.providers.google.cloud.sensors.bigtable.BigtableHook')
     def test_wait_ready(self, mock_hook):
@@ -110,7 +124,11 @@ class BigtableWaitForTableReplicationTest(unittest.TestCase):
             instance_id=INSTANCE_ID,
             table_id=TABLE_ID,
             task_id="id",
-            gcp_conn_id=GCP_CONN_ID
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         self.assertTrue(op.poke(None))
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )

--- a/tests/providers/google/cloud/sensors/test_gcs.py
+++ b/tests/providers/google/cloud/sensors/test_gcs.py
@@ -35,6 +35,8 @@ TEST_DELEGATE_TO = "TEST_DELEGATE_TO"
 
 TEST_GCP_CONN_ID = 'TEST_GCP_CONN_ID'
 
+TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
+
 TEST_PREFIX = "TEST_PREFIX"
 
 TEST_DAG_ID = 'unit_tests_gcs_sensor'
@@ -65,6 +67,7 @@ class TestGoogleCloudStorageObjectSensor(TestCase):
             object=TEST_OBJECT,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.exists.return_value = True
 
@@ -73,7 +76,8 @@ class TestGoogleCloudStorageObjectSensor(TestCase):
         self.assertEqual(True, result)
         mock_hook.assert_called_once_with(
             delegate_to=TEST_DELEGATE_TO,
-            google_cloud_storage_conn_id=TEST_GCP_CONN_ID
+            google_cloud_storage_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.exists.assert_called_once_with(TEST_BUCKET, TEST_OBJECT)
 
@@ -111,13 +115,15 @@ class TestGoogleCloudStorageObjectUpdatedSensor(TestCase):
             object=TEST_OBJECT,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.is_updated_after.return_value = True
         result = task.poke(mock.MagicMock())
 
         mock_hook.assert_called_once_with(
             delegate_to=TEST_DELEGATE_TO,
-            google_cloud_storage_conn_id=TEST_GCP_CONN_ID
+            google_cloud_storage_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.is_updated_after.assert_called_once_with(TEST_BUCKET, TEST_OBJECT, mock.ANY)
         self.assertEqual(True, result)
@@ -132,13 +138,15 @@ class TestGoogleCloudStoragePrefixSensor(TestCase):
             prefix=TEST_PREFIX,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.list.return_value = ["NOT_EMPTY_LIST"]
         result = task.poke(mock.MagicMock)
 
         mock_hook.assert_called_once_with(
             delegate_to=TEST_DELEGATE_TO,
-            google_cloud_storage_conn_id=TEST_GCP_CONN_ID
+            google_cloud_storage_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.list.assert_called_once_with(TEST_BUCKET, prefix=TEST_PREFIX)
         self.assertEqual(True, result)
@@ -165,6 +173,7 @@ class TestGoogleCloudStoragePrefixSensor(TestCase):
             prefix=TEST_PREFIX,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
             poke_interval=0)
         generated_messages = ['test-prefix/obj%s' % i for i in range(5)]
         mock_hook.return_value.list.return_value = generated_messages
@@ -173,7 +182,8 @@ class TestGoogleCloudStoragePrefixSensor(TestCase):
 
         mock_hook.assert_called_once_with(
             delegate_to=TEST_DELEGATE_TO,
-            google_cloud_storage_conn_id=TEST_GCP_CONN_ID
+            google_cloud_storage_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.list.assert_called_once_with(TEST_BUCKET, prefix=TEST_PREFIX)
         self.assertEqual(response, generated_messages)
@@ -214,6 +224,7 @@ class TestGCSUploadSessionCompleteSensor(TestCase):
             allow_delete=False,
             google_cloud_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
             dag=self.dag
         )
 
@@ -225,6 +236,7 @@ class TestGCSUploadSessionCompleteSensor(TestCase):
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         self.assertEqual(mock_hook.return_value, self.sensor.hook)
 

--- a/tests/providers/google/cloud/transfers/test_adls_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_adls_to_gcs.py
@@ -29,6 +29,7 @@ MOCK_FILES = ["test/TEST1.csv", "test/TEST2.csv", "test/path/TEST3.csv",
               "test/path/PARQUET.parquet", "test/path/PIC.png"]
 AZURE_CONN_ID = 'azure_data_lake_default'
 GCS_CONN_ID = 'google_cloud_default'
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestAdlsToGoogleCloudStorageOperator(unittest.TestCase):
@@ -64,7 +65,8 @@ class TestAdlsToGoogleCloudStorageOperator(unittest.TestCase):
             dest_gcs=GCS_PATH,
             replace=False,
             azure_data_lake_conn_id=AZURE_CONN_ID,
-            google_cloud_storage_conn_id=GCS_CONN_ID
+            google_cloud_storage_conn_id=GCS_CONN_ID,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         adls_one_mock_hook.return_value.list.return_value = MOCK_FILES
@@ -95,7 +97,10 @@ class TestAdlsToGoogleCloudStorageOperator(unittest.TestCase):
         adls_one_mock_hook.assert_called_once_with(azure_data_lake_conn_id=AZURE_CONN_ID)
         adls_two_mock_hook.assert_called_once_with(azure_data_lake_conn_id=AZURE_CONN_ID)
         gcs_mock_hook.assert_called_once_with(
-            google_cloud_storage_conn_id=GCS_CONN_ID, delegate_to=None)
+            google_cloud_storage_conn_id=GCS_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         # we expect MOCK_FILES to be uploaded
         self.assertEqual(sorted(MOCK_FILES), sorted(uploaded_files))

--- a/tests/providers/google/cloud/transfers/test_facebook_ads_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_facebook_ads_to_gcs.py
@@ -21,6 +21,7 @@ from airflow.providers.google.cloud.transfers.facebook_ads_to_gcs import Faceboo
 GCS_BUCKET = "airflow_bucket_fb"
 GCS_OBJ_PATH = "Temp/this_is_my_report_json.json"
 GCS_CONN_ID = "google_cloud_default"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 FACEBOOK_ADS_CONN_ID = "facebook_default"
 API_VERSION = "v6.0"
 FIELDS = [
@@ -56,13 +57,17 @@ class TestFacebookAdsReportToGcsOperator:
                                             params=PARAMS,
                                             object_name=GCS_OBJ_PATH,
                                             bucket_name=GCS_BUCKET,
-                                            task_id="run_operator")
+                                            task_id="run_operator",
+                                            impersonation_chain=IMPERSONATION_CHAIN,)
         op.execute({})
         mock_ads_hook.assert_called_once_with(facebook_conn_id=FACEBOOK_ADS_CONN_ID,
                                               api_version=API_VERSION)
         mock_ads_hook.return_value.bulk_facebook_report.assert_called_once_with(params=PARAMS,
                                                                                 fields=FIELDS)
-        mock_gcs_hook.assert_called_once_with(gcp_conn_id=GCS_CONN_ID)
+        mock_gcs_hook.assert_called_once_with(
+            gcp_conn_id=GCS_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         mock_gcs_hook.return_value.upload.assert_called_once_with(bucket_name=GCS_BUCKET,
                                                                   object_name=GCS_OBJ_PATH,
                                                                   filename=mock.ANY,

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -29,6 +29,7 @@ TASK_ID = "test-gcs-to-sftp-operator"
 GCP_CONN_ID = "GCP_CONN_ID"
 SFTP_CONN_ID = "SFTP_CONN_ID"
 DELEGATE_TO = "DELEGATE_TO"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 TEST_BUCKET = "test-bucket"
 SOURCE_OBJECT_WILDCARD_FILENAME = "test_object*.txt"
@@ -58,10 +59,13 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
             delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute({})
         gcs_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
 
@@ -88,10 +92,13 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
             delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
 

--- a/tests/providers/google/cloud/transfers/test_s3_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_s3_to_gcs.py
@@ -30,6 +30,7 @@ GCS_PATH_PREFIX = 'gs://gcs-bucket/data/'
 MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
 AWS_CONN_ID = 'aws_default'
 GCS_CONN_ID = 'google_cloud_default'
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestS3ToGoogleCloudStorageOperator(unittest.TestCase):
@@ -42,7 +43,9 @@ class TestS3ToGoogleCloudStorageOperator(unittest.TestCase):
             prefix=S3_PREFIX,
             delimiter=S3_DELIMITER,
             gcp_conn_id=GCS_CONN_ID,
-            dest_gcs=GCS_PATH_PREFIX)
+            dest_gcs=GCS_PATH_PREFIX,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         self.assertEqual(operator.task_id, TASK_ID)
         self.assertEqual(operator.bucket, S3_BUCKET)
@@ -50,6 +53,7 @@ class TestS3ToGoogleCloudStorageOperator(unittest.TestCase):
         self.assertEqual(operator.delimiter, S3_DELIMITER)
         self.assertEqual(operator.gcp_conn_id, GCS_CONN_ID)
         self.assertEqual(operator.dest_gcs, GCS_PATH_PREFIX)
+        self.assertEqual(operator.google_impersonation_chain, IMPERSONATION_CHAIN)
 
     @mock.patch('airflow.providers.google.cloud.transfers.s3_to_gcs.S3Hook')
     @mock.patch('airflow.providers.amazon.aws.operators.s3_list.S3Hook')
@@ -64,7 +68,9 @@ class TestS3ToGoogleCloudStorageOperator(unittest.TestCase):
             prefix=S3_PREFIX,
             delimiter=S3_DELIMITER,
             dest_gcs_conn_id=GCS_CONN_ID,
-            dest_gcs=GCS_PATH_PREFIX)
+            dest_gcs=GCS_PATH_PREFIX,
+            google_impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         s3_one_mock_hook.return_value.list_keys.return_value = MOCK_FILES
         s3_two_mock_hook.return_value.list_keys.return_value = MOCK_FILES
@@ -81,7 +87,10 @@ class TestS3ToGoogleCloudStorageOperator(unittest.TestCase):
         s3_one_mock_hook.assert_called_once_with(aws_conn_id=AWS_CONN_ID, verify=None)
         s3_two_mock_hook.assert_called_once_with(aws_conn_id=AWS_CONN_ID, verify=None)
         gcs_mock_hook.assert_called_once_with(
-            google_cloud_storage_conn_id=GCS_CONN_ID, delegate_to=None)
+            google_cloud_storage_conn_id=GCS_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         # we expect MOCK_FILES to be uploaded
         self.assertEqual(sorted(MOCK_FILES), sorted(uploaded_files))
@@ -107,6 +116,11 @@ class TestS3ToGoogleCloudStorageOperator(unittest.TestCase):
         s3_two_mock_hook.return_value.list_keys.return_value = MOCK_FILES
 
         operator.execute(None)
+        gcs_mock_hook.assert_called_once_with(
+            google_cloud_storage_conn_id=GCS_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=None,
+        )
         gcs_mock_hook.return_value.upload.assert_has_calls(
             [
                 mock.call('gcs-bucket', 'data/TEST2.csv', mock.ANY, gzip=True),

--- a/tests/providers/google/cloud/transfers/test_sftp_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sftp_to_gcs.py
@@ -29,6 +29,7 @@ TASK_ID = "test-gcs-to-sftp-operator"
 GCP_CONN_ID = "GCP_CONN_ID"
 SFTP_CONN_ID = "SFTP_CONN_ID"
 DELEGATE_TO = "DELEGATE_TO"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 DEFAULT_MIME_TYPE = "application/octet-stream"
 
@@ -64,10 +65,13 @@ class TestSFTPToGCSOperator(unittest.TestCase):
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
             delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
 
@@ -96,10 +100,13 @@ class TestSFTPToGCSOperator(unittest.TestCase):
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
             delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute(None)
         gcs_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         sftp_hook.assert_called_once_with(SFTP_CONN_ID)
 

--- a/tests/providers/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sheets_to_gcs.py
@@ -28,6 +28,7 @@ VALUES = [[1, 2, 3]]
 BUCKET = "destination_bucket"
 PATH = "path/to/reports"
 GCP_CONN_ID = "test"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestGoogleSheetsToGCSOperator:
@@ -97,13 +98,20 @@ class TestGoogleSheetsToGCSOperator:
             sheet_filter=FILTER,
             destination_path=PATH,
             gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context)
 
         mock_sheet_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
-        mock_gcs_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, delegate_to=None)
+        mock_gcs_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         mock_sheet_hook.return_value.get_sheet_titles.assert_called_once_with(
             spreadsheet_id=SPREADSHEET_ID, sheet_filter=FILTER

--- a/tests/providers/google/marketing_platform/operators/test_analytics.py
+++ b/tests/providers/google/marketing_platform/operators/test_analytics.py
@@ -31,6 +31,7 @@ ACCOUNT_ID = "the_knight_who_says_ni!"
 DATA_SOURCE = "Monthy Python"
 API_VERSION = "v3"
 GCP_CONN_ID = "google_cloud_default"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 BUCKET = "gs://bucket"
 BUCKET_OBJECT_NAME = "file.csv"
 
@@ -42,7 +43,10 @@ class TestGoogleAnalyticsListAccountsOperator(unittest.TestCase):
     )
     def test_execute(self, hook_mock):
         op = GoogleAnalyticsListAccountsOperator(
-            api_version=API_VERSION, gcp_conn_id=GCP_CONN_ID, task_id="test_task"
+            api_version=API_VERSION,
+            gcp_conn_id=GCP_CONN_ID,
+            task_id="test_task",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context=None)
         hook_mock.assert_called_once()
@@ -61,12 +65,15 @@ class TestGoogleAnalyticsRetrieveAdsLinksListOperator(unittest.TestCase):
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
             task_id="test_task",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context=None)
         hook_mock.assert_called_once()
         hook_mock.return_value.list_ad_words_links.assert_called_once()
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            api_version=API_VERSION,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         hook_mock.return_value.list_ad_words_links.assert_called_once_with(
             account_id=ACCOUNT_ID, web_property_id=WEB_PROPERTY_ID
@@ -86,12 +93,15 @@ class TestGoogleAnalyticsGetAdsLinkOperator(unittest.TestCase):
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
             task_id="test_task",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context=None)
         hook_mock.assert_called_once()
         hook_mock.return_value.get_ad_words_link.assert_called_once()
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            api_version=API_VERSION,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         hook_mock.return_value.get_ad_words_link.assert_called_once_with(
             account_id=ACCOUNT_ID,
@@ -124,12 +134,20 @@ class TestGoogleAnalyticsDataImportUploadOperator(unittest.TestCase):
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
             task_id="test_task",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context=None)
 
-        gcs_hook_mock.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, delegate_to=None)
+        gcs_hook_mock.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
         ga_hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         gcs_hook_mock.return_value.download.assert_called_once_with(
@@ -163,7 +181,10 @@ class TestGoogleAnalyticsDeletePreviousDataUploadsOperator:
         )
         op.execute(context=None)
         mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
 
         mock_hook.return_value.list_uploads.assert_called_once_with(
@@ -244,10 +265,15 @@ how_to_make_doughnuts,2
             custom_dimension_header_mapping=mapping,
             gcp_conn_id=GCP_CONN_ID,
             task_id="test_task",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(context=None)
 
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, delegate_to=None)
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         mock_hook.return_value.download.assert_called_once_with(
             bucket_name=BUCKET, object_name=BUCKET_OBJECT_NAME, filename=filename

--- a/tests/providers/google/marketing_platform/operators/test_campaign_manager.py
+++ b/tests/providers/google/marketing_platform/operators/test_campaign_manager.py
@@ -64,7 +64,10 @@ class TestGoogleCampaignManagerDeleteReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.delete_report.assert_called_once_with(
             profile_id=profile_id, report_id=report_id
@@ -130,13 +133,18 @@ class TestGoogleCampaignManagerGetReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.get_report_file.assert_called_once_with(
             profile_id=profile_id, report_id=report_id, file_id=file_id
         )
         gcs_hook_mock.assert_called_once_with(
-            google_cloud_storage_conn_id=GCP_CONN_ID, delegate_to=None
+            google_cloud_storage_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=None,
         )
         gcs_hook_mock.return_value.upload.assert_called_once_with(
             bucket_name=bucket_name,
@@ -178,7 +186,10 @@ class TestGoogleCampaignManagerInsertReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.insert_report.assert_called_once_with(
             profile_id=profile_id, report=report
@@ -233,7 +244,10 @@ class TestGoogleCampaignManagerRunReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.run_report.assert_called_once_with(
             profile_id=profile_id, report_id=report_id, synchronous=synchronous

--- a/tests/providers/google/marketing_platform/operators/test_display_video.py
+++ b/tests/providers/google/marketing_platform/operators/test_display_video.py
@@ -30,6 +30,7 @@ from airflow.providers.google.marketing_platform.operators.display_video import 
 API_VERSION = "api_version"
 GCP_CONN_ID = "google_cloud_default"
 DELEGATE_TO: Optional[str] = None
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestGoogleDisplayVideo360CreateReportOperator(TestCase):
@@ -54,7 +55,10 @@ class TestGoogleDisplayVideo360CreateReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.create_query.assert_called_once_with(query=body)
         xcom_mock.assert_called_once_with(None, key="report_id", value=query_id)
@@ -89,7 +93,10 @@ class TestGoogleDisplayVideo360DeleteReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.delete_query.assert_called_once_with(query_id=query_id)
 
@@ -151,12 +158,17 @@ class TestGoogleDisplayVideo360GetReportOperator(TestCase):
         )
         op.execute(context=None)
         mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         mock_hook.return_value.get_query.assert_called_once_with(query_id=report_id)
 
         mock_gcs_hook.assert_called_once_with(
-            google_cloud_storage_conn_id=GCP_CONN_ID, delegate_to=None
+            google_cloud_storage_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=None,
         )
         mock_gcs_hook.return_value.upload.assert_called_once_with(
             bucket_name=bucket_name,
@@ -190,7 +202,10 @@ class TestGoogleDisplayVideo360RunReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.run_query.assert_called_once_with(
             query_id=report_id, params=params
@@ -231,6 +246,7 @@ class TestGoogleDisplayVideo360DownloadLineItemsOperator(TestCase):
             gcp_conn_id=GCP_CONN_ID,
             delegate_to=DELEGATE_TO,
             task_id="test_task",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         op.execute(context=None)
@@ -244,10 +260,15 @@ class TestGoogleDisplayVideo360DownloadLineItemsOperator(TestCase):
         )
 
         gcs_hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO,
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, api_version=API_VERSION, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            api_version=API_VERSION,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         hook_mock.return_value.download_line_items.assert_called_once_with(
             request_body=request_body
@@ -285,11 +306,16 @@ class TestGoogleDisplayVideo360UploadLineItemsOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, api_version=API_VERSION, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            api_version=API_VERSION,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=None,
         )
 
         gcs_hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO,
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=None,
         )
 
         gcs_hook_mock.return_value.download.assert_called_once_with(
@@ -333,11 +359,15 @@ class TestGoogleDisplayVideo360SDFtoGCSOperator(TestCase):
             api_version=API_VERSION,
             gcp_conn_id=GCP_CONN_ID,
             task_id="test_task",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         op.execute(context=None)
         mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, api_version=API_VERSION, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            api_version=API_VERSION,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         mock_hook.return_value.get_sdf_download_operation.assert_called_once()
@@ -359,7 +389,9 @@ class TestGoogleDisplayVideo360SDFtoGCSOperator(TestCase):
 
         gcs_mock_hook.assert_called_once()
         gcs_mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         gcs_mock_hook.return_value.upload.assert_called_once()
@@ -392,7 +424,10 @@ class TestGoogleDisplayVideo360CreateSDFDownloadTaskOperator(TestCase):
 
         op.execute(context=None)
         mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, api_version=API_VERSION, delegate_to=DELEGATE_TO
+            gcp_conn_id=GCP_CONN_ID,
+            api_version=API_VERSION,
+            delegate_to=DELEGATE_TO,
+            impersonation_chain=None,
         )
 
         mock_hook.return_value.create_sdf_download_operation.assert_called_once()

--- a/tests/providers/google/marketing_platform/operators/test_search_ads.py
+++ b/tests/providers/google/marketing_platform/operators/test_search_ads.py
@@ -49,7 +49,10 @@ class TestGoogleSearchAdsInsertReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.insert_report.assert_called_once_with(report=report)
         xcom_mock.assert_called_once_with(None, key="report_id", value=report_id)
@@ -111,7 +114,10 @@ class TestGoogleSearchAdsDownloadReportOperator(TestCase):
         )
         op.execute(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.get_file.assert_called_once_with(
             report_fragment=0, report_id=report_id

--- a/tests/providers/google/marketing_platform/sensors/test_campaign_manager.py
+++ b/tests/providers/google/marketing_platform/sensors/test_campaign_manager.py
@@ -50,7 +50,10 @@ class TestGoogleCampaignManagerDeleteReportOperator(TestCase):
         )
         result = op.poke(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.get_report.assert_called_once_with(
             profile_id=profile_id, report_id=report_id, file_id=file_id

--- a/tests/providers/google/marketing_platform/sensors/test_display_video.py
+++ b/tests/providers/google/marketing_platform/sensors/test_display_video.py
@@ -42,7 +42,10 @@ class TestGoogleDisplayVideo360ReportSensor(TestCase):
         )
         op.poke(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.get_query.assert_called_once_with(query_id=report_id)
 
@@ -63,7 +66,10 @@ class TestGoogleDisplayVideo360Sensor(TestCase):
         )
         op.poke(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.get_sdf_download_operation.assert_called_once_with(
             operation_name=operation_name

--- a/tests/providers/google/marketing_platform/sensors/test_search_ads.py
+++ b/tests/providers/google/marketing_platform/sensors/test_search_ads.py
@@ -39,6 +39,9 @@ class TestSearchAdsReportSensor(TestCase):
         )
         op.poke(context=None)
         hook_mock.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None, api_version=API_VERSION
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            api_version=API_VERSION,
+            impersonation_chain=None,
         )
         hook_mock.return_value.get.assert_called_once_with(report_id=report_id)

--- a/tests/providers/google/suite/transfers/test_gcs_to_gdrive.py
+++ b/tests/providers/google/suite/transfers/test_gcs_to_gdrive.py
@@ -22,6 +22,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.google.suite.transfers.gcs_to_gdrive import GCSToGoogleDriveOperator
 
 MODULE = "airflow.providers.google.suite.transfers.gcs_to_gdrive"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
 class TestGcsToGDriveOperator(unittest.TestCase):
@@ -43,7 +44,11 @@ class TestGcsToGDriveOperator(unittest.TestCase):
 
         mock_gcs_hook.assert_has_calls(
             [
-                mock.call(delegate_to=None, google_cloud_storage_conn_id="google_cloud_default"),
+                mock.call(
+                    delegate_to=None,
+                    google_cloud_storage_conn_id="google_cloud_default",
+                    impersonation_chain=None,
+                ),
                 mock.call().download(
                     bucket_name="data", filename="TMP1", object_name="sales/sales-2017/january.avro"
                 ),
@@ -52,7 +57,11 @@ class TestGcsToGDriveOperator(unittest.TestCase):
 
         mock_gdrive.assert_has_calls(
             [
-                mock.call(delegate_to=None, gcp_conn_id="google_cloud_default"),
+                mock.call(
+                    delegate_to=None,
+                    gcp_conn_id="google_cloud_default",
+                    impersonation_chain=None,
+                ),
                 mock.call().upload_file(
                     local_location="TMP1", remote_location="copied_sales/2017/january-backup.avro"
                 ),
@@ -74,12 +83,17 @@ class TestGcsToGDriveOperator(unittest.TestCase):
             source_bucket="data",
             source_object="sales/sales-2017/*.avro",
             destination_object="copied_sales/2017/",
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         task.execute(mock.MagicMock())
         mock_gcs_hook.assert_has_calls(
             [
-                mock.call(delegate_to=None, google_cloud_storage_conn_id="google_cloud_default"),
+                mock.call(
+                    delegate_to=None,
+                    google_cloud_storage_conn_id="google_cloud_default",
+                    impersonation_chain=IMPERSONATION_CHAIN,
+                ),
                 mock.call().list("data", delimiter=".avro", prefix="sales/sales-2017/"),
                 mock.call().download(bucket_name="data", filename="TMP1", object_name="sales/A.avro"),
                 mock.call().download(bucket_name="data", filename="TMP2", object_name="sales/B.avro"),
@@ -89,7 +103,11 @@ class TestGcsToGDriveOperator(unittest.TestCase):
 
         mock_gdrive.assert_has_calls(
             [
-                mock.call(delegate_to=None, gcp_conn_id="google_cloud_default"),
+                mock.call(
+                    delegate_to=None,
+                    gcp_conn_id="google_cloud_default",
+                    impersonation_chain=IMPERSONATION_CHAIN,
+                ),
                 mock.call().upload_file(local_location="TMP1", remote_location="sales/A.avro"),
                 mock.call().upload_file(local_location="TMP2", remote_location="sales/B.avro"),
                 mock.call().upload_file(local_location="TMP3", remote_location="sales/C.avro"),
@@ -109,12 +127,17 @@ class TestGcsToGDriveOperator(unittest.TestCase):
             source_bucket="data",
             source_object="sales/sales-2017/*.avro",
             move_object=True,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
 
         task.execute(mock.MagicMock())
         mock_gcs_hook.assert_has_calls(
             [
-                mock.call(delegate_to=None, google_cloud_storage_conn_id="google_cloud_default"),
+                mock.call(
+                    delegate_to=None,
+                    google_cloud_storage_conn_id="google_cloud_default",
+                    impersonation_chain=IMPERSONATION_CHAIN,
+                ),
                 mock.call().list("data", delimiter=".avro", prefix="sales/sales-2017/"),
                 mock.call().download(bucket_name="data", filename="TMP1", object_name="sales/A.avro"),
                 mock.call().delete("data", "sales/A.avro"),
@@ -127,7 +150,11 @@ class TestGcsToGDriveOperator(unittest.TestCase):
 
         mock_gdrive.assert_has_calls(
             [
-                mock.call(delegate_to=None, gcp_conn_id="google_cloud_default"),
+                mock.call(
+                    delegate_to=None,
+                    gcp_conn_id="google_cloud_default",
+                    impersonation_chain=IMPERSONATION_CHAIN,
+                ),
                 mock.call().upload_file(local_location="TMP1", remote_location="sales/A.avro"),
                 mock.call().upload_file(local_location="TMP2", remote_location="sales/B.avro"),
                 mock.call().upload_file(local_location="TMP3", remote_location="sales/C.avro"),

--- a/tests/providers/google/suite/transfers/test_gcs_to_sheets.py
+++ b/tests/providers/google/suite/transfers/test_gcs_to_sheets.py
@@ -20,6 +20,7 @@ import mock
 from airflow.providers.google.suite.transfers.gcs_to_sheets import GCSToGoogleSheetsOperator
 
 GCP_CONN_ID = "test"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 SPREADSHEET_ID = "1234567890"
 VALUES = [[1, 2, 3]]
 BUCKET = "destination_bucket"
@@ -44,13 +45,20 @@ class TestGCSToGoogleSheets:
             bucket_name=BUCKET,
             object_name=PATH,
             gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute(None)
 
         mock_sheet_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID, delegate_to=None
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
         )
-        mock_gcs_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, delegate_to=None)
+        mock_gcs_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
 
         mock_gcs_hook.return_value.download.assert_called_once_with(
             bucket_name=BUCKET, object_name=PATH, filename=filename


### PR DESCRIPTION
This PR adds [direct impersonation of a service account in Google services](https://cloud.google.com/iam/docs/understanding-service-accounts#directly_impersonating_a_service_account). Part-of https://github.com/apache/airflow/issues/8803

A few notes summarizing the changes:
- no changes in `GKEStartPodOperator`, `DataflowCreateJavaJobOperator` and `DataflowCreatePythonJobOperator` - as these operators do not use `Credentials` class for authentication
- in case of operators that connect to multiple Google services, all hooks use the same value of `impersonation_chain` (if applicable)
- in case of operators that also communicate with services of other cloud providers, the argument is named `google_impersonation_chain`
- changed `get_credentials_and_project` method of `_CredentialProvider` class so that if `impersonation_chain` argument is used then `project_id` returned is extracted from the e-mail of the impersonated account (`target_principal`). This is for the scenario when impersonated service account is from different project than the account from Connection.
`project_id` will still be overridden if specified in Connection's extras or explicitly in operator's arguments.
- `GCSToS3Operator` was modified so that it no longer derivatives from `GCSListObjectsOperator`
- `impersonation_chain` was moved to be the last argument of hooks (if it was not already) to avoid potentially breaking changes when initializing these hooks with positional arguments

---
Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.