### PR TITLE
Support pass command as args in k8s executor

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1869,6 +1869,14 @@
       type: string
       example: ~
       default: "False"
+    - name: override_container_entrypoint
+      description: |
+        if True, the airflow command overrides container's entrypoint
+        if False, the airflow command is passed as args to the container's entrypoint
+      version_added: ~
+      type: string
+      example: ~
+      default: "True"
     - name: worker_pods_creation_batch_size
       description: |
         Number of Kubernetes Worker Pod creation calls per scheduler loop.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -889,6 +889,10 @@ delete_worker_pods = True
 # failed worker pods will not be deleted so users can investigate them.
 delete_worker_pods_on_failure = False
 
+# if True, the airflow command overrides container's entrypoint
+# if False, the airflow command is passed as args to the container's entrypoint
+override_container_entrypoint = True
+
 # Number of Kubernetes Worker Pod creation calls per scheduler loop.
 # Note that the current default of "1" will only launch a single pod
 # per-heartbeat. It is HIGHLY recommended that users increase this

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -450,6 +450,7 @@ class PodGenerator:
         try_number: int,
         date: str,
         command: List[str],
+        args: List[str],
         kube_executor_config: Optional[k8s.V1Pod],
         worker_config: k8s.V1Pod,
         namespace: str,
@@ -473,6 +474,7 @@ class PodGenerator:
                 'kubernetes_executor': 'True',
             },
             cmds=command,
+            args=args,
             name=pod_id
         ).gen_pod()
 

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -395,6 +395,67 @@ class TestPodGenerator(unittest.TestCase):
         }, result)
 
     @mock.patch('uuid.uuid4')
+    def test_construct_pod_with_args(self, mock_uuid):
+        mock_uuid.return_value = self.static_uuid
+        executor_config = k8s.V1Pod(
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name='',
+                        resources=k8s.V1ResourceRequirements(
+                            limits={
+                                'cpu': '1m',
+                                'memory': '1G'
+                            }
+                        )
+                    )
+                ]
+            )
+        )
+        worker_config = k8s.V1Pod()
+
+        result = PodGenerator.construct_pod(
+            'dag_id',
+            'task_id',
+            'pod_id',
+            3,
+            'date',
+            ['command'],
+            ['args'],
+            executor_config,
+            worker_config,
+            'namespace',
+            'uuid',
+        )
+        sanitized_result = self.k8s_client.sanitize_for_serialization(result)
+
+        self.assertEqual({
+            'apiVersion': 'v1',
+            'kind': 'Pod',
+            'metadata': self.metadata,
+            'spec': {
+                'containers': [{
+                    'args': ['args'],
+                    'command': ['command'],
+                    'env': [],
+                    'envFrom': [],
+                    'name': 'base',
+                    'ports': [],
+                    'resources': {
+                        'limits': {
+                            'cpu': '1m',
+                            'memory': '1G'
+                        }
+                    },
+                    'volumeMounts': []
+                }],
+                'hostNetwork': False,
+                'imagePullSecrets': [],
+                'volumes': []
+            }
+        }, sanitized_result)
+
+    @mock.patch('uuid.uuid4')
     def test_construct_pod_empty_worker_config(self, mock_uuid):
         mock_uuid.return_value = self.static_uuid
         executor_config = k8s.V1Pod(
@@ -421,6 +482,7 @@ class TestPodGenerator(unittest.TestCase):
             3,
             'date',
             ['command'],
+            [],
             executor_config,
             worker_config,
             'namespace',
@@ -481,6 +543,7 @@ class TestPodGenerator(unittest.TestCase):
             3,
             'date',
             ['command'],
+            [],
             executor_config,
             worker_config,
             'namespace',
@@ -564,6 +627,7 @@ class TestPodGenerator(unittest.TestCase):
             3,
             'date',
             ['command'],
+            [],
             executor_config,
             worker_config,
             'namespace',

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -388,6 +388,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
             1,
             "2019-11-21 11:08:22.920875",
             ["bash -c 'ls /'"],
+            [],
             None,
             worker_config.as_pod(),
             "default",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


The current implementation overrides the image's entrypoint, which is less ideal. Users may want to use their own entrypoint to do additional setup and clean up, before and after the airflow tasks.



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
