### PR TITLE
Remove items with None from requests & limits dicts in Kubernetes Resources

### DIFF
--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -87,17 +87,21 @@ class Resources(K8SModel):
             self.request_ephemeral_storage is not None
 
     def to_k8s_client_obj(self):
+        limits = {
+            'cpu': self.limit_cpu,
+            'memory': self.limit_memory,
+            'nvidia.com/gpu': self.limit_gpu,
+            'ephemeral-storage': self.limit_ephemeral_storage
+        }
+        requests = {
+            'cpu': self.request_cpu,
+            'memory': self.request_memory,
+            'ephemeral-storage': self.request_ephemeral_storage}
+        limits = {k: v for k, v in limits.items() if v is not None}
+        requests = {k: v for k, v in requests.items() if v is not None}
         return k8s.V1ResourceRequirements(
-            limits={
-                'cpu': self.limit_cpu,
-                'memory': self.limit_memory,
-                'nvidia.com/gpu': self.limit_gpu,
-                'ephemeral-storage': self.limit_ephemeral_storage
-            },
-            requests={
-                'cpu': self.request_cpu,
-                'memory': self.request_memory,
-                'ephemeral-storage': self.request_ephemeral_storage}
+            limits=limits,
+            requests=requests
         )
 
     def attach_to_pod(self, pod):

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -404,7 +404,6 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             'limits': {
                 'memory': '64Mi',
                 'cpu': 0.25,
-                'nvidia.com/gpu': None,
                 'ephemeral-storage': '2Gi'
             }
         }

--- a/tests/kubernetes/models/test_pod.py
+++ b/tests/kubernetes/models/test_pod.py
@@ -132,16 +132,12 @@ class TestPod(unittest.TestCase):
                                     {
                                         'limits':
                                             {
-                                                'cpu': None,
-                                                'memory': None,
-                                                'nvidia.com/gpu': '100G',
-                                                'ephemeral-storage': None
+                                                'nvidia.com/gpu': '100G'
                                             },
                                         'requests':
                                             {
                                                 'cpu': '100Mi',
-                                                'memory': '1G',
-                                                'ephemeral-storage': None
+                                                'memory': '1G'
                                             }
                                 }
                             }

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -219,11 +219,8 @@ class LocalSettingsTest(unittest.TestCase):
                 pod.spec.containers[0].resources.to_dict(),
                 {
                     'limits': {
-                        'cpu': None,
-                        'memory': None,
-                        'ephemeral-storage': None,
                         'nvidia.com/gpu': '200G'},
-                    'requests': {'cpu': '200Mi', 'ephemeral-storage': None, 'memory': '2G'}
+                    'requests': {'cpu': '200Mi', 'memory': '2G'}
                 }
             )
 


### PR DESCRIPTION
closes: #9827 

Since using 1.10.11, ALL pods that did not get requests/limits gets `0` as default value instead of removing the `None` key 
This causes all pods that used to run in previous version to be evicted... 

