### PR TITLE
Remove old configuration from BoringCyborg

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -231,16 +231,6 @@ firstPRMergeComment: >
 firstIssueWelcomeComment: >
   Thanks for opening your first issue here! Be sure to follow the issue template!
 
-insertIssueLinkInPrDescription:
-  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"
-  matchers:
-    jiraIssueMatch:
-      titleIssueIdRegexp: \[(AIRFLOW-[0-9]{4})\]
-      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1})"
-    docOnlyIssueMatch:
-      titleIssueIdRegexp: \[(AIRFLOW-X{4})\]
-      descriptionIssueLink: "`Document only change, no JIRA issue`"
-
 checkUpToDate:
   - airflow/migrations/*
   - airflow/migrations/**/*


### PR DESCRIPTION
This was redundant as PR template has been changed

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
