### PR TITLE
Fix Warning when using a different Sphinx Builder

### DIFF
--- a/docs/exts/redirects.py
+++ b/docs/exts/redirects.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 
 
 def generate_redirects(app):
-    """Generaate redirects files."""
+    """Generate redirects files."""
     redirect_file_path = os.path.join(app.srcdir, app.config.redirects_file)
     if not os.path.exists(redirect_file_path):
         raise ExtensionError(f"Could not find redirects file at '{redirect_file_path}'")
@@ -38,7 +38,7 @@ def generate_redirects(app):
 
     if not isinstance(app.builder, builders.StandaloneHTMLBuilder):
         log.warning(
-            "The plugin is support only 'html' builder, but you are using '{type(app.builder)}'. Skipping..."
+            f"The plugin supports only 'html' builder, but you are using '{type(app.builder)}'. Skipping..."
         )
         return
 


### PR DESCRIPTION
**Before**:

```
[AutoAPI] Reading files... [100%] /opt/airflow/airflow/kubernetes/pod_launcher.py
[AutoAPI] Mapping Data
[AutoAPI] Rendering Data
WARNING: The plugin is support only 'html' builder, but you are using '{type(app.builder)}'. Skipping...
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
