### PR TITLE
Add typing coverage and fix small bug in sqlite

### DIFF
--- a/airflow/providers/sqlite/hooks/sqlite.py
+++ b/airflow/providers/sqlite/hooks/sqlite.py
@@ -29,7 +29,7 @@ class SqliteHook(DbApiHook):
     conn_name_attr = 'sqlite_conn_id'
     default_conn_name = 'sqlite_default'
 
-    def get_conn(self):
+    def get_conn(self) -> sqlite3.dbapi2.Connection:
         """
         Returns a sqlite connection object
         """

--- a/airflow/providers/sqlite/hooks/sqlite.py
+++ b/airflow/providers/sqlite/hooks/sqlite.py
@@ -28,12 +28,12 @@ class SqliteHook(DbApiHook):
 
     conn_name_attr = 'sqlite_conn_id'
     default_conn_name = 'sqlite_default'
-    supports_autocommit = False
 
     def get_conn(self):
         """
         Returns a sqlite connection object
         """
-        conn = self.get_connection(self.sqlite_conn_id)  # pylint: disable=no-member
-        conn = sqlite3.connect(conn.host)
+        conn_id = getattr(self, self.conn_name_attr)
+        airflow_conn = self.get_connection(conn_id)
+        conn = sqlite3.connect(airflow_conn.host)
         return conn

--- a/airflow/providers/sqlite/operators/sqlite.py
+++ b/airflow/providers/sqlite/operators/sqlite.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Iterable, Mapping, Optional, Union
+from typing import Any, Iterable, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
@@ -51,7 +51,7 @@ class SqliteOperator(BaseOperator):
         self.sql = sql
         self.parameters = parameters or []
 
-    def execute(self, context):
+    def execute(self, context: Mapping[Any, Any]) -> None:
         self.log.info('Executing: %s', self.sql)
         hook = SqliteHook(sqlite_conn_id=self.sqlite_conn_id)
         hook.run(self.sql, parameters=self.parameters)

--- a/tests/providers/sqlite/hooks/test_sqlite.py
+++ b/tests/providers/sqlite/hooks/test_sqlite.py
@@ -32,7 +32,7 @@ class TestSqliteHookConn(unittest.TestCase):
         self.connection = Connection(host='host')
 
         class UnitTestSqliteHook(SqliteHook):
-            conn_name_attr = 'sqlite_conn_id'
+            conn_name_attr = 'test_conn_id'
 
         self.db_hook = UnitTestSqliteHook()
         self.db_hook.get_connection = mock.Mock()
@@ -42,6 +42,13 @@ class TestSqliteHookConn(unittest.TestCase):
     def test_get_conn(self, mock_connect):
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with('host')
+
+    @patch('airflow.providers.sqlite.hooks.sqlite.sqlite3.connect')
+    def test_get_conn_non_default_id(self, mock_connect):
+        self.db_hook.test_conn_id = 'non_default'
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with('host')
+        self.db_hook.get_connection.assert_called_once_with('non_default')
 
 
 class TestSqliteHook(unittest.TestCase):

--- a/tests/providers/sqlite/hooks/test_sqlite.py
+++ b/tests/providers/sqlite/hooks/test_sqlite.py
@@ -45,7 +45,7 @@ class TestSqliteHookConn(unittest.TestCase):
 
     @patch('airflow.providers.sqlite.hooks.sqlite.sqlite3.connect')
     def test_get_conn_non_default_id(self, mock_connect):
-        self.db_hook.test_conn_id = 'non_default'
+        self.db_hook.test_conn_id = 'non_default'  # pylint: disable=attribute-defined-outside-init
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with('host')
         self.db_hook.get_connection.assert_called_once_with('non_default')


### PR DESCRIPTION
1. Fix small bug that kept subclasses of `SqliteHook` from being able to use a custom `conn_name_attr`.
2. Remove unnecessary class attribute `supports_autocommit` [since the same value is provided in the parent class `DbApiHook`](https://github.com/apache/airflow/blob/a6db84afe1b2824149f735105665da39c2d7b6db/airflow/hooks/dbapi_hook.py#L54)
3. Finish adding type annotations to the hook and operator

This one was pretty interesting. I actually created https://github.com/apache/airflow/issues/10147 and then started adding the type annotations. Then the `mypy` check helped uncover the bug, too!

```bash
airflow/providers/sqlite/hooks/sqlite.py:37: error: "SqliteHook" has no attribute "sqlite_conn_id"
            conn = self.get_connection(self.sqlite_conn_id)  # pylint: disable=no-member
                                       ^
```

`mypy` also got confused by having two different variables called `conn`:

```bash
airflow/providers/sqlite/hooks/sqlite.py:38: error: Incompatible types in assignment (expression has type
"sqlite3.dbapi2.Connection", variable has type "airflow.models.connection.Connection")
            conn = sqlite3.connect(conn.host)
                   ^
```

Changing the airflow `Connection` object to `airflow_conn` helped clear that up.

closes: #10147
related: #9708

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
