### PR TITLE
Move roles to CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -105,7 +105,7 @@ Committers/Maintainers
 Committers are community members that have write access to the project’s repositories, i.e., they can modify the code,
 documentation, and website by themselves and also accept other contributions.
 
-The official list of committers can be found `here <https://airflow.apache.org/docs/>`__.
+The official list of committers can be found `here <https://airflow.apache.org/docs/stable/project.html#committers>`__.
 
 Additionally, committers are listed in a few other places (some of these may only be visible to existing committers):
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,8 +48,8 @@ Committers are responsible for:
 
 * Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__
 * Reviewing & Merging Pull-Requests
-* Scanning and responding to JIRAs
-* Responding to questions on the dev mailing list (dev@airflow.incubator.apache.org)
+* Scanning and responding to Github issues
+* Responding to questions on the dev mailing list (dev@airflow.apache.org)
 
 Becoming a Committer
 --------------------
@@ -60,12 +60,12 @@ Candidates for new committers are typically people that are active contributors 
 The key aspects of a committer are:
 
 * Consistent contributions over the past 6 months
-* Expressed understanding of Airflow Core or has displayed holistic understanding of a particular part and made
+* Understanding of Airflow Core or has displayed a holistic understanding of a particular part and made
   contributions towards a more strategic goal
-* Understands contributor/committer guidelines: `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
-* Quality of the commits, and asses the impact of the changes
-* Visibility on discussions on the dev mailing list and the Slack channel
-* Testing Release Candidates to improve the release cycle
+* Understanding of contributor/committer guidelines: `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
+* Quality of the commits
+* Visibility in community discussions (dev mailing list, Slack and Github)
+* Testing Release Candidates
 
 
 Contributors

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,70 +17,6 @@
 
 .. contents:: :local:
 
-Roles
-=============
-
-There are several roles within the Airflow Open-Source community.
-
-
-PMC Member
------------
-The PMC (Project Management Committee) is a group of maintainers that drives changes in the way that
-Airflow is managed as a project.
-
-Considering Apache, the role of the PMC is primarily to ensure that Airflow conforms to Apache's processes
-and guidelines.
-
-Committers/Maintainers
-----------------------
-
-Committers are community members that have write access to the project’s repositories, i.e., they can modify the code,
-documentation, and website by themselves and also accept other contributions.
-
-The official list of committers can be found `here <https://airflow.apache.org/docs/>`__.
-
-Additionally, committers are listed in a few other places (some of these may only be visible to existing committers):
-
-* https://whimsy.apache.org/roster/ppmc/airflow
-* https://github.com/orgs/apache/teams/airflow-committers/members
-
-Committers are responsible for:
-
-* Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__
-* Reviewing & Merging Pull-Requests
-* Scanning and responding to Github issues
-* Responding to questions on the dev mailing list (dev@airflow.apache.org)
-
-Becoming a Committer
---------------------
-
-There is no strict protocol for becoming a committer.
-Candidates for new committers are typically people that are active contributors and community members.
-
-The key aspects of a committer are:
-
-* Consistent contributions over the past 6 months
-* Understanding of Airflow Core or has displayed a holistic understanding of a particular part and made
-  contributions towards a more strategic goal
-* Understanding of contributor/committer guidelines: `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
-* Quality of the commits
-* Visibility in community discussions (dev mailing list, Slack and Github)
-* Testing Release Candidates
-
-
-Contributors
-------------
-
-A contributor is anyone who wants to contribute code, documentation, tests, ideas, or anything to the
-Apache Airflow project.
-
-Contributors are responsible for:
-
-* Fixing bugs
-* Adding features
-* Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__.
-
-
 Contributions
 =============
 
@@ -148,6 +84,69 @@ If you are proposing a new feature:
 -   Remember that this is a volunteer-driven project, and that contributions are
     welcome :)
 
+
+Roles
+=============
+
+There are several roles within the Airflow Open-Source community.
+
+
+PMC Member
+-----------
+The PMC (Project Management Committee) is a group of maintainers that drives changes in the way that
+Airflow is managed as a project.
+
+Considering Apache, the role of the PMC is primarily to ensure that Airflow conforms to Apache's processes
+and guidelines.
+
+Committers/Maintainers
+----------------------
+
+Committers are community members that have write access to the project’s repositories, i.e., they can modify the code,
+documentation, and website by themselves and also accept other contributions.
+
+The official list of committers can be found `here <https://airflow.apache.org/docs/>`__.
+
+Additionally, committers are listed in a few other places (some of these may only be visible to existing committers):
+
+* https://whimsy.apache.org/roster/ppmc/airflow
+* https://github.com/orgs/apache/teams/airflow-committers/members
+
+Committers are responsible for:
+
+* Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__
+* Reviewing & Merging Pull-Requests
+* Scanning and responding to Github issues
+* Responding to questions on the dev mailing list (dev@airflow.apache.org)
+
+Becoming a Committer
+--------------------
+
+There is no strict protocol for becoming a committer.
+Candidates for new committers are typically people that are active contributors and community members.
+
+The key aspects of a committer are:
+
+* Consistent contributions over the past 6 months
+* Understanding of Airflow Core or has displayed a holistic understanding of a particular part and made
+  contributions towards a more strategic goal
+* Understanding of contributor/committer guidelines: `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
+* Quality of the commits
+* Visibility in community discussions (dev mailing list, Slack and Github)
+* Testing Release Candidates
+
+
+Contributors
+------------
+
+A contributor is anyone who wants to contribute code, documentation, tests, ideas, or anything to the
+Apache Airflow project.
+
+Contributors are responsible for:
+
+* Fixing bugs
+* Adding features
+* Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__.
 
 Contribution Workflow
 =====================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,6 +17,66 @@
 
 .. contents:: :local:
 
+Roles
+=============
+
+There are several roles within the Airflow Open-Source community.
+
+
+PMC Member
+-----------
+The PMC (Project Management Committee) is a group of maintainers that drives changes in the way
+Airflow is managed as a project.
+
+As we consider Apache, the role of the PMC is primarily to ensure that Airflow conforms to Apache's processes
+and guidelines.
+
+Committers/Maintainers
+----------------------
+
+Committers are community members that have write access to the project’s repositories, i.e., they can modify the code,
+documentation, and website by themselves and also accept other contributions.
+
+The official list of committers can be found `here <https://airflow.apache.org/docs/>`__.
+
+Additionally, committers are listed in a few other places (some of these may only be visible to existing committers):
+
+* https://whimsy.apache.org/roster/ppmc/airflow
+* https://github.com/orgs/apache/teams/airflow-committers/members
+
+Committers are responsible for:
+
+* Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__
+* Reviewing & Merging Pull-Requests
+* Scanning and responding to JIRAs
+* Responding to questions on the dev mailing list ( dev@airflow.incubator.apache.org )
+
+Becoming a Committer
+--------------------
+
+There is no strict protocol for becoming a committer.
+Candidates for new committers are typically people that are active contributors and community members.
+
+The key aspects of a committer are:
+
+* Consistent contributions over the past 6 months
+* Expressed understanding of Airflow Core or has displayed holistic understanding of a particular part and made
+  contributions towards a more strategic goal
+* Understands contributor/committer guidelines : `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
+* Quality of the commits, and asses the impact of the changes
+* Visibility on discussions on the dev maillist and the Slack channel
+* Testing Release Candidates to improve the release cycle
+
+
+Contributors
+------------
+
+Contributors are responsible for:
+
+* Fixing bugs
+* Adding features
+* Championing one or more items on the * Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__.
+
 Contributions
 =============
 
@@ -154,7 +214,7 @@ You can use the default Breeze configuration as follows:
 
 .. code-block:: bash
 
-   ./breeze --initialize-local-virtualenv
+   ./breeze initialize-local-virtualenv
 
 6. Open your IDE (for example, PyCharm) and select the virtualenv you created
    as the project's default virtualenv in your IDE.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,10 +25,10 @@ There are several roles within the Airflow Open-Source community.
 
 PMC Member
 -----------
-The PMC (Project Management Committee) is a group of maintainers that drives changes in the way
+The PMC (Project Management Committee) is a group of maintainers that drives changes in the way that
 Airflow is managed as a project.
 
-As we consider Apache, the role of the PMC is primarily to ensure that Airflow conforms to Apache's processes
+Considering Apache, the role of the PMC is primarily to ensure that Airflow conforms to Apache's processes
 and guidelines.
 
 Committers/Maintainers
@@ -62,20 +62,24 @@ The key aspects of a committer are:
 * Consistent contributions over the past 6 months
 * Expressed understanding of Airflow Core or has displayed holistic understanding of a particular part and made
   contributions towards a more strategic goal
-* Understands contributor/committer guidelines : `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
+* Understands contributor/committer guidelines: `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
 * Quality of the commits, and asses the impact of the changes
-* Visibility on discussions on the dev maillist and the Slack channel
+* Visibility on discussions on the dev mailing list and the Slack channel
 * Testing Release Candidates to improve the release cycle
 
 
 Contributors
 ------------
 
+A contributor is anyone who wants to contribute code, documentation, tests, ideas, or anything to the
+Apache Airflow project.
+
 Contributors are responsible for:
 
 * Fixing bugs
 * Adding features
-* Championing one or more items on the * Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__.
+* Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__.
+
 
 Contributions
 =============
@@ -143,6 +147,7 @@ If you are proposing a new feature:
 -   Keep the scope as narrow as possible to make it easier to implement.
 -   Remember that this is a volunteer-driven project, and that contributions are
     welcome :)
+
 
 Contribution Workflow
 =====================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ Committers are responsible for:
 * Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__
 * Reviewing & Merging Pull-Requests
 * Scanning and responding to JIRAs
-* Responding to questions on the dev mailing list ( dev@airflow.incubator.apache.org )
+* Responding to questions on the dev mailing list (dev@airflow.incubator.apache.org)
 
 Becoming a Committer
 --------------------


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adds [roles](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=62694605) to [CONTRIBUTING.rst](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst) as requested in #10184 .
Also fixes a typo in breeze command.

Closes #10184 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
