### PR TITLE
Acquire lock on db for the time of migration

### DIFF
--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -99,7 +99,15 @@ def run_migrations_online():
         )
 
         with context.begin_transaction():
+            if connection.dialect.name == 'mysql' and connection.dialect.server_version_info >= (5, 6):
+                connection.execute("select GET_LOCK('alembic',1800);")
+            if connection.dialect.name == 'postgresql':
+                context.get_context()._ensure_version_table()  # pylint: disable=protected-access
+                connection.execute("LOCK TABLE alembic_version IN ACCESS EXCLUSIVE MODE")
             context.run_migrations()
+            if connection.dialect.name == 'mysql' and connection.dialect.server_version_info >= (5, 6):
+                connection.execute("select RELEASE_LOCK('alembic');")
+            # for Postgres lock is released when transaction ends
 
 
 if context.is_offline_mode():


### PR DESCRIPTION
We have a situation when both web server and k8s airflow-initdb can
start migrations at the same time.

Alembic in no way supports concurrent migrations.

The solution is based on https://github.com/sqlalchemy/alembic/issues/633

Change-Id: I5b894c947ec2e56efab622357e160e7c300b7b99

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
