### PR TITLE
Remove stat_name_handler attribute in plugins.rst

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -241,7 +241,6 @@ definitions in Airflow.
         flask_blueprints = [bp]
         appbuilder_views = [v_appbuilder_package]
         appbuilder_menu_items = [appbuilder_mitem]
-        stat_name_handler = staticmethod(stat_name_dummy_handler)
         global_operator_extra_links = [GoogleLink(),]
         operator_extra_links = [S3LogLink(), ]
 


### PR DESCRIPTION
We dropped plugin support for this. https://github.com/apache/airflow/blob/master/UPDATING.md#drop-plugin-support-for-stat_name_handler

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
