### PR TITLE
Log task_instance execution duration as milliseconds

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1200,7 +1200,7 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         task_copy.post_execute(context=context, result=result)
 
         end_time = time.time()
-        duration = end_time - start_time
+        duration = timedelta(seconds=end_time - start_time)
         Stats.timing('dag.{dag_id}.{task_id}.duration'.format(dag_id=task_copy.dag_id,
                                                               task_id=task_copy.task_id),
                      duration)


### PR DESCRIPTION
This is best achieved by passing a `timedelta()` to `Stats.timing()`, and leave worrying about time units to that method.

This is my fix for #10629, for the master branch. A separate pull request will be made for the v1-10 branch.