### PR TITLE
Remove Unnecessary list literal in Tuple for Kylin Operator

### DIFF
--- a/airflow/providers/apache/kylin/operators/kylin_cube.py
+++ b/airflow/providers/apache/kylin/operators/kylin_cube.py
@@ -110,7 +110,7 @@ class KylinCubeOperator(BaseOperator):
                  is_track_job: Optional[bool] = False,
                  interval: int = 60,
                  timeout: int = 60 * 60 * 24,
-                 eager_error_status=tuple(["ERROR", "DISCARDED", "KILLED", "SUICIDAL", "STOPPED"]),
+                 eager_error_status=("ERROR", "DISCARDED", "KILLED", "SUICIDAL", "STOPPED"),
                  **kwargs):
         super().__init__(**kwargs)
         self.kylin_conn_id = kylin_conn_id


### PR DESCRIPTION
It is unnecessary to use a list or tuple literal within a call to tuple.

Before:
```
In [1]: tuple(["ERROR", "DISCARDED", "KILLED", "SUICIDAL", "STOPPED"])
Out[1]: ('ERROR', 'DISCARDED', 'KILLED', 'SUICIDAL', 'STOPPED')
```

After:

```
In [4]: ("ERROR", "DISCARDED", "KILLED", "SUICIDAL", "STOPPED",)
Out[4]: ('ERROR', 'DISCARDED', 'KILLED', 'SUICIDAL', 'STOPPED')
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
