### PR TITLE
Migrate speccy to spectral in OpenAPI linting.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -209,9 +209,9 @@ repos:
         entry: koalaman/shellcheck:stable -x -a
         files: ^breeze$|^breeze-complete$|\.sh$|^hooks/build$|^hooks/push$|\.bash$|\.bats$
       - id: lint-openapi
-        name: Lint OpenAPI using speccy
+        name: Lint OpenAPI using spectral
         language: docker_image
-        entry: wework/speccy lint -r default -r ./scripts/ci/speccy_rules/connexion.yml
+        entry: stoplight/spectral lint
         files: ^airflow/api_connexion/openapi/
       - id: lint-openapi
         name: Lint OpenAPI using openapi-spec-validator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -211,7 +211,7 @@ repos:
       - id: lint-openapi
         name: Lint OpenAPI using spectral
         language: docker_image
-        entry: stoplight/spectral lint
+        entry: stoplight/spectral lint -r ./scripts/ci/spectral_rules/connexion.yml
         files: ^airflow/api_connexion/openapi/
       - id: lint-openapi
         name: Lint OpenAPI using openapi-spec-validator

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1476,8 +1476,9 @@ components:
           readOnly: true
           nullable: true
         state:
-          $ref: '#/components/schemas/DagState'
           readOnly: True
+          allOf:
+            - $ref: '#/components/schemas/DagState'
         external_trigger:
           type: boolean
           default: true
@@ -1856,7 +1857,8 @@ components:
               readOnly: true
             dag_run_timeout:
               nullable: true
-              $ref: '#/components/schemas/TimeDelta'
+              allOf:
+                - $ref: '#/components/schemas/TimeDelta'
             doc_md:
               type: string
               readOnly: true
@@ -1938,10 +1940,12 @@ components:
           type: number
           readOnly: true
         execution_timeout:
-          $ref: '#/components/schemas/TimeDelta'
           nullable: true
+          allOf:
+            - $ref: '#/components/schemas/TimeDelta'
         retry_delay:
-          $ref: '#/components/schemas/TimeDelta'
+          allOf:
+            - $ref: '#/components/schemas/TimeDelta'
           nullable: true
         retry_exponential_backoff:
           type: boolean

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1476,9 +1476,8 @@ components:
           readOnly: true
           nullable: true
         state:
+          $ref: '#/components/schemas/DagState'
           readOnly: True
-          oneOf:
-            - $ref: '#/components/schemas/DagState'
         external_trigger:
           type: boolean
           default: true
@@ -1856,9 +1855,8 @@ components:
               format: 'date-time'
               readOnly: true
             dag_run_timeout:
-              oneOf:
-                - type: 'null'
-                - $ref: '#/components/schemas/TimeDelta'
+              nullable: true
+              $ref: '#/components/schemas/TimeDelta'
             doc_md:
               type: string
               readOnly: true
@@ -1940,13 +1938,11 @@ components:
           type: number
           readOnly: true
         execution_timeout:
-          oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/TimeDelta'
+          $ref: '#/components/schemas/TimeDelta'
+          nullable: true
         retry_delay:
-          oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/TimeDelta'
+          $ref: '#/components/schemas/TimeDelta'
+          nullable: true
         retry_exponential_backoff:
           type: boolean
           readOnly: true

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1477,7 +1477,7 @@ components:
           nullable: true
         state:
           readOnly: True
-          allOf:
+          oneOf:
             - $ref: '#/components/schemas/DagState'
         external_trigger:
           type: boolean
@@ -1856,8 +1856,8 @@ components:
               format: 'date-time'
               readOnly: true
             dag_run_timeout:
-              nullable: true
-              allOf:
+              oneOf:
+                - type: 'null'
                 - $ref: '#/components/schemas/TimeDelta'
             doc_md:
               type: string
@@ -1940,13 +1940,13 @@ components:
           type: number
           readOnly: true
         execution_timeout:
-          nullable: true
-          allOf:
+          oneOf:
+            - type: 'null'
             - $ref: '#/components/schemas/TimeDelta'
         retry_delay:
-          allOf:
+          oneOf:
+            - type: 'null'
             - $ref: '#/components/schemas/TimeDelta'
-          nullable: true
         retry_exponential_backoff:
           type: boolean
           readOnly: true

--- a/scripts/ci/spectral_rules/connexion.yml
+++ b/scripts/ci/spectral_rules/connexion.yml
@@ -15,8 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+extends: spectral:oas
+
 rules:
-  - name: operation-x-openapi-router-controller
-    object: operation
+  operation-x-openapi-router-controller:
     description: operation should have a x-openapi-router-controller attribute
-    truthy: x-openapi-router-controller
+    given: $.paths[*][get,post,put,patch,delete,head,options,trace]
+    severity: error
+    then:
+      field: x-openapi-router-controller
+      function: truthy

--- a/scripts/ci/spectral_rules/connexion.yml
+++ b/scripts/ci/spectral_rules/connexion.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-extends: spectral:oas
 
 rules:
   operation-x-openapi-router-controller:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Replaces speccy with spectral for OpenAPI linting.
Fixes a bug where sibling properties of `$ref` were being ignored, as describe in the [OpenAPI docs](https://swagger.io/docs/specification/using-ref/).

Closes #10001 

@mik-laj Let me know if there's anything else you need me to do regarding this 😃 .

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
