### PR TITLE
Respect DAG Serialization setting when running sync_perm

### DIFF
--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Sync permission command"""
+from airflow import settings
 from airflow.models import DagBag
 from airflow.utils import cli as cli_utils
 from airflow.www.app import cached_app
@@ -28,7 +29,7 @@ def sync_perm(args):
     print('Updating permission, view-menu for all existing roles')
     appbuilder.sm.sync_roles()
     print('Updating permission on all DAG views')
-    dags = DagBag().dags.values()
+    dags = DagBag(store_serialized_dags=settings.STORE_SERIALIZED_DAGS).dags.values()
     for dag in dags:
         appbuilder.sm.sync_perm_for_dag(
             dag.dag_id,

--- a/tests/cli/commands/test_sync_perm_command.py
+++ b/tests/cli/commands/test_sync_perm_command.py
@@ -33,6 +33,7 @@ class TestCliSyncPerm(unittest.TestCase):
 
     @mock.patch("airflow.cli.commands.sync_perm_command.cached_app")
     @mock.patch("airflow.cli.commands.sync_perm_command.DagBag")
+    @mock.patch("airflow.settings.STORE_SERIALIZED_DAGS", True)
     def test_cli_sync_perm(self, dagbag_mock, mock_cached_app):
         self.expect_dagbag_contains([
             DAG('has_access_control',
@@ -51,6 +52,7 @@ class TestCliSyncPerm(unittest.TestCase):
 
         assert appbuilder.sm.sync_roles.call_count == 1
 
+        dagbag_mock.assert_called_once_with(store_serialized_dags=True)
         self.assertEqual(2, len(appbuilder.sm.sync_perm_for_dag.mock_calls))
         appbuilder.sm.sync_perm_for_dag.assert_any_call(
             'has_access_control',


### PR DESCRIPTION
We run this on Webserver Startup and when DAG Serialization is enabled we expect that no files are required but because of this bug the files were still looked for.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
