### PR TITLE
Fixes rat-check pre-commit in case Airflow is added as subrepo

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -4,6 +4,7 @@
 .github/*
 .gitignore
 .gitattributes
+.gitrepo
 .airflow_db_initialised
 .airflowignore
 .coverage


### PR DESCRIPTION
In case Apache Airflow directory is added as subrepo, a new
.gitrepo file is created in the Airflow sources. When you try to
run pre-commit checks, the RAT check fails in this case.

Adding it to .rat-excludes fixes the problem

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
