### PR TITLE
Fix docs build uploading artifacts

### DIFF
--- a/scripts/ci/libraries/_runs.sh
+++ b/scripts/ci/libraries/_runs.sh
@@ -21,7 +21,7 @@ function run_docs() {
     docker run "${EXTRA_DOCKER_FLAGS[@]}" -t \
             --entrypoint "/usr/local/bin/dumb-init"  \
             "${AIRFLOW_CI_IMAGE}" \
-            "--" "/opt/airflow/docs/build_docs.py" "${@}"
+            "--" "/opt/airflow/scripts/in_container/run_docs_build.sh" "${@}"
 }
 
 

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -272,3 +272,7 @@ function install_released_airflow_version() {
     INSTALLS=("apache-airflow==${1}" "werkzeug<1.0.0")
     pip install --upgrade "${INSTALLS[@]}"
 }
+
+
+export CI=${CI:="false"}
+export GITHUB_ACTIONS=${GITHUB_ACTIONS:="false"}

--- a/scripts/in_container/run_docs_build.sh
+++ b/scripts/in_container/run_docs_build.sh
@@ -28,7 +28,7 @@ sudo rm -rf "${AIRFLOW_SOURCES}/docs/_api/*"
 
 sudo -E "${AIRFLOW_SOURCES}/docs/build_docs.py" "${@}"
 
-if [[ ${GITHUB_ACTIONS} == "true" && -d "${AIRFLOW_SOURCES}/docs/_build/html" ]]; then
+if [[ ${GITHUB_ACTIONS:="false"} == "true" && -d "${AIRFLOW_SOURCES}/docs/_build/html" ]]; then
     rm -rf "/files/documentation"
     cp -r "${AIRFLOW_SOURCES}/docs/_build/html" "/files/documentation"
 fi


### PR DESCRIPTION
Rather than callig the python build we should call the bash
script which not only builds the docs but also copies them
to the /files dir so that they can be uploaded by the artifact
uploader

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
