### PR TITLE
Updated REST API call so GET requests pass payload in query string instead of request body

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -175,7 +175,8 @@ class DatabricksHook(BaseHook):
             try:
                 response = request_func(
                     url,
-                    json=json,
+                    json=json if method == 'POST' or method == 'PATCH' else None,
+                    params=json if method == 'GET' else None,
                     auth=auth,
                     headers=USER_AGENT_HEADER,
                     timeout=self.timeout_seconds)

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -175,7 +175,7 @@ class DatabricksHook(BaseHook):
             try:
                 response = request_func(
                     url,
-                    json=json if method in ('POST','PATCH') else None,
+                    json=json if method in ('POST', 'PATCH') else None,
                     params=json if method == 'GET' else None,
                     auth=auth,
                     headers=USER_AGENT_HEADER,

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -175,7 +175,7 @@ class DatabricksHook(BaseHook):
             try:
                 response = request_func(
                     url,
-                    json=json if method == 'POST' or method == 'PATCH' else None,
+                    json=json if method in ('POST','PATCH') else None,
                     params=json if method == 'GET' else None,
                     auth=auth,
                     headers=USER_AGENT_HEADER,

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -269,6 +269,7 @@ class TestDatabricksHook(unittest.TestCase):
             json={
                 'cluster_name': 'new_name'
             },
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -289,6 +290,7 @@ class TestDatabricksHook(unittest.TestCase):
                 'notebook_task': NOTEBOOK_TASK,
                 'new_cluster': NEW_CLUSTER,
             },
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -309,6 +311,7 @@ class TestDatabricksHook(unittest.TestCase):
                 'spark_python_task': SPARK_PYTHON_TASK,
                 'new_cluster': NEW_CLUSTER,
             },
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -335,6 +338,7 @@ class TestDatabricksHook(unittest.TestCase):
                 'jar_params': JAR_PARAMS,
                 'job_id': JOB_ID
             },
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -348,7 +352,8 @@ class TestDatabricksHook(unittest.TestCase):
         self.assertEqual(run_page_url, RUN_PAGE_URL)
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
-            json={'run_id': RUN_ID},
+            json=None,
+            params={'run_id': RUN_ID},
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -362,7 +367,8 @@ class TestDatabricksHook(unittest.TestCase):
         self.assertEqual(job_id, JOB_ID)
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
-            json={'run_id': RUN_ID},
+            json=None,
+            params={'run_id': RUN_ID},            
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -379,7 +385,8 @@ class TestDatabricksHook(unittest.TestCase):
             STATE_MESSAGE))
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
-            json={'run_id': RUN_ID},
+            json=None,
+            params={'run_id': RUN_ID},
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -393,6 +400,7 @@ class TestDatabricksHook(unittest.TestCase):
         mock_requests.post.assert_called_once_with(
             cancel_run_endpoint(HOST),
             json={'run_id': RUN_ID},
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -409,6 +417,7 @@ class TestDatabricksHook(unittest.TestCase):
         mock_requests.post.assert_called_once_with(
             start_cluster_endpoint(HOST),
             json={'cluster_id': CLUSTER_ID},
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -425,6 +434,7 @@ class TestDatabricksHook(unittest.TestCase):
         mock_requests.post.assert_called_once_with(
             restart_cluster_endpoint(HOST),
             json={'cluster_id': CLUSTER_ID},
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
@@ -441,6 +451,7 @@ class TestDatabricksHook(unittest.TestCase):
         mock_requests.post.assert_called_once_with(
             terminate_cluster_endpoint(HOST),
             json={'cluster_id': CLUSTER_ID},
+            params=None,
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -368,7 +368,7 @@ class TestDatabricksHook(unittest.TestCase):
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
             json=None,
-            params={'run_id': RUN_ID},            
+            params={'run_id': RUN_ID},
             auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)


### PR DESCRIPTION
This PR addresses an issue with the way GET requests were being built/sent in the databricks hook. In the original implementation, the request payload is sent in the body of the request and not in the query string parameters, which can be lost when the traffic passes through a WAF.

This in turn causes the operator to fail while polling for job status (GET) after a successful submission (POST).

I made a similar PR in the v1.10-stable branch, this one addresses the hook in the master branch.