### PR TITLE
Fix typo on reattach property of kubernetespodoperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -287,9 +287,11 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                     self.reattach_on_restart:
                 self.log.info("found a running pod with labels %s but a different try_number"
                               "Will attach to this pod and monitor instead of starting new one", labels)
-                final_state, _, result = self.create_new_pod_for_operator(labels, launcher)
+                final_state, result = self.monitor_launched_pod(launcher, pod_list.items[0])
             elif len(pod_list.items) == 1:
-                final_state, result = self.monitor_launched_pod(launcher, pod_list[0])
+                self.log.info("found a running pod with labels %s."
+                              "Will monitor this pod instead of starting new one", labels)
+                final_state, result = self.monitor_launched_pod(launcher, pod_list.items[0])
             else:
                 self.log.info("creating pod with labels %s and launcher %s", labels, launcher)
                 final_state, _, result = self.create_new_pod_for_operator(labels, launcher)


### PR DESCRIPTION
related: #10021

Fix typo in KubernetesPodOperator to get the expected behavior of reattach property

From #10021
![image](https://user-images.githubusercontent.com/15086022/88890905-948a7d80-d242-11ea-8052-90202678ff52.png)
