### PR TITLE
Add labels param to Google MLEngine Operators

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_mlengine.py
+++ b/airflow/providers/google/cloud/example_dags/example_mlengine.py
@@ -73,6 +73,7 @@ with models.DAG(
         package_uris=[TRAINER_URI],
         training_python_module=TRAINER_PY_MODULE,
         training_args=[],
+        labels={"job_type": "training"},
     )
     # [END howto_operator_gcp_mlengine_training]
 
@@ -169,6 +170,7 @@ with models.DAG(
         data_format="TEXT",
         input_paths=[PREDICTION_INPUT],
         output_path=PREDICTION_OUTPUT,
+        labels={"job_type": "prediction"},
     )
     # [END howto_operator_gcp_mlengine_get_prediction]
 

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -953,6 +953,8 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         will be printed out. In 'CLOUD' mode, a real MLEngine training job
         creation request will be issued.
     :type mode: str
+    :param labels: a dictionary containing labels for the job; passed to BigQuery
+    :type labels: dict
     """
 
     template_fields = [
@@ -990,6 +992,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
                  mode: str = 'PRODUCTION',
+                 labels: Optional[dict] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self._project_id = project_id
@@ -1006,6 +1009,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         self._gcp_conn_id = gcp_conn_id
         self._delegate_to = delegate_to
         self._mode = mode
+        self._labels = labels
 
         if not self._project_id:
             raise AirflowException('Google Cloud project id is required.')
@@ -1056,6 +1060,9 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
             self.log.info('In dry_run mode.')
             self.log.info('MLEngine Training job request is: %s', training_request)
             return
+
+        if self._labels:
+            training_request['trainingInput']['labels'] = self._labels
 
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id, delegate_to=self._delegate_to)

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -21,7 +21,7 @@ This module contains GCP MLEngine operators.
 import logging
 import re
 import warnings
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
@@ -152,7 +152,7 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
         have domain-wide delegation enabled.
     :type delegate_to: str
     :param labels: a dictionary containing labels for the job; passed to BigQuery
-    :type labels: dict
+    :type labels: Dict[str, str]
     :raises: ``ValueError``: if a unique model/version origin cannot be
         determined.
     """
@@ -185,7 +185,7 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
-                 labels: Optional[dict] = None,
+                 labels: Optional[Dict[str, str]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
 
@@ -238,9 +238,9 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
                 'region': self._region
             }
         }
-
         if self._labels:
             prediction_request['labels'] = self._labels
+
         if self._uri:
             prediction_request['predictionInput']['uri'] = self._uri
         elif self._model_name:
@@ -960,7 +960,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         creation request will be issued.
     :type mode: str
     :param labels: a dictionary containing labels for the job; passed to BigQuery
-    :type labels: dict
+    :type labels: Dict[str, str]
     """
 
     template_fields = [
@@ -998,7 +998,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
                  gcp_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
                  mode: str = 'PRODUCTION',
-                 labels: Optional[dict] = None,
+                 labels: Optional[Dict[str, str]] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self._project_id = project_id
@@ -1049,9 +1049,9 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
                 'args': self._training_args,
             }
         }
-
         if self._labels:
             training_request['labels'] = self._labels
+
         if self._runtime_version:
             training_request['trainingInput']['runtimeVersion'] = self._runtime_version
 

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -151,6 +151,8 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
         For this to work, the service account making the request must
         have domain-wide delegation enabled.
     :type delegate_to: str
+    :param labels: a dictionary containing labels for the job; passed to BigQuery
+    :type labels: dict
     :raises: ``ValueError``: if a unique model/version origin cannot be
         determined.
     """
@@ -183,6 +185,7 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
                  project_id: Optional[str] = None,
                  gcp_conn_id: str = 'google_cloud_default',
                  delegate_to: Optional[str] = None,
+                 labels: Optional[dict] = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
 
@@ -200,6 +203,7 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
         self._signature_name = signature_name
         self._gcp_conn_id = gcp_conn_id
         self._delegate_to = delegate_to
+        self._labels = labels
 
         if not self._project_id:
             raise AirflowException('Google Cloud project id is required.')
@@ -258,6 +262,10 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
         if self._signature_name:
             prediction_request['predictionInput'][
                 'signatureName'] = self._signature_name
+
+        if self._labels:
+            prediction_request['predictionInput'][
+                'labels'] = self._labels
 
         hook = MLEngineHook(self._gcp_conn_id, self._delegate_to)
 

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -239,6 +239,8 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
             }
         }
 
+        if self._labels:
+            prediction_request['labels'] = self._labels
         if self._uri:
             prediction_request['predictionInput']['uri'] = self._uri
         elif self._model_name:
@@ -262,10 +264,6 @@ class MLEngineStartBatchPredictionJobOperator(BaseOperator):
         if self._signature_name:
             prediction_request['predictionInput'][
                 'signatureName'] = self._signature_name
-
-        if self._labels:
-            prediction_request['predictionInput'][
-                'labels'] = self._labels
 
         hook = MLEngineHook(self._gcp_conn_id, self._delegate_to)
 
@@ -1052,6 +1050,8 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
             }
         }
 
+        if self._labels:
+            training_request['labels'] = self._labels
         if self._runtime_version:
             training_request['trainingInput']['runtimeVersion'] = self._runtime_version
 
@@ -1068,9 +1068,6 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
             self.log.info('In dry_run mode.')
             self.log.info('MLEngine Training job request is: %s', training_request)
             return
-
-        if self._labels:
-            training_request['trainingInput']['labels'] = self._labels
 
         hook = MLEngineHook(
             gcp_conn_id=self._gcp_conn_id, delegate_to=self._delegate_to)

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -60,10 +60,10 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
         'inputPaths': ['gs://legal-bucket/fake-input-path/*'],
         'outputPath': 'gs://legal-bucket/fake-output-path',
         'region': 'us-east1',
-        'labels': {'some-key': 'some-value'},
     }
     SUCCESS_MESSAGE_MISSING_INPUT = {
         'jobId': 'test_prediction',
+        'labels': {'some': 'labels'},
         'predictionOutput': {
             'outputPath': 'gs://fake-output-path',
             'predictionCount': 5000,
@@ -75,6 +75,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
     BATCH_PREDICTION_DEFAULT_ARGS = {
         'project_id': 'test-project',
         'job_id': 'test_prediction',
+        'labels': {'some': 'labels'},
         'region': 'us-east1',
         'data_format': 'TEXT',
         'input_paths': ['gs://legal-bucket-dash-Capital/legal-input-path/*'],
@@ -117,7 +118,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             input_paths=input_with_model['inputPaths'],
             output_path=input_with_model['outputPath'],
             model_name=input_with_model['modelName'].split('/')[-1],
-            labels=input_with_model['labels'],
+            labels={'some': 'labels'},
             dag=self.dag,
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)
@@ -127,6 +128,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             project_id='test-project',
             job={
                 'jobId': 'test_prediction',
+                'labels': {'some': 'labels'},
                 'predictionInput': input_with_model
             },
             use_existing_job_fn=ANY
@@ -157,7 +159,6 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             output_path=input_with_version['outputPath'],
             model_name=input_with_version['versionName'].split('/')[-3],
             version_name=input_with_version['versionName'].split('/')[-1],
-            labels=input_with_version['labels'],
             dag=self.dag,
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)
@@ -195,7 +196,6 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             input_paths=input_with_uri['inputPaths'],
             output_path=input_with_uri['outputPath'],
             uri=input_with_uri['uri'],
-            labels=input_with_uri['labels'],
             dag=self.dag,
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)
@@ -312,11 +312,13 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
         'training_args': '--some_arg=\'aaa\'',
         'region': 'us-east1',
         'scale_tier': 'STANDARD_1',
+        'labels': {'some': 'labels'},
         'task_id': 'test-training',
         'start_date': days_ago(1)
     }
     TRAINING_INPUT = {
         'jobId': 'test_training',
+        'labels': {'some': 'labels'},
         'trainingInput': {
             'scaleTier': 'STANDARD_1',
             'packageUris': ['gs://some-bucket/package1'],
@@ -353,7 +355,6 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
         training_input['trainingInput']['runtimeVersion'] = '1.6'
         training_input['trainingInput']['pythonVersion'] = '3.5'
         training_input['trainingInput']['jobDir'] = 'gs://some-bucket/jobs/test_training'
-        training_input['trainingInput']['labels'] = {'some': 'labels'}
 
         success_response = self.TRAINING_INPUT.copy()
         success_response['state'] = 'SUCCEEDED'
@@ -364,7 +365,6 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
             runtime_version='1.6',
             python_version='3.5',
             job_dir='gs://some-bucket/jobs/test_training',
-            labels={'some': 'labels'},
             **self.TRAINING_DEFAULT_ARGS)
         training_op.execute(MagicMock())
 

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -60,6 +60,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
         'inputPaths': ['gs://legal-bucket/fake-input-path/*'],
         'outputPath': 'gs://legal-bucket/fake-output-path',
         'region': 'us-east1',
+        'labels': {'some-key': 'some-value'},
     }
     SUCCESS_MESSAGE_MISSING_INPUT = {
         'jobId': 'test_prediction',
@@ -116,6 +117,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             input_paths=input_with_model['inputPaths'],
             output_path=input_with_model['outputPath'],
             model_name=input_with_model['modelName'].split('/')[-1],
+            labels=input_with_model['labels'],
             dag=self.dag,
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)
@@ -155,6 +157,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             output_path=input_with_version['outputPath'],
             model_name=input_with_version['versionName'].split('/')[-3],
             version_name=input_with_version['versionName'].split('/')[-1],
+            labels=input_with_version['labels'],
             dag=self.dag,
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)
@@ -192,6 +195,7 @@ class TestMLEngineBatchPredictionOperator(unittest.TestCase):
             input_paths=input_with_uri['inputPaths'],
             output_path=input_with_uri['outputPath'],
             uri=input_with_uri['uri'],
+            labels=input_with_uri['labels'],
             dag=self.dag,
             task_id='test-prediction')
         prediction_output = prediction_task.execute(None)

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -349,6 +349,7 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
         training_input['trainingInput']['runtimeVersion'] = '1.6'
         training_input['trainingInput']['pythonVersion'] = '3.5'
         training_input['trainingInput']['jobDir'] = 'gs://some-bucket/jobs/test_training'
+        training_input['trainingInput']['labels'] = {'some': 'labels'}
 
         success_response = self.TRAINING_INPUT.copy()
         success_response['state'] = 'SUCCEEDED'
@@ -359,6 +360,7 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
             runtime_version='1.6',
             python_version='3.5',
             job_dir='gs://some-bucket/jobs/test_training',
+            labels={'some': 'labels'},
             **self.TRAINING_DEFAULT_ARGS)
         training_op.execute(MagicMock())
 


### PR DESCRIPTION
Pass the `labels` parameter to the training jobs for two Google Machine Learning Operators. This will bring each of them up to snuff with `BigQueryExecuteQueryOperator`, which already accepts this parameter.

closes: #10165