### PR TITLE
Update README.md and fix incorrect version in Installing from PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ if needed. This means that from time to time plain `pip install apache-airflow` 
 produce unusable Airflow installation.
 
 In order to have repeatable installation, however, introduced in **Airflow 1.10.10** and updated in
-**Airflow 1.10.12** we also keep a set of "known-to-be-working" constraint files in the
+**Airflow 1.10.11** we also keep a set of "known-to-be-working" constraint files in the
 orphan `constraints-master` and `constraints-1-10` branches. We keep those "known-to-be-working"
 constraints files separately per major/minor python version.
 You can use them as constraint files when installing Airflow from PyPI. Note that you have to specify
@@ -111,14 +111,14 @@ correct Airflow tag/version/branch and python versions in the URL.
 1. Installing just airflow:
 
 ```bash
-pip install apache-airflow==1.10.12 \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-1.10.12/constraints-3.7.txt"
+pip install apache-airflow==1.10.11 \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-1.10.11/constraints-3.7.txt"
 ```
 
 2. Installing with extras (for example postgres,google)
 ```bash
 pip install apache-airflow[postgres,google]==1.10.11 \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-1.10.12/constraints-3.7.txt"
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-1.10.11/constraints-3.7.txt"
 ```
 
 ## Official Docker images


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

the current stage version is 1.10.11, in [Installing from PyPI](https://github.com/apache/airflow#installing-from-pypi), it's point to nonexistent version 1.10.12
