### PR TITLE
[GH-9708] Add type annotations to sqlite modules

### DIFF
--- a/airflow/providers/sqlite/hooks/sqlite.py
+++ b/airflow/providers/sqlite/hooks/sqlite.py
@@ -29,7 +29,7 @@ class SqliteHook(DbApiHook):
     conn_name_attr = 'sqlite_conn_id'
     default_conn_name = 'sqlite_default'
 
-    def get_conn(self):
+    def get_conn(self) -> sqlite3.dbapi2.Connection:
         """
         Returns a sqlite connection object
         """

--- a/airflow/providers/sqlite/operators/sqlite.py
+++ b/airflow/providers/sqlite/operators/sqlite.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Iterable, Mapping, Optional, Union
+from typing import Any, Iterable, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
@@ -51,7 +51,7 @@ class SqliteOperator(BaseOperator):
         self.sql = sql
         self.parameters = parameters or []
 
-    def execute(self, context):
+    def execute(self, context: Mapping[Any, Any]) -> None:
         self.log.info('Executing: %s', self.sql)
         hook = SqliteHook(sqlite_conn_id=self.sqlite_conn_id)
         hook.run(self.sql, parameters=self.parameters)


### PR DESCRIPTION
Add type annotation to the sqlite modules.

Note that for the checks to pass, https://github.com/apache/airflow/pull/10156 will need to be merged in first with this rebased on top.

related: #9708 and https://github.com/apache/airflow/issues/10147

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
