### PR TITLE
[k8s] Store the raw ti key info to pod annotations

### DIFF
--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -107,14 +107,12 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
                 pod_generator.make_safe_label_value(dag_id)
             )
 
-    @unittest.skipIf(AirflowKubernetesScheduler is None,
-                     "kubernetes python package is not installed")
     def test_execution_date_serialize_deserialize(self):
         datetime_obj = datetime.now()
         serialized_datetime = \
-            AirflowKubernetesScheduler._datetime_to_label_safe_datestring(
+            pod_generator.datetime_to_label_safe_datestring(
                 datetime_obj)
-        new_datetime_obj = AirflowKubernetesScheduler._label_safe_datestring_to_datetime(
+        new_datetime_obj = pod_generator.label_safe_datestring_to_datetime(
             serialized_datetime)
 
         self.assertEqual(datetime_obj, new_datetime_obj)


### PR DESCRIPTION
The value of annotations can store the raw dag_id, task_id and
execution_date so that k8s executor can easily map pod event back
to the task instance

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
