### PR TITLE
URL encode execution date in the Last Run link

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -372,7 +372,7 @@
         last_run = json[safe_dag_id].last_run;
         g = d3.select('div#last-run-' + safe_dag_id)
         g.selectAll('a')
-          .attr("href", "{{ url_for('Airflow.graph') }}?dag_id=" + encodeURIComponent(dag_id) + "&execution_date=" + last_run)
+          .attr("href", "{{ url_for('Airflow.graph') }}?dag_id=" + encodeURIComponent(dag_id) + "&execution_date=" + encodeURIComponent(last_run))
           .insert(isoDateToTimeEl.bind(null, last_run, {title: false}));
         g.selectAll('span')
           // We don't translate the timezone in the tooltip, that stays in UTC.


### PR DESCRIPTION
closes: #10434

The problem is when `execution_date` is passed in the URL unencoded for the "Last Run" link it results in an incorrect `pendulum` datetime when `pendulum.parse()` is used in the codebase. The time of the pendulum datetime gets incorrectly returned as `00:00:00` no matter what time the execution date has. URL encoding the `execution_date` value fixes the problem.

This was already fixed in all other places `execution_date` is used in URLs years ago with commit https://github.com/apache/airflow/commit/9ec7f0f04bcec67fa62fbd85085acaa5e3b298b7, but Last Run is more recent so this was missed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
