### PR TITLE
Wrong key in DAGs Persistent Volume Claim

### DIFF
--- a/chart/templates/dags-persistent-volume-claim.yaml
+++ b/chart/templates/dags-persistent-volume-claim.yaml
@@ -31,11 +31,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.dags.persistence.size | quote }}
-  {{- if .Values.dags.persistence.storageClass }}
-  {{- if (eq "-" .Values.dags.persistence.storageClass) }}
+  {{- if .Values.dags.persistence.storageClassName }}
+  {{- if (eq "-" .Values.dags.persistence.storageClassName) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.dags.persistence.storageClass }}"
+  storageClassName: "{{ .Values.dags.persistence.storageClassName }}"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/tests/dags-persistent-volume-claim_test.yaml
+++ b/chart/tests/dags-persistent-volume-claim_test.yaml
@@ -51,7 +51,7 @@ tests:
           enabled: true
           size: 1G
           existingClaim: ~
-          storageClass: "MyStorageClass"
+          storageClassName: "MyStorageClass"
           accessMode: ReadWriteMany
     asserts:
       - equal:


### PR DESCRIPTION
The `storageClassName` in `chart/templates/dags-persistent-volume-claim.yaml` is referencing the value `dags.persistence.storageClass` that does not exist in `chart/values.yaml`.
