### PR TITLE
Exclude CSRF tokens in Log's attribute "extra" in database

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -43,11 +43,12 @@ def action_logging(f: T) -> T:
             else:
                 user = g.user.username
 
+            fields_skip_logging = {'csrf_token', '_csrf_token'}
             log = Log(
                 event=f.__name__,
                 task_instance=None,
                 owner=user,
-                extra=str(list(request.values.items())),
+                extra=str([(k, v) for k, v in request.values.items() if k not in fields_skip_logging]),
                 task_id=request.values.get('task_id'),
                 dag_id=request.values.get('dag_id'))
 


### PR DESCRIPTION

## Background

Currently `action_logging` decorator adds all values in `request.values` into `extra` field when add log to database. Due to this, CSRF tokens are also persisted in the logs.

![Airflow](https://user-images.githubusercontent.com/11539188/91641450-cac74280-ea24-11ea-8a1c-6397c54943eb.png)


## What Does This PR Do

This PR excludes either `csrf_token` or `_csrf_token` from the values to be persisted into database.

## Why We May Need This Change

- Even though CSRF token may not be extremely sensitive, it may be better to exclude it when we add log into database. 

- From another perspective, persisting it in database doesn't help (no matter in terms of auditing or debugging).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
