### PR TITLE
Fix Start Date tooltip on DAGs page not showing actual start_date

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -370,14 +370,15 @@
     function lastDagRunsHandler(error, json) {
       for(var safe_dag_id in json) {
         dag_id = json[safe_dag_id].dag_id;
-        last_run = json[safe_dag_id].last_run;
+        execution_date = json[safe_dag_id].execution_date;
+        start_date = json[safe_dag_id].start_date;
         g = d3.select('div#last-run-' + safe_dag_id)
         g.selectAll('a')
-          .attr('href', '{{ url_for('Airflow.graph') }}?dag_id=' + encodeURIComponent(dag_id) + '&execution_date=' + encodeURIComponent(last_run))
-          .insert(isoDateToTimeEl.bind(null, last_run, {title: false}));
+          .attr('href', '{{ url_for('Airflow.graph') }}?dag_id=' + encodeURIComponent(dag_id) + '&execution_date=' + encodeURIComponent(execution_date))
+          .insert(isoDateToTimeEl.bind(null, execution_date, {title: false}));
         g.selectAll('span')
           // We don't translate the timezone in the tooltip, that stays in UTC.
-          .attr('data-original-title', 'Start Date: ' + last_run)
+          .attr('data-original-title', 'Start Date: ' + start_date)
           .style('display', null);
         g.selectAll('.loading-last-run').remove();
       }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -726,7 +726,9 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             return wwwutils.json_response({})
 
         query = session.query(
-            DagRun.dag_id, sqla.func.max(DagRun.execution_date).label('last_run')
+            DagRun.dag_id,
+            sqla.func.max(DagRun.execution_date).label('execution_date'),
+            sqla.func.max(DagRun.start_date).label('start_date'),
         ).group_by(DagRun.dag_id)
 
         # Filter to only ask for accessible and selected dags
@@ -735,7 +737,8 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         resp = {
             r.dag_id.replace('.', '__dot__'): {
                 'dag_id': r.dag_id,
-                'last_run': r.last_run.isoformat(),
+                'execution_date': r.execution_date.isoformat(),
+                'start_date': r.start_date.isoformat(),
             } for r in query
         }
         return wwwutils.json_response(resp)


### PR DESCRIPTION
Closes: #10350
Replaces PR https://github.com/apache/airflow/pull/10556

It has been reported that the last run's execution date was incorrectly being displayed for both the last run's link text as well as the "Start Date" in the (i) tooltip on the DAGs page. This was happening in the RBAC UI. For example, this was wrong, the "Start Date" was _not_ `2020-08-08T00:00:00+00:00`, that is the `execution_date`:
![Screen Shot 2020-08-28 at 11 42 09 AM](https://user-images.githubusercontent.com/45696489/91604632-e4cd2c00-e923-11ea-8da5-55a2d101be94.png)

This PR fixes it so it shows the _actual_ `start_date` for the "Start Date" tooltip instead of the `execution_date`, like it used to do in non-RBAC (Flask-admin) UI and before the RBAC UI was changed to load the latest_dagruns asynchronously:
![Screen Shot 2020-08-28 at 11 41 00 AM](https://user-images.githubusercontent.com/45696489/91605066-b4d25880-e924-11ea-8454-2c78e83d3a72.png)

Ever since the PR https://github.com/apache/airflow/pull/4005 which loads the latest_dagruns asynchronously the correct Start Date was lost. This PR replaces the correct Start Date.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
