### PR TITLE
The PIP version is not pinned to 19.0.2 any more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ ARG AIRFLOW_HOME=/opt/airflow
 ARG AIRFLOW_UID="50000"
 ARG AIRFLOW_GID="50000"
 
-ARG PIP_VERSION="19.0.2"
 ARG CASS_DRIVER_BUILD_CONCURRENCY="8"
 
 ARG PYTHON_BASE_IMAGE="python:3.6-slim-buster"
@@ -145,11 +144,6 @@ RUN KEY="A4A9406876FCBD3C456770C88C718D3B5072E1F5" \
         mysql-client \
     && apt-get autoremove -yqq --purge \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ARG PIP_VERSION
-ENV PIP_VERSION=${PIP_VERSION}
-
-RUN pip install --upgrade pip==${PIP_VERSION}
 
 ARG AIRFLOW_REPO=apache/airflow
 ENV AIRFLOW_REPO=${AIRFLOW_REPO}
@@ -327,10 +321,6 @@ RUN KEY="A4A9406876FCBD3C456770C88C718D3B5072E1F5" \
         mysql-client \
     && apt-get autoremove -yqq --purge \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ARG PIP_VERSION
-ENV PIP_VERSION=${PIP_VERSION}
-RUN pip install --upgrade pip==${PIP_VERSION}
 
 ENV AIRFLOW_UID=${AIRFLOW_UID}
 ENV AIRFLOW_GID=${AIRFLOW_GID}

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -166,13 +166,6 @@ ARG PIP_NO_CACHE_DIR="true"
 ENV PIP_NO_CACHE_DIR=${PIP_NO_CACHE_DIR}
 RUN echo "Pip no cache dir: ${PIP_NO_CACHE_DIR}"
 
-# PIP version used to install dependencies
-ARG PIP_VERSION="19.0.2"
-ENV PIP_VERSION=${PIP_VERSION}
-RUN echo "Pip version: ${PIP_VERSION}"
-
-RUN pip install --upgrade pip==${PIP_VERSION}
-
 ARG HOME=/root
 ENV HOME=${HOME}
 

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -276,8 +276,6 @@ The following build arguments (``--build-arg`` in docker build command) can be u
 | ``PIP_NO_CACHE_DIR``                     | ``true``                                 | if true, then no pip cache will be       |
 |                                          |                                          | stored                                   |
 +------------------------------------------+------------------------------------------+------------------------------------------+
-| ``PIP_VERSION``                          | ``19.0.2``                               | version of PIP to use                    |
-+------------------------------------------+------------------------------------------+------------------------------------------+
 | ``HOME``                                 | ``/root``                                | Home directory of the root user (CI      |
 |                                          |                                          | image has root user as default)          |
 +------------------------------------------+------------------------------------------+------------------------------------------+
@@ -419,8 +417,6 @@ The following build arguments (``--build-arg`` in docker build command) can be u
 |                                          |                                          | OpenShift Guidelines compatibility       |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``AIRFLOW_USER_HOME_DIR``                | ``/home/airflow``                        | Home directory of the Airflow user       |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``PIP_VERSION``                          | ``19.0.2``                               | version of PIP to use                    |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``CASS_DRIVER_BUILD_CONCURRENCY``        | ``8``                                    | Number of processors to use for          |
 |                                          |                                          | cassandra PIP install (speeds up         |


### PR DESCRIPTION
Fixes #10516

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
