### PR TITLE
Group UPDATING.md  entries in into smaller sections

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -62,31 +62,33 @@ More tips can be found in the guide:
 https://developers.google.com/style/inclusive-documentation
 
 -->
-### GCSTaskHandler has been moved
+### Other changes
+
+#### GCSTaskHandler has been moved
 The `GCSTaskHandler` class from `airflow.utils.log.gcs_task_handler` has been moved to
 `airflow.providers.google.cloud.log.gcs_task_handler`. This is because it has items specific to `google cloud`.
 
-### WasbTaskHandler has been moved
+#### WasbTaskHandler has been moved
 The `WasbTaskHandler` class from `airflow.utils.log.wasb_task_handler` has been moved to
 `airflow.providers.microsoft.azure.log.wasb_task_handler`. This is because it has items specific to `azure`.
 
-### StackdriverTaskHandler has been moved
+#### StackdriverTaskHandler has been moved
 The `StackdriverTaskHandler` class from `airflow.utils.log.stackdriver_task_handler` has been moved to
 `airflow.providers.google.cloud.log.stackdriver_task_handler`. This is because it has items specific to `google cloud`.
 
-### S3TaskHandler has been moved
+#### S3TaskHandler has been moved
 The `S3TaskHandler` class from `airflow.utils.log.s3_task_handler` has been moved to
 `airflow.providers.amazon.aws.log.s3_task_handler`. This is because it has items specific to `aws`.
 
-### ElasticsearchTaskHandler has been moved
+#### ElasticsearchTaskHandler has been moved
 The `ElasticsearchTaskHandler` class from `airflow.utils.log.es_task_handler` has been moved to
 `airflow.providers.elasticsearch.log.es_task_handler`. This is because it has items specific to `elasticsearch`.
 
-### CloudwatchTaskHandler has been  moved
+#### CloudwatchTaskHandler has been  moved
 The `CloudwatchTaskHandler` class from `airflow.utils.log.cloudwatch_task_handler` has been moved to
 `airflow.providers.amazon.aws.log.cloudwatch_task_handler`. This is because it has items specific to `aws`.
 
-### SendGrid emailer has been moved
+#### SendGrid emailer has been moved
 Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
 package was supported by the community. The project was passed to the Apache community and currently the
 entire code is maintained by the community, so now the division has no justification, and it is only due
@@ -107,7 +109,7 @@ email_backend = airflow.providers.sendgrid.utils.emailer.send_email
 
 The old configuration still works but can be abandoned.
 
-### Weekday enum has been moved
+#### Weekday enum has been moved
 Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
 package was supported by the community. The project was passed to the Apache community and currently the
 entire code is maintained by the community, so now the division has no justification, and it is only due
@@ -115,7 +117,7 @@ to historical reasons.
 
 To clean up, `Weekday` enum has been moved from `airflow.contrib.utils` into `airflow.utils` module.
 
-### airflow.contrib.utils.log has been moved
+#### airflow.contrib.utils.log has been moved
 Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
 package was supported by the community. The project was passed to the Apache community and currently the
 entire code is maintained by the community, so now the division has no justification, and it is only due
@@ -125,7 +127,7 @@ To clean up, modules in `airflow.contrib.utils.log` have been moved into `airflo
 this includes:
 * `TaskHandlerWithCustomFormatter` class
 
-### Deprecated method in Connection
+#### Deprecated method in Connection
 
 The connection module has new deprecated methods:
 
@@ -151,12 +153,12 @@ default representation (`__repr__`).
 The old method is still works but can be abandoned at any time. The changes are intended to delete method
 that are rarely used.
 
-### BaseOperator uses metaclass
+#### BaseOperator uses metaclass
 
 `BaseOperator` class uses a `BaseOperatorMeta` as a metaclass. This meta class is based on
 `abc.ABCMeta`. If your custom operator uses different metaclass then you will have to adjust it.
 
-### Not-nullable conn_type column in connection table
+#### Not-nullable conn_type column in connection table
 
 The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
 by application logic, but was not enforced by the database schema.
@@ -164,7 +166,7 @@ by application logic, but was not enforced by the database schema.
 If you made any modifications to the table directly, make sure you don't have
 null in the conn_type column.
 
-### DAG.create_dagrun accepts run_type and does not require run_id
+#### DAG.create_dagrun accepts run_type and does not require run_id
 This change is caused by adding `run_type` column to `DagRun`.
 
 Previous signature:
@@ -200,7 +202,7 @@ Airflow should construct dagruns using `run_type` and `execution_date`, creation
 `run_id` is preserved for user actions.
 
 
-### Standardised "extra" requirements
+#### Standardised "extra" requirements
 
 We standardised the Extras names and synchronized providers package names with the main airflow extras.
 
@@ -228,7 +230,7 @@ For example instead of `pip install apache-airflow[atlas]` you should use
 
 The deprecated extras will be removed in 2.1:
 
-### Skipped tasks can satisfy wait_for_downstream
+#### Skipped tasks can satisfy wait_for_downstream
 
 Previously, a task instance with `wait_for_downstream=True` will only run if the downstream task of
 the previous task instance is successful. Meanwhile, a task instance with `depends_on_past=True`
@@ -238,7 +240,7 @@ To maintain consistent behavior, both successful or skipped downstream task can 
 `wait_for_downstream=True` flag.
 
 
-### Use DagRunType.SCHEDULED.value instead of DagRun.ID_PREFIX
+#### Use DagRunType.SCHEDULED.value instead of DagRun.ID_PREFIX
 
 All the run_id prefixes for different kind of DagRuns have been grouped into a single
 enum in `airflow.utils.types.DagRunType`.
@@ -262,7 +264,7 @@ Replaced by:
 scheduled
 ```
 
-### Ability to patch Pool.DEFAULT_POOL_NAME in BaseOperator
+#### Ability to patch Pool.DEFAULT_POOL_NAME in BaseOperator
 It was not possible to patch pool in BaseOperator as the signature sets the default value of pool
 as Pool.DEFAULT_POOL_NAME.
 While using subdagoperator in unittest(without initializing the sqlite db), it was throwing the
@@ -272,7 +274,7 @@ sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: slot_
 ```
 Fix for this, https://github.com/apache/airflow/pull/8587
 
-### Change signature of BigQueryGetDatasetTablesOperator
+#### Change signature of BigQueryGetDatasetTablesOperator
 Was:
 ```python
 BigQueryGetDatasetTablesOperator(dataset_id: str, dataset_resource: dict, ...)
@@ -282,13 +284,13 @@ and now it is:
 BigQueryGetDatasetTablesOperator(dataset_resource: dict, dataset_id: Optional[str] = None, ...)
 ```
 
-### Unify `hostname_callable` option in `core` section
+#### Unify `hostname_callable` option in `core` section
 
 The previous option used a colon(`:`) to split the module from function. Now the dot(`.`) is used.
 
 The change aims to unify the format of all options that refer to objects in the `airflow.cfg` file.
 
-### Changes in BigQueryHook
+#### Changes in BigQueryHook
 In general all hook methods are decorated with `@GoogleBaseHook.fallback_to_default_project_id` thus
 parameters to hook can only be passed via keyword arguments.
 
@@ -304,7 +306,7 @@ previous one was (project_id, dataset_id, ...) (breaking change)
 - `get_tabledata` returns list of rows instead of API response in dict format. This method is deprecated in
  favor of `list_rows`. (breaking change)
 
-### Added mypy plugin to preserve types of decorated functions
+#### Added mypy plugin to preserve types of decorated functions
 
 Mypy currently doesn't support precise type information for decorated
 functions; see https://github.com/python/mypy/issues/3157 for details.
@@ -318,7 +320,7 @@ plugins =
   airflow.mypy.plugin.decorators
 ```
 
-### Use project_id argument consistently across GCP hooks and operators
+#### Use project_id argument consistently across GCP hooks and operators
 
 - Changed order of arguments in DataflowHook.start_python_dataflow. Uses
     with positional arguments may break.
@@ -333,7 +335,7 @@ plugins =
 - Added optional project_id argument to DataflowCreatePythonJobOperator
     constructor.
 
-### GCSUploadSessionCompleteSensor signature change
+#### GCSUploadSessionCompleteSensor signature change
 
 To provide more precise control in handling of changes to objects in
 underlying GCS Bucket the constructor of this sensor now has changed.
@@ -356,7 +358,7 @@ Will now call:
 Where '.keep' is a single file at your prefix that the sensor should not consider new.
 
 
-### Rename pool statsd metrics
+#### Rename pool statsd metrics
 
 Used slot has been renamed to running slot to make the name self-explanatory
 and the code more maintainable.
@@ -365,36 +367,36 @@ This means `pool.used_slots.<pool_name>` metric has been renamed to
 `pool.running_slots.<pool_name>`. The `Used Slots` column in Pools Web UI view
 has also been changed to `Running Slots`.
 
-### Remove SQL support in base_hook
+#### Remove SQL support in base_hook
 
 Remove ``get_records`` and ``get_pandas_df`` and ``run`` from base_hook, which only apply for sql like hook,
 If want to use them, or your custom hook inherit them, please use ``dbapi_hook``
 
-### Changes to SalesforceHook
+#### Changes to SalesforceHook
 
 Replace parameter ``sandbox`` with ``domain``. According to change in simple-salesforce package
 
-### Rename parameter name in PinotAdminHook.create_segment
+#### Rename parameter name in PinotAdminHook.create_segment
 
 Rename parameter name from ``format`` to ``segment_format`` in PinotAdminHook function create_segment fro pylint compatible
 
-### Rename parameter name in HiveMetastoreHook.get_partitions
+#### Rename parameter name in HiveMetastoreHook.get_partitions
 
 Rename parameter name from ``filter`` to ``partition_filter`` in HiveMetastoreHook function get_partitions for pylint compatible
 
-### Remove unnecessary parameter in FTPHook.list_directory
+#### Remove unnecessary parameter in FTPHook.list_directory
 
 Remove unnecessary parameter ``nlst`` in FTPHook function list_directory for pylint compatible
 
-### Remove unnecessary parameter in PostgresHook function copy_expert
+#### Remove unnecessary parameter in PostgresHook function copy_expert
 
 Remove unnecessary parameter ``open`` in PostgresHook function copy_expert for pylint compatible
 
-### Change parameter name in OpsgenieAlertOperator
+#### Change parameter name in OpsgenieAlertOperator
 
 Change parameter name from ``visibleTo`` to ``visible_to`` in OpsgenieAlertOperator for pylint compatible
 
-### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
+#### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
 
 Previously, you could assign a task to a DAG as follows:
 
@@ -412,12 +414,12 @@ with DAG('my_dag'):
     dummy = DummyOperator(task_id='dummy')
 ```
 
-### Deprecating ignore_first_depends_on_past on backfill command and default it to True
+#### Deprecating ignore_first_depends_on_past on backfill command and default it to True
 
 When doing backfill with `depends_on_past` dags, users will need to pass `--ignore-first-depends-on-past`.
 We should default it as `true` to avoid confusion
 
-### Custom executors is loaded using full import path
+#### Custom executors is loaded using full import path
 
 In previous versions of Airflow it was possible to use plugins to load custom executors. It is still
 possible, but the configuration has changed. Now you don't have to create a plugin to configure a
@@ -440,7 +442,7 @@ executor = my_acme_company.executors.MyCustomExecutor
 
 The old configuration is still works but can be abandoned at any time.
 
-### Removed sub-package imports from `airflow/__init__.py`
+#### Removed sub-package imports from `airflow/__init__.py`
 
 The imports `LoggingMixin`, `conf`, and `AirflowException` have been removed from `airflow/__init__.py`.
 All implicit references of these objects will no longer be valid. To migrate, all usages of each old path must be
@@ -452,7 +454,7 @@ replaced with its corresponding new path.
 | ``airflow.conf``             | ``airflow.configuration.conf``                   |
 | ``airflow.AirflowException`` | ``airflow.exceptions.AirflowException``          |
 
-### Added `airflow dags test` CLI command
+#### Added `airflow dags test` CLI command
 
 A new command was added to the CLI for executing one full run of a DAG for a given execution date, similar to
 `airflow tasks test`. Example usage:
@@ -462,7 +464,7 @@ airflow dags test [dag_id] [execution_date]
 airflow dags test example_branch_operator 2018-01-01
 ```
 
-### Drop plugin support for stat_name_handler
+#### Drop plugin support for stat_name_handler
 
 In previous version, you could use plugins mechanism to configure ``stat_name_handler``. You should now use the `stat_name_handler`
 option in `[scheduler]` section to achieve the same effect.
@@ -484,7 +486,7 @@ stat_name_handler=test_plugin.my_stat_name_handler
 
 This change is intended to simplify the statsd configuration.
 
-### Move methods from BiqQueryBaseCursor to BigQueryHook
+#### Move methods from BiqQueryBaseCursor to BigQueryHook
 
 To simplify BigQuery operators (no need of `Cursor`) and standardize usage of hooks within all GCP integration methods from `BiqQueryBaseCursor`
 were moved to `BigQueryHook`. Using them by from `Cursor` object is still possible due to preserved backward compatibility but they will raise `DeprecationWarning`.
@@ -517,7 +519,7 @@ The following methods were moved:
 | airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.run_with_configuration        | airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration        |
 | airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.update_dataset                | airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset                |
 
-### Standardize handling http exception in BigQuery
+#### Standardize handling http exception in BigQuery
 
 Since BigQuery is the part of the GCP it was possible to simplify the code by handling the exceptions
 by usage of the `airflow.providers.google.common.hooks.base.GoogleBaseHook.catch_http_exception` decorator however it changes
@@ -526,7 +528,7 @@ exceptions raised by the following methods:
 * `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.create_empty_dataset` raises `AirflowException` instead of `ValueError`.
 * `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.get_dataset` raises `AirflowException` instead of `ValueError`.
 
-### Remove airflow.utils.file.TemporaryDirectory
+#### Remove airflow.utils.file.TemporaryDirectory
 
 Since Airflow dropped support for Python < 3.5 there's no need to have this custom
 implementation of `TemporaryDirectory` because the same functionality is provided by
@@ -536,7 +538,7 @@ Now users instead of `import from airflow.utils.files import TemporaryDirectory`
 do `from tempfile import TemporaryDirectory`. Both context managers provide the same
 interface, thus no additional changes should be required.
 
-### Chain and cross_downstream moved from helpers to BaseOperator
+#### Chain and cross_downstream moved from helpers to BaseOperator
 
 The `chain` and `cross_downstream` methods are now moved to airflow.models.baseoperator module from
 `airflow.utils.helpers` module.
@@ -564,11 +566,11 @@ from airflow.models.baseoperator import chain
 from airflow.models.baseoperator import cross_downstream
 ```
 
-### Change python3 as Dataflow Hooks/Operators default interpreter
+#### Change python3 as Dataflow Hooks/Operators default interpreter
 
 Now the `py_interpreter` argument for DataFlow Hooks/Operators has been changed from python2 to python3.
 
-### Logging configuration has been moved to new section
+#### Logging configuration has been moved to new section
 
 The following configurations have been moved from `[core]` to the new `[logging]` section.
 
@@ -591,7 +593,7 @@ The following configurations have been moved from `[core]` to the new `[logging]
 * `dag_processor_manager_log_location`
 * `task_log_reader`
 
-### Simplification of CLI commands
+#### Simplification of CLI commands
 
 #### Grouped to improve UX of CLI
 
@@ -677,35 +679,35 @@ For Airflow long option, use [kebab-case](https://en.wikipedia.org/wiki/Letter_c
 | ``--use_random_password``          | ``--use-random-password``          |
 | ``--skip_serve_logs``              | ``--skip-serve-logs``              |
 
-### Remove serve_logs command from CLI
+#### Remove serve_logs command from CLI
 
 The ``serve_logs`` command has been deleted. This command should be run only by internal application mechanisms
 and there is no need for it to be accessible from the CLI interface.
 
-### dag_state CLI command
+#### dag_state CLI command
 
 If the DAGRun was triggered with conf key/values passed in, they will also be printed in the dag_state CLI response
 ie. running, {"name": "bob"}
 whereas in in prior releases it just printed the state:
 ie. running
 
-### Remove gcp_service_account_keys option in airflow.cfg file
+#### Remove gcp_service_account_keys option in airflow.cfg file
 
 This option has been removed because it is no longer supported by the Google Kubernetes Engine. The new
 recommended service account keys for the Google Cloud Platform management method is
 [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
 
-### BranchPythonOperator has a return value
+#### BranchPythonOperator has a return value
 `BranchPythonOperator` will now return a value equal to the `task_id` of the chosen branch,
 where previously it returned None. Since it inherits from BaseOperator it will do an
 `xcom_push` of this value if `do_xcom_push=True`. This is useful for downstream decision-making.
 
-### Removal of airflow.AirflowMacroPlugin class
+#### Removal of airflow.AirflowMacroPlugin class
 
 The class was there in airflow package but it has not been used (apparently since 2015).
 It has been removed.
 
-### Changes to settings
+#### Changes to settings
 
 CONTEXT_MANAGER_DAG was removed from settings. It's role has been taken by `DagContext` in
 'airflow.models.dag'. One of the reasons was that settings should be rather static than store
@@ -720,7 +722,7 @@ versions. This was leading to EmrStepSensor not being able to find their corresp
 changes in the EmrAddStepsOperator, EmrTerminateJobFlowOperator and EmrCreateJobFlowOperator this issue is
 solved.
 
-### Removal of redirect_stdout, redirect_stderr
+#### Removal of redirect_stdout, redirect_stderr
 
 Function `redirect_stderr` and `redirect_stdout` from `airflow.utils.log.logging_mixin` module has
 been deleted because it can be easily replaced by the standard library.
@@ -750,7 +752,7 @@ with redirect_stdout(StreamLogWriter(logger, logging.INFO)), \
     print("I Love Airflow")
 ```
 
-### Changes to SQLSensor
+#### Changes to SQLSensor
 
 SQLSensor now consistent with python `bool()` function and the `allow_null` parameter has been removed.
 
@@ -759,12 +761,12 @@ changes the previous response receiving `NULL` or `'0'`. Earlier `'0'` has been 
 criteria. `NULL` has been treated depending on value of `allow_null`parameter.  But all the previous
 behaviour is still achievable setting param `success` to `lambda x: x is None or str(x) not in ('0', '')`.
 
-### Idempotency in BigQuery operators
+#### Idempotency in BigQuery operators
 Idempotency was added to `BigQueryCreateEmptyTableOperator` and `BigQueryCreateEmptyDatasetOperator`.
 But to achieve that try / except clause was removed from `create_empty_dataset` and `create_empty_table`
 methods of `BigQueryHook`.
 
-### Migration of AWS components
+#### Migration of AWS components
 
 All AWS components (hooks, operators, sensors, example DAGs) will be grouped together as decided in
 [AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths). Migrated
@@ -788,7 +790,7 @@ Migrated are:
 | airflow.contrib.sensors.aws_athena_sensor.AthenaSensor       | airflow.providers.amazon.aws.sensors.athena.AthenaSensor        |
 | airflow.contrib.sensors.aws_sqs_sensor.SQSSensor             | airflow.providers.amazon.aws.sensors.sqs.SQSSensor        |
 
-### AWS Batch Operator
+#### AWS Batch Operator
 
 The `AwsBatchOperator` was refactored to extract an `AwsBatchClient` (and inherit from it).  The
 changes are mostly backwards compatible and clarify the public API for these classes; some
@@ -805,11 +807,11 @@ The `AwsBatchOperator` can use a new `waiters` parameter, an instance of `AwsBat
 specify that custom job waiters will be used to monitor a batch job.  See the latest API
 documentation for details.
 
-### AthenaSensor
+#### AthenaSensor
 
 Replace parameter `max_retires` with `max_retries` to fix typo.
 
-### Additional arguments passed to BaseOperator cause an exception
+#### Additional arguments passed to BaseOperator cause an exception
 
 Previous versions of Airflow took additional arguments and displayed a message on the console. When the
 message was not noticed by users, it caused very difficult to detect errors.
@@ -818,12 +820,12 @@ In order to restore the previous behavior, you must set an ``True`` in  the ``al
 option of section ``[operators]`` in the ``airflow.cfg`` file. In the future it is possible to completely
 delete this option.
 
-### Simplification of the TriggerDagRunOperator
+#### Simplification of the TriggerDagRunOperator
 
 The TriggerDagRunOperator now takes a `conf` argument to which a dict can be provided as conf for the DagRun.
 As a result, the `python_callable` argument was removed. PR: https://github.com/apache/airflow/pull/6317.
 
-### Changes in Google Cloud Platform related hooks
+#### Changes in Google Cloud Platform related hooks
 
 The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather
 than positional ones in all methods where `project_id` is used. The methods throw an explanatory exception
@@ -837,7 +839,7 @@ Hooks involved:
 
 Other GCP hooks are unaffected.
 
-### Fernet is enabled by default
+#### Fernet is enabled by default
 
 The fernet mechanism is enabled by default to increase the security of the default installation.  In order to
 restore the previous behavior, the user must consciously set an empty key in the ``fernet_key`` option of
@@ -846,7 +848,7 @@ section ``[core]`` in the ``airflow.cfg`` file.
 At the same time, this means that the `apache-airflow[crypto]` extra-packages are always installed.
 However, this requires that your operating system has ``libffi-dev`` installed.
 
-### Changes to Google PubSub Operators, Hook and Sensor
+#### Changes to Google PubSub Operators, Hook and Sensor
 In the `PubSubPublishOperator` and `PubSubHook.publsh` method the data field in a message should be bytestring (utf-8 encoded) rather than base64 encoded string.
 
 Due to the normalization of the parameters within GCP operators and hooks a parameters like `project` or `topic_project`
@@ -867,14 +869,14 @@ Affected components:
  * airflow.providers.google.cloud.operators.pubsub.PubSubPublishOperator
  * airflow.providers.google.cloud.sensors.pubsub.PubSubPullSensor
 
-### Removed Hipchat integration
+#### Removed Hipchat integration
 
 Hipchat has reached end of life and is no longer available.
 
 For more information please see
 https://community.atlassian.com/t5/Stride-articles/Stride-and-Hipchat-Cloud-have-reached-End-of-Life-updated/ba-p/940248
 
-### The gcp_conn_id parameter in GKEPodOperator is required
+#### The gcp_conn_id parameter in GKEPodOperator is required
 
 In previous versions, it was possible to pass the `None` value to the `gcp_conn_id` in the GKEPodOperator
 operator, which resulted in credentials being determined according to the
@@ -886,7 +888,7 @@ specifying the service account.
 Detailed information about connection management is available:
 [Google Cloud Platform Connection](https://airflow.apache.org/howto/connection/gcp.html).
 
-### Normalize gcp_conn_id for Google Cloud Platform
+#### Normalize gcp_conn_id for Google Cloud Platform
 
 Previously not all hooks and operators related to Google Cloud Platform use
 `gcp_conn_id` as parameter for GCP connection. There is currently one parameter
@@ -920,7 +922,7 @@ Following components were affected by normalization:
   * airflow.operators.cassandra_to_gcs.CassandraToGoogleCloudStorageOperator
   * airflow.operators.bigquery_to_bigquery.BigQueryToBigQueryOperator
 
-### Changes to propagating Kubernetes worker annotations
+#### Changes to propagating Kubernetes worker annotations
 
 `kubernetes_annotations` configuration section has been removed.
 A new key `worker_annotations` has been added to existing `kubernetes` section instead.
@@ -937,7 +939,7 @@ it should be rewritten to
 worker_annotations = { "annotation_key" : "annotation_value", "annotation_key2" : "annotation_value2" }
 ```
 
-### Changes to import paths and names of GCP operators and hooks
+#### Changes to import paths and names of GCP operators and hooks
 
 According to [AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths)
 operators related to Google Cloud Platform has been moved from contrib to core.
@@ -1124,7 +1126,7 @@ The following table shows changes in import paths.
 |airflow.contrib.sensors.pubsub_sensor.PubSubPullSensor                                                            |airflow.providers.google.cloud.sensors.pubsub.PubSubPullSensor                                                                |
 
 
-### Remove provide_context
+#### Remove provide_context
 
 `provide_context` argument on the PythonOperator was removed. The signature of the callable passed to the PythonOperator is now inferred and argument values are always automatically provided. There is no need to explicitly provide or not provide the context anymore. For example:
 
@@ -1164,16 +1166,16 @@ The change is backwards compatible, setting `provide_context` will add the `prov
 
 PR: [#5990](https://github.com/apache/airflow/pull/5990)
 
-### Changes to FileSensor
+#### Changes to FileSensor
 
 FileSensor is now takes a glob pattern, not just a filename. If the filename you are looking for has `*`, `?`, or `[` in it then you should replace these with `[*]`, `[?]`, and `[[]`.
 
-### Change dag loading duration metric name
+#### Change dag loading duration metric name
 Change DAG file loading duration metric from
 `dag.loading-duration.<dag_id>` to `dag.loading-duration.<dag_file>`. This is to
 better handle the case when a DAG file has multiple DAGs.
 
-### Changes to ImapHook, ImapAttachmentSensor and ImapAttachmentToS3Operator
+#### Changes to ImapHook, ImapAttachmentSensor and ImapAttachmentToS3Operator
 
 ImapHook:
 * The order of arguments has changed for `has_mail_attachment`,
@@ -1188,68 +1190,68 @@ ImapAttachmentToS3Operator:
 * The order of arguments has changed for `__init__`.
 * A new `imap_mail_filter` argument has been added to `__init__`.
 
-### Changes to `SubDagOperator`
+#### Changes to `SubDagOperator`
 
 `SubDagOperator` is changed to use Airflow scheduler instead of backfill
 to schedule tasks in the subdag. User no longer need to specify the executor
 in `SubDagOperator`.
 
-### Variables removed from the task instance context
+#### Variables removed from the task instance context
 
 The following variables were removed from the task instance context:
 - end_date
 - latest_date
 - tables
 
-### Moved provide_gcp_credential_file decorator to GoogleBaseHook
+#### Moved provide_gcp_credential_file decorator to GoogleBaseHook
 
 To simplify the code, the decorator has been moved from the inner-class.
 
 Instead of `@GoogleBaseHook._Decorators.provide_gcp_credential_file`,
 you should write `@GoogleBaseHook.provide_gcp_credential_file`
 
-### Changes to S3Hook
+#### Changes to S3Hook
 
 Note: The order of arguments has changed for `check_for_prefix`.
 The `bucket_name` is now optional. It falls back to the `connection schema` attribute.
 The `delete_objects` now returns `None` instead of a response, since the method now makes multiple api requests when the keys list length is > 1000.
 
-### Changes to Google Transfer Operator
+#### Changes to Google Transfer Operator
 To obtain pylint compatibility the `filter ` argument in `GcpTransferServiceOperationsListOperator`
 has been renamed to `request_filter`.
 
-### Changes in  Google Cloud Transfer Hook
+#### Changes in  Google Cloud Transfer Hook
  To obtain pylint compatibility the `filter` argument in `GCPTransferServiceHook.list_transfer_job` and
  `GCPTransferServiceHook.list_transfer_operations` has been renamed to `request_filter`.
 
-### CLI reorganization
+#### CLI reorganization
 
 The Airflow CLI has been organized so that related commands are grouped
 together as subcommands. The `airflow list_dags` command is now `airflow
 dags list`, `airflow pause` is `airflow dags pause`, `airflow config` is `airflow config list`, etc.
 For a complete list of updated CLI commands, see https://airflow.apache.org/cli.html.
 
-### Removal of Mesos Executor
+#### Removal of Mesos Executor
 
 The Mesos Executor is removed from the code base as it was not widely used and not maintained. [Mailing List Discussion on deleting it](https://lists.apache.org/thread.html/daa9500026b820c6aaadeffd66166eae558282778091ebbc68819fb7@%3Cdev.airflow.apache.org%3E).
 
-### Increase standard Dataproc disk sizes
+#### Increase standard Dataproc disk sizes
 
 It is highly recommended to have 1TB+ disk size for Dataproc to have sufficient throughput:
 https://cloud.google.com/compute/docs/disks/performance
 
 Hence, the default value for `master_disk_size` in DataprocCreateClusterOperator has beeen changes from 500GB to 1TB.
 
-### Changes to SalesforceHook
+#### Changes to SalesforceHook
 
 * renamed `sign_in` function to `get_conn`
 
-### HTTPHook verify default value changed from False to True.
+#### HTTPHook verify default value changed from False to True.
 
 The HTTPHook is now secured by default: `verify=True`.
 This can be overwriten by using the extra_options param as `{'verify': False}`.
 
-### Changes to GoogleCloudStorageHook
+#### Changes to GoogleCloudStorageHook
 
 * The following parameters have been replaced in all the methods in GCSHook:
   * `bucket` is changed to `bucket_name`
@@ -1257,7 +1259,7 @@ This can be overwriten by using the extra_options param as `{'verify': False}`.
 
 * The `maxResults` parameter in `GoogleCloudStorageHook.list` has been renamed to `max_results` for consistency.
 
-### Changes to CloudantHook
+#### Changes to CloudantHook
 
 * upgraded cloudant version from `>=0.5.9,<2.0` to `>=2.0`
 * removed the use of the `schema` attribute in the connection
@@ -1273,7 +1275,7 @@ with CloudantHook().get_conn() as cloudant_session:
 
 See the [docs](https://python-cloudant.readthedocs.io/en/latest/) for more information on how to use the new cloudant version.
 
-### Unify default conn_id for Google Cloud Platform
+#### Unify default conn_id for Google Cloud Platform
 
 Previously not all hooks and operators related to Google Cloud Platform use
 ``google_cloud_default`` as a default conn_id. There is currently one default
@@ -1284,21 +1286,21 @@ deprecated GCP conn_id, you need to explicitly pass their conn_id into
 operators/hooks. Otherwise, ``google_cloud_default`` will be used as GCP's conn_id
 by default.
 
-### Removed deprecated import mechanism
+#### Removed deprecated import mechanism
 
 The deprecated import mechanism has been removed so the import of modules becomes more consistent and explicit.
 
 For example: `from airflow.operators import BashOperator`
 becomes `from airflow.operators.bash_operator import BashOperator`
 
-### Changes to sensor imports
+#### Changes to sensor imports
 
 Sensors are now accessible via `airflow.sensors` and no longer via `airflow.operators.sensors`.
 
 For example: `from airflow.operators.sensors import BaseSensorOperator`
 becomes `from airflow.sensors.base_sensor_operator import BaseSensorOperator`
 
-### Renamed "extra" requirements for cloud providers
+#### Renamed "extra" requirements for cloud providers
 
 Subpackages for specific services have been combined into one variant for
 each cloud provider. The name of the subpackage for the Google Cloud Platform
@@ -1317,7 +1319,7 @@ If you want to install integration for Google Cloud Platform, then instead of
 `pip install 'apache-airflow[gcp_api]'`, you should execute `pip install 'apache-airflow[gcp]'`.
 The old way will work until the release of Airflow 2.1.
 
-### Deprecate legacy UI in favor of FAB RBAC UI
+#### Deprecate legacy UI in favor of FAB RBAC UI
 
 Previously we were using two versions of UI, which were hard to maintain as we need to implement/update the same feature
 in both versions. With this change we've removed the older UI in favor of Flask App Builder RBAC UI. No need to set the
@@ -1331,7 +1333,7 @@ including `authenticate`, `filter_by_owner`, `owner_mode`, and `rbac`.
 
 We should not use the `run_duration` option anymore. This used to be for restarting the scheduler from time to time, but right now the scheduler is getting more stable and therefore using this setting is considered bad and might cause an inconsistent state.
 
-### CLI Changes
+#### CLI Changes
 
 The ability to manipulate users from the command line has been changed. 'airflow create_user' and 'airflow delete_user' and 'airflow list_users' has been grouped to a single command `airflow users` with optional flags `--create`, `--list` and `--delete`.
 
@@ -1362,7 +1364,7 @@ To remove a user from a role:
 airflow users --remove-role --username jondoe --role Public
 ```
 
-### Unification of `do_xcom_push` flag
+#### Unification of `do_xcom_push` flag
 The `do_xcom_push` flag (a switch to push the result of an operator to xcom or not) was appearing in different incarnations in different operators. It's function has been unified under a common name (`do_xcom_push`) on `BaseOperator`. This way it is also easy to globally disable pushing results to xcom.
 
 The following operators were affected:
@@ -1378,13 +1380,13 @@ The following operators were affected:
 
 See [AIRFLOW-3249](https://jira.apache.org/jira/browse/AIRFLOW-3249) for details
 
-### Changes to Dataproc related Operators
+#### Changes to Dataproc related Operators
 The 'properties' and 'jars' properties for the Dataproc related operators (`DataprocXXXOperator`) have been renamed from
 `dataproc_xxxx_properties` and `dataproc_xxx_jars`  to `dataproc_properties`
 and `dataproc_jars`respectively.
 Arguments for dataproc_properties dataproc_jars
 
-### Changes to skipping behaviour of LatestOnlyOperator
+#### Changes to skipping behaviour of LatestOnlyOperator
 
 In previous versions, the `LatestOnlyOperator` forcefully skipped all (direct and undirect) downstream tasks on its own. From this version on the operator will **only skip direct downstream** tasks and the scheduler will handle skipping any further downstream dependencies.
 
@@ -1394,11 +1396,11 @@ If the DAG relies on tasks with other trigger rules (i.e. `all_done`) being skip
 
 The goal of this change is to achieve a more consistent and configurale cascading behaviour based on the `BaseBranchOperator` (see [AIRFLOW-2923](https://jira.apache.org/jira/browse/AIRFLOW-2923) and [AIRFLOW-1784](https://jira.apache.org/jira/browse/AIRFLOW-1784)).
 
-### Change default snowflake_conn_id for Snowflake hook and operators
+#### Change default snowflake_conn_id for Snowflake hook and operators
 
 When initializing a Snowflake hook or operator, the value used for `snowflake_conn_id` was always `snowflake_conn_id`, regardless of whether or not you specified a value for it. The default `snowflake_conn_id` value is now switched to `snowflake_default` for consistency and will be properly overriden when specified.
 
-### Simplify the response payload of endpoints /dag_stats and /task_stats
+#### Simplify the response payload of endpoints /dag_stats and /task_stats
 
 The response of endpoints `/dag_stats` and `/task_stats` help UI fetch brief statistics about DAGs and Tasks. The format was like
 
@@ -1446,7 +1448,7 @@ Now the `dag_id` will not appear repeated in the payload, and the response forma
 }
 ```
 
-### Change in DagBag signature
+#### Change in DagBag signature
 
 Passing `store_serialized_dags` argument to DagBag.__init__ and accessing `DagBag.store_serialized_dags` property
 are deprecated and will be removed in future versions.
@@ -1479,13 +1481,12 @@ arguments, please change `store_serialized_dags` to `read_dags_from_db`.
 Similarly, if you were using `DagBag().store_serialized_dags` property, change it to
 `DagBag().read_dags_from_db`.
 
-### TimeSensor is now timezone aware
+#### TimeSensor is now timezone aware
 
 Previously `TimeSensor` always compared the `target_time` with the current time in UTC.
 
 Now it will compare `target_time` with the current time in the timezone of the DAG,
 defaulting to the `default_timezone` in the global config.
-
 
 ## Airflow 1.10.11
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -962,9 +962,181 @@ Hipchat has reached end of life and is no longer available.
 
 For more information please see
 https://community.atlassian.com/t5/Stride-articles/Stride-and-Hipchat-Cloud-have-reached-End-of-Life-updated/ba-p/940248
+### Changes to the core operators/hooks
 
+#### BaseOperator uses metaclass
 
-### Other changes
+`BaseOperator` class uses a `BaseOperatorMeta` as a metaclass. This meta class is based on
+`abc.ABCMeta`. If your custom operator uses different metaclass then you will have to adjust it.
+
+#### Remove SQL support in base_hook
+
+Remove ``get_records`` and ``get_pandas_df`` and ``run`` from base_hook, which only apply for sql like hook,
+If want to use them, or your custom hook inherit them, please use ``dbapi_hook``
+
+#### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
+
+Previously, you could assign a task to a DAG as follows:
+
+```python
+dag = DAG('my_dag')
+dummy = DummyOperator(task_id='dummy')
+
+dag >> dummy
+```
+
+This is no longer supported. Instead, we recommend using the DAG as context manager:
+
+```python
+with DAG('my_dag'):
+    dummy = DummyOperator(task_id='dummy')
+```
+
+#### Chain and cross_downstream moved from helpers to BaseOperator
+
+The `chain` and `cross_downstream` methods are now moved to airflow.models.baseoperator module from
+`airflow.utils.helpers` module.
+
+The baseoperator module seems to be a better choice to keep
+closely coupled methods together. Helpers module is supposed to contain standalone helper methods
+that can be imported by all classes.
+
+The `chain` method and `cross_downstream` method both use BaseOperator. If any other package imports
+any classes or functions from helpers module, then it automatically has an
+implicit dependency to BaseOperator. That can often lead to cyclic dependencies.
+
+More information in [AIFLOW-6392](https://issues.apache.org/jira/browse/AIRFLOW-6392)
+
+In Airflow <2.0 you imported those two methods like this:
+
+```python
+from airflow.utils.helpers import chain
+from airflow.utils.helpers import cross_downstream
+```
+
+In Airflow 2.0 it should be changed to:
+```python
+from airflow.models.baseoperator import chain
+from airflow.models.baseoperator import cross_downstream
+```
+
+#### BranchPythonOperator has a return value
+`BranchPythonOperator` will now return a value equal to the `task_id` of the chosen branch,
+where previously it returned None. Since it inherits from BaseOperator it will do an
+`xcom_push` of this value if `do_xcom_push=True`. This is useful for downstream decision-making.
+
+#### Changes to SQLSensor
+
+SQLSensor now consistent with python `bool()` function and the `allow_null` parameter has been removed.
+
+It will resolve after receiving any value  that is casted to `True` with python `bool(value)`. That
+changes the previous response receiving `NULL` or `'0'`. Earlier `'0'` has been treated as success
+criteria. `NULL` has been treated depending on value of `allow_null`parameter.  But all the previous
+behaviour is still achievable setting param `success` to `lambda x: x is None or str(x) not in ('0', '')`.
+
+#### Simplification of the TriggerDagRunOperator
+
+The TriggerDagRunOperator now takes a `conf` argument to which a dict can be provided as conf for the DagRun.
+As a result, the `python_callable` argument was removed. PR: https://github.com/apache/airflow/pull/6317.
+
+#### Remove provide_context in PythonOperator
+
+`provide_context` argument on the PythonOperator was removed. The signature of the callable passed to the PythonOperator is now inferred and argument values are always automatically provided. There is no need to explicitly provide or not provide the context anymore. For example:
+
+```python
+def myfunc(execution_date):
+    print(execution_date)
+
+python_operator = PythonOperator(task_id='mytask', python_callable=myfunc, dag=dag)
+```
+
+Notice you don't have to set provide_context=True, variables from the task context are now automatically detected and provided.
+
+All context variables can still be provided with a double-asterisk argument:
+
+```python
+def myfunc(**context):
+    print(context)  # all variables will be provided to context
+
+python_operator = PythonOperator(task_id='mytask', python_callable=myfunc)
+```
+
+The task context variable names are reserved names in the callable function, hence a clash with `op_args` and `op_kwargs` results in an exception:
+
+```python
+def myfunc(dag):
+    # raises a ValueError because "dag" is a reserved name
+    # valid signature example: myfunc(mydag)
+
+python_operator = PythonOperator(
+    task_id='mytask',
+    op_args=[1],
+    python_callable=myfunc,
+)
+```
+
+The change is backwards compatible, setting `provide_context` will add the `provide_context` variable to the `kwargs` (but won't do anything).
+
+PR: [#5990](https://github.com/apache/airflow/pull/5990)
+
+#### Changes to FileSensor
+
+FileSensor is now takes a glob pattern, not just a filename. If the filename you are looking for has `*`, `?`, or `[` in it then you should replace these with `[*]`, `[?]`, and `[[]`.
+
+#### Changes to `SubDagOperator`
+
+`SubDagOperator` is changed to use Airflow scheduler instead of backfill
+to schedule tasks in the subdag. User no longer need to specify the executor
+in `SubDagOperator`.
+
+#### Removed deprecated import mechanism
+
+The deprecated import mechanism has been removed so the import of modules becomes more consistent and explicit.
+
+For example: `from airflow.operators import BashOperator`
+becomes `from airflow.operators.bash_operator import BashOperator`
+
+#### Changes to sensor imports
+
+Sensors are now accessible via `airflow.sensors` and no longer via `airflow.operators.sensors`.
+
+For example: `from airflow.operators.sensors import BaseSensorOperator`
+becomes `from airflow.sensors.base_sensor_operator import BaseSensorOperator`
+
+#### Unification of `do_xcom_push` flag
+The `do_xcom_push` flag (a switch to push the result of an operator to xcom or not) was appearing in different incarnations in different operators. It's function has been unified under a common name (`do_xcom_push`) on `BaseOperator`. This way it is also easy to globally disable pushing results to xcom.
+
+The following operators were affected:
+
+* DatastoreExportOperator (Backwards compatible)
+* DatastoreImportOperator (Backwards compatible)
+* KubernetesPodOperator (Not backwards compatible)
+* SSHOperator (Not backwards compatible)
+* WinRMOperator (Not backwards compatible)
+* BashOperator (Not backwards compatible)
+* DockerOperator (Not backwards compatible)
+* SimpleHttpOperator (Not backwards compatible)
+
+See [AIRFLOW-3249](https://jira.apache.org/jira/browse/AIRFLOW-3249) for details
+
+#### Changes to skipping behaviour of LatestOnlyOperator
+
+In previous versions, the `LatestOnlyOperator` forcefully skipped all (direct and undirect) downstream tasks on its own. From this version on the operator will **only skip direct downstream** tasks and the scheduler will handle skipping any further downstream dependencies.
+
+No change is needed if only the default trigger rule `all_success` is being used.
+
+If the DAG relies on tasks with other trigger rules (i.e. `all_done`) being skipped by the `LatestOnlyOperator`, adjustments to the DAG need to be made to commodate the change in behaviour, i.e. with additional edges from the `LatestOnlyOperator`.
+
+The goal of this change is to achieve a more consistent and configurale cascading behaviour based on the `BaseBranchOperator` (see [AIRFLOW-2923](https://jira.apache.org/jira/browse/AIRFLOW-2923) and [AIRFLOW-1784](https://jira.apache.org/jira/browse/AIRFLOW-1784)).
+
+#### TimeSensor is now timezone aware
+
+Previously `TimeSensor` always compared the `target_time` with the current time in UTC.
+
+Now it will compare `target_time` with the current time in the timezone of the DAG,
+defaulting to the `default_timezone` in the global config.
+
+### Changes to the core Python API
 
 #### Weekday enum has been moved
 Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
@@ -1000,19 +1172,6 @@ default representation (`__repr__`).
 
 The old method is still works but can be abandoned at any time. The changes are intended to delete method
 that are rarely used.
-
-#### BaseOperator uses metaclass
-
-`BaseOperator` class uses a `BaseOperatorMeta` as a metaclass. This meta class is based on
-`abc.ABCMeta`. If your custom operator uses different metaclass then you will have to adjust it.
-
-#### Not-nullable conn_type column in connection table
-
-The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
-by application logic, but was not enforced by the database schema.
-
-If you made any modifications to the table directly, make sure you don't have
-null in the conn_type column.
 
 #### DAG.create_dagrun accepts run_type and does not require run_id
 This change is caused by adding `run_type` column to `DagRun`.
@@ -1050,44 +1209,6 @@ Airflow should construct dagruns using `run_type` and `execution_date`, creation
 `run_id` is preserved for user actions.
 
 
-#### Standardised "extra" requirements
-
-We standardised the Extras names and synchronized providers package names with the main airflow extras.
-
-We deprecated a number of extras in 2.0.
-
-| Deprecated extras | New extras       |
-|-------------------|------------------|
-| atlas             | apache.atlas     |
-| aws               | amazon           |
-| azure             | microsoft.azure  |
-| cassandra         | apache.cassandra |
-| druid             | apache.druid     |
-| gcp               | google           |
-| gcp_api           | google           |
-| hdfs              | apache.hdfs      |
-| hive              | apache.hive      |
-| kubernetes        | cncf.kubernetes  |
-| mssql             | microsoft.mssql  |
-| pinot             | apache.pinot     |
-| webhdfs           | apache.webhdfs   |
-| winrm             | apache.winrm     |
-
-For example instead of `pip install apache-airflow[atlas]` you should use
-`pip install apache-airflow[apache.atlas]` .
-
-The deprecated extras will be removed in 2.1:
-
-#### Skipped tasks can satisfy wait_for_downstream
-
-Previously, a task instance with `wait_for_downstream=True` will only run if the downstream task of
-the previous task instance is successful. Meanwhile, a task instance with `depends_on_past=True`
-will run if the previous task instance is either successful or skipped. These two flags are close siblings
-yet they have different behavior. This inconsistency in behavior made the API less intuitive to users.
-To maintain consistent behavior, both successful or skipped downstream task can now satisfy the
-`wait_for_downstream=True` flag.
-
-
 #### Use DagRunType.SCHEDULED.value instead of DagRun.ID_PREFIX
 
 All the run_id prefixes for different kind of DagRuns have been grouped into a single
@@ -1112,58 +1233,6 @@ Replaced by:
 scheduled
 ```
 
-#### Ability to patch Pool.DEFAULT_POOL_NAME in BaseOperator
-It was not possible to patch pool in BaseOperator as the signature sets the default value of pool
-as Pool.DEFAULT_POOL_NAME.
-While using subdagoperator in unittest(without initializing the sqlite db), it was throwing the
-following error:
-```
-sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: slot_pool.
-```
-Fix for this, https://github.com/apache/airflow/pull/8587
-
-#### Added mypy plugin to preserve types of decorated functions
-
-Mypy currently doesn't support precise type information for decorated
-functions; see https://github.com/python/mypy/issues/3157 for details.
-To preserve precise type definitions for decorated functions, we now
-include a mypy plugin to preserve precise type definitions for decorated
-functions. To use the plugin, update your setup.cfg:
-
-```
-[mypy]
-plugins =
-  airflow.mypy.plugin.decorators
-```
-
-#### Remove SQL support in base_hook
-
-Remove ``get_records`` and ``get_pandas_df`` and ``run`` from base_hook, which only apply for sql like hook,
-If want to use them, or your custom hook inherit them, please use ``dbapi_hook``
-
-#### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
-
-Previously, you could assign a task to a DAG as follows:
-
-```python
-dag = DAG('my_dag')
-dummy = DummyOperator(task_id='dummy')
-
-dag >> dummy
-```
-
-This is no longer supported. Instead, we recommend using the DAG as context manager:
-
-```python
-with DAG('my_dag'):
-    dummy = DummyOperator(task_id='dummy')
-```
-
-#### Deprecating ignore_first_depends_on_past on backfill command and default it to True
-
-When doing backfill with `depends_on_past` dags, users will need to pass `--ignore-first-depends-on-past`.
-We should default it as `true` to avoid confusion
-
 #### Removed sub-package imports from `airflow/__init__.py`
 
 The imports `LoggingMixin`, `conf`, and `AirflowException` have been removed from `airflow/__init__.py`.
@@ -1187,39 +1256,6 @@ implementation of `TemporaryDirectory` because the same functionality is provide
 Now users instead of `import from airflow.utils.files import TemporaryDirectory` should
 do `from tempfile import TemporaryDirectory`. Both context managers provide the same
 interface, thus no additional changes should be required.
-
-#### Chain and cross_downstream moved from helpers to BaseOperator
-
-The `chain` and `cross_downstream` methods are now moved to airflow.models.baseoperator module from
-`airflow.utils.helpers` module.
-
-The baseoperator module seems to be a better choice to keep
-closely coupled methods together. Helpers module is supposed to contain standalone helper methods
-that can be imported by all classes.
-
-The `chain` method and `cross_downstream` method both use BaseOperator. If any other package imports
-any classes or functions from helpers module, then it automatically has an
-implicit dependency to BaseOperator. That can often lead to cyclic dependencies.
-
-More information in [AIFLOW-6392](https://issues.apache.org/jira/browse/AIRFLOW-6392)
-
-In Airflow <2.0 you imported those two methods like this:
-
-```python
-from airflow.utils.helpers import chain
-from airflow.utils.helpers import cross_downstream
-```
-
-In Airflow 2.0 it should be changed to:
-```python
-from airflow.models.baseoperator import chain
-from airflow.models.baseoperator import cross_downstream
-```
-
-#### BranchPythonOperator has a return value
-`BranchPythonOperator` will now return a value equal to the `task_id` of the chosen branch,
-where previously it returned None. Since it inherits from BaseOperator it will do an
-`xcom_push` of this value if `do_xcom_push=True`. This is useful for downstream decision-making.
 
 #### Removal of airflow.AirflowMacroPlugin class
 
@@ -1264,15 +1300,6 @@ with redirect_stdout(StreamLogWriter(logger, logging.INFO)), \
     print("I Love Airflow")
 ```
 
-#### Changes to SQLSensor
-
-SQLSensor now consistent with python `bool()` function and the `allow_null` parameter has been removed.
-
-It will resolve after receiving any value  that is casted to `True` with python `bool(value)`. That
-changes the previous response receiving `NULL` or `'0'`. Earlier `'0'` has been treated as success
-criteria. `NULL` has been treated depending on value of `allow_null`parameter.  But all the previous
-behaviour is still achievable setting param `success` to `lambda x: x is None or str(x) not in ('0', '')`.
-
 #### Additional arguments passed to BaseOperator cause an exception
 
 Previous versions of Airflow took additional arguments and displayed a message on the console. When the
@@ -1282,66 +1309,6 @@ In order to restore the previous behavior, you must set an ``True`` in  the ``al
 option of section ``[operators]`` in the ``airflow.cfg`` file. In the future it is possible to completely
 delete this option.
 
-#### Simplification of the TriggerDagRunOperator
-
-The TriggerDagRunOperator now takes a `conf` argument to which a dict can be provided as conf for the DagRun.
-As a result, the `python_callable` argument was removed. PR: https://github.com/apache/airflow/pull/6317.
-
-#### Remove provide_context
-
-`provide_context` argument on the PythonOperator was removed. The signature of the callable passed to the PythonOperator is now inferred and argument values are always automatically provided. There is no need to explicitly provide or not provide the context anymore. For example:
-
-```python
-def myfunc(execution_date):
-    print(execution_date)
-
-python_operator = PythonOperator(task_id='mytask', python_callable=myfunc, dag=dag)
-```
-
-Notice you don't have to set provide_context=True, variables from the task context are now automatically detected and provided.
-
-All context variables can still be provided with a double-asterisk argument:
-
-```python
-def myfunc(**context):
-    print(context)  # all variables will be provided to context
-
-python_operator = PythonOperator(task_id='mytask', python_callable=myfunc)
-```
-
-The task context variable names are reserved names in the callable function, hence a clash with `op_args` and `op_kwargs` results in an exception:
-
-```python
-def myfunc(dag):
-    # raises a ValueError because "dag" is a reserved name
-    # valid signature example: myfunc(mydag)
-
-python_operator = PythonOperator(
-    task_id='mytask',
-    op_args=[1],
-    python_callable=myfunc,
-)
-```
-
-The change is backwards compatible, setting `provide_context` will add the `provide_context` variable to the `kwargs` (but won't do anything).
-
-PR: [#5990](https://github.com/apache/airflow/pull/5990)
-
-#### Changes to FileSensor
-
-FileSensor is now takes a glob pattern, not just a filename. If the filename you are looking for has `*`, `?`, or `[` in it then you should replace these with `[*]`, `[?]`, and `[[]`.
-
-#### Change dag loading duration metric name
-Change DAG file loading duration metric from
-`dag.loading-duration.<dag_id>` to `dag.loading-duration.<dag_file>`. This is to
-better handle the case when a DAG file has multiple DAGs.
-
-#### Changes to `SubDagOperator`
-
-`SubDagOperator` is changed to use Airflow scheduler instead of backfill
-to schedule tasks in the subdag. User no longer need to specify the executor
-in `SubDagOperator`.
-
 #### Variables removed from the task instance context
 
 The following variables were removed from the task instance context:
@@ -1349,19 +1316,120 @@ The following variables were removed from the task instance context:
 - latest_date
 - tables
 
-#### Removed deprecated import mechanism
+#### Change in DagBag signature
 
-The deprecated import mechanism has been removed so the import of modules becomes more consistent and explicit.
+Passing `store_serialized_dags` argument to DagBag.__init__ and accessing `DagBag.store_serialized_dags` property
+are deprecated and will be removed in future versions.
 
-For example: `from airflow.operators import BashOperator`
-becomes `from airflow.operators.bash_operator import BashOperator`
 
-#### Changes to sensor imports
+**Previous signature**:
 
-Sensors are now accessible via `airflow.sensors` and no longer via `airflow.operators.sensors`.
+```python
+DagBag(
+    dag_folder=None,
+    include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
+    safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
+    store_serialized_dags=False
+):
+```
 
-For example: `from airflow.operators.sensors import BaseSensorOperator`
-becomes `from airflow.sensors.base_sensor_operator import BaseSensorOperator`
+**current**:
+```python
+DagBag(
+    dag_folder=None,
+    include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
+    safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
+    read_dags_from_db=False
+):
+```
+
+If you were using positional arguments, it requires no change but if you were using keyword
+arguments, please change `store_serialized_dags` to `read_dags_from_db`.
+
+Similarly, if you were using `DagBag().store_serialized_dags` property, change it to
+`DagBag().read_dags_from_db`.
+
+#### Ability to patch Pool.DEFAULT_POOL_NAME in BaseOperator
+It was not possible to patch pool in BaseOperator as the signature sets the default value of pool
+as Pool.DEFAULT_POOL_NAME.
+While using subdagoperator in unittest(without initializing the sqlite db), it was throwing the
+following error:
+```
+sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: slot_pool.
+```
+Fix for this, https://github.com/apache/airflow/pull/8587
+
+### Other changes
+
+#### Not-nullable conn_type column in connection table
+
+The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
+by application logic, but was not enforced by the database schema.
+
+If you made any modifications to the table directly, make sure you don't have
+null in the conn_type column.
+
+#### Standardised "extra" requirements
+
+We standardised the Extras names and synchronized providers package names with the main airflow extras.
+
+We deprecated a number of extras in 2.0.
+
+| Deprecated extras | New extras       |
+|-------------------|------------------|
+| atlas             | apache.atlas     |
+| aws               | amazon           |
+| azure             | microsoft.azure  |
+| cassandra         | apache.cassandra |
+| druid             | apache.druid     |
+| gcp               | google           |
+| gcp_api           | google           |
+| hdfs              | apache.hdfs      |
+| hive              | apache.hive      |
+| kubernetes        | cncf.kubernetes  |
+| mssql             | microsoft.mssql  |
+| pinot             | apache.pinot     |
+| webhdfs           | apache.webhdfs   |
+| winrm             | apache.winrm     |
+
+For example instead of `pip install apache-airflow[atlas]` you should use
+`pip install apache-airflow[apache.atlas]` .
+
+The deprecated extras will be removed in 2.1:
+
+#### Skipped tasks can satisfy wait_for_downstream
+
+Previously, a task instance with `wait_for_downstream=True` will only run if the downstream task of
+the previous task instance is successful. Meanwhile, a task instance with `depends_on_past=True`
+will run if the previous task instance is either successful or skipped. These two flags are close siblings
+yet they have different behavior. This inconsistency in behavior made the API less intuitive to users.
+To maintain consistent behavior, both successful or skipped downstream task can now satisfy the
+`wait_for_downstream=True` flag.
+
+#### Added mypy plugin to preserve types of decorated functions
+
+Mypy currently doesn't support precise type information for decorated
+functions; see https://github.com/python/mypy/issues/3157 for details.
+To preserve precise type definitions for decorated functions, we now
+include a mypy plugin to preserve precise type definitions for decorated
+functions. To use the plugin, update your setup.cfg:
+
+```
+[mypy]
+plugins =
+  airflow.mypy.plugin.decorators
+```
+
+#### Deprecating ignore_first_depends_on_past on backfill command and default it to True
+
+When doing backfill with `depends_on_past` dags, users will need to pass `--ignore-first-depends-on-past`.
+We should default it as `true` to avoid confusion
+
+#### Change dag loading duration metric name
+Change DAG file loading duration metric from
+`dag.loading-duration.<dag_id>` to `dag.loading-duration.<dag_file>`. This is to
+better handle the case when a DAG file has multiple DAGs.
+
 
 #### Renamed "extra" requirements for cloud providers
 
@@ -1381,32 +1449,6 @@ If you want to install integration for Amazon Web Services, then instead of
 If you want to install integration for Google Cloud Platform, then instead of
 `pip install 'apache-airflow[gcp_api]'`, you should execute `pip install 'apache-airflow[gcp]'`.
 The old way will work until the release of Airflow 2.1.
-
-#### Unification of `do_xcom_push` flag
-The `do_xcom_push` flag (a switch to push the result of an operator to xcom or not) was appearing in different incarnations in different operators. It's function has been unified under a common name (`do_xcom_push`) on `BaseOperator`. This way it is also easy to globally disable pushing results to xcom.
-
-The following operators were affected:
-
-* DatastoreExportOperator (Backwards compatible)
-* DatastoreImportOperator (Backwards compatible)
-* KubernetesPodOperator (Not backwards compatible)
-* SSHOperator (Not backwards compatible)
-* WinRMOperator (Not backwards compatible)
-* BashOperator (Not backwards compatible)
-* DockerOperator (Not backwards compatible)
-* SimpleHttpOperator (Not backwards compatible)
-
-See [AIRFLOW-3249](https://jira.apache.org/jira/browse/AIRFLOW-3249) for details
-
-#### Changes to skipping behaviour of LatestOnlyOperator
-
-In previous versions, the `LatestOnlyOperator` forcefully skipped all (direct and undirect) downstream tasks on its own. From this version on the operator will **only skip direct downstream** tasks and the scheduler will handle skipping any further downstream dependencies.
-
-No change is needed if only the default trigger rule `all_success` is being used.
-
-If the DAG relies on tasks with other trigger rules (i.e. `all_done`) being skipped by the `LatestOnlyOperator`, adjustments to the DAG need to be made to commodate the change in behaviour, i.e. with additional edges from the `LatestOnlyOperator`.
-
-The goal of this change is to achieve a more consistent and configurale cascading behaviour based on the `BaseBranchOperator` (see [AIRFLOW-2923](https://jira.apache.org/jira/browse/AIRFLOW-2923) and [AIRFLOW-1784](https://jira.apache.org/jira/browse/AIRFLOW-1784)).
 
 #### Change default snowflake_conn_id for Snowflake hook and operators
 
@@ -1459,46 +1501,6 @@ Now the `dag_id` will not appear repeated in the payload, and the response forma
 ...
 }
 ```
-
-#### Change in DagBag signature
-
-Passing `store_serialized_dags` argument to DagBag.__init__ and accessing `DagBag.store_serialized_dags` property
-are deprecated and will be removed in future versions.
-
-
-**Previous signature**:
-
-```python
-DagBag(
-    dag_folder=None,
-    include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
-    safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
-    store_serialized_dags=False
-):
-```
-
-**current**:
-```python
-DagBag(
-    dag_folder=None,
-    include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
-    safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
-    read_dags_from_db=False
-):
-```
-
-If you were using positional arguments, it requires no change but if you were using keyword
-arguments, please change `store_serialized_dags` to `read_dags_from_db`.
-
-Similarly, if you were using `DagBag().store_serialized_dags` property, change it to
-`DagBag().read_dags_from_db`.
-
-#### TimeSensor is now timezone aware
-
-Previously `TimeSensor` always compared the `target_time` with the current time in UTC.
-
-Now it will compare `target_time` with the current time in the timezone of the DAG,
-defaulting to the `default_timezone` in the global config.
 
 ## Airflow 1.10.11
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -890,6 +890,79 @@ Note: The order of arguments has changed for `check_for_prefix`.
 The `bucket_name` is now optional. It falls back to the `connection schema` attribute.
 The `delete_objects` now returns `None` instead of a response, since the method now makes multiple api requests when the keys list length is > 1000.
 
+### Changes in other provider packages
+
+#### Changes to SalesforceHook
+
+Replace parameter ``sandbox`` with ``domain``. According to change in simple-salesforce package
+
+#### Rename parameter name in PinotAdminHook.create_segment
+
+Rename parameter name from ``format`` to ``segment_format`` in PinotAdminHook function create_segment fro pylint compatible
+
+#### Rename parameter name in HiveMetastoreHook.get_partitions
+
+Rename parameter name from ``filter`` to ``partition_filter`` in HiveMetastoreHook function get_partitions for pylint compatible
+
+#### Remove unnecessary parameter in FTPHook.list_directory
+
+Remove unnecessary parameter ``nlst`` in FTPHook function list_directory for pylint compatible
+
+#### Remove unnecessary parameter in PostgresHook function copy_expert
+
+Remove unnecessary parameter ``open`` in PostgresHook function copy_expert for pylint compatible
+
+#### Change parameter name in OpsgenieAlertOperator
+
+Change parameter name from ``visibleTo`` to ``visible_to`` in OpsgenieAlertOperator for pylint compatible
+
+#### Changes to ImapHook, ImapAttachmentSensor and ImapAttachmentToS3Operator
+
+ImapHook:
+* The order of arguments has changed for `has_mail_attachment`,
+`retrieve_mail_attachments` and `download_mail_attachments`.
+* A new `mail_filter` argument has been added to each of those.
+
+ImapAttachmentSensor:
+* The order of arguments has changed for `__init__`.
+* A new `mail_filter` argument has been added to `__init__`.
+
+ImapAttachmentToS3Operator:
+* The order of arguments has changed for `__init__`.
+* A new `imap_mail_filter` argument has been added to `__init__`.
+
+#### Changes to SalesforceHook
+
+* renamed `sign_in` function to `get_conn`
+
+#### HTTPHook verify default value changed from False to True.
+
+The HTTPHook is now secured by default: `verify=True`.
+This can be overwriten by using the extra_options param as `{'verify': False}`.
+
+#### Changes to CloudantHook
+
+* upgraded cloudant version from `>=0.5.9,<2.0` to `>=2.0`
+* removed the use of the `schema` attribute in the connection
+* removed `db` function since the database object can also be retrieved by calling `cloudant_session['database_name']`
+
+For example:
+```python
+from airflow.contrib.hooks.cloudant_hook import CloudantHook
+
+with CloudantHook().get_conn() as cloudant_session:
+    database = cloudant_session['database_name']
+```
+
+See the [docs](https://python-cloudant.readthedocs.io/en/latest/) for more information on how to use the new cloudant version.
+
+#### Removed Hipchat integration
+
+Hipchat has reached end of life and is no longer available.
+
+For more information please see
+https://community.atlassian.com/t5/Stride-articles/Stride-and-Hipchat-Cloud-have-reached-End-of-Life-updated/ba-p/940248
+
 
 ### Other changes
 
@@ -1068,30 +1141,6 @@ plugins =
 Remove ``get_records`` and ``get_pandas_df`` and ``run`` from base_hook, which only apply for sql like hook,
 If want to use them, or your custom hook inherit them, please use ``dbapi_hook``
 
-#### Changes to SalesforceHook
-
-Replace parameter ``sandbox`` with ``domain``. According to change in simple-salesforce package
-
-#### Rename parameter name in PinotAdminHook.create_segment
-
-Rename parameter name from ``format`` to ``segment_format`` in PinotAdminHook function create_segment fro pylint compatible
-
-#### Rename parameter name in HiveMetastoreHook.get_partitions
-
-Rename parameter name from ``filter`` to ``partition_filter`` in HiveMetastoreHook function get_partitions for pylint compatible
-
-#### Remove unnecessary parameter in FTPHook.list_directory
-
-Remove unnecessary parameter ``nlst`` in FTPHook function list_directory for pylint compatible
-
-#### Remove unnecessary parameter in PostgresHook function copy_expert
-
-Remove unnecessary parameter ``open`` in PostgresHook function copy_expert for pylint compatible
-
-#### Change parameter name in OpsgenieAlertOperator
-
-Change parameter name from ``visibleTo`` to ``visible_to`` in OpsgenieAlertOperator for pylint compatible
-
 #### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
 
 Previously, you could assign a task to a DAG as follows:
@@ -1238,13 +1287,6 @@ delete this option.
 The TriggerDagRunOperator now takes a `conf` argument to which a dict can be provided as conf for the DagRun.
 As a result, the `python_callable` argument was removed. PR: https://github.com/apache/airflow/pull/6317.
 
-#### Removed Hipchat integration
-
-Hipchat has reached end of life and is no longer available.
-
-For more information please see
-https://community.atlassian.com/t5/Stride-articles/Stride-and-Hipchat-Cloud-have-reached-End-of-Life-updated/ba-p/940248
-
 #### Remove provide_context
 
 `provide_context` argument on the PythonOperator was removed. The signature of the callable passed to the PythonOperator is now inferred and argument values are always automatically provided. There is no need to explicitly provide or not provide the context anymore. For example:
@@ -1294,21 +1336,6 @@ Change DAG file loading duration metric from
 `dag.loading-duration.<dag_id>` to `dag.loading-duration.<dag_file>`. This is to
 better handle the case when a DAG file has multiple DAGs.
 
-#### Changes to ImapHook, ImapAttachmentSensor and ImapAttachmentToS3Operator
-
-ImapHook:
-* The order of arguments has changed for `has_mail_attachment`,
-`retrieve_mail_attachments` and `download_mail_attachments`.
-* A new `mail_filter` argument has been added to each of those.
-
-ImapAttachmentSensor:
-* The order of arguments has changed for `__init__`.
-* A new `mail_filter` argument has been added to `__init__`.
-
-ImapAttachmentToS3Operator:
-* The order of arguments has changed for `__init__`.
-* A new `imap_mail_filter` argument has been added to `__init__`.
-
 #### Changes to `SubDagOperator`
 
 `SubDagOperator` is changed to use Airflow scheduler instead of backfill
@@ -1321,31 +1348,6 @@ The following variables were removed from the task instance context:
 - end_date
 - latest_date
 - tables
-
-#### Changes to SalesforceHook
-
-* renamed `sign_in` function to `get_conn`
-
-#### HTTPHook verify default value changed from False to True.
-
-The HTTPHook is now secured by default: `verify=True`.
-This can be overwriten by using the extra_options param as `{'verify': False}`.
-
-#### Changes to CloudantHook
-
-* upgraded cloudant version from `>=0.5.9,<2.0` to `>=2.0`
-* removed the use of the `schema` attribute in the connection
-* removed `db` function since the database object can also be retrieved by calling `cloudant_session['database_name']`
-
-For example:
-```python
-from airflow.contrib.hooks.cloudant_hook import CloudantHook
-
-with CloudantHook().get_conn() as cloudant_session:
-    database = cloudant_session['database_name']
-```
-
-See the [docs](https://python-cloudant.readthedocs.io/en/latest/) for more information on how to use the new cloudant version.
 
 #### Removed deprecated import mechanism
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -62,6 +62,152 @@ More tips can be found in the guide:
 https://developers.google.com/style/inclusive-documentation
 
 -->
+### CLI changes
+
+#### Simplification of CLI commands
+
+The ability to manipulate users from the command line has been changed. 'airflow create_user' and 'airflow delete_user' and 'airflow list_users' has been grouped to a single command `airflow users` with optional flags `--create`, `--list` and `--delete`.
+
+Example Usage:
+
+To create a new user:
+```bash
+airflow users --create --username jondoe --lastname doe --firstname jon --email jdoe@apache.org --role Viewer --password test
+```
+
+To list users:
+```bash
+airflow users --list
+```
+
+To delete a user:
+```bash
+airflow users --delete --username jondoe
+```
+
+To add a user to a role:
+```bash
+airflow users --add-role --username jondoe --role Public
+```
+
+To remove a user from a role:
+```bash
+airflow users --remove-role --username jondoe --role Public
+```
+
+#### CLI reorganization
+
+The Airflow CLI has been organized so that related commands are grouped
+together as subcommands. The `airflow list_dags` command is now `airflow
+dags list`, `airflow pause` is `airflow dags pause`, `airflow config` is `airflow config list`, etc.
+For a complete list of updated CLI commands, see https://airflow.apache.org/cli.html.
+
+#### Grouped to improve UX of CLI
+
+Some commands have been grouped to improve UX of CLI. New commands are available according to the following table:
+
+| Old command               | New command                        |
+|---------------------------|------------------------------------|
+| ``airflow worker``        | ``airflow celery worker``          |
+| ``airflow flower``        | ``airflow celery flower``          |
+
+#### Cli use exactly single character for short option style change
+
+For Airflow short option, use exactly one single character, New commands are available according to the following table:
+
+| Old command                                          | New command                                         |
+| :----------------------------------------------------| :---------------------------------------------------|
+| ``airflow (dags\|tasks\|scheduler) [-sd, --subdir]`` | ``airflow (dags\|tasks\|scheduler) [-S, --subdir]`` |
+| ``airflow tasks test [-dr, --dry_run]``              | ``airflow tasks test [-n, --dry-run]``              |
+| ``airflow dags backfill [-dr, --dry_run]``           | ``airflow dags backfill [-n, --dry-run]``           |
+| ``airflow tasks clear [-dx, --dag_regex]``           | ``airflow tasks clear [-R, --dag-regex]``           |
+| ``airflow kerberos [-kt, --keytab]``                 | ``airflow kerberos [-k, --keytab]``                 |
+| ``airflow tasks run [-int, --interactive]``          | ``airflow tasks run [-N, --interactive]``           |
+| ``airflow webserver [-hn, --hostname]``              | ``airflow webserver [-H, --hostname]``              |
+| ``airflow celery worker [-cn, --celery_hostname]``   | ``airflow celery worker [-H, --celery-hostname]``   |
+| ``airflow celery flower [-hn, --hostname]``          | ``airflow celery flower [-H, --hostname]``          |
+| ``airflow celery flower [-fc, --flower_conf]``       | ``airflow celery flower [-c, --flower-conf]``       |
+| ``airflow celery flower [-ba, --basic_auth]``        | ``airflow celery flower [-A, --basic-auth]``        |
+| ``airflow celery flower [-tp, --task_params]``       | ``airflow celery flower [-t, --task-params]``       |
+| ``airflow celery flower [-pm, --post_mortem]``       | ``airflow celery flower [-m, --post-mortem]``       |
+
+For Airflow long option, use [kebab-case](https://en.wikipedia.org/wiki/Letter_case) instead of [snake_case](https://en.wikipedia.org/wiki/Snake_case)
+
+| Old option                         | New option                         |
+| :--------------------------------- | :--------------------------------- |
+| ``--task_regex``                   | ``--task-regex``                   |
+| ``--start_date``                   | ``--start-date``                   |
+| ``--end_date``                     | ``--end-date``                     |
+| ``--dry_run``                      | ``--dry-run``                      |
+| ``--no_backfill``                  | ``--no-backfill``                  |
+| ``--mark_success``                 | ``--mark-success``                 |
+| ``--donot_pickle``                 | ``--donot-pickle``                 |
+| ``--ignore_dependencies``          | ``--ignore-dependencies``          |
+| ``--ignore_first_depends_on_past`` | ``--ignore-first-depends-on-past`` |
+| ``--delay_on_limit``               | ``--delay-on-limit``               |
+| ``--reset_dagruns``                | ``--reset-dagruns``                |
+| ``--rerun_failed_tasks``           | ``--rerun-failed-tasks``           |
+| ``--run_backwards``                | ``--run-backwards``                |
+| ``--only_failed``                  | ``--only-failed``                  |
+| ``--only_running``                 | ``--only-running``                 |
+| ``--exclude_subdags``              | ``--exclude-subdags``              |
+| ``--exclude_parentdag``            | ``--exclude-parentdag``            |
+| ``--dag_regex``                    | ``--dag-regex``                    |
+| ``--run_id``                       | ``--run-id``                       |
+| ``--exec_date``                    | ``--exec-date``                    |
+| ``--ignore_all_dependencies``      | ``--ignore-all-dependencies``      |
+| ``--ignore_depends_on_past``       | ``--ignore-depends-on-past``       |
+| ``--ship_dag``                     | ``--ship-dag``                     |
+| ``--job_id``                       | ``--job-id``                       |
+| ``--cfg_path``                     | ``--cfg-path``                     |
+| ``--ssl_cert``                     | ``--ssl-cert``                     |
+| ``--ssl_key``                      | ``--ssl-key``                      |
+| ``--worker_timeout``               | ``--worker-timeout``               |
+| ``--access_logfile``               | ``--access-logfile``               |
+| ``--error_logfile``                | ``--error-logfile``                |
+| ``--dag_id``                       | ``--dag-id``                       |
+| ``--num_runs``                     | ``--num-runs``                     |
+| ``--do_pickle``                    | ``--do-pickle``                    |
+| ``--celery_hostname``              | ``--celery-hostname``              |
+| ``--broker_api``                   | ``--broker-api``                   |
+| ``--flower_conf``                  | ``--flower-conf``                  |
+| ``--url_prefix``                   | ``--url-prefix``                   |
+| ``--basic_auth``                   | ``--basic-auth``                   |
+| ``--task_params``                  | ``--task-params``                  |
+| ``--post_mortem``                  | ``--post-mortem``                  |
+| ``--conn_uri``                     | ``--conn-uri``                     |
+| ``--conn_type``                    | ``--conn-type``                    |
+| ``--conn_host``                    | ``--conn-host``                    |
+| ``--conn_login``                   | ``--conn-login``                   |
+| ``--conn_password``                | ``--conn-password``                |
+| ``--conn_schema``                  | ``--conn-schema``                  |
+| ``--conn_port``                    | ``--conn-port``                    |
+| ``--conn_extra``                   | ``--conn-extra``                   |
+| ``--use_random_password``          | ``--use-random-password``          |
+| ``--skip_serve_logs``              | ``--skip-serve-logs``              |
+
+#### Remove serve_logs command from CLI
+
+The ``serve_logs`` command has been deleted. This command should be run only by internal application mechanisms
+and there is no need for it to be accessible from the CLI interface.
+
+#### dag_state CLI command
+
+If the DAGRun was triggered with conf key/values passed in, they will also be printed in the dag_state CLI response
+ie. running, {"name": "bob"}
+whereas in in prior releases it just printed the state:
+ie. running
+
+#### Added `airflow dags test` CLI command
+
+A new command was added to the CLI for executing one full run of a DAG for a given execution date, similar to
+`airflow tasks test`. Example usage:
+
+```
+airflow dags test [dag_id] [execution_date]
+airflow dags test example_branch_operator 2018-01-01
+```
+
 ### Other changes
 
 #### GCSTaskHandler has been moved
@@ -454,16 +600,6 @@ replaced with its corresponding new path.
 | ``airflow.conf``             | ``airflow.configuration.conf``                   |
 | ``airflow.AirflowException`` | ``airflow.exceptions.AirflowException``          |
 
-#### Added `airflow dags test` CLI command
-
-A new command was added to the CLI for executing one full run of a DAG for a given execution date, similar to
-`airflow tasks test`. Example usage:
-
-```
-airflow dags test [dag_id] [execution_date]
-airflow dags test example_branch_operator 2018-01-01
-```
-
 #### Drop plugin support for stat_name_handler
 
 In previous version, you could use plugins mechanism to configure ``stat_name_handler``. You should now use the `stat_name_handler`
@@ -592,104 +728,6 @@ The following configurations have been moved from `[core]` to the new `[logging]
 * `log_processor_filename_template`
 * `dag_processor_manager_log_location`
 * `task_log_reader`
-
-#### Simplification of CLI commands
-
-#### Grouped to improve UX of CLI
-
-Some commands have been grouped to improve UX of CLI. New commands are available according to the following table:
-
-| Old command               | New command                        |
-|---------------------------|------------------------------------|
-| ``airflow worker``        | ``airflow celery worker``          |
-| ``airflow flower``        | ``airflow celery flower``          |
-
-#### Cli use exactly single character for short option style change
-
-For Airflow short option, use exactly one single character, New commands are available according to the following table:
-
-| Old command                                          | New command                                         |
-| :----------------------------------------------------| :---------------------------------------------------|
-| ``airflow (dags\|tasks\|scheduler) [-sd, --subdir]`` | ``airflow (dags\|tasks\|scheduler) [-S, --subdir]`` |
-| ``airflow tasks test [-dr, --dry_run]``              | ``airflow tasks test [-n, --dry-run]``              |
-| ``airflow dags backfill [-dr, --dry_run]``           | ``airflow dags backfill [-n, --dry-run]``           |
-| ``airflow tasks clear [-dx, --dag_regex]``           | ``airflow tasks clear [-R, --dag-regex]``           |
-| ``airflow kerberos [-kt, --keytab]``                 | ``airflow kerberos [-k, --keytab]``                 |
-| ``airflow tasks run [-int, --interactive]``          | ``airflow tasks run [-N, --interactive]``           |
-| ``airflow webserver [-hn, --hostname]``              | ``airflow webserver [-H, --hostname]``              |
-| ``airflow celery worker [-cn, --celery_hostname]``   | ``airflow celery worker [-H, --celery-hostname]``   |
-| ``airflow celery flower [-hn, --hostname]``          | ``airflow celery flower [-H, --hostname]``          |
-| ``airflow celery flower [-fc, --flower_conf]``       | ``airflow celery flower [-c, --flower-conf]``       |
-| ``airflow celery flower [-ba, --basic_auth]``        | ``airflow celery flower [-A, --basic-auth]``        |
-| ``airflow celery flower [-tp, --task_params]``       | ``airflow celery flower [-t, --task-params]``       |
-| ``airflow celery flower [-pm, --post_mortem]``       | ``airflow celery flower [-m, --post-mortem]``       |
-
-For Airflow long option, use [kebab-case](https://en.wikipedia.org/wiki/Letter_case) instead of [snake_case](https://en.wikipedia.org/wiki/Snake_case)
-
-| Old option                         | New option                         |
-| :--------------------------------- | :--------------------------------- |
-| ``--task_regex``                   | ``--task-regex``                   |
-| ``--start_date``                   | ``--start-date``                   |
-| ``--end_date``                     | ``--end-date``                     |
-| ``--dry_run``                      | ``--dry-run``                      |
-| ``--no_backfill``                  | ``--no-backfill``                  |
-| ``--mark_success``                 | ``--mark-success``                 |
-| ``--donot_pickle``                 | ``--donot-pickle``                 |
-| ``--ignore_dependencies``          | ``--ignore-dependencies``          |
-| ``--ignore_first_depends_on_past`` | ``--ignore-first-depends-on-past`` |
-| ``--delay_on_limit``               | ``--delay-on-limit``               |
-| ``--reset_dagruns``                | ``--reset-dagruns``                |
-| ``--rerun_failed_tasks``           | ``--rerun-failed-tasks``           |
-| ``--run_backwards``                | ``--run-backwards``                |
-| ``--only_failed``                  | ``--only-failed``                  |
-| ``--only_running``                 | ``--only-running``                 |
-| ``--exclude_subdags``              | ``--exclude-subdags``              |
-| ``--exclude_parentdag``            | ``--exclude-parentdag``            |
-| ``--dag_regex``                    | ``--dag-regex``                    |
-| ``--run_id``                       | ``--run-id``                       |
-| ``--exec_date``                    | ``--exec-date``                    |
-| ``--ignore_all_dependencies``      | ``--ignore-all-dependencies``      |
-| ``--ignore_depends_on_past``       | ``--ignore-depends-on-past``       |
-| ``--ship_dag``                     | ``--ship-dag``                     |
-| ``--job_id``                       | ``--job-id``                       |
-| ``--cfg_path``                     | ``--cfg-path``                     |
-| ``--ssl_cert``                     | ``--ssl-cert``                     |
-| ``--ssl_key``                      | ``--ssl-key``                      |
-| ``--worker_timeout``               | ``--worker-timeout``               |
-| ``--access_logfile``               | ``--access-logfile``               |
-| ``--error_logfile``                | ``--error-logfile``                |
-| ``--dag_id``                       | ``--dag-id``                       |
-| ``--num_runs``                     | ``--num-runs``                     |
-| ``--do_pickle``                    | ``--do-pickle``                    |
-| ``--celery_hostname``              | ``--celery-hostname``              |
-| ``--broker_api``                   | ``--broker-api``                   |
-| ``--flower_conf``                  | ``--flower-conf``                  |
-| ``--url_prefix``                   | ``--url-prefix``                   |
-| ``--basic_auth``                   | ``--basic-auth``                   |
-| ``--task_params``                  | ``--task-params``                  |
-| ``--post_mortem``                  | ``--post-mortem``                  |
-| ``--conn_uri``                     | ``--conn-uri``                     |
-| ``--conn_type``                    | ``--conn-type``                    |
-| ``--conn_host``                    | ``--conn-host``                    |
-| ``--conn_login``                   | ``--conn-login``                   |
-| ``--conn_password``                | ``--conn-password``                |
-| ``--conn_schema``                  | ``--conn-schema``                  |
-| ``--conn_port``                    | ``--conn-port``                    |
-| ``--conn_extra``                   | ``--conn-extra``                   |
-| ``--use_random_password``          | ``--use-random-password``          |
-| ``--skip_serve_logs``              | ``--skip-serve-logs``              |
-
-#### Remove serve_logs command from CLI
-
-The ``serve_logs`` command has been deleted. This command should be run only by internal application mechanisms
-and there is no need for it to be accessible from the CLI interface.
-
-#### dag_state CLI command
-
-If the DAGRun was triggered with conf key/values passed in, they will also be printed in the dag_state CLI response
-ie. running, {"name": "bob"}
-whereas in in prior releases it just printed the state:
-ie. running
 
 #### Remove gcp_service_account_keys option in airflow.cfg file
 
@@ -1224,13 +1262,6 @@ has been renamed to `request_filter`.
  To obtain pylint compatibility the `filter` argument in `GCPTransferServiceHook.list_transfer_job` and
  `GCPTransferServiceHook.list_transfer_operations` has been renamed to `request_filter`.
 
-#### CLI reorganization
-
-The Airflow CLI has been organized so that related commands are grouped
-together as subcommands. The `airflow list_dags` command is now `airflow
-dags list`, `airflow pause` is `airflow dags pause`, `airflow config` is `airflow config list`, etc.
-For a complete list of updated CLI commands, see https://airflow.apache.org/cli.html.
-
 #### Removal of Mesos Executor
 
 The Mesos Executor is removed from the code base as it was not widely used and not maintained. [Mailing List Discussion on deleting it](https://lists.apache.org/thread.html/daa9500026b820c6aaadeffd66166eae558282778091ebbc68819fb7@%3Cdev.airflow.apache.org%3E).
@@ -1332,37 +1363,6 @@ including `authenticate`, `filter_by_owner`, `owner_mode`, and `rbac`.
 #### Remove run_duration
 
 We should not use the `run_duration` option anymore. This used to be for restarting the scheduler from time to time, but right now the scheduler is getting more stable and therefore using this setting is considered bad and might cause an inconsistent state.
-
-#### CLI Changes
-
-The ability to manipulate users from the command line has been changed. 'airflow create_user' and 'airflow delete_user' and 'airflow list_users' has been grouped to a single command `airflow users` with optional flags `--create`, `--list` and `--delete`.
-
-Example Usage:
-
-To create a new user:
-```bash
-airflow users --create --username jondoe --lastname doe --firstname jon --email jdoe@apache.org --role Viewer --password test
-```
-
-To list users:
-```bash
-airflow users --list
-```
-
-To delete a user:
-```bash
-airflow users --delete --username jondoe
-```
-
-To add a user to a role:
-```bash
-airflow users --add-role --username jondoe --role Public
-```
-
-To remove a user from a role:
-```bash
-airflow users --remove-role --username jondoe --role Public
-```
 
 #### Unification of `do_xcom_push` flag
 The `do_xcom_push` flag (a switch to push the result of an operator to xcom or not) was appearing in different incarnations in different operators. It's function has been unified under a common name (`do_xcom_push`) on `BaseOperator`. This way it is also easy to globally disable pushing results to xcom.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1359,7 +1359,7 @@ sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: slot_
 ```
 Fix for this, https://github.com/apache/airflow/pull/8587
 
-### Other changes
+### Database changes
 
 #### Not-nullable conn_type column in connection table
 
@@ -1368,6 +1368,8 @@ by application logic, but was not enforced by the database schema.
 
 If you made any modifications to the table directly, make sure you don't have
 null in the conn_type column.
+
+### Other changes
 
 #### Standardised "extra" requirements
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -47,6 +47,13 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+The 2.0 release of the Airflow is a significant upgrade, and includes substantial major changes,
+and some of them may be breaking. Existing code written for earlier versions of this project will may require updates
+to use this version. Sometimes necessary configuration changes are also required.
+This document describes the changes that have been made, and what you need to do to update your usage.
+
+If you experience issues or have questions, please file [an issue](https://github.com/apache/airflow/issues/new/choose).
+
 <!--
 
 I'm glad you want to write a new note. Remember that this note is intended for users.
@@ -63,6 +70,11 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 ### CLI changes
+
+The Airflow CLI has been organized so that related commands are grouped together as subcommands,
+which means that if you use these commands in your scripts, you have to make changes to them.
+
+This section describes the changes that have been made, and what you need to do to update your script.
 
 #### Simplification of CLI commands
 
@@ -213,7 +225,10 @@ airflow dags test example_branch_operator 2018-01-01
 When doing backfill with `depends_on_past` dags, users will need to pass `--ignore-first-depends-on-past`.
 We should default it as `true` to avoid confusion
 
-### Database changes
+### Database schema changes
+
+In order to migrate the database, you should use the command `airflow db upgrade`, but in
+some cases manual steps are required.
 
 #### Not-nullable conn_type column in connection table
 
@@ -225,7 +240,13 @@ null in the conn_type column.
 
 ### Configuration changes
 
+This release contains many changes that require a change in the configuration of this application or
+other application that integrate with it.
+
+This section describes the changes that have been made, and what you need to do to.
+
 #### airflow.contrib.utils.log has been moved
+
 Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
 package was supported by the community. The project was passed to the Apache community and currently the
 entire code is maintained by the community, so now the division has no justification, and it is only due
@@ -370,7 +391,6 @@ section ``[core]`` in the ``airflow.cfg`` file.
 At the same time, this means that the `apache-airflow[crypto]` extra-packages are always installed.
 However, this requires that your operating system has ``libffi-dev`` installed.
 
-
 #### Changes to propagating Kubernetes worker annotations
 
 `kubernetes_annotations` configuration section has been removed.
@@ -421,6 +441,12 @@ Change DAG file loading duration metric from
 better handle the case when a DAG file has multiple DAGs.
 
 ### Changes to the core operators/hooks
+
+We strive to ensure that there are no changes that may affect the end user and your files, but this
+release may contain changes that will require changes to your DAG files.
+
+This section describes the changes that have been made, and what you need to do to update your DAG File,
+if you use core operators or any other.
 
 #### BaseOperator uses metaclass
 
@@ -605,14 +631,23 @@ To maintain consistent behavior, both successful or skipped downstream task can 
 
 ### Changes to the core Python API
 
+We strive to ensure that there are no changes that may affect the end user, and your Python files, but this
+release may contain changes that will require changes to your plugins, DAG File or other integration.
+
+Only changes unique to this provider are described here. You should still pay attention to the changes that
+have been made to the core (including core operators) as they can affect the integration behavior
+of this provider.
+
+This section describes the changes that have been made, and what you need to do to update your Python files.
+
 #### Weekday enum has been moved
+
 Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
 package was supported by the community. The project was passed to the Apache community and currently the
 entire code is maintained by the community, so now the division has no justification, and it is only due
 to historical reasons.
 
 To clean up, `Weekday` enum has been moved from `airflow.contrib.utils` into `airflow.utils` module.
-
 
 #### Deprecated method in Connection
 
@@ -827,6 +862,17 @@ sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: slot_
 Fix for this, https://github.com/apache/airflow/pull/8587
 
 ### Changes in `google` provider package
+
+We strive to ensure that there are no changes that may affect the end user and your Python files, but this
+release may contain changes that will require changes to your configuration, DAG Files or other integration
+e.g. custom operators.
+
+Only changes unique to this provider are described here. You should still pay attention to the changes that
+have been made to the core (including core operators) as they can affect the integration behavior
+of this provider.
+
+This section describes the changes that have been made, and what you need to do to update your if
+you use operators or hooks which integrate with Google services (including Google Cloud Platform - GCP).
 
 #### Use project_id argument consistently across GCP hooks and operators
 
@@ -1259,6 +1305,17 @@ BigQueryGetDatasetTablesOperator(dataset_resource: dict, dataset_id: Optional[st
 
 ### Changes in `amazon` provider package
 
+We strive to ensure that there are no changes that may affect the end user, and your Python files, but this
+release may contain changes that will require changes to your configuration, DAG Files or other integration
+e.g. custom operators.
+
+Only changes unique to this provider are described here. You should still pay attention to the changes that
+have been made to the core (including core operators) as they can affect the integration behavior
+of this provider.
+
+This section describes the changes that have been made, and what you need to do to update your if
+you use operators or hooks which integrate with Amazon services (including Amazon Web Service - AWS).
+
 #### Change default aws_conn_id in EMR operators
 
 The default value for the [aws_conn_id](https://airflow.apache.org/howto/manage-connections.html#amazon-web-services) was accidently set to 's3_default' instead of 'aws_default' in some of the emr operators in previous
@@ -1318,6 +1375,17 @@ The `bucket_name` is now optional. It falls back to the `connection schema` attr
 The `delete_objects` now returns `None` instead of a response, since the method now makes multiple api requests when the keys list length is > 1000.
 
 ### Changes in other provider packages
+
+We strive to ensure that there are no changes that may affect the end user and your Python files, but this
+release may contain changes that will require changes to your configuration, DAG Files or other integration
+e.g. custom operators.
+
+Only changes unique to providers are described here. You should still pay attention to the changes that
+have been made to the core (including core operators) as they can affect the integration behavior
+of this provider.
+
+This section describes the changes that have been made, and what you need to do to update your if
+you use any code located in `airflow.providers` package.
 
 #### Changes to SalesforceHook
 
@@ -1395,6 +1463,8 @@ https://community.atlassian.com/t5/Stride-articles/Stride-and-Hipchat-Cloud-have
 When initializing a Snowflake hook or operator, the value used for `snowflake_conn_id` was always `snowflake_conn_id`, regardless of whether or not you specified a value for it. The default `snowflake_conn_id` value is now switched to `snowflake_default` for consistency and will be properly overriden when specified.
 
 ### Other changes
+
+This release also includes changes that fall outside any of the sections above.
 
 #### Standardised "extra" requirements
 


### PR DESCRIPTION
Reading entries was a nightmare. We have too many changes and the user may have problems finding the entries that are relevant to him.

I have grouped the entries into the following sections.

- CLI changes
- Database schema changes
- Configuration changes
- Changes to the core operators/hooks
- Changes to the core Python API
- Changes in `google` provider package
- Changes in `amazon` provider package
- Changes in other provider packages
- Other changes

The fact that we have a mess in this file also means that some guides is added to the project documentation, which makes it difficult to find them.
https://airflow.readthedocs.io/en/latest/stable-rest-api/migration.html (CC: @ephraimbuddy )


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
