### PR TITLE
add info about update mask to API doc introduction

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -104,7 +104,19 @@ info:
         "open_slots": 0
     }
     ```
+    ### Update Mask
+    Update mask is available as a query parameter in patch endpoints. It is used to notify the
+    API which fields you want to update. Using `update_mask` makes it easier to update objects
+    by helping the server know which fields to update in an object instead of updating all fields.
+    The update request ignores any fields that aren't specified in the field mask, leaving them with
+    their current values.
 
+    Example:
+    ```
+      resource = request.get('/resource/my-id').json()
+      resource['my_field'] = 'new-value'
+      request.patch('/resource/my-id?update_mask=my_field', data=json.dumps(resource))
+    ```
 
     ## Versioning and Endpoint Lifecycle
 
@@ -161,12 +173,6 @@ info:
     For details on configuring the authentication, see
     [API Authorization](https://airflow.readthedocs.io/en/latest/security/api.html).
 
-    # Update Mask
-    Update mask is available as a parameter in patch endpoints. It is used to notify the
-    API which fields you want to update. Using `update_mask` improves the API performance
-    by helping the server know which fields to update in an object instead of iterating
-    through all fields. The update request ignores any fields that aren't specified in
-    the field mask, leaving them with their current values.
 
   version: '1.0.0'
   license:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -160,6 +160,14 @@ info:
 
     For details on configuring the authentication, see
     [API Authorization](https://airflow.readthedocs.io/en/latest/security/api.html).
+
+    # Update Mask
+    Update mask is available as a parameter in patch endpoints. It is used to notify the
+    API which fields you want to update. Using `update_mask` improves the API performance
+    by helping the server know which fields to update in an object instead of iterating
+    through all fields. The update request ignores any fields that aren't specified in
+    the field mask, leaving them with their current values.
+
   version: '1.0.0'
   license:
     name: Apache 2.0


### PR DESCRIPTION
This PR adds information about update_mask to the REST API reference documentation

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
