### PR TITLE
Refactor DataprocCreateCluster operator to use simpler interface

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -64,16 +64,10 @@ CLUSTER_CONFIG = {
 # Update options
 # [START how_to_cloud_dataproc_updatemask_cluster_operator]
 CLUSTER_UPDATE = {
-    "config": {
-        "worker_config": {"num_instances": 3},
-        "secondary_worker_config": {"num_instances": 3},
-    }
+    "config": {"worker_config": {"num_instances": 3}, "secondary_worker_config": {"num_instances": 3}}
 }
 UPDATE_MASK = {
-    "paths": [
-        "config.worker_config.num_instances",
-        "config.secondary_worker_config.num_instances",
-    ]
+    "paths": ["config.worker_config.num_instances", "config.secondary_worker_config.num_instances"]
 }
 # [END how_to_cloud_dataproc_updatemask_cluster_operator]
 
@@ -142,11 +136,7 @@ HADOOP_JOB = {
 }
 # [END how_to_cloud_dataproc_hadoop_config]
 
-with models.DAG(
-    "example_gcp_dataproc",
-    start_date=days_ago(1),
-    schedule_interval=None,
-) as dag:
+with models.DAG("example_gcp_dataproc", start_date=days_ago(1), schedule_interval=None) as dag:
     # [START how_to_cloud_dataproc_create_cluster_operator]
     create_cluster = DataprocCreateClusterOperator(
         task_id="create_cluster",
@@ -173,10 +163,7 @@ with models.DAG(
         task_id="pig_task", job=PIG_JOB, location=REGION, project_id=PROJECT_ID
     )
     spark_sql_task = DataprocSubmitJobOperator(
-        task_id="spark_sql_task",
-        job=SPARK_SQL_JOB,
-        location=REGION,
-        project_id=PROJECT_ID,
+        task_id="spark_sql_task", job=SPARK_SQL_JOB, location=REGION, project_id=PROJECT_ID
     )
 
     spark_task = DataprocSubmitJobOperator(
@@ -203,10 +190,7 @@ with models.DAG(
 
     # [START how_to_cloud_dataproc_delete_cluster_operator]
     delete_cluster = DataprocDeleteClusterOperator(
-        task_id="delete_cluster",
-        project_id=PROJECT_ID,
-        cluster_name=CLUSTER_NAME,
-        region=REGION,
+        task_id="delete_cluster", project_id=PROJECT_ID, cluster_name=CLUSTER_NAME, region=REGION
     )
     # [END how_to_cloud_dataproc_delete_cluster_operator]
 

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -34,7 +34,7 @@ from airflow.utils.dates import days_ago
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "an-id")
 CLUSTER_NAME = os.environ.get("GCP_DATAPROC_CLUSTER_NAME", "example-project")
 REGION = os.environ.get("GCP_LOCATION", "europe-west1")
-ZONE = os.environ.get("GCP_REGION", "europe-west-1b")
+ZONE = os.environ.get("GCP_REGION", "europe-west1-b")
 BUCKET = os.environ.get("GCP_DATAPROC_BUCKET", "dataproc-system-tests")
 OUTPUT_FOLDER = "wordcount"
 OUTPUT_PATH = "gs://{}/{}/".format(BUCKET, OUTPUT_FOLDER)

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -46,20 +46,16 @@ SPARKR_URI = "gs://{}/{}".format(BUCKET, SPARKR_MAIN)
 # Cluster definition
 # [START how_to_cloud_dataproc_create_cluster]
 
-CLUSTER = {
-    "project_id": PROJECT_ID,
-    "cluster_name": CLUSTER_NAME,
-    "config": {
-        "master_config": {
-            "num_instances": 1,
-            "machine_type_uri": "n1-standard-4",
-            "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 1024},
-        },
-        "worker_config": {
-            "num_instances": 2,
-            "machine_type_uri": "n1-standard-4",
-            "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 1024},
-        },
+CLUSTER_CONFIG = {
+    "master_config": {
+        "num_instances": 1,
+        "machine_type_uri": "n1-standard-4",
+        "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 1024},
+    },
+    "worker_config": {
+        "num_instances": 2,
+        "machine_type_uri": "n1-standard-4",
+        "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 1024},
     },
 }
 
@@ -68,10 +64,16 @@ CLUSTER = {
 # Update options
 # [START how_to_cloud_dataproc_updatemask_cluster_operator]
 CLUSTER_UPDATE = {
-    "config": {"worker_config": {"num_instances": 3}, "secondary_worker_config": {"num_instances": 3},}
+    "config": {
+        "worker_config": {"num_instances": 3},
+        "secondary_worker_config": {"num_instances": 3},
+    }
 }
 UPDATE_MASK = {
-    "paths": ["config.worker_config.num_instances", "config.secondary_worker_config.num_instances",]
+    "paths": [
+        "config.worker_config.num_instances",
+        "config.secondary_worker_config.num_instances",
+    ]
 }
 # [END how_to_cloud_dataproc_updatemask_cluster_operator]
 
@@ -140,10 +142,18 @@ HADOOP_JOB = {
 }
 # [END how_to_cloud_dataproc_hadoop_config]
 
-with models.DAG("example_gcp_dataproc", start_date=days_ago(1), schedule_interval=None,) as dag:
+with models.DAG(
+    "example_gcp_dataproc",
+    start_date=days_ago(1),
+    schedule_interval=None,
+) as dag:
     # [START how_to_cloud_dataproc_create_cluster_operator]
     create_cluster = DataprocCreateClusterOperator(
-        task_id="create_cluster", project_id=PROJECT_ID, cluster=CLUSTER, region=REGION
+        task_id="create_cluster",
+        project_id=PROJECT_ID,
+        cluster_config=CLUSTER_CONFIG,
+        region=REGION,
+        cluster_name=CLUSTER_NAME,
     )
     # [END how_to_cloud_dataproc_create_cluster_operator]
 
@@ -163,7 +173,10 @@ with models.DAG("example_gcp_dataproc", start_date=days_ago(1), schedule_interva
         task_id="pig_task", job=PIG_JOB, location=REGION, project_id=PROJECT_ID
     )
     spark_sql_task = DataprocSubmitJobOperator(
-        task_id="spark_sql_task", job=SPARK_SQL_JOB, location=REGION, project_id=PROJECT_ID,
+        task_id="spark_sql_task",
+        job=SPARK_SQL_JOB,
+        location=REGION,
+        project_id=PROJECT_ID,
     )
 
     spark_task = DataprocSubmitJobOperator(
@@ -190,7 +203,10 @@ with models.DAG("example_gcp_dataproc", start_date=days_ago(1), schedule_interva
 
     # [START how_to_cloud_dataproc_delete_cluster_operator]
     delete_cluster = DataprocDeleteClusterOperator(
-        task_id="delete_cluster", project_id=PROJECT_ID, cluster_name=CLUSTER_NAME, region=REGION,
+        task_id="delete_cluster",
+        project_id=PROJECT_ID,
+        cluster_name=CLUSTER_NAME,
+        region=REGION,
     )
     # [END how_to_cloud_dataproc_delete_cluster_operator]
 

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -225,6 +225,27 @@ class DataprocHook(GoogleBaseHook):
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
 
+    @cached_property
+    def get_template_client(self) -> WorkflowTemplateServiceClient:
+        """
+        Returns WorkflowTemplateServiceClient.
+        """
+        return WorkflowTemplateServiceClient(
+            credentials=self._get_credentials(), client_info=self.client_info
+        )
+
+    def get_job_client(self, location: Optional[str] = None) -> JobControllerClient:
+        """
+        Returns JobControllerClient.
+        """
+        client_options = (
+            {'api_endpoint': '{}-dataproc.googleapis.com:443'.format(location)} if location else None
+        )
+
+        return JobControllerClient(
+            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+        )
+
     @GoogleBaseHook.fallback_to_default_project_id
     def create_cluster(
         self,
@@ -290,27 +311,6 @@ class DataprocHook(GoogleBaseHook):
             metadata=metadata,
         )
         return result
-
-    @cached_property
-    def get_template_client(self) -> WorkflowTemplateServiceClient:
-        """
-        Returns WorkflowTemplateServiceClient.
-        """
-        return WorkflowTemplateServiceClient(
-            credentials=self._get_credentials(), client_info=self.client_info
-        )
-
-    def get_job_client(self, location: Optional[str] = None) -> JobControllerClient:
-        """
-        Returns JobControllerClient.
-        """
-        client_options = (
-            {'api_endpoint': '{}-dataproc.googleapis.com:443'.format(location)} if location else None
-        )
-
-        return JobControllerClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
-        )
 
     @GoogleBaseHook.fallback_to_default_project_id
     def delete_cluster(

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -63,7 +63,10 @@ class DataProcJobBuilder:
         self.job_type = job_type
         self.job = {
             "job": {
-                "reference": {"project_id": project_id, "job_id": name,},
+                "reference": {
+                    "project_id": project_id,
+                    "job_id": name,
+                },
                 "placement": {"cluster_name": cluster_name},
                 "labels": {'airflow-version': 'v' + airflow_version.replace('.', '-').replace('+', '-')},
                 job_type: {},
@@ -225,6 +228,72 @@ class DataprocHook(GoogleBaseHook):
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
 
+    @GoogleBaseHook.fallback_to_default_project_id
+    def create_cluster(
+        self,
+        region: str,
+        project_id: str,
+        cluster_name: str,
+        cluster_config: Union[Dict, Cluster],
+        labels: Optional[Dict[str, str]] = None,
+        request_id: Optional[str] = None,
+        retry: Optional[Retry] = None,
+        timeout: Optional[float] = None,
+        metadata: Optional[Sequence[Tuple[str, str]]] = None,
+    ):
+        """
+        Creates a cluster in a project.
+
+        :param project_id: Required. The ID of the Google Cloud Platform project that the cluster belongs to.
+        :type project_id: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
+        :param cluster_name: Name of the cluster to create
+        :type cluster_name: str
+        :param labels: Labels that will be assigned to created cluster
+        :type labels: Dict[str, str]
+        :param cluster_config: Required. The cluster config to create.
+            If a dict is provided, it must be of the same form as the protobuf message
+            :class:`~google.cloud.dataproc_v1.types.ClusterConfig`
+        :type cluster_config: Union[Dict, google.cloud.dataproc_v1.types.ClusterConfig]
+        :param request_id: Optional. A unique id used to identify the request. If the server receives two
+            ``CreateClusterRequest`` requests with the same id, then the second request will be ignored and
+            the first ``google.longrunning.Operation`` created and stored in the backend is returned.
+        :type request_id: str
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        # Dataproc labels must conform to the following regex:
+        # [a-z]([-a-z0-9]*[a-z0-9])? (current airflow version string follows
+        # semantic versioning spec: x.y.z).
+        labels = labels or {}
+        labels.update({'airflow-version': 'v' + airflow_version.replace('.', '-').replace('+', '-')})
+
+        cluster = {
+            "project_id": project_id,
+            "cluster_name": cluster_name,
+            "config": cluster_config,
+            "labels": labels,
+        }
+
+        client = self.get_cluster_client(location=region)
+        result = client.create_cluster(
+            project_id=project_id,
+            region=region,
+            cluster=cluster,
+            request_id=request_id,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        return result
+
     @cached_property
     def get_template_client(self) -> WorkflowTemplateServiceClient:
         """
@@ -245,53 +314,6 @@ class DataprocHook(GoogleBaseHook):
         return JobControllerClient(
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
-
-    @GoogleBaseHook.fallback_to_default_project_id
-    def create_cluster(
-        self,
-        region: str,
-        cluster: Union[Dict, Cluster],
-        project_id: str,
-        request_id: Optional[str] = None,
-        retry: Optional[Retry] = None,
-        timeout: Optional[float] = None,
-        metadata: Optional[Sequence[Tuple[str, str]]] = None,
-    ):
-        """
-        Creates a cluster in a project.
-
-        :param project_id: Required. The ID of the Google Cloud Platform project that the cluster belongs to.
-        :type project_id: str
-        :param region: Required. The Cloud Dataproc region in which to handle the request.
-        :type region: str
-        :param cluster: Required. The cluster to create.
-            If a dict is provided, it must be of the same form as the protobuf message
-            :class:`~google.cloud.dataproc_v1.types.Cluster`
-        :type cluster: Union[Dict, google.cloud.dataproc_v1.types.Cluster]
-        :param request_id: Optional. A unique id used to identify the request. If the server receives two
-            ``CreateClusterRequest`` requests with the same id, then the second request will be ignored and
-            the first ``google.longrunning.Operation`` created and stored in the backend is returned.
-        :type request_id: str
-        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
-            retried.
-        :type retry: google.api_core.retry.Retry
-        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
-            ``retry`` is specified, the timeout applies to each individual attempt.
-        :type timeout: float
-        :param metadata: Additional metadata that is provided to the method.
-        :type metadata: Sequence[Tuple[str, str]]
-        """
-        client = self.get_cluster_client(location=region)
-        result = client.create_cluster(
-            project_id=project_id,
-            region=region,
-            cluster=cluster,
-            request_id=request_id,
-            retry=retry,
-            timeout=timeout,
-            metadata=metadata,
-        )
-        return result
 
     @GoogleBaseHook.fallback_to_default_project_id
     def delete_cluster(

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -63,10 +63,7 @@ class DataProcJobBuilder:
         self.job_type = job_type
         self.job = {
             "job": {
-                "reference": {
-                    "project_id": project_id,
-                    "job_id": name,
-                },
+                "reference": {"project_id": project_id, "job_id": name},
                 "placement": {"cluster_name": cluster_name},
                 "labels": {'airflow-version': 'v' + airflow_version.replace('.', '-').replace('+', '-')},
                 job_type: {},

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -232,10 +232,10 @@ class ClusterGenerator:
     def _get_init_action_timeout(self):
         match = re.match(r"^(\d+)([sm])$", self.init_action_timeout)
         if match:
+            val = float(match.group(1))
             if match.group(2) == "s":
-                return {"seconds": int(self.init_action_timeout)}
+                return {"seconds": int(val)}
             elif match.group(2) == "m":
-                val = float(match.group(1))
                 return {"seconds": int(timedelta(minutes=val).total_seconds())}
 
         raise AirflowException(

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -155,10 +155,11 @@ class ClusterGenerator:
     """
 
     # pylint: disable=too-many-arguments,too-many-locals
+    @DataprocHook.fallback_to_default_project_id
     def __init__(
         self,
-        project_id: str,
         cluster_name: str,
+        project_id: Optional[str] = None,
         num_workers: Optional[int] = None,
         zone: Optional[str] = None,
         network_uri: Optional[str] = None,
@@ -240,7 +241,7 @@ class ClusterGenerator:
         match = re.match(r"^(\d+)([sm])$", self.init_action_timeout)
         if match:
             if match.group(2) == "s":
-                return {"seconds": self.init_action_timeout}
+                return {"seconds": int(self.init_action_timeout)}
             elif match.group(2) == "m":
                 val = float(match.group(1))
                 return {"seconds": int(timedelta(minutes=val).total_seconds())}
@@ -294,7 +295,9 @@ class ClusterGenerator:
                 '%Y-%m-%dT%H:%M:%S.%fZ'
             )
         elif self.auto_delete_ttl:
-            cluster_data['config']['lifecycle_config']['auto_delete_ttl'] = {"seconds": self.auto_delete_ttl}
+            cluster_data['config']['lifecycle_config']['auto_delete_ttl'] = {
+                "seconds": int(self.auto_delete_ttl)
+            }
 
         return cluster_data
 
@@ -713,7 +716,7 @@ class DataprocScaleClusterOperator(BaseOperator):
         return scale_data
 
     @property
-    def _graceful_decommission_timeout_object(self) -> Optional[Dict]:
+    def _graceful_decommission_timeout_object(self) -> Optional[Dict[str, int]]:
         if not self.graceful_decommission_timeout:
             return None
 

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -181,7 +181,6 @@ class ClusterGenerator:
         worker_disk_type: str = 'pd-standard',
         worker_disk_size: int = 1024,
         num_preemptible_workers: int = 0,
-        region: Optional[str] = None,
         service_account: Optional[str] = None,
         service_account_scopes: Optional[List[str]] = None,
         idle_delete_ttl: Optional[int] = None,
@@ -192,7 +191,6 @@ class ClusterGenerator:
     ) -> None:
 
         self.project_id = project_id
-        self.region = region
         self.num_masters = num_masters
         self.num_workers = num_workers
         self.num_preemptible_workers = num_preemptible_workers
@@ -454,6 +452,15 @@ class DataprocCreateClusterOperator(BaseOperator):
     :type impersonation_chain: Union[str, Sequence[str]]
     """
 
+    template_fields = (
+        'project_id',
+        'region',
+        'cluster_config',
+        'cluster_name',
+        'labels',
+        'impersonation_chain',
+    )
+
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -516,15 +523,6 @@ class DataprocCreateClusterOperator(BaseOperator):
         self.delete_on_error = delete_on_error
         self.use_if_exists = use_if_exists
         self.impersonation_chain = impersonation_chain
-
-    template_fields = (
-        'project_id',
-        'region',
-        'cluster_config',
-        'cluster_name',
-        'labels',
-        'impersonation_chain',
-    )
 
     def _create_cluster(self, hook: DataprocHook):
         operation = hook.create_cluster(

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -58,10 +58,7 @@ class TestDataprocHook(unittest.TestCase):
             self.hook = DataprocHook(gcp_conn_id="test")
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(
-        DATAPROC_STRING.format("DataprocHook.client_info"),
-        new_callable=mock.PropertyMock,
-    )
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("ClusterControllerClient"))
     def test_get_cluster_client(self, mock_client, mock_client_info, mock_get_credentials):
         self.hook.get_cluster_client(location=GCP_LOCATION)
@@ -72,23 +69,16 @@ class TestDataprocHook(unittest.TestCase):
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(
-        DATAPROC_STRING.format("DataprocHook.client_info"),
-        new_callable=mock.PropertyMock,
-    )
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
     def test_get_template_client(self, mock_client, mock_client_info, mock_get_credentials):
         _ = self.hook.get_template_client
         mock_client.assert_called_once_with(
-            credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            credentials=mock_get_credentials.return_value, client_info=mock_client_info.return_value
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(
-        DATAPROC_STRING.format("DataprocHook.client_info"),
-        new_callable=mock.PropertyMock,
-    )
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("JobControllerClient"))
     def test_get_job_client(self, mock_client, mock_client_info, mock_get_credentials):
         self.hook.get_job_client(location=GCP_LOCATION)
@@ -219,13 +209,7 @@ class TestDataprocHook(unittest.TestCase):
         )
         mock_client.workflow_template_path.assert_called_once_with(GCP_PROJECT, GCP_LOCATION, template_name)
         mock_client.instantiate_workflow_template.assert_called_once_with(
-            name=NAME,
-            version=None,
-            parameters=None,
-            request_id=None,
-            retry=None,
-            timeout=None,
-            metadata=None,
+            name=NAME, version=None, parameters=None, request_id=None, retry=None, timeout=None, metadata=None
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
@@ -237,12 +221,7 @@ class TestDataprocHook(unittest.TestCase):
         )
         mock_client.region_path.assert_called_once_with(GCP_PROJECT, GCP_LOCATION)
         mock_client.instantiate_inline_workflow_template.assert_called_once_with(
-            parent=PARENT,
-            template=template,
-            request_id=None,
-            retry=None,
-            timeout=None,
-            metadata=None,
+            parent=PARENT, template=template, request_id=None, retry=None, timeout=None, metadata=None
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job"))
@@ -252,12 +231,7 @@ class TestDataprocHook(unittest.TestCase):
             mock.MagicMock(status=mock.MagicMock(state=JobStatus.ERROR)),
         ]
         with self.assertRaises(AirflowException):
-            self.hook.wait_for_job(
-                job_id=JOB_ID,
-                location=GCP_LOCATION,
-                project_id=GCP_PROJECT,
-                wait_time=0,
-            )
+            self.hook.wait_for_job(job_id=JOB_ID, location=GCP_LOCATION, project_id=GCP_PROJECT, wait_time=0)
         calls = [
             mock.call(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),
             mock.call(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -32,8 +32,15 @@ JOB_ID = "test-id"
 TASK_ID = "test-task-id"
 GCP_LOCATION = "global"
 GCP_PROJECT = "test-project"
-CLUSTER = {"test": "test"}
+CLUSTER_CONFIG = {"test": "test"}
+LABELS = {"test": "test"}
 CLUSTER_NAME = "cluster-name"
+CLUSTER = {
+    "cluster_name": CLUSTER_NAME,
+    "config": CLUSTER_CONFIG,
+    "labels": LABELS,
+    "project_id": GCP_PROJECT,
+}
 
 PARENT = "parent"
 NAME = "name"
@@ -52,7 +59,8 @@ class TestDataprocHook(unittest.TestCase):
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
     @mock.patch(
-        DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock,
+        DATAPROC_STRING.format("DataprocHook.client_info"),
+        new_callable=mock.PropertyMock,
     )
     @mock.patch(DATAPROC_STRING.format("ClusterControllerClient"))
     def test_get_cluster_client(self, mock_client, mock_client_info, mock_get_credentials):
@@ -65,18 +73,21 @@ class TestDataprocHook(unittest.TestCase):
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
     @mock.patch(
-        DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock,
+        DATAPROC_STRING.format("DataprocHook.client_info"),
+        new_callable=mock.PropertyMock,
     )
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
     def test_get_template_client(self, mock_client, mock_client_info, mock_get_credentials):
         _ = self.hook.get_template_client
         mock_client.assert_called_once_with(
-            credentials=mock_get_credentials.return_value, client_info=mock_client_info.return_value,
+            credentials=mock_get_credentials.return_value,
+            client_info=mock_client_info.return_value,
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
     @mock.patch(
-        DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock,
+        DATAPROC_STRING.format("DataprocHook.client_info"),
+        new_callable=mock.PropertyMock,
     )
     @mock.patch(DATAPROC_STRING.format("JobControllerClient"))
     def test_get_job_client(self, mock_client, mock_client_info, mock_get_credentials):
@@ -89,7 +100,13 @@ class TestDataprocHook(unittest.TestCase):
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_cluster_client"))
     def test_create_cluster(self, mock_client):
-        self.hook.create_cluster(project_id=GCP_PROJECT, region=GCP_LOCATION, cluster=CLUSTER)
+        self.hook.create_cluster(
+            project_id=GCP_PROJECT,
+            region=GCP_LOCATION,
+            cluster_name=CLUSTER_NAME,
+            cluster_config=CLUSTER_CONFIG,
+            labels=LABELS,
+        )
         mock_client.assert_called_once_with(location=GCP_LOCATION)
         mock_client.return_value.create_cluster.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -220,7 +237,12 @@ class TestDataprocHook(unittest.TestCase):
         )
         mock_client.region_path.assert_called_once_with(GCP_PROJECT, GCP_LOCATION)
         mock_client.instantiate_inline_workflow_template.assert_called_once_with(
-            parent=PARENT, template=template, request_id=None, retry=None, timeout=None, metadata=None,
+            parent=PARENT,
+            template=template,
+            request_id=None,
+            retry=None,
+            timeout=None,
+            metadata=None,
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job"))
@@ -231,7 +253,10 @@ class TestDataprocHook(unittest.TestCase):
         ]
         with self.assertRaises(AirflowException):
             self.hook.wait_for_job(
-                job_id=JOB_ID, location=GCP_LOCATION, project_id=GCP_PROJECT, wait_time=0,
+                job_id=JOB_ID,
+                location=GCP_LOCATION,
+                project_id=GCP_PROJECT,
+                wait_time=0,
             )
         calls = [
             mock.call(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -72,24 +72,21 @@ CLUSTER = {
         },
         "master_config": {
             "num_instances": 2,
-            "machine_type_uri": "https://www.googleapis.com/compute/v1/projects/"
-            "project_id/zones/zone/machineTypes/master_machine_type",
+            "machine_type_uri": "projects/project_id/zones/zone/machineTypes/master_machine_type",
             "disk_config": {"boot_disk_type": "master_disk_type", "boot_disk_size_gb": 128},
             "image_uri": "https://www.googleapis.com/compute/beta/projects/"
             "custom_image_project_id/global/images/custom_image",
         },
         "worker_config": {
             "num_instances": 2,
-            "machine_type_uri": "https://www.googleapis.com/compute/v1/projects/"
-            "project_id/zones/zone/machineTypes/worker_machine_type",
+            "machine_type_uri": "projects/project_id/zones/zone/machineTypes/worker_machine_type",
             "disk_config": {"boot_disk_type": "worker_disk_type", "boot_disk_size_gb": 256},
             "image_uri": "https://www.googleapis.com/compute/beta/projects/"
             "custom_image_project_id/global/images/custom_image",
         },
         "secondary_worker_config": {
             "num_instances": 4,
-            "machine_type_uri": "https://www.googleapis.com/compute/v1/projects/"
-            "project_id/zones/zone/machineTypes/worker_machine_type",
+            "machine_type_uri": "projects/project_id/zones/zone/machineTypes/worker_machine_type",
             "disk_config": {"boot_disk_type": "worker_disk_type", "boot_disk_size_gb": 256},
             "is_preemptible": True,
         },
@@ -97,11 +94,16 @@ CLUSTER = {
             "properties": {"properties": "data"},
             "optional_components": ["optional_components"],
         },
-        "lifecycle_config": {"idle_delete_ttl": "60s", "auto_delete_time": "2019-09-12T00:00:00.000000Z"},
+        "lifecycle_config": {
+            "idle_delete_ttl": {'seconds': 60},
+            "auto_delete_time": "2019-09-12T00:00:00.000000Z",
+        },
         "encryption_config": {"gce_pd_kms_key_name": "customer_managed_key"},
         "autoscaling_config": {"policy_uri": "autoscaling_policy"},
         "config_bucket": "storage_bucket",
-        "initialization_actions": [{"executable_file": "init_actions_uris", "execution_timeout": "600s"}],
+        "initialization_actions": [
+            {"executable_file": "init_actions_uris", "execution_timeout": {'seconds': 600}}
+        ],
     },
     "labels": {"labels": "data", "airflow-version": AIRFLOW_VERSION},
 }

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -87,10 +87,7 @@ CONFIG = {
         "disk_config": {"boot_disk_type": "worker_disk_type", "boot_disk_size_gb": 256},
         "is_preemptible": True,
     },
-    "software_config": {
-        "properties": {"properties": "data"},
-        "optional_components": ["optional_components"],
-    },
+    "software_config": {"properties": {"properties": "data"}, "optional_components": ["optional_components"]},
     "lifecycle_config": {
         "idle_delete_ttl": {'seconds': 60},
         "auto_delete_time": "2019-09-12T00:00:00.000000Z",
@@ -107,12 +104,7 @@ LABELS = {"labels": "data", "airflow-version": AIRFLOW_VERSION}
 
 LABELS.update({'airflow-version': 'v' + airflow_version.replace('.', '-').replace('+', '-')})
 
-CLUSTER = {
-    "project_id": "project_id",
-    "cluster_name": CLUSTER_NAME,
-    "config": CONFIG,
-    "labels": LABELS,
-}
+CLUSTER = {"project_id": "project_id", "cluster_name": CLUSTER_NAME, "config": CONFIG, "labels": LABELS}
 
 UPDATE_MASK = {
     "paths": ["config.worker_config.num_instances", "config.secondary_worker_config.num_instances"]

--- a/tests/providers/google/cloud/operators/test_dataproc_system.py
+++ b/tests/providers/google/cloud/operators/test_dataproc_system.py
@@ -15,18 +15,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import os
-
 import pytest
 
+from airflow.providers.google.cloud.example_dags.example_dataproc import PYSPARK_MAIN, BUCKET, SPARKR_MAIN
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_DATAPROC_KEY
 from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTest, provide_gcp_context
 
-BUCKET = os.environ.get("GCP_DATAPROC_BUCKET", "dataproc-system-tests")
-PYSPARK_MAIN = os.environ.get("PYSPARK_MAIN", "hello_world.py")
-PYSPARK_URI = "gs://{}/{}".format(BUCKET, PYSPARK_MAIN)
-SPARKR_MAIN = os.environ.get("SPARKR_MAIN", "hello_world.R")
-SPARKR_URI = "gs://{}/{}".format(BUCKET, SPARKR_MAIN)
+GCS_URI = f"gs://{BUCKET}"
 
 pyspark_file = """
 #!/usr/bin/python
@@ -57,12 +52,12 @@ class DataprocExampleDagsTest(GoogleSystemTest):
     def setUp(self):
         super().setUp()
         self.create_gcs_bucket(BUCKET)
-        self.upload_content_to_gcs(lines=pyspark_file, bucket=PYSPARK_URI, filename=PYSPARK_MAIN)
-        self.upload_content_to_gcs(lines=sparkr_file, bucket=SPARKR_URI, filename=SPARKR_MAIN)
+        self.upload_content_to_gcs(lines=pyspark_file, bucket=GCS_URI, filename=PYSPARK_MAIN)
+        self.upload_content_to_gcs(lines=sparkr_file, bucket=GCS_URI, filename=SPARKR_MAIN)
 
     @provide_gcp_context(GCP_DATAPROC_KEY)
     def tearDown(self):
-        self.delete_gcs_bucket(BUCKET)
+        # self.delete_gcs_bucket(BUCKET)
         super().tearDown()
 
     @provide_gcp_context(GCP_DATAPROC_KEY)

--- a/tests/providers/google/cloud/operators/test_dataproc_system.py
+++ b/tests/providers/google/cloud/operators/test_dataproc_system.py
@@ -57,7 +57,7 @@ class DataprocExampleDagsTest(GoogleSystemTest):
 
     @provide_gcp_context(GCP_DATAPROC_KEY)
     def tearDown(self):
-        # self.delete_gcs_bucket(BUCKET)
+        self.delete_gcs_bucket(BUCKET)
         super().tearDown()
 
     @provide_gcp_context(GCP_DATAPROC_KEY)

--- a/tests/test_utils/gcp_system_helpers.py
+++ b/tests/test_utils/gcp_system_helpers.py
@@ -153,7 +153,7 @@ class GoogleSystemTest(SystemTest):
             with open(tmp_path, "w") as file:
                 file.writelines(lines)
                 file.flush()
-            os.chmod(tmp_path, 555)
+            os.chmod(tmp_path, 777)
             cls.upload_to_gcs(tmp_path, bucket_name)
 
     @classmethod


### PR DESCRIPTION
DataprocCreateCluster requires now:
- cluster config
- cluster name
- project id

In this way users don't have to pass project_id two times (in cluster definition and as parameter). The cluster object is built in `create_cluster` hook method

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
