### PR TITLE
Make Kubernetes tests pass locally

### DIFF
--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import sys
 import unittest
 import uuid
-import sys
 from unittest import mock
 
 from kubernetes.client import ApiClient, models as k8s

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -16,6 +16,7 @@
 # under the License.
 import unittest
 import uuid
+import sys
 from unittest import mock
 
 from kubernetes.client import ApiClient, models as k8s
@@ -730,7 +731,8 @@ class TestPodGenerator(unittest.TestCase):
         self.assertEqual(client_spec, res)
 
     def test_deserialize_model_file(self):
-        fixture = 'tests/kubernetes/pod.yaml'
+
+        fixture = sys.path[0] + '/tests/kubernetes/pod.yaml'
         result = PodGenerator.deserialize_model_file(fixture)
         sanitized_res = self.k8s_client.sanitize_for_serialization(result)
         self.assertEqual(sanitized_res, self.deserialize_result)

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -16,6 +16,7 @@
 # under the License.
 #
 import unittest
+import sys
 from unittest.mock import ANY
 
 import mock
@@ -879,7 +880,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         ], configmaps)
 
     def test_pod_template_file(self):
-        fixture = 'tests/kubernetes/pod.yaml'
+        fixture = sys.path[0] + '/tests/kubernetes/pod.yaml'
         self.kube_config.pod_template_file = fixture
         worker_config = WorkerConfiguration(self.kube_config)
         result = worker_config.as_pod()

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import unittest
 import sys
+import unittest
 from unittest.mock import ANY
 
 import mock


### PR DESCRIPTION
Currently Kuberentes tests only all pass within breeze.

This PR makes them read the local path so they can pass in any
system.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
