### PR TITLE
Improve .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -23,6 +23,7 @@ Arthur Wiedmer <arthur@apache.org> <arthur.wiedmer@gmail.com>
 Bolke de Bruin <bolke@xs4all.nl> <bolke@Bolkes-MacBook-Pro.local>
 Bolke de Bruin <bolke@xs4all.nl> <bolkedebruin@users.noreply.github.com>
 Benjamin Grenier <52801483+benjamingrenier@users.noreply.github.com>
+Chip Myers Jr. <chip.myersjr@gmail.com>
 Chris Riccomini <criccomini@apache.org> <chrisr@wepay.com>
 Chris Riccomini <criccomini@apache.org> <criccomini@users.noreply.github.com>
 Dan Davydov <ddavydov@twitter.com> <dan.davydov@airbnb.com>
@@ -63,6 +64,7 @@ Maxime Beauchemin <maxime.beauchemin@apache.org> <maxime_beauchemin@i-0963e1d9.i
 Maxime Beauchemin <maxime.beauchemin@apache.org> <maxime_beauchemin@i-a94af485.inst.aws.airbnb.com>
 Maxime Beauchemin <maxime.beauchemin@apache.org> <maxime.beauchemin@airbnb.com>
 Maxime Beauchemin <maxime.beauchemin@apache.org> <maximebeauchemin@gmail.com>
+Maxime Beauchemin <maxime.beauchemin@apache.org> <maxime_beauchemin@maxime-beauchemin.local>
 Michael Chirico <michaelchirico4@gmail.com>
 Michael Chirico <michaelchirico4@gmail.com> <michael.chirico@grabtaxi.com>
 Michał Słowikowski <michalslowikowski00@gmail.com>
@@ -71,6 +73,10 @@ Mustafa Gök <sd.mustafagok@gmail.com> <gokmust@itu.edu.tr>
 Niels Zeilemaker <niels@zeilemaker.nl>
 Niels Zeilemaker <niels@zeilemaker.nl> <nielszeilemaker@godatadriven.com>
 Nikolay Kolev <nikolays@wepay.com>
+Patrick McKenna <patrick.b.mckenna@gmail.com>
+Patrick McKenna <patrick.b.mckenna@gmail.com> <patrickmckenna@github.com>
+Patrick Leo Tardif <plt@rdif.me>
+Patrick Leo Tardif <plt@rdif.me> <patrick_tardif@unassigned0391.local>
 Peng Chen <pengchen@xiaohongshu.com> <348707924@qq.com>
 Pradeep Bhadani <pradeep.bhadani@gmail.com>
 Rafael Bottega <rbottega@worldremit.com> <boittega@gmail.com>
@@ -91,3 +97,4 @@ Tomek Urbaszek <turbaszek@apache.org> <tomasz.urbaszek@polidea.com>
 Xiaodong Deng <xd_deng@hotmail.com>
 Xiaodong Deng <xd_deng@hotmail.com> <11539188+XD-DENG@users.noreply.github.com>
 Yuen-Kuei Hsueh <ph.study@gmail.com>
+Zikun Zhu <33176974+zikun@users.noreply.github.com>


### PR DESCRIPTION
This improves output of `git shortlog -sne` which we use to analyze Airflow contributor community