### PR TITLE
Fix typo in KubernetesPodOperator

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1002,7 +1002,7 @@ New Features
 - [AIRFLOW-4306] Global operator extra links (#5094)
 - [AIRFLOW-4812] Add batch images annotation (#5433)
 - [AIRFLOW-4135] Add Google Cloud Build operator and hook (#5251)
-- [AIRFLOW-4781] Add the ability to specify ports in kubernetesOperator (#5410)
+- [AIRFLOW-4781] Add the ability to specify ports in KubernetesPodOperator (#5410)
 - [AIRFLOW-4521] Pause dag also pause its subdags (#5283)
 - [AIRFLOW-4738] Enforce exampleinclude for example DAGs (#5375)
 - [AIRFLOW-4326] Airflow AWS SQS Operator (#5110)

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -861,7 +861,6 @@ kube
 kubeclient
 kubeconfig
 kubernetes
-kubernetesOperator
 kv
 kwarg
 kwargs


### PR DESCRIPTION
`kubernetesOperator` -> `KubernetesPodOperator`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
