### PR TITLE
Covert single quoted docstring to triple

### DIFF
--- a/tests/utils/perf/perf_kit/sqlalchemy.py
+++ b/tests/utils/perf/perf_kit/sqlalchemy.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
 
     # Example:
     def case():
-        "Case of logging om/"
+        """Case of logging om/"""
         import logging
         from unittest import mock
 


### PR DESCRIPTION
As a convention we use Triple quoted docstring

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
