### PR TITLE
[kubernetes][monitor_pod] decode k8s logs when collecting with airflow logger

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -125,7 +125,8 @@ class PodLauncher(LoggingMixin):
         """
         if get_logs:
             logs = self.read_pod_logs(pod)
-            if isinstance(logs, str):
+            import sys
+            if sys.version_info[0] == 2:
                 logs.encode('utf-8')
             else:
                 logs.decode('utf-8')

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -125,6 +125,10 @@ class PodLauncher(LoggingMixin):
         """
         if get_logs:
             logs = self.read_pod_logs(pod)
+            if isinstance(logs, str):
+                logs.encode('utf-8')
+            else:
+                logs.decode('utf-8')
             for line in logs:
                 self.log.info(line)
         result = None

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -126,12 +126,11 @@ class PodLauncher(LoggingMixin):
         if get_logs:
             logs = self.read_pod_logs(pod)
             import sys
-            if sys.version_info[0] == 2:
-                logs.encode('utf-8')
-            else:
-                logs.decode('utf-8')
             for line in logs:
-                self.log.info(line)
+                if sys.version_info[0] == 2:
+                    self.log.info(line)
+                else:
+                    self.log.info(line.decode('utf-8'))
         result = None
         if self.extract_xcom:
             while self.base_container_is_running(pod):

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -405,7 +405,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             )
             context = create_context(k)
             k.execute(context=context)
-            mock_logger.info.assert_any_call(b"retrieved from mount\n")
+            mock_logger.info.assert_any_call("retrieved from mount\n")
             actual_pod = self.api_client.sanitize_for_serialization(k.pod)
             self.expected_pod['spec']['containers'][0]['args'] = args
             self.expected_pod['spec']['containers'][0]['volumeMounts'] = [{


### PR DESCRIPTION
When running Task with KubernetesPodOperator and collecting logs back to airflow, logs are being collected to airflow logger as byte string. It's not a problem with asiic string, but if it contains unicode string, log file will show unicode byte, not readable at all. So this PR decode to utf-8 first, then log to file.

This change has been running perfectly on our production.