### PR TITLE
Run create-user-job as user with specified id

### DIFF
--- a/chart/templates/create-user-job.yaml
+++ b/chart/templates/create-user-job.yaml
@@ -43,6 +43,8 @@ spec:
         component: create-user-job
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+          runAsUser: {{ .Values.uid }}
       restartPolicy: OnFailure
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}


### PR DESCRIPTION
In secured cluster there is a need to run this job with specific user id
