### PR TITLE
Fix typo: duplicated "the"

### DIFF
--- a/airflow/providers/google/cloud/utils/field_validator.py
+++ b/airflow/providers/google/cloud/utils/field_validator.py
@@ -91,7 +91,7 @@ following types:
   ranges of values), booleans or any other types of fields.
 * API version: (key="api_version") if API version is specified, then the field will only
   be validated when api_version used at field validator initialization matches exactly the
-  the version specified. If you want to declare fields that are available in several
+  version specified. If you want to declare fields that are available in several
   versions of the APIs, you should specify the field as many times as many API versions
   should be supported (each time with different API version).
 * if none of the keys ("type", "regexp", "custom_validation" - the field is not validated

--- a/airflow/providers/google/firebase/example_dags/example_firestore.py
+++ b/airflow/providers/google/firebase/example_dags/example_firestore.py
@@ -36,7 +36,7 @@ If you want to run this example, you must do the following:
 
 1. Create Google Cloud project and enable the BigQuery API
 2. Create the Firebase project
-3. Create a bucket in the same location as the the Firebase project
+3. Create a bucket in the same location as the Firebase project
 4. Grant Firebase admin account permissions to manage BigQuery. This is required to create a dataset.
 5. Create a bucket in Firebase project and
 6. Give read/write access for Firebase admin to bucket to step no. 5.

--- a/backport_packages/refactor_backport_packages.py
+++ b/backport_packages/refactor_backport_packages.py
@@ -381,7 +381,7 @@ class RefactorBackportPackages:
         """
         Fixes to "amazon" providers package.
 
-        Copies some of the classes used from core Airflow to "common.utils" package of the
+        Copies some of the classes used from core Airflow to "common.utils" package of
         the provider and renames imports to use them from there.
 
         We copy typing_compat.py and change import as in example diff:

--- a/tests/api/common/experimental/test_mark_tasks.py
+++ b/tests/api/common/experimental/test_mark_tasks.py
@@ -271,7 +271,7 @@ class TestMarkTasks(unittest.TestCase):
         self.assertEqual(len(altered), 14)
 
         # cannot use snapshot here as that will require drilling down the
-        # the sub dag tree essentially recreating the same code as in the
+        # sub dag tree essentially recreating the same code as in the
         # tested logic.
         self.verify_state(self.dag2, task_ids, [self.execution_dates[0]],
                           State.SUCCESS, [])


### PR DESCRIPTION
Just fixed typo: duplicated "the"

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
