### PR TITLE
Fix duplicate task_ids in example_http.py

### DIFF
--- a/airflow/providers/http/example_dags/example_http.py
+++ b/airflow/providers/http/example_dags/example_http.py
@@ -71,7 +71,7 @@ task_get_op = SimpleHttpOperator(
 )
 # [END howto_operator_http_task_get_op]
 # [START howto_operator_http_task_get_op_response_filter]
-task_get_op = SimpleHttpOperator(
+task_get_op_response_filter = SimpleHttpOperator(
     task_id='get_op_response_filter',
     method='GET',
     endpoint='get',
@@ -110,4 +110,5 @@ task_http_sensor_check = HttpSensor(
     dag=dag,
 )
 # [END howto_operator_http_http_sensor_check]
-task_http_sensor_check >> task_post_op >> task_get_op >> task_put_op >> task_del_op >> task_post_op_formenc
+task_http_sensor_check >> task_post_op >> task_get_op >> task_get_op_response_filter
+task_get_op_response_filter >> task_put_op >> task_del_op >> task_post_op_formenc


### PR DESCRIPTION
`task_get_op` was previously defined twice, hence the first one was not used when the DAG was run

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
