### PR TITLE
Fix timestamp tooltip redundancy

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -373,11 +373,7 @@
         g = d3.select('div#last-run-' + safe_dag_id)
         g.selectAll('a')
           .attr("href", "{{ url_for('Airflow.graph') }}?dag_id=" + encodeURIComponent(dag_id) + "&execution_date=" + last_run)
-          .insert(isoDateToTimeEl.bind(null, last_run, {title: false}));
-        g.selectAll('span')
-          // We don't translate the timezone in the tooltip, that stays in UTC.
-          .attr("data-original-title", "Start Date: " + last_run)
-          .style('display', null);
+          .insert(isoDateToTimeEl.bind(null, last_run));
         g.selectAll(".loading-last-run").remove();
       }
       d3.selectAll(".loading-last-run").remove();


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Closes: apache/airflow#10350

On the DAGs index view, the previous _**i**_ tooltip displayed the UTC timestamp regardless of the currently selected display timezone. This could be redundant if UTC was selected.

I've removed the _**i**_ tooltip and instead enabled the `title` attribute on the existing `<time></time>` element which will [conditionally show a UTC tooltip](https://github.com/astronomer/airflow/blob/master/airflow/www/static/js/datetime-utils.js#L49-L51) on hover _if_ the display timezone is not UTC. The "UTC:" prefix instead of "Start Date:" also helps clarify the relevance of the timestamp.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/3267/91215137-18b90f00-e6e2-11ea-8501-2d85ae3fa65d.png)  | ![image](https://user-images.githubusercontent.com/3267/91215056-f4f5c900-e6e1-11ea-870d-7cc171f87c8c.png)  |


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
