### PR TITLE
Fix helm chart with dag persistence issue

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -145,10 +145,12 @@ spec:
               subPath: airflow_local_settings.py
               readOnly: true
 {{- end }}
-{{- if .Values.dags.gitSync.enabled }}
+{{- if or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
             - name: dags
               mountPath: {{ template "airflow_dags_mount_path" . }}
+  {{- if or .Values.dags.gitSync.enabled }}
         {{- include "git_sync_container" . | indent 8 }}
+  {{- end }}
 {{- end }}
         # Always start the garbage collector sidecar.
         - name: scheduler-gc


### PR DESCRIPTION
Fix: The volume doesn't mount if dags.persistence.enabled is true.

The problem:
After I enabled dags.persistence,  the webserver and workers can use the PVC correctly, but the scheduler still use its own volume.
I was using the following setting:
```
dags:
  persistence:
    enabled: true
    existingClaim: airflow-poc-dags-pvc
  gitSync:
    enabled: false
```

Reason:
The dags volume is not correctly mounted when dags.persistence.enabled=true.
