### PR TITLE
Fix typo in "wait_for_done"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2553,7 +2553,7 @@ Airflow 1.10.0, 2018-08-03
 - [AIRFLOW-2002] Do not swallow exception on logging import
 - [AIRFLOW-2004] Import flash from flask not flask.login
 - [AIRFLOW-1997] Fix GCP operator doc strings
-- [AIRFLOW-1996] Update DataflowHook waitfordone for Streaming type job[]
+- [AIRFLOW-1996] Update DataflowHook wait_for_done for Streaming type job
 - [AIRFLOW-1995][Airflow 1995] add on_kill method to SqoopOperator
 - [AIRFLOW-1770] Allow HiveOperator to take in a file
 - [AIRFLOW-1994] Change background color of Scheduled state Task Instances

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1287,7 +1287,6 @@ videointelligence
 virtualenv
 vm
 volumeMounts
-waitfordone
 wasb
 webProperty
 webhdfs


### PR DESCRIPTION
`waitfordone` -> `wait_for_done`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
