### PR TITLE
ensure a zipped DAG can locate the modules it provides 

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -381,8 +381,8 @@ class DagBag(BaseDagBag, LoggingMixin):
 
     def _is_system_module(self, module_name):
         """
-        :return: True if the module comes from the platform (and ought to stay loaded) or might come from
-        the actions of a DAG (in which case it's safer to unload it before reloading it)
+        :return True if the module comes from the platform (and ought to stay loaded) or might come from
+          the actions of a DAG (in which case it's safer to unload it before reloading it)
         """
 
         if module_name in ["sys", "types", "__main__", "websocket", "airflow"]:


### PR DESCRIPTION
closes: #10616

This PR provides a fix for the issue where DAG packages (zips) which provides possibly distinct versions of a support library might receive the wrong version from a different DAG

~~To facilitate the review, it isn't yet squashed as requested; there are four commits~~: _(edit: after rebasing it to master, keeping the four commits wasn't feasible anymore. )_

1. Unit tests that demonstrate the issue (and fail)
2. a refactoring of DagBag.process_file to break up that function into more manageable pieces 
3. a first-level resolution of the issue (effectively, every module loaded by a DAG within a zip is immediately taken off the global namespace, so that the next DAG pack can try again), which still fails in case a DAG zip attempts to provide a different version of an otherwise globally-supplied module (e.g. an updated tzdb or something like that)
4. a correction to the previous, ensuring zipped DAG get loaded in a clean and neutral environment
5. an improvement on the previous, in order to avoid unloading modules between files of the same DAG package (they will be intended to share dependencies if they have any)

(Another issue that is fixed in passing is that previously, the sys.path would grow indefinitely each time the DagBag loads or reloads a zipped DAG)

