### PR TITLE
Mounting from sources is disabled for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
 
 env:
 
-  MOUNT_LOCAL_SOURCES: "true"
+  MOUNT_LOCAL_SOURCES: "false"
   MOUNT_FILES: "true"
   FORCE_ANSWER_TO_QUESTIONS: "yes"
   FORCE_PULL_IMAGES: "true"


### PR DESCRIPTION
We had to enable mounting from sources for a short while
because we had to find a way to add new scripts to the
"workflow_run" workflow we have. This also requires
the #10470 to be merged - perf_kit to be moved to tests.utils because
it was in a separate directory and image without mounting sources
could not run the tests.

It also partially addresses the #10445 problem where
there was difference between sources in the image and coming
from the master. This comes from GitHub running merge on
non-conflicting changes in the PR and something that will
be addressed shortly.

The issue #10471 discusses this in detail.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
