### PR TITLE
Deprecate BaseHook.get_connections method (#10135)

### DIFF
--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -47,6 +47,7 @@ class BaseHook(LoggingMixin):
             "`BaseHook.get_connections` method will be deprecated in the future."
             "Please use `BaseHook.get_connection` instead.",
             PendingDeprecationWarning,
+            stacklevel=2,
         )
         return [cls.get_connection(conn_id)]
 

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -17,6 +17,7 @@
 # under the License.
 """Base class for all hooks"""
 import logging
+import warnings
 from typing import Any, List
 
 from airflow.models.connection import Connection
@@ -42,7 +43,12 @@ class BaseHook(LoggingMixin):
         :param conn_id: connection id
         :return: array of connections
         """
-        return Connection.get_connections_from_secrets(conn_id)
+        warnings.warn(
+            "`BaseHook.get_connections` method will be deprecated in the future."
+            "Please use `BaseHook.get_connection` instead.",
+            PendingDeprecationWarning,
+        )
+        return [cls.get_connection(conn_id)]
 
     @classmethod
     def get_connection(cls, conn_id: str) -> Connection:
@@ -52,7 +58,7 @@ class BaseHook(LoggingMixin):
         :param conn_id: connection id
         :return: connection
         """
-        conn = cls.get_connections(conn_id)[0]
+        conn = Connection.get_connection_from_secrets(conn_id)
         if conn.host:
             log.info(
                 "Using connection to: id: %s. Host: %s, Port: %s, Schema: %s, Login: %s, Password: %s, "

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -19,7 +19,7 @@
 import json
 import warnings
 from json import JSONDecodeError
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse
 
 from sqlalchemy import Boolean, Column, Integer, String, Text
@@ -332,15 +332,15 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
         return obj
 
     @classmethod
-    def get_connections_from_secrets(cls, conn_id: str) -> List['Connection']:
+    def get_connection_from_secrets(cls, conn_id: str) -> 'Connection':
         """
-        Get all connections as an iterable.
+        Get connection by conn_id.
 
         :param conn_id: connection id
-        :return: array of connections
+        :return: connection
         """
         for secrets_backend in ensure_secrets_loaded():
-            conn_list = secrets_backend.get_connections(conn_id=conn_id)
-            if conn_list:
-                return list(conn_list)
+            conn = secrets_backend.get_connection(conn_id=conn_id)
+            if conn:
+                return conn
         raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -78,6 +78,7 @@ class BaseSecretsBackend(ABC):
             "This method is deprecated. Please use "
             "`airflow.secrets.base_secrets.BaseSecretsBackend.get_connection`.",
             PendingDeprecationWarning,
+            stacklevel=2,
         )
         conn = self.get_connection(conn_id=conn_id)
         if conn:

--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import warnings
 from abc import ABC
 from typing import TYPE_CHECKING, List, Optional
 
@@ -51,7 +52,7 @@ class BaseSecretsBackend(ABC):
         """
         raise NotImplementedError()
 
-    def get_connections(self, conn_id: str) -> List['Connection']:
+    def get_connection(self, conn_id: str) -> Optional['Connection']:
         """
         Return connection object with a given ``conn_id``.
 
@@ -62,9 +63,26 @@ class BaseSecretsBackend(ABC):
 
         conn_uri = self.get_conn_uri(conn_id=conn_id)
         if not conn_uri:
-            return []
+            return None
         conn = Connection(conn_id=conn_id, uri=conn_uri)
-        return [conn]
+        return conn
+
+    def get_connections(self, conn_id: str) -> List['Connection']:
+        """
+        Return connection object with a given ``conn_id``.
+
+        :param conn_id: connection id
+        :type conn_id: str
+        """
+        warnings.warn(
+            "This method is deprecated. Please use "
+            "`airflow.secrets.base_secrets.BaseSecretsBackend.get_connection`.",
+            PendingDeprecationWarning,
+        )
+        conn = self.get_connection(conn_id=conn_id)
+        if conn:
+            return [conn]
+        return []
 
     def get_variable(self, key: str) -> Optional[str]:
         """

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -330,6 +330,7 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
             "This method is deprecated. Please use "
             "`airflow.secrets.local_filesystem.LocalFilesystemBackend.get_connection`.",
             PendingDeprecationWarning,
+            stacklevel=2,
         )
         conn = self.get_connection(conn_id=conn_id)
         if conn:

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -23,7 +23,7 @@ import warnings
 from collections import defaultdict
 from inspect import signature
 from json import JSONDecodeError
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 import yaml
 
@@ -38,6 +38,9 @@ from airflow.utils.file import COMMENT_PATTERN
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
 
 
 def get_connection_parameter_names() -> Set[str]:
@@ -258,7 +261,7 @@ def load_connections_dict(file_path: str) -> Dict[str, Any]:
 
     ``JSON``, `YAML` and ``.env`` files are supported.
 
-    :return: A dictionary where the key contains a connection ID and the value contains a list of connections.
+    :return: A dictionary where the key contains a connection ID and the value contains the connection.
     :rtype: Dict[str, airflow.models.connection.Connection]
     """
     log.debug("Loading connection")
@@ -310,16 +313,27 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
         return secrets
 
     @property
-    def _local_connections(self) -> Dict[str, List[Any]]:
+    def _local_connections(self) -> Dict[str, 'Connection']:
         if not self.connections_file:
             self.log.debug("The file for connection is not specified. Skipping")
             # The user may not specify any file.
             return {}
         return load_connections_dict(self.connections_file)
 
-    def get_connections(self, conn_id: str) -> List[Any]:
+    def get_connection(self, conn_id: str) -> Optional['Connection']:
         if conn_id in self._local_connections:
-            return [self._local_connections[conn_id]]
+            return self._local_connections[conn_id]
+        return None
+
+    def get_connections(self, conn_id: str) -> List[Any]:
+        warnings.warn(
+            "This method is deprecated. Please use "
+            "`airflow.secrets.local_filesystem.LocalFilesystemBackend.get_connection`.",
+            PendingDeprecationWarning,
+        )
+        conn = self.get_connection(conn_id=conn_id)
+        if conn:
+            return [conn]
         return []
 
     def get_variable(self, key: str) -> Optional[str]:

--- a/airflow/secrets/metastore.py
+++ b/airflow/secrets/metastore.py
@@ -45,6 +45,7 @@ class MetastoreBackend(BaseSecretsBackend):
             "This method is deprecated. Please use "
             "`airflow.secrets.metastore.MetastoreBackend.get_connection`.",
             PendingDeprecationWarning,
+            stacklevel=3,
         )
         conn = self.get_connection(conn_id=conn_id, session=session)
         if conn:

--- a/airflow/secrets/metastore.py
+++ b/airflow/secrets/metastore.py
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """Objects relating to sourcing connections from metastore database"""
-
-from typing import TYPE_CHECKING, List
+import warnings
+from typing import TYPE_CHECKING, List, Optional
 
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.session import provide_session
@@ -31,12 +31,25 @@ class MetastoreBackend(BaseSecretsBackend):
 
     # pylint: disable=missing-docstring
     @provide_session
-    def get_connections(self, conn_id, session=None) -> List['Connection']:
+    def get_connection(self, conn_id, session=None) -> Optional['Connection']:
         from airflow.models.connection import Connection
 
-        conn_list = session.query(Connection).filter(Connection.conn_id == conn_id).all()
+        conn = session.query(Connection).filter(Connection.conn_id == conn_id).first()
         session.expunge_all()
-        return conn_list
+        return conn
+
+    # pylint: disable=missing-docstring
+    @provide_session
+    def get_connections(self, conn_id, session=None) -> List['Connection']:
+        warnings.warn(
+            "This method is deprecated. Please use "
+            "`airflow.secrets.metastore.MetastoreBackend.get_connection`.",
+            PendingDeprecationWarning,
+        )
+        conn = self.get_connection(conn_id=conn_id, session=session)
+        if conn:
+            return [conn]
+        return []
 
     @provide_session
     def get_variable(self, key: str, session=None):

--- a/docs/security/secrets/secrets-backend/index.rst
+++ b/docs/security/secrets/secrets-backend/index.rst
@@ -83,7 +83,7 @@ Roll your own secrets backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend` and must implement either
-:py:meth:`~airflow.secrets.BaseSecretsBackend.get_connections` or :py:meth:`~airflow.secrets.BaseSecretsBackend.get_conn_uri`.
+:py:meth:`~airflow.secrets.BaseSecretsBackend.get_connection` or :py:meth:`~airflow.secrets.BaseSecretsBackend.get_conn_uri`.
 
 After writing your backend class, provide the fully qualified class name in the ``backend`` key in the ``[secrets]``
 section of ``airflow.cfg``.

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ doc = [
     'sphinxcontrib-httpdomain>=1.7.0',
     "sphinxcontrib-redoc>=1.6.0",
     "sphinxcontrib-spelling==5.2.1",
-    # f"sphinx-airflow-theme @ {_SPHINX_AIRFLOW_THEME_URL}",
+    f"sphinx-airflow-theme @ {_SPHINX_AIRFLOW_THEME_URL}",
 ]
 docker = [
     'docker~=3.0',

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ doc = [
     'sphinxcontrib-httpdomain>=1.7.0',
     "sphinxcontrib-redoc>=1.6.0",
     "sphinxcontrib-spelling==5.2.1",
-    f"sphinx-airflow-theme @ {_SPHINX_AIRFLOW_THEME_URL}",
+    # f"sphinx-airflow-theme @ {_SPHINX_AIRFLOW_THEME_URL}",
 ]
 docker = [
     'docker~=3.0',

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -385,7 +385,7 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
 
     @mock.patch(
         "airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook.get_connection",
-        return_value=[Connection(host="localhost", port=9802)],
+        return_value=Connection(host="localhost", port=9802),
     )
     @mock.patch("airflow.providers.apache.hive.hooks.hive.socket")
     def test_error_metastore_client(self, socket_mock, _find_valid_server_mock):

--- a/tests/providers/google/suite/hooks/test_drive.py
+++ b/tests/providers/google/suite/hooks/test_drive.py
@@ -25,14 +25,14 @@ from tests.providers.google.cloud.utils.base_gcp_mock import GCP_CONNECTION_WITH
 
 class TestGoogleDriveHook(unittest.TestCase):
     def setUp(self):
-        self.patcher_get_connections = mock.patch(
-            "airflow.hooks.base_hook.BaseHook.get_connections", return_value=[GCP_CONNECTION_WITH_PROJECT_ID]
+        self.patcher_get_connection = mock.patch(
+            "airflow.hooks.base_hook.BaseHook.get_connection", return_value=GCP_CONNECTION_WITH_PROJECT_ID
         )
-        self.patcher_get_connections.start()
+        self.patcher_get_connection.start()
         self.gdrive_hook = GoogleDriveHook(gcp_conn_id="test")
 
     def tearDown(self) -> None:
-        self.patcher_get_connections.stop()
+        self.patcher_get_connection.stop()
 
     @mock.patch(
         "airflow.providers.google.common.hooks.base_google.GoogleBaseHook._authorize",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #10135

Deprecates the use of `BaseHook.get_connections`

- [x] Unit tests coverage for changes
- [x] Relevant documentation is updated including usage instructions.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
