### PR TITLE
Add correct signatures for operators in amazon provider package

### DIFF
--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -58,7 +58,7 @@ class AWSAthenaOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-        self,
+        self, *,
         query: str,
         database: str,
         output_location: str,

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -99,7 +99,7 @@ class AwsBatchOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         job_name,
         job_definition,
         job_queue,

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -45,7 +45,7 @@ class CloudFormationCreateStackOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             stack_name,
             params,
             aws_conn_id='aws_default',
@@ -83,7 +83,7 @@ class CloudFormationDeleteStackOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             stack_name,
             params=None,
             aws_conn_id='aws_default',

--- a/airflow/providers/amazon/aws/operators/datasync.py
+++ b/airflow/providers/amazon/aws/operators/datasync.py
@@ -107,7 +107,7 @@ class AWSDataSyncOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         aws_conn_id="aws_default",
         wait_interval_seconds=5,
         task_arn=None,

--- a/airflow/providers/amazon/aws/operators/ec2_start_instance.py
+++ b/airflow/providers/amazon/aws/operators/ec2_start_instance.py
@@ -44,7 +44,7 @@ class EC2StartInstanceOperator(BaseOperator):
     ui_fgcolor = "#ffffff"
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  aws_conn_id: str = "aws_default",
                  region_name: Optional[str] = None,

--- a/airflow/providers/amazon/aws/operators/ec2_stop_instance.py
+++ b/airflow/providers/amazon/aws/operators/ec2_stop_instance.py
@@ -44,7 +44,7 @@ class EC2StopInstanceOperator(BaseOperator):
     ui_fgcolor = "#ffffff"
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  instance_id: str,
                  aws_conn_id: str = "aws_default",
                  region_name: Optional[str] = None,

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -113,7 +113,7 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
     template_fields = ('overrides',)
 
     @apply_defaults
-    def __init__(self, task_definition, cluster, overrides,  # pylint: disable=too-many-arguments
+    def __init__(self, *, task_definition, cluster, overrides,  # pylint: disable=too-many-arguments
                  aws_conn_id=None, region_name=None, launch_type='EC2',
                  group=None, placement_constraints=None, platform_version='LATEST',
                  network_configuration=None, tags=None, awslogs_group=None,

--- a/airflow/providers/amazon/aws/operators/emr_add_steps.py
+++ b/airflow/providers/amazon/aws/operators/emr_add_steps.py
@@ -50,7 +50,7 @@ class EmrAddStepsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             job_flow_id=None,
             job_flow_name=None,
             cluster_states=None,

--- a/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
@@ -43,7 +43,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             aws_conn_id='aws_default',
             emr_conn_id='emr_default',
             job_flow_overrides=None,

--- a/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
+++ b/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
@@ -39,7 +39,7 @@ class EmrModifyClusterOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             cluster_id: str,
             step_concurrency_level: int,
             aws_conn_id: str = 'aws_default',

--- a/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
@@ -36,7 +36,7 @@ class EmrTerminateJobFlowOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             job_flow_id,
             aws_conn_id='aws_default',
             **kwargs):

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -57,7 +57,7 @@ class AwsGlueJobOperator(BaseOperator):
     ui_color = '#ededed'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  job_name='aws_glue_default_job',
                  job_desc='AWS Glue Job with Airflow',
                  script_location=None,

--- a/airflow/providers/amazon/aws/operators/s3_bucket.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.utils.decorators import apply_defaults
 
 
 class S3CreateBucketOperator(BaseOperator):
@@ -39,7 +40,8 @@ class S3CreateBucketOperator(BaseOperator):
     :param region_name: AWS region_name. If not specified fetched from connection.
     :type region_name: Optional[str]
     """
-    def __init__(self,
+    @apply_defaults
+    def __init__(self, *,
                  bucket_name,
                  aws_conn_id: Optional[str] = "aws_default",
                  region_name: Optional[str] = None,

--- a/airflow/providers/amazon/aws/operators/s3_copy_object.py
+++ b/airflow/providers/amazon/aws/operators/s3_copy_object.py
@@ -69,7 +69,7 @@ class S3CopyObjectOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             source_bucket_key,
             dest_bucket_key,
             source_bucket_name=None,

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -63,7 +63,7 @@ class S3DeleteObjectsOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             bucket,
             keys=None,
             prefix=None,

--- a/airflow/providers/amazon/aws/operators/s3_file_transform.py
+++ b/airflow/providers/amazon/aws/operators/s3_file_transform.py
@@ -84,7 +84,7 @@ class S3FileTransformOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             source_s3_key: str,
             dest_s3_key: str,
             transform_script: Optional[str] = None,

--- a/airflow/providers/amazon/aws/operators/s3_list.py
+++ b/airflow/providers/amazon/aws/operators/s3_list.py
@@ -69,7 +69,7 @@ class S3ListOperator(BaseOperator):
     ui_color = '#ffd700'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket,
                  prefix='',
                  delimiter='',

--- a/airflow/providers/amazon/aws/operators/sagemaker_base.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_base.py
@@ -41,7 +41,7 @@ class SageMakerBaseOperator(BaseOperator):
     integer_fields = []  # type: Iterable[Iterable[str]]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  config,
                  aws_conn_id='aws_default',
                  **kwargs):

--- a/airflow/providers/amazon/aws/operators/sagemaker_endpoint.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_endpoint.py
@@ -71,7 +71,7 @@ class SageMakerEndpointOperator(SageMakerBaseOperator):
     """
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  config,
                  wait_for_completion=True,
                  check_interval=30,

--- a/airflow/providers/amazon/aws/operators/sagemaker_endpoint_config.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_endpoint_config.py
@@ -40,7 +40,7 @@ class SageMakerEndpointConfigOperator(SageMakerBaseOperator):
     ]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  config,
                  **kwargs):
         super().__init__(config=config,

--- a/airflow/providers/amazon/aws/operators/sagemaker_model.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_model.py
@@ -37,7 +37,7 @@ class SageMakerModelOperator(SageMakerBaseOperator):
     """
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  config,
                  **kwargs):
         super().__init__(config=config,

--- a/airflow/providers/amazon/aws/operators/sagemaker_processing.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_processing.py
@@ -52,7 +52,7 @@ class SageMakerProcessingOperator(SageMakerBaseOperator):
     """
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  config,
                  aws_conn_id,
                  wait_for_completion=True,

--- a/airflow/providers/amazon/aws/operators/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_training.py
@@ -58,7 +58,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
     ]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  config,
                  wait_for_completion=True,
                  print_log=True,

--- a/airflow/providers/amazon/aws/operators/sagemaker_transform.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_transform.py
@@ -62,7 +62,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
     """
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  config,
                  wait_for_completion=True,
                  check_interval=30,

--- a/airflow/providers/amazon/aws/operators/sagemaker_tuning.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_tuning.py
@@ -55,7 +55,7 @@ class SageMakerTuningOperator(SageMakerBaseOperator):
     ]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  config,
                  wait_for_completion=True,
                  check_interval=30,

--- a/airflow/providers/amazon/aws/operators/sns.py
+++ b/airflow/providers/amazon/aws/operators/sns.py
@@ -44,7 +44,7 @@ class SnsPublishOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             target_arn,
             message,
             aws_conn_id='aws_default',

--- a/airflow/providers/amazon/aws/operators/sqs.py
+++ b/airflow/providers/amazon/aws/operators/sqs.py
@@ -42,7 +42,7 @@ class SQSPublishOperator(BaseOperator):
     ui_color = '#6ad3fa'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  sqs_queue,
                  message_content,
                  message_attributes=None,

--- a/airflow/providers/amazon/aws/operators/step_function_get_execution_output.py
+++ b/airflow/providers/amazon/aws/operators/step_function_get_execution_output.py
@@ -41,7 +41,7 @@ class StepFunctionGetExecutionOutputOperator(BaseOperator):
     ui_color = '#f9c915'
 
     @apply_defaults
-    def __init__(self, execution_arn: str, aws_conn_id='aws_default', region_name=None, **kwargs):
+    def __init__(self, *, execution_arn: str, aws_conn_id='aws_default', region_name=None, **kwargs):
         super().__init__(**kwargs)
         self.execution_arn = execution_arn
         self.aws_conn_id = aws_conn_id

--- a/airflow/providers/amazon/aws/operators/step_function_start_execution.py
+++ b/airflow/providers/amazon/aws/operators/step_function_start_execution.py
@@ -48,7 +48,7 @@ class StepFunctionStartExecutionOperator(BaseOperator):
     ui_color = '#f9c915'
 
     @apply_defaults
-    def __init__(self, state_machine_arn: str, name: Optional[str] = None,
+    def __init__(self, *, state_machine_arn: str, name: Optional[str] = None,
                  state_machine_input: Union[dict, str, None] = None,
                  aws_conn_id='aws_default', region_name=None,
                  **kwargs):

--- a/airflow/providers/amazon/aws/sensors/athena.py
+++ b/airflow/providers/amazon/aws/sensors/athena.py
@@ -51,13 +51,13 @@ class AthenaSensor(BaseSensorOperator):
     ui_color = '#66c3ff'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  query_execution_id: str,
                  max_retries: Optional[int] = None,
                  aws_conn_id: str = 'aws_default',
                  sleep_time: int = 10,
-                 *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+                 **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         self.aws_conn_id = aws_conn_id
         self.query_execution_id = query_execution_id
         self.sleep_time = sleep_time

--- a/airflow/providers/amazon/aws/sensors/cloud_formation.py
+++ b/airflow/providers/amazon/aws/sensors/cloud_formation.py
@@ -40,13 +40,12 @@ class CloudFormationCreateStackSensor(BaseSensorOperator):
     ui_color = '#C5CAE9'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  stack_name,
                  aws_conn_id='aws_default',
                  region_name=None,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.stack_name = stack_name
         self.hook = AWSCloudFormationHook(aws_conn_id=aws_conn_id, region_name=region_name)
 
@@ -76,13 +75,12 @@ class CloudFormationDeleteStackSensor(BaseSensorOperator):
     ui_color = '#C5CAE9'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  stack_name,
                  aws_conn_id='aws_default',
                  region_name=None,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.aws_conn_id = aws_conn_id
         self.region_name = region_name
         self.stack_name = stack_name

--- a/airflow/providers/amazon/aws/sensors/ec2_instance_state.py
+++ b/airflow/providers/amazon/aws/sensors/ec2_instance_state.py
@@ -43,16 +43,15 @@ class EC2InstanceStateSensor(BaseSensorOperator):
     valid_states = ["running", "stopped", "terminated"]
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  target_state: str,
                  instance_id: str,
                  aws_conn_id: str = "aws_default",
                  region_name: Optional[str] = None,
-                 *args,
                  **kwargs):
         if target_state not in self.valid_states:
             raise ValueError(f"Invalid target_state: {target_state}")
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.target_state = target_state
         self.instance_id = instance_id
         self.aws_conn_id = aws_conn_id

--- a/airflow/providers/amazon/aws/sensors/emr_base.py
+++ b/airflow/providers/amazon/aws/sensors/emr_base.py
@@ -42,10 +42,10 @@ class EmrBaseSensor(BaseSensorOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             aws_conn_id='aws_default',
-            *args, **kwargs):
-        super().__init__(*args, **kwargs)
+            **kwargs):
+        super().__init__(**kwargs)
         self.aws_conn_id = aws_conn_id
         self.target_states = None  # will be set in subclasses
         self.failed_states = None  # will be set in subclasses

--- a/airflow/providers/amazon/aws/sensors/emr_job_flow.py
+++ b/airflow/providers/amazon/aws/sensors/emr_job_flow.py
@@ -46,13 +46,12 @@ class EmrJobFlowSensor(EmrBaseSensor):
     template_ext = ()
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  job_flow_id: str,
                  target_states: Optional[Iterable[str]] = None,
                  failed_states: Optional[Iterable[str]] = None,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.job_flow_id = job_flow_id
         self.target_states = target_states or ['TERMINATED']
         self.failed_states = failed_states or ['TERMINATED_WITH_ERRORS']

--- a/airflow/providers/amazon/aws/sensors/emr_step.py
+++ b/airflow/providers/amazon/aws/sensors/emr_step.py
@@ -46,14 +46,13 @@ class EmrStepSensor(EmrBaseSensor):
     template_ext = ()
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  job_flow_id: str,
                  step_id: str,
                  target_states: Optional[Iterable[str]] = None,
                  failed_states: Optional[Iterable[str]] = None,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.job_flow_id = job_flow_id
         self.step_id = step_id
         self.target_states = target_states or ['COMPLETED']

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -35,13 +35,12 @@ class AwsGlueJobSensor(BaseSensorOperator):
     template_fields = ('job_name', 'run_id')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  job_name,
                  run_id,
                  aws_conn_id='aws_default',
-                 *args,
                  **kwargs):
-        super(AwsGlueJobSensor, self).__init__(*args, **kwargs)
+        super(AwsGlueJobSensor, self).__init__(**kwargs)
         self.job_name = job_name
         self.run_id = run_id
         self.aws_conn_id = aws_conn_id

--- a/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
+++ b/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
@@ -51,16 +51,15 @@ class AwsGlueCatalogPartitionSensor(BaseSensorOperator):
     ui_color = '#C5CAE9'
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  table_name, expression="ds='{{ ds }}'",
                  aws_conn_id='aws_default',
                  region_name=None,
                  database_name='default',
                  poke_interval=60 * 3,
-                 *args,
                  **kwargs):
         super().__init__(
-            poke_interval=poke_interval, *args, **kwargs)
+            poke_interval=poke_interval, **kwargs)
         self.aws_conn_id = aws_conn_id
         self.region_name = region_name
         self.table_name = table_name

--- a/airflow/providers/amazon/aws/sensors/redshift.py
+++ b/airflow/providers/amazon/aws/sensors/redshift.py
@@ -33,13 +33,12 @@ class AwsRedshiftClusterSensor(BaseSensorOperator):
     template_fields = ('cluster_identifier', 'target_status')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  cluster_identifier,
                  target_status='available',
                  aws_conn_id='aws_default',
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.cluster_identifier = cluster_identifier
         self.target_status = target_status
         self.aws_conn_id = aws_conn_id

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -58,15 +58,14 @@ class S3KeySensor(BaseSensorOperator):
     template_fields = ('bucket_key', 'bucket_name')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket_key,
                  bucket_name=None,
                  wildcard_match=False,
                  aws_conn_id='aws_default',
                  verify=None,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         # Parse
         if bucket_name is None:
             parsed_url = urlparse(bucket_key)

--- a/airflow/providers/amazon/aws/sensors/s3_keys_unchanged.py
+++ b/airflow/providers/amazon/aws/sensors/s3_keys_unchanged.py
@@ -72,7 +72,7 @@ class S3KeysUnchangedSensor(BaseSensorOperator):
     template_fields = ('bucket_name', 'prefix')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket_name: str,
                  prefix: str,
                  aws_conn_id: str = 'aws_default',
@@ -81,9 +81,9 @@ class S3KeysUnchangedSensor(BaseSensorOperator):
                  min_objects: int = 1,
                  previous_objects: Optional[Set[str]] = None,
                  allow_delete: bool = True,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
 
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.bucket = bucket_name
         self.prefix = prefix

--- a/airflow/providers/amazon/aws/sensors/s3_prefix.py
+++ b/airflow/providers/amazon/aws/sensors/s3_prefix.py
@@ -54,15 +54,14 @@ class S3PrefixSensor(BaseSensorOperator):
     template_fields = ('prefix', 'bucket_name')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  bucket_name,
                  prefix,
                  delimiter='/',
                  aws_conn_id='aws_default',
                  verify=None,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         # Parse
         self.bucket_name = bucket_name
         self.prefix = prefix

--- a/airflow/providers/amazon/aws/sensors/sagemaker_base.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_base.py
@@ -32,10 +32,10 @@ class SageMakerBaseSensor(BaseSensorOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             aws_conn_id='aws_default',
-            *args, **kwargs):
-        super().__init__(*args, **kwargs)
+            **kwargs):
+        super().__init__(**kwargs)
         self.aws_conn_id = aws_conn_id
         self.hook = None
 

--- a/airflow/providers/amazon/aws/sensors/sagemaker_endpoint.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_endpoint.py
@@ -34,11 +34,10 @@ class SageMakerEndpointSensor(SageMakerBaseSensor):
     template_ext = ()
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  endpoint_name,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.endpoint_name = endpoint_name
 
     def non_terminal_states(self):

--- a/airflow/providers/amazon/aws/sensors/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_training.py
@@ -38,12 +38,11 @@ class SageMakerTrainingSensor(SageMakerBaseSensor):
     template_ext = ()
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  job_name,
                  print_log=True,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.job_name = job_name
         self.print_log = print_log
         self.positions = {}

--- a/airflow/providers/amazon/aws/sensors/sagemaker_transform.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_transform.py
@@ -35,11 +35,10 @@ class SageMakerTransformSensor(SageMakerBaseSensor):
     template_ext = ()
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  job_name,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.job_name = job_name
 
     def non_terminal_states(self):

--- a/airflow/providers/amazon/aws/sensors/sagemaker_tuning.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_tuning.py
@@ -35,11 +35,10 @@ class SageMakerTuningSensor(SageMakerBaseSensor):
     template_ext = ()
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  job_name,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.job_name = job_name
 
     def non_terminal_states(self):

--- a/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/airflow/providers/amazon/aws/sensors/sqs.py
@@ -44,14 +44,13 @@ class SQSSensor(BaseSensorOperator):
     template_fields = ('sqs_queue', 'max_messages')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  sqs_queue,
                  aws_conn_id='aws_default',
                  max_messages=5,
                  wait_time_seconds=1,
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.sqs_queue = sqs_queue
         self.aws_conn_id = aws_conn_id
         self.max_messages = max_messages

--- a/airflow/providers/amazon/aws/sensors/step_function_execution.py
+++ b/airflow/providers/amazon/aws/sensors/step_function_execution.py
@@ -47,9 +47,9 @@ class StepFunctionExecutionSensor(BaseSensorOperator):
     ui_color = '#66c3ff'
 
     @apply_defaults
-    def __init__(self, execution_arn: str, aws_conn_id='aws_default', region_name=None,
-                 *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *, execution_arn: str, aws_conn_id='aws_default', region_name=None,
+                 **kwargs):
+        super().__init__(**kwargs)
         self.execution_arn = execution_arn
         self.aws_conn_id = aws_conn_id
         self.region_name = region_name

--- a/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
@@ -31,6 +31,7 @@ from uuid import uuid4
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.aws_dynamodb import AwsDynamoDBHook
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.utils.decorators import apply_defaults
 
 
 def _convert_item_to_json_bytes(item):
@@ -90,15 +91,16 @@ class DynamoDBToS3Operator(BaseOperator):
     :param process_func: How we transforms a dynamodb item to bytes. By default we dump the json
     """
 
-    def __init__(self,
+    @apply_defaults
+    def __init__(self, *,
                  dynamodb_table_name: str,
                  s3_bucket_name: str,
                  file_size: int,
                  dynamodb_scan_kwargs: Optional[Dict[str, Any]] = None,
                  s3_key_prefix: str = '',
                  process_func: Callable[[Dict[str, Any]], bytes] = _convert_item_to_json_bytes,
-                 *args, **kwargs):
-        super().__init__(*args, **kwargs)
+                 **kwargs):
+        super().__init__(**kwargs)
         self.file_size = file_size
         self.process_func = process_func
         self.dynamodb_table_name = dynamodb_table_name

--- a/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -78,7 +78,7 @@ class GCSToS3Operator(GCSListObjectsOperator):
     ui_color = '#f0eee4'
 
     @apply_defaults
-    def __init__(self,  # pylint: disable=too-many-arguments
+    def __init__(self, *,  # pylint: disable=too-many-arguments
                  bucket,
                  prefix=None,
                  delimiter=None,
@@ -89,7 +89,6 @@ class GCSToS3Operator(GCSListObjectsOperator):
                  dest_s3_key=None,
                  dest_verify=None,
                  replace=False,
-                 *args,
                  **kwargs):
 
         if google_cloud_storage_conn_id:
@@ -104,7 +103,6 @@ class GCSToS3Operator(GCSListObjectsOperator):
             delimiter=delimiter,
             gcp_conn_id=gcp_conn_id,
             delegate_to=delegate_to,
-            *args,
             **kwargs
         )
 

--- a/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
@@ -85,13 +85,13 @@ class GoogleApiToS3Operator(BaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
+        self, *,
         google_api_service_name,
         google_api_service_version,
         google_api_endpoint_path,
         google_api_endpoint_params,
         s3_destination_key,
-        *args,
+
         google_api_response_via_xcom=None,
         google_api_endpoint_params_via_xcom=None,
         google_api_endpoint_params_via_xcom_task_ids=None,
@@ -103,7 +103,7 @@ class GoogleApiToS3Operator(BaseOperator):
         aws_conn_id='aws_default',
         **kwargs
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.google_api_service_name = google_api_service_name
         self.google_api_service_version = google_api_service_version
         self.google_api_endpoint_path = google_api_endpoint_path

--- a/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
+++ b/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
@@ -62,7 +62,7 @@ class HiveToDynamoDBOperator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-            self,
+            self, *,
             sql,
             table_name,
             table_keys,
@@ -73,8 +73,8 @@ class HiveToDynamoDBOperator(BaseOperator):
             schema='default',
             hiveserver2_conn_id='hiveserver2_default',
             aws_conn_id='aws_default',
-            *args, **kwargs):
-        super().__init__(*args, **kwargs)
+            **kwargs):
+        super().__init__(**kwargs)
         self.sql = sql
         self.table_name = table_name
         self.table_keys = table_keys

--- a/airflow/providers/amazon/aws/transfers/imap_attachment_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/imap_attachment_to_s3.py
@@ -53,7 +53,7 @@ class ImapAttachmentToS3Operator(BaseOperator):
     template_fields = ('imap_attachment_name', 's3_key', 'imap_mail_filter')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  imap_attachment_name,
                  s3_key,
                  imap_check_regex=False,
@@ -62,9 +62,8 @@ class ImapAttachmentToS3Operator(BaseOperator):
                  s3_overwrite=False,
                  imap_conn_id='imap_default',
                  s3_conn_id='aws_default',
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.imap_attachment_name = imap_attachment_name
         self.s3_key = s3_key
         self.imap_check_regex = imap_check_regex

--- a/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -41,7 +41,7 @@ class MongoToS3Operator(BaseOperator):
     # pylint: disable=too-many-instance-attributes
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  mongo_conn_id,
                  s3_conn_id,
                  mongo_collection,
@@ -50,8 +50,8 @@ class MongoToS3Operator(BaseOperator):
                  s3_key,
                  mongo_db=None,
                  replace=False,
-                 *args, **kwargs):
-        super().__init__(*args, **kwargs)
+                 **kwargs):
+        super().__init__(**kwargs)
         # Conn Ids
         self.mongo_conn_id = mongo_conn_id
         self.s3_conn_id = s3_conn_id

--- a/airflow/providers/amazon/aws/transfers/mysql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mysql_to_s3.py
@@ -68,7 +68,7 @@ class MySQLToS3Operator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             query: str,
             s3_bucket: str,
             s3_key: str,
@@ -78,8 +78,8 @@ class MySQLToS3Operator(BaseOperator):
             pd_csv_kwargs: Optional[dict] = None,
             index: Optional[bool] = False,
             header: Optional[bool] = False,
-            *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+            **kwargs) -> None:
+        super().__init__(**kwargs)
         self.query = query
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key

--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -71,7 +71,7 @@ class RedshiftToS3Operator(BaseOperator):
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
-            self,
+            self, *,
             schema: str,
             table: str,
             s3_bucket: str,
@@ -83,8 +83,8 @@ class RedshiftToS3Operator(BaseOperator):
             autocommit: bool = False,
             include_header: bool = False,
             table_as_file_name: bool = True,  # Set to True by default for not breaking current workflows
-            *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+            **kwargs) -> None:
+        super().__init__(**kwargs)
         self.schema = schema
         self.table = table
         self.s3_bucket = s3_bucket

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -64,7 +64,7 @@ class S3ToRedshiftOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self,
+            self, *,
             schema: str,
             table: str,
             s3_bucket: str,
@@ -74,8 +74,8 @@ class S3ToRedshiftOperator(BaseOperator):
             verify: Optional[Union[bool, str]] = None,
             copy_options: Optional[List] = None,
             autocommit: bool = False,
-            *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+            **kwargs) -> None:
+        super().__init__(**kwargs)
         self.schema = schema
         self.table = table
         self.s3_bucket = s3_bucket

--- a/airflow/providers/amazon/aws/transfers/s3_to_sftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_sftp.py
@@ -49,15 +49,14 @@ class S3ToSFTPOperator(BaseOperator):
     template_fields = ('s3_key', 'sftp_path')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  s3_bucket,
                  s3_key,
                  sftp_path,
                  sftp_conn_id='ssh_default',
                  s3_conn_id='aws_default',
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.sftp_conn_id = sftp_conn_id
         self.sftp_path = sftp_path
         self.s3_bucket = s3_bucket

--- a/airflow/providers/amazon/aws/transfers/sftp_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sftp_to_s3.py
@@ -49,15 +49,14 @@ class SFTPToS3Operator(BaseOperator):
     template_fields = ('s3_key', 'sftp_path')
 
     @apply_defaults
-    def __init__(self,
+    def __init__(self, *,
                  s3_bucket,
                  s3_key,
                  sftp_path,
                  sftp_conn_id='ssh_default',
                  s3_conn_id='aws_default',
-                 *args,
                  **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.sftp_conn_id = sftp_conn_id
         self.sftp_path = sftp_path
         self.s3_bucket = s3_bucket


### PR DESCRIPTION
This PR closes part of #9942, It enforces keyword-only arguments for amazon provider operators
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
