### PR TITLE
Add typing coverage to mysql providers package

### DIFF
--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -20,7 +20,7 @@
 This module allows to connect to a MySQL database.
 """
 import json
-from typing import Any, Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.models import Connection

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -184,7 +184,7 @@ class MySqlHook(DbApiHook):
         conn.commit()
 
     @staticmethod
-    def _serialize_cell(cell: object, conn: Connection) -> object:  # pylint: disable=signature-differs
+    def _serialize_cell(cell: object, conn: Connection = None) -> object:  # pylint: disable=signature-differs
         """
         MySQLdb converts an argument to a literal
         when passing those separately to execute. Hence, this method does nothing.

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -19,9 +19,8 @@
 """
 This module allows to connect to a MySQL database.
 """
-from typing import Any, Dict, Tuple
-
 import json
+from typing import Any, Dict, Tuple
 
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.models import Connection

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -20,7 +20,7 @@
 This module allows to connect to a MySQL database.
 """
 import json
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.models import Connection
@@ -183,7 +183,8 @@ class MySqlHook(DbApiHook):
         conn.commit()
 
     @staticmethod
-    def _serialize_cell(cell: object, conn: Connection = None) -> object:  # pylint: disable=signature-differs
+    def _serialize_cell(cell: object,
+                        conn: Optional[Connection] = None) -> object:  # pylint: disable=signature-differs
         """
         MySQLdb converts an argument to a literal
         when passing those separately to execute. Hence, this method does nothing.

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -123,7 +123,7 @@ class MySqlHook(DbApiHook):
 
         return conn_config
 
-    def get_conn(self) -> Any:
+    def get_conn(self):
         """
         Establishes a connection to a mysql database
         by extracting the connection configuration from the Airflow connection.

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -19,10 +19,12 @@
 """
 This module allows to connect to a MySQL database.
 """
+from typing import Any, Dict, Tuple
 
 import json
 
 from airflow.hooks.dbapi_hook import DbApiHook
+from airflow.models import Connection
 
 
 class MySqlHook(DbApiHook):
@@ -44,18 +46,18 @@ class MySqlHook(DbApiHook):
     default_conn_name = 'mysql_default'
     supports_autocommit = True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.schema = kwargs.pop("schema", None)
         self.connection = kwargs.pop("connection", None)
 
-    def set_autocommit(self, conn, autocommit):
+    def set_autocommit(self, conn: Connection, autocommit: bool) -> None:
         """
         MySql connection sets autocommit in a different way.
         """
         conn.autocommit(autocommit)
 
-    def get_autocommit(self, conn):
+    def get_autocommit(self, conn: Connection) -> bool:
         """
         MySql connection gets autocommit in a different way.
 
@@ -66,7 +68,7 @@ class MySqlHook(DbApiHook):
         """
         return conn.get_autocommit()
 
-    def _get_conn_config_mysql_client(self, conn):
+    def _get_conn_config_mysql_client(self, conn: Connection) -> Dict:
         conn_config = {
             "user": conn.login,
             "passwd": conn.password or '',
@@ -108,7 +110,7 @@ class MySqlHook(DbApiHook):
             conn_config["local_infile"] = 1
         return conn_config
 
-    def _get_conn_config_mysql_connector_python(self, conn):
+    def _get_conn_config_mysql_connector_python(self, conn: Connection) -> Dict:
         conn_config = {
             'user': conn.login,
             'password': conn.password or '',
@@ -122,7 +124,7 @@ class MySqlHook(DbApiHook):
 
         return conn_config
 
-    def get_conn(self):
+    def get_conn(self) -> Any:
         """
         Establishes a connection to a mysql database
         by extracting the connection configuration from the Airflow connection.
@@ -149,7 +151,7 @@ class MySqlHook(DbApiHook):
 
         raise ValueError('Unknown MySQL client name provided!')
 
-    def get_uri(self):
+    def get_uri(self) -> str:
         conn = self.get_connection(getattr(self, self.conn_name_attr))
         uri = super().get_uri()
         if conn.extra_dejson.get('charset', False):
@@ -157,7 +159,7 @@ class MySqlHook(DbApiHook):
             return "{uri}?charset={charset}".format(uri=uri, charset=charset)
         return uri
 
-    def bulk_load(self, table, tmp_file):
+    def bulk_load(self, table: str, tmp_file: str) -> None:
         """
         Loads a tab-delimited file into a database table
         """
@@ -169,7 +171,7 @@ class MySqlHook(DbApiHook):
             """.format(tmp_file=tmp_file, table=table))
         conn.commit()
 
-    def bulk_dump(self, table, tmp_file):
+    def bulk_dump(self, table: str, tmp_file: str) -> None:
         """
         Dumps a database table into a tab-delimited file
         """
@@ -182,7 +184,7 @@ class MySqlHook(DbApiHook):
         conn.commit()
 
     @staticmethod
-    def _serialize_cell(cell, conn):  # pylint: disable=signature-differs
+    def _serialize_cell(cell: object, conn: Connection) -> object:  # pylint: disable=signature-differs
         """
         MySQLdb converts an argument to a literal
         when passing those separately to execute. Hence, this method does nothing.
@@ -197,7 +199,7 @@ class MySqlHook(DbApiHook):
 
         return cell
 
-    def get_iam_token(self, conn):
+    def get_iam_token(self, conn: Connection) -> Tuple[str, int]:
         """
         Uses AWSHook to retrieve a temporary password to connect to MySQL
         Port is required. If none is provided, default 3306 is used
@@ -214,7 +216,10 @@ class MySqlHook(DbApiHook):
         token = client.generate_db_auth_token(conn.host, port, conn.login)
         return token, port
 
-    def bulk_load_custom(self, table, tmp_file, duplicate_key_handling='IGNORE', extra_options=''):
+    def bulk_load_custom(self, table: str,
+                         tmp_file: str,
+                         duplicate_key_handling: str = 'IGNORE',
+                         extra_options: str = '') -> None:
         """
         A more configurable way to load local data from a file into the database.
 

--- a/airflow/providers/mysql/operators/mysql.py
+++ b/airflow/providers/mysql/operators/mysql.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Iterable, Mapping, Optional, Union, Dict
+from typing import Dict, Iterable, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook

--- a/airflow/providers/mysql/operators/mysql.py
+++ b/airflow/providers/mysql/operators/mysql.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Iterable, Mapping, Optional, Union
+from typing import Iterable, Mapping, Optional, Union, Dict
 
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
@@ -54,7 +54,7 @@ class MySqlOperator(BaseOperator):
             parameters: Optional[Union[Mapping, Iterable]] = None,
             autocommit: bool = False,
             database: Optional[str] = None,
-            **kwargs):
+            **kwargs) -> None:
         super().__init__(**kwargs)
         self.mysql_conn_id = mysql_conn_id
         self.sql = sql
@@ -62,7 +62,7 @@ class MySqlOperator(BaseOperator):
         self.parameters = parameters
         self.database = database
 
-    def execute(self, context):
+    def execute(self, context: Dict) -> None:
         self.log.info('Executing: %s', self.sql)
         hook = MySqlHook(mysql_conn_id=self.mysql_conn_id,
                          schema=self.database)

--- a/airflow/providers/mysql/transfers/presto_to_mysql.py
+++ b/airflow/providers/mysql/transfers/presto_to_mysql.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook

--- a/airflow/providers/mysql/transfers/presto_to_mysql.py
+++ b/airflow/providers/mysql/transfers/presto_to_mysql.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional
+from typing import Optional, Dict
 
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
@@ -64,7 +64,7 @@ class PrestoToMySqlOperator(BaseOperator):
         self.mysql_preoperator = mysql_preoperator
         self.presto_conn_id = presto_conn_id
 
-    def execute(self, context):
+    def execute(self, context: Dict) -> None:
         presto = PrestoHook(presto_conn_id=self.presto_conn_id)
         self.log.info("Extracting data from Presto: %s", self.sql)
         results = presto.get_records(self.sql)

--- a/airflow/providers/mysql/transfers/s3_to_mysql.py
+++ b/airflow/providers/mysql/transfers/s3_to_mysql.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import os
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook

--- a/airflow/providers/mysql/transfers/s3_to_mysql.py
+++ b/airflow/providers/mysql/transfers/s3_to_mysql.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import os
-from typing import Optional
+from typing import Optional, Dict
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -67,7 +67,7 @@ class S3ToMySqlOperator(BaseOperator):
         self.aws_conn_id = aws_conn_id
         self.mysql_conn_id = mysql_conn_id
 
-    def execute(self, context: dict) -> None:
+    def execute(self, context: Dict) -> None:
         """
         Executes the transfer operation from S3 to MySQL.
 

--- a/airflow/providers/mysql/transfers/vertica_to_mysql.py
+++ b/airflow/providers/mysql/transfers/vertica_to_mysql.py
@@ -16,9 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Dict, Optional
 from contextlib import closing
 from tempfile import NamedTemporaryFile
+from typing import Dict, Optional
 
 import MySQLdb
 import unicodecsv as csv
@@ -82,8 +82,8 @@ class VerticaToMySqlOperator(BaseOperator):
             mysql_table: str,
             vertica_conn_id: str = 'vertica_default',
             mysql_conn_id: str = 'mysql_default',
-            mysql_preoperator: Optional[str] = None,
-            mysql_postoperator: Optional[str] = None,
+            mysql_preoperator: str = None,
+            mysql_postoperator: str = None,
             bulk_load: bool = False,
             *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/airflow/providers/mysql/transfers/vertica_to_mysql.py
+++ b/airflow/providers/mysql/transfers/vertica_to_mysql.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Dict, Optional
 from contextlib import closing
 from tempfile import NamedTemporaryFile
 
@@ -65,6 +66,7 @@ class VerticaToMySqlOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
+<<<<<<< HEAD
             *,
             sql,
             mysql_table,
@@ -75,6 +77,17 @@ class VerticaToMySqlOperator(BaseOperator):
             bulk_load=False,
             **kwargs):
         super().__init__(**kwargs)
+=======
+            sql: str,
+            mysql_table: str,
+            vertica_conn_id: str = 'vertica_default',
+            mysql_conn_id: str = 'mysql_default',
+            mysql_preoperator: Optional[str] = None,
+            mysql_postoperator: Optional[str] = None,
+            bulk_load: bool = False,
+            *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+>>>>>>> 1cbbae022... add typing coverage to mysql providers package
         self.sql = sql
         self.mysql_table = mysql_table
         self.mysql_conn_id = mysql_conn_id
@@ -83,7 +96,7 @@ class VerticaToMySqlOperator(BaseOperator):
         self.vertica_conn_id = vertica_conn_id
         self.bulk_load = bulk_load
 
-    def execute(self, context):
+    def execute(self, context: Dict) -> None:
         vertica = VerticaHook(vertica_conn_id=self.vertica_conn_id)
         mysql = MySqlHook(mysql_conn_id=self.mysql_conn_id)
 

--- a/airflow/providers/mysql/transfers/vertica_to_mysql.py
+++ b/airflow/providers/mysql/transfers/vertica_to_mysql.py
@@ -18,7 +18,7 @@
 
 from contextlib import closing
 from tempfile import NamedTemporaryFile
-from typing import Dict, Optional
+from typing import Optional
 
 import MySQLdb
 import unicodecsv as csv
@@ -66,28 +66,15 @@ class VerticaToMySqlOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-<<<<<<< HEAD
-            *,
-            sql,
-            mysql_table,
-            vertica_conn_id='vertica_default',
-            mysql_conn_id='mysql_default',
-            mysql_preoperator=None,
-            mysql_postoperator=None,
-            bulk_load=False,
-            **kwargs):
-        super().__init__(**kwargs)
-=======
             sql: str,
             mysql_table: str,
             vertica_conn_id: str = 'vertica_default',
             mysql_conn_id: str = 'mysql_default',
-            mysql_preoperator: str = None,
-            mysql_postoperator: str = None,
+            mysql_preoperator: Optional[str] = None,
+            mysql_postoperator: Optional[str] = None,
             bulk_load: bool = False,
             *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
->>>>>>> 1cbbae022... add typing coverage to mysql providers package
         self.sql = sql
         self.mysql_table = mysql_table
         self.mysql_conn_id = mysql_conn_id

--- a/airflow/providers/mysql/transfers/vertica_to_mysql.py
+++ b/airflow/providers/mysql/transfers/vertica_to_mysql.py
@@ -96,7 +96,7 @@ class VerticaToMySqlOperator(BaseOperator):
         self.vertica_conn_id = vertica_conn_id
         self.bulk_load = bulk_load
 
-    def execute(self, context: Dict) -> None:
+    def execute(self, context):
         vertica = VerticaHook(vertica_conn_id=self.vertica_conn_id)
         mysql = MySqlHook(mysql_conn_id=self.mysql_conn_id)
 


### PR DESCRIPTION
related: #9708 
Adding typing annotations to mysql providers package.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
