### PR TITLE
Chart rbac modifications

### DIFF
--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -19,7 +19,7 @@
 ## Airflow Pod Launcher Role
 #################################
 {{- if and .Values.rbacEnabled .Values.allowPodLaunching }}
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-pod-launcher-role

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -21,7 +21,7 @@
 {{- if and .Values.rbacEnabled .Values.allowPodLaunching }}
 {{- $grantScheduler := or (eq .Values.executor "LocalExecutor") (eq .Values.executor "SequentialExecutor") (eq .Values.executor "KubernetesExecutor") }}
 {{- $grantWorker := or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "KubernetesExecutor") }}
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-pod-launcher-rolebinding
@@ -35,7 +35,7 @@ metadata:
 {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ .Release.Name }}-pod-launcher-role
 subjects:
 {{- if $grantScheduler }}


### PR DESCRIPTION
I've tested it and in secured environments "ClusterRole" is often not allowed. What is the point of using here ClusterRole if for example in pod-cleanup-role.yaml is just a Role? It makes chart easier to use across corporations environements.