### PR TITLE
Use sys.exit() instead of exit() in setup_backport_packages.py

### DIFF
--- a/backport_packages/setup_backport_packages.py
+++ b/backport_packages/setup_backport_packages.py
@@ -1143,7 +1143,7 @@ def update_release_notes_for_packages(provider_ids: List[str], release_version: 
         print()
         print(f"ERROR! There are in total: {bad} entities badly named out of {total} entities ")
         print()
-        exit(1)
+        sys.exit(1)
 
 
 def get_all_backportable_providers() -> List[str]:
@@ -1174,19 +1174,19 @@ if __name__ == "__main__":
 ERROR! Missing first param"
 """, file=sys.stderr)
         usage()
-        exit(1)
+        sys.exit(1)
     if sys.argv[1] == "--version-suffix":
         if len(sys.argv) < 3:
             print("""
 ERROR! --version-suffix needs parameter!
 """, file=sys.stderr)
             usage()
-            exit(1)
+            sys.exit(1)
         suffix = sys.argv[2]
         sys.argv = [sys.argv[0]] + sys.argv[3:]
     elif "--help" in sys.argv or "-h" in sys.argv or len(sys.argv) < 2:
         usage()
-        exit(0)
+        sys.exit(0)
 
     if sys.argv[1] not in possible_first_params:
         print(f"""
@@ -1194,18 +1194,18 @@ ERROR! Wrong first param: {sys.argv[1]}
 """, file=sys.stderr)
         usage()
         print()
-        exit(1)
+        sys.exit(1)
 
     if sys.argv[1] == LIST_PROVIDERS_PACKAGES:
         providers = PROVIDERS_REQUIREMENTS.keys()
         for provider in providers:
             print(provider)
-        exit(0)
+        sys.exit(0)
     elif sys.argv[1] == LIST_BACKPORTABLE_PACKAGES:
         providers = get_all_backportable_providers()
         for provider in providers:
             print(provider)
-        exit(0)
+        sys.exit(0)
     elif sys.argv[1] == UPDATE_PACKAGE_RELEASE_NOTES:
         release_ver = ""
         if len(sys.argv) > 2 and re.match(r'\d{4}\.\d{2}\.\d{2}', sys.argv[2]):
@@ -1221,7 +1221,7 @@ ERROR! Wrong first param: {sys.argv[1]}
             package_list = sys.argv[2:]
         print()
         update_release_notes_for_packages(package_list, release_version=release_ver)
-        exit(0)
+        sys.exit(0)
 
     provider_package = sys.argv[1]
     if provider_package not in get_provider_packages():


### PR DESCRIPTION
The `exit` and `quit` functions are actually `site.Quitter` objects and are loaded, at interpreter start up, from `site.py`. However, if the interpreter is started with the `-S` flag, or a custom `site.py` is used then `exit` and `quit` may not be present. It is recommended to use `sys.exit()` which is built into the interpreter and is guaranteed to be present.

Previously, `exit()` was used and wouls fail if the interpreter is passed the `-S` option.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
