### PR TITLE
Update base classes used in bigquery_check_operator to renamed versions

### DIFF
--- a/airflow/contrib/operators/bigquery_check_operator.py
+++ b/airflow/contrib/operators/bigquery_check_operator.py
@@ -18,12 +18,12 @@
 # under the License.
 
 from airflow.contrib.hooks.bigquery_hook import BigQueryHook
-from airflow.operators.check_operator import \
-    CheckOperator, ValueCheckOperator, IntervalCheckOperator
+from airflow.operators.sql import \
+    SQLCheckOperator, SQLValueCheckOperator, SQLIntervalCheckOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class BigQueryCheckOperator(CheckOperator):
+class BigQueryCheckOperator(SQLCheckOperator):
     """
     Performs checks against BigQuery. The ``BigQueryCheckOperator`` expects
     a sql query that will return a single row. Each value on that
@@ -79,7 +79,7 @@ class BigQueryCheckOperator(CheckOperator):
                             use_legacy_sql=self.use_legacy_sql)
 
 
-class BigQueryValueCheckOperator(ValueCheckOperator):
+class BigQueryValueCheckOperator(SQLValueCheckOperator):
     """
     Performs a simple value check using sql code.
 
@@ -111,7 +111,7 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
                             use_legacy_sql=self.use_legacy_sql)
 
 
-class BigQueryIntervalCheckOperator(IntervalCheckOperator):
+class BigQueryIntervalCheckOperator(SQLIntervalCheckOperator):
     """
     Checks that the values of metrics given as SQL expressions are within
     a certain tolerance of the ones from days_back before.


### PR DESCRIPTION
`airflow.contrib.operators.bigquery_check_operator.BigQueryValueCheckOperator` [is derived from](https://github.com/apache/airflow/blob/69cc8370e486e00dd526e96c2b0aacd348ee255e/airflow/contrib/operators/bigquery_check_operator.py#L82) `airflow.operators.check_operator.ValueCheckOperator` but needs to be derived from `airflow.operators.sql.SQLValueCheckOperator` instead.

Until this is done, airflow generates a lot of warnings from [this](https://github.com/apache/airflow/blob/69cc8370e486e00dd526e96c2b0aacd348ee255e/airflow/operators/check_operator.py#L81) line of code.

Fixes #10271