### PR TITLE
Add correct signatures for operators in google provider package

### DIFF
--- a/airflow/providers/google/ads/operators/ads.py
+++ b/airflow/providers/google/ads/operators/ads.py
@@ -63,7 +63,7 @@ class GoogleAdsListAccountsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         bucket: str,
         object_name: str,
         gcp_conn_id: str = "google_cloud_default",

--- a/airflow/providers/google/cloud/operators/automl.py
+++ b/airflow/providers/google/cloud/operators/automl.py
@@ -64,7 +64,7 @@ class AutoMLTrainModelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         model: dict,
         location: str,
         project_id: Optional[str] = None,
@@ -138,7 +138,7 @@ class AutoMLPredictOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         model_id: str,
         location: str,
         payload: dict,
@@ -230,7 +230,7 @@ class AutoMLBatchPredictOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         model_id: str,
         input_config: dict,
         output_config: dict,
@@ -309,7 +309,7 @@ class AutoMLCreateDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset: dict,
         location: str,
         project_id: Optional[str] = None,
@@ -384,7 +384,7 @@ class AutoMLImportDataOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: str,
         location: str,
         input_config: dict,
@@ -474,7 +474,7 @@ class AutoMLTablesListColumnSpecsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         dataset_id: str,
         table_spec_id: str,
         location: str,
@@ -556,7 +556,7 @@ class AutoMLTablesUpdateDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset: dict,
         location: str,
         update_mask: Optional[dict] = None,
@@ -623,7 +623,7 @@ class AutoMLGetModelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         model_id: str,
         location: str,
         project_id: Optional[str] = None,
@@ -689,7 +689,7 @@ class AutoMLDeleteModelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         model_id: str,
         location: str,
         project_id: Optional[str] = None,
@@ -765,7 +765,7 @@ class AutoMLDeployModelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         model_id: str,
         location: str,
         project_id: Optional[str] = None,
@@ -844,7 +844,7 @@ class AutoMLTablesListTableSpecsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: str,
         location: str,
         page_size: Optional[int] = None,
@@ -915,7 +915,7 @@ class AutoMLListDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         project_id: Optional[str] = None,
         metadata: Optional[MetaData] = None,
@@ -985,7 +985,7 @@ class AutoMLDeleteDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: Union[str, List[str]],
         location: str,
         project_id: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -141,7 +141,7 @@ class BigQueryCheckOperator(CheckOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         sql: str,
         gcp_conn_id: str = 'google_cloud_default',
         bigquery_conn_id: Optional[str] = None,
@@ -196,7 +196,7 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         sql: str,
         pass_value: Any,
         tolerance: Any = None,
@@ -270,7 +270,7 @@ class BigQueryIntervalCheckOperator(IntervalCheckOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         table: str,
         metrics_thresholds: dict,
         date_filter_column: str = 'ds',
@@ -364,7 +364,7 @@ class BigQueryGetDataOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: str,
         table_id: str,
         max_results: int = 100,
@@ -528,6 +528,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
     # pylint: disable=too-many-arguments, too-many-locals
     @apply_defaults
     def __init__(self,
+                 *,
                  sql: Union[str, Iterable],
                  destination_dataset_table: Optional[str] = None,
                  write_disposition: Optional[str] = 'WRITE_EMPTY',
@@ -783,7 +784,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
     # pylint: disable=too-many-arguments
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: str,
         table_id: str,
         table_resource: Optional[Dict[str, Any]] = None,
@@ -962,7 +963,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
     # pylint: disable=too-many-arguments,too-many-locals
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         bucket: str,
         source_objects: List,
         destination_project_dataset_table: str,
@@ -1130,7 +1131,7 @@ class BigQueryDeleteDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: str,
         project_id: Optional[str] = None,
         delete_contents: bool = False,
@@ -1210,6 +1211,7 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  dataset_id: Optional[str] = None,
                  project_id: Optional[str] = None,
                  dataset_reference: Optional[Dict] = None,
@@ -1279,6 +1281,7 @@ class BigQueryGetDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  dataset_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -1329,7 +1332,7 @@ class BigQueryGetDatasetTablesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: str,
         project_id: Optional[str] = None,
         max_results: Optional[int] = None,
@@ -1386,7 +1389,7 @@ class BigQueryPatchDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: str,
         dataset_resource: dict,
         project_id: Optional[str] = None,
@@ -1453,7 +1456,7 @@ class BigQueryUpdateDatasetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_resource: dict,
         fields: Optional[List[str]] = None,
         dataset_id: Optional[str] = None,
@@ -1518,7 +1521,7 @@ class BigQueryDeleteTableOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         deletion_dataset_table: str,
         gcp_conn_id: str = 'google_cloud_default',
         bigquery_conn_id: Optional[str] = None,
@@ -1589,7 +1592,7 @@ class BigQueryUpsertTableOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dataset_id: str,
         table_resource: dict,
         project_id: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/bigquery_dts.py
+++ b/airflow/providers/google/cloud/operators/bigquery_dts.py
@@ -66,7 +66,7 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         transfer_config: dict,
         project_id: Optional[str] = None,
         authorization_code: Optional[str] = None,
@@ -132,7 +132,7 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         transfer_config_id: str,
         project_id: Optional[str] = None,
         retry: Retry = None,
@@ -208,7 +208,7 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         transfer_config_id: str,
         project_id: Optional[str] = None,
         requested_time_range: Optional[dict] = None,

--- a/airflow/providers/google/cloud/operators/bigtable.py
+++ b/airflow/providers/google/cloud/operators/bigtable.py
@@ -94,7 +94,7 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
     template_fields: Iterable[str] = ['project_id', 'instance_id', 'main_cluster_id', 'main_cluster_zone']
 
     @apply_defaults
-    def __init__(self,  # pylint: disable=too-many-arguments
+    def __init__(self, *,   # pylint: disable=too-many-arguments
                  instance_id: str,
                  main_cluster_id: str,
                  main_cluster_zone: str,
@@ -181,7 +181,7 @@ class BigtableDeleteInstanceOperator(BaseOperator, BigtableValidationMixin):
     template_fields = ['project_id', 'instance_id']  # type: Iterable[str]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -241,7 +241,7 @@ class BigtableCreateTableOperator(BaseOperator, BigtableValidationMixin):
     template_fields = ['project_id', 'instance_id', 'table_id']  # type: Iterable[str]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  table_id: str,
                  project_id: Optional[str] = None,
@@ -331,7 +331,7 @@ class BigtableDeleteTableOperator(BaseOperator, BigtableValidationMixin):
     template_fields = ['project_id', 'instance_id', 'table_id']  # type: Iterable[str]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  table_id: str,
                  project_id: Optional[str] = None,
@@ -396,7 +396,7 @@ class BigtableUpdateClusterOperator(BaseOperator, BigtableValidationMixin):
     template_fields = ['project_id', 'instance_id', 'cluster_id', 'nodes']  # type: Iterable[str]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  cluster_id: str,
                  nodes: int,

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -184,7 +184,7 @@ class CloudBuildCreateBuildOperator(BaseOperator):
     template_ext = ['.yml', '.yaml', '.json']
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  body: Union[dict, str],
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = "google_cloud_default",

--- a/airflow/providers/google/cloud/operators/cloud_memorystore.py
+++ b/airflow/providers/google/cloud/operators/cloud_memorystore.py
@@ -83,7 +83,7 @@ class CloudMemorystoreCreateInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         instance_id: str,
         instance: Union[Dict, Instance],
@@ -149,7 +149,7 @@ class CloudMemorystoreDeleteInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         instance: str,
         project_id: Optional[str] = None,
@@ -226,7 +226,7 @@ class CloudMemorystoreExportInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         instance: str,
         output_config: Union[Dict, OutputConfig],
@@ -304,7 +304,7 @@ class CloudMemorystoreFailoverInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         instance: str,
         data_protection_mode: FailoverInstanceRequest.DataProtectionMode,
@@ -368,7 +368,7 @@ class CloudMemorystoreGetInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         instance: str,
         project_id: Optional[str] = None,
@@ -447,7 +447,7 @@ class CloudMemorystoreImportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         instance: str,
         input_config: Union[Dict, InputConfig],
@@ -515,7 +515,7 @@ class CloudMemorystoreListInstancesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         page_size: int,
         project_id: Optional[str] = None,
@@ -606,7 +606,7 @@ class CloudMemorystoreUpdateInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         update_mask: Union[Dict, FieldMask],
         instance: Union[Dict, Instance],
         location: Optional[str] = None,
@@ -685,7 +685,7 @@ class CloudMemorystoreScaleInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         memory_size_gb: int,
         location: Optional[str] = None,
         instance_id: Optional[str] = None,
@@ -783,7 +783,7 @@ class CloudMemorystoreCreateInstanceAndImportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         instance_id: str,
         instance: Union[Dict, Instance],
@@ -877,7 +877,7 @@ class CloudMemorystoreExportAndDeleteInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         instance: str,
         output_config: Union[Dict, OutputConfig],

--- a/airflow/providers/google/cloud/operators/cloud_sql.py
+++ b/airflow/providers/google/cloud/operators/cloud_sql.py
@@ -154,7 +154,7 @@ class CloudSQLBaseOperator(BaseOperator):
     :type api_version: str
     """
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -236,7 +236,7 @@ class CloudSQLCreateInstanceOperator(CloudSQLBaseOperator):
     # [END gcp_sql_create_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  body: dict,
                  instance: str,
                  project_id: Optional[str] = None,
@@ -317,7 +317,7 @@ class CloudSQLInstancePatchOperator(CloudSQLBaseOperator):
     # [END gcp_sql_patch_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  body: dict,
                  instance: str,
                  project_id: Optional[str] = None,
@@ -373,7 +373,7 @@ class CloudSQLDeleteInstanceOperator(CloudSQLBaseOperator):
     # [END gcp_sql_delete_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -426,7 +426,7 @@ class CloudSQLCreateInstanceDatabaseOperator(CloudSQLBaseOperator):
     # [END gcp_sql_db_create_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance: str,
                  body: dict,
                  project_id: Optional[str] = None,
@@ -505,7 +505,7 @@ class CloudSQLPatchInstanceDatabaseOperator(CloudSQLBaseOperator):
     # [END gcp_sql_db_patch_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance: str,
                  database: str,
                  body: dict,
@@ -578,7 +578,7 @@ class CloudSQLDeleteInstanceDatabaseOperator(CloudSQLBaseOperator):
     # [END gcp_sql_db_delete_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance: str,
                  database: str,
                  project_id: Optional[str] = None,
@@ -644,7 +644,7 @@ class CloudSQLExportInstanceOperator(CloudSQLBaseOperator):
     # [END gcp_sql_export_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance: str,
                  body: dict,
                  project_id: Optional[str] = None,
@@ -724,7 +724,7 @@ class CloudSQLImportInstanceOperator(CloudSQLBaseOperator):
     # [END gcp_sql_import_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance: str,
                  body: dict,
                  project_id: Optional[str] = None,
@@ -795,7 +795,7 @@ class CloudSQLExecuteQueryOperator(BaseOperator):
     # [END gcp_sql_query_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  sql: Union[List[str], str],
                  autocommit: bool = False,
                  parameters: Optional[Union[Dict, Iterable]] = None,

--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -197,7 +197,7 @@ class CloudDataTransferServiceCreateJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         body: dict,
         aws_conn_id: str = 'aws_default',
         gcp_conn_id: str = 'google_cloud_default',
@@ -255,7 +255,7 @@ class CloudDataTransferServiceUpdateJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         job_name: str,
         body: dict,
         aws_conn_id: str = 'aws_default',
@@ -311,7 +311,7 @@ class CloudDataTransferServiceDeleteJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         job_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
@@ -358,7 +358,7 @@ class CloudDataTransferServiceGetOperationOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
@@ -454,7 +454,7 @@ class CloudDataTransferServicePauseOperationOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
@@ -496,7 +496,7 @@ class CloudDataTransferServiceResumeOperationOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
@@ -539,7 +539,7 @@ class CloudDataTransferServiceCancelOperationOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         operation_name: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
@@ -627,7 +627,7 @@ class CloudDataTransferServiceS3ToGCSOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         s3_bucket: str,
         gcs_bucket: str,
         project_id: Optional[str] = None,
@@ -769,7 +769,7 @@ class CloudDataTransferServiceGCSToGCSOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         source_bucket: str,
         destination_bucket: str,
         project_id: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/compute.py
+++ b/airflow/providers/google/cloud/operators/compute.py
@@ -39,7 +39,7 @@ class ComputeEngineBaseOperator(BaseOperator):
     """
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  zone: str,
                  resource_id: str,
                  project_id: Optional[str] = None,
@@ -96,7 +96,7 @@ class ComputeEngineStartInstanceOperator(ComputeEngineBaseOperator):
     # [END gce_instance_start_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  zone: str,
                  resource_id: str,
                  project_id: Optional[str] = None,
@@ -144,7 +144,7 @@ class ComputeEngineStopInstanceOperator(ComputeEngineBaseOperator):
     # [END gce_instance_stop_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  zone: str,
                  resource_id: str,
                  project_id: Optional[str] = None,
@@ -202,7 +202,7 @@ class ComputeEngineSetMachineTypeOperator(ComputeEngineBaseOperator):
     # [END gce_instance_set_machine_type_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  zone: str,
                  resource_id: str,
                  body: dict,
@@ -324,7 +324,7 @@ class ComputeEngineCopyInstanceTemplateOperator(ComputeEngineBaseOperator):
     # [END gce_instance_template_copy_operator_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  resource_id: str,
                  body_patch: dict,
                  project_id: Optional[str] = None,
@@ -434,7 +434,7 @@ class ComputeEngineInstanceGroupUpdateManagerTemplateOperator(ComputeEngineBaseO
     # [END gce_igm_update_template_operator_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  resource_id: str,
                  zone: str,
                  source_template: str,

--- a/airflow/providers/google/cloud/operators/datacatalog.py
+++ b/airflow/providers/google/cloud/operators/datacatalog.py
@@ -82,7 +82,7 @@ class CloudDataCatalogCreateEntryOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         entry_group: str,
         entry_id: str,
@@ -185,7 +185,7 @@ class CloudDataCatalogCreateEntryGroupOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         entry_group_id: str,
         entry_group: Union[Dict, EntryGroup],
@@ -288,7 +288,7 @@ class CloudDataCatalogCreateTagOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         location: str,
         entry_group: str,
         entry: str,
@@ -404,7 +404,7 @@ class CloudDataCatalogCreateTagTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         tag_template_id: str,
         tag_template: Union[Dict, TagTemplate],
@@ -507,7 +507,7 @@ class CloudDataCatalogCreateTagTemplateFieldOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         tag_template: str,
         tag_template_field_id: str,
@@ -603,7 +603,7 @@ class CloudDataCatalogDeleteEntryOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         entry_group: str,
         entry: str,
@@ -674,7 +674,7 @@ class CloudDataCatalogDeleteEntryGroupOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         entry_group: str,
         project_id: Optional[str] = None,
@@ -754,7 +754,7 @@ class CloudDataCatalogDeleteTagOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         entry_group: str,
         entry: str,
@@ -839,7 +839,7 @@ class CloudDataCatalogDeleteTagTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         tag_template: str,
         force: bool,
@@ -922,7 +922,7 @@ class CloudDataCatalogDeleteTagTemplateFieldOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         tag_template: str,
         field: str,
@@ -1005,7 +1005,7 @@ class CloudDataCatalogGetEntryOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         entry_group: str,
         entry: str,
@@ -1086,7 +1086,7 @@ class CloudDataCatalogGetEntryGroupOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         entry_group: str,
         read_mask: Union[Dict, FieldMask],
@@ -1161,7 +1161,7 @@ class CloudDataCatalogGetTagTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         tag_template: str,
         project_id: Optional[str] = None,
@@ -1241,7 +1241,7 @@ class CloudDataCatalogListTagsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         entry_group: str,
         entry: str,
@@ -1321,7 +1321,7 @@ class CloudDataCatalogLookupEntryOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         linked_resource: Optional[str] = None,
         sql_resource: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -1400,7 +1400,7 @@ class CloudDataCatalogRenameTagTemplateFieldOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         tag_template: str,
         field: str,
@@ -1507,7 +1507,7 @@ class CloudDataCatalogSearchCatalogOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         scope: Union[Dict, SearchCatalogRequest.Scope],
         query: str,
         page_size: int = 100,
@@ -1598,7 +1598,7 @@ class CloudDataCatalogUpdateEntryOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         entry: Union[Dict, Entry],
         update_mask: Union[Dict, FieldMask],
         location: Optional[str] = None,
@@ -1695,7 +1695,7 @@ class CloudDataCatalogUpdateTagOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         tag: Union[Dict, Tag],
         update_mask: Union[Dict, FieldMask],
         location: Optional[str] = None,
@@ -1796,7 +1796,7 @@ class CloudDataCatalogUpdateTagTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         tag_template: Union[Dict, TagTemplate],
         update_mask: Union[Dict, FieldMask],
         location: Optional[str] = None,
@@ -1899,7 +1899,7 @@ class CloudDataCatalogUpdateTagTemplateFieldOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         tag_template_field: Union[Dict, TagTemplateField],
         update_mask: Union[Dict, FieldMask],
         tag_template_field_name: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -179,21 +179,20 @@ class DataflowCreateJavaJobOperator(BaseOperator):
 
     # pylint: disable=too-many-arguments
     @apply_defaults
-    def __init__(
-            self,
-            jar: str,
-            job_name: str = '{{task.task_id}}',
-            dataflow_default_options: Optional[dict] = None,
-            options: Optional[dict] = None,
-            project_id: Optional[str] = None,
-            location: str = DEFAULT_DATAFLOW_LOCATION,
-            gcp_conn_id: str = 'google_cloud_default',
-            delegate_to: Optional[str] = None,
-            poll_sleep: int = 10,
-            job_class: Optional[str] = None,
-            check_if_running: CheckJobRunning = CheckJobRunning.WaitForRun,
-            multiple_jobs: Optional[bool] = None,
-            **kwargs) -> None:
+    def __init__(self, *,
+                 jar: str,
+                 job_name: str = '{{task.task_id}}',
+                 dataflow_default_options: Optional[dict] = None,
+                 options: Optional[dict] = None,
+                 project_id: Optional[str] = None,
+                 location: str = DEFAULT_DATAFLOW_LOCATION,
+                 gcp_conn_id: str = 'google_cloud_default',
+                 delegate_to: Optional[str] = None,
+                 poll_sleep: int = 10,
+                 job_class: Optional[str] = None,
+                 check_if_running: CheckJobRunning = CheckJobRunning.WaitForRun,
+                 multiple_jobs: Optional[bool] = None,
+                 **kwargs) -> None:
         super().__init__(**kwargs)
 
         dataflow_default_options = dataflow_default_options or {}
@@ -364,7 +363,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-            self,
+            self, *,
             template: str,
             job_name: str = '{{task.task_id}}',
             options: Optional[Dict[str, Any]] = None,
@@ -492,7 +491,7 @@ class DataflowCreatePythonJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-            self,
+            self, *,
             py_file: str,
             job_name: str = '{{task.task_id}}',
             dataflow_default_options: Optional[dict] = None,

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -57,7 +57,7 @@ class CloudDataFusionRestartInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         instance_name: str,
         location: str,
         project_id: Optional[str] = None,
@@ -117,7 +117,7 @@ class CloudDataFusionDeleteInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         instance_name: str,
         location: str,
         project_id: Optional[str] = None,
@@ -180,7 +180,7 @@ class CloudDataFusionCreateInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         instance_name: str,
         instance: Dict[str, Any],
         location: str,
@@ -270,7 +270,7 @@ class CloudDataFusionUpdateInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         instance_name: str,
         instance: Dict[str, Any],
         update_mask: str,
@@ -336,7 +336,7 @@ class CloudDataFusionGetInstanceOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         instance_name: str,
         location: str,
         project_id: Optional[str] = None,
@@ -402,7 +402,7 @@ class CloudDataFusionCreatePipelineOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         pipeline_name: str,
         pipeline: Dict[str, Any],
         instance_name: str,
@@ -480,7 +480,7 @@ class CloudDataFusionDeletePipelineOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         pipeline_name: str,
         instance_name: str,
         location: str,
@@ -559,7 +559,7 @@ class CloudDataFusionListPipelinesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         instance_name: str,
         location: str,
         artifact_name: Optional[str] = None,
@@ -644,7 +644,7 @@ class CloudDataFusionStartPipelineOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         pipeline_name: str,
         instance_name: str,
         location: str,
@@ -734,7 +734,7 @@ class CloudDataFusionStopPipelineOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         pipeline_name: str,
         instance_name: str,
         location: str,

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -455,7 +455,7 @@ class DataprocCreateClusterOperator(BaseOperator):
     template_fields = ('project_id', 'region', 'cluster')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  region: str = 'global',
                  project_id: Optional[str] = None,
                  cluster: Optional[Dict] = None,
@@ -570,7 +570,7 @@ class DataprocScaleClusterOperator(BaseOperator):
     template_fields = ['cluster_name', 'project_id', 'region']
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  cluster_name: str,
                  project_id: Optional[str] = None,
                  region: str = 'global',
@@ -695,7 +695,7 @@ class DataprocDeleteClusterOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: str,
         region: str,
         cluster_name: str,
@@ -779,7 +779,7 @@ class DataprocJobBaseOperator(BaseOperator):
     job_type = ""
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  job_name: str = '{{task.task_id}}_{{ds_nodash}}',
                  cluster_name: str = "cluster-1",
                  dataproc_properties: Optional[Dict] = None,
@@ -911,7 +911,7 @@ class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         query: Optional[str] = None,
         query_uri: Optional[str] = None,
         variables: Optional[Dict] = None,
@@ -976,7 +976,7 @@ class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         query: Optional[str] = None,
         query_uri: Optional[str] = None,
         variables: Optional[Dict] = None,
@@ -1041,7 +1041,7 @@ class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         query: Optional[str] = None,
         query_uri: Optional[str] = None,
         variables: Optional[Dict] = None,
@@ -1113,7 +1113,7 @@ class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         main_jar: Optional[str] = None,
         main_class: Optional[str] = None,
         arguments: Optional[List] = None,
@@ -1185,7 +1185,7 @@ class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         main_jar: Optional[str] = None,
         main_class: Optional[str] = None,
         arguments: Optional[List] = None,
@@ -1284,7 +1284,7 @@ class DataprocSubmitPySparkJobOperator(DataprocJobBaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         main: str,
         arguments: Optional[List] = None,
         archives: Optional[List] = None,
@@ -1402,7 +1402,7 @@ class DataprocInstantiateWorkflowTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         template_id: str,
         region: str,
         project_id: Optional[str] = None,
@@ -1492,7 +1492,7 @@ class DataprocInstantiateInlineWorkflowTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         template: Dict,
         region: str,
         project_id: Optional[str] = None,
@@ -1563,7 +1563,7 @@ class DataprocSubmitJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: str,
         location: str,
         job: Dict,
@@ -1651,7 +1651,7 @@ class DataprocUpdateClusterOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         location: str,
         cluster_name: str,
         cluster: Union[Dict, Cluster],

--- a/airflow/providers/google/cloud/operators/datastore.py
+++ b/airflow/providers/google/cloud/operators/datastore.py
@@ -227,8 +227,7 @@ class CloudDatastoreAllocateIdsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
-        *,
+        self, *,
         partial_keys: List,
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
@@ -277,8 +276,7 @@ class CloudDatastoreBeginTransactionOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
-        *,
+        self, *,
         transaction_options: Dict[str, Any],
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
@@ -327,8 +325,7 @@ class CloudDatastoreCommitOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
-        *,
+        self, *,
         body: Dict[str, Any],
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
@@ -377,8 +374,7 @@ class CloudDatastoreRollbackOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
-        *,
+        self, *,
         transaction: str,
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
@@ -426,8 +422,7 @@ class CloudDatastoreRunQueryOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
-        *,
+        self, *,
         body: Dict[str, Any],
         project_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
@@ -470,8 +465,7 @@ class CloudDatastoreGetOperationOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
-        *,
+        self, *,
         name: str,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
@@ -509,8 +503,7 @@ class CloudDatastoreDeleteOperationOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
-        *,
+        self, *,
         name: str,
         delegate_to: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',

--- a/airflow/providers/google/cloud/operators/dlp.py
+++ b/airflow/providers/google/cloud/operators/dlp.py
@@ -65,7 +65,7 @@ class CloudDLPCancelDLPJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dlp_job_id: str,
         project_id: Optional[str] = None,
         retry: Optional[Retry] = None,
@@ -133,7 +133,7 @@ class CloudDLPCreateDeidentifyTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         deidentify_template: Optional[Union[Dict, DeidentifyTemplate]] = None,
@@ -214,7 +214,7 @@ class CloudDLPCreateDLPJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: Optional[str] = None,
         inspect_job: Optional[Union[Dict, InspectJobConfig]] = None,
         risk_job: Optional[Union[Dict, RiskAnalysisJobConfig]] = None,
@@ -301,7 +301,7 @@ class CloudDLPCreateInspectTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         inspect_template: Optional[InspectTemplate] = None,
@@ -377,7 +377,7 @@ class CloudDLPCreateJobTriggerOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: Optional[str] = None,
         job_trigger: Optional[Union[Dict, JobTrigger]] = None,
         trigger_id: Optional[str] = None,
@@ -457,7 +457,7 @@ class CloudDLPCreateStoredInfoTypeOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         config: Optional[StoredInfoTypeConfig] = None,
@@ -553,7 +553,7 @@ class CloudDLPDeidentifyContentOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: Optional[str] = None,
         deidentify_config: Optional[Union[Dict, DeidentifyConfig]] = None,
         inspect_config: Optional[Union[Dict, InspectConfig]] = None,
@@ -624,7 +624,7 @@ class CloudDLPDeleteDeidentifyTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         template_id: str,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -686,7 +686,7 @@ class CloudDLPDeleteDLPJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dlp_job_id: str,
         project_id: Optional[str] = None,
         retry: Optional[Retry] = None,
@@ -747,7 +747,7 @@ class CloudDLPDeleteInspectTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         template_id: str,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -808,7 +808,7 @@ class CloudDLPDeleteJobTriggerOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         job_trigger_id: str,
         project_id: Optional[str] = None,
         retry: Optional[Retry] = None,
@@ -874,7 +874,7 @@ class CloudDLPDeleteStoredInfoTypeOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         stored_info_type_id: str,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -939,7 +939,7 @@ class CloudDLPGetDeidentifyTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         template_id: str,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -999,7 +999,7 @@ class CloudDLPGetDLPJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         dlp_job_id: str,
         project_id: Optional[str] = None,
         retry: Optional[Retry] = None,
@@ -1059,7 +1059,7 @@ class CloudDLPGetInspectTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         template_id: str,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -1119,7 +1119,7 @@ class CloudDLPGetDLPJobTriggerOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         job_trigger_id: str,
         project_id: Optional[str] = None,
         retry: Optional[Retry] = None,
@@ -1184,7 +1184,7 @@ class CloudDLPGetStoredInfoTypeOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         stored_info_type_id: str,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -1257,7 +1257,7 @@ class CloudDLPInspectContentOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: Optional[str] = None,
         inspect_config: Optional[Union[Dict, InspectConfig]] = None,
         item: Optional[Union[Dict, ContentItem]] = None,
@@ -1327,7 +1327,7 @@ class CloudDLPListDeidentifyTemplatesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         page_size: Optional[int] = None,
@@ -1398,7 +1398,7 @@ class CloudDLPListDLPJobsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: Optional[str] = None,
         results_filter: Optional[str] = None,
         page_size: Optional[int] = None,
@@ -1464,7 +1464,7 @@ class CloudDLPListInfoTypesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         language_code: Optional[str] = None,
         results_filter: Optional[str] = None,
         retry: Optional[Retry] = None,
@@ -1528,7 +1528,7 @@ class CloudDLPListInspectTemplatesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         page_size: Optional[int] = None,
@@ -1597,7 +1597,7 @@ class CloudDLPListJobTriggersOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: Optional[str] = None,
         page_size: Optional[int] = None,
         order_by: Optional[str] = None,
@@ -1667,7 +1667,7 @@ class CloudDLPListStoredInfoTypesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         page_size: Optional[int] = None,
@@ -1748,7 +1748,7 @@ class CloudDLPRedactImageOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: Optional[str] = None,
         inspect_config: Optional[Union[Dict, InspectConfig]] = None,
         image_redaction_configs: Optional[Union[Dict, RedactImageRequest.ImageRedactionConfig]] = None,
@@ -1834,7 +1834,7 @@ class CloudDLPReidentifyContentOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         project_id: Optional[str] = None,
         reidentify_config: Optional[Union[Dict, DeidentifyConfig]] = None,
         inspect_config: Optional[Union[Dict, InspectConfig]] = None,
@@ -1917,7 +1917,7 @@ class CloudDLPUpdateDeidentifyTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         template_id: str,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -1997,7 +1997,7 @@ class CloudDLPUpdateInspectTemplateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         template_id: str,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -2073,7 +2073,7 @@ class CloudDLPUpdateJobTriggerOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         job_trigger_id,
         project_id: Optional[str] = None,
         job_trigger: Optional[JobTrigger] = None,
@@ -2151,7 +2151,7 @@ class CloudDLPUpdateStoredInfoTypeOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         stored_info_type_id,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/functions.py
+++ b/airflow/providers/google/cloud/operators/functions.py
@@ -122,7 +122,7 @@ class CloudFunctionDeployFunctionOperator(BaseOperator):
     # [END gcf_function_deploy_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  location: str,
                  body: Dict,
                  project_id: Optional[str] = None,
@@ -314,7 +314,7 @@ class CloudFunctionDeleteFunctionOperator(BaseOperator):
     # [END gcf_function_delete_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  name: str,
                  gcp_conn_id: str = 'google_cloud_default',
                  api_version: str = 'v1',
@@ -371,7 +371,7 @@ class CloudFunctionInvokeFunctionOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         function_id: str,
         input_data: Dict,
         location: str,

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -100,7 +100,7 @@ class GCSCreateBucketOperator(BaseOperator):
     ui_color = '#f0eee4'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket_name: str,
                  resource: Optional[Dict] = None,
                  storage_class: str = 'MULTI_REGIONAL',
@@ -187,7 +187,7 @@ class GCSListObjectsOperator(BaseOperator):
     ui_color = '#f0eee4'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket: str,
                  prefix: Optional[str] = None,
                  delimiter: Optional[str] = None,
@@ -251,7 +251,7 @@ class GCSDeleteObjectsOperator(BaseOperator):
     template_fields = ('bucket_name', 'prefix', 'objects')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket_name: str,
                  objects: Optional[Iterable[str]] = None,
                  prefix: Optional[str] = None,
@@ -328,7 +328,7 @@ class GCSBucketCreateAclEntryOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         bucket: str,
         entity: str,
         role: str,
@@ -396,7 +396,7 @@ class GCSObjectCreateAclEntryOperator(BaseOperator):
     # [END gcs_object_create_acl_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket: str,
                  object_name: str,
                  entity: str,
@@ -463,7 +463,7 @@ class GCSFileTransformOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         source_bucket: str,
         source_object: str,
         transform_script: Union[str, List[str]],
@@ -548,7 +548,7 @@ class GCSDeleteBucketOperator(BaseOperator):
     template_fields = ('bucket_name', "gcp_conn_id")
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket_name: str,
                  force: bool = True,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -615,7 +615,7 @@ class GCSSynchronizeBucketsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         source_bucket: str,
         destination_bucket: str,
         source_object: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -74,6 +74,7 @@ class GKEDeleteClusterOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  name: str,
                  location: str,
                  project_id: Optional[str] = None,
@@ -152,6 +153,7 @@ class GKECreateClusterOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  location: str,
                  body: Optional[Union[Dict, Cluster]],
                  project_id: Optional[str] = None,
@@ -224,6 +226,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  location: str,
                  cluster_name: str,
                  use_internal_ip: bool = False,

--- a/airflow/providers/google/cloud/operators/life_sciences.py
+++ b/airflow/providers/google/cloud/operators/life_sciences.py
@@ -50,6 +50,7 @@ class LifeSciencesRunPipelineOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  body: dict,
                  location: str,
                  project_id: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -168,6 +168,7 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,  # pylint: disable=too-many-arguments
+                 *,
                  job_id: str,
                  region: str,
                  data_format: str,
@@ -317,6 +318,7 @@ class MLEngineManageModelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model: dict,
                  operation: str = 'create',
                  project_id: Optional[str] = None,
@@ -379,6 +381,7 @@ class MLEngineCreateModelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model: dict,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -426,6 +429,7 @@ class MLEngineGetModelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model_name: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -476,6 +480,7 @@ class MLEngineDeleteModelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model_name: str,
                  delete_contents: bool = False,
                  project_id: Optional[str] = None,
@@ -560,6 +565,7 @@ class MLEngineManageVersionOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model_name: str,
                  version_name: Optional[str] = None,
                  version: Optional[dict] = None,
@@ -655,6 +661,7 @@ class MLEngineCreateVersionOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model_name: str,
                  version: dict,
                  project_id: Optional[str] = None,
@@ -721,6 +728,7 @@ class MLEngineSetDefaultVersionOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model_name: str,
                  version_name: str,
                  project_id: Optional[str] = None,
@@ -783,6 +791,7 @@ class MLEngineListVersionsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model_name: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -843,6 +852,7 @@ class MLEngineDeleteVersionOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  model_name: str,
                  version_name: str,
                  project_id: Optional[str] = None,
@@ -965,6 +975,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,  # pylint: disable=too-many-arguments
+                 *,
                  job_id: str,
                  package_uris: List[str],
                  training_python_module: str,
@@ -1103,6 +1114,7 @@ class MLEngineTrainingCancelJobOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
+                 *,
                  job_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',

--- a/airflow/providers/google/cloud/operators/natural_language.py
+++ b/airflow/providers/google/cloud/operators/natural_language.py
@@ -27,6 +27,7 @@ from google.protobuf.json_format import MessageToDict
 
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.natural_language import CloudNaturalLanguageHook
+from airflow.utils.decorators import apply_defaults
 
 MetaData = Sequence[Tuple[str, str]]
 
@@ -59,8 +60,9 @@ class CloudNaturalLanguageAnalyzeEntitiesOperator(BaseOperator):
     template_fields = ("document", "gcp_conn_id")
     # [END natural_language_analyze_entities_template_fields]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         document: Union[dict, Document],
         encoding_type: Optional[enums.EncodingType] = None,
         retry: Optional[Retry] = None,
@@ -118,8 +120,9 @@ class CloudNaturalLanguageAnalyzeEntitySentimentOperator(BaseOperator):
     template_fields = ("document", "gcp_conn_id")
     # [END natural_language_analyze_entity_sentiment_template_fields]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         document: Union[dict, Document],
         encoding_type: Optional[enums.EncodingType] = None,
         retry: Optional[Retry] = None,
@@ -180,8 +183,9 @@ class CloudNaturalLanguageAnalyzeSentimentOperator(BaseOperator):
     template_fields = ("document", "gcp_conn_id")
     # [END natural_language_analyze_sentiment_template_fields]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         document: Union[dict, Document],
         encoding_type: Optional[enums.EncodingType] = None,
         retry: Optional[Retry] = None,
@@ -235,8 +239,9 @@ class CloudNaturalLanguageClassifyTextOperator(BaseOperator):
     template_fields = ("document", "gcp_conn_id")
     # [END natural_language_classify_text_template_fields]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         document: Union[dict, Document],
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,

--- a/airflow/providers/google/cloud/operators/pubsub.py
+++ b/airflow/providers/google/cloud/operators/pubsub.py
@@ -112,21 +112,21 @@ class PubSubCreateTopicOperator(BaseOperator):
     # pylint: disable=too-many-arguments
     @apply_defaults
     def __init__(
-            self,
-            topic: str,
-            project_id: Optional[str] = None,
-            fail_if_exists: bool = False,
-            gcp_conn_id: str = 'google_cloud_default',
-            delegate_to: Optional[str] = None,
-            labels: Optional[Dict[str, str]] = None,
-            message_storage_policy: Union[Dict, MessageStoragePolicy] = None,
-            kms_key_name: Optional[str] = None,
-            retry: Optional[Retry] = None,
-            timeout: Optional[float] = None,
-            metadata: Optional[Sequence[Tuple[str, str]]] = None,
-            project: Optional[str] = None,
-            **kwargs) -> None:
-
+        self, *,
+        topic: str,
+        project_id: Optional[str] = None,
+        fail_if_exists: bool = False,
+        gcp_conn_id: str = 'google_cloud_default',
+        delegate_to: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
+        message_storage_policy: Union[Dict, MessageStoragePolicy] = None,
+        kms_key_name: Optional[str] = None,
+        retry: Optional[Retry] = None,
+        timeout: Optional[float] = None,
+        metadata: Optional[Sequence[Tuple[str, str]]] = None,
+        project: Optional[str] = None,
+        **kwargs
+    ) -> None:
         # To preserve backward compatibility
         # TODO: remove one day
         if project:
@@ -308,30 +308,31 @@ class PubSubCreateSubscriptionOperator(BaseOperator):
     # pylint: disable=too-many-arguments
     @apply_defaults
     def __init__(
-            self,
-            topic: str,
-            project_id: Optional[str] = None,
-            subscription: Optional[str] = None,
-            subscription_project_id: Optional[str] = None,
-            ack_deadline_secs: int = 10,
-            fail_if_exists: bool = False,
-            gcp_conn_id: str = 'google_cloud_default',
-            delegate_to: Optional[str] = None,
-            push_config: Optional[Union[Dict, PushConfig]] = None,
-            retain_acked_messages: Optional[bool] = None,
-            message_retention_duration: Optional[Union[Dict, Duration]] = None,
-            labels: Optional[Dict[str, str]] = None,
-            enable_message_ordering: bool = False,
-            expiration_policy: Optional[Union[Dict, ExpirationPolicy]] = None,
-            filter_: Optional[str] = None,
-            dead_letter_policy: Optional[Union[Dict, DeadLetterPolicy]] = None,
-            retry_policy: Optional[Union[Dict, RetryPolicy]] = None,
-            retry: Optional[Retry] = None,
-            timeout: Optional[float] = None,
-            metadata: Optional[Sequence[Tuple[str, str]]] = None,
-            topic_project: Optional[str] = None,
-            subscription_project: Optional[str] = None,
-            **kwargs) -> None:
+        self, *,
+        topic: str,
+        project_id: Optional[str] = None,
+        subscription: Optional[str] = None,
+        subscription_project_id: Optional[str] = None,
+        ack_deadline_secs: int = 10,
+        fail_if_exists: bool = False,
+        gcp_conn_id: str = 'google_cloud_default',
+        delegate_to: Optional[str] = None,
+        push_config: Optional[Union[Dict, PushConfig]] = None,
+        retain_acked_messages: Optional[bool] = None,
+        message_retention_duration: Optional[Union[Dict, Duration]] = None,
+        labels: Optional[Dict[str, str]] = None,
+        enable_message_ordering: bool = False,
+        expiration_policy: Optional[Union[Dict, ExpirationPolicy]] = None,
+        filter_: Optional[str] = None,
+        dead_letter_policy: Optional[Union[Dict, DeadLetterPolicy]] = None,
+        retry_policy: Optional[Union[Dict, RetryPolicy]] = None,
+        retry: Optional[Retry] = None,
+        timeout: Optional[float] = None,
+        metadata: Optional[Sequence[Tuple[str, str]]] = None,
+        topic_project: Optional[str] = None,
+        subscription_project: Optional[str] = None,
+        **kwargs
+    ) -> None:
 
         # To preserve backward compatibility
         # TODO: remove one day
@@ -461,18 +462,18 @@ class PubSubDeleteTopicOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
-            topic: str,
-            project_id: Optional[str] = None,
-            fail_if_not_exists: bool = False,
-            gcp_conn_id: str = 'google_cloud_default',
-            delegate_to: Optional[str] = None,
-            retry: Optional[Retry] = None,
-            timeout: Optional[float] = None,
-            metadata: Optional[Sequence[Tuple[str, str]]] = None,
-            project: Optional[str] = None,
-            **kwargs) -> None:
-
+        self, *,
+        topic: str,
+        project_id: Optional[str] = None,
+        fail_if_not_exists: bool = False,
+        gcp_conn_id: str = 'google_cloud_default',
+        delegate_to: Optional[str] = None,
+        retry: Optional[Retry] = None,
+        timeout: Optional[float] = None,
+        metadata: Optional[Sequence[Tuple[str, str]]] = None,
+        project: Optional[str] = None,
+        **kwargs
+    ) -> None:
         # To preserve backward compatibility
         # TODO: remove one day
         if project:
@@ -572,18 +573,18 @@ class PubSubDeleteSubscriptionOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
-            subscription: str,
-            project_id: Optional[str] = None,
-            fail_if_not_exists: bool = False,
-            gcp_conn_id: str = 'google_cloud_default',
-            delegate_to: Optional[str] = None,
-            retry: Optional[Retry] = None,
-            timeout: Optional[float] = None,
-            metadata: Optional[Sequence[Tuple[str, str]]] = None,
-            project: Optional[str] = None,
-            **kwargs) -> None:
-
+        self, *,
+        subscription: str,
+        project_id: Optional[str] = None,
+        fail_if_not_exists: bool = False,
+        gcp_conn_id: str = 'google_cloud_default',
+        delegate_to: Optional[str] = None,
+        retry: Optional[Retry] = None,
+        timeout: Optional[float] = None,
+        metadata: Optional[Sequence[Tuple[str, str]]] = None,
+        project: Optional[str] = None,
+        **kwargs
+    ) -> None:
         # To preserve backward compatibility
         # TODO: remove one day
         if project:
@@ -676,15 +677,15 @@ class PubSubPublishMessageOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
-            topic: str,
-            messages: List,
-            project_id: Optional[str] = None,
-            gcp_conn_id: str = 'google_cloud_default',
-            delegate_to: Optional[str] = None,
-            project: Optional[str] = None,
-            **kwargs) -> None:
-
+        self, *,
+        topic: str,
+        messages: List,
+        project_id: Optional[str] = None,
+        gcp_conn_id: str = 'google_cloud_default',
+        delegate_to: Optional[str] = None,
+        project: Optional[str] = None,
+        **kwargs
+    ) -> None:
         # To preserve backward compatibility
         # TODO: remove one day
         if project:
@@ -760,15 +761,15 @@ class PubSubPullOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
-            project_id: str,
-            subscription: str,
-            max_messages: int = 5,
-            ack_messages: bool = False,
-            messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]] = None,
-            gcp_conn_id: str = 'google_cloud_default',
-            delegate_to: Optional[str] = None,
-            **kwargs
+        self, *,
+        project_id: str,
+        subscription: str,
+        max_messages: int = 5,
+        ack_messages: bool = False,
+        messages_callback: Optional[Callable[[List[ReceivedMessage], Dict[str, Any]], Any]] = None,
+        gcp_conn_id: str = 'google_cloud_default',
+        delegate_to: Optional[str] = None,
+        **kwargs
     ) -> None:
         super().__init__(**kwargs)
         self.gcp_conn_id = gcp_conn_id
@@ -806,9 +807,9 @@ class PubSubPullOperator(BaseOperator):
         return ret
 
     def _default_message_callback(
-            self,
-            pulled_messages: List[ReceivedMessage],
-            context: Dict[str, Any],  # pylint: disable=unused-argument
+        self,
+        pulled_messages: List[ReceivedMessage],
+        context: Dict[str, Any],  # pylint: disable=unused-argument
     ):
         """
         This method can be overridden by subclasses or by `messages_callback` constructor argument.

--- a/airflow/providers/google/cloud/operators/spanner.py
+++ b/airflow/providers/google/cloud/operators/spanner.py
@@ -60,7 +60,7 @@ class SpannerDeployInstanceOperator(BaseOperator):
     # [END gcp_spanner_deploy_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  configuration_name: str,
                  node_count: int,
@@ -121,7 +121,7 @@ class SpannerDeleteInstanceOperator(BaseOperator):
     # [END gcp_spanner_delete_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
@@ -177,7 +177,7 @@ class SpannerQueryDatabaseInstanceOperator(BaseOperator):
     # [END gcp_spanner_query_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  database_id: str,
                  query: Union[str, List[str]],
@@ -260,7 +260,7 @@ class SpannerDeployDatabaseInstanceOperator(BaseOperator):
     # [END gcp_spanner_database_deploy_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  database_id: str,
                  ddl_statements: List[str],
@@ -334,7 +334,7 @@ class SpannerUpdateDatabaseInstanceOperator(BaseOperator):
     # [END gcp_spanner_database_update_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  database_id: str,
                  ddl_statements: List[str],
@@ -406,7 +406,7 @@ class SpannerDeleteDatabaseInstanceOperator(BaseOperator):
     # [END gcp_spanner_database_delete_template_fields]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  database_id: str,
                  project_id: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/speech_to_text.py
+++ b/airflow/providers/google/cloud/operators/speech_to_text.py
@@ -64,7 +64,7 @@ class CloudSpeechToTextRecognizeSpeechOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         audio: RecognitionAudio,
         config: RecognitionConfig,
         project_id: Optional[str] = None,

--- a/airflow/providers/google/cloud/operators/stackdriver.py
+++ b/airflow/providers/google/cloud/operators/stackdriver.py
@@ -82,7 +82,7 @@ class StackdriverListAlertPoliciesOperator(BaseOperator):
     # pylint: disable=too-many-arguments
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         format_: Optional[str] = None,
         filter_: Optional[str] = None,
         order_by: Optional[str] = None,
@@ -163,7 +163,7 @@ class StackdriverEnableAlertPoliciesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         filter_: Optional[str] = None,
         retry: Optional[str] = DEFAULT,
         timeout: Optional[float] = DEFAULT,
@@ -235,7 +235,7 @@ class StackdriverDisableAlertPoliciesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         filter_: Optional[str] = None,
         retry: Optional[str] = DEFAULT,
         timeout: Optional[float] = DEFAULT,
@@ -309,7 +309,7 @@ class StackdriverUpsertAlertOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         alerts: str,
         retry: Optional[str] = DEFAULT,
         timeout: Optional[float] = DEFAULT,
@@ -379,7 +379,7 @@ class StackdriverDeleteAlertOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         name: str,
         retry: Optional[str] = DEFAULT,
         timeout: Optional[float] = DEFAULT,
@@ -469,7 +469,7 @@ class StackdriverListNotificationChannelsOperator(BaseOperator):
     # pylint: disable=too-many-arguments
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         format_: Optional[str] = None,
         filter_: Optional[str] = None,
         order_by: Optional[str] = None,
@@ -553,7 +553,7 @@ class StackdriverEnableNotificationChannelsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         filter_: Optional[str] = None,
         retry: Optional[str] = DEFAULT,
         timeout: Optional[float] = DEFAULT,
@@ -626,7 +626,7 @@ class StackdriverDisableNotificationChannelsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         filter_: Optional[str] = None,
         retry: Optional[str] = DEFAULT,
         timeout: Optional[float] = DEFAULT,
@@ -701,7 +701,7 @@ class StackdriverUpsertNotificationChannelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         channels: str,
         retry: Optional[str] = DEFAULT,
         timeout: Optional[str] = DEFAULT,
@@ -772,7 +772,7 @@ class StackdriverDeleteNotificationChannelOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         name: str,
         retry: Optional[str] = DEFAULT,
         timeout: Optional[float] = DEFAULT,

--- a/airflow/providers/google/cloud/operators/tasks.py
+++ b/airflow/providers/google/cloud/operators/tasks.py
@@ -76,7 +76,7 @@ class CloudTasksQueueCreateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         task_queue: Queue,
         project_id: Optional[str] = None,
@@ -168,7 +168,7 @@ class CloudTasksQueueUpdateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         task_queue: Queue,
         project_id: Optional[str] = None,
         location: Optional[str] = None,
@@ -235,7 +235,7 @@ class CloudTasksQueueGetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         project_id: Optional[str] = None,
@@ -299,7 +299,7 @@ class CloudTasksQueuesListOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         project_id: Optional[str] = None,
         results_filter: Optional[str] = None,
@@ -362,7 +362,7 @@ class CloudTasksQueueDeleteOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         project_id: Optional[str] = None,
@@ -422,7 +422,7 @@ class CloudTasksQueuePurgeOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         project_id: Optional[str] = None,
@@ -483,7 +483,7 @@ class CloudTasksQueuePauseOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         project_id: Optional[str] = None,
@@ -544,7 +544,7 @@ class CloudTasksQueueResumeOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         project_id: Optional[str] = None,
@@ -621,7 +621,7 @@ class CloudTasksTaskCreateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         location: str,
         queue_name: str,
         task: Union[Dict, Task],
@@ -702,7 +702,7 @@ class CloudTasksTaskGetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         task_name: str,
@@ -775,7 +775,7 @@ class CloudTasksTasksListOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         project_id: Optional[str] = None,
@@ -849,7 +849,7 @@ class CloudTasksTaskDeleteOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         task_name: str,
@@ -923,7 +923,7 @@ class CloudTasksTaskRunOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         queue_name: str,
         task_name: str,

--- a/airflow/providers/google/cloud/operators/text_to_speech.py
+++ b/airflow/providers/google/cloud/operators/text_to_speech.py
@@ -81,7 +81,7 @@ class CloudTextToSpeechSynthesizeOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         input_data: Union[Dict, SynthesisInput],
         voice: Union[Dict, VoiceSelectionParams],
         audio_config: Union[Dict, AudioConfig],

--- a/airflow/providers/google/cloud/operators/translate.py
+++ b/airflow/providers/google/cloud/operators/translate.py
@@ -79,7 +79,7 @@ class CloudTranslateTextOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         values: Union[List[str], str],
         target_language: str,
         format_: str,

--- a/airflow/providers/google/cloud/operators/translate_speech.py
+++ b/airflow/providers/google/cloud/operators/translate_speech.py
@@ -103,7 +103,7 @@ class CloudTranslateSpeechOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         audio: RecognitionAudio,
         config: RecognitionConfig,
         target_language: str,

--- a/airflow/providers/google/cloud/operators/video_intelligence.py
+++ b/airflow/providers/google/cloud/operators/video_intelligence.py
@@ -27,6 +27,7 @@ from google.protobuf.json_format import MessageToDict
 
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.video_intelligence import CloudVideoIntelligenceHook
+from airflow.utils.decorators import apply_defaults
 
 
 class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
@@ -68,8 +69,9 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
     template_fields = ("input_uri", "output_uri", "gcp_conn_id")
     # [END gcp_video_intelligence_detect_labels_template_fields]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         input_uri: str,
         input_content: Optional[bytes] = None,
         output_uri: Optional[str] = None,
@@ -146,8 +148,9 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
     template_fields = ("input_uri", "output_uri", "gcp_conn_id")
     # [END gcp_video_intelligence_detect_explicit_content_template_fields]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         input_uri: str,
         output_uri: Optional[str] = None,
         input_content: Optional[bytes] = None,
@@ -224,8 +227,9 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
     template_fields = ("input_uri", "output_uri", "gcp_conn_id")
     # [END gcp_video_intelligence_detect_video_shots_template_fields]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         input_uri: str,
         output_uri: Optional[str] = None,
         input_content: Optional[bytes] = None,

--- a/airflow/providers/google/cloud/operators/vision.py
+++ b/airflow/providers/google/cloud/operators/vision.py
@@ -75,7 +75,7 @@ class CloudVisionCreateProductSetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         product_set: Union[dict, ProductSet],
         location: str,
         project_id: Optional[str] = None,
@@ -150,7 +150,7 @@ class CloudVisionGetProductSetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         product_set_id: str,
         project_id: Optional[str] = None,
@@ -234,7 +234,7 @@ class CloudVisionUpdateProductSetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         product_set: Union[Dict, ProductSet],
         location: Optional[str] = None,
         product_set_id: Optional[str] = None,
@@ -307,7 +307,7 @@ class CloudVisionDeleteProductSetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         product_set_id: str,
         project_id: Optional[str] = None,
@@ -384,7 +384,7 @@ class CloudVisionCreateProductOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         product: str,
         project_id: Optional[str] = None,
@@ -462,7 +462,7 @@ class CloudVisionGetProductOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         product_id: str,
         project_id: Optional[str] = None,
@@ -557,7 +557,7 @@ class CloudVisionUpdateProductOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         product: Union[Dict, Product],
         location: Optional[str] = None,
         product_id: Optional[str] = None,
@@ -635,7 +635,7 @@ class CloudVisionDeleteProductOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         product_id: str,
         project_id: Optional[str] = None,
@@ -695,7 +695,7 @@ class CloudVisionImageAnnotateOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         request: Union[Dict, AnnotateImageRequest],
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
@@ -774,7 +774,7 @@ class CloudVisionCreateReferenceImageOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         reference_image: Union[Dict, ReferenceImage],
         product_id: str,
@@ -863,7 +863,7 @@ class CloudVisionDeleteReferenceImageOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         location: str,
         product_id: str,
         reference_image_id: str,
@@ -939,7 +939,7 @@ class CloudVisionAddProductToProductSetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         product_set_id: str,
         product_id: str,
         location: str,
@@ -1009,7 +1009,7 @@ class CloudVisionRemoveProductFromProductSetOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         product_set_id: str,
         product_id: str,
         location: str,

--- a/airflow/providers/google/firebase/operators/firestore.py
+++ b/airflow/providers/google/firebase/operators/firestore.py
@@ -52,6 +52,7 @@ class CloudFirestoreExportDatabaseOperator(BaseOperator):
     @apply_defaults
     def __init__(
         self,
+        *,
         body: Dict,
         database_id: str = "(default)",
         project_id: Optional[str] = None,

--- a/airflow/providers/google/marketing_platform/operators/analytics.py
+++ b/airflow/providers/google/marketing_platform/operators/analytics.py
@@ -55,7 +55,7 @@ class GoogleAnalyticsListAccountsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         api_version: str = "v3",
         gcp_conn_id: str = "google_cloud_default",
         **kwargs
@@ -103,7 +103,7 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         account_id: str,
         web_property_ad_words_link_id: str,
         web_property_id: str,
@@ -158,7 +158,7 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         account_id: str,
         web_property_id: str,
         api_version: str = "v3",
@@ -213,7 +213,7 @@ class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         storage_bucket: str,
         storage_name_object: str,
         account_id: str,

--- a/airflow/providers/google/marketing_platform/operators/campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/operators/campaign_manager.py
@@ -70,7 +70,7 @@ class GoogleCampaignManagerDeleteReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         profile_id: str,
         report_name: Optional[str] = None,
         report_id: Optional[str] = None,
@@ -163,7 +163,7 @@ class GoogleCampaignManagerDownloadReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         profile_id: str,
         report_id: str,
         file_id: str,
@@ -281,7 +281,7 @@ class GoogleCampaignManagerInsertReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         profile_id: str,
         report: Dict[str, Any],
         api_version: str = "v3.3",
@@ -356,7 +356,7 @@ class GoogleCampaignManagerRunReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         profile_id: str,
         report_id: str,
         synchronous: bool = False,
@@ -438,7 +438,7 @@ class GoogleCampaignManagerBatchInsertConversionsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         profile_id: str,
         conversions: List[Dict[str, Any]],
         encryption_entity_type: str,
@@ -525,7 +525,7 @@ class GoogleCampaignManagerBatchUpdateConversionsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         profile_id: str,
         conversions: List[Dict[str, Any]],
         encryption_entity_type: str,

--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -62,7 +62,7 @@ class GoogleDisplayVideo360CreateReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         body: Dict[str, Any],
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
@@ -124,7 +124,7 @@ class GoogleDisplayVideo360DeleteReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         report_id: Optional[str] = None,
         report_name: Optional[str] = None,
         api_version: str = "v1",
@@ -204,7 +204,7 @@ class GoogleDisplayVideo360DownloadReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         report_id: str,
         bucket_name: str,
         report_name: Optional[str] = None,
@@ -309,7 +309,7 @@ class GoogleDisplayVideo360RunReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         report_id: str,
         params: Dict[str, Any],
         api_version: str = "v1",
@@ -360,7 +360,7 @@ class GoogleDisplayVideo360DownloadLineItemsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         request_body: Dict[str, Any],
         bucket_name: str,
         object_name: str,
@@ -435,7 +435,7 @@ class GoogleDisplayVideo360UploadLineItemsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         bucket_name: str,
         object_name: str,
         api_version: str = "v1.1",
@@ -506,7 +506,7 @@ class GoogleDisplayVideo360CreateSDFDownloadTaskOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         body_request: Dict[str, Any],
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
@@ -569,7 +569,7 @@ class GoogleDisplayVideo360SDFtoGCSOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         operation_name: str,
         bucket_name: str,
         object_name: str,

--- a/airflow/providers/google/marketing_platform/operators/search_ads.py
+++ b/airflow/providers/google/marketing_platform/operators/search_ads.py
@@ -57,7 +57,7 @@ class GoogleSearchAdsInsertReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         report: Dict[str, Any],
         api_version: str = "v2",
         gcp_conn_id: str = "google_cloud_default",
@@ -124,7 +124,7 @@ class GoogleSearchAdsDownloadReportOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         report_id: str,
         bucket_name: str,
         report_name: Optional[str] = None,

--- a/airflow/providers/google/suite/operators/sheets.py
+++ b/airflow/providers/google/suite/operators/sheets.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.google.suite.hooks.sheets import GSheetsHook
+from airflow.utils.decorators import apply_defaults
 
 
 class GoogleSheetsCreateSpreadsheetOperator(BaseOperator):
@@ -40,8 +41,9 @@ class GoogleSheetsCreateSpreadsheetOperator(BaseOperator):
 
     template_fields = ["spreadsheet"]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         spreadsheet: Dict[str, Any],
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,

--- a/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
@@ -78,17 +78,16 @@ class GCSToGoogleDriveOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         source_bucket: str,
         source_object: str,
         destination_object: Optional[str] = None,
         move_object: bool = False,
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
-        *args,
         **kwargs
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.source_bucket = source_bucket
         self.source_object = source_object

--- a/airflow/providers/google/suite/transfers/gcs_to_sheets.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_sheets.py
@@ -22,6 +22,7 @@ from typing import Any, Optional
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.suite.hooks.sheets import GSheetsHook
+from airflow.utils.decorators import apply_defaults
 
 
 class GCSToGoogleSheetsOperator(BaseOperator):
@@ -53,18 +54,18 @@ class GCSToGoogleSheetsOperator(BaseOperator):
         "spreadsheet_range",
     ]
 
+    @apply_defaults
     def __init__(
-        self,
+        self, *,
         spreadsheet_id: str,
         bucket_name: str,
         object_name: Optional[str] = None,
         spreadsheet_range: str = "Sheet1",
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
-        *args,
         **kwargs,
     ) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.gcp_conn_id = gcp_conn_id
         self.spreadsheet_id = spreadsheet_id

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -83,7 +83,7 @@ class TestGoogleCloudPlatformContainerOperator(unittest.TestCase):
                                      body=body,
                                      task_id=PROJECT_TASK_ID)
 
-    # pylint: disable=no-value-for-parameter
+    # pylint: disable=missing-kwoa
     @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.GKEHook')
     def test_create_execute_error_project_id(self, mock_hook):
         with self.assertRaises(AirflowException):
@@ -118,7 +118,7 @@ class TestGoogleCloudPlatformContainerOperator(unittest.TestCase):
                                      name=CLUSTER_NAME,
                                      task_id=PROJECT_TASK_ID)
 
-    # pylint: disable=no-value-for-parameter
+    # pylint: disable=missing-kwoa
     @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.GKEHook')
     def test_delete_execute_error_cluster_name(self, mock_hook):
         with self.assertRaises(AirflowException):
@@ -126,7 +126,7 @@ class TestGoogleCloudPlatformContainerOperator(unittest.TestCase):
                                      location=PROJECT_LOCATION,
                                      task_id=PROJECT_TASK_ID)
 
-    # pylint: disable=no-value-for-parameter
+    # pylint: disable=missing-kwoa
     @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.GKEHook')
     def test_delete_execute_error_location(self, mock_hook):
         with self.assertRaises(AirflowException):

--- a/tests/providers/google/cloud/operators/test_speech_to_text.py
+++ b/tests/providers/google/cloud/operators/test_speech_to_text.py
@@ -48,7 +48,7 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.return_value.recognize_speech.return_value = True
 
         with self.assertRaises(AirflowException) as e:
-            CloudSpeechToTextRecognizeSpeechOperator(  # pylint: disable=no-value-for-parameter
+            CloudSpeechToTextRecognizeSpeechOperator(  # pylint: disable=missing-kwoa
                 project_id=PROJECT_ID, gcp_conn_id=GCP_CONN_ID, audio=AUDIO, task_id="id"
             ).execute(context={"task_instance": Mock()})
 
@@ -61,7 +61,7 @@ class TestCloudSql(unittest.TestCase):
         mock_hook.return_value.recognize_speech.return_value = True
 
         with self.assertRaises(AirflowException) as e:
-            CloudSpeechToTextRecognizeSpeechOperator(  # pylint: disable=no-value-for-parameter
+            CloudSpeechToTextRecognizeSpeechOperator(  # pylint: disable=missing-kwoa
                 project_id=PROJECT_ID, gcp_conn_id=GCP_CONN_ID, config=CONFIG, task_id="id"
             ).execute(context={"task_instance": Mock()})
 


### PR DESCRIPTION
This PR closes part of #9942, It enforces keyword-only arguments for google provider operators

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
