### PR TITLE
Discontinue using deprecated methods in GCSToBigQueryOperator

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -90,7 +90,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         """
         Returns a BigQuery PEP 249 connection object.
         """
-        service = self.get_service()
+        service = self.get_client()
         return BigQueryConnection(
             service=service,
             project_id=self.project_id,

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -258,7 +258,7 @@ class GCSToBigQueryOperator(BaseOperator):
         cursor = conn.cursor()
 
         if self.external_table:
-            cursor.create_external_table(
+            bq_hook.create_external_table(
                 external_project_dataset_table=self.destination_project_dataset_table,
                 schema_fields=schema_fields,
                 source_uris=source_uris,
@@ -276,7 +276,7 @@ class GCSToBigQueryOperator(BaseOperator):
                 encryption_configuration=self.encryption_configuration
             )
         else:
-            cursor.run_load(
+            bq_hook.insert_job(configuration=dict(
                 destination_project_dataset_table=self.destination_project_dataset_table,
                 schema_fields=schema_fields,
                 source_uris=source_uris,
@@ -297,8 +297,9 @@ class GCSToBigQueryOperator(BaseOperator):
                 time_partitioning=self.time_partitioning,
                 cluster_fields=self.cluster_fields,
                 encryption_configuration=self.encryption_configuration)
+            )
 
-        if cursor.use_legacy_sql:
+        if bq_hook.use_legacy_sql:
             escaped_table_name = f'[{self.destination_project_dataset_table}]'
         else:
             escaped_table_name = f'`{self.destination_project_dataset_table}`'

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -40,7 +40,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
                                          max_id_key=MAX_ID_KEY)
 
         # using legacy SQL
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql = True
+        bq_hook.return_value.use_legacy_sql = True
 
         operator.execute(None)
 
@@ -59,7 +59,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
                                          max_id_key=MAX_ID_KEY)
 
         # using non-legacy SQL
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql = False
+        bq_hook.return_value.use_legacy_sql = False
 
         operator.execute(None)
 


### PR DESCRIPTION
Several methods used in `GCSToBigQueryOperator` are deprecated. Switch to use the preferred methods, updating parameters and tests as needed.

related: #10288

Note: I only had time to tackle the operator mentioned by the user who opened the issue. It looks like the other Big Query transfer operators have the same issue. I could tackle those at a later date.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
