### PR TITLE
Display conf as a Json in the DagRun list view

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -268,7 +268,7 @@ def datetime_f(attr_name):
     return dt
 # pylint: enable=invalid-name
 
- 
+
 def json_f(attr_name):
     """Returns a formatted string with HTML for given JSON serializable"""
     def json_(attr):
@@ -276,7 +276,7 @@ def json_f(attr_name):
         serialized = json.dumps(f)
         return Markup('<nobr>{}</nobr>').format(serialized)  # noqa
     return json_
- 
+
 
 def dag_link(attr):
     """Generates a URL to the Graph View for a Dag."""

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -268,6 +268,7 @@ def datetime_f(attr_name):
     return dt
 # pylint: enable=invalid-name
 
+ 
 def json_f(attr_name):
     """Returns a formatted string with HTML for given JSON serializable"""
     def json_(attr):
@@ -275,7 +276,7 @@ def json_f(attr_name):
         serialized = json.dumps(f)
         return Markup('<nobr>{}</nobr>').format(serialized)  # noqa
     return json_
-# pylint: enable=invalid-name
+ 
 
 def dag_link(attr):
     """Generates a URL to the Graph View for a Dag."""

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -268,6 +268,14 @@ def datetime_f(attr_name):
     return dt
 # pylint: enable=invalid-name
 
+def json_f(attr_name):
+    """Returns a formatted string with HTML for given JSON serializable"""
+    def json_(attr):
+        f = attr.get(attr_name)
+        serialized = json.dumps(f)
+        return Markup('<nobr>{}</nobr>').format(serialized)  # noqa
+    return json_
+# pylint: enable=invalid-name
 
 def dag_link(attr):
     """Generates a URL to the Graph View for a Dag."""

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2628,6 +2628,7 @@ class DagRunModelView(AirflowModelView):
         'start_date': wwwutils.datetime_f('start_date'),
         'dag_id': wwwutils.dag_link,
         'run_id': wwwutils.dag_run_link,
+        'conf': wwwutils.json_f('conf'),
     }
 
     @action('muldelete', "Delete", "Are you sure you want to delete selected records?",

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2860,7 +2860,7 @@ class TestDagRunModelView(TestBase):
         self.assertEqual(dr.conf, {"include": "me"})
 
         resp = self.client.get('/dagrun/list', follow_redirects=True)
-        self.check_content_in_response("{&#39;include&#39;: &#39;me&#39;}", resp)
+        self.check_content_in_response("{&#34;include&#34;: &#34;me&#34;}", resp)
 
 
 class TestDecorators(TestBase):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Implements a formatter that it being used by the DagRun list view to display the passed conf.
As discussed in #10519, it standardized the requested conf is passed as a Json and should be displayed as a Json (not as a python str).
This also facilitates the to reuse of previews manually triggered dags confs (copy from dagrun list -> use to trigger a new dagrun).

Closes: #10519

PS: sent a commit message out of standard, next time I will get it right :) 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
