### PR TITLE
Show a few lines of tracebacks for DAG import errors in web UI

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -229,6 +229,21 @@
       type: string
       example: ~
       default: "30"
+    - name: dagbag_import_error_tracebacks
+      description: |
+        Should a traceback be shown in the UI for dagbag import errors,
+        instead of just the exception message
+      version_added: 2.0.0
+      type: boolean
+      example: ~
+      default: "True"
+    - name: dagbag_import_error_traceback_depth
+      description: |
+        If tracebacks are shown, how many entries from the traceback should be shown
+      version_added: 2.0.0
+      type: integer
+      example: ~
+      default: "2"
     - name: dag_file_processor_timeout
       description: |
         How long before timing out a DagFileProcessor, which processes a dag file

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -142,6 +142,13 @@ donot_pickle = True
 # How long before timing out a python file import
 dagbag_import_timeout = 30
 
+# Should a traceback be shown in the UI for dagbag import errors,
+# instead of just the exception message
+dagbag_import_error_tracebacks = True
+
+# If tracebacks are shown, how many entries from the traceback should be shown
+dagbag_import_error_traceback_depth = 2
+
 # How long before timing out a DagFileProcessor, which processes a dag file
 dag_file_processor_timeout = 50
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -23,6 +23,7 @@ import importlib.util
 import os
 import sys
 import textwrap
+import traceback
 import warnings
 import zipfile
 from datetime import datetime, timedelta
@@ -114,6 +115,9 @@ class DagBag(BaseDagBag, LoggingMixin):
         self.read_dags_from_db = read_dags_from_db
         # Only used by read_dags_from_db=True
         self.dags_last_fetched: Dict[str, datetime] = {}
+
+        self.dagbag_import_error_tracebacks = conf.getboolean('core', 'dagbag_import_error_tracebacks')
+        self.dagbag_import_error_traceback_depth = conf.getint('core', 'dagbag_import_error_traceback_depth')
 
         self.collect_dags(
             dag_folder=dag_folder,
@@ -275,7 +279,12 @@ class DagBag(BaseDagBag, LoggingMixin):
                 return [new_module]
             except Exception as e:  # pylint: disable=broad-except
                 self.log.exception("Failed to import: %s", filepath)
-                self.import_errors[filepath] = str(e)
+                if self.dagbag_import_error_tracebacks:
+                    self.import_errors[filepath] = traceback.format_exc(
+                        limit=-self.dagbag_import_error_traceback_depth
+                    )
+                else:
+                    self.import_errors[filepath] = str(e)
         return []
 
     def _load_modules_from_zip(self, filepath, safe_mode):
@@ -314,7 +323,12 @@ class DagBag(BaseDagBag, LoggingMixin):
                 mods.append(current_module)
             except Exception as e:  # pylint: disable=broad-except
                 self.log.exception("Failed to import: %s", filepath)
-                self.import_errors[filepath] = str(e)
+                if self.dagbag_import_error_tracebacks:
+                    self.import_errors[filepath] = traceback.format_exc(
+                        limit=-self.dagbag_import_error_traceback_depth
+                    )
+                else:
+                    self.import_errors[filepath] = str(e)
         return mods
 
     def _process_modules(self, filepath, mods, file_last_changed_on_disk):

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -277,6 +277,10 @@ label[for="timezone-other"],
   margin-bottom: 15px;
 }
 
+.dag-import-error {
+  white-space: pre;
+}
+
 /* stylelint-disable declaration-block-single-line-max-declarations */
 .hll { background-color: #ffc; }
 .c { color: #408080; font-style: italic; } /* Comment */

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -65,9 +65,7 @@
                 <div id="alerts" class="panel-collapse collapse in">
                   <div class="panel-body" >
                     {% for category, m in dag_import_errors %}
-                        <div class="alert alert-error">
-                            {{ m }}
-                        </div>
+                        <div class="alert alert-error dag-import-error">{{ m }}</div>
                     {% endfor %}
                   </div>
                 </div>

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1262,6 +1262,8 @@ tokopedia
 tolerations
 tooltip
 tooltips
+traceback
+tracebacks
 travis
 trojan
 tsv


### PR DESCRIPTION
This PR allows for partial import error tracebacks to be exposed on the UI, if enabled. This extra context can be very help for users without access to the parsing logs to determine why their DAGs are failing to import properly.

Disabled:
![before](https://user-images.githubusercontent.com/66968678/91735545-b04ab180-eb69-11ea-9aab-636771d6d104.png)

Enabled:
![after](https://user-images.githubusercontent.com/66968678/91735585-bc367380-eb69-11ea-8cb9-7f52a6372025.png)

