### PR TITLE
Add masterConfig parameter to MLEngineStartTrainingJobOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1102,6 +1102,9 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
     :param master_type: Cloud ML Engine machine name.
         Must be set when scale_tier is CUSTOM. (templated)
     :type master_type: str
+    :param master_config: Cloud ML Engine master config.
+    master_type must be set if master_config is provided. (templated)
+    :type master_type: dict
     :param runtime_version: The Google Cloud ML runtime version to use for
         training. (templated)
     :type runtime_version: str
@@ -1147,6 +1150,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         '_region',
         '_scale_tier',
         '_master_type',
+        '_master_config',
         '_runtime_version',
         '_python_version',
         '_job_dir',
@@ -1166,6 +1170,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         region: str,
         scale_tier: Optional[str] = None,
         master_type: Optional[str] = None,
+        master_config: Optional[dict] = None,
         runtime_version: Optional[str] = None,
         python_version: Optional[str] = None,
         job_dir: Optional[str] = None,
@@ -1186,6 +1191,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         self._region = region
         self._scale_tier = scale_tier
         self._master_type = master_type
+        self._master_config = master_config
         self._runtime_version = runtime_version
         self._python_version = python_version
         self._job_dir = job_dir
@@ -1209,6 +1215,8 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
             raise AirflowException('Google Compute Engine region is required.')
         if self._scale_tier is not None and self._scale_tier.upper() == "CUSTOM" and not self._master_type:
             raise AirflowException('master_type must be set when scale_tier is CUSTOM')
+        if self._master_config and not self._master_type:
+            raise AirflowException('master_type must be set when master_config is provided')
 
     def execute(self, context):
         job_id = _normalize_mlengine_job_id(self._job_id)
@@ -1236,6 +1244,8 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
 
         if self._scale_tier is not None and self._scale_tier.upper() == "CUSTOM":
             training_request['trainingInput']['masterType'] = self._master_type
+            if self._master_config:
+                training_request['trainingInput']['masterConfig'] = self._master_config
 
         if self._mode == 'DRY_RUN':
             self.log.info('In dry_run mode.')

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1103,7 +1103,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         Must be set when scale_tier is CUSTOM. (templated)
     :type master_type: str
     :param master_config: Cloud ML Engine master config.
-    master_type must be set if master_config is provided. (templated)
+        master_type must be set if master_config is provided. (templated)
     :type master_type: dict
     :param runtime_version: The Google Cloud ML runtime version to use for
         training. (templated)
@@ -1244,6 +1244,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
 
         if self._scale_tier is not None and self._scale_tier.upper() == "CUSTOM":
             training_request['trainingInput']['masterType'] = self._master_type
+
             if self._master_config:
                 training_request['trainingInput']['masterConfig'] = self._master_config
 

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1170,7 +1170,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         region: str,
         scale_tier: Optional[str] = None,
         master_type: Optional[str] = None,
-        master_config: Optional[dict] = None,
+        master_config: Optional[Dict] = None,
         runtime_version: Optional[str] = None,
         python_version: Optional[str] = None,
         job_dir: Optional[str] = None,

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -353,7 +353,7 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
     @patch('airflow.providers.google.cloud.operators.mlengine.MLEngineHook')
     def test_success_create_training_job_with_master_config(self, mock_hook):
         custom_training_default_args: dict = self.TRAINING_DEFAULT_ARGS.copy()
-        custom_training_default_args.pop('scaleTier')
+        custom_training_default_args['scaleTier'] = 'CUSTOM'
 
         training_input = copy.deepcopy(self.TRAINING_INPUT)
         training_input['trainingInput']['runtimeVersion'] = '1.6'
@@ -374,9 +374,8 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
             runtime_version='1.6',
             python_version='3.5',
             job_dir='gs://some-bucket/jobs/test_training',
-            scale_tier='CUSTOM',
             master_type='n1-standard-4',
-            master_config={'acceleratorConfig': {'count': 1, 'type': 'NVIDIA_TESLA_P4'},},
+            master_config={'acceleratorConfig': {'count': '1', 'type': 'NVIDIA_TESLA_P4'},},
             **custom_training_default_args,
         )
         training_op.execute(MagicMock())

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -352,7 +352,7 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
 
     @patch('airflow.providers.google.cloud.operators.mlengine.MLEngineHook')
     def test_success_create_training_job_with_master_config(self, mock_hook):
-        custom_training_default_args: dict = self.TRAINING_DEFAULT_ARGS.copy()
+        custom_training_default_args: dict = copy.deepcopy(self.TRAINING_DEFAULT_ARGS)
         custom_training_default_args['scaleTier'] = 'CUSTOM'
 
         training_input = copy.deepcopy(self.TRAINING_INPUT)
@@ -362,7 +362,7 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
         training_input['trainingInput']['scaleTier'] = 'CUSTOM'
         training_input['trainingInput']['masterType'] = 'n1-standard-4'
         training_input['trainingInput']['masterConfig'] = {
-            'acceleratorConfig': {'count': 1, 'type': 'NVIDIA_TESLA_P4'},
+            'acceleratorConfig': {'count': '1', 'type': 'NVIDIA_TESLA_P4'},
         }
 
         success_response = training_input.copy()

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -365,7 +365,7 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
             'acceleratorConfig': {'count': 1, 'type': 'NVIDIA_TESLA_P4'},
         }
 
-        success_response = self.TRAINING_INPUT.copy()
+        success_response = training_input.copy()
         success_response['state'] = 'SUCCEEDED'
         hook_instance = mock_hook.return_value
         hook_instance.create_job.return_value = success_response

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -351,6 +351,46 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
         )
 
     @patch('airflow.providers.google.cloud.operators.mlengine.MLEngineHook')
+    def test_success_create_training_job_with_master_config(self, mock_hook):
+        custom_training_default_args: dict = self.TRAINING_DEFAULT_ARGS.copy()
+        custom_training_default_args.pop('scaleTier')
+
+        training_input = copy.deepcopy(self.TRAINING_INPUT)
+        training_input['trainingInput']['runtimeVersion'] = '1.6'
+        training_input['trainingInput']['pythonVersion'] = '3.5'
+        training_input['trainingInput']['jobDir'] = 'gs://some-bucket/jobs/test_training'
+        training_input['trainingInput']['scaleTier'] = 'CUSTOM'
+        training_input['trainingInput']['masterType'] = 'n1-standard-4'
+        training_input['trainingInput']['masterConfig'] = {
+            'acceleratorConfig': {'count': 1, 'type': 'NVIDIA_TESLA_P4'},
+        }
+
+        success_response = self.TRAINING_INPUT.copy()
+        success_response['state'] = 'SUCCEEDED'
+        hook_instance = mock_hook.return_value
+        hook_instance.create_job.return_value = success_response
+
+        training_op = MLEngineStartTrainingJobOperator(
+            runtime_version='1.6',
+            python_version='3.5',
+            job_dir='gs://some-bucket/jobs/test_training',
+            scale_tier='CUSTOM',
+            master_type='n1-standard-4',
+            master_config={'acceleratorConfig': {'count': 1, 'type': 'NVIDIA_TESLA_P4'},},
+            **custom_training_default_args,
+        )
+        training_op.execute(MagicMock())
+
+        mock_hook.assert_called_once_with(
+            gcp_conn_id='google_cloud_default', delegate_to=None, impersonation_chain=None,
+        )
+        # Make sure only 'create_job' is invoked on hook instance
+        self.assertEqual(len(hook_instance.mock_calls), 1)
+        hook_instance.create_job.assert_called_once_with(
+            project_id='test-project', job=training_input, use_existing_job_fn=ANY
+        )
+
+    @patch('airflow.providers.google.cloud.operators.mlengine.MLEngineHook')
     def test_success_create_training_job_with_optional_args(self, mock_hook):
         training_input = copy.deepcopy(self.TRAINING_INPUT)
         training_input['trainingInput']['runtimeVersion'] = '1.6'

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -353,7 +353,7 @@ class TestMLEngineTrainingOperator(unittest.TestCase):
     @patch('airflow.providers.google.cloud.operators.mlengine.MLEngineHook')
     def test_success_create_training_job_with_master_config(self, mock_hook):
         custom_training_default_args: dict = copy.deepcopy(self.TRAINING_DEFAULT_ARGS)
-        custom_training_default_args['scaleTier'] = 'CUSTOM'
+        custom_training_default_args['scale_tier'] = 'CUSTOM'
 
         training_input = copy.deepcopy(self.TRAINING_INPUT)
         training_input['trainingInput']['runtimeVersion'] = '1.6'


### PR DESCRIPTION
**Jira**
My PR addresses the following Airflow Jira issues and references them in the PR title. 
https://issues.apache.org/jira/browse/AAR-487

**Description**
_Why this is important?_
At the moment when you spin up a training, you cannot specify an accelerator, so when you end up with a CUSTOM tier and a standard machine, you cannot add GPUs that would speed up the training process.

_Documentation_
It refers to the follow [REST API Documentation](https://cloud.google.com/ai-platform/training/docs/reference/rest/v1/projects.jobs#traininginput).
 

> Optional. The configuration for your master worker.
> 
> You should only set masterConfig.acceleratorConfig if masterType is set to a Compute Engine machine type. Learn about restrictions on accelerator configurations for training.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
