### PR TITLE
[GH-9708] Add type annotations to two AWS Athena modules

### DIFF
--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+from typing import Any, Dict, Mapping, Optional
 from uuid import uuid4
 
 from airflow.models import BaseOperator
@@ -39,7 +40,7 @@ class AWSAthenaOperator(BaseOperator):
     :param sleep_time: Time to wait between two consecutive call to check query status on athena
     :type sleep_time: int
     :param max_tries: Number of times to poll for query state before function exits
-    :type max_triex: int
+    :type max_tries: int
     """
 
     ui_color = '#44b5e2'
@@ -49,16 +50,16 @@ class AWSAthenaOperator(BaseOperator):
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        query,
-        database,
-        output_location,
-        aws_conn_id="aws_default",
-        client_request_token=None,
-        workgroup="primary",
-        query_execution_context=None,
-        result_configuration=None,
-        sleep_time=30,
-        max_tries=None,
+        query: str,
+        database: str,
+        output_location: str,
+        aws_conn_id: str = "aws_default",
+        client_request_token: Optional[str] = None,
+        workgroup: str = "primary",
+        query_execution_context: Optional[Dict[str, str]] = None,
+        result_configuration: Optional[Dict[Any, Any]] = None,
+        sleep_time: int = 30,
+        max_tries: int = 0,
         *args,
         **kwargs
     ):
@@ -69,32 +70,31 @@ class AWSAthenaOperator(BaseOperator):
         self.aws_conn_id = aws_conn_id
         self.client_request_token = client_request_token or str(uuid4())
         self.workgroup = workgroup
-        self.query_execution_context = query_execution_context or {}
-        self.result_configuration = result_configuration or {}
+        self.query_execution_context = query_execution_context or {'Database': self.database}
+        self.result_configuration = result_configuration or {'OutputLocation': self.output_location}
         self.sleep_time = sleep_time
         self.max_tries = max_tries
-        self.query_execution_id = None
-        self.hook = None
+        self.query_execution_id: str = ""
 
-    def get_hook(self):
+    def get_hook(self) -> AWSAthenaHook:
         """Create and return an AWSAthenaHook."""
         return AWSAthenaHook(self.aws_conn_id, sleep_time=self.sleep_time)
 
-    def execute(self, context):
+    def execute(self, context: Mapping[Any, Any]) -> str:
         """
         Run Presto Query on Athena
         """
-        self.hook = self.get_hook()
+        hook = self.get_hook()
 
         self.query_execution_context['Database'] = self.database
         self.result_configuration['OutputLocation'] = self.output_location
-        self.query_execution_id = self.hook.run_query(self.query, self.query_execution_context,
-                                                      self.result_configuration, self.client_request_token,
-                                                      self.workgroup)
-        query_status = self.hook.poll_query_status(self.query_execution_id, self.max_tries)
+        self.query_execution_id = hook.run_query(self.query, self.query_execution_context,
+                                                 self.result_configuration, self.client_request_token,
+                                                 self.workgroup)
+        query_status = hook.poll_query_status(self.query_execution_id, self.max_tries)
 
         if query_status in AWSAthenaHook.FAILURE_STATES:
-            error_message = self.hook.get_state_change_reason(self.query_execution_id)
+            error_message = hook.get_state_change_reason(self.query_execution_id)
             raise Exception(
                 'Final state of Athena job is {}, query_execution_id is {}. Error: {}'
                 .format(query_status, self.query_execution_id, error_message))
@@ -106,16 +106,17 @@ class AWSAthenaOperator(BaseOperator):
 
         return self.query_execution_id
 
-    def on_kill(self):
+    def on_kill(self) -> None:
         """
         Cancel the submitted athena query
         """
+        hook = self.get_hook()
         if self.query_execution_id:
             self.log.info('⚰️⚰️⚰️ Received a kill Signal. Time to Die')
             self.log.info(
                 'Stopping Query with executionId - %s', self.query_execution_id
             )
-            response = self.hook.stop_query(self.query_execution_id)
+            response = hook.stop_query(self.query_execution_id)
             http_status_code = None
             try:
                 http_status_code = response['ResponseMetadata']['HTTPStatusCode']
@@ -128,4 +129,4 @@ class AWSAthenaOperator(BaseOperator):
                     self.log.info(
                         'Polling Athena for query with id %s to reach final state', self.query_execution_id
                     )
-                    self.hook.poll_query_status(self.query_execution_id)
+                    hook.poll_query_status(self.query_execution_id)

--- a/airflow/providers/amazon/aws/sensors/athena.py
+++ b/airflow/providers/amazon/aws/sensors/athena.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Any, Mapping, Optional
+
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.athena import AWSAthenaHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -49,11 +51,11 @@ class AthenaSensor(BaseSensorOperator):
 
     @apply_defaults
     def __init__(self,
-                 query_execution_id,
-                 max_retries=None,
-                 aws_conn_id='aws_default',
-                 sleep_time=10,
-                 *args, **kwargs):
+                 query_execution_id: str,
+                 max_retries: Optional[int],
+                 aws_conn_id: str = 'aws_default',
+                 sleep_time: int = 10,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.aws_conn_id = aws_conn_id
         self.query_execution_id = query_execution_id
@@ -71,8 +73,6 @@ class AthenaSensor(BaseSensorOperator):
             return False
         return True
 
-    def get_hook(self):
+    def get_hook(self) -> AWSAthenaHook:
         """Create and return an AWSAthenaHook"""
-        if not self.hook:
-            self.hook = AWSAthenaHook(self.aws_conn_id, self.sleep_time)
-        return self.hook
+        return AWSAthenaHook(self.aws_conn_id, self.sleep_time)

--- a/airflow/providers/amazon/aws/sensors/athena.py
+++ b/airflow/providers/amazon/aws/sensors/athena.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Mapping, Optional
+from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.athena import AWSAthenaHook


### PR DESCRIPTION
Add type annotations to `AthenaSensor` and `AWSAthenaOperator`. Of note on `AWSAthenaOperator` in particular, I removed `hook` as an attribute, which was always defaulting to `None`. I tried to keep it , but continually ran into errors like this:

>airflow/providers/amazon/aws/operators/athena.py:122: error: Item "None" of "Optional[AWSAthenaHook]" has no attribute "stop_query"
>                response = self.hook.stop_query(self.query_execution_id)

Any ideas on how to add typing when an attribute starts as `None` and gets set later? Or is the point of these errors that that is not necessary?

I also intentionally put this into two commits since the `AWSAthenaHook` changes were a little more straightforward. I could pull the operator ones out if need be.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

**partially** closes: #9008 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
