### PR TITLE
Fix missing dash in flag for statsd container

### DIFF
--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -61,7 +61,7 @@ spec:
           image: {{- include "statsd_image" . | indent 1 }}
           imagePullPolicy: {{ .Values.images.statsd.pullPolicy }}
           args:
-            - "-statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
+            - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           resources:
 {{ toYaml .Values.statsd.resources | indent 12 }}
           ports:


### PR DESCRIPTION
This PR fixes a bug in the definition of `statsd` container in helm-chart. 

With current master helm-chart the `airflow-statsd` pod fails and collecting logs from the pod with `kubectl logs` returns the message:

`statsd_exporter: error: unknown short flag '-s', try --help`

Following the suggestion from https://github.com/prometheus/statsd_exporter/issues/155, I have added additional dash to `-statsd.mapping-config` flag in the definition of `statsd` container inside `statsd-deployment.yaml` file, which seems to fix the pod.

---
Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Target Github ISSUE in description if exists
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.