### PR TITLE
Fixes problem with Python image not ready to be pushed

### DIFF
--- a/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
@@ -32,11 +32,11 @@ function build_prod_images_on_ci() {
         # Tries to wait for the image indefinitely
         # skips further image checks - since we already have the target image
 
-        wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}" \
-            "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}" "${AIRFLOW_PROD_IMAGE}"
+        wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}" \
+            ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_IMAGE}"
 
-        wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}" \
-            "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}" "${AIRFLOW_PROD_BUILD_IMAGE}"
+        wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}" \
+            ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_BUILD_IMAGE}"
     fi
 
     build_prod_images

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -702,14 +702,14 @@ function build_prod_images() {
 # Waits for image tag to appear in Github Registry, pulls it and tags with the target tag
 # Parameters:
 #  $1 - image name to wait for
-#  $2 - tag to wait for
+#  $2 - suffix of the image to wait for
 #  $3, $4, ... - target tags to tag the image with
 function wait_for_image_tag {
     IMAGE_NAME="${1}"
-    TAG_TO_WAIT_FOR=${2}
+    IMAGE_SUFFIX=${2}
     shift 2
 
-    IMAGE_TO_WAIT_FOR="${IMAGE_NAME}:${TAG_TO_WAIT_FOR}"
+    IMAGE_TO_WAIT_FOR="${IMAGE_NAME}${IMAGE_SUFFIX}"
     echo
     echo "Waiting for image ${IMAGE_TO_WAIT_FOR}"
     echo
@@ -722,8 +722,12 @@ function wait_for_image_tag {
             sleep 10
         else
             echo
-            echo "The image ${IMAGE_TO_WAIT_FOR} downloaded."
+            echo "The image ${IMAGE_TO_WAIT_FOR} with '${IMAGE_NAME}' tag"
             echo
+            echo
+            echo "Tagging ${IMAGE_TO_WAIT_FOR} as ${IMAGE_NAME}."
+            echo
+            docker tag  "${IMAGE_TO_WAIT_FOR}" "${IMAGE_NAME}"
             for TARGET_TAG in "${@}"; do
                 echo
                 echo "Tagging ${IMAGE_TO_WAIT_FOR} as ${TARGET_TAG}."


### PR DESCRIPTION
When we pull image from base registry we should also push
it to the GitHub Registry so that we can track the
origin of the run.

Note that it merely pushes the tag - the image will be
directly pulled from the registry so this will only update
the tag in registry.

Bug introduced in #10368



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
