### PR TITLE
Use check_output to capture in celery task

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -75,8 +75,10 @@ def execute_command(command_to_exec: CommandType) -> None:
     log.info("Executing command in Celery: %s", command_to_exec)
     env = os.environ.copy()
     try:
-        subprocess.check_call(command_to_exec, stderr=subprocess.STDOUT,
-                              close_fds=True, env=env)
+        # pylint: disable=unexpected-keyword-arg
+        subprocess.check_output(command_to_exec, stderr=subprocess.STDOUT,
+                                close_fds=True, env=env)
+        # pylint: disable=unexpected-keyword-arg
     except subprocess.CalledProcessError as e:
         log.exception('execute_command encountered a CalledProcessError')
         log.error(e.output)

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -197,16 +197,16 @@ class TestCeleryExecutor(unittest.TestCase):
         [['airflow', 'version'], ValueError],
         [['airflow', 'tasks', 'run'], None]
     ))
-    @mock.patch('subprocess.check_call')
-    def test_command_validation(self, command, expected_exception, mock_check_call):
+    @mock.patch('subprocess.check_output')
+    def test_command_validation(self, command, expected_exception, mock_check_output):
         # Check that we validate _on the receiving_ side, not just sending side
         if expected_exception:
             with pytest.raises(expected_exception):
                 celery_executor.execute_command(command)
-            mock_check_call.assert_not_called()
+            mock_check_output.assert_not_called()
         else:
             celery_executor.execute_command(command)
-            mock_check_call.assert_called_once_with(
+            mock_check_output.assert_called_once_with(
                 command, stderr=mock.ANY, close_fds=mock.ANY, env=mock.ANY,
             )
 


### PR DESCRIPTION
See: https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError

The `check_call` does not set `output` to the `subprocess.CalledProcessError` so the `log.error(e.output)` [code](https://github.com/apache/airflow/pull/10310/files#diff-b850a1772ed27487a98e199be3d1c36eR84) is always `None`.

By using `check_ouput`, when there is `CalledProcessError`, it will correctly log the error output

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
