### PR TITLE
WIP: Add permission controls to stable API.

### DIFF
--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -20,7 +20,7 @@ from typing import Callable, Sequence, Tuple, TypeVar, cast
 
 from flask import Response, current_app
 
-from airflow.api_connexion.exceptions import Unauthenticated
+from airflow.api_connexion.exceptions import PermissionDenied, Unauthenticated
 
 T = TypeVar("T", bound=Callable)  # pylint: disable=invalid-name
 

--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -48,7 +48,7 @@ def requires_access(permissions: Sequence[Tuple[str, str]]) -> Callable[[T], T]:
             appbuilder = current_app.appbuilder
             for permission in permissions:
                 if not appbuilder.sm.has_access(*permission):
-                    raise PermissionDenied("Forbidden", 403)
+                    raise PermissionDenied()
 
             return func(*args, **kwargs)
 

--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -48,7 +48,7 @@ def requires_access(permissions: Sequence[Tuple[str, str]]) -> Callable[[T], T]:
             appbuilder = current_app.appbuilder
             for permission in permissions:
                 if not appbuilder.sm.has_access(*permission):
-                    return Response("Forbidden", 403)
+                    raise PermissionDenied("Forbidden", 403)
 
             return func(*args, **kwargs)
 


### PR DESCRIPTION
This adds permission checking to the stable API. This will integrate with the endpoints as a function decorator, with the following format `@security.requires_access([("can_edit", "Pool")])`. The decorator should be placed after the `@security.requires_authentication` decorator.

The permissions should use the new resource-focused permissions, as explained in related issue (#8112), rather than the existing permissions designed around UI views.

related: #8112 

When complete, this PR will include the following pieces:

- [x]  `@security.requires_access()` decorator function.
- [ ]  Stable API endpoints decorated with required permissions.
- [ ]  Tests for stable API endpoint permissions.
- [ ]  Docs explaining API permissions.


Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
