### PR TITLE
Test exact match of Executor name

### DIFF
--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -55,7 +55,7 @@ class TestExecutorLoader(unittest.TestCase):
         }):
             executor = ExecutorLoader.get_default_executor()
             self.assertIsNotNone(executor)
-            self.assertIn(executor_name, executor.__class__.__name__)
+            self.assertEqual(executor_name, executor.__class__.__name__)
 
     @mock.patch("airflow.plugins_manager.plugins", [
         FakePlugin()
@@ -67,7 +67,7 @@ class TestExecutorLoader(unittest.TestCase):
         }):
             executor = ExecutorLoader.get_default_executor()
             self.assertIsNotNone(executor)
-            self.assertIn("FakeExecutor", executor.__class__.__name__)
+            self.assertEqual("FakeExecutor", executor.__class__.__name__)
 
     def test_should_support_custom_path(self):
         with conf_vars({
@@ -75,4 +75,4 @@ class TestExecutorLoader(unittest.TestCase):
         }):
             executor = ExecutorLoader.get_default_executor()
             self.assertIsNotNone(executor)
-            self.assertIn("FakeExecutor", executor.__class__.__name__)
+            self.assertEqual("FakeExecutor", executor.__class__.__name__)


### PR DESCRIPTION
Use `self.assertEqual` instead of `self.assertIn` to do an exact match of string name instead of partial match

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
