### PR TITLE
Fix typo in Athena sensor retries

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -805,6 +805,10 @@ The `AwsBatchOperator` can use a new `waiters` parameter, an instance of `AwsBat
 specify that custom job waiters will be used to monitor a batch job.  See the latest API
 documentation for details.
 
+### AthenaSensor
+
+Replace parameter `max_retires` with `max_retries` to fix typo.
+
 ### Additional arguments passed to BaseOperator cause an exception
 
 Previous versions of Airflow took additional arguments and displayed a message on the console. When the

--- a/airflow/providers/amazon/aws/sensors/athena.py
+++ b/airflow/providers/amazon/aws/sensors/athena.py
@@ -25,16 +25,16 @@ from airflow.utils.decorators import apply_defaults
 class AthenaSensor(BaseSensorOperator):
     """
     Asks for the state of the Query until it reaches a failure state or success state.
-    If it fails, failing the task.
+    If the query fails, the task will fail.
 
     :param query_execution_id: query_execution_id to check the state of
     :type query_execution_id: str
-    :param max_retires: Number of times to poll for query state before
+    :param max_retries: Number of times to poll for query state before
         returning the current state, defaults to None
-    :type max_retires: int
+    :type max_retries: int
     :param aws_conn_id: aws connection to use, defaults to 'aws_default'
     :type aws_conn_id: str
-    :param sleep_time: Time to wait between two consecutive call to
+    :param sleep_time: Time in seconds to wait between two consecutive call to
         check query status on athena, defaults to 10
     :type sleep_time: int
     """
@@ -50,7 +50,7 @@ class AthenaSensor(BaseSensorOperator):
     @apply_defaults
     def __init__(self,
                  query_execution_id,
-                 max_retires=None,
+                 max_retries=None,
                  aws_conn_id='aws_default',
                  sleep_time=10,
                  *args, **kwargs):
@@ -58,11 +58,11 @@ class AthenaSensor(BaseSensorOperator):
         self.aws_conn_id = aws_conn_id
         self.query_execution_id = query_execution_id
         self.sleep_time = sleep_time
-        self.max_retires = max_retires
+        self.max_retries = max_retries
         self.hook = None
 
     def poke(self, context):
-        state = self.get_hook().poll_query_status(self.query_execution_id, self.max_retires)
+        state = self.get_hook().poll_query_status(self.query_execution_id, self.max_retries)
 
         if state in self.FAILURE_STATES:
             raise AirflowException('Athena sensor failed')

--- a/tests/providers/amazon/aws/sensors/test_athena.py
+++ b/tests/providers/amazon/aws/sensors/test_athena.py
@@ -31,7 +31,7 @@ class TestAthenaSensor(unittest.TestCase):
         self.sensor = AthenaSensor(task_id='test_athena_sensor',
                                    query_execution_id='abc',
                                    sleep_time=5,
-                                   max_retires=1,
+                                   max_retries=1,
                                    aws_conn_id='aws_default')
 
     @mock.patch.object(AWSAthenaHook, 'poll_query_status', side_effect=("SUCCEEDED",))


### PR DESCRIPTION
Understanding that it is an attribute name, which could have downstream consequences, correct the spelling of `max_retries` in the Athena sensor and reword some of the docstring.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
