### PR TITLE
You can sync your fork master with apache/airflow master via UI

### DIFF
--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -1,0 +1,17 @@
+# File: .github/workflows/repo-sync.yml
+name: Force sync master from apache/airflow
+on:
+  workflow_dispatch:
+jobs:
+  repo-sync:
+    if: github.repository != 'apache/airflow'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: repo-sync
+        uses: repo-sync/github-sync@v2
+        with:
+          source_repo: "apache/airflow"
+          source_branch: "master"
+          destination_branch: "master"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -194,6 +194,9 @@ Step 4: Prepare PR
    * Find the test class where you should add tests. For the example ticket,
      this is `test_email.py <https://github.com/apache/airflow/blob/master/tests/utils/test_email.py>`__.
 
+   * Make sure your fork's master is synced with Apache Airflow's master before you create a branch. See
+     `How to sync your fork <#how-to-sync-your-fork>`_ for details.
+
    * Create a local branch for your development. Make sure to use latest
      ``apache/master`` as base for the branch. See `How to Rebase PR <#how-to-rebase-pr>`_ for some details
      on setting up the ``apache`` remote. Note, some people develop their changes directly in their own
@@ -862,6 +865,19 @@ commands:
     # Check JS code in .js and .html files, report any errors/warnings and fix them if possible
     yarn run lint:fix
 
+How to sync your fork
+=====================
+
+When you have your fork, you should periodically synchronize the master of your fork with the
+Apache Airflow master. In order to do that you can ``git pull`` to your local git repository from
+apache remote and push the master (often with ``--force`` to your fork). There is also an easy
+way using ``Force sync master from apache/airflow`` workflow. You can go to "Actions" in your repository and
+choose the workflow and manually trigger the workflow using "Run workflow" command.
+
+This will force-push the master from apache/airflow to the master in your fork. Note that in case you
+modified the master in your fork, you might loose those changes.
+
+
 How to rebase PR
 ================
 
@@ -872,7 +888,6 @@ clearly separate your changes from changes of others, puts responsibility of pro
 author of the change. It also produces a "single-line" series of commits in master branch which
 makes it much easier to understand what was going on and to find reasons for problems (it is especially
 useful for "bisecting" when looking for a commit that introduced some bugs.
-
 
 First of all - you can read about rebase workflow here:
 `Merging vs. rebasing <https://www.atlassian.com/git/tutorials/merging-vs-rebasing>`_ - this is an

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -869,7 +869,7 @@ How to sync your fork
 =====================
 
 When you have your fork, you should periodically synchronize the master of your fork with the
-Apache Airflow master. In order to do that you can ``git pull`` to your local git repository from
+Apache Airflow master. In order to do that you can ``git pull --rebase`` to your local git repository from
 apache remote and push the master (often with ``--force`` to your fork). There is also an easy
 way using ``Force sync master from apache/airflow`` workflow. You can go to "Actions" in your repository and
 choose the workflow and manually trigger the workflow using "Run workflow" command.


### PR DESCRIPTION
We are using newly added feature of GitHub to add manually triggered
workflow to enable manually-triggered force-syncing of your fork
with apache/airflow.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
