### PR TITLE
Fix to make y-axis label of Tries chart visible

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1786,6 +1786,8 @@ class Airflow(AirflowBaseView):
         tis = dag.get_task_instances(start_date=min_date, end_date=base_date)
         tries = sorted(list({ti.try_number for ti in tis}))
         max_date = max([ti.execution_date for ti in tis]) if tries else None
+        chart.create_y_axis('yAxis', format='.02f', custom_format=False, label='Tries')
+        chart.axislist['yAxis']['axisLabelDistance'] = '-15'
 
         session.commit()
 


### PR DESCRIPTION
This is to make y-axis label visible for the 'Trie's chart. This change does not include unit-test since it GUI related.
Please take a look at the screenshots.

Before:
<img width="1367" alt=" before_fix" src="https://user-images.githubusercontent.com/24769868/89096926-3e772080-d38f-11ea-9538-fb8f90def62c.png">

After:
<img width="1397" alt="after_fix" src="https://user-images.githubusercontent.com/24769868/89096934-4931b580-d38f-11ea-8f58-658056bb932e.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
