### PR TITLE
Handle IntegrityError while creating TIs

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -482,7 +482,7 @@ class DagRun(Base, LoggingMixin):
             session.commit()
         except IntegrityError as err:
             self.log.info(str(err))
-            self.log.info(f'Hit IntegrityError while creating the TIs for '
+            self.log.info('Hit IntegrityError while creating the TIs for '
                           f'{dag.dag_id} - {self.execution_date}.')
             self.log.info('Doing session rollback.')
             session.rollback()

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -21,6 +21,7 @@ from typing import Any, List, Optional, Tuple, Union
 from sqlalchemy import (
     Boolean, Column, DateTime, Index, Integer, PickleType, String, UniqueConstraint, and_, func, or_,
 )
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import synonym
 from sqlalchemy.orm.session import Session
@@ -439,10 +440,10 @@ class DagRun(Base, LoggingMixin):
         tis = self.get_task_instances(session=session)
 
         # check for removed or restored tasks
-        task_ids = []
+        task_ids = set()
         for ti in tis:
             task_instance_mutation_hook(ti)
-            task_ids.append(ti.task_id)
+            task_ids.add(ti.task_id)
             task = None
             try:
                 task = dag.get_task(ti.task_id)
@@ -477,7 +478,14 @@ class DagRun(Base, LoggingMixin):
                 task_instance_mutation_hook(ti)
                 session.add(ti)
 
-        session.commit()
+        try:
+            session.commit()
+        except IntegrityError as err:
+            self.log.info(str(err))
+            self.log.info(f'Hit IntegrityError while creating the TIs for {dag.dag_id} - {self.execution_date}.')
+            self.log.info('Doing session rollback.')
+            session.rollback()
+
 
     @staticmethod
     def get_run(session, dag_id, execution_date):

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -482,10 +482,10 @@ class DagRun(Base, LoggingMixin):
             session.commit()
         except IntegrityError as err:
             self.log.info(str(err))
-            self.log.info(f'Hit IntegrityError while creating the TIs for {dag.dag_id} - {self.execution_date}.')
+            self.log.info(f'Hit IntegrityError while creating the TIs for '
+                          f'{dag.dag_id} - {self.execution_date}.')
             self.log.info('Doing session rollback.')
             session.rollback()
-
 
     @staticmethod
     def get_run(session, dag_id, execution_date):

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -574,9 +574,10 @@ class TestDagRun(unittest.TestCase):
         self.assertEqual('first_task', first_ti.task_id)
         self.assertEqual(State.NONE, first_ti.state)
 
-        # Lets assume that the above TI was added into DB by webserver, so when
-        # the scheduler queries the DB, it found 0 TIs for the dag and proceeds
-        # further to create TIs.
+        # Lets assume that the above TI was added into DB by webserver, but if scheduler
+        # is running the same method at the same time it would find 0 TIs for this dag
+        # and proceeds further to create TIs. Hence mocking DagRun.get_task_instances
+        # method to return an empty list of TIs.
         with mock.patch.object(DagRun, 'get_task_instances') as mock_gtis:
             mock_gtis.return_value = []
             dagrun.verify_integrity()

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -565,6 +565,24 @@ class TestDagRun(unittest.TestCase):
         flaky_ti.refresh_from_db()
         self.assertEqual(State.NONE, flaky_ti.state)
 
+    def test_already_added_task_instances_can_be_ignored(self):
+        dag = DAG('triggered_dag', start_date=DEFAULT_DATE)
+        dag.add_task(DummyOperator(task_id='first_task', owner='test'))
+
+        dagrun = self.create_dag_run(dag)
+        first_ti = dagrun.get_task_instances()[0]
+        self.assertEqual('first_task', first_ti.task_id)
+        self.assertEqual(State.NONE, first_ti.state)
+
+        # Lets assume that the above TI was added into DB by webserver, so when
+        # the scheduler queries the DB, it found 0 TIs for the dag and proceeds
+        # further to create TIs.
+        with mock.patch.object(DagRun, 'get_task_instances') as mock_gtis:
+            mock_gtis.return_value = []
+            dagrun.verify_integrity()
+            first_ti.refresh_from_db()
+            self.assertEqual(State.NONE, first_ti.state)
+
     @parameterized.expand([(state,) for state in State.task_states])
     @mock.patch('airflow.models.dagrun.task_instance_mutation_hook')
     def test_task_instance_mutation_hook(self, state, mock_hook):


### PR DESCRIPTION
**Background**
While doing a trigger_dag from UI, DagRun gets created first and then webserver starts creating TIs. Meanwhile, Scheduler also picks up the DagRun and starts creating the TIs, which results in IntegrityError as the Primary key constraint gets violated. This happens when a DAG has a good number of tasks (500+). 

Also, changing the TIs array with a set for faster lookups. 