### PR TITLE
Add generate_yaml command to easily test KubernetesExecutor before deploying pods

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -145,7 +145,7 @@ ARG_END_DATE = Arg(
 ARG_OUTPUT_PATH = Arg(
     ("-o", "--output-path",),
     help="The output for generated yaml files",
-    type=argparse.FileType('w')
+    type=argparse.FileType('w'),
     default="/tmp/airflow_yaml_output/")
 ARG_DRY_RUN = Arg(
     ("-n", "--dry-run"),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -156,7 +156,8 @@ ARG_END_DATE = Arg(
 ARG_OUTPUT_PATH = Arg(
     ("-o", "--output-path",),
     help="The output for generated yaml files",
-    default="/tmp/airflow_yaml_output/")
+    type=str,
+    default=os.getcwd())
 ARG_DRY_RUN = Arg(
     ("-n", "--dry-run"),
     help="Perform a dry run for each task. Only renders Template Fields for each task, nothing else",

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -70,8 +70,8 @@ class DefaultHelpParser(argparse.ArgumentParser):
             try:
                 from kubernetes.client import models
                 if not models:
-                    message = 'kubernetes subcommand requires that ' \
-                              'you pip install the kubernetes python client'
+                    message = "kubernetes subcommand requires that ' \
+                              'you run pip install 'apache-airflow[cncf.kubernetes]'"
                     raise ArgumentError(action, message)
             except Exception:  # pylint: disable=W0703
                 message = 'kubernetes subcommand requires that you pip install the kubernetes python client'

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -67,10 +67,6 @@ class DefaultHelpParser(argparse.ArgumentParser):
             message = f'celery subcommand works only with CeleryExecutor, your current executor: {executor}'
             raise ArgumentError(action, message)
         if value == 'kubernetes':
-            if executor != ExecutorLoader.KUBERNETES_EXECUTOR:
-                message = f'kubernetes subcommand works only with KubernetesExecutor, ' \
-                          f'your current executor: {executor}'
-                raise ArgumentError(action, message)
             try:
                 from kubernetes.client import models
                 if not models:
@@ -1275,11 +1271,11 @@ CONFIG_COMMANDS = (
 
 KUBERNETES_COMMANDS = (
     ActionCommand(
-        name='generate_kubernetes_pod_yaml',
+        name='generate-dag-yaml',
         help="Generate YAML files for all tasks in DAG. Useful for debugging tasks without "
              "launching into a cluster",
         func=lazy_load_command('airflow.cli.commands.dag_command.generate_pod_yaml'),
-        args=(ARG_SUBDIR, ARG_DAG_ID, ARG_OUTPUT_PATH, ARG_EXEC_DATE),
+        args=(ARG_DAG_ID, ARG_EXECUTION_DATE, ARG_SUBDIR, ARG_OUTPUT_PATH),
     ),
 )
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -145,7 +145,6 @@ ARG_END_DATE = Arg(
 ARG_OUTPUT_PATH = Arg(
     ("-o", "--output-path",),
     help="The output for generated yaml files",
-    type=argparse.FileType('w'),
     default="/tmp/airflow_yaml_output/")
 ARG_DRY_RUN = Arg(
     ("-n", "--dry-run"),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -142,6 +142,11 @@ ARG_END_DATE = Arg(
     ("-e", "--end-date"),
     help="Override end_date YYYY-MM-DD",
     type=parsedate)
+ARG_OUTPUT_PATH = Arg(
+    ("-o", "--output-path",),
+    help="The output for generated yaml files",
+    type=argparse.FileType('w')
+    default="/tmp/airflow_yaml_output/")
 ARG_DRY_RUN = Arg(
     ("-n", "--dry-run"),
     help="Perform a dry run for each task. Only renders Template Fields for each task, nothing else",
@@ -777,6 +782,12 @@ DAGS_COMMANDS = (
         help="List all the DAGs",
         func=lazy_load_command('airflow.cli.commands.dag_command.dag_list_dags'),
         args=(ARG_SUBDIR, ARG_OUTPUT),
+    ),
+    ActionCommand(
+        name='generate_kubernetes_pod_yaml',
+        help="Generate YAML files for all tasks in DAG",
+        func=lazy_load_command('airflow.cli.commands.dag_command.generate_pod_yaml'),
+        args=(ARG_SUBDIR, ARG_DAG_ID, ARG_OUTPUT_PATH, ARG_EXEC_DATE),
     ),
     ActionCommand(
         name='report',

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -394,7 +394,7 @@ def generate_pod_yaml(args):
 
     execution_date = args.execution_date
     dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)
-    yaml_output_path = args.output_path or "/tmp/airflow_generated_yaml/"
+    yaml_output_path = args.output_path
     kube_config = KubeConfig()
     for task in dag.tasks:
         ti = TaskInstance(task, execution_date)
@@ -415,11 +415,11 @@ def generate_pod_yaml(args):
         api_client = ApiClient()
         date_string = pod_generator.datetime_to_label_safe_datestring(execution_date)
         yaml_file_name = f"{args.dag_id}_{ti.task_id}_{date_string}.yml"
-        os.makedirs(os.path.dirname(yaml_output_path), exist_ok=True)
-        with open(yaml_output_path + yaml_file_name, "w") as output:
+        os.makedirs(os.path.dirname(yaml_output_path + "/airflow_yaml_output/"), exist_ok=True)
+        with open(yaml_output_path + "/airflow_yaml_output/" + yaml_file_name, "w") as output:
             sanitized_pod = api_client.sanitize_for_serialization(pod)
             output.write(yaml.dump(sanitized_pod))
-    print(f"YAML output can be found at {yaml_output_path}")
+    print(f"YAML output can be found at {yaml_output_path}/airflow_yaml_output/")
 
 
 @provide_session

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -37,7 +37,7 @@ from airflow.executors.debug_executor import DebugExecutor
 from airflow.jobs.base_job import BaseJob
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.models.dag import DAG
-from airflow.utils import cli as cli_utils, timezone
+from airflow.utils import cli as cli_utils
 from airflow.utils.cli import get_dag, get_dag_by_file_location, process_subdir, sigint_handler
 from airflow.utils.dot_renderer import render_dag
 from airflow.utils.session import create_session, provide_session
@@ -392,7 +392,7 @@ def generate_pod_yaml(args):
     from airflow.kubernetes.worker_configuration import WorkerConfiguration
     from airflow.settings import pod_mutation_hook
 
-    execution_date = args.exec_date or timezone.utcnow()
+    execution_date = args.execution_date
     dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)
     yaml_output_path = args.output_path or "/tmp/airflow_generated_yaml/"
     kube_config = KubeConfig()

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -384,11 +384,14 @@ def dag_list_dag_runs(args, dag=None):
 def generate_pod_yaml(args):
     """Generates yaml files for each task in the DAG. Used for testing output of KubernetesExecutor"""
 
+    from kubernetes.client.api_client import ApiClient
+
     from airflow.executors.kubernetes_executor import AirflowKubernetesScheduler, KubeConfig
     from airflow.kubernetes import pod_generator
     from airflow.kubernetes.pod_generator import PodGenerator
     from airflow.kubernetes.worker_configuration import WorkerConfiguration
     from airflow.settings import pod_mutation_hook
+
     execution_date = args.exec_date or timezone.utcnow()
     dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)
     yaml_output_path = args.output_path or "/tmp/airflow_generated_yaml/"
@@ -409,8 +412,6 @@ def generate_pod_yaml(args):
             worker_config=WorkerConfiguration(kube_config=kube_config).as_pod()
         )
         pod_mutation_hook(pod)
-
-        from kubernetes.client.api_client import ApiClient
         api_client = ApiClient()
         date_string = pod_generator.datetime_to_label_safe_datestring(execution_date)
         yaml_file_name = f"{args.dag_id}_{ti.task_id}_{date_string}.yml"

--- a/docs/executor/kubernetes.rst
+++ b/docs/executor/kubernetes.rst
@@ -38,6 +38,9 @@ The volumes are optional and depend on your configuration. There are two volumes
 
   - Another option is to use S3/GCS/etc to store logs
 
+To troubleshoot issue with KubernetesExecutor, you can use ``airflow kubernetes generate-dag-yaml`` command.
+This command dumps generates the pods as they will be launched in Kubernetes and dumps them into yaml files for you to inspect.
+
 KubernetesExecutor Architecture
 ################################
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -143,8 +143,8 @@ class TestCliDags(unittest.TestCase):
         with tempfile.TemporaryDirectory("airflow_dry_run_test/") as directory:
             file_name = "example_bash_operator_run_after_loop_2020-11-03T00_00_00_plus_00_00.yml"
             dag_command.generate_pod_yaml(self.parser.parse_args([
-                'kubernetes', 'generate_kubernetes_pod_yaml',
-                "--output-path", directory, "--exec-date", "2020-11-03", 'example_bash_operator']))
+                'kubernetes', 'generate-dag-yaml',
+                'example_bash_operator', "2020-11-03", "--output-path", directory]))
             self.assertEqual(len(os.listdir(directory)), 6)
             self.assertTrue(os.path.isfile(directory + file_name))
             self.assertGreater(os.stat(directory + file_name).st_size, 0)

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -18,6 +18,7 @@
 import contextlib
 import io
 import os
+import shutil
 import tempfile
 import unittest
 from datetime import datetime, timedelta
@@ -138,6 +139,19 @@ class TestCliDags(unittest.TestCase):
         self.assertIn("label=example_bash_operator", out)
         self.assertIn("graph [label=example_bash_operator labelloc=t rankdir=LR]", out)
         self.assertIn("runme_2 -> run_after_loop", out)
+
+    def test_generate_dag_yaml(self):
+
+        directory = "/tmp/airflow_dry_run_test/"
+        file_name = "example_bash_operator_run_after_loop_2020-11-03T00_00_00.yml"
+        if os.path.exists(directory):
+            shutil.rmtree(directory)
+        dag_command.generate_pod_yaml(self.parser.parse_args([
+            'dags', 'generate_kubernetes_pod_yaml',
+            "--output-path", directory, 'example_bash_operator']))
+        self.assertEqual(len(os.listdir(directory)), 6)
+        self.assertTrue(os.path.isfile(directory + file_name))
+        self.assertGreater(os.stat(directory + file_name).st_size, 0)
 
     @mock.patch("airflow.cli.commands.dag_command.render_dag")
     def test_show_dag_dave(self, mock_render_dag):

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -145,9 +145,11 @@ class TestCliDags(unittest.TestCase):
             dag_command.generate_pod_yaml(self.parser.parse_args([
                 'kubernetes', 'generate-dag-yaml',
                 'example_bash_operator', "2020-11-03", "--output-path", directory]))
-            self.assertEqual(len(os.listdir(directory)), 6)
-            self.assertTrue(os.path.isfile(directory + file_name))
-            self.assertGreater(os.stat(directory + file_name).st_size, 0)
+            self.assertEqual(len(os.listdir(directory)), 1)
+            out_dir = directory + "/airflow_yaml_output/"
+            self.assertEqual(len(os.listdir(out_dir)), 6)
+            self.assertTrue(os.path.isfile(out_dir + file_name))
+            self.assertGreater(os.stat(out_dir + file_name).st_size, 0)
 
     @mock.patch("airflow.cli.commands.dag_command.render_dag")
     def test_show_dag_dave(self, mock_render_dag):

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -143,12 +143,12 @@ class TestCliDags(unittest.TestCase):
     def test_generate_dag_yaml(self):
 
         directory = "/tmp/airflow_dry_run_test/"
-        file_name = "example_bash_operator_run_after_loop_2020-11-03T00_00_00.yml"
+        file_name = "example_bash_operator_run_after_loop_2020-11-03T00_00_00_plus_00_00.yml"
         if os.path.exists(directory):
             shutil.rmtree(directory)
         dag_command.generate_pod_yaml(self.parser.parse_args([
             'dags', 'generate_kubernetes_pod_yaml',
-            "--output-path", directory, 'example_bash_operator']))
+            "--output-path", directory, "--exec-date", "2020-11-03", 'example_bash_operator']))
         self.assertEqual(len(os.listdir(directory)), 6)
         self.assertTrue(os.path.isfile(directory + file_name))
         self.assertGreater(os.stat(directory + file_name).st_size, 0)

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -18,7 +18,6 @@
 import contextlib
 import io
 import os
-import shutil
 import tempfile
 import unittest
 from datetime import datetime, timedelta
@@ -141,17 +140,14 @@ class TestCliDags(unittest.TestCase):
         self.assertIn("runme_2 -> run_after_loop", out)
 
     def test_generate_dag_yaml(self):
-
-        directory = "/tmp/airflow_dry_run_test/"
-        file_name = "example_bash_operator_run_after_loop_2020-11-03T00_00_00_plus_00_00.yml"
-        if os.path.exists(directory):
-            shutil.rmtree(directory)
-        dag_command.generate_pod_yaml(self.parser.parse_args([
-            'dags', 'generate_kubernetes_pod_yaml',
-            "--output-path", directory, "--exec-date", "2020-11-03", 'example_bash_operator']))
-        self.assertEqual(len(os.listdir(directory)), 6)
-        self.assertTrue(os.path.isfile(directory + file_name))
-        self.assertGreater(os.stat(directory + file_name).st_size, 0)
+        with tempfile.TemporaryDirectory("airflow_dry_run_test/") as directory:
+            file_name = "example_bash_operator_run_after_loop_2020-11-03T00_00_00_plus_00_00.yml"
+            dag_command.generate_pod_yaml(self.parser.parse_args([
+                'kubernetes', 'generate_kubernetes_pod_yaml',
+                "--output-path", directory, "--exec-date", "2020-11-03", 'example_bash_operator']))
+            self.assertEqual(len(os.listdir(directory)), 6)
+            self.assertTrue(os.path.isfile(directory + file_name))
+            self.assertGreater(os.stat(directory + file_name).st_size, 0)
 
     @mock.patch("airflow.cli.commands.dag_command.render_dag")
     def test_show_dag_dave(self, mock_render_dag):


### PR DESCRIPTION
To aide in migration testing (and general testing going forward)
we're adding a dry-run command to the airflow CLI. This command will
allow users to see the YAML of a KubernetesExecutor task without running it
in Kubernetes.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
