### PR TITLE
SkipMixin: Add missing session.commit() and test

### DIFF
--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -151,6 +151,9 @@ class SkipMixin(LoggingMixin):
                 self._set_state_to_skipped(
                     dag_run, ti.execution_date, skip_tasks, session=session
                 )
+                # For some reason, session.commit() needs to happen before xcom_push.
+                # Otherwise the session is not committed.
+                session.commit()
                 ti.xcom_push(
                     key=XCOM_SKIPMIXIN_KEY, value={XCOM_SKIPMIXIN_FOLLOWED: branch_task_ids}
                 )


### PR DESCRIPTION
I don't know the reason, but if we omit the `session.commit()` that I just added, `test_skip_all_except`  fails because task3 state is None instead of SKIPPED. I think it's an issue with sqlalchemy or sqlite and not much to do with Airflow itself.

(NOTE: The impact of this bug being fixed here is pretty minimal and hard to catch because even though this line does not set the state to SKIPPED, the newly introduced `NotPreviouslySkippedDep` actually causes the scheduler to skip the task that are supposed to be skipped. So to the user, this bug being fixed here had almost no impact other than in some test cases. But this session.commit() is needed in case in the future someone calls `skip_all_except()` and expects the state to be set to SKIPPED for the skipped tests).