### PR TITLE
clean-logs script for Dockerfile: trim logs before sleep

### DIFF
--- a/scripts/in_container/prod/clean-logs.sh
+++ b/scripts/in_container/prod/clean-logs.sh
@@ -29,9 +29,9 @@ EVERY=$((15*60))
 echo "Cleaning logs every $EVERY seconds"
 
 while true; do
-  seconds=$(( $(date -u +%s) % EVERY))
-  [[ $seconds -lt 1 ]] || sleep $((EVERY - seconds))
-
   echo "Trimming airflow logs to ${RETENTION} days."
   find "${DIRECTORY}"/logs -mtime +"${RETENTION}" -name '*.log' -delete
+
+  seconds=$(( $(date -u +%s) % EVERY))
+  [[ $seconds -lt 1 ]] || sleep $((EVERY - seconds))
 done


### PR DESCRIPTION
If the pod restarts before the sleep time is over, the trim command will not run. I think it's better if we reorder the commands to execute the delete and then go to sleep. At the moment sleep is every 15 mins but people will just increase the EVERY line if they want longer sleep time and can encounter this bug.
