### PR TITLE
Stops running workflow_run for scheduled runs in forks

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -52,6 +52,7 @@ jobs:
       sourceHeadSha: ${{ steps.cancel.outputs.sourceHeadSha }}
       sourceEvent: ${{ steps.cancel.outputs.sourceEvent }}
       cacheDirective: ${{ steps.cache-directive.outputs.docker-cache }}
+    if: github.repository == 'apache/airflow' || github.event.workflow_run.event != "schedule"
     steps:
       - name: "Cancel duplicated 'CI Build' runs"
         uses: potiuk/cancel-workflow-runs@v2
@@ -148,6 +149,7 @@ jobs:
       Source Sha: ${{ needs.cancel-workflow-runs.outputs.sourceHeadSha }}
     runs-on: ubuntu-latest
     needs: [cancel-workflow-runs]
+    if: github.repository == 'apache/airflow' || github.event.workflow_run.event != "schedule"
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     steps:
@@ -172,6 +174,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         image-type: [CI, PROD]
       fail-fast: true
+    if: github.repository == 'apache/airflow' || github.event.workflow_run.event != "schedule"
     env:
       BACKEND: postgres
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}


### PR DESCRIPTION
There is still one build running for forks regularly, even though
we disabled all scheduled runs in #10448, there is still one
case with nightly build that we should disable.
The run is the "workflow_run"
executed for the nightly scheduled "CI Build" run that still gets
triggered.

This change skips those run in forjs in case the "source event"
is "schedule"
 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
