### PR TITLE
Unpin pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -464,7 +464,7 @@ devel = [
     'pre-commit',
     'pylint==2.5.3',
     'pysftp',
-    'pytest<6.0.0',  # FIXME: pylint complaining for pytest.mark.* on v6.0
+    'pytest',
     'pytest-cov',
     'pytest-instafail',
     'pytest-rerunfailures',


### PR DESCRIPTION
The pytest bug in 6.0.0 has been fixed in 6.0.1.
See changelog for details: https://docs.pytest.org/en/stable/changelog.html#pytest-6-0-1-2020-07-30

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
