### PR TITLE
Fix KubernetesPodOperator reattachment

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -300,13 +300,12 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     def handle_pod_overlap(self, labels, try_numbers_match, launcher, pod_list):
         """
 
-        @param labels: labels used to determine if a pod is repeated
-        @type labels: dict
-        @param try_numbers_match: do the try numbers match? Only needed for logging purposes
-        @type try_numbers_match: bool
-        @param launcher: PodLauncher
-        @param pod_list: list of pods found
-        @return:
+        :param labels: labels used to determine if a pod is repeated
+        :type labels: dict
+        :param try_numbers_match: do the try numbers match? Only needed for logging purposes
+        :type try_numbers_match: bool
+        :param launcher: PodLauncher
+        :param pod_list: list of pods found
         """
         if try_numbers_match:
             log_line = "found a running pod with labels {} and the same try_number.".format(labels)

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -277,7 +277,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
 
             pod_list = client.list_namespaced_pod(self.namespace, label_selector=label_selector)
 
-            if len(pod_list.items) > 1:
+            if len(pod_list.items) > 1 and self.reattach_on_restart:
                 raise AirflowException(
                     'More than one pod running with labels: '
                     '{label_selector}'.format(label_selector=label_selector))
@@ -302,7 +302,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
 
         In cases where the Scheduler restarts while a KubernetsPodOperator task is running,
         this function will either continue to monitor the existing pod or launch a new pod
-        based on the `reattach_on_restart` config.
+        based on the `reattach_on_restart` parameter.
 
         :param labels: labels used to determine if a pod is repeated
         :type labels: dict

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -300,6 +300,10 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     def handle_pod_overlap(self, labels, try_numbers_match, launcher, pod_list):
         """
 
+        In cases where the Scheduler restarts while a KubernetsPodOperator task is running,
+        this function will either continue to monitor the existing pod or launch a new pod
+        based on the `reattach_on_restart` config.
+
         :param labels: labels used to determine if a pod is repeated
         :type labels: dict
         :param try_numbers_match: do the try numbers match? Only needed for logging purposes

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -284,16 +284,9 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
 
             launcher = pod_launcher.PodLauncher(kube_client=client, extract_xcom=self.do_xcom_push)
 
-            if len(pod_list.items) == 1 and \
-                    self._try_numbers_do_not_match(context, pod_list.items[0]) and \
-                    self.reattach_on_restart:
-                self.log.info("found a running pod with labels %s but a different try_number"
-                              "Will attach to this pod and monitor instead of starting new one", labels)
-                final_state, result = self.monitor_launched_pod(launcher, pod_list.items[0])
-            elif len(pod_list.items) == 1:
-                self.log.info("found a running pod with labels %s."
-                              "Will monitor this pod instead of starting new one", labels)
-                final_state, result = self.monitor_launched_pod(launcher, pod_list.items[0])
+            if len(pod_list.items) == 1:
+                try_numbers_match = self._try_numbers_match(context, pod_list.items[0])
+                final_state, result = self.handle_pod_overlap(try_numbers_match, labels, launcher, pod_list)
             else:
                 self.log.info("creating pod with labels %s and launcher %s", labels, launcher)
                 final_state, _, result = self.create_new_pod_for_operator(labels, launcher)
@@ -304,14 +297,28 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         except AirflowException as ex:
             raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
 
+    def handle_pod_overlap(self, labels, try_numbers_match, launcher, pod_list):
+        if try_numbers_match:
+            log_line = "found a running pod with labels {} and the same try_number.".format(labels)
+        else:
+            log_line = "found a running pod with labels {} but a different try_number.".format(labels)
+
+        if self.reattach_on_restart:
+            self.log.info(log_line + " Will attach to this pod and monitor instead of starting new one")
+            final_state, result = self.monitor_launched_pod(launcher, pod_list.items[0])
+        else:
+            self.log.info(log_line + "creating pod with labels %s and launcher %s", labels, launcher)
+            final_state, _, result = self.create_new_pod_for_operator(labels, launcher)
+        return final_state, result
+
     @staticmethod
     def _get_pod_identifying_label_string(labels):
         filtered_labels = {label_id: label for label_id, label in labels.items() if label_id != 'try_number'}
         return ','.join([label_id + '=' + label for label_id, label in sorted(filtered_labels.items())])
 
     @staticmethod
-    def _try_numbers_do_not_match(context, pod):
-        return pod.metadata.labels['try_number'] != context['ti'].try_number
+    def _try_numbers_match(context, pod):
+        return pod.metadata.labels['try_number'] == context['ti'].try_number
 
     @staticmethod
     def _set_resources(resources):


### PR DESCRIPTION
in 1.10.11 we introduced a bug where the KubernetesPodOperator
was not properly reattaching due to implementation errors.

This fix will allow users to  determine reattachment based on the
`reattach_on_restart` config

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
