### PR TITLE
overlap pod should only be checked on running pods

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -276,7 +276,6 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
             label_selector = self._get_pod_identifying_label_string(labels)
 
             pod_list = client.list_namespaced_pod(self.namespace, label_selector=label_selector)
-            
             running_pods = [pod for pod in pod_list.items if pod.status.phase == 'Running']
 
             if len(running_pods) > 1 and self.reattach_on_restart:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -288,7 +288,8 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
 
             if len(running_pods) == 1:
                 try_numbers_match = self._try_numbers_match(context, running_pods[0])
-                final_state, result = self.handle_pod_overlap(labels, try_numbers_match, launcher, running_pods[0])
+                final_state, result = self.handle_pod_overlap(
+                    labels, try_numbers_match, launcher, running_pods[0])
             else:
                 self.log.info("creating pod with labels %s and launcher %s", labels, launcher)
                 final_state, _, result = self.create_new_pod_for_operator(labels, launcher)


### PR DESCRIPTION
now, KubernetesPodOperator will check if there is an existing pod of this task, if the pod matches, it can be reused.  But is does not filter completed or failed pods.  when the task failed, it cannot be retried because there is already one failed pod with the label.

```
[2020-08-19 23:14:56,770] {{taskinstance.py:1150}} ERROR - Pod Launching failed: More than one pod running with labels: dag_id=IncrementDataBuild_wjwjyrmyy,execution_date=2020-08-19T164816.2350170000-ac196c6dc,task_id=exportdata-wjwjyrmyy
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/airflow/contrib/operators/kubernetes_pod_operator.py", line 276, in execute
    '{label_selector}'.format(label_selector=label_selector))
airflow.exceptions.AirflowException: More than one pod running with labels: dag_id=build,execution_date=2020-08-19T164816.2350170000-ac196c6dc,task_id=exportdata
```