### PR TITLE
Improves stability of reported coverage and makes it nicer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,12 +203,11 @@ jobs:
         with:
           name: kind-logs-${{matrix.kube-mode}}-${{matrix.python-version}}-${{matrix.kubernetes-version}}
           path: /tmp/kind_logs_*
-      - uses: codecov/codecov-action@v1
-        name: Upload Coverage report to codecov
+      - uses: actions/upload-artifact@v2
+        name: Upload artifact for coverage
         with:
-          file: ./files/coverage.xml
-          flags: >
-            kubernetes-tests-${{matrix.kube-mode}}-${{matrix.python-version}}-${{matrix.kubernetes-version}}
+          name: coverage-k8s-${{matrix.kube-mode}}-${{matrix.python-version}}-${{matrix.kubernetes-version}}
+          path: ./files/coverage.xml
 
   tests-postgres:
     timeout-minutes: 80
@@ -245,11 +244,12 @@ jobs:
         with:
           name: airflow-logs-${{matrix.test-type}}-${{matrix.python-version}}-${{matrix.postgres-version}}
           path: './files/airflow_logs*'
-      - uses: codecov/codecov-action@v1
-        name: Upload Coverage report to codecov
+      - uses: actions/upload-artifact@v2
+        name: Upload artifact for coverage
         with:
-          file: ./files/coverage.xml
-          flags: postgres-tests-${{matrix.test-type}}-${{matrix.python-version}}-${{matrix.postgres-version}}
+          name: >
+            coverage-postgres-${{matrix.test-type}}-${{matrix.python-version}}-${{matrix.postgres-version}}
+          path: ./files/coverage.xml
 
   tests-mysql:
     timeout-minutes: 80
@@ -286,11 +286,11 @@ jobs:
         with:
           name: airflow-logs-${{matrix.test-type}}-${{matrix.python-version}}-${{matrix.mysql-version}}
           path: './files/airflow_logs*'
-      - uses: codecov/codecov-action@v1
-        name: Upload Coverage report to codecov
+      - uses: actions/upload-artifact@v2
+        name: Upload artifact for coverage
         with:
-          file: ./files/coverage.xml
-          flags: mysql-tests-${{matrix.test-type}}-${{matrix.python-version}}-${{matrix.mysql-version}}
+          name: coverage-mysql-${{matrix.test-type}}-${{matrix.python-version}}-${{matrix.mysql-version}}
+          path: ./files/coverage.xml
 
   tests-sqlite:
     timeout-minutes: 80
@@ -325,11 +325,92 @@ jobs:
         with:
           name: airflow-logs-${{matrix.test-type}}-${{matrix.python-version}}
           path: './files/airflow_logs*'
-      - uses: codecov/codecov-action@v1
-        name: Upload Coverage report to codecov
+      - uses: actions/upload-artifact@v2
+        name: Upload artifact for coverage
         with:
-          file: ./files/coverage.xml
-          flags: sqlite-tests-${{matrix.test-type}}-${{matrix.python-version}}
+          name: coverage-sqlite-${{matrix.test-type}}-${{matrix.python-version}}
+          path: ./files/coverage.xml
+
+  tests-quarantined:
+    timeout-minutes: 80
+    name: "Quarantined tests"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: [trigger-tests]
+    strategy:
+      matrix:
+        python-version: [3.6]
+        postgres-version: [9.6]
+      fail-fast: false
+    env:
+      BACKEND: postgres
+      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+      POSTGRES_VERSION: ${{ matrix.postgres-version }}
+      RUN_TESTS: "true"
+      TEST_TYPE: Quarantined
+      NUM_RUNS: 10
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    if: needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: "Set issue id for master"
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "::set-env name=ISSUE_ID::10118"
+      - name: "Set issue id for v1-10-stable"
+        if: github.ref == 'refs/heads/v1-10-stable'
+        run: |
+          echo "::set-env name=ISSUE_ID::10127"
+      - name: "Set issue id for v1-10-test"
+        if: github.ref == 'refs/heads/v1-10-test'
+        run: |
+          echo "::set-env name=ISSUE_ID::10128"
+      - name: "Free space"
+        run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+      - name: "Build CI image ${{ matrix.python-version }}"
+        run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
+      - name: "Tests"
+        run: ./scripts/ci/testing/ci_run_airflow_testing.sh
+      - uses: actions/upload-artifact@v2
+        name: Upload Quarantine test results
+        if: always()
+        with:
+          name: 'quarantined_tests'
+          path: 'files/test_result.xml'
+      - uses: actions/upload-artifact@v2
+        name: Upload airflow logs
+        if: always()
+        with:
+          name: airflow-logs-quarantined-${{matrix.python-version}}-${{ matrix.postgres-version }}
+          path: './files/airflow_logs*'
+      - uses: actions/upload-artifact@v2
+        name: Upload artifact for coverage
+        with:
+          name: coveragage-quarantined-${{matrix.test-type}}-${{matrix.python-version}}
+          path: ./files/coverage.xml
+
+  upload-coverage:
+    timeout-minutes: 5
+    name: "Upload coverage"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs:
+      - tests-kubernetes
+      - tests-postgres
+      - tests-sqlite
+      - tests-mysql
+      - tests-quarantined
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: ./coverage-files
+      - uses: codecov/codecov-action@v1
+        name: Upload All coverage reports to codecov
+        with:
+          directory: ./coverage-files
 
   helm-tests:
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,10 +405,13 @@ jobs:
       - tests-quarantined
     steps:
       - uses: actions/download-artifact@v2
+        name: Download all artifacts from the current build
         with:
           path: ./coverage-files
+      - name: Removes unnecessary artifacts
+        run: ls ./coverage-files | grep -v coverage | xargs rm -rf
       - uses: codecov/codecov-action@v1
-        name: Upload All coverage reports to codecov
+        name: Upload all coverage reports to codecov
         with:
           directory: ./coverage-files
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         name: Upload artifact for coverage
         with:
-          name: coveragage-quarantined-${{matrix.test-type}}-${{matrix.python-version}}
+          name: coverage-quarantined-${{matrix.test-type}}-${{matrix.python-version}}
           path: ./files/coverage.xml
 
   upload-coverage:

--- a/.github/workflows/quarantined.yaml
+++ b/.github/workflows/quarantined.yaml
@@ -21,10 +21,6 @@ on:
   schedule:
     # Run quarantined builds 4 times a day to gather better quarantine stats
     - cron: '35 */6 * * *'
-  push:
-    branches: ['master', 'v1-10-test', 'v1-10-stable']
-  pull_request:
-    branches: ['master', 'v1-10-test', 'v1-10-stable']
 
 env:
   MOUNT_LOCAL_SOURCES: "false"
@@ -43,21 +39,10 @@ env:
 
 jobs:
 
-  cancel-previous-workflow-run:
-    timeout-minutes: 60
-    name: "Cancel previous workflow run"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: potiuk/cancel-workflow-runs@v1
-        with:
-          workflow: quarantined.yaml
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   trigger-tests:
     timeout-minutes: 5
     name: "Checks if tests should be run"
     runs-on: ubuntu-latest
-    needs: [cancel-previous-workflow-run]
     outputs:
       run-tests: ${{ steps.trigger-tests.outputs.run-tests }}
     steps:
@@ -121,9 +106,3 @@ jobs:
         with:
           name: airflow-logs-quarantined-${{matrix.python-version}}-${{ matrix.postgres-version }}
           path: './files/airflow_logs*'
-      - uses: codecov/codecov-action@v1
-        name: Upload Coverage report to codecov
-        with:
-          file: ./files/coverage.xml
-          flags: >
-            kubernetes-tests-${{matrix.python-version}}-${{ matrix.postgres-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,7 @@ repos:
         name: Add license for all yaml files
         exclude: ^\.github/.*$
         types: [yaml]
+        files: \.yml$|\.yaml$
         args:
           - --comment-style
           - "|#|"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "85...100"
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        base: auto
+        paths:
+          - "airflow"
+        # advanced
+        branches:
+          - master
+          - v1-10-stable
+          - v1-10-test
+        if_not_found: success
+        if_ci_failed: error
+        informational: true
+        only_pulls: false
+    patch:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        base: auto
+        # advanced
+        branches:
+          - master
+          - v1-10-stable
+          - v1-10-test
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        paths:
+          - "airflow"
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment: false


### PR DESCRIPTION
With this change we only upload coverage report in the case
when all tests were successuful and actually executed. This means
that coverage report will not be run when the job gets canceled.

Currently a lof of coverage reports gathered contain far less
coverage because when static check fails or docs some test jobs
could already submit their coverage - resulting in partial coverage
reports.

With this change we also remove comment from coverage report
and replace it with (for now) informational status message published
to github. If we see that it works, we can change it to a
PR-failing status if coverage drops for a given PR.

This way we might get our coverage monotonously increasing :).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
