### PR TITLE
BoringCyborg Bot: Fix Automated Labels for serialized & secrets

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -168,11 +168,13 @@ labelPRBasedOnFilePath:
     - airflow/providers/**/secrets/*
     - tests/secrets/*
     - tests/providers/**/secrets/*
-    - docs/howto/use-alternative-secrets-backend.rst
+    - docs/howto/secrets-backend/*
 
   area:Serialization:
     - airflow/serialization/*
+    - airflow/models/serialized_dag.py
     - tests/serialization/*
+    - tests/models/test_serialized_dag.py
     - docs/dag-serialization.rst
 
 # Various Flags to control behaviour of the "Labeler"


### PR DESCRIPTION
- docs/howto/use-alternative-secrets-backend.rst has been renamed & split into docs/howto/secrets-backend/*
- Add more paths for Serialization

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
