### PR TITLE
Make KubernetesExecutor recognize kubernetes_labels

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -578,8 +578,9 @@ def merge_objects(base_obj, client_obj):
     client_obj_cp = copy.deepcopy(client_obj)
 
     if isinstance(base_obj, dict) and isinstance(client_obj_cp, dict):
-        client_obj_cp.update(base_obj)
-        return client_obj_cp
+        base_obj_cp = copy.deepcopy(base_obj)
+        base_obj_cp.update(client_obj_cp)
+        return base_obj_cp
 
     for base_key in base_obj.to_dict().keys():
         base_val = getattr(base_obj, base_key, None)

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -430,6 +430,7 @@ class WorkerConfiguration(LoggingMixin):
             volumes=self._get_volumes(),
             volume_mounts=self._get_volume_mounts(),
             init_containers=self._get_init_containers(),
+            labels=self.kube_config.kube_labels,
             annotations=self.kube_config.kube_annotations,
             affinity=self.kube_config.kube_affinity,
             tolerations=self.kube_config.kube_tolerations,

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -398,6 +398,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
             'dag_id': 'test_dag_id',
             'execution_date': '2019-11-21 11:08:22.920875',
             'kubernetes_executor': 'True',
+            'my_label': 'label_id',
             'task_id': 'test_task_id',
             'try_number': '1'
         }


### PR DESCRIPTION
KubernetesExecutor needs to inject `kubernetes_labels` configs
into the worker_config

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
