### PR TITLE
Remove all "noinspection" comments native to IntelliJ

### DIFF
--- a/airflow/api/auth/backend/deny_all.py
+++ b/airflow/api/auth/backend/deny_all.py
@@ -35,7 +35,6 @@ T = TypeVar("T", bound=Callable)  # pylint: disable=invalid-name
 def requires_authentication(function: T):
     """Decorator for functions that require authentication"""
 
-    # noinspection PyUnusedLocal
     @wraps(function)
     def decorated(*args, **kwargs):  # pylint: disable=unused-argument
         return Response("Forbidden", 403)

--- a/airflow/api/auth/backend/kerberos_auth.py
+++ b/airflow/api/auth/backend/kerberos_auth.py
@@ -47,7 +47,6 @@ from socket import getfqdn
 from typing import Callable, Optional, Tuple, TypeVar, Union, cast
 
 import kerberos
-# noinspection PyProtectedMember
 from flask import Response, _request_ctx_stack as stack, g, make_response, request  # type: ignore
 from requests.auth import AuthBase
 from requests_kerberos import HTTPKerberosAuth

--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -34,10 +34,9 @@ class Client(api_client.Client):
         resp = getattr(self._session, method.lower())(**params)  # pylint: disable=not-callable
         if not resp.ok:
             # It is justified here because there might be many resp types.
-            # noinspection PyBroadException
             try:
                 data = resp.json()
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  # noqa pylint: disable=broad-except
                 data = {}
             raise OSError(data.get('error', 'Server error'))
 

--- a/airflow/api/common/experimental/delete_dag.py
+++ b/airflow/api/common/experimental/delete_dag.py
@@ -52,8 +52,7 @@ def delete_dag(dag_id: str, keep_records_in_log: bool = True, session=None) -> i
 
     count = 0
 
-    # noinspection PyUnresolvedReferences,PyProtectedMember
-    for model in models.base.Base._decl_class_registry.values():  # pylint: disable=protected-access
+    for model in models.base.Base._decl_class_registry.values():  # noqa pylint: disable=protected-access
         if hasattr(model, "dag_id"):
             if keep_records_in_log and model.__name__ == 'Log':
                 continue

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -237,7 +237,6 @@ class CeleryExecutor(BaseExecutor):
 
     def update_task_state(self, key: TaskInstanceKey, state: str, info: Any) -> None:
         """Updates state of a single task."""
-        # noinspection PyBroadException
         try:
             if self.last_state[key] != state:
                 if state == celery_states.SUCCESS:
@@ -246,16 +245,16 @@ class CeleryExecutor(BaseExecutor):
                     del self.last_state[key]
                 elif state == celery_states.FAILURE:
                     self.fail(key, info)
-                    del self.tasks[key]
+                    del self.tasks[key]  # noqa
                     del self.last_state[key]
                 elif state == celery_states.REVOKED:
                     self.fail(key, info)
-                    del self.tasks[key]
+                    del self.tasks[key]  # noqa
                     del self.last_state[key]
                 else:
                     self.log.info("Unexpected state: %s", state)
                     self.last_state[key] = state
-        except Exception:  # pylint: disable=broad-except
+        except Exception:  # noqa pylint: disable=broad-except
             self.log.exception("Error syncing the Celery executor, ignoring it.")
 
     def end(self, synchronous: bool = False) -> None:

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -739,13 +739,12 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
         )
 
         for task in queued_tasks:
-            # noinspection PyProtectedMember
             # pylint: disable=protected-access
             dict_string = (
                 "dag_id={},task_id={},execution_date={},airflow-worker={}".format(
                     pod_generator.make_safe_label_value(task.dag_id),
                     pod_generator.make_safe_label_value(task.task_id),
-                    AirflowKubernetesScheduler._datetime_to_label_safe_datestring(
+                    AirflowKubernetesScheduler._datetime_to_label_safe_datestring(  # noqa
                         task.execution_date
                     ),
                     self.worker_uuid

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -154,7 +154,6 @@ class LocalExecutor(BaseExecutor):
             self.executor.workers_active = 0
 
         # pylint: disable=unused-argument # pragma: no cover
-        # noinspection PyUnusedLocal
         def execute_async(self,
                           key: TaskInstanceKey,
                           command: CommandType,
@@ -224,7 +223,6 @@ class LocalExecutor(BaseExecutor):
             for worker in self.executor.workers:
                 worker.start()
 
-        # noinspection PyUnusedLocal
         def execute_async(
             self,
             key: TaskInstanceKey,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -41,7 +41,6 @@ from airflow.exceptions import AirflowException
 from airflow.lineage import apply_lineage, prepare_lineage
 from airflow.models.base import Operator
 from airflow.models.pool import Pool
-# noinspection PyPep8Naming
 from airflow.models.taskinstance import Context, TaskInstance, clear_task_instances
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
@@ -321,7 +320,6 @@ class BaseOperator(Operator, LoggingMixin, metaclass=BaseOperatorMeta):
     # Set to True before calling execute method
     _lock_for_execution = False
 
-    # noinspection PyUnusedLocal
     # pylint: disable=too-many-arguments,too-many-locals, too-many-statements
     @apply_defaults
     def __init__(
@@ -429,8 +427,7 @@ class BaseOperator(Operator, LoggingMixin, metaclass=BaseOperatorMeta):
             self.retry_delay = retry_delay
         else:
             self.log.debug("Retry_delay isn't timedelta object, assuming secs")
-            # noinspection PyTypeChecker
-            self.retry_delay = timedelta(seconds=retry_delay)
+            self.retry_delay = timedelta(seconds=retry_delay)  # noqa
         self.retry_exponential_backoff = retry_exponential_backoff
         self.max_retry_delay = max_retry_delay
         self.params = params or {}  # Available in templates!
@@ -705,7 +702,7 @@ class BaseOperator(Operator, LoggingMixin, metaclass=BaseOperatorMeta):
         """
         from airflow.models.xcom_arg import XComArg
 
-        def apply_set_upstream(arg: Any):
+        def apply_set_upstream(arg: Any): # noqa
             if isinstance(arg, XComArg):
                 self.set_upstream(arg.operator)
             elif isinstance(arg, (tuple, set, list)):
@@ -823,14 +820,12 @@ class BaseOperator(Operator, LoggingMixin, metaclass=BaseOperatorMeta):
         result = cls.__new__(cls)
         memo[id(self)] = result
 
-        # noinspection PyProtectedMember
         shallow_copy = cls.shallow_copy_attrs + \
             cls._base_operator_shallow_copy_attrs  # pylint: disable=protected-access
 
         for k, v in self.__dict__.items():
             if k not in shallow_copy:
-                # noinspection PyArgumentList
-                setattr(result, k, copy.deepcopy(v, memo))
+                setattr(result, k, copy.deepcopy(v, memo))  # noqa
             else:
                 setattr(result, k, copy.copy(v))
         return result
@@ -909,7 +904,7 @@ class BaseOperator(Operator, LoggingMixin, metaclass=BaseOperatorMeta):
             if type(content) is not tuple:  # pylint: disable=unidiomatic-typecheck
                 # Special case for named tuples
                 return content.__class__(
-                    *(self.render_template(element, context, jinja_env) for element in content)
+                    *(self.render_template(element, context, jinja_env) for element in content)  # noqa
                 )
             else:
                 return tuple(self.render_template(element, context, jinja_env) for element in content)
@@ -944,7 +939,7 @@ class BaseOperator(Operator, LoggingMixin, metaclass=BaseOperatorMeta):
 
     def get_template_env(self) -> jinja2.Environment:
         """Fetch a Jinja template environment from the DAG or instantiate empty environment if no DAG."""
-        return self.dag.get_template_env() if self.has_dag() else jinja2.Environment(cache_size=0)
+        return self.dag.get_template_env() if self.has_dag() else jinja2.Environment(cache_size=0)  # noqa
 
     def prepare_template(self) -> None:
         """
@@ -1181,7 +1176,6 @@ class BaseOperator(Operator, LoggingMixin, metaclass=BaseOperatorMeta):
 
         # relationships can only be set if the tasks share a single DAG. Tasks
         # without a DAG are assigned to that DAG.
-        # noinspection PyProtectedMember
         dags = {
             task._dag.dag_id: task._dag  # type: ignore  # pylint: disable=protected-access
             for task in [self] + task_list if task.has_dag()}

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -147,8 +147,7 @@ class SerializedDagModel(Base):
         if isinstance(self.data, dict):
             dag = SerializedDAG.from_dict(self.data)  # type: Any
         else:
-            # noinspection PyTypeChecker
-            dag = SerializedDAG.from_json(self.data)
+            dag = SerializedDAG.from_json(self.data)  # noqa
         return dag
 
     @classmethod

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Manages all plugins."""
-# noinspection PyDeprecation
 import importlib
 import importlib.machinery
 import importlib.util
@@ -193,7 +192,6 @@ def load_plugins_from_plugin_directory():
 
 
 # pylint: disable=protected-access
-# noinspection Mypy,PyTypeHints
 def make_module(name: str, objects: List[Any]):
     """Creates new module."""
     if not objects:

--- a/airflow/providers/apache/hdfs/hooks/hdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/hdfs.py
@@ -34,7 +34,6 @@ class HDFSHookException(AirflowException):
     """Exception specific for HDFS"""
 
 
-# noinspection PyAbstractClass
 class HDFSHook(BaseHook):
     """
     Interact with HDFS. This class is a wrapper around the snakebite library.

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -217,7 +217,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.node_selectors = node_selectors or {}
         self.annotations = annotations or {}
         self.affinity = affinity or {}
-        self.resources = self._set_resources(resources)
+        self.resources = self._set_resources(resources)  # noqa
         self.config_file = config_file
         self.image_pull_secrets = image_pull_secrets
         self.service_account_name = service_account_name
@@ -300,7 +300,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     def handle_pod_overlap(self, labels, try_numbers_match, launcher, pod_list):
         """
 
-        In cases where the Scheduler restarts while a KubernetsPodOperator task is running,
+        In cases where the Scheduler restarts while a KubernetesPodOperator task is running,
         this function will either continue to monitor the existing pod or launch a new pod
         based on the `reattach_on_restart` parameter.
 
@@ -393,7 +393,6 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
             pod=self.full_pod_spec,
         ).gen_pod()
 
-        # noinspection PyTypeChecker
         pod = append_to_pod(
             pod,
             self.pod_runtime_info_envs +

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -78,8 +78,7 @@ class RunState:
         return str(self.__dict__)
 
 
-# noinspection PyAbstractClass
-class DatabricksHook(BaseHook):
+class DatabricksHook(BaseHook):  # noqa
     """
     Interact with Databricks.
 

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -325,12 +325,11 @@ class DockerOperator(BaseOperator):
         if self.tls_ca_cert and self.tls_client_cert and self.tls_client_key:
             # Ignore type error on SSL version here - it is deprecated and type annotation is wrong
             # it should be string
-            # noinspection PyTypeChecker
             tls_config = tls.TLSConfig(
                 ca_cert=self.tls_ca_cert,
                 client_cert=(self.tls_client_cert, self.tls_client_key),
                 verify=True,
-                ssl_version=self.tls_ssl_version,
+                ssl_version=self.tls_ssl_version,  # noqa
                 assert_hostname=self.tls_hostname
             )
             self.docker_url = self.docker_url.replace('tcp://', 'https://')

--- a/airflow/providers/google/cloud/example_dags/example_bigtable.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigtable.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# noinspection LongLine
 """
 Example Airflow DAG that creates and performs following operations on Cloud Bigtable:
 - creates an Instance

--- a/airflow/providers/google/cloud/hooks/cloud_build.py
+++ b/airflow/providers/google/cloud/hooks/cloud_build.py
@@ -29,7 +29,6 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 TIME_TO_SLEEP_IN_SECONDS = 5
 
 
-# noinspection PyAbstractClass
 class CloudBuildHook(GoogleBaseHook):
     """
     Hook for the Google Cloud Build APIs.

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -70,7 +70,6 @@ class CloudSqlOperationStatus:
     UNKNOWN = "UNKNOWN"
 
 
-# noinspection PyAbstractClass
 class CloudSQLHook(GoogleBaseHook):
     """
     Hook for Google Cloud SQL APIs.
@@ -680,8 +679,7 @@ CONNECTION_URIS = {
 CLOUD_SQL_VALID_DATABASE_TYPES = ['postgres', 'mysql']
 
 
-# noinspection PyAbstractClass
-class CloudSQLDatabaseHook(BaseHook):
+class CloudSQLDatabaseHook(BaseHook):  # noqa
     # pylint: disable=too-many-instance-attributes
     """
     Serves DB connection configuration for Google Cloud SQL (Connections

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -118,7 +118,6 @@ def gen_job_name(job_name: str) -> str:
     return f"{job_name}_{uniq}"
 
 
-# noinspection PyAbstractClass
 class CloudDataTransferServiceHook(GoogleBaseHook):
     """
     Hook for Google Storage Transfer Service.

--- a/airflow/providers/google/cloud/hooks/compute.py
+++ b/airflow/providers/google/cloud/hooks/compute.py
@@ -40,7 +40,6 @@ class GceOperationStatus:
     DONE = "DONE"
 
 
-# noinspection PyAbstractClass
 class ComputeEngineHook(GoogleBaseHook):
     """
     Hook for Google Compute Engine APIs.
@@ -93,7 +92,7 @@ class ComputeEngineHook(GoogleBaseHook):
         :type project_id: str
         :return: None
         """
-        response = self.get_conn().instances().start(  # pylint: disable=no-member
+        response = self.get_conn().instances().start(  # noqa pylint: disable=no-member
             project=project_id,
             zone=zone,
             instance=resource_id
@@ -124,7 +123,7 @@ class ComputeEngineHook(GoogleBaseHook):
         :type project_id: str
         :return: None
         """
-        response = self.get_conn().instances().stop(  # pylint: disable=no-member
+        response = self.get_conn().instances().stop(  # noqa pylint: disable=no-member
             project=project_id,
             zone=zone,
             instance=resource_id
@@ -183,7 +182,7 @@ class ComputeEngineHook(GoogleBaseHook):
         body: Dict,
         project_id: str
     ) -> Dict:
-        return self.get_conn().instances().setMachineType(  # pylint: disable=no-member
+        return self.get_conn().instances().setMachineType(  # noqa pylint: disable=no-member
             project=project_id, zone=zone, instance=resource_id, body=body)\
             .execute(num_retries=self.num_retries)
 
@@ -203,7 +202,7 @@ class ComputeEngineHook(GoogleBaseHook):
             https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates
         :rtype: dict
         """
-        response = self.get_conn().instanceTemplates().get(  # pylint: disable=no-member
+        response = self.get_conn().instanceTemplates().get(  # noqa pylint: disable=no-member
             project=project_id,
             instanceTemplate=resource_id
         ).execute(num_retries=self.num_retries)
@@ -234,7 +233,7 @@ class ComputeEngineHook(GoogleBaseHook):
         :type project_id: str
         :return: None
         """
-        response = self.get_conn().instanceTemplates().insert(  # pylint: disable=no-member
+        response = self.get_conn().instanceTemplates().insert(  # noqa pylint: disable=no-member
             project=project_id,
             body=body,
             requestId=request_id
@@ -271,7 +270,7 @@ class ComputeEngineHook(GoogleBaseHook):
             https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers
         :rtype: dict
         """
-        response = self.get_conn().instanceGroupManagers().get(  # pylint: disable=no-member
+        response = self.get_conn().instanceGroupManagers().get(  # noqa pylint: disable=no-member
             project=project_id,
             zone=zone,
             instanceGroupManager=resource_id
@@ -310,7 +309,7 @@ class ComputeEngineHook(GoogleBaseHook):
         :type project_id: str
         :return: None
         """
-        response = self.get_conn().instanceGroupManagers().patch(  # pylint: disable=no-member
+        response = self.get_conn().instanceGroupManagers().patch(  # noqa pylint: disable=no-member
             project=project_id,
             zone=zone,
             instanceGroupManager=resource_id,
@@ -345,7 +344,6 @@ class ComputeEngineHook(GoogleBaseHook):
         service = self.get_conn()
         while True:
             if zone is None:
-                # noinspection PyTypeChecker
                 operation_response = self._check_global_operation_status(
                     service=service,
                     operation_name=operation_name,
@@ -353,7 +351,6 @@ class ComputeEngineHook(GoogleBaseHook):
                     num_retries=self.num_retries
                 )
             else:
-                # noinspection PyTypeChecker
                 operation_response = self._check_zone_operation_status(
                     service, operation_name, project_id, zone, self.num_retries)
             if operation_response.get("status") == GceOperationStatus.DONE:

--- a/airflow/providers/google/cloud/hooks/functions.py
+++ b/airflow/providers/google/cloud/hooks/functions.py
@@ -31,7 +31,6 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 TIME_TO_SLEEP_IN_SECONDS = 1
 
 
-# noinspection PyAbstractClass
 class CloudFunctionsHook(GoogleBaseHook):
     """
     Hook for the Google Cloud Functions APIs.

--- a/airflow/providers/google/cloud/hooks/kms.py
+++ b/airflow/providers/google/cloud/hooks/kms.py
@@ -40,7 +40,6 @@ def _b64decode(s: str) -> bytes:
     return base64.b64decode(s.encode("utf-8"))
 
 
-# noinspection PyAbstractClass
 class CloudKMSHook(GoogleBaseHook):
     """
     Hook for Google Cloud Key Management service.

--- a/airflow/providers/google/cloud/hooks/life_sciences.py
+++ b/airflow/providers/google/cloud/hooks/life_sciences.py
@@ -30,7 +30,6 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 TIME_TO_SLEEP_IN_SECONDS = 5
 
 
-# noinspection PyAbstractClass
 class LifeSciencesHook(GoogleBaseHook):
     """
     Hook for the Google Cloud Life Sciences APIs.

--- a/airflow/providers/google/cloud/hooks/natural_language.py
+++ b/airflow/providers/google/cloud/hooks/natural_language.py
@@ -30,7 +30,6 @@ from google.cloud.language_v1.types import (
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
-# noinspection PyAbstractClass
 class CloudNaturalLanguageHook(GoogleBaseHook):
     """
     Hook for Google Cloud Natural Language Service.

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -44,7 +44,6 @@ class PubSubException(Exception):
     """
 
 
-# noinspection PyAbstractClass
 class PubSubHook(GoogleBaseHook):
     """
     Hook for accessing Google Pub/Sub.

--- a/airflow/providers/google/cloud/hooks/secret_manager.py
+++ b/airflow/providers/google/cloud/hooks/secret_manager.py
@@ -22,7 +22,6 @@ from airflow.providers.google.cloud._internal_client.secret_manager_client impor
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
-# noinspection PyAbstractClass
 class SecretsManagerHook(GoogleBaseHook):
     """
     Hook for the Google Secret Manager API.

--- a/airflow/providers/google/cloud/hooks/spanner.py
+++ b/airflow/providers/google/cloud/hooks/spanner.py
@@ -119,7 +119,6 @@ class SpannerHook(GoogleBaseHook):
         :param func: Method of the instance to be called.
         :type func: Callable[google.cloud.spanner_v1.instance.Instance]
         """
-        # noinspection PyUnresolvedReferences
         instance = self._get_client(project_id=project_id).instance(
             instance_id=instance_id, configuration_name=configuration_name,
             node_count=node_count, display_name=display_name)

--- a/airflow/providers/google/firebase/hooks/firestore.py
+++ b/airflow/providers/google/firebase/hooks/firestore.py
@@ -29,7 +29,6 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 TIME_TO_SLEEP_IN_SECONDS = 5
 
 
-# noinspection PyAbstractClass
 class CloudFirestoreHook(GoogleBaseHook):
     """
     Hook for the Google Firestore APIs.

--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -24,7 +24,6 @@ from googleapiclient.http import MediaFileUpload
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
-# noinspection PyAbstractClass
 class GoogleDriveHook(GoogleBaseHook):
     """
     Hook for the Google Drive APIs.

--- a/airflow/providers/grpc/hooks/grpc.py
+++ b/airflow/providers/grpc/hooks/grpc.py
@@ -120,7 +120,6 @@ class GrpcHook(BaseHook):
                 else:
                     yield from response
             except grpc.RpcError as ex:
-                # noinspection PyUnresolvedReferences
                 self.log.exception(
                     "Error occurred when calling the grpc service: %s, method: %s \
                     status code: %s, error details: %s",

--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -265,8 +265,7 @@ class _VaultClient(LoggingMixin):  # pylint: disable=too-many-instance-attribute
             _client.auth.github.login(token=self.token)
 
     def _auth_gcp(self, _client: hvac.Client) -> None:
-        # noinspection PyProtectedMember
-        from airflow.providers.google.cloud.utils.credentials_provider import (
+        from airflow.providers.google.cloud.utils.credentials_provider import (  # noqa
             _get_scopes, get_credentials_and_project_id,
         )
         scopes = _get_scopes(self.gcp_scopes)

--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -24,7 +24,6 @@ from hvac.exceptions import VaultError
 from requests import Response
 
 from airflow.hooks.base_hook import BaseHook
-# noinspection PyProtectedMember
 from airflow.providers.hashicorp._internal_client.vault_client import (  # noqa
     DEFAULT_KUBERNETES_JWT_PATH, DEFAULT_KV_ENGINE_VERSION, _VaultClient,
 )

--- a/airflow/providers/redis/hooks/redis.py
+++ b/airflow/providers/redis/hooks/redis.py
@@ -24,7 +24,6 @@ from redis import Redis
 from airflow.hooks.base_hook import BaseHook
 
 
-# noinspection PyAbstractClass
 class RedisHook(BaseHook):
     """
     Wrapper for connection to interact with Redis in-memory data structure store

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -24,8 +24,7 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 
 
-# noinspection PyAbstractClass
-class SlackHook(BaseHook):
+class SlackHook(BaseHook):  # noqa
     """
     Creates a Slack connection, to be used for calls. Takes both Slack API token directly and
     connection that has Slack API token. If both supplied, Slack API token will be used.

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -601,7 +601,6 @@ class SerializedDAG(DAG, BaseSerialization):
 
             for task_id in serializable_task.downstream_task_ids:
                 # Bypass set_upstream etc here - it does more than we want
-                # noinspection PyProtectedMember
                 dag.task_dict[task_id]._upstream_task_ids.add(serializable_task.task_id)  # noqa: E501 # pylint: disable=protected-access
 
         return dag

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -867,11 +867,10 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
             self.log.info("There are %s files in %s", len(self._file_paths), self._dag_directory)
             self.set_file_paths(self._file_paths)
 
-            # noinspection PyBroadException
             try:
                 self.log.debug("Removing old import errors")
                 self.clear_nonexistent_import_errors()  # pylint: disable=no-value-for-parameter
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  # noqa pylint: disable=broad-except
                 self.log.exception("Error removing old import errors")
 
     def _print_stat(self):

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -23,15 +23,12 @@ from sqlalchemy import Table
 
 from airflow import settings
 from airflow.configuration import conf
-# noinspection PyUnresolvedReferences
 from airflow.jobs.base_job import BaseJob  # noqa: F401 # pylint: disable=unused-import
-# noinspection PyUnresolvedReferences
 from airflow.models import (  # noqa: F401 # pylint: disable=unused-import
     DAG, XCOM_RETURN_KEY, BaseOperator, BaseOperatorLink, Connection, DagBag, DagModel, DagPickle, DagRun,
     DagTag, Log, Pool, SkipMixin, SlaMiss, TaskFail, TaskInstance, TaskReschedule, Variable, XCom,
 )
 # We need to add this model manually to get reset working well
-# noinspection PyUnresolvedReferences
 from airflow.models.serialized_dag import SerializedDagModel  # noqa: F401  # pylint: disable=unused-import
 # TODO: remove create_session once we decide to break backward compatibility
 from airflow.utils.session import (  # noqa: F401 # pylint: disable=unused-import
@@ -665,11 +662,9 @@ def drop_airflow_models(connection):
     Base.metadata.remove(user)
     Base.metadata.remove(chart)
     # alembic adds significant import time, so we import it lazily
-    # noinspection PyUnresolvedReferences
-    from alembic.migration import MigrationContext
+    from alembic.migration import MigrationContext  # noqa
     migration_ctx = MigrationContext.configure(connection)
-    # noinspection PyProtectedMember
-    version = migration_ctx._version  # pylint: disable=protected-access
+    version = migration_ctx._version  # noqa pylint: disable=protected-access
     if version.exists(connection):
         version.drop(connection)
 

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -169,7 +169,6 @@ def find_dag_file_paths(directory: str, file_paths: list, safe_mode: bool):
 
     for file_path in find_path_from_directory(
             directory, ".airflowignore"):
-        # noinspection PyBroadException
         try:
             if not os.path.isfile(file_path):
                 continue
@@ -180,7 +179,7 @@ def find_dag_file_paths(directory: str, file_paths: list, safe_mode: bool):
                 continue
 
             file_paths.append(file_path)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:  # noqa pylint: disable=broad-except
             log.exception("Error while examining %s", file_path)
 
 

--- a/airflow/www/extensions/init_manifest_files.py
+++ b/airflow/www/extensions/init_manifest_files.py
@@ -32,7 +32,6 @@ def configure_manifest_files(app):
     manifest = {}
 
     def parse_manifest_json():
-        # noinspection PyBroadException
         try:
             manifest_file = os.path.join(os.path.dirname(__file__), os.pardir, 'static/dist/manifest.json')
             with open(manifest_file, 'r') as file:
@@ -40,7 +39,7 @@ def configure_manifest_files(app):
 
                 for source, target in manifest.copy().items():
                     manifest[source] = os.path.join("dist", target)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:  # noqa pylint: disable=broad-except
             print("Please make sure to build the frontend in static/ directory and restart the server")
 
     def get_asset_url(filename):

--- a/backport_packages/import_all_provider_classes.py
+++ b/backport_packages/import_all_provider_classes.py
@@ -56,7 +56,6 @@ def import_all_provider_classes(source_path: str,
                 module_name = package_name + "." + file[:-3] if file != "__init__.py" else package_name
                 if print_imports:
                     print(f"Importing module: {module_name}")
-                # noinspection PyBroadException
                 try:
                     _module = importlib.import_module(module_name)
                     for attribute_name in dir(_module):
@@ -66,7 +65,7 @@ def import_all_provider_classes(source_path: str,
                             if print_imports:
                                 print(f"Imported {class_name}")
                             imported_classes.append(class_name)
-                except Exception:
+                except Exception:  # noqa
                     exception_str = traceback.format_exc()
                     tracebacks.append(exception_str)
     if tracebacks:

--- a/backport_packages/refactor_backport_packages.py
+++ b/backport_packages/refactor_backport_packages.py
@@ -119,7 +119,6 @@ class RefactorBackportPackages:
 
         :param class_name: name to remove
         """
-        # noinspection PyUnusedLocal
         def _remover(node: LN, capture: Capture, filename: Filename) -> None:
             node.remove()
 
@@ -194,7 +193,6 @@ class RefactorBackportPackages:
                  )
 
         """
-        # noinspection PyUnusedLocal
         def add_provide_context_to_python_operator(node: LN, capture: Capture, filename: Filename) -> None:
             fn_args = capture['function_arguments'][0]
             if len(fn_args.children) > 0 and (not isinstance(fn_args.children[-1], Leaf)
@@ -273,7 +271,6 @@ class RefactorBackportPackages:
                      self.max_ingestion_time = max_ingestion_time
 
         """
-        # noinspection PyUnusedLocal
         def remove_super_init_call_modifier(node: LN, capture: Capture, filename: Filename) -> None:
             for ch in node.post_order():
                 if isinstance(ch, Leaf) and ch.value == "super":
@@ -309,7 +306,6 @@ class RefactorBackportPackages:
              ) as dag:
 
         """
-        # noinspection PyUnusedLocal
         def remove_tags_modifier(_: LN, capture: Capture, filename: Filename) -> None:
             for node in capture['function_arguments'][0].post_order():
                 if isinstance(node, Leaf) and node.value == "tags" and node.type == TOKEN.NAME:
@@ -373,7 +369,6 @@ class RefactorBackportPackages:
                 isinstance(node.children[0], Leaf) and node.children[0].value == '@' and \
                 isinstance(node.children[1], Leaf) and node.children[1].value == 'poke_mode_only'
 
-        # noinspection PyUnusedLocal
         def remove_poke_mode_only_modifier(node: LN, capture: Capture, filename: Filename) -> None:
             for child in capture['node'].parent.children:
                 if is_poke_mode_only_decorator(child):
@@ -405,7 +400,6 @@ class RefactorBackportPackages:
 
         """
 
-        # noinspection PyUnusedLocal
         def amazon_package_filter(node: LN, capture: Capture, filename: Filename) -> bool:
             return filename.startswith("./airflow/providers/amazon/")
 
@@ -539,11 +533,9 @@ class RefactorBackportPackages:
              KEY_REGEX = re.compile(r'^[\\w.-]+$')
 
         """
-        # noinspection PyUnusedLocal
         def google_package_filter(node: LN, capture: Capture, filename: Filename) -> bool:
             return filename.startswith("./airflow/providers/google/")
 
-        # noinspection PyUnusedLocal
         def pure_airflow_models_filter(node: LN, capture: Capture, filename: Filename) -> bool:
             """Check if select is exactly [airflow, . , models]"""
             return len(list(node.children[1].leaves())) == 3
@@ -640,7 +632,6 @@ class RefactorBackportPackages:
 
 
         """
-        # noinspection PyUnusedLocal
         def odbc_package_filter(node: LN, capture: Capture, filename: Filename) -> bool:
             return filename.startswith("./airflow/providers/odbc/")
 
@@ -659,7 +650,7 @@ class RefactorBackportPackages:
             rename("airflow.providers.odbc.utils.helpers")
         )
 
-    def do_refactor(self, in_process: bool = False) -> None:
+    def do_refactor(self, in_process: bool = False) -> None:  # noqa
         self.rename_deprecated_modules()
         self.refactor_amazon_package()
         self.refactor_google_package()

--- a/backport_packages/setup_backport_packages.py
+++ b/backport_packages/setup_backport_packages.py
@@ -53,7 +53,6 @@ from setup import PROVIDERS_REQUIREMENTS  # noqa # isort:skip
 # Note - we do not test protocols as they are not really part of the official API of
 # Apache Airflow
 
-# noinspection DuplicatedCode
 logger = logging.getLogger(__name__)  # noqa
 
 PY3 = sys.version_info[0] == 3
@@ -174,8 +173,7 @@ class CleanCommand(Command):
     def finalize_options(self):
         """Set final values for options."""
 
-    # noinspection PyMethodMayBeStatic
-    def run(self):
+    def run(self):  # noqa
         """Run command to remove temporary files and directories."""
         os.chdir(dirname(__file__))
         os.system('rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info')

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -484,14 +484,13 @@ def parse_sphinx_warnings(warning_text: str) -> List[DocBuildError]:
             continue
         warning_parts = sphinx_warning.split(":", 2)
         if len(warning_parts) == 3:
-            # noinspection PyBroadException
             try:
                 sphinx_build_errors.append(
                     DocBuildError(
                         file_path=warning_parts[0], line_no=int(warning_parts[1]), message=warning_parts[2]
                     )
                 )
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  # noqa pylint: disable=broad-except
                 # If an exception occurred while parsing the warning message, display the raw warning message.
                 sphinx_build_errors.append(
                     DocBuildError(

--- a/docs/exts/docroles.py
+++ b/docs/exts/docroles.py
@@ -59,7 +59,6 @@ def get_template_field(env, fullname):
     return list(template_fields)
 
 
-# noinspection PyUnusedLocal
 def template_field_role(app,
                         typ,  # pylint: disable=unused-argument
                         rawtext,

--- a/docs/exts/exampleinclude.py
+++ b/docs/exts/exampleinclude.py
@@ -130,7 +130,6 @@ class ExampleInclude(SphinxDirective):
 
 
 # pylint: disable=protected-access
-# noinspection PyProtectedMember
 def register_source(app, env, modname):
     """
     Registers source code.
@@ -147,7 +146,6 @@ def register_source(app, env, modname):
 
     code_tags = app.emit_firstresult("viewcode-find-source", modname)
     if code_tags is None:
-        # noinspection PyBroadException
         try:
             analyzer = ModuleAnalyzer.for_module(modname)
         except Exception as ex:  # pylint: disable=broad-except
@@ -208,7 +206,6 @@ def create_node(env, relative_path, show_button):
     return paragraph
 
 
-# noinspection PyProtectedMember
 # pylint: disable=protected-access
 def doctree_read(app, doctree):
     """

--- a/docs/exts/removemarktransform.py
+++ b/docs/exts/removemarktransform.py
@@ -22,12 +22,11 @@
 import re
 
 from docutils import nodes
-# noinspection PyUnresolvedReferences
-from pygments.lexers import Python3Lexer, PythonLexer, guess_lexer  # pylint: disable=no-name-in-module
+from pygments.lexers import Python3Lexer, PythonLexer, guess_lexer  # noqa pylint: disable=no-name-in-module
 from sphinx.transforms import SphinxTransform
 from sphinx.transforms.post_transforms.code import TrimDoctestFlagsTransform
 
-docmark_re = re.compile(r"\s*#\s*\[(START|END)\s*[a-z_A-Z]+\].*$", re.MULTILINE)
+docmark_re = re.compile(r"\s*#\s*\[(START|END)\s*[a-z_A-Z]+].*$", re.MULTILINE)
 
 
 class TrimDocMarkerFlagsTransform(SphinxTransform):
@@ -59,11 +58,10 @@ class TrimDocMarkerFlagsTransform(SphinxTransform):
         if language in ("py", "py3", "python", "python3", "default"):
             return True
         elif language == "guess":
-            # noinspection PyBroadException
             try:
                 lexer = guess_lexer(node.rawsource)
                 return isinstance(lexer, (PythonLexer, Python3Lexer))
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  # noqa pylint: disable=broad-except
                 pass
 
         return False

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -44,7 +44,6 @@ from airflow.utils import timezone
 from airflow.version import version as airflow_version
 
 
-# noinspection DuplicatedCode
 def create_context(task):
     dag = DAG(dag_id="dag")
     tzinfo = pendulum.timezone("Europe/Amsterdam")
@@ -59,7 +58,6 @@ def create_context(task):
     }
 
 
-# noinspection DuplicatedCode,PyUnusedLocal
 class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
     def get_current_task_name(self):

--- a/scripts/in_container/update_quarantined_test_status.py
+++ b/scripts/in_container/update_quarantined_test_status.py
@@ -89,10 +89,9 @@ def parse_test_history(line: str) -> Optional[TestHistory]:
         parsed_url = urlsplit(http_url)
         the_id = parsed_url[3].split("=")[1]
         comment = values[5] if len(values) >= 6 else ""
-        # noinspection PyBroadException
         try:
             states = parse_state_history(values[3])
-        except Exception:
+        except Exception:  # noqa
             states = []
         return TestHistory(
             test_id=the_id,
@@ -114,10 +113,9 @@ def parse_body(body: str) -> Dict[str, TestHistory]:
         if parse:
             if not line.startswith("|"):
                 break
-            # noinspection PyBroadException
             try:
                 status = parse_test_history(line)
-            except Exception:
+            except Exception:  # noqa
                 continue
             if status:
                 test_history_map[status.test_id] = status

--- a/scripts/tools/list-integrations.py
+++ b/scripts/tools/list-integrations.py
@@ -95,8 +95,7 @@ If you want to count the operators/sensors in each providers package, you can us
         sort -n -r
 """
 
-# noinspection PyTypeChecker
-parser = argparse.ArgumentParser(
+parser = argparse.ArgumentParser(  # noqa
     description=HELP,
     formatter_class=argparse.RawTextHelpFormatter,
     epilog=EPILOG

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ from setuptools import Command, find_packages, setup
 logger = logging.getLogger(__name__)
 
 # Kept manually in sync with airflow.__version__
-# noinspection PyUnresolvedReferences
-spec = util.spec_from_file_location("airflow.version", os.path.join('airflow', 'version.py'))
-# noinspection PyUnresolvedReferences
+spec = util.spec_from_file_location("airflow.version", os.path.join('airflow', 'version.py'))  # noqa
 mod = util.module_from_spec(spec)
 spec.loader.exec_module(mod)  # type: ignore
 version = mod.version  # type: ignore
@@ -45,7 +43,6 @@ PY38 = PY3 and sys.version_info[1] >= 8
 
 my_dir = dirname(__file__)
 
-# noinspection PyUnboundLocalVariable
 try:
     with io.open(os.path.join(my_dir, 'README.md'), encoding='utf-8') as f:
         long_description = f.read()
@@ -75,8 +72,7 @@ class CleanCommand(Command):
     def finalize_options(self):
         """Set final values for options."""
 
-    # noinspection PyMethodMayBeStatic
-    def run(self):
+    def run(self):  # noqa
         """Run command to remove temporary files and directories."""
         os.chdir(my_dir)
         os.system('rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info')
@@ -97,8 +93,7 @@ class CompileAssets(Command):
     def finalize_options(self):
         """Set final values for options."""
 
-    # noinspection PyMethodMayBeStatic
-    def run(self):
+    def run(self):  # noqa
         """Run a command to compile and build assets."""
         subprocess.check_call('./airflow/www/compile_assets.sh')
 
@@ -118,8 +113,7 @@ class ListExtras(Command):
     def finalize_options(self):
         """Set final values for options."""
 
-    # noinspection PyMethodMayBeStatic
-    def run(self):
+    def run(self):  # noqa
         """List extras."""
         print("\n".join(wrap(", ".join(EXTRAS_REQUIREMENTS.keys()), 100)))
 

--- a/tests/build_provider_packages_dependencies.py
+++ b/tests/build_provider_packages_dependencies.py
@@ -121,8 +121,7 @@ class ImportFinder(NodeVisitor):
     def process_import(self, import_name: str):
         self.imports.append(import_name)
 
-    # noinspection PyMethodMayBeStatic
-    def get_import_name_from_import_from(self, node: ImportFrom) -> List[str]:
+    def get_import_name_from_import_from(self, node: ImportFrom) -> List[str]:  # noqa
         """
         Retrieves import name from the "from" import.
         :param node: ImportFrom name
@@ -135,12 +134,10 @@ class ImportFinder(NodeVisitor):
             import_names.append(fullname)
         return import_names
 
-    # noinspection PyPep8Naming
     def visit_Import(self, node: Import):  # pylint: disable=invalid-name
         for alias in node.names:
             self.process_import(alias.name)
 
-    # noinspection PyPep8Naming
     def visit_ImportFrom(self, node: ImportFrom):  # pylint: disable=invalid-name
         if node.module == '__future__':
             return

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -24,11 +24,10 @@ import unittest
 from unittest import mock
 
 # leave this it is used by the test worker
-# noinspection PyUnresolvedReferences
 import celery.contrib.testing.tasks  # noqa: F401 pylint: disable=unused-import
 import pytest
 from celery import Celery
-from celery.backends.base import BaseBackend, BaseKeyValueStoreBackend
+from celery.backends.base import BaseBackend, BaseKeyValueStoreBackend  # noqa
 from celery.backends.database import DatabaseBackend
 from celery.contrib.testing.worker import start_worker
 from kombu.asynchronous import set_event_loop

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -292,8 +292,7 @@ class TestBaseOperatorMethods(unittest.TestCase):
         dag = DAG(dag_id='test_chain', start_date=datetime.now())
         [op1, op2] = [DummyOperator(task_id='t{i}'.format(i=i), dag=dag) for i in range(1, 3)]
         with self.assertRaises(TypeError):
-            # noinspection PyTypeChecker
-            chain([op1, op2], 1)
+            chain([op1, op2], 1)  # noqa
 
     def test_chain_different_length_iterable(self):
         dag = DAG(dag_id='test_chain', start_date=datetime.now())

--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -46,7 +46,6 @@ result_configuration = {
 }
 
 
-# noinspection PyUnusedLocal
 # pylint: disable=unused-argument
 class TestAWSAthenaOperator(unittest.TestCase):
 

--- a/tests/providers/amazon/aws/operators/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_training.py
@@ -77,7 +77,6 @@ create_training_params = \
     }
 
 
-# noinspection PyUnusedLocal
 # pylint: disable=unused-argument
 class TestSageMakerTrainingOperator(unittest.TestCase):
 

--- a/tests/providers/apache/livy/hooks/test_livy.py
+++ b/tests/providers/apache/livy/hooks/test_livy.py
@@ -90,7 +90,7 @@ class TestLivyHook(unittest.TestCase):
                 driver_cores=2,
                 driver_memory='1M',
                 executor_memory='1m',
-                executor_cores='1',
+                executor_cores='1',  # noqa
                 num_executors='10',
             )
 
@@ -150,11 +150,10 @@ class TestLivyHook(unittest.TestCase):
 
         with self.subTest('numeric'):
             with self.assertRaises(ValueError):
-                LivyHook._validate_size_format(1)
+                LivyHook._validate_size_format(1)  # noqa
 
         with self.subTest('None'):
-            # noinspection PyTypeChecker
-            self.assertTrue(LivyHook._validate_size_format(None))
+            self.assertTrue(LivyHook._validate_size_format(None))  # noqa
 
     def test_validate_list_of_stringables(self):
         with self.subTest('valid list'):
@@ -189,11 +188,11 @@ class TestLivyHook(unittest.TestCase):
 
         with self.subTest('None'):
             with self.assertRaises(ValueError):
-                LivyHook._validate_list_of_stringables(None)
+                LivyHook._validate_list_of_stringables(None)  # noqa
 
         with self.subTest('int'):
             with self.assertRaises(ValueError):
-                LivyHook._validate_list_of_stringables(1)
+                LivyHook._validate_list_of_stringables(1)  # noqa
 
         with self.subTest('string'):
             with self.assertRaises(ValueError):
@@ -214,20 +213,17 @@ class TestLivyHook(unittest.TestCase):
 
         with self.subTest('none'):
             try:
-                # noinspection PyTypeChecker
-                LivyHook._validate_extra_conf(None)
+                LivyHook._validate_extra_conf(None)  # noqa
             except ValueError:
                 self.fail("Exception raised")
 
         with self.subTest('not a dict 1'):
             with self.assertRaises(ValueError):
-                # noinspection PyTypeChecker
-                LivyHook._validate_extra_conf('k1=v1')
+                LivyHook._validate_extra_conf('k1=v1')  # noqa
 
         with self.subTest('not a dict 2'):
             with self.assertRaises(ValueError):
-                # noinspection PyTypeChecker
-                LivyHook._validate_extra_conf([('k1', 'v1'), ('k2', 0)])
+                LivyHook._validate_extra_conf([('k1', 'v1'), ('k2', 0)])  # noqa
 
         with self.subTest('nested dict'):
             with self.assertRaises(ValueError):
@@ -424,7 +420,6 @@ class TestLivyHook(unittest.TestCase):
         for val in [None, 'one', {'a': 'b'}]:
             with self.subTest('get_batch {}'.format(val)):
                 with self.assertRaises(TypeError):
-                    # noinspection PyTypeChecker
                     hook.get_batch(val)
 
     @requests_mock.mock()
@@ -442,7 +437,6 @@ class TestLivyHook(unittest.TestCase):
         for val in [None, 'one', {'a': 'b'}]:
             with self.subTest('get_batch {}'.format(val)):
                 with self.assertRaises(TypeError):
-                    # noinspection PyTypeChecker
                     hook.get_batch_state(val)
 
     @requests_mock.mock()
@@ -460,7 +454,6 @@ class TestLivyHook(unittest.TestCase):
         for val in [None, 'one', {'a': 'b'}]:
             with self.subTest('get_batch {}'.format(val)):
                 with self.assertRaises(TypeError):
-                    # noinspection PyTypeChecker
                     hook.delete_batch(val)
 
     def test_check_session_id(self):
@@ -478,7 +471,7 @@ class TestLivyHook(unittest.TestCase):
 
         with self.subTest('None'):
             with self.assertRaises(TypeError):
-                LivyHook._validate_session_id(None)
+                LivyHook._validate_session_id(None)  # noqa
 
         with self.subTest('random string'):
             with self.assertRaises(TypeError):

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -27,10 +27,8 @@ from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import Kubernete
 from airflow.utils import timezone
 
 
-# noinspection PyUnusedLocal
 class TestKubernetesPodOperator(unittest.TestCase):
 
-    # noinspection DuplicatedCode
     @staticmethod
     def create_context(task):
         dag = DAG(dag_id="dag")

--- a/tests/providers/elasticsearch/log/elasticmock/__init__.py
+++ b/tests/providers/elasticsearch/log/elasticmock/__init__.py
@@ -49,7 +49,6 @@ from .fake_elasticsearch import FakeElasticsearch
 ELASTIC_INSTANCES = {}  # type: Dict[str, FakeElasticsearch]
 
 
-# noinspection PyUnusedLocal
 def _get_elasticmock(hosts=None, *args, **kwargs):  # pylint: disable=unused-argument
     host = _normalize_hosts(hosts)[0]
     elastic_key = '{0}:{1}'.format(

--- a/tests/providers/elasticsearch/log/elasticmock/fake_elasticsearch.py
+++ b/tests/providers/elasticsearch/log/elasticmock/fake_elasticsearch.py
@@ -48,7 +48,6 @@ from .utilities import get_random_id
 
 
 # pylint: disable=redefined-builtin
-# noinspection PyShadowingBuiltins
 class FakeElasticsearch(Elasticsearch):
     __documents_dict = None
 

--- a/tests/providers/google/cloud/_internal_client/test_secret_manager_client.py
+++ b/tests/providers/google/cloud/_internal_client/test_secret_manager_client.py
@@ -27,7 +27,6 @@ from airflow.version import version
 INTERNAL_CLIENT_MODULE = "airflow.providers.google.cloud._internal_client.secret_manager_client"
 
 
-# noinspection DuplicatedCode,PyUnresolvedReferences
 class TestSecretManagerClient(TestCase):
 
     @mock.patch(INTERNAL_CLIENT_MODULE + ".SecretManagerServiceClient")

--- a/tests/providers/google/cloud/secrets/test_secret_manager.py
+++ b/tests/providers/google/cloud/secrets/test_secret_manager.py
@@ -41,7 +41,6 @@ MODULE_NAME = "airflow.providers.google.cloud.secrets.secret_manager"
 CLIENT_MODULE_NAME = "airflow.providers.google.cloud._internal_client.secret_manager_client"
 
 
-# noinspection DuplicatedCode
 class TestCloudSecretManagerBackend(TestCase):
     @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")
     @mock.patch(CLIENT_MODULE_NAME + ".SecretManagerServiceClient")

--- a/tests/providers/grpc/hooks/test_grpc.py
+++ b/tests/providers/grpc/hooks/test_grpc.py
@@ -52,15 +52,14 @@ def get_airflow_connection_with_port():
     )
 
 
-# noinspection PyMethodMayBeStatic,PyUnusedLocal
 class StubClass:
     def __init__(self, _):  # pylint: disable=unused-argument
         pass
 
-    def single_call(self, data):
+    def single_call(self, data):  # noqa
         return data
 
-    def stream_call(self, data):  # pylint: disable=unused-argument
+    def stream_call(self, data):  # noqa pylint: disable=unused-argument
         return ["streaming", "call"]
 
 
@@ -68,7 +67,6 @@ class TestGrpcHook(unittest.TestCase):
     def setUp(self):
         self.channel_mock = mock.patch('grpc.Channel').start()
 
-    # noinspection PyUnusedLocal
     def custom_conn_func(self, _):
         mocked_channel = self.channel_mock.return_value
         return mocked_channel

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -25,7 +25,6 @@ from mock import mock_open, patch
 from airflow.providers.hashicorp._internal_client.vault_client import _VaultClient  # noqa
 
 
-# noinspection DuplicatedCode,PyUnresolvedReferences
 class TestVaultClient(TestCase):
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -25,7 +25,6 @@ from mock import PropertyMock, mock_open, patch
 from airflow.providers.hashicorp.hooks.vault import VaultHook
 
 
-# noinspection DuplicatedCode,PyUnresolvedReferences
 class TestVaultHook(TestCase):
 
     @staticmethod

--- a/tests/utils/perf/perf_kit/sqlalchemy.py
+++ b/tests/utils/perf/perf_kit/sqlalchemy.py
@@ -32,7 +32,6 @@ def _pretty_format_sql(text: str):
     return text
 
 
-# noinspection PyUnusedLocal
 class TraceQueries:
     """
     Tracking SQL queries in a code block.
@@ -138,8 +137,7 @@ class TraceQueries:
         event.listen(airflow.settings.engine, "before_cursor_execute", self.before_cursor_execute)
         event.listen(airflow.settings.engine, "after_cursor_execute", self.after_cursor_execute)
 
-    # noinspection PyShadowingNames
-    def __exit__(self, type_, value, traceback):  # pylint: disable=redefined-outer-name
+    def __exit__(self, type_, value, traceback):  # noqa pylint: disable=redefined-outer-name
         import airflow.settings
         event.remove(airflow.settings.engine, "before_cursor_execute", self.before_cursor_execute)
         event.remove(airflow.settings.engine, "after_cursor_execute", self.after_cursor_execute)
@@ -176,8 +174,7 @@ class CountQueries:
         event.listen(airflow.settings.engine, "after_cursor_execute", self.after_cursor_execute)
         return self.result
 
-    # noinspection PyShadowingNames
-    def __exit__(self, type_, value, traceback):  # pylint: disable=redefined-outer-name
+    def __exit__(self, type_, value, traceback):  # noqa pylint: disable=redefined-outer-name
         import airflow.settings
 
         event.remove(airflow.settings.engine, "after_cursor_execute", self.after_cursor_execute)
@@ -209,7 +206,7 @@ if __name__ == "__main__":
 
     # Example:
     def case():
-        "Case of logging om/"
+        """Case of logging om/"""
         import logging
         from unittest import mock
 


### PR DESCRIPTION
We have already fixed a lot of problems that were marked
with those, also IntelluiJ gotten a bit smarter on not
detecting false positives as well as understand more
pylint annotation. Wherever the problem remained
we replaced it with # noqa comments - as it is
also well understood by IntelliJ.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
