### PR TITLE
[kubernetes][pod_launcher] decode k8s logs in monitor_pod

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -126,7 +126,7 @@ class PodLauncher(LoggingMixin):
         if get_logs:
             logs = self.read_pod_logs(pod)
             for line in logs:
-                self.log.info(line)
+                self.log.info(line.decode('utf-8'))
         result = None
         if self.extract_xcom:
             while self.base_container_is_running(pod):

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -405,7 +405,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             )
             context = create_context(k)
             k.execute(context=context)
-            mock_logger.info.assert_any_call(b"retrieved from mount\n")
+            mock_logger.info.assert_any_call("retrieved from mount\n")
             actual_pod = self.api_client.sanitize_for_serialization(k.pod)
             self.expected_pod['spec']['containers'][0]['args'] = args
             self.expected_pod['spec']['containers'][0]['volumeMounts'] = [{


### PR DESCRIPTION
I have found when using airflow with k8s pod, when logs is sent back from k8s to airflow, it's not being logged as string, instead it's byte string, not being decoded. This isn't a problem when using non-unicode character, however for unicode character, it's being displayed as bytes. Here is my change, decode the byte string first then log into airflow logger.

I have tested on our production environment, it's working perfectly.
