### PR TITLE
Adds 'cncf.kubernetes' package back to backport provider packages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ci-images]
     env:
-      INSTALL_AIRFLOW_VERSION: "1.10.10"
+      INSTALL_AIRFLOW_VERSION: "1.10.12"
       PYTHON_MAJOR_MINOR_VERSION: 3.6
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:

--- a/airflow/providers/cncf/kubernetes/ADDITIONAL_INFO.md
+++ b/airflow/providers/cncf/kubernetes/ADDITIONAL_INFO.md
@@ -1,0 +1,24 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+## Additional limitations
+
+This provider is only usable with Apache Airflow >= 1.10.12 version due to refactorings implemented in
+Apache Airflow 1.10.11 and fixes implemented in 1.10.11. The package has appropriate requirements
+set so you should not be able to install it with Apache Airflow < 1.10.12.

--- a/backport_packages/PROVIDERS_README_TEMPLATE.md.jinja2
+++ b/backport_packages/PROVIDERS_README_TEMPLATE.md.jinja2
@@ -25,7 +25,6 @@ Release: {{ RELEASE_NO_LEADING_ZEROS }}
 
 - [Backport package](#backport-package)
 - [Installation](#installation)
-- [Compatibility](#compatibility)
 {%- if PIP_REQUIREMENTS %}
 - [PIP requirements](#pip-requirements)
 {%- endif %}
@@ -68,11 +67,6 @@ want to use this backport package.
 
 You can install this package on top of an existing airflow 1.10.* installation via
 `pip install {{PACKAGE_PIP_NAME}}`
-
-## Compatibility
-
-For full compatibility and test status of the backport packages check
-[Airflow Backport Package Compatibility](https://cwiki.apache.org/confluence/display/AIRFLOW/Backported+providers+packages+for+Airflow+1.10.*+series)
 
 {%- if PIP_REQUIREMENTS %}
 

--- a/backport_packages/setup_backport_packages.py
+++ b/backport_packages/setup_backport_packages.py
@@ -259,7 +259,13 @@ def do_setup_package_providers(provider_package_id: str,
     package_prefix = f'airflow.providers.{provider_package_id}'
     found_packages = find_packages()
     found_packages = [package for package in found_packages if package.startswith(package_prefix)]
-    install_requires = ['apache-airflow~=1.10']
+
+    airflow_dependency = 'apache-airflow~=1.10' if provider_package_id != 'cncf.kubernetes' \
+        else 'apache-airflow>=1.10.12, <2.0.0'
+
+    install_requires = [
+        airflow_dependency
+    ]
     install_requires.extend(package_dependencies)
     setuptools_setup(
         name=package_name,
@@ -1152,8 +1158,7 @@ def get_all_backportable_providers() -> List[str]:
     for Airflow 1.10 anyway.
     :return: list of providers that are considered for backport packages
     """
-    # TODO: Maybe we should fix it and release cncf.kubernetes separately
-    excluded_providers = ["cncf.kubernetes", "papermill"]
+    excluded_providers = ["papermill"]
     return [prov for prov in PROVIDERS_REQUIREMENTS.keys() if prov not in excluded_providers]
 
 


### PR DESCRIPTION

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
