### PR TITLE
Use assertEqual instead of assertTrue in tests/utils/test_dates.py

### DIFF
--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -30,14 +30,13 @@ class TestDates(unittest.TestCase):
         today = pendulum.today()
         today_midnight = pendulum.instance(datetime.fromordinal(today.date().toordinal()))
 
-        self.assertTrue(dates.days_ago(0) == today_midnight)
+        self.assertEqual(dates.days_ago(0), today_midnight)
+        self.assertEqual(dates.days_ago(100), today_midnight + timedelta(days=-100))
 
-        self.assertTrue(dates.days_ago(100) == today_midnight + timedelta(days=-100))
-
-        self.assertTrue(dates.days_ago(0, hour=3) == today_midnight + timedelta(hours=3))
-        self.assertTrue(dates.days_ago(0, minute=3) == today_midnight + timedelta(minutes=3))
-        self.assertTrue(dates.days_ago(0, second=3) == today_midnight + timedelta(seconds=3))
-        self.assertTrue(dates.days_ago(0, microsecond=3) == today_midnight + timedelta(microseconds=3))
+        self.assertEqual(dates.days_ago(0, hour=3), today_midnight + timedelta(hours=3))
+        self.assertEqual(dates.days_ago(0, minute=3), today_midnight + timedelta(minutes=3))
+        self.assertEqual(dates.days_ago(0, second=3), today_midnight + timedelta(seconds=3))
+        self.assertEqual(dates.days_ago(0, microsecond=3), today_midnight + timedelta(microseconds=3))
 
     def test_parse_execution_date(self):
         execution_date_str_wo_ms = '2017-11-02 00:00:00'


### PR DESCRIPTION
`assertEqual` will show show the proper diff instead of just "False is not True" error

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
