### PR TITLE
Update CHANGELOG removing duplicate from 1.10.10

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -317,7 +317,6 @@ Misc/Internal
 - Requirements now depend on python version (#7841)
 - Bring back reset db explicitly called at CI entry (#7798)
 - Fixes unclean installation of Airflow 1.10 (#7796)
-- Change name of the common environment initialization function (#7805)
 - [AIRFLOW-7029] Use separate docker image for running license check (#7678)
 - [AIRFLOW-5842] Swtch to Debian buster image as a base (#7647)
 - [AIRFLOW-5828] Move build logic out from hooks/build (#7618)


### PR DESCRIPTION
- Removing duplicate entry from 1.10.10 CHANGELOG

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
