### PR TITLE
Use more human readable table heading labels on DAG details

### DIFF
--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -22,59 +22,59 @@
 {% block page_title %}{{ dag.dag_id }} - DAG Details - Airflow{% endblock %}
 
 {% block content %}
-    {{ super() }}
-    <h2>{{ title }}</h2>
-    <div>
-      {% for state, count in states %}
+  {{ super() }}
+  <h2>{{ title }}</h2>
+  <div>
+    {% for state, count in states %}
       <a
-          class="btn"
-          style="border: none; background-color:{{ State.color(state)}}; color: {{ State.color_fg(state) }};"
-          href="{{ url_for('TaskInstanceModelView.list', _flt_3_dag_id=dag.dag_id, _flt_3_state=state) }}">
+        class="btn"
+        style="border: none; background-color:{{ State.color(state)}}; color: {{ State.color_fg(state) }};"
+        href="{{ url_for('TaskInstanceModelView.list', _flt_3_dag_id=dag.dag_id, _flt_3_state=state) }}">
         {{ state }} <span class="badge">{{ count }}</span>
       </a>
-      {% endfor %}
-    </div>
-    <br>
-    <table class="table table-striped table-bordered">
-      <tr>
-        <th>schedule_interval</td>
-        <td>{{ dag.schedule_interval }}</td>
-      </tr>
-      <tr>
-        <th>start_date</td>
-        <td>{{ dag.start_date }}</td>
-      </tr>
-      <tr>
-        <th>end_date</td>
-        <td>{{ dag.end_date }}</td>
-      </tr>
-      <tr>
-        <th>max_active_runs</td>
-        <td>{{ active_runs | length }} / {{ dag.max_active_runs }}</td>
-      </tr>
-      <tr>
-        <th>concurrency</td>
-        <td>{{ dag.concurrency }}</td>
-      </tr>
-      <tr>
-        <th>default_args</td>
-        <td><code>{{ dag.default_args }}</code></td>
-      </tr>
-      <tr>
-        <th>tasks count</td>
-        <td>{{ dag.tasks|length }}</td>
-      </tr>
-      <tr>
-        <th>task ids</td>
-        <td>{{ dag.task_ids }}</td>
-      </tr>
-      <tr>
-        <th>filepath</td>
-        <td>{{ dag.filepath }}</td>
-      </tr>
-      <tr>
-        <th>owner</td>
-        <td>{{ dag.owner }}</td>
-      </tr>
-    </table >
+    {% endfor %}
+  </div>
+  <br>
+  <table class="table table-striped table-bordered">
+    <tr>
+      <th>Schedule Interval</th>
+      <td>{{ dag.schedule_interval }}</td>
+    </tr>
+    <tr>
+      <th>Start Date</th>
+      <td>{{ dag.start_date }}</td>
+    </tr>
+    <tr>
+      <th>End Date</th>
+      <td>{{ dag.end_date }}</td>
+    </tr>
+    <tr>
+      <th>Max Active Runs</th>
+      <td>{{ active_runs | length }} / {{ dag.max_active_runs }}</td>
+    </tr>
+    <tr>
+      <th>Concurrency</th>
+      <td>{{ dag.concurrency }}</td>
+    </tr>
+    <tr>
+      <th>Default Args</th>
+      <td><code>{{ dag.default_args }}</code></td>
+    </tr>
+    <tr>
+      <th>Tasks Count</th>
+      <td>{{ dag.tasks|length }}</td>
+    </tr>
+    <tr>
+      <th>Task IDs</th>
+      <td>{{ dag.task_ids }}</td>
+    </tr>
+    <tr>
+      <th>Filepath</th>
+      <td>{{ dag.filepath }}</td>
+    </tr>
+    <tr>
+      <th>Owner</th>
+      <td>{{ dag.owner }}</td>
+    </tr>
+  </table>
 {% endblock %}


### PR DESCRIPTION
- Updates the DAG Details table headings to use more human readable (and consistent) text formatting.
- Fixes the markup used on these headings to use `<th></th>` pairs instead of mixed `<th></td>`. While I believe the mixed may be technically allowed, it is not general practice.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/3267/90071239-37231180-dcc3-11ea-8aee-263d2ab31b25.png)  | ![image](https://user-images.githubusercontent.com/3267/90071193-22df1480-dcc3-11ea-8829-b2dffad8f348.png) |


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
