### PR TITLE
Optimise production image building during k8s tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,9 @@ jobs:
         run: ./scripts/ci/images/ci_prepare_prod_image_on_ci.sh
       - name: "Deploy airflow to cluster"
         run: ./scripts/ci/kubernetes/ci_deploy_app_to_kubernetes.sh
+        env:
+          # We have the right image pulled already by the previous step
+          SKIP_BUILDING_PROD_IMAGE: "true"
       - name: "Cache virtualenv for kubernetes testing"
         uses: actions/cache@v2
         env:

--- a/breeze
+++ b/breeze
@@ -723,6 +723,7 @@ function parse_arguments() {
           echo "Skips checking image for rebuilds"
           echo
           export CHECK_IMAGE_FOR_REBUILD="false"
+          export SKIP_BUILDING_PROD_IMAGE="true"
           shift ;;
         -L|--build-cache-local)
           echo "Use local cache to build images"
@@ -816,6 +817,7 @@ function parse_arguments() {
           export GITHUB_REGISTRY_PULL_IMAGE_TAG="${2}"
           export GITHUB_REGISTRY_PUSH_IMAGE_TAG="${2}"
           export CHECK_IMAGE_FOR_REBUILD="false"
+          export SKIP_BUILDING_PROD_IMAGE="true"
           export MOUNT_LOCAL_SOURCES="false"
           export SKIP_CHECK_REMOTE_IMAGE="true"
           shift 2;;

--- a/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
@@ -37,9 +37,10 @@ function build_prod_images_on_ci() {
 
         wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}" \
             ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_BUILD_IMAGE}"
+    else
+        build_prod_images
     fi
 
-    build_prod_images
 
     # Disable force pulling forced above this is needed for the subsequent scripts so that
     # They do not try to pull/build images again

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -637,6 +637,15 @@ function prepare_prod_build() {
 # selected by Breeze flags or environment variables.
 function build_prod_images() {
     print_build_info
+
+    if [[ ${SKIP_BUILDING_PROD_IMAGE:="false"} == "true" ]]; then
+        print_info
+        print_info "Skip building production image. Assume the one we have is good!"
+        print_info
+        return
+    fi
+
+
     pull_prod_images_if_needed
 
     if [[ "${DOCKER_CACHE}" == "disabled" ]]; then


### PR DESCRIPTION
We do not have to rebuild PROD images now because we changed
the strategy of preparing the image for k8s tests instead of
embedding dags during build with EMBEDDED_DAGS build arg we
are now extending the image with FROM: clause and add dags
on top of the PROD base image. We've been rebuilding the
image twice during each k8s run - once in Prepare PROD image
and once in "Deploy airflow to cluster" both are not needed
and both lasted ~ 2m 30s, so we should save around 5m for every
K8S jobi (~30% as the while K8S test job is around 15m).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
