### PR TITLE
Fixes flaky kubernetes Pod Operator tests

### DIFF
--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -61,6 +61,10 @@ def create_context(task):
 # noinspection DuplicatedCode,PyUnusedLocal
 class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
+    def get_current_task_name(self):
+        # reverse test name to make pod name unique (it has limited length)
+        return "_" + unittest.TestCase.id(self).replace(".", "_")[::-1]
+
     def setUp(self):
         self.maxDiff = None  # pylint: disable=invalid-name
         self.api_client = ApiClient()
@@ -76,7 +80,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                     'airflow_version': airflow_version.replace('+', '-'),
                     'execution_date': '2016-01-01T0100000100-a2f50a31f',
                     'dag_id': 'dag',
-                    'task_id': 'task',
+                    'task_id': ANY,
                     'try_number': '1'},
             },
             'spec': {
@@ -120,7 +124,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             config_file=new_config_path,
@@ -139,7 +143,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test1",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             config_file=new_config_path,
@@ -157,7 +161,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
         )
@@ -175,7 +179,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             is_delete_operator_pod=True,
@@ -194,7 +198,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             hostnetwork=True,
@@ -215,7 +219,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             hostnetwork=True,
@@ -238,7 +242,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             schedulername=scheduler_name
@@ -260,7 +264,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             node_selectors=node_selectors,
@@ -287,7 +291,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             resources=resources,
@@ -335,7 +339,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             affinity=affinity,
@@ -356,7 +360,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             ports=[port],
@@ -395,7 +399,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 volume_mounts=[volume_mount],
                 volumes=[volume],
                 name="test",
-                task_id="task",
+                task_id="task" + self.get_current_task_name(),
                 in_cluster=False,
                 do_xcom_push=False,
             )
@@ -430,7 +434,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             security_context=security_context,
@@ -455,7 +459,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             security_context=security_context,
@@ -480,7 +484,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             security_context=security_context,
@@ -500,7 +504,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             startup_timeout_seconds=5,
@@ -521,7 +525,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             startup_timeout_seconds=5,
@@ -546,7 +550,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=bad_internal_command,
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
         )
@@ -567,7 +571,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=args,
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=True,
         )
@@ -599,7 +603,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             configmaps=[configmap],
@@ -632,7 +636,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             secrets=secrets,
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
         )
@@ -707,7 +711,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             volumes=[volume],
             init_containers=[init_container],
             in_cluster=False,
@@ -735,7 +739,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             start_mock):  # pylint: disable=unused-argument
         from airflow.utils.state import State
         k = KubernetesPodOperator(
-            task_id='task',
+            task_id="task" + self.get_current_task_name(),
             pod_template_file='tests/kubernetes/pod.yaml',
             do_xcom_push=True
         )
@@ -811,7 +815,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             arguments=["echo 10"],
             labels={"foo": "bar"},
             name="test",
-            task_id="task",
+            task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
             priority_class_name=priority_class_name,
@@ -834,7 +838,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 arguments=["echo 10"],
                 labels={"foo": "bar"},
                 name=pod_name_too_long,
-                task_id="task",
+                task_id="task" + self.get_current_task_name(),
                 in_cluster=False,
                 do_xcom_push=False,
             )


### PR DESCRIPTION
All Pod Operator tests were using the same task id which made it
flaky as sometimes failed tests were still being deleted while
subsequent success tests already started. That lead to random 404
(not found) errors when the failed test was picked up first.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
