### PR TITLE
Revert Clean up DAG serializations based on last_updated (#7424)

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1466,14 +1466,6 @@
       type: string
       example: ~
       default: "30"
-    - name: dag_cleanup_interval
-      description: |
-        How often unseen Dags should be marked inactive and their serializations deleted.
-        Setting to 0 will disable DAG cleanup. Defaults to 5 minutes
-      version_added: ~
-      type: string
-      example: ~
-      default: "300"
     - name: scheduler_health_check_threshold
       description: |
         If the last scheduler heartbeat happened more than scheduler_health_check_threshold

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -730,10 +730,6 @@ dag_dir_list_interval = 300
 # How often should stats be printed to the logs. Setting to 0 will disable printing stats
 print_stats_interval = 30
 
-# How often unseen Dags should be marked inactive and their serializations deleted.
-# Setting to 0 will disable DAG cleanup. Defaults to 5 minutes
-dag_cleanup_interval = 300
-
 # If the last scheduler heartbeat happened more than scheduler_health_check_threshold
 # ago (in seconds), scheduler is considered unhealthy.
 # This is used by the health check in the "/health" endpoint

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -18,7 +18,7 @@ import logging
 import os
 import struct
 from datetime import datetime
-from typing import Iterable, Optional
+from typing import Iterable, List, Optional
 
 from sqlalchemy import BigInteger, Column, String, UnicodeText, exists
 
@@ -137,14 +137,12 @@ class DagCode(Base):
 
     @classmethod
     @provide_session
-    def remove_unused_code(cls, session=None):
-        """Deletes code that no longer has any DAGs referencing it .
+    def remove_deleted_code(cls, alive_dag_filelocs: List[str], session=None):
+        """Deletes code not included in alive_dag_filelocs.
 
+        :param alive_dag_filelocs: file paths of alive DAGs
         :param session: ORM Session
         """
-        from airflow.models.dag import DagModel
-
-        alive_dag_filelocs = [fileloc for fileloc, in session.query(DagModel.fileloc).all()]
         alive_fileloc_hashes = [
             cls.dag_fileloc_hash(fileloc) for fileloc in alive_dag_filelocs]
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -707,6 +707,7 @@ fetchmany
 fetchone
 filehandle
 fileloc
+filelocs
 filepath
 filesize
 filesystem

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -20,7 +20,7 @@ from datetime import timedelta
 
 from mock import patch
 
-from airflow import AirflowException, example_dags as example_dags_module, models
+from airflow import AirflowException, example_dags as example_dags_module
 from airflow.models import DagBag
 from airflow.models.dagcode import DagCode
 # To move it to a shared module.
@@ -100,24 +100,6 @@ class TestDagCode(unittest.TestCase):
 
         with self.assertRaises(AirflowException):
             self._write_two_example_dags()
-
-    def test_remove_unused_code(self):
-        example_dags = make_example_dags(example_dags_module)
-        self._write_example_dags()
-
-        bash_dag = example_dags['example_bash_operator']
-        with create_session() as session:
-            for model in models.base.Base._decl_class_registry.values():  # pylint: disable=protected-access
-                if hasattr(model, "dag_id"):
-                    session.query(model) \
-                        .filter(model.dag_id == bash_dag.dag_id) \
-                        .delete(synchronize_session='fetch')
-
-            self.assertEqual(session.query(DagCode).filter(DagCode.fileloc == bash_dag.fileloc).count(), 1)
-
-            DagCode.remove_unused_code()
-
-            self.assertEqual(session.query(DagCode).filter(DagCode.fileloc == bash_dag.fileloc).count(), 0)
 
     def _compare_example_dags(self, example_dags):
         with create_session() as session:

--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -25,7 +25,6 @@ from airflow.models import DagBag
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel as SDM
 from airflow.serialization.serialized_objects import SerializedDAG
-from airflow.utils import timezone
 from airflow.utils.session import create_session
 from tests.test_utils.asserts import assert_queries_count
 
@@ -127,23 +126,19 @@ class SerializedDagModelTest(unittest.TestCase):
         SDM.remove_dag(dag_removed_by_id.dag_id)
         self.assertFalse(SDM.has_dag(dag_removed_by_id.dag_id))
 
-    def test_remove_stale_dags(self):
+    def test_remove_dags_by_filepath(self):
+        """DAGs can be removed from database."""
         example_dags_list = list(self._write_example_dags().values())
         # Remove SubDags from the list as they are not stored in DB in a separate row
         # and are directly added in Json blob of the main DAG
         filtered_example_dags_list = [dag for dag in example_dags_list if not dag.is_subdag]
-        # Tests removing a stale DAG
-        stale_dag = SDM(filtered_example_dags_list[0])
-        fresh_dag = SDM(filtered_example_dags_list[1])
-        # Overwrite stale_dag's last_updated to be 10 minutes ago
-        stale_dag.last_updated = timezone.utcnow() - timezone.dt.timedelta(seconds=600)
-        with create_session() as session:
-            session.merge(stale_dag)
-            session.commit()
-        # Remove any stale DAGs older than 5 minutes
-        SDM.remove_stale_dags(timezone.utcnow() - timezone.dt.timedelta(seconds=300))
-        self.assertFalse(SDM.has_dag(stale_dag.dag_id))
-        self.assertTrue(SDM.has_dag(fresh_dag.dag_id))
+        # Tests removing by file path.
+        dag_removed_by_file = filtered_example_dags_list[0]
+        # remove repeated files for those DAGs that define multiple dags in the same file (set comprehension)
+        example_dag_files = list({dag.full_filepath for dag in filtered_example_dags_list})
+        example_dag_files.remove(dag_removed_by_file.full_filepath)
+        SDM.remove_deleted_dags(example_dag_files)
+        self.assertFalse(SDM.has_dag(dag_removed_by_file.dag_id))
 
     def test_bulk_sync_to_db(self):
         dags = [

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -322,30 +322,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager._kill_timed_out_processors()
         mock_dag_file_processor.kill.assert_not_called()
 
-    @mock.patch("airflow.utils.dag_processing.STORE_SERIALIZED_DAGS", True)
-    @mock.patch("airflow.utils.timezone.utcnow", MagicMock(return_value=DEFAULT_DATE))
-    @mock.patch("airflow.models.DAG")
-    @mock.patch("airflow.models.serialized_dag.SerializedDagModel")
-    def test_cleanup_stale_dags_no_serialization(self, sdm_mock, dag_mock):
-        manager = DagFileProcessorManager(
-            dag_directory='directory',
-            max_runs=1,
-            processor_factory=MagicMock().return_value,
-            processor_timeout=timedelta(seconds=50),
-            dag_ids=[],
-            pickle_dags=False,
-            signal_conn=MagicMock(),
-            async_mode=True)
-
-        manager.last_dag_cleanup_time = DEFAULT_DATE - timezone.dt.timedelta(seconds=301)
-        manager._file_process_interval = 30
-        manager._min_serialized_dag_update_interval = 30
-
-        expected_min_last_seen = DEFAULT_DATE - timezone.dt.timedelta(seconds=(50 + 30 + 30))
-        manager._cleanup_stale_dags()
-        dag_mock.deactivate_stale_dags.assert_called_with(expected_min_last_seen)
-        sdm_mock.remove_stale_dags.assert_called_with(expected_min_last_seen)
-
 
 class TestDagFileProcessorAgent(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR reverts the behavior of https://github.com/apache/airflow/pull/7424

Serialized DAGs are now refreshed based on `min_serialized_dag_fetch_interval` & `min_serialized_dag_update_interval`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
