### PR TITLE
Add pre 1.10.11 Kubernetes Paths back with Deprecation Warning

### DIFF
--- a/airflow/contrib/kubernetes/kube_client.py
+++ b/airflow/contrib/kubernetes/kube_client.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,4 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+"""This module is deprecated. Please use `airflow.kubernetes.kube_client`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.kubernetes.kube_client import *   # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.kubernetes.kube_client`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -14,9 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This module is deprecated. Please use `airflow.kubernetes.pod`."""
 
-import kubernetes.client.models as k8s
-from airflow.kubernetes.pod import Resources
+import warnings
+
+# pylint: disable=unused-import
+from airflow.kubernetes.pod import Port, Resources   # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.kubernetes.pod`.",
+    DeprecationWarning, stacklevel=2
+)
 
 
 class Pod(object):
@@ -86,6 +94,10 @@ class Pod(object):
             pod_runtime_info_envs=None,
             dnspolicy=None
     ):
+        warnings.warn(
+            "Using `airflow.contrib.kubernetes.pod.Pod` is deprecated. Please use `k8s.V1Pod`.",
+            DeprecationWarning, stacklevel=2
+        )
         self.image = image
         self.envs = envs or {}
         self.cmds = cmds
@@ -119,6 +131,7 @@ class Pod(object):
 
         :return: k8s.V1Pod
         """
+        import kubernetes.client.models as k8s
         meta = k8s.V1ObjectMeta(
             labels=self.labels,
             name=self.name,

--- a/airflow/contrib/kubernetes/pod_runtime_info_env.py
+++ b/airflow/contrib/kubernetes/pod_runtime_info_env.py
@@ -14,3 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This module is deprecated. Please use `airflow.kubernetes.pod_runtime_info_env`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv    # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.kubernetes.pod_runtime_info_env`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/kubernetes/refresh_config.py
+++ b/airflow/contrib/kubernetes/refresh_config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,4 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+"""This module is deprecated. Please use `airflow.kubernetes.refresh_config`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.kubernetes.refresh_config import (   # noqa
+    RefreshConfiguration, RefreshKubeConfigLoader, load_kube_config
+)
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.kubernetes.refresh_config`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/kubernetes/secret.py
+++ b/airflow/contrib/kubernetes/secret.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,4 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+"""This module is deprecated. Please use `airflow.kubernetes.secret`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.kubernetes.secret import Secret   # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.kubernetes.secret`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/kubernetes/volume.py
+++ b/airflow/contrib/kubernetes/volume.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,4 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+"""This module is deprecated. Please use `airflow.kubernetes.volume`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.kubernetes.volume import Volume   # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.kubernetes.volume`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/contrib/kubernetes/volume_mount.py
+++ b/airflow/contrib/kubernetes/volume_mount.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,4 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+"""This module is deprecated. Please use `airflow.kubernetes.volume_mount`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.kubernetes.volume_mount import VolumeMount   # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.kubernetes.volume_mount`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -17,6 +17,7 @@
 """Launches PODs"""
 import json
 import time
+import warnings
 from datetime import datetime as dt
 
 import tenacity
@@ -93,6 +94,10 @@ class PodLauncher(LoggingMixin):
             # attempts to run pod_mutation_hook using k8s.V1Pod, if this
             # fails we attempt to run by converting pod to Old Pod
         except AttributeError:
+            warnings.warn(
+                "Using `airflow.contrib.kubernetes.pod.Pod` is deprecated. "
+                "Please use `k8s.V1Pod` instead.", DeprecationWarning, stacklevel=2
+            )
             dummy_pod = convert_to_airflow_pod(pod)
             settings.pod_mutation_hook(dummy_pod)
             dummy_pod = dummy_pod.to_v1_kubernetes_pod()

--- a/airflow/kubernetes/pod_launcher_helper.py
+++ b/airflow/kubernetes/pod_launcher_helper.py
@@ -21,7 +21,7 @@ import kubernetes.client.models as k8s  # noqa
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.kubernetes.pod import Port
-from airflow.kubernetes_deprecated.pod import Pod
+from airflow.contrib.kubernetes.pod import Pod
 
 
 def convert_to_airflow_pod(pod):

--- a/airflow/kubernetes/pod_runtime_info_env.py
+++ b/airflow/kubernetes/pod_runtime_info_env.py
@@ -19,7 +19,6 @@ Classes for interacting with Kubernetes API
 """
 
 import copy
-import kubernetes.client.models as k8s
 from airflow.kubernetes.k8s_model import K8SModel
 
 
@@ -43,6 +42,7 @@ class PodRuntimeInfoEnv(K8SModel):
         """
         :return: kubernetes.client.models.V1EnvVar
         """
+        import kubernetes.client.models as k8s
         return k8s.V1EnvVar(
             name=self.name,
             value_from=k8s.V1EnvVarSource(

--- a/airflow/kubernetes/secret.py
+++ b/airflow/kubernetes/secret.py
@@ -20,7 +20,6 @@ Classes for interacting with Kubernetes API
 
 import uuid
 import copy
-import kubernetes.client.models as k8s
 from airflow.exceptions import AirflowConfigException
 from airflow.kubernetes.k8s_model import K8SModel
 
@@ -65,6 +64,7 @@ class Secret(K8SModel):
         self.key = key
 
     def to_env_secret(self):
+        import kubernetes.client.models as k8s
         return k8s.V1EnvVar(
             name=self.deploy_target,
             value_from=k8s.V1EnvVarSource(
@@ -76,11 +76,13 @@ class Secret(K8SModel):
         )
 
     def to_env_from_secret(self):
+        import kubernetes.client.models as k8s
         return k8s.V1EnvFromSource(
             secret_ref=k8s.V1SecretEnvSource(name=self.secret)
         )
 
     def to_volume_secret(self):
+        import kubernetes.client.models as k8s
         vol_id = 'secretvol{}'.format(uuid.uuid4())
         return (
             k8s.V1Volume(

--- a/airflow/kubernetes/volume_mount.py
+++ b/airflow/kubernetes/volume_mount.py
@@ -19,7 +19,6 @@ Classes for interacting with Kubernetes API
 """
 
 import copy
-import kubernetes.client.models as k8s
 from airflow.kubernetes.k8s_model import K8SModel
 
 
@@ -49,8 +48,8 @@ class VolumeMount(K8SModel):
         Converts to k8s object.
 
         :return Volume Mount k8s object
-
         """
+        import kubernetes.client.models as k8s
         return k8s.V1VolumeMount(
             name=self.name,
             mount_path=self.mount_path,

--- a/tests/kubernetes/models/test_pod.py
+++ b/tests/kubernetes/models/test_pod.py
@@ -76,7 +76,7 @@ class TestPod(unittest.TestCase):
         }, result)
 
     def test_to_v1_pod(self):
-        from airflow.kubernetes_deprecated.pod import Pod as DeprecatedPod
+        from airflow.contrib.kubernetes.pod import Pod as DeprecatedPod
         from airflow.kubernetes.volume import Volume
         from airflow.kubernetes.volume_mount import VolumeMount
         from airflow.kubernetes.pod import Resources

--- a/tests/kubernetes/test_pod_launcher_helper.py
+++ b/tests/kubernetes/test_pod_launcher_helper.py
@@ -20,7 +20,7 @@ from airflow.kubernetes.pod import Port
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.pod_launcher_helper import convert_to_airflow_pod
-from airflow.kubernetes_deprecated.pod import Pod
+from airflow.contrib.kubernetes.pod import Pod
 import kubernetes.client.models as k8s
 
 
@@ -84,7 +84,8 @@ class TestPodLauncherHelper(unittest.TestCase):
 
         self.assertDictEqual(expected_dict, result_dict)
 
-    def pull_out_volumes(self, result_dict):
+    @staticmethod
+    def pull_out_volumes(result_dict):
         parsed_configs = []
         for volume in result_dict['volumes']:
             vol = {'name': volume['name']}


### PR DESCRIPTION
The paths were removed without any pending deprecation warning and might break deployments

This PR adds back paths to `airflow.contrib.kubernetes`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
