### PR TITLE
Updated REST API call so GET requests pass payload in query string instead of request body

### DIFF
--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -136,7 +136,8 @@ class DatabricksHook(BaseHook):
             try:
                 response = request_func(
                     url,
-                    json=json,
+                    json=json if method == 'POST' else None,
+                    params=json if method == 'GET' else None,
                     auth=auth,
                     headers=USER_AGENT_HEADER,
                     timeout=self.timeout_seconds)

--- a/tests/contrib/hooks/test_databricks_hook.py
+++ b/tests/contrib/hooks/test_databricks_hook.py
@@ -267,6 +267,7 @@ class DatabricksHookTest(unittest.TestCase):
                 'notebook_task': NOTEBOOK_TASK,
                 'new_cluster': NEW_CLUSTER,
             },
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -293,6 +294,7 @@ class DatabricksHookTest(unittest.TestCase):
                 'jar_params': JAR_PARAMS,
                 'job_id': JOB_ID
             },
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -306,7 +308,8 @@ class DatabricksHookTest(unittest.TestCase):
         self.assertEqual(run_page_url, RUN_PAGE_URL)
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
-            json={'run_id': RUN_ID},
+            json=None,
+            params={'run_id': RUN_ID},
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -323,7 +326,8 @@ class DatabricksHookTest(unittest.TestCase):
             STATE_MESSAGE))
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
-            json={'run_id': RUN_ID},
+            json=None,
+            params={'run_id': RUN_ID},
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -337,6 +341,7 @@ class DatabricksHookTest(unittest.TestCase):
         mock_requests.post.assert_called_once_with(
             cancel_run_endpoint(HOST),
             json={'run_id': RUN_ID},
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -353,6 +358,7 @@ class DatabricksHookTest(unittest.TestCase):
         mock_requests.post.assert_called_once_with(
             start_cluster_endpoint(HOST),
             json={'cluster_id': CLUSTER_ID},
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -369,6 +375,7 @@ class DatabricksHookTest(unittest.TestCase):
         mock_requests.post.assert_called_once_with(
             restart_cluster_endpoint(HOST),
             json={'cluster_id': CLUSTER_ID},
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -385,6 +392,7 @@ class DatabricksHookTest(unittest.TestCase):
         mock_requests.post.assert_called_once_with(
             terminate_cluster_endpoint(HOST),
             json={'cluster_id': CLUSTER_ID},
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)


### PR DESCRIPTION
This PR addresses an issue with the way GET requests were being built/sent in the databricks hook.  In the original implementation, the request payload is sent in the body of the request and not in the query string parameters, which can be lost when the traffic passes through a WAF.  

This in turn causes the operator to fail while polling for job status (GET) after a successful submission (POST).


