### PR TITLE
Add @dag decorator

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -50,6 +50,18 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Change default value for dag_run_conf_overrides_params
+
+DagRun configuration dictionary will now by default overwrite params dictionary. If you pass some key-value pairs
+through ``airflow dags backfill -c`` or ``airflow dags trigger -c``, the key-value pairs will
+override the existing ones in params. You can revert this behaviour by setting `dag_run_conf_overrides_params` to `False`
+in your `airflow.cfg`.
+
+### DAG discovery safe mode is now case insensitive
+
+When `DAG_DISCOVERY_SAFE_MODE` is active, Airflow will now filter all files that contain the string `airflow` and `dag`
+in a case insensitive mode. This is being changed to better support the new `@dag` decorator.
+
 ### Change to Permissions
 
 The DAG-level permission actions, `can_dag_read` and `can_dag_edit` are going away. They are being replaced with `can_read` and `can_edit`. When a role is given DAG-level access, the resource name (or "view menu", in Flask App-Builder parlance) will now be prefixed with `DAG:`. So the action `can_dag_read` on `example_dag_id`, is now represented as `can_read` on `DAG:example_dag_id`.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -318,7 +318,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "False"
+      default: "True"
     - name: worker_precheck
       description: |
         Worker initialisation check to validate Metadata Database connection

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -185,7 +185,7 @@ killed_task_cleanup_time = 60
 # Whether to override params with dag_run.conf. If you pass some key-value pairs
 # through ``airflow dags backfill -c`` or
 # ``airflow dags trigger -c``, the key-value pairs will override the existing ones in params.
-dag_run_conf_overrides_params = False
+dag_run_conf_overrides_params = True
 
 # Worker initialisation check to validate Metadata Database connection
 worker_precheck = False

--- a/airflow/decorators.py
+++ b/airflow/decorators.py
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.operators.python import task  # noqa # pylint: disable=unused-import
 from airflow.models.dag import dag  # noqa # pylint: disable=unused-import
+from airflow.operators.python import task  # noqa # pylint: disable=unused-import

--- a/airflow/decorators.py
+++ b/airflow/decorators.py
@@ -16,3 +16,4 @@
 # under the License.
 
 from airflow.operators.python import task  # noqa # pylint: disable=unused-import
+from airflow.models.dag import dag  # noqa # pylint: disable=unused-import

--- a/airflow/example_dags/example_dag_decorator.py
+++ b/airflow/example_dags/example_dag_decorator.py
@@ -23,6 +23,7 @@ from typing import Dict
 from airflow.decorators import dag, task
 from airflow.operators.email import EmailOperator
 from airflow.providers.http.operators.http import SimpleHttpOperator
+from airflow.utils.dates import days_ago
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -30,8 +31,8 @@ DEFAULT_ARGS = {
 
 
 # [START dag_decorator_usage]
-@dag(default_args=DEFAULT_ARGS, schedule_interval=None)
-def send_server_ip(email: str = 'example@example.com'):
+@dag(default_args=DEFAULT_ARGS, schedule_interval=None, start_date=days_ago(2))
+def example_dag_decorator(email: str = 'example@example.com'):
     """
     DAG to send server IP to email.
 
@@ -40,7 +41,7 @@ def send_server_ip(email: str = 'example@example.com'):
     """
     # Using default connection as it's set to httpbin.org by default
     get_ip = SimpleHttpOperator(
-        task_id='get_ip', endpoint='get', method='GET', xcom_push=True
+        task_id='get_ip', endpoint='get', method='GET'
     )
 
     @task(multiple_outputs=True)
@@ -61,5 +62,5 @@ def send_server_ip(email: str = 'example@example.com'):
     )
 
 
-DAG = send_server_ip()
+DAG = example_dag_decorator()
 # [END dag_decorator_usage]

--- a/airflow/example_dags/example_dag_decorator.py
+++ b/airflow/example_dags/example_dag_decorator.py
@@ -18,21 +18,16 @@
 
 
 import json
-from datetime import timedelta
 from typing import Dict
 
 from airflow.decorators import dag, task
 from airflow.operators.email import EmailOperator
 from airflow.providers.http.operators.http import SimpleHttpOperator
-from airflow.utils import timezone
 
 DEFAULT_ARGS = {
-    "owner": "test",
-    "depends_on_past": True,
-    "start_date": timezone.utcnow(),
-    "retries": 1,
-    "retry_delay": timedelta(minutes=1),
+    "owner": "airflow",
 }
+
 
 # [START dag_decorator_usage]
 @dag(default_args=DEFAULT_ARGS, schedule_interval=None)
@@ -53,7 +48,7 @@ def send_server_ip(email: str = 'example@example.com'):
         external_ip = json.loads(raw_json)['origin']
         return {
             'subject': f'Server connected from {external_ip}',
-            'body': f'Seems like today your server executing Airflow is connected from the IP {external_ip}<br>'
+            'body': f'Seems like today your server executing Airflow is connected from IP {external_ip}<br>'
         }
 
     email_info = prepare_email(get_ip.output)

--- a/airflow/example_dags/example_dag_decorator.py
+++ b/airflow/example_dags/example_dag_decorator.py
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import json
+from datetime import timedelta
+from typing import Dict
+
+from airflow.decorators import dag, task
+from airflow.operators.email import EmailOperator
+from airflow.providers.http.operators.http import SimpleHttpOperator
+from airflow.utils import timezone
+
+DEFAULT_ARGS = {
+    "owner": "test",
+    "depends_on_past": True,
+    "start_date": timezone.utcnow(),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+# [START dag_decorator_usage]
+@dag(default_args=DEFAULT_ARGS, schedule_interval=None)
+def send_server_ip(email: str = 'example@example.com'):
+    # Using default connection as it's set to httpbin.org by default
+    get_ip = SimpleHttpOperator(
+        task_id='get_ip', endpoint='get', method='GET', xcom_push=True
+    )
+
+    @task(multiple_outputs=True)
+    def prepare_email(raw_json: str) -> Dict[str, str]:
+        external_ip = json.loads(raw_json)['origin']
+        return {
+            'subject': f'Server connected from {external_ip}',
+            'body': f'Seems like today your server executing Airflow is connected from the external IP {external_ip}<br>'
+        }
+
+    email_info = prepare_email(get_ip.output)
+
+    EmailOperator(
+        task_id='send_email',
+        to=email,
+        subject=email_info['subject'],
+        html_content=email_info['body']
+    )
+
+
+DAG = send_server_ip()
+# [END dag_decorator_usage]

--- a/airflow/example_dags/example_dag_decorator.py
+++ b/airflow/example_dags/example_dag_decorator.py
@@ -62,5 +62,5 @@ def example_dag_decorator(email: str = 'example@example.com'):
     )
 
 
-DAG = example_dag_decorator()
+dag = example_dag_decorator()
 # [END dag_decorator_usage]

--- a/airflow/example_dags/example_dag_decorator.py
+++ b/airflow/example_dags/example_dag_decorator.py
@@ -37,6 +37,12 @@ DEFAULT_ARGS = {
 # [START dag_decorator_usage]
 @dag(default_args=DEFAULT_ARGS, schedule_interval=None)
 def send_server_ip(email: str = 'example@example.com'):
+    """
+    DAG to send server IP to email.
+
+    :param email: Email to send IP to. Defaults to example@example.com.
+    :type email: str
+    """
     # Using default connection as it's set to httpbin.org by default
     get_ip = SimpleHttpOperator(
         task_id='get_ip', endpoint='get', method='GET', xcom_push=True
@@ -47,7 +53,7 @@ def send_server_ip(email: str = 'example@example.com'):
         external_ip = json.loads(raw_json)['origin']
         return {
             'subject': f'Server connected from {external_ip}',
-            'body': f'Seems like today your server executing Airflow is connected from the external IP {external_ip}<br>'
+            'body': f'Seems like today your server executing Airflow is connected from the IP {external_ip}<br>'
         }
 
     email_info = prepare_email(get_ip.output)

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -853,8 +853,8 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             jinja_env = self.get_template_env()
 
         # Imported here to avoid circular dependency
-        from airflow.models.xcom_arg import XComArg
         from airflow.models.dagparam import DagParam
+        from airflow.models.xcom_arg import XComArg
 
         if isinstance(content, str):
             if any(content.endswith(ext) for ext in self.template_ext):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -854,6 +854,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
 
         # Imported here to avoid circular dependency
         from airflow.models.xcom_arg import XComArg
+        from airflow.models.dagparam import DagParam
 
         if isinstance(content, str):
             if any(content.endswith(ext) for ext in self.template_ext):
@@ -861,7 +862,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
                 return jinja_env.get_template(content).render(**context)
             else:
                 return jinja_env.from_string(content).render(**context)
-        elif isinstance(content, XComArg):
+        elif isinstance(content, (XComArg, DagParam):
             return content.resolve(context)
 
         if isinstance(content, tuple):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -862,7 +862,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
                 return jinja_env.get_template(content).render(**context)
             else:
                 return jinja_env.from_string(content).render(**context)
-        elif isinstance(content, (XComArg, DagParam):
+        elif isinstance(content, (XComArg, DagParam)):
             return content.resolve(context)
 
         if isinstance(content, tuple):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -696,6 +696,13 @@ class DAG(BaseDag, LoggingMixin):
         self._pickle_id = value
 
     def param(self, name, default):
+        """
+        Return a DagParam object for current dag.
+
+        :param name: dag parameter name.
+        :param default: fallback value for dag parameter.
+        :return: DagParam instance for specified name and current dag.
+        """
         return DagParam(self, name, default)
 
     @property

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -696,7 +696,7 @@ class DAG(BaseDag, LoggingMixin):
     def pickle_id(self, value: int) -> None:
         self._pickle_id = value
 
-    def param(self, name, default = None):
+    def param(self, name: str, default=None) -> DagParam:
         """
         Return a DagParam object for current dag.
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -49,6 +49,7 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag
 from airflow.models.dagcode import DagCode
 from airflow.models.dagpickle import DagPickle
+from airflow.models.dagparam import DagParam
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import Context, TaskInstance, clear_task_instances
 from airflow.security import permissions
@@ -693,6 +694,9 @@ class DAG(BaseDag, LoggingMixin):
     @pickle_id.setter
     def pickle_id(self, value: int) -> None:
         self._pickle_id = value
+
+    def param(self, name, default):
+        return DagParam(self, name, default)
 
     @property
     def tasks(self) -> List[BaseOperator]:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -27,11 +27,11 @@ import traceback
 import warnings
 from collections import OrderedDict
 from datetime import datetime, timedelta
+from inspect import signature
 from typing import (
     TYPE_CHECKING, Callable, Collection, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple, Type, Union,
     cast,
 )
-from inspect import signature
 
 import jinja2
 import pendulum
@@ -49,8 +49,8 @@ from airflow.models.base import ID_LEN, Base
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag
 from airflow.models.dagcode import DagCode
-from airflow.models.dagpickle import DagPickle
 from airflow.models.dagparam import DagParam
+from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import Context, TaskInstance, clear_task_instances
 from airflow.security import permissions
@@ -704,7 +704,7 @@ class DAG(BaseDag, LoggingMixin):
         :param default: fallback value for dag parameter.
         :return: DagParam instance for specified name and current dag.
         """
-        return DagParam(current_dag=self, name=name, default=default)
+        return DagParam(name=name, default=default)
 
     @property
     def tasks(self) -> List[BaseOperator]:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2234,6 +2234,9 @@ def dag(*dag_args, **dag_kwargs):
 
             # Initialize DAG with bound arguments
             with DAG(*dag_bound_args.args, **dag_bound_args.kwargs) as dag_obj:
+                # Set DAG documentation from function documentation.
+                if f.__doc__:
+                    dag_obj.doc_md = f.__doc__
 
                 # Generate DAGParam for each function arg/kwarg and replace it for calling the function.
                 # All args/kwargs for function will be DAGParam object and  will be replaced on execution time.

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2204,6 +2204,7 @@ class DagModel(Base):
 
         log.info("Setting next_dagrun for %s to %s", dag.dag_id, self.next_dagrun)
 
+
 def dag(*dag_args, **dag_kwargs):
     """
     Python dag decorator. Wraps a function into an Airflow DAG.
@@ -2239,7 +2240,7 @@ def dag(*dag_args, **dag_kwargs):
                     dag_obj.doc_md = f.__doc__
 
                 # Generate DAGParam for each function arg/kwarg and replace it for calling the function.
-                # All args/kwargs for function will be DAGParam object and  will be replaced on execution time.
+                # All args/kwargs for function will be DAGParam object and replaced on execution time.
                 f_kwargs = {}
                 for name, value in f_sig.arguments.items():
                     f_kwargs[name] = dag_obj.param(name, value)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -704,7 +704,7 @@ class DAG(BaseDag, LoggingMixin):
         :param default: fallback value for dag parameter.
         :return: DagParam instance for specified name and current dag.
         """
-        return DagParam(dag=self, name=name, default=default)
+        return DagParam(current_dag=self, name=name, default=default)
 
     @property
     def tasks(self) -> List[BaseOperator]:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -703,7 +703,7 @@ class DAG(BaseDag, LoggingMixin):
         :param default: fallback value for dag parameter.
         :return: DagParam instance for specified name and current dag.
         """
-        return DagParam(self, name, default)
+        return DagParam(dag=self, name=name, default=default)
 
     @property
     def tasks(self) -> List[BaseOperator]:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -696,7 +696,7 @@ class DAG(BaseDag, LoggingMixin):
     def pickle_id(self, value: int) -> None:
         self._pickle_id = value
 
-    def param(self, name, default):
+    def param(self, name, default = None):
         """
         Return a DagParam object for current dag.
 
@@ -704,7 +704,7 @@ class DAG(BaseDag, LoggingMixin):
         :param default: fallback value for dag parameter.
         :return: DagParam instance for specified name and current dag.
         """
-        return DagParam(name=name, default=default)
+        return DagParam(current_dag=self, name=name, default=default)
 
     @property
     def tasks(self) -> List[BaseOperator]:

--- a/airflow/models/dagparam.py
+++ b/airflow/models/dagparam.py
@@ -42,7 +42,7 @@ class DagParam:
     :type default: Any
     """
 
-    def __init__(self, current_dag: 'airflow.models.DAG', name: str, default: Optional[Any] = None):
+    def __init__(self, current_dag, name: str, default: Optional[Any] = None):
         if default:
             current_dag.params[name] = default
         self._name = name

--- a/airflow/models/dagparam.py
+++ b/airflow/models/dagparam.py
@@ -35,14 +35,14 @@ class DagParam:
           EmailOperator(subject=dag.param('subject', 'Hi from Airflow!'))
 
     :param current_dag: Dag being used for parameter.
-    :type current_dag: DAG
+    :type current_dag: airflow.models.DAG
     :param name: key value which is used to set the parameter
     :type name: str
     :param default: Default value used if no parameter was set.
     :type default: Any
     """
 
-    def __init__(self, current_dag, name: str, default: Optional[Any] = None):
+    def __init__(self, current_dag: 'airflow.models.DAG', name: str, default: Optional[Any] = None):
         if default:
             current_dag.params[name] = default
         self._name = name
@@ -50,8 +50,7 @@ class DagParam:
 
     def resolve(self, context: Dict) -> Any:
         """
-        Pull DagParam value from DagRun context. This method is run during ``op.execute()``
-        in respectable context.
+        Pull DagParam value from DagRun context. This method is run during ``op.execute()``.
         """
         default = self._default
         if not self._default:

--- a/airflow/models/dagparam.py
+++ b/airflow/models/dagparam.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Dict, List, Union
+
+from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG  # pylint: disable=R0401
+from airflow.models.xcom import XCOM_RETURN_KEY
+from inspect import signature, Parameter
+from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
+
+import functools
+
+class DagParam:
+    """
+    
+    """
+
+    def __init__(self, dag: DAG, name: str, default: Any):
+        dag.params[name] = default
+        self._name = name
+        self._default = default
+
+    def resolve(self, context: Dict) -> Any:
+        """
+        Pull XCom value for the existing arg. This method is run during ``op.execute()``
+        in respectable context.
+        """
+        return self.context.get('params', {}).get(self._name, self._default)
+
+
+def dag(*dag_args, **dag_kwargs):
+    def wrapper(f: Callable):
+        dag_sig = signature(DAG.__init__).bind(dag_id=f.__name__)
+        dag_sig = dag_sig.bind(*dag_args, **dag_kwargs)
+        @functools.wraps(f)
+        def factory(*args, **kwargs):
+            sig = signature(f).bind(*args, **kwargs).apply_defaults()
+            with DAG(*dag_sig.args, **dag_sig.kwargs) as dag:
+                f_kwargs = {}
+                for name, value in sig.arguments.items():
+                    f_kwargs[name] = dag.param(name, value)
+                f(**f_kwargs)
+            return dag
+        return factory
+    return wrapper

--- a/airflow/models/dagparam.py
+++ b/airflow/models/dagparam.py
@@ -49,9 +49,7 @@ class DagParam:
         self._default = default
 
     def resolve(self, context: Dict) -> Any:
-        """
-        Pull DagParam value from DagRun context. This method is run during ``op.execute()``.
-        """
+        """Pull DagParam value from DagRun context. This method is run during ``op.execute()``."""
         default = self._default
         if not self._default:
             default = context['params'].get(self._name, None)

--- a/airflow/models/dagparam.py
+++ b/airflow/models/dagparam.py
@@ -22,7 +22,7 @@ class DagParam:
     """
     Class that represents a DAG run parameter.
 
-    It can be used to parametrized your dags.
+    It can be used to parameterize your dags.
 
     **Example**:
 

--- a/airflow/models/dagparam.py
+++ b/airflow/models/dagparam.py
@@ -22,25 +22,21 @@ class DagParam:
     """
     Class that represents a DAG run parameter.
 
-    It can be used to parameterize your dags.
+    It can be used to parameterize your dags. You can overwrite its value by setting it on conf
+    when you trigger your DagRun.
 
     **Example**:
 
         with DAG(...) as dag:
           EmailOperator(subject=dag.param('subject', 'Hi from Airflow!'))
 
-    This object can be used in legacy Operators via Jinja.
-
-    :param current_dag: Dag that will be used to pull the parameter from.
-    :type current_dag: airflow.models.dag.DAG
     :param name: key value which is used to set the parameter
     :type name: str
     :param default: Default value used if no parameter was set.
     :type default: Any
     """
 
-    def __init__(self, current_dag, name: str, default: Any):
-        current_dag.params[name] = default
+    def __init__(self, name: str, default: Any):
         self._name = name
         self._default = default
 
@@ -49,4 +45,4 @@ class DagParam:
         Pull DagParam value from DagRun context. This method is run during ``op.execute()``
         in respectable context.
         """
-        return context.get('params', {}).get(self._name, self._default)
+        return context['dag_run'].conf.get(self._name, self._default)

--- a/airflow/models/dagparam.py
+++ b/airflow/models/dagparam.py
@@ -15,12 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, Callable
-
-from inspect import signature
-
-
-import functools
+from typing import Any, Dict
 
 
 class DagParam:
@@ -55,31 +50,3 @@ class DagParam:
         in respectable context.
         """
         return context.get('params', {}).get(self._name, self._default)
-
-
-def dag(*dag_args, **dag_kwargs):
-    """
-    Python dag decorator. Wraps a function into an Airflow DAG.
-    Accepts kwargs for operator kwarg. Can be used to parametrize DAGs.
-
-    :param dag_args: Arguments for DAG object
-    :type dag_args: list
-    :param dag_kwargs: Kwargs for DAG object.
-    :type dag_kwargs: dict
-    """
-    def wrapper(f: Callable):
-        from airflow.models.dag import DAG
-        dag_sig = signature(DAG.__init__)
-        dag_sig = dag_sig.bind_partial(*dag_args, **dag_kwargs)
-        @functools.wraps(f)
-        def factory(*args, **kwargs):
-            f_sig = signature(f).bind(*args, **kwargs)
-            f_sig.apply_defaults()
-            with DAG(*dag_sig.args, dag_id=f.__name__, **dag_sig.kwargs) as dag_obj:
-                f_kwargs = {}
-                for name, value in f_sig.arguments.items():
-                    f_kwargs[name] = dag_obj.param(name, value)
-                f(**f_kwargs)
-            return dag_obj
-        return factory
-    return wrapper

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -207,4 +207,5 @@ def might_contain_dag(file_path: str, safe_mode: bool, zip_file: Optional[zipfil
             return True
         with open(file_path, 'rb') as dag_file:
             content = dag_file.read()
-    return all(s in content for s in (b'DAG', b'airflow'))
+    content = content.lower()
+    return all(s in content for s in (b'dag', b'airflow'))

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -62,6 +62,8 @@ logical workflow.
    all Python files instead, disable the ``DAG_DISCOVERY_SAFE_MODE``
    configuration flag.
 
+.. _concepts:scope:
+
 Scope
 -----
 
@@ -101,6 +103,8 @@ any of its operators. This makes it easy to apply a common parameter to many ope
     dag = DAG('my_dag', default_args=default_args)
     op = DummyOperator(task_id='dummy', dag=dag)
     print(op.owner) # Airflow
+
+.. _concepts:context_manager:
 
 Context Manager
 ---------------
@@ -167,8 +171,9 @@ DAG decorator
 
 .. versionadded:: 2.0.0
 
-In addition to creating DAGs using context managed, in Airflow 2.0 you can also create DAGs from a function.
-DAG decorator creates a DAG generator function. This function when called returns a DAG.
+In addition to creating DAGs using :ref:`context manager <concepts:context_manager>`, in Airflow 2.0 you can also
+create DAGs from a function. DAG decorator creates a DAG generator function. Any function decorated with ``@dag``
+returns a DAG object.
 
 DAG decorator also sets up the parameters you have in the function as DAG params. This allows you to parameterize
 your DAGs and set the parameters when triggering the DAG manually. See
@@ -183,8 +188,9 @@ Example DAG with decorator:
     :start-after: [START dag_decorator_usage]
     :end-before: [END dag_decorator_usage]
 
-.. note:: Note that Airflow will only load DAGs that appear in ``globals()``. Which means you need to make sure to have
-  a variable for your returned DAG in the module scope. Otherwise Airflow won't detect your decorated DAG.
+.. note:: Note that Airflow will only load DAGs that appear in ``globals()`` as noted in :ref:`scope section <concepts:scope>`.
+  This means you need to make sure to have a variable for your returned DAG is in the module scope.
+  Otherwise Airflow won't detect your decorated DAG.
 
 .. _concepts:executor_config:
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -178,7 +178,6 @@ Example DAG with decorator:
 
 .. exampleinclude:: /../airflow/example_dags/example_dag_decorator.py
     :language: python
-    :dedent: 4
     :start-after: [START dag_decorator_usage]
     :end-before: [END dag_decorator_usage]
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -58,8 +58,8 @@ arbitrary number of tasks. In general, each one should correspond to a single
 logical workflow.
 
 .. note:: When searching for DAGs, Airflow only considers Python files
-   that contain the strings "airflow" and "dag" by default. To consider
-   all Python files instead, disable the ``DAG_DISCOVERY_SAFE_MODE``
+   that contain the strings "airflow" and "dag" by default (case-insensitive).
+   To consider all Python files instead, disable the ``DAG_DISCOVERY_SAFE_MODE``
    configuration flag.
 
 .. _concepts:scope:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -176,37 +176,16 @@ your DAGs and set the parameters when triggering the DAG manually. See
 
 Example DAG with decorator:
 
-.. code-block:: python
+.. exampleinclude:: /../airflow/example_dags/example_dag_decorator.py
+    :language: python
+    :dedent: 4
+    :start-after: [START dag_decorator_usage]
+    :end-before: [END dag_decorator_usage]
 
-  from airflow.decorators import dag, task
-
-  @dag(default_args=default_args, schedule_interval=None)
-  def send_server_ip(email: 'example@example.com')
-
-    # Using default connection as it's set to httpbin.org by default
-    get_ip = SimpleHttpOperator(
-        task_id='get_ip', endpoint='get', method='GET', xcom_push=True
-    )
-
-    @task(multiple_outputs=True)
-    def prepare_email(raw_json: str) -> Dict[str, str]:
-      external_ip = json.loads(raw_json)['origin']
-      return {
-        'subject':f'Server connected from {external_ip}',
-        'body': f'Seems like today your server executing Airflow is connected from the external IP {external_ip}<br>'
-      }
-
-    email_info = prepare_email(get_ip.output)
-
-    send_email = EmailOperator(
-        task_id='send_email',
-        to=email,
-        subject=email_info['subject'],
-        html_content=email_info['body']
-    )
-
-  my_dag = send_server_ip()
-
+.. note:: Note that Airflow will only load DAGs that appear in``globals()``. Which means you need to make sure to have
+  a variable for your returned DAG in the module scope. Otherwise Airflow won't detect your decorated DAG. In addition,
+  you may want to make your dag variable named ``DAG`` such that Airflow doesn't skip this module when the
+  ``DAG_DISCOVERY_SAFE_MODE`` is activated.
 
 .. _concepts:executor_config:
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -58,7 +58,7 @@ arbitrary number of tasks. In general, each one should correspond to a single
 logical workflow.
 
 .. note:: When searching for DAGs, Airflow only considers Python files
-   that contain the strings "airflow" and "DAG" by default. To consider
+   that contain the strings "airflow" and "dag" by default. To consider
    all Python files instead, disable the ``DAG_DISCOVERY_SAFE_MODE``
    configuration flag.
 
@@ -184,9 +184,7 @@ Example DAG with decorator:
     :end-before: [END dag_decorator_usage]
 
 .. note:: Note that Airflow will only load DAGs that appear in ``globals()``. Which means you need to make sure to have
-  a variable for your returned DAG in the module scope. Otherwise Airflow won't detect your decorated DAG. In addition,
-  you may want to make your dag variable named ``DAG`` such that Airflow doesn't skip this module when the
-  ``DAG_DISCOVERY_SAFE_MODE`` is activated.
+  a variable for your returned DAG in the module scope. Otherwise Airflow won't detect your decorated DAG.
 
 .. _concepts:executor_config:
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -174,6 +174,8 @@ DAG decorator also sets up the parameters you have in the function as DAG params
 your DAGs and set the parameters when triggering the DAG manually. See
 :ref:`Passing Parameters when triggering dags <dagrun:parameters>` to learn how to pass parameters when triggering DAGs.
 
+You can also use the parameters on jinja templates by using the ``{{context.params}}`` dictionary.
+
 Example DAG with decorator:
 
 .. exampleinclude:: /../airflow/example_dags/example_dag_decorator.py

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -170,7 +170,7 @@ DAG decorator
 In addition to creating DAGs using context managed, in Airflow 2.0 you can also create DAGs from a function.
 DAG decorator creates a DAG generator function. This function when called returns a DAG.
 
-DAG decorator also sets up the parameters you have in the function as DAG params. This allows you to parametrize
+DAG decorator also sets up the parameters you have in the function as DAG params. This allows you to parameterize
 your DAGs and set the parameters when triggering the DAG manually. See
 :ref:`Passing Parameters when triggering dags <dagrun:parameters>` to learn how to pass parameters when triggering DAGs.
 
@@ -181,7 +181,7 @@ Example DAG with decorator:
     :start-after: [START dag_decorator_usage]
     :end-before: [END dag_decorator_usage]
 
-.. note:: Note that Airflow will only load DAGs that appear in``globals()``. Which means you need to make sure to have
+.. note:: Note that Airflow will only load DAGs that appear in ``globals()``. Which means you need to make sure to have
   a variable for your returned DAG in the module scope. Otherwise Airflow won't detect your decorated DAG. In addition,
   you may want to make your dag variable named ``DAG`` such that Airflow doesn't skip this module when the
   ``DAG_DISCOVERY_SAFE_MODE`` is activated.

--- a/docs/dag-run.rst
+++ b/docs/dag-run.rst
@@ -195,6 +195,8 @@ The default is the current date in the UTC timezone.
 
 In addition, you can also manually trigger a DAG Run using the web UI (tab **DAGs** -> column **Links** -> button **Trigger Dag**)
 
+.. _dagrun:parameters:
+
 Passing Parameters when triggering dags
 ------------------------------------------
 

--- a/tests/core/test_example_dags_system.py
+++ b/tests/core/test_example_dags_system.py
@@ -25,9 +25,10 @@ from tests.test_utils.system_tests_class import SystemTest
 class TestExampleDagsSystem(SystemTest):
     @parameterized.expand([
         "example_bash_operator",
-        "example_branch_operator"
-        "tutorial_etl_dag"
-        "tutorial_functional_etl_dag"
+        "example_branch_operator",
+        "tutorial_etl_dag",
+        "tutorial_functional_etl_dag",
+        "example_dag_decorator",
     ])
     def test_dag_example(self, dag_id):
         self.run_dag(dag_id=dag_id)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1830,8 +1830,6 @@ class TestDagDecorator:
         with pytest.raises(TypeError):
             noop_pipeline()
 
-
-
     def test_xcom_pass_to_op(self):
         @dag_decorator(default_args=self.DEFAULT_ARGS)
         def xcom_pass_to_op(value=self.VALUE):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -57,7 +57,6 @@ from airflow.utils.types import DagRunType
 from airflow.utils.weight_rule import WeightRule
 from tests.models import DEFAULT_DATE
 from tests.test_utils.asserts import assert_queries_count
-from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs
 
 TEST_DATE = datetime_tz(2015, 1, 2, 0, 0)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1805,6 +1805,18 @@ class TestDagDecorator:
         assert isinstance(dag, DAG)
         assert dag.dag_id, 'test'
 
+    def test_default_dag_id(self):
+        @dag_decorator(default_args=self.DEFAULT_ARGS)
+        def noop_pipeline():
+            @task
+            def return_num(num):
+                return num
+
+            return_num(4)
+        dag = noop_pipeline()
+        assert isinstance(dag, DAG)
+        assert dag.dag_id, 'noop_pipeline'
+
     def test_fails_if_arg_not_set(self):
         @dag_decorator(default_args=self.DEFAULT_ARGS)
         def noop_pipeline(value):
@@ -1818,17 +1830,7 @@ class TestDagDecorator:
         with pytest.raises(TypeError):
             noop_pipeline()
 
-    def test_dag_id_function_name(self):
-        @dag_decorator(default_args=self.DEFAULT_ARGS)
-        def noop_pipeline():
-            @task
-            def return_num(num):
-                return num
 
-            return_num(4)
-        dag = noop_pipeline()
-        assert isinstance(dag, DAG)
-        assert dag.dag_id, 'noop_pipeline'
 
     def test_xcom_pass_to_op(self):
         @dag_decorator(default_args=self.DEFAULT_ARGS)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1805,7 +1805,7 @@ class TestDagDecorator:
         assert isinstance(dag, DAG)
         assert dag.dag_id, 'test'
 
-    def test_arg_not_set_fail(self):
+    def test_fails_if_arg_not_set(self):
         @dag_decorator(default_args=self.DEFAULT_ARGS)
         def noop_pipeline(value):
             @task
@@ -1813,6 +1813,8 @@ class TestDagDecorator:
                 return num
 
             return_num(value)
+
+        # Test that if arg is not passed it raises a type error as expected.
         with pytest.raises(TypeError):
             noop_pipeline()
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1801,8 +1801,9 @@ class TestDagDecorator:
                 return num
 
             return_num(4)
-
-        assert noop_pipeline().dag_id, 'test'
+        dag = noop_pipeline()
+        assert isinstance(dag, DAG)
+        assert dag.dag_id, 'test'
 
     def test_arg_not_set_fail(self):
         @dag_decorator(default_args=self.DEFAULT_ARGS)
@@ -1823,8 +1824,9 @@ class TestDagDecorator:
                 return num
 
             return_num(4)
-
-        assert noop_pipeline().dag_id, 'noop_pipeline'
+        dag = noop_pipeline()
+        assert isinstance(dag, DAG)
+        assert dag.dag_id, 'noop_pipeline'
 
     def test_xcom_pass_to_op(self):
         @dag_decorator(default_args=self.DEFAULT_ARGS)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1849,7 +1849,7 @@ class TestDagDecorator(unittest.TestCase):
 
         # Test that if arg is not passed it raises a type error as expected.
         with pytest.raises(TypeError):
-            noop_pipeline()  # pylint: ignore
+            noop_pipeline()  # pylint: disable=no-value-for-parameter
 
     def test_dag_param_resolves(self):
         """Test that dag param is correctly resolved by operator"""

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -1,3 +1,4 @@
+
 import unittest
 from datetime import timedelta
 

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -20,8 +20,7 @@ import unittest
 from datetime import timedelta
 
 from airflow.models.dag import DAG
-from airflow.operators.python import (
-    task)
+from airflow.operators.python import task
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
@@ -43,7 +42,8 @@ class TestDagParamRuntime(unittest.TestCase):
         super().tearDown()
         clear_db_runs()
 
-    def test_xcom_pass_to_op(self):
+    def test_dag_param_resolves(self):
+        """Test dagparam resolves on operator execution"""
         with DAG(dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS) as dag:
             value = dag.param('value', default=self.VALUE)
 
@@ -60,7 +60,34 @@ class TestDagParamRuntime(unittest.TestCase):
             state=State.RUNNING
         )
 
+        # pylint: disable=maybe-no-member
         xcom_arg.operator.run(start_date=self.DEFAULT_DATE, end_date=self.DEFAULT_DATE)
 
         ti = dr.get_task_instances()[0]
         assert ti.xcom_pull() == self.VALUE
+
+    def test_dag_param_overwrite(self):
+        """Test dag param is overwritten from dagrun config"""
+        with DAG(dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS) as dag:
+            value = dag.param('value', default=self.VALUE)
+
+            @task
+            def return_num(num):
+                return num
+
+            xcom_arg = return_num(value)
+
+        new_value = 2
+        dr = dag.create_dagrun(
+            run_id=DagRunType.MANUAL.value,
+            start_date=timezone.utcnow(),
+            execution_date=self.DEFAULT_DATE,
+            state=State.RUNNING,
+            conf={'value': new_value}
+        )
+
+        # pylint: disable=maybe-no-member
+        xcom_arg.operator.run(start_date=self.DEFAULT_DATE, end_date=self.DEFAULT_DATE)
+
+        ti = dr.get_task_instances()[0]
+        assert ti.xcom_pull(), new_value

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -18,9 +18,7 @@ class TestDagParamRuntime(unittest.TestCase):
         "retries": 1,
         "retry_delay": timedelta(minutes=1),
     }
-
     VALUE = 42
-
     DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
     def tearDown(self):

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -1,0 +1,64 @@
+from airflow.models.dag import DAG
+from airflow.utils.types import DagRunType
+from airflow.models.dagparam import dag
+from airflow.operators.python import (
+    PythonOperator
+)
+from tests.test_utils.config import conf_vars
+from datetime import datetime, timedelta, timezone
+
+DEFAULT_ARGS = {
+    "owner": "test",
+    "depends_on_past": True,
+    "start_date": datetime.today(),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+
+VALUE = 42
+
+class TestDagParamRuntime:
+    def test_xcom_pass_to_op(self):
+        with DAG(dag_id="test_xcom_pass_to_op", default_args=DEFAULT_ARGS) as dag:
+            value = dag.param('value', default=VALUE)
+            operator = PythonOperator(
+                python_callable=id,
+                op_args=[value],
+                task_id="return_value_1",
+                do_xcom_push=True,
+            )
+        dr = dag.create_dagrun(
+            run_id=DagRunType.MANUAL.value,
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING
+        )
+
+        operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        ti = dr.get_task_instances()[0]
+        assert ti.xcom_pull() == VALUE
+
+
+class TestDagDecorator:
+    @conf_vars({("core", "executor"): "DebugExecutor"})
+    def test_xcom_pass_to_op(self):
+
+        @dag(default_args=DEFAULT_ARGS)
+        def test_pipeline(some_param, other_param=VALUE):
+            operator = PythonOperator(
+                python_callable=id,
+                op_args=[some_param],
+                task_id="some_param"
+            )
+
+            other_param = PythonOperator(
+                python_callable=id,
+                op_args=[some_param],
+                task_id="some_param"
+            )
+
+        d = test_pipeline(VALUE)
+
+        d.run()

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 import unittest
 from datetime import timedelta

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -1,16 +1,26 @@
+import unittest
+from datetime import datetime, timedelta
+
+from airflow.jobs.scheduler_job import TI
+from airflow.models import DagRun
 from airflow.models.dag import DAG
-from airflow.utils.types import DagRunType
-from airflow.models.dagparam import dag
+from airflow.models.dagparam import dag as dag_decorator
 from airflow.operators.python import (
-    PythonOperator
-)
+    PythonOperator,
+    task)
+from airflow.utils import timezone
+from airflow.utils.state import State
+from airflow.utils.types import DagRunType
 from tests.test_utils.config import conf_vars
-from datetime import datetime, timedelta, timezone
+from airflow.utils.session import create_session
+from airflow.utils.state import State
+from airflow.utils.types import DagRunType
+from tests.test_utils.db import clear_db_runs
 
 DEFAULT_ARGS = {
     "owner": "test",
     "depends_on_past": True,
-    "start_date": datetime.today(),
+    "start_date": timezone.utcnow(),
     "retries": 1,
     "retry_delay": timedelta(minutes=1),
 }
@@ -18,16 +28,22 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 VALUE = 42
 
-class TestDagParamRuntime:
+
+class TestDagParamRuntime(unittest.TestCase):
+
+    def tearDown(self):
+        super().tearDown()
+        clear_db_runs()
+
     def test_xcom_pass_to_op(self):
         with DAG(dag_id="test_xcom_pass_to_op", default_args=DEFAULT_ARGS) as dag:
             value = dag.param('value', default=VALUE)
-            operator = PythonOperator(
-                python_callable=id,
-                op_args=[value],
-                task_id="return_value_1",
-                do_xcom_push=True,
-            )
+            @task
+            def return_num(num):
+                return num
+
+            xcom_arg = return_num(value)
+
         dr = dag.create_dagrun(
             run_id=DagRunType.MANUAL.value,
             start_date=timezone.utcnow(),
@@ -35,7 +51,7 @@ class TestDagParamRuntime:
             state=State.RUNNING
         )
 
-        operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        xcom_arg.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
         ti = dr.get_task_instances()[0]
         assert ti.xcom_pull() == VALUE
@@ -45,19 +61,19 @@ class TestDagDecorator:
     @conf_vars({("core", "executor"): "DebugExecutor"})
     def test_xcom_pass_to_op(self):
 
-        @dag(default_args=DEFAULT_ARGS)
+        @dag_decorator(default_args=DEFAULT_ARGS)
         def test_pipeline(some_param, other_param=VALUE):
-            operator = PythonOperator(
-                python_callable=id,
-                op_args=[some_param],
-                task_id="some_param"
-            )
 
-            other_param = PythonOperator(
-                python_callable=id,
-                op_args=[some_param],
-                task_id="some_param"
-            )
+            @task
+            def some_task(param):
+                return param
+
+            @task
+            def another_task(param):
+                return param
+
+            some_task(some_param)
+            another_task(other_param)
 
         d = test_pipeline(VALUE)
 

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -1,43 +1,36 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import timedelta
 
-from airflow.jobs.scheduler_job import TI
-from airflow.models import DagRun
 from airflow.models.dag import DAG
-from airflow.models.dagparam import dag as dag_decorator
 from airflow.operators.python import (
-    PythonOperator,
     task)
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
-from tests.test_utils.config import conf_vars
-from airflow.utils.session import create_session
-from airflow.utils.state import State
-from airflow.utils.types import DagRunType
 from tests.test_utils.db import clear_db_runs
-
-DEFAULT_ARGS = {
-    "owner": "test",
-    "depends_on_past": True,
-    "start_date": timezone.utcnow(),
-    "retries": 1,
-    "retry_delay": timedelta(minutes=1),
-}
-DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-
-VALUE = 42
 
 
 class TestDagParamRuntime(unittest.TestCase):
+    DEFAULT_ARGS = {
+        "owner": "test",
+        "depends_on_past": True,
+        "start_date": timezone.utcnow(),
+        "retries": 1,
+        "retry_delay": timedelta(minutes=1),
+    }
+
+    VALUE = 42
+
+    DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
     def tearDown(self):
         super().tearDown()
         clear_db_runs()
 
     def test_xcom_pass_to_op(self):
-        with DAG(dag_id="test_xcom_pass_to_op", default_args=DEFAULT_ARGS) as dag:
-            value = dag.param('value', default=VALUE)
+        with DAG(dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS) as dag:
+            value = dag.param('value', default=self.VALUE)
+
             @task
             def return_num(num):
                 return num
@@ -47,34 +40,11 @@ class TestDagParamRuntime(unittest.TestCase):
         dr = dag.create_dagrun(
             run_id=DagRunType.MANUAL.value,
             start_date=timezone.utcnow(),
-            execution_date=DEFAULT_DATE,
+            execution_date=self.DEFAULT_DATE,
             state=State.RUNNING
         )
 
-        xcom_arg.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        xcom_arg.operator.run(start_date=self.DEFAULT_DATE, end_date=self.DEFAULT_DATE)
 
         ti = dr.get_task_instances()[0]
-        assert ti.xcom_pull() == VALUE
-
-
-class TestDagDecorator:
-    @conf_vars({("core", "executor"): "DebugExecutor"})
-    def test_xcom_pass_to_op(self):
-
-        @dag_decorator(default_args=DEFAULT_ARGS)
-        def test_pipeline(some_param, other_param=VALUE):
-
-            @task
-            def some_task(param):
-                return param
-
-            @task
-            def another_task(param):
-                return param
-
-            some_task(some_param)
-            another_task(other_param)
-
-        d = test_pipeline(VALUE)
-
-        d.run()
+        assert ti.xcom_pull() == self.VALUE

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -95,7 +95,9 @@ class TestDagParamRuntime(unittest.TestCase):
 
     def test_dag_param_default(self):
         """Test dag param is overwritten from dagrun config"""
-        with DAG(dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS, params={'value': 'test'}) as dag:
+        with DAG(
+            dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS, params={'value': 'test'}
+        ) as dag:
             value = dag.param('value')
 
             @task


### PR DESCRIPTION
As a user I want to easily wrap a function to be a dag (or TaskGroup whenever AIP-34 is approved).

This introduces @dag decorator for easier dag construction based on python functions.

Summary of changes:
- Change `dag_run_conf_overrides_params` default to `True`. This is in order to make behaviour consistent.
- Add `@dag` decorator that generates DAG on invocation (see documentation and example DAG for usage)
- Change filter for `DAG_DISCOVERY_SAFE_MODE` to discover dags with `dag` in it in lowercase. This is due to `@dag` not needing any `DAG`. We can narrow this a bit if this is too generic.


Needs:
- Suggestions to test it works w dag serialization?