### PR TITLE
Add Stacktrace when DagFileProcessorManager gets killed

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -18,6 +18,7 @@
 """Processes DAGs."""
 import enum
 import importlib
+import inspect
 import logging
 import multiprocessing
 import os
@@ -693,6 +694,7 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         Helper method to clean up DAG file processors to avoid leaving orphan processes.
         """
         self.log.info("Exiting gracefully upon receiving signal %s", signum)
+        self.log.debug("Current Stacktrace is: %s", '\n'.join(map(str, inspect.stack())))
         self.terminate()
         self.end()
         self.log.debug("Finished terminating DAG processors.")


### PR DESCRIPTION
*Scheduler - DagFileProcessorManager* is the process that often gets hung due to various reasons. Found that having access to the stacktrace would be very helpful in debugging the root cause.

Should be helpful in resolving issue #7935