### PR TITLE
[GH-10147] Use conn_name_attr for SqliteHook connection

### DIFF
--- a/airflow/providers/sqlite/hooks/sqlite.py
+++ b/airflow/providers/sqlite/hooks/sqlite.py
@@ -28,12 +28,12 @@ class SqliteHook(DbApiHook):
 
     conn_name_attr = 'sqlite_conn_id'
     default_conn_name = 'sqlite_default'
-    supports_autocommit = False
 
     def get_conn(self):
         """
         Returns a sqlite connection object
         """
-        conn = self.get_connection(self.sqlite_conn_id)  # pylint: disable=no-member
-        conn = sqlite3.connect(conn.host)
+        conn_id = getattr(self, self.conn_name_attr)
+        airflow_conn = self.get_connection(conn_id)
+        conn = sqlite3.connect(airflow_conn.host)
         return conn

--- a/tests/providers/sqlite/hooks/test_sqlite.py
+++ b/tests/providers/sqlite/hooks/test_sqlite.py
@@ -32,7 +32,7 @@ class TestSqliteHookConn(unittest.TestCase):
         self.connection = Connection(host='host')
 
         class UnitTestSqliteHook(SqliteHook):
-            conn_name_attr = 'sqlite_conn_id'
+            conn_name_attr = 'test_conn_id'
 
         self.db_hook = UnitTestSqliteHook()
         self.db_hook.get_connection = mock.Mock()
@@ -42,6 +42,13 @@ class TestSqliteHookConn(unittest.TestCase):
     def test_get_conn(self, mock_connect):
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with('host')
+
+    @patch('airflow.providers.sqlite.hooks.sqlite.sqlite3.connect')
+    def test_get_conn_non_default_id(self, mock_connect):
+        self.db_hook.test_conn_id = 'non_default'  # pylint: disable=attribute-defined-outside-init
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with('host')
+        self.db_hook.get_connection.assert_called_once_with('non_default')
 
 
 class TestSqliteHook(unittest.TestCase):


### PR DESCRIPTION
`DbApiHook` allows for a `conn_name_attr` to be changed in subclasses, however `SqliteHook`'s `get_conn` method is always calling the main class attribute. Find the correct attribute and use this to establish the connection.

Add pylint override to allow attribute setting outside init for test case.

This PR came out of https://github.com/apache/airflow/pull/10148.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
