### PR TITLE
Sets default timeout for the job waiting for images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,6 @@ jobs:
         run: ./scripts/ci/openapi/client_codegen_diff.sh
 
   ci-images:
-    timeout-minutes: 60
     name: "Wait for CI images"
     runs-on: ubuntu-latest
     needs: [build-info, helm-tests, test-openapi-client-generation]
@@ -512,7 +511,6 @@ jobs:
           directory: "./coverage-files"
 
   prod-images:
-    timeout-minutes: 60
     name: "Wait for PROD images"
     runs-on: ubuntu-latest
     needs: [build-info]


### PR DESCRIPTION
In normal circumstances those jobs will wait for a short time
(4-15 minutes depenfding on the state of the base image).
However there might be some cases when there are a lot of jobs
or when there is some queueing problems in GitHub that
the "Build Images" job will be queued and not start quickly.

This happened on 24th of August 2020 for example when several
jobs failed because the "Build Image" was queued and only
run after the "CI Build" job timed out.

Usually those situations tends to be resolved by GitHub support
or they resolve themselves as the jobs will be finishing and
freing the queue. However in those cases we should give the
waiting job as much time as GitHub Action allows by default
for the job to run (360 minutes). This is no harm - we can
alwayc cancel those jobs manually and they are just two
jobs running so it should not cause any problem.

Note that if someone would see that the job is running for
a long time - the contributor will likely push amended
commit and it will also cancel such waiting job, so
this is even less likely to have long runnning waiting jobs.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
