### PR TITLE
BugFix: K8s Executor Multinamespace mode is evaluated to true by default

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -189,7 +189,7 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
         # cluster has RBAC enabled, your scheduler may need service account permissions to
         # create, watch, get, and delete pods in this namespace.
         self.kube_namespace = conf.get(self.kubernetes_section, 'namespace')
-        self.multi_namespace_mode = conf.get(self.kubernetes_section, 'multi_namespace_mode')
+        self.multi_namespace_mode = conf.getboolean(self.kubernetes_section, 'multi_namespace_mode')
         # The Kubernetes Namespace in which pods will be created by the executor. Note
         # that if your
         # cluster has RBAC enabled, your workers may need service account permissions to
@@ -290,14 +290,14 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
 
     def __init__(self,
                  namespace: Optional[str],
-                 mult_namespace_mode: bool,
+                 multi_namespace_mode: bool,
                  watcher_queue: 'Queue[KubernetesWatchType]',
                  resource_version: Optional[str],
                  worker_uuid: Optional[str],
                  kube_config: Configuration):
         super().__init__()
         self.namespace = namespace
-        self.multi_namespace_mode = mult_namespace_mode
+        self.multi_namespace_mode = multi_namespace_mode
         self.worker_uuid = worker_uuid
         self.watcher_queue = watcher_queue
         self.resource_version = resource_version
@@ -446,7 +446,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         resource_version = KubeResourceVersion.get_current_resource_version()
         watcher = KubernetesJobWatcher(watcher_queue=self.watcher_queue,
                                        namespace=self.kube_config.kube_namespace,
-                                       mult_namespace_mode=self.kube_config.multi_namespace_mode,
+                                       multi_namespace_mode=self.kube_config.multi_namespace_mode,
                                        resource_version=resource_version,
                                        worker_uuid=self.worker_uuid,
                                        kube_config=self.kube_config)


### PR DESCRIPTION
Bug was reported for 1.10.12rc2 on Slack:

![image](https://user-images.githubusercontent.com/8811558/90692779-9c4fa780-e26d-11ea-8b33-283e62947eb6.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
