### PR TITLE
Contrainer [scheduler-logs] commands conflicted with entrypoint

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -163,7 +163,7 @@ spec:
         # we don't have elasticsearch enabled.
         - name: scheduler-logs
           image: {{ template "airflow_image" . }}
-          args: ["airflow", "serve_logs"]
+          args: ["serve_logs"]
           ports:
             - name: worker-logs
               containerPort: {{ .Values.ports.workerLogs }}


### PR DESCRIPTION
 Should remove the command "airflow" from the args, because the entrypoint is "airflow".

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
