### PR TITLE
Add support for creating multiple replicated clusters in Bigtable hook and operator

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -19,6 +19,7 @@
 This module contains a Google Cloud Bigtable Hook.
 """
 import enum
+import warnings
 from typing import Dict, List, Optional, Sequence, Union
 
 from google.cloud.bigtable import Client
@@ -109,6 +110,7 @@ class BigtableHook(GoogleBaseHook):
         main_cluster_id: str,
         main_cluster_zone: str,
         project_id: str,
+        replica_clusters: Optional[List[Dict[str, str]]] = None,
         replica_cluster_id: Optional[str] = None,
         replica_cluster_zone: Optional[str] = None,
         instance_display_name: Optional[str] = None,
@@ -132,11 +134,15 @@ class BigtableHook(GoogleBaseHook):
         :param project_id: Optional, Google Cloud Platform project ID where the
             BigTable exists. If set to None or missing,
             the default project_id from the GCP connection is used.
+        :type replica_clusters: List[Dict[str, str]]
+        :param replica_clusters: (optional) A list of replica clusters for the new
+            instance. Each cluster dictionary contains an id and a zone.
+            Example: [{"id": "replica-1", "zone": "us-west1-a"}]
         :type replica_cluster_id: str
-        :param replica_cluster_id: (optional) The ID for replica cluster for the new
+        :param replica_cluster_id: (deprecated) The ID for replica cluster for the new
             instance.
         :type replica_cluster_zone: str
-        :param replica_cluster_zone: (optional)  The zone for replica cluster.
+        :param replica_cluster_zone: (deprecated)  The zone for replica cluster.
         :type instance_type: enums.Instance.Type
         :param instance_type: (optional) The type of the instance.
         :type instance_display_name: str
@@ -173,12 +179,24 @@ class BigtableHook(GoogleBaseHook):
             )
         ]
         if replica_cluster_id and replica_cluster_zone:
+            warnings.warn(
+                "The replica_cluster_id and replica_cluster_zone parameter have been deprecated."
+                "You should pass the replica_clusters parameter.", DeprecationWarning, stacklevel=2)
             clusters.append(instance.cluster(
-                replica_cluster_id,
-                replica_cluster_zone,
-                cluster_nodes,
-                cluster_storage_type
+                    replica_cluster_id,
+                    replica_cluster_zone,
+                    cluster_nodes,
+                    cluster_storage_type
             ))
+        if replica_clusters:
+            for replica_cluster in replica_clusters:
+                if "id" in replica_cluster and "zone" in replica_cluster:
+                    clusters.append(instance.cluster(
+                        replica_cluster["id"],
+                        replica_cluster["zone"],
+                        cluster_nodes,
+                        cluster_storage_type
+                    ))
         operation = instance.create(
             clusters=clusters
         )

--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -183,10 +183,10 @@ class BigtableHook(GoogleBaseHook):
                 "The replica_cluster_id and replica_cluster_zone parameter have been deprecated."
                 "You should pass the replica_clusters parameter.", DeprecationWarning, stacklevel=2)
             clusters.append(instance.cluster(
-                    replica_cluster_id,
-                    replica_cluster_zone,
-                    cluster_nodes,
-                    cluster_storage_type
+                replica_cluster_id,
+                replica_cluster_zone,
+                cluster_nodes,
+                cluster_storage_type
             ))
         if replica_clusters:
             for replica_cluster in replica_clusters:

--- a/airflow/providers/google/cloud/operators/bigtable.py
+++ b/airflow/providers/google/cloud/operators/bigtable.py
@@ -68,10 +68,15 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
     :type project_id: str
     :param project_id: Optional, the ID of the GCP project.  If set to None or missing,
             the default project_id from the GCP connection is used.
+    :type replica_clusters: List[Dict[str, str]]
+    :param replica_clusters: (optional) A list of replica clusters for the new
+        instance. Each cluster dictionary contains an id and a zone.
+        Example: [{"id": "replica-1", "zone": "us-west1-a"}]
     :type replica_cluster_id: str
-    :param replica_cluster_id: (optional) The ID for replica cluster for the new instance.
+    :param replica_cluster_id: (deprecated) The ID for replica cluster for the new
+        instance.
     :type replica_cluster_zone: str
-    :param replica_cluster_zone: (optional)  The zone for replica cluster.
+    :param replica_cluster_zone: (deprecated)  The zone for replica cluster.
     :type instance_type: enum.IntEnum
     :param instance_type: (optional) The type of the instance.
     :type instance_display_name: str
@@ -100,6 +105,7 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
                  main_cluster_id: str,
                  main_cluster_zone: str,
                  project_id: Optional[str] = None,
+                 replica_clusters: Optional[List[Dict[str, str]]] = None,
                  replica_cluster_id: Optional[str] = None,
                  replica_cluster_zone: Optional[str] = None,
                  instance_display_name: Optional[str] = None,
@@ -114,6 +120,7 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
         self.instance_id = instance_id
         self.main_cluster_id = main_cluster_id
         self.main_cluster_zone = main_cluster_zone
+        self.replica_clusters = replica_clusters
         self.replica_cluster_id = replica_cluster_id
         self.replica_cluster_zone = replica_cluster_zone
         self.instance_display_name = instance_display_name
@@ -145,6 +152,7 @@ class BigtableCreateInstanceOperator(BaseOperator, BigtableValidationMixin):
                 instance_id=self.instance_id,
                 main_cluster_id=self.main_cluster_id,
                 main_cluster_zone=self.main_cluster_zone,
+                replica_clusters=self.replica_clusters,
                 replica_cluster_id=self.replica_cluster_id,
                 replica_cluster_zone=self.replica_cluster_zone,
                 instance_display_name=self.instance_display_name,

--- a/tests/providers/google/cloud/operators/test_bigtable.py
+++ b/tests/providers/google/cloud/operators/test_bigtable.py
@@ -36,6 +36,11 @@ PROJECT_ID = 'test_project_id'
 INSTANCE_ID = 'test-instance-id'
 CLUSTER_ID = 'test-cluster-id'
 CLUSTER_ZONE = 'us-central1-f'
+REPLICATE_CLUSTERS = [
+    {'id': 'replica-1', 'zone': 'us-west1-a'},
+    {'id': 'replica-2', 'zone': 'us-central1-f'},
+    {'id': 'replica-3', 'zone': 'us-east1-d'},
+]
 GCP_CONN_ID = 'test-gcp-conn-id'
 NODES = 5
 INSTANCE_DISPLAY_NAME = "test instance"
@@ -131,6 +136,66 @@ class TestBigtableInstanceCreate(unittest.TestCase):
             main_cluster_id=CLUSTER_ID,
             main_cluster_zone=CLUSTER_ZONE,
             project_id=PROJECT_ID,
+            replica_clusters=None,
+            replica_cluster_id=None,
+            replica_cluster_zone=None,
+            timeout=None
+        )
+
+    @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
+    def test_create_instance_that_doesnt_exists(self, mock_hook):
+        mock_hook.return_value.get_instance.return_value = None
+        op = BigtableCreateInstanceOperator(
+            project_id=PROJECT_ID,
+            instance_id=INSTANCE_ID,
+            main_cluster_id=CLUSTER_ID,
+            main_cluster_zone=CLUSTER_ZONE,
+            task_id="id",
+            gcp_conn_id=GCP_CONN_ID
+        )
+        op.execute(None)
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.return_value.create_instance.assert_called_once_with(
+            cluster_nodes=None,
+            cluster_storage_type=None,
+            instance_display_name=None,
+            instance_id=INSTANCE_ID,
+            instance_labels=None,
+            instance_type=None,
+            main_cluster_id=CLUSTER_ID,
+            main_cluster_zone=CLUSTER_ZONE,
+            project_id=PROJECT_ID,
+            replica_clusters=None,
+            replica_cluster_id=None,
+            replica_cluster_zone=None,
+            timeout=None
+        )
+
+    @mock.patch('airflow.providers.google.cloud.operators.bigtable.BigtableHook')
+    def test_create_instance_with_replicas_that_doesnt_exists(self, mock_hook):
+        mock_hook.return_value.get_instance.return_value = None
+        op = BigtableCreateInstanceOperator(
+            project_id=PROJECT_ID,
+            instance_id=INSTANCE_ID,
+            main_cluster_id=CLUSTER_ID,
+            main_cluster_zone=CLUSTER_ZONE,
+            replica_clusters=REPLICATE_CLUSTERS,
+            task_id="id",
+            gcp_conn_id=GCP_CONN_ID
+        )
+        op.execute(None)
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.return_value.create_instance.assert_called_once_with(
+            cluster_nodes=None,
+            cluster_storage_type=None,
+            instance_display_name=None,
+            instance_id=INSTANCE_ID,
+            instance_labels=None,
+            instance_type=None,
+            main_cluster_id=CLUSTER_ID,
+            main_cluster_zone=CLUSTER_ZONE,
+            project_id=PROJECT_ID,
+            replica_clusters=REPLICATE_CLUSTERS,
             replica_cluster_id=None,
             replica_cluster_zone=None,
             timeout=None


### PR DESCRIPTION
Add support for creating multiple replicated clusters in Bigtable hook and operator

closes: #10474

Changes:
1. Added a new parameter called **replica_clusters** to allow creating multiple Bigtable replicated clusters
2. Made existing **replica_cluster_id** and **replica_cluster_zone** deprecated, but still working
3. Added unit tests for both hook and operator
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
