### PR TITLE
Fix support for asctime field in JSON formatted logs

### DIFF
--- a/airflow/utils/log/json_formatter.py
+++ b/airflow/utils/log/json_formatter.py
@@ -40,6 +40,9 @@ class JSONFormatter(logging.Formatter):
         self.json_fields = json_fields
         self.extras = extras
 
+    def usesTime(self):
+        return self.json_fields.count('asctime') > 0
+
     def format(self, record):
         super().format(record)
         record_dict = {label: getattr(record, label, None)

--- a/tests/utils/log/test_json_formatter.py
+++ b/tests/utils/log/test_json_formatter.py
@@ -37,6 +37,15 @@ class TestJSONFormatter(unittest.TestCase):
         json_fmt = JSONFormatter()
         self.assertIsNotNone(json_fmt)
 
+    def test_uses_time(self):
+        """
+        Test usesTime method from JSONFormatter
+        """
+        json_fmt_asctime = JSONFormatter(json_fields=["asctime", "label"])
+        json_fmt_no_asctime = JSONFormatter(json_fields=["label"])
+        self.assertTrue(json_fmt_asctime.usesTime())
+        self.assertFalse(json_fmt_no_asctime.usesTime())
+
     def test_format(self):
         """
         Test format method from JSONFormatter


### PR DESCRIPTION
The JSON Formatter utilized by the Elasticsearch provider did not generate a timestamp for the `asctime` field when it was included in the `json_fields` configuration option. This pull request addresses that issue by defining a function that supersedes the `usesTime` fuction in the logging.Formatter superclass.

closes: #10024