### PR TITLE
Add packages to function names in bash

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1046,7 +1046,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   ####################################################################################################
 
-  Usage: breeze [FLAGS] [COMMAND] -- <EXTRA_ARGS>
+  usage: breeze [FLAGS] [COMMAND] -- <EXTRA_ARGS>
 
   By default the script enters the  CI container and drops you to bash shell, but you can choose
   one of the commands to run specific actions instead.

--- a/breeze
+++ b/breeze
@@ -78,7 +78,7 @@ export EXTRA_STATIC_CHECK_OPTIONS
 # scripts/ci/libraries/_initialization.sh and breeze-complete script (which sets-up auto-complete).
 #
 #######################################################################################################
-function setup_default_breeze_constants() {
+function breeze::setup_default_breeze_constants() {
     # Indicates that we are inside Breeze environment
     export BREEZE=true
     readonly BREEZE
@@ -183,7 +183,7 @@ function setup_default_breeze_constants() {
 #    OSTYPE
 #
 #######################################################################################################
-function initialize_virtualenv() {
+function breeze::initialize_virtualenv() {
     # Check if we are inside virtualenv
     set +e
     echo -e "import sys\nif not hasattr(sys,'base_prefix'):\n  sys.exit(1)" |
@@ -256,7 +256,7 @@ function initialize_virtualenv() {
 #    OSTYPE
 #
 #######################################################################################################
-function setup_autocomplete() {
+function breeze::setup_autocomplete() {
     echo "Installing bash/zsh completion for local user"
     echo
     "${AIRFLOW_SOURCES}/confirm" "This will create ~/.bash_completion.d/ directory and modify ~/.*rc files"
@@ -340,7 +340,7 @@ EOF
 #
 # Prints information about the current configuration of Breeze - if you enter breeze interactively
 # and you did not suppress cheatsheet or asciiart, it also prints those. It also prints values
-# of constants set by read_saved_environment_variables() function and other initialization functions.
+# of constants set by breeze::read_saved_environment_variables() function and other initialization functions.
 #
 # Used globals:
 #
@@ -363,7 +363,7 @@ EOF
 #    Prints the information about the build to stdout.
 #
 #######################################################################################################
-function print_badge() {
+function breeze::print_badge() {
     local backend_version=""
     if [[ ${BACKEND} == "postgres" ]]; then
         backend_version="${POSTGRES_VERSION}"
@@ -421,7 +421,7 @@ EOF
 
                                Branch name:            ${BRANCH_NAME}
                                Docker image:           ${AIRFLOW_PROD_IMAGE}
-                               Airflow source version: $(get_airflow_version_from_production_image)
+                               Airflow source version: $(build_images::get_airflow_version_from_production_image)
 EOF
         else
             cat <<EOF
@@ -526,7 +526,7 @@ EOF
 #   Creates the convenience command file that can be run to use the docker command.
 #
 #######################################################################################################
-function prepare_command_file() {
+function breeze::prepare_command_file() {
     local file="${1}"
     local command="${2}"
     local compose_file="${3}"
@@ -588,7 +588,7 @@ EOF
 #     BUILT_CI_IMAGE_FLAG_FILE
 #
 #######################################################################################################
-function prepare_command_files() {
+function breeze::prepare_command_files() {
     local main_ci_docker_compose_file=${SCRIPTS_CI_DIR}/docker-compose/base.yml
     local main_prod_docker_compose_file=${SCRIPTS_CI_DIR}/docker-compose/base.yml
     local backend_docker_compose_file=${SCRIPTS_CI_DIR}/docker-compose/backend-${BACKEND}.yml
@@ -638,11 +638,11 @@ function prepare_command_files() {
     readonly DOCKER_COMPOSE_RUN_SCRIPT_FOR_PROD
 
     # Prepare script for "run docker compose CI command"
-    prepare_command_file "${BUILD_CACHE_DIR}/${DOCKER_COMPOSE_RUN_SCRIPT_FOR_CI}" \
+    breeze::prepare_command_file "${BUILD_CACHE_DIR}/${DOCKER_COMPOSE_RUN_SCRIPT_FOR_CI}" \
         "\"\${@}\"" "${compose_ci_file}" "${AIRFLOW_CI_IMAGE}"
 
     # Prepare script for "run docker compose PROD command"
-    prepare_command_file "${BUILD_CACHE_DIR}/${DOCKER_COMPOSE_RUN_SCRIPT_FOR_PROD}" \
+    breeze::prepare_command_file "${BUILD_CACHE_DIR}/${DOCKER_COMPOSE_RUN_SCRIPT_FOR_PROD}" \
         "\"\${@}\"" "${compose_prod_file}" "${AIRFLOW_PROD_IMAGE}"
 }
 
@@ -658,25 +658,25 @@ function prepare_command_files() {
 #   Prints detailed help for all commands to stdout.
 #
 #######################################################################################################
-function do_help_all() {
+function breeze::do_help_all() {
     echo
-    print_line
-    usage
-    print_line
+    breeze::print_line
+    breeze::usage
+    breeze::print_line
     echo
     echo
     echo "Detailed usage"
     echo
-    print_line
+    breeze::print_line
     echo
     local subcommand
     for subcommand in ${ALL_BREEZE_COMMANDS}; do
-        detailed_usage "${subcommand}"
-        print_line
+        breeze::detailed_usage "${subcommand}"
+        breeze::print_line
         echo
     done
     echo
-    flags
+    breeze::flags
 }
 
 #######################################################################################################
@@ -684,11 +684,11 @@ function do_help_all() {
 # Parses all arguments that can be passed to Breeze command - that includes command to run and flags.
 #
 # Updated global constants:
-#      By the end of this function, all the constants from `make_constants_read_only` function are set
+#      By the end of this function, all the constants from `initialization::make_constants_read_only` function are set
 #      and they are set as read-only.
 #
 #######################################################################################################
-function parse_arguments() {
+function breeze::parse_arguments() {
     set -u
     local params
     if ! params=$(getopt \
@@ -725,7 +725,7 @@ function parse_arguments() {
             ;;
         -i | --integration)
             local integration=${2}
-            check_and_save_allowed_param "INTEGRATION" "integration" "--integration"
+            parameters::check_and_save_allowed_param "INTEGRATION" "integration" "--integration"
             echo "Integration: ${integration}"
             if [[ ${integration} == "all" ]]; then
                 for integration in ${_BREEZE_ALLOWED_INTEGRATIONS}; do
@@ -1185,15 +1185,15 @@ function parse_arguments() {
             exit 0
             ;;
         help)
-            usage
+            breeze::usage
             exit 0
             ;;
         help-all)
-            do_help_all
+            breeze::do_help_all
             exit 0
             ;;
         *)
-            usage
+            breeze::usage
             echo >&2
             echo >&2 "ERROR: Unknown command ${1}"
             echo >&2
@@ -1207,10 +1207,10 @@ function parse_arguments() {
 
     if [[ ${run_help} == "true" ]]; then
         if [[ ${last_subcommand} == "" ]]; then
-            usage
-            flag_footer
+            breeze::usage
+            breeze::flag_footer
         else
-            detailed_usage "${last_subcommand}"
+            breeze::detailed_usage "${last_subcommand}"
         fi
         exit 0
     fi
@@ -1234,7 +1234,7 @@ function parse_arguments() {
 #       FORMATTED_* constant variables that can be used in Breeze Help output
 #
 #######################################################################################################
-function prepare_formatted_versions() {
+function breeze::prepare_formatted_versions() {
     local indent=15
     local list_prefix
     list_prefix=$(printf "%-${indent}s" " ")
@@ -1310,7 +1310,7 @@ function prepare_formatted_versions() {
 
 # shellcheck disable=SC2034,SC2090,SC2089,SC2155
 
-function prepare_usage() {
+function breeze::prepare_usage() {
     # Note that MacOS uses Bash 3.* and we cannot use associative arrays
     export USAGE_SHELL="[Default] Enters interactive shell in the container"
     readonly USAGE_SHELL
@@ -1397,7 +1397,7 @@ ${CMDNAME} shell [FLAGS] [-- <EXTRA_ARGS>]
             --github-image-id 209845560' - pull/use image with RUN_ID
 
 Flags:
-$(flag_footer)
+$(breeze::flag_footer)
 "
     readonly DETAILED_USAGE_SHELL
     export DETAILED_USAGE_EXEC="
@@ -1437,12 +1437,12 @@ ${CMDNAME} build-image [FLAGS]
       specific COMMIT_SHA tag or RUN_ID.
 
 Flags:
-$(flag_airflow_variants)
-$(flag_choose_different_airflow_version)
-$(flag_production_image)
-$(flag_build_docker_images)
-$(flag_pull_push_docker_images)
-$(flag_verbosity)
+$(breeze::flag_airflow_variants)
+$(breeze::flag_choose_different_airflow_version)
+$(breeze::flag_production_image)
+$(breeze::flag_build_docker_images)
+$(breeze::flag_pull_push_docker_images)
+$(breeze::flag_verbosity)
 "
     readonly DETAILED_USAGE_BUILD_IMAGE
     export DETAILED_USAGE_CLEANUP_IMAGE="
@@ -1453,9 +1453,9 @@ ${CMDNAME} cleanup-image [FLAGS]
       with --all) to reclaim that space.
 
 Flags:
-$(flag_airflow_variants)
-$(flag_production_image)
-$(flag_verbosity)
+$(breeze::flag_airflow_variants)
+$(breeze::flag_production_image)
+$(breeze::flag_verbosity)
 "
     readonly DETAILED_USAGE_CLEANUP_IMAGE
     export DETAILED_USAGE_DOCKER_COMPOSE="
@@ -1468,9 +1468,9 @@ ${CMDNAME} docker-compose [FLAGS] COMMAND [-- <EXTRA_ARGS>]
       '${CMDNAME} docker-compose pull -- --ignore-pull-failures'
 
 Flags:
-$(flag_airflow_variants)
-$(flag_backend_variants)
-$(flag_verbosity)
+$(breeze::flag_airflow_variants)
+$(breeze::flag_backend_variants)
+$(breeze::flag_verbosity)
 "
     readonly DETAILED_USAGE_DOCKER_COMPOSE
     export DETAILED_USAGE_FLAGS="
@@ -1505,7 +1505,7 @@ ${CMDNAME} prepare-backport-packages [FLAGS] [YYYY.MM.DD] [PACKAGE_ID ...]
         '.' for example 'apache.hive'
 
 Flags:
-$(flag_verbosity)
+$(breeze::flag_verbosity)
 "
     readonly DETAILED_USAGE_PREPARE_BACKPORT_README
     export DETAILED_USAGE_GENERATE_CONSTRAINTS="
@@ -1520,8 +1520,8 @@ ${CMDNAME} generate-constraints [FLAGS]
       CRON job in CI automatically.
 
 Flags:
-$(flag_airflow_variants)
-$(flag_verbosity)
+$(breeze::flag_airflow_variants)
+$(breeze::flag_verbosity)
 "
     readonly DETAILED_USAGE_GENERATE_CONSTRAINTS
     export DETAILED_USAGE_INITIALIZE_LOCAL_VIRTUALENV="
@@ -1534,7 +1534,7 @@ ${CMDNAME} initialize-local-virtualenv [FLAGS]
       activated before running this command.
 
 Flags:
-$(flag_airflow_variants)
+$(breeze::flag_airflow_variants)
 "
     readonly DETAILED_USAGE_INITIALIZE_LOCAL_VIRTUALENV
     export DETAILED_USAGE_PREPARE_BACKPORT_PACKAGES="
@@ -1562,8 +1562,8 @@ ${CMDNAME} prepare-backport-packages [FLAGS] [PACKAGE_ID ...]
         for example 'apache.hive'
 
 Flags:
-$(flag_version_suffix)
-$(flag_verbosity)
+$(breeze::flag_version_suffix)
+$(breeze::flag_verbosity)
 "
     readonly DETAILED_USAGE_PREPARE_BACKPORT_PACKAGES
     export DETAILED_USAGE_PUSH_IMAGE="
@@ -1595,8 +1595,8 @@ ${CMDNAME} push_image [FLAGS]
             --github-image-id 209845560' - to push with RUN_ID
 
 Flags:
-$(flag_pull_push_docker_images)
-$(flag_verbosity)
+$(breeze::flag_pull_push_docker_images)
+$(breeze::flag_verbosity)
 "
     readonly DETAILED_USAGE_PUSH_IMAGE
     export DETAILED_USAGE_KIND_CLUSTER="
@@ -1612,8 +1612,8 @@ ${CMDNAME} kind-cluster [FLAGS] OPERATION
 ${FORMATTED_KIND_OPERATIONS}
 
 Flags:
-$(flag_airflow_variants)
-$(flag_build_docker_images)
+$(breeze::flag_airflow_variants)
+$(breeze::flag_build_docker_images)
 "
     readonly DETAILED_USAGE_KIND_CLUSTER
     export DETAILED_USAGE_SETUP_AUTOCOMPLETE="
@@ -1640,7 +1640,7 @@ ${CMDNAME} restart [FLAGS]
       especially useful if you switch between different versions of Airflow.
 
 Flags:
-$(flag_footer)
+$(breeze::flag_footer)
 "
     readonly DETAILED_USAGE_RESTART
     export DETAILED_USAGE_STATIC_CHECK="
@@ -1675,7 +1675,7 @@ ${CMDNAME} tests [FLAGS] [TEST_TARGET ..] [-- <EXTRA_ARGS>]
       '${CMDNAME} tests tests
 
 Flags:
-$(flag_footer)
+$(breeze::flag_footer)
 "
     readonly DETAILED_USAGE_TESTS
     export DETAILED_USAGE_TOGGLE_SUPPRESS_CHEATSHEET="
@@ -1715,7 +1715,7 @@ ${CMDNAME} help-all
 # Outputs:
 #     Writes the capitalized name of the variable to stdout
 #######################################################################################################
-function get_variable_from_lowercase_name() {
+function breeze::get_variable_from_lowercase_name() {
     local prefix="${1}"
     local name="${2}"
     local suffix
@@ -1730,10 +1730,10 @@ function get_variable_from_lowercase_name() {
 # Arguments:
 #     lowercase command name
 # Outputs:
-#    Usage information for the command.
+#    usage information for the command.
 #######################################################################################################
-function get_usage() {
-    get_variable_from_lowercase_name "USAGE" "${1}"
+function breeze::get_usage() {
+    breeze::get_variable_from_lowercase_name "USAGE" "${1}"
 }
 
 #######################################################################################################
@@ -1744,8 +1744,8 @@ function get_usage() {
 # Outputs:
 #    Detailed usage information for the command.
 #######################################################################################################
-function get_detailed_usage() {
-    get_variable_from_lowercase_name "DETAILED_USAGE" "${1}"
+function breeze::get_detailed_usage() {
+    breeze::get_variable_from_lowercase_name "DETAILED_USAGE" "${1}"
 }
 
 #######################################################################################################
@@ -1761,10 +1761,10 @@ function get_detailed_usage() {
 # Outputs:
 #    General usage information for all commands.
 #######################################################################################################
-function usage() {
+function breeze::usage() {
     echo "
 
-Usage: ${CMDNAME} [FLAGS] [COMMAND] -- <EXTRA_ARGS>
+usage: ${CMDNAME} [FLAGS] [COMMAND] -- <EXTRA_ARGS>
 
 By default the script enters the  CI container and drops you to bash shell, but you can choose
 one of the commands to run specific actions instead.
@@ -1774,19 +1774,19 @@ Add --help after each command to see details:
 Commands without arguments:
 "
     for subcommand in ${BREEZE_COMMANDS}; do
-        printf "  %-40s %s\n" "${subcommand}" "$(get_usage "${subcommand}")"
+        printf "  %-40s %s\n" "${subcommand}" "$(breeze::get_usage "${subcommand}")"
     done
     echo "
 Commands with arguments:
 "
     for subcommand in ${BREEZE_EXTRA_ARG_COMMANDS}; do
-        printf "  %-30s%-10s %s\n" "${subcommand}" "<ARG>" "$(get_usage "${subcommand}")"
+        printf "  %-30s%-10s %s\n" "${subcommand}" "<ARG>" "$(breeze::get_usage "${subcommand}")"
     done
     echo "
 Help commands:
 "
     for subcommand in ${BREEZE_HELP_COMMANDS}; do
-        printf "  %-40s %s\n" "${subcommand}" "$(get_usage "${subcommand}")"
+        printf "  %-40s %s\n" "${subcommand}" "$(breeze::get_usage "${subcommand}")"
     done
     echo
 }
@@ -1802,13 +1802,13 @@ Help commands:
 #    Detailed  usage information for the command
 #######################################################################################################
 # Prints detailed usage for command specified
-function detailed_usage() {
+function breeze::detailed_usage() {
     subcommand=${1}
     echo "
 
 Detailed usage for command: ${subcommand}
 
-$(get_detailed_usage "${subcommand}")
+$(breeze::get_detailed_usage "${subcommand}")
 
 "
 }
@@ -1820,7 +1820,7 @@ $(get_detailed_usage "${subcommand}")
 # Outputs:
 #    Footer common for all commands.
 #######################################################################################################
-function flag_footer() {
+function breeze::flag_footer() {
     echo "
 Run '${CMDNAME} flags' to see all applicable flags.
 "
@@ -1836,7 +1836,7 @@ Run '${CMDNAME} flags' to see all applicable flags.
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_airflow_variants() {
+function breeze::flag_airflow_variants() {
     echo "
 -p, --python <PYTHON_MAJOR_MINOR_VERSION>
         Python version used for the image. This is always major/minor version.
@@ -1862,7 +1862,7 @@ ${FORMATTED_PYTHON_MAJOR_MINOR_VERSIONS}
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_backend_variants() {
+function breeze::flag_backend_variants() {
     echo "
 -b, --backend <BACKEND>
         Backend to use for tests - it determines which database is used.
@@ -1891,7 +1891,7 @@ ${FORMATTED_MYSQL_VERSIONS}
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_production_image() {
+function breeze::flag_production_image() {
     echo "
 -I, --production-image
         Use production image for entering the environment and builds (not for tests).
@@ -1909,7 +1909,7 @@ function flag_production_image() {
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_breeze_actions() {
+function breeze::flag_breeze_actions() {
     echo "
 -d, --db-reset
         Resets the database at entry to the environment. It will drop all the tables
@@ -1942,7 +1942,7 @@ ${FORMATTED_INTEGRATIONS}
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_kubernetes_configuration() {
+function breeze::flag_kubernetes_configuration() {
     echo "
 Configuration for the KinD Kubernetes cluster and tests:
 
@@ -1988,7 +1988,7 @@ ${FORMATTED_HELM_VERSIONS}
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_local_file_mounting() {
+function breeze::flag_local_file_mounting() {
     echo "
 -l, --skip-mounting-local-sources
         Skips mounting local volume with sources - you get exactly what is in the
@@ -2007,7 +2007,7 @@ function flag_local_file_mounting() {
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_choose_different_airflow_version() {
+function breeze::flag_choose_different_airflow_version() {
     echo "
 -a, --install-airflow-version <INSTALL_AIRFLOW_VERSION>
         If specified, installs Airflow directly from PIP released version. This happens at
@@ -2028,7 +2028,7 @@ ${FORMATTED_INSTALL_AIRFLOW_VERSIONS}
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_assume_answers_to_questions() {
+function breeze::flag_assume_answers_to_questions() {
     echo "
 -y, --assume-yes
         Assume 'yes' answer to all questions.
@@ -2048,7 +2048,7 @@ function flag_assume_answers_to_questions() {
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_credentials() {
+function breeze::flag_credentials() {
     echo "
 -f, --forward-credentials
         Forwards host credentials to docker container. Use with care as it will make
@@ -2063,7 +2063,7 @@ function flag_credentials() {
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_verbosity() {
+function breeze::flag_verbosity() {
     echo "
 -v, --verbose
         Show verbose information about executed docker, kind, kubectl, helm commands. Useful for
@@ -2082,7 +2082,7 @@ function flag_verbosity() {
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_help() {
+function breeze::flag_help() {
     echo "
 -h, --help
         Shows detailed help message for the command specified.
@@ -2100,7 +2100,7 @@ function flag_help() {
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_build_docker_images() {
+function breeze::flag_build_docker_images() {
     echo "
 -F, --force-build-images
         Forces building of the local docker images. The images are rebuilt
@@ -2183,7 +2183,7 @@ ${FORMATTED_DEFAULT_PROD_EXTRAS}
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_pull_push_docker_images() {
+function breeze::flag_pull_push_docker_images() {
     echo "
 -D, --dockerhub-user
         DockerHub user used to pull, push and build images. Default: ${_BREEZE_DEFAULT_DOCKERHUB_USER:=}.
@@ -2223,7 +2223,7 @@ function flag_pull_push_docker_images() {
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flag_version_suffix() {
+function breeze::flag_version_suffix() {
     echo "
 -S, --version-suffix-for-pypi
         Adds optional suffix to the version in the generated backport package. It can be used
@@ -2242,67 +2242,67 @@ function flag_version_suffix() {
 # Outputs:
 #    Flag information.
 #######################################################################################################
-function flags() {
+function breeze::flags() {
     echo "
-$(print_line)
+$(breeze::print_line)
 
 Summary of all flags supported by Breeze:
 
-$(print_star_line)
+$(breeze::print_star_line)
  Choose Airflow variant
-$(flag_airflow_variants)
+$(breeze::flag_airflow_variants)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Choose backend to run for Airflow
-$(flag_backend_variants)
+$(breeze::flag_backend_variants)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Enable production image
-$(flag_production_image)
+$(breeze::flag_production_image)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Additional actions executed while entering breeze
-$(flag_breeze_actions)
+$(breeze::flag_breeze_actions)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Kind kubernetes and Kubernetes tests configuration(optional)
-$(flag_kubernetes_configuration)
+$(breeze::flag_kubernetes_configuration)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Manage mounting local files
-$(flag_local_file_mounting)
+$(breeze::flag_local_file_mounting)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Assume answers to questions
-$(flag_assume_answers_to_questions)
+$(breeze::flag_assume_answers_to_questions)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Choose different Airflow version to install or run
-$(flag_choose_different_airflow_version)
+$(breeze::flag_choose_different_airflow_version)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Credentials
-$(flag_credentials)
+$(breeze::flag_credentials)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Flags for building Docker images (both CI and production)
-$(flag_build_docker_images)
+$(breeze::flag_build_docker_images)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Flags for pulling/pushing Docker images (both CI and production)
-$(flag_pull_push_docker_images)
+$(breeze::flag_pull_push_docker_images)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Flags for generation of the backport packages
-$(flag_version_suffix)
+$(breeze::flag_version_suffix)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Increase verbosity of the scripts
-$(flag_verbosity)
+$(breeze::flag_verbosity)
 
-$(print_star_line)
+$(breeze::print_star_line)
  Print detailed help message
-$(flag_help)
+$(breeze::flag_help)
 "
 }
 
@@ -2313,7 +2313,7 @@ $(flag_help)
 # Outputs:
 #    Prints header line.
 #######################################################################################################
-function print_header_line() {
+function breeze::print_header_line() {
     if [ ${VERBOSE:="false"} == "true" ]; then
         echo
         printf '=%.0s' $(seq "${SCREEN_WIDTH}")
@@ -2328,12 +2328,12 @@ function print_header_line() {
 # Outputs:
 #    Prints line.
 #######################################################################################################
-function print_line() {
+function breeze::print_line() {
     printf '#%.0s' $(seq "${SCREEN_WIDTH}")
 }
 
 # Prints star line filling screen indented_screen_width
-function print_star_line() {
+function breeze::print_star_line() {
     printf '*%.0s' $(seq "${SCREEN_WIDTH}")
 }
 
@@ -2365,38 +2365,38 @@ function print_star_line() {
 #
 #######################################################################################################
 
-function read_saved_environment_variables() {
-    BACKEND="${BACKEND:=$(read_from_file BACKEND)}"
+function breeze::read_saved_environment_variables() {
+    BACKEND="${BACKEND:=$(parameters::read_from_file BACKEND)}"
     BACKEND=${BACKEND:-${_BREEZE_DEFAULT_BACKEND}}
 
-    KUBERNETES_MODE="${KUBERNETES_MODE:=$(read_from_file KUBERNETES_MODE)}"
+    KUBERNETES_MODE="${KUBERNETES_MODE:=$(parameters::read_from_file KUBERNETES_MODE)}"
     KUBERNETES_MODE=${KUBERNETES_MODE:=${_BREEZE_DEFAULT_KUBERNETES_MODE}}
 
-    KUBERNETES_VERSION="${KUBERNETES_VERSION:=$(read_from_file KUBERNETES_VERSION)}"
+    KUBERNETES_VERSION="${KUBERNETES_VERSION:=$(parameters::read_from_file KUBERNETES_VERSION)}"
     KUBERNETES_VERSION=${KUBERNETES_VERSION:=${_BREEZE_DEFAULT_KUBERNETES_VERSION}}
 
-    KIND_VERSION="${KIND_VERSION:=$(read_from_file KIND_VERSION)}"
+    KIND_VERSION="${KIND_VERSION:=$(parameters::read_from_file KIND_VERSION)}"
     KIND_VERSION=${KIND_VERSION:=${_BREEZE_DEFAULT_KIND_VERSION}}
 
-    HELM_VERSION="${HELM_VERSION:=$(read_from_file HELM_VERSION)}"
+    HELM_VERSION="${HELM_VERSION:=$(parameters::read_from_file HELM_VERSION)}"
     HELM_VERSION=${HELM_VERSION:=${_BREEZE_DEFAULT_HELM_VERSION}}
 
-    POSTGRES_VERSION="${POSTGRES_VERSION:=$(read_from_file POSTGRES_VERSION)}"
+    POSTGRES_VERSION="${POSTGRES_VERSION:=$(parameters::read_from_file POSTGRES_VERSION)}"
     POSTGRES_VERSION=${POSTGRES_VERSION:=${_BREEZE_DEFAULT_POSTGRES_VERSION}}
 
-    MYSQL_VERSION="${MYSQL_VERSION:=$(read_from_file MYSQL_VERSION)}"
+    MYSQL_VERSION="${MYSQL_VERSION:=$(parameters::read_from_file MYSQL_VERSION)}"
     MYSQL_VERSION=${MYSQL_VERSION:=${_BREEZE_DEFAULT_MYSQL_VERSION}}
 
     # Here you read DockerHub user/account that you use
     # You can populate your own images in DockerHub this way and work with the,
     # You can override it with "--dockerhub-user" option and it will be stored in .build directory
-    DOCKERHUB_USER="${DOCKERHUB_USER:=$(read_from_file DOCKERHUB_USER)}"
+    DOCKERHUB_USER="${DOCKERHUB_USER:=$(parameters::read_from_file DOCKERHUB_USER)}"
     DOCKERHUB_USER="${DOCKERHUB_USER:=${_BREEZE_DEFAULT_DOCKERHUB_USER}}"
 
     # Here you read DockerHub repo that you use
     # You can populate your own images in DockerHub this way and work with them
     # You can override it with "--dockerhub-repo" option and it will be stored in .build directory
-    DOCKERHUB_REPO="${DOCKERHUB_REPO:=$(read_from_file DOCKERHUB_REPO)}"
+    DOCKERHUB_REPO="${DOCKERHUB_REPO:=$(parameters::read_from_file DOCKERHUB_REPO)}"
     DOCKERHUB_REPO="${DOCKERHUB_REPO:=${_BREEZE_DEFAULT_DOCKERHUB_REPO}}"
 }
 
@@ -2427,8 +2427,8 @@ function read_saved_environment_variables() {
 #
 # Output: saved variable files in .build,
 #######################################################################################################
-function check_and_save_all_params() {
-    check_and_save_allowed_param "PYTHON_MAJOR_MINOR_VERSION" "Python version" "--python"
+function breeze::check_and_save_all_params() {
+    parameters::check_and_save_allowed_param "PYTHON_MAJOR_MINOR_VERSION" "Python version" "--python"
 
     if [[ -n "${INSTALL_AIRFLOW_REFERENCE=}" ]]; then
         if [[ ${INSTALL_AIRFLOW_REFERENCE=} == *1_10* ]]; then
@@ -2452,17 +2452,17 @@ function check_and_save_all_params() {
         fi
     fi
 
-    check_and_save_allowed_param "BACKEND" "backend" "--backend"
-    check_and_save_allowed_param "KUBERNETES_MODE" "Kubernetes mode" "--kubernetes-mode"
-    check_and_save_allowed_param "KUBERNETES_VERSION" "Kubernetes version" "--kubernetes-version"
-    check_and_save_allowed_param "KIND_VERSION" "KinD version" "--kind-version"
-    check_and_save_allowed_param "HELM_VERSION" "Helm version" "--helm-version"
-    check_and_save_allowed_param "POSTGRES_VERSION" "Postgres version" "--postgres-version"
-    check_and_save_allowed_param "MYSQL_VERSION" "Mysql version" "--mysql-version"
+    parameters::check_and_save_allowed_param "BACKEND" "backend" "--backend"
+    parameters::check_and_save_allowed_param "KUBERNETES_MODE" "Kubernetes mode" "--kubernetes-mode"
+    parameters::check_and_save_allowed_param "KUBERNETES_VERSION" "Kubernetes version" "--kubernetes-version"
+    parameters::check_and_save_allowed_param "KIND_VERSION" "KinD version" "--kind-version"
+    parameters::check_and_save_allowed_param "HELM_VERSION" "Helm version" "--helm-version"
+    parameters::check_and_save_allowed_param "POSTGRES_VERSION" "Postgres version" "--postgres-version"
+    parameters::check_and_save_allowed_param "MYSQL_VERSION" "Mysql version" "--mysql-version"
 
     # Can't verify those - they can be anything, so let's just save them
-    save_to_file DOCKERHUB_USER
-    save_to_file DOCKERHUB_REPO
+    parameters::save_to_file DOCKERHUB_USER
+    parameters::save_to_file DOCKERHUB_REPO
 }
 
 #######################################################################################################
@@ -2477,17 +2477,17 @@ function check_and_save_all_params() {
 #     MYSQL_HOST_PORT
 #
 #######################################################################################################
-function print_cheatsheet() {
+function breeze::print_cheatsheet() {
     if [[ ! -f ${SUPPRESS_CHEATSHEET_FILE} && ${command_to_run} == "enter_breeze" ]]; then
         echo
         echo
-        print_line
+        breeze::print_line
         echo
         echo "                                  Airflow Breeze CHEATSHEET"
         echo
         set +e
         if ! command -v breeze; then
-            print_line
+            breeze::print_line
             echo
             echo " Adding breeze to your path:"
             echo "    When you exit the environment, you can add sources of Airflow to the path - you can"
@@ -2497,7 +2497,7 @@ function print_cheatsheet() {
             echo
         fi
         set -e
-        print_line
+        breeze::print_line
 
         echo
         echo " Port forwarding:"
@@ -2525,23 +2525,23 @@ function print_cheatsheet() {
 # Used global constants:
 #     CMDNAME
 #######################################################################################################
-function print_setup_instructions() {
+function breeze::print_setup_instructions() {
     if [[ ${command_to_run} == "enter_breeze" ]]; then
         # shellcheck disable=SC2034  # Unused variables left for comp_breeze usage
         if ! typeset -f "_comp_breeze" >/dev/null; then
-            print_line
+            breeze::print_line
             echo
             echo "  You can setup autocomplete by running '${CMDNAME} setup-autocomplete'"
             echo
             echo
         fi
-        print_line
+        breeze::print_line
         echo
         echo "  You can toggle ascii/cheatsheet by running:"
         echo "      * ${CMDNAME} toggle-suppress-cheatsheet"
         echo "      * ${CMDNAME} toggle-suppress-asciiart"
         echo
-        print_line
+        breeze::print_line
         echo
         echo
         echo
@@ -2555,7 +2555,7 @@ function print_setup_instructions() {
 # this is used in case static check command is used.
 #
 #######################################################################################################
-function make_sure_precommit_is_installed() {
+function breeze::make_sure_precommit_is_installed() {
     echo
     echo "Making sure pre-commit is installed"
     echo
@@ -2587,7 +2587,7 @@ function make_sure_precommit_is_installed() {
 #    BUILT_CI_IMAGE_FLAG_FILE
 #
 #######################################################################################################
-function remove_images() {
+function breeze::remove_images() {
     docker rmi "${PYTHON_BASE_IMAGE}"  || true
     docker rmi "${AIRFLOW_CI_IMAGE}"   || true
     docker rmi "${AIRFLOW_PROD_IMAGE}" || true
@@ -2602,7 +2602,7 @@ function remove_images() {
 #   static_check
 #
 #######################################################################################################
-function run_static_checks() {
+function breeze::run_static_checks() {
     if [[ ${static_check} == "all" ]]; then
         echo
         echo "Running: pre-commit run" "${EXTRA_STATIC_CHECK_OPTIONS[@]}" "$@"
@@ -2642,49 +2642,49 @@ function run_static_checks() {
 #   command_to_run
 #
 #######################################################################################################
-function run_build_command() {
+function breeze::run_build_command() {
     case "${command_to_run}" in
     run_tests | run_docker_compose)
-        prepare_ci_build
-        rebuild_ci_image_if_needed
+        build_images::prepare_ci_build
+        build_images::rebuild_ci_image_if_needed
         ;;
     enter_breeze)
         if [[ ${PRODUCTION_IMAGE} == "true" ]]; then
-            prepare_prod_build
+            build_images::prepare_prod_build
         else
-            prepare_ci_build
-            rebuild_ci_image_if_needed
+            build_images::prepare_ci_build
+            build_images::rebuild_ci_image_if_needed
         fi
         ;;
     build_docs | perform_static_checks | perform_generate_constraints | perform_prepare_backport_readme | perform_prepare_backport_packages)
-        prepare_ci_build
-        rebuild_ci_image_if_needed
+        build_images::prepare_ci_build
+        build_images::rebuild_ci_image_if_needed
         ;;
     perform_push_image)
         if [[ ${PRODUCTION_IMAGE} == "true" ]]; then
-            prepare_prod_build
+            build_images::prepare_prod_build
         else
-            prepare_ci_build
-            rebuild_ci_image_if_needed
+            build_images::prepare_ci_build
+            build_images::rebuild_ci_image_if_needed
         fi
         ;;
     build_image)
         if [[ ${PRODUCTION_IMAGE} == "true" ]]; then
-            prepare_prod_build
-            build_prod_images
+            build_images::prepare_prod_build
+            build_images::build_prod_images
         else
-            prepare_ci_build
-            calculate_md5sum_for_all_files
-            build_ci_image
-            update_all_md5_files
-            build_ci_image_manifest
+            build_images::prepare_ci_build
+            md5sum::calculate_md5sum_for_all_files
+            build_images::build_ci_image
+            md5sum::update_all_md5
+            build_images::build_ci_image_manifest
         fi
         ;;
     cleanup_image | run_exec)
         if [[ ${PRODUCTION_IMAGE} == "true" ]]; then
-            prepare_prod_build
+            build_images::prepare_prod_build
         else
-            prepare_ci_build
+            build_images::prepare_ci_build
         fi
         ;;
     perform_initialize_local_virtualenv | perform_setup_autocomplete | toggle_suppress_cheatsheet | toggle_suppress_asciiart ) ;;
@@ -2702,8 +2702,8 @@ function run_build_command() {
             echo "Checks status of KinD cluster"
         elif [[ ${KIND_CLUSTER_OPERATION} == "deploy" ]]; then
             echo "Deploys Airflow to KinD cluster"
-            prepare_prod_build
-            build_prod_images
+            build_images::prepare_prod_build
+            build_images::build_prod_images
         elif [[ ${KIND_CLUSTER_OPERATION} == "test" ]]; then
             echo "Run Kubernetes tests with the KinD cluster "
         elif [[ ${KIND_CLUSTER_OPERATION} == "shell" ]]; then
@@ -2753,7 +2753,7 @@ function run_build_command() {
 # Set Global variables:
 #     RUN_TESTS
 #######################################################################################################
-function run_breeze_command() {
+function breeze::run_breeze_command() {
     set +u
     local dc_run_file
     if [[ ${PRODUCTION_IMAGE} == "true" ]]; then
@@ -2799,43 +2799,43 @@ function run_breeze_command() {
         set -u
         ;;
     perform_static_checks)
-        make_sure_precommit_is_installed
-        run_static_checks "${@}"
+        breeze::make_sure_precommit_is_installed
+        breeze::run_static_checks "${@}"
         ;;
     build_image) ;;
 
     cleanup_image)
-        remove_images
+        breeze::remove_images
         ;;
     perform_generate_constraints)
-        run_generate_constraints
+        runs::run_generate_constraints
         ;;
     perform_prepare_backport_packages)
-        run_prepare_backport_packages "${@}"
+        runs::run_prepare_backport_packages "${@}"
         ;;
     perform_prepare_backport_readme)
-        run_prepare_backport_readme "${@}"
+        runs::run_prepare_backport_readme "${@}"
         ;;
     perform_push_image)
         if [[ ${PRODUCTION_IMAGE} == "true" ]]; then
-            push_prod_images
+            push_pull_remove_images::push_prod_images
         else
-            push_ci_images
+            push_pull_remove_images::push_ci_images
         fi
         ;;
     perform_initialize_local_virtualenv)
-        initialize_virtualenv
+        breeze::initialize_virtualenv
         ;;
     perform_setup_autocomplete)
-        setup_autocomplete
+        breeze::setup_autocomplete
         ;;
     manage_kind_cluster)
-        make_sure_kubernetes_tools_are_installed
-        get_kind_cluster_name
-        perform_kind_cluster_operation "${KIND_CLUSTER_OPERATION}"
+        kind::make_sure_kubernetes_tools_are_installed
+        kind::get_kind_cluster_name
+        kind::perform_kind_cluster_operation "${KIND_CLUSTER_OPERATION}"
         ;;
     build_docs)
-        run_docs "${@}"
+        runs::run_docs "${@}"
         ;;
     toggle_suppress_cheatsheet)
         if [[ -f "${SUPPRESS_CHEATSHEET_FILE}" ]]; then
@@ -2882,73 +2882,73 @@ function run_breeze_command() {
 #      4. DEFAULT_PYTHON_MAJOR_MINOR_VERSION from scripts/ci/libraries/_initialization.sh
 #
 # Here points 2. and 3. are realised. If result is empty string , the 4. will be set in
-#      the next step (basic_sanity_checks() is called and the version is still not set by then)
+#      the next step (sanity_checks::basic_sanity_checks() is called and the version is still not set by then)
 #      finally, if  --python flag is specified, it will override whatever is set above.
 #
-# We need to run after initialize_common_environment (so that read_from_file function is present)
+# We need to run after initialization::initialize_common_environment (so that parameters::read_from_file function is present)
 # But before we set the default value for Python
 #
 # Used and modified global constants:
 #     PYTHON_MAJOR_MINOR_VERSION
 #######################################################################################################
-function determine_python_version_to_use_in_breeze() {
-    PYTHON_MAJOR_MINOR_VERSION="${PYTHON_MAJOR_MINOR_VERSION:=$(read_from_file PYTHON_MAJOR_MINOR_VERSION)}"
+function breeze::determine_python_version_to_use_in_breeze() {
+    PYTHON_MAJOR_MINOR_VERSION="${PYTHON_MAJOR_MINOR_VERSION:=$(parameters::read_from_file PYTHON_MAJOR_MINOR_VERSION)}"
     export PYTHON_MAJOR_MINOR_VERSION
 }
 
 
-setup_default_breeze_constants
+breeze::setup_default_breeze_constants
 
-initialize_common_environment
+initialization::initialize_common_environment
 
-determine_python_version_to_use_in_breeze
+breeze::determine_python_version_to_use_in_breeze
 
-basic_sanity_checks
+sanity_checks::basic_sanity_checks
 
-script_start
+start_end::script_start
 
-trap script_end EXIT
+traps::add_trap start_end::script_end EXIT
 
-prepare_formatted_versions
+breeze::prepare_formatted_versions
 
-prepare_usage
+breeze::prepare_usage
 
 set +u
-parse_arguments "${@}"
+breeze::parse_arguments "${@}"
 
-print_header_line
+breeze::print_header_line
 
-forget_last_answer
+build_images::forget_last_answer
 
-read_saved_environment_variables
+breeze::read_saved_environment_variables
 
-check_and_save_all_params
+breeze::check_and_save_all_params
 
-determine_docker_cache_strategy
+build_images::determine_docker_cache_strategy
 
-get_docker_image_names
+build_images::get_docker_image_names
 
-make_constants_read_only
+initialization::make_constants_read_only
 
-sanitize_mounted_files
+sanity_checks::sanitize_mounted_files
 
-prepare_command_files
+breeze::prepare_command_files
 
-run_build_command
+breeze::run_build_command
 
-print_header_line
+breeze::print_header_line
 
-print_badge
+breeze::print_badge
 
-print_cheatsheet
+breeze::print_cheatsheet
 
-print_setup_instructions
+breeze::print_setup_instructions
 
 set +u # Account for an empty array
-run_breeze_command "${REMAINING_ARGS[@]}"
+breeze::run_breeze_command "${REMAINING_ARGS[@]}"
 
 set +u # Account for an empty array
 if [[ -n ${second_command_to_run} ]]; then
     command_to_run=${second_command_to_run}
-    run_breeze_command "${REMAINING_ARGS[@]}"
+    breeze::run_breeze_command "${REMAINING_ARGS[@]}"
 fi

--- a/scripts/ci/backport_packages/ci_prepare_backport_packages.sh
+++ b/scripts/ci/backport_packages/ci_prepare_backport_packages.sh
@@ -18,8 +18,8 @@
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
-run_prepare_backport_packages "$@"
+runs::run_prepare_backport_packages "$@"

--- a/scripts/ci/backport_packages/ci_prepare_backport_readme.sh
+++ b/scripts/ci/backport_packages/ci_prepare_backport_readme.sh
@@ -18,8 +18,8 @@
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
-run_prepare_backport_readme "$@"
+runs::run_prepare_backport_readme "$@"

--- a/scripts/ci/backport_packages/ci_test_backport_packages_import_all_classes.sh
+++ b/scripts/ci/backport_packages/ci_test_backport_packages_import_all_classes.sh
@@ -31,8 +31,8 @@ function run_test_package_import_all_classes() {
         "--" "/opt/airflow/scripts/in_container/run_test_package_import_all_classes.sh"
 }
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
 run_test_package_import_all_classes

--- a/scripts/ci/backport_packages/ci_test_backport_packages_install_separately.sh
+++ b/scripts/ci/backport_packages/ci_test_backport_packages_install_separately.sh
@@ -26,8 +26,8 @@ function run_test_package_installation_separately() {
         "--" "/opt/airflow/scripts/in_container/run_test_package_installation_separately.sh"
 }
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
 run_test_package_installation_separately

--- a/scripts/ci/constraints/ci_generate_constraints.sh
+++ b/scripts/ci/constraints/ci_generate_constraints.sh
@@ -18,8 +18,8 @@
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
-run_generate_constraints
+runs::run_generate_constraints

--- a/scripts/ci/docs/ci_docs.sh
+++ b/scripts/ci/docs/ci_docs.sh
@@ -18,8 +18,8 @@
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
-run_docs "${@}"
+runs::run_docs "${@}"

--- a/scripts/ci/images/ci_build_dockerhub.sh
+++ b/scripts/ci/images/ci_build_dockerhub.sh
@@ -55,17 +55,17 @@ if [[ ${DOCKER_TAG} == *python*-ci ]]; then
     echo "Building CI image"
     echo
     rm -rf "${BUILD_CACHE_DIR}"
-    prepare_ci_build
-    rebuild_ci_image_if_needed
-    push_ci_images
+    build_images::prepare_ci_build
+    build_images::rebuild_ci_image_if_needed
+    push_pull_remove_images::push_ci_images
 elif [[ ${DOCKER_TAG} == *python* ]]; then
     echo
     echo "Building prod image"
     echo
     rm -rf "${BUILD_CACHE_DIR}"
-    prepare_prod_build
-    build_prod_images
-    push_prod_images
+    build_images::prepare_prod_build
+    build_images::build_prod_images
+    push_pull_remove_images::push_prod_images
 else
     echo
     echo "Skipping the build in Dockerhub. The tag is not good: ${DOCKER_TAG}"

--- a/scripts/ci/images/ci_prepare_ci_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_ci_image_on_ci.sh
@@ -21,14 +21,14 @@
 # Builds or waits for the CI image in the CI environment
 # Depending on "USE_GITHUB_REGISTRY" and "GITHUB_REGISTRY_WAIT_FOR_IMAGE" setting
 function build_ci_image_on_ci() {
-    prepare_ci_build
+    build_images::prepare_ci_build
 
     rm -rf "${BUILD_CACHE_DIR}"
     mkdir -pv "${BUILD_CACHE_DIR}"
 
     if [[ ${USE_GITHUB_REGISTRY} == "true" && ${GITHUB_REGISTRY_WAIT_FOR_IMAGE} == "true" ]]; then
         # Pretend that the image was build. We already have image with the right sources baked in!
-        calculate_md5sum_for_all_files
+        md5sum::calculate_md5sum_for_all_files
 
         # Tries to wait for the images indefinitely
         # skips further image checks - since we already have the target image
@@ -39,16 +39,16 @@ function build_ci_image_on_ci() {
         fi
         # first we pull base python image. We will need it to re-push it after master build
         # Becoming the new "latest" image for other builds
-        wait_for_image_tag "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}" \
+        build_images::wait_for_image_tag "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}" \
             "${PYTHON_TAG_SUFFIX}" "${PYTHON_BASE_IMAGE}"
 
         # And then the base image
-        wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}" \
+        build_images::wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}" \
             ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_CI_IMAGE}"
 
-        update_all_md5_files
+        md5sum::update_all_md5
     else
-        rebuild_ci_image_if_needed
+        build_images::rebuild_ci_image_if_needed
     fi
 
     # Disable force pulling forced above this is needed for the subsequent scripts so that

--- a/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
@@ -21,7 +21,7 @@
 # Builds or waits for the PROD image in the CI environment
 # Depending on the "USE_GITHUB_REGISTRY" and "GITHUB_REGISTRY_WAIT_FOR_IMAGE" setting
 function build_prod_images_on_ci() {
-    prepare_prod_build
+    build_images::prepare_prod_build
 
     rm -rf "${BUILD_CACHE_DIR}"
     mkdir -pv "${BUILD_CACHE_DIR}"
@@ -31,13 +31,13 @@ function build_prod_images_on_ci() {
         # Tries to wait for the image indefinitely
         # skips further image checks - since we already have the target image
 
-        wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}" \
+        build_images::wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}" \
             ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_IMAGE}"
 
-        wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}" \
+        build_images::wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}" \
             ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_BUILD_IMAGE}"
     else
-        build_prod_images
+        build_images::build_prod_images
     fi
 
 

--- a/scripts/ci/images/ci_push_ci_images.sh
+++ b/scripts/ci/images/ci_push_ci_images.sh
@@ -18,6 +18,6 @@
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-push_ci_images
+push_pull_remove_images::push_ci_images

--- a/scripts/ci/images/ci_push_production_images.sh
+++ b/scripts/ci/images/ci_push_production_images.sh
@@ -18,6 +18,6 @@
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-prepare_prod_build
+build_images::prepare_prod_build
 
-push_prod_images
+push_pull_remove_images::push_prod_images

--- a/scripts/ci/images/ci_wait_for_all_ci_images.sh
+++ b/scripts/ci/images/ci_wait_for_all_ci_images.sh
@@ -47,10 +47,10 @@ echo
 # shellcheck source=scripts/ci/libraries/_all_libs.sh
 source "${AIRFLOW_SOURCES}/scripts/ci/libraries/_all_libs.sh"
 
-initialize_common_environment
+initialization::initialize_common_environment
 
 for PYTHON_MAJOR_MINOR_VERSION in "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[@]}"
 do
     export AIRFLOW_CI_IMAGE_NAME="${BRANCH_NAME}-python${PYTHON_MAJOR_MINOR_VERSION}-ci"
-    wait_for_github_registry_image "${AIRFLOW_CI_IMAGE_NAME}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+    push_pull_remove_images::wait_for_github_registry_image "${AIRFLOW_CI_IMAGE_NAME}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
 done

--- a/scripts/ci/images/ci_wait_for_all_prod_images.sh
+++ b/scripts/ci/images/ci_wait_for_all_prod_images.sh
@@ -47,12 +47,12 @@ echo
 # shellcheck source=scripts/ci/libraries/_all_libs.sh
 source "${AIRFLOW_SOURCES}/scripts/ci/libraries/_all_libs.sh"
 
-initialize_common_environment
+initialization::initialize_common_environment
 
 for PYTHON_MAJOR_MINOR_VERSION in "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[@]}"
 do
     export AIRFLOW_PROD_IMAGE_NAME="${BRANCH_NAME}-python${PYTHON_MAJOR_MINOR_VERSION}"
     export AIRFLOW_PROD_BUILD_IMAGE_NAME="${BRANCH_NAME}-python${PYTHON_MAJOR_MINOR_VERSION}-build"
-    wait_for_github_registry_image "${AIRFLOW_PROD_IMAGE_NAME}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
-    wait_for_github_registry_image "${AIRFLOW_PROD_BUILD_IMAGE_NAME}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+    push_pull_remove_images::wait_for_github_registry_image "${AIRFLOW_PROD_IMAGE_NAME}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+    push_pull_remove_images::wait_for_github_registry_image "${AIRFLOW_PROD_BUILD_IMAGE_NAME}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
 done

--- a/scripts/ci/kubernetes/ci_deploy_app_to_kubernetes.sh
+++ b/scripts/ci/kubernetes/ci_deploy_app_to_kubernetes.sh
@@ -19,14 +19,14 @@
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 set -euo pipefail
 
-add_trap "dump_kind_logs" EXIT HUP INT TERM
+traps::add_trap "kind::dump_kind_logs" EXIT HUP INT TERM
 
-make_sure_kubernetes_tools_are_installed
-get_kind_cluster_name
-prepare_prod_build
-build_prod_images
-build_image_for_kubernetes_tests
-load_image_to_kind_cluster
-deploy_airflow_with_helm
-forward_port_to_kind_webserver
-deploy_test_kubernetes_resources
+kind::make_sure_kubernetes_tools_are_installed
+kind::get_kind_cluster_name
+build_images::prepare_prod_build
+build_images::build_prod_images
+kind::build_image_for_kubernetes_tests
+kind::load_image_to_kind_cluster
+kind::deploy_airflow_with_helm
+kind::forward_port_to_kind_webserver
+kind::deploy_test_kubernetes_resources

--- a/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
@@ -18,10 +18,10 @@
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-make_sure_kubernetes_tools_are_installed
-get_kind_cluster_name
+kind::make_sure_kubernetes_tools_are_installed
+kind::get_kind_cluster_name
 
-add_trap dump_kind_logs EXIT HUP INT TERM
+traps::add_trap kind::dump_kind_logs EXIT HUP INT TERM
 
 INTERACTIVE="false"
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -21,7 +21,7 @@
 CURRENT_PYTHON_MAJOR_MINOR_VERSIONS=()
 
 # Creates directories for Breeze
-function create_directories() {
+function initialization::create_directories() {
     # This folder is mounted to inside the container in /files folder. This is the way how
     # We can exchange DAGs, scripts, packages etc with the container environment
     export FILES_DIR="${AIRFLOW_SOURCES}/files"
@@ -51,7 +51,7 @@ function create_directories() {
     readonly CACHE_TMP_FILE_DIR
 
     if [[ ${SKIP_CACHE_DELETION=} != "true" ]]; then
-        add_trap "rm -rf -- '${CACHE_TMP_FILE_DIR}'" EXIT HUP INT TERM
+        traps::add_trap "rm -rf -- '${CACHE_TMP_FILE_DIR}'" EXIT HUP INT TERM
     fi
 
     OUTPUT_LOG="${CACHE_TMP_FILE_DIR}/out.log"
@@ -60,7 +60,7 @@ function create_directories() {
 }
 
 # Very basic variables that MUST be set
-function initialize_base_variables() {
+function initialization::initialize_base_variables() {
     # Default port numbers for forwarded ports
     export WEBSERVER_HOST_PORT=${WEBSERVER_HOST_PORT:="28080"}
     export POSTGRES_HOST_PORT=${POSTGRES_HOST_PORT:="25433"}
@@ -100,7 +100,7 @@ function initialize_base_variables() {
 }
 
 # Determine current branch
-function initialize_branch_variables() {
+function initialization::initialize_branch_variables() {
     # Default branch used - this will be different in different branches
     export DEFAULT_BRANCH="master"
     export DEFAULT_CONSTRAINTS_BRANCH="constraints-master"
@@ -112,7 +112,7 @@ function initialize_branch_variables() {
 }
 
 # Determine dockerhub user/repo used for push/pull
-function initialize_dockerhub_variables() {
+function initialization::initialize_dockerhub_variables() {
     # You can override DOCKERHUB_USER to use your own DockerHub account and play with your
     # own docker images. In this case you can build images locally and push them
     export DOCKERHUB_USER=${DOCKERHUB_USER:="apache"}
@@ -123,7 +123,7 @@ function initialize_dockerhub_variables() {
 }
 
 # Determine available integrations
-function initialize_available_integrations() {
+function initialization::initialize_available_integrations() {
     export AVAILABLE_INTEGRATIONS="cassandra kerberos mongo openldap presto rabbitmq redis"
 }
 
@@ -132,7 +132,7 @@ function initialize_available_integrations() {
 FILES_FOR_REBUILD_CHECK=()
 
 # Determine which files trigger rebuild check
-function initialize_files_for_rebuild_check() {
+function initialization::initialize_files_for_rebuild_check() {
     FILES_FOR_REBUILD_CHECK+=(
         "setup.py"
         "setup.cfg"
@@ -161,7 +161,7 @@ FILES_TO_CLEANUP_ON_EXIT=()
 EXTRA_DOCKER_FLAGS=()
 
 # Determine behaviour of mounting sources to the container
-function initialize_mount_variables() {
+function initialization::initialize_mount_variables() {
 
     # Whether necessary for airflow run local sources are mounted to docker
     export MOUNT_LOCAL_SOURCES=${MOUNT_LOCAL_SOURCES:="true"}
@@ -170,20 +170,20 @@ function initialize_mount_variables() {
     export MOUNT_FILES=${MOUNT_FILES:="true"}
 
     if [[ ${MOUNT_LOCAL_SOURCES} == "true" ]]; then
-        print_info
-        print_info "Mounting necessary host volumes to Docker"
-        print_info
-        read -r -a EXTRA_DOCKER_FLAGS <<<"$(convert_local_mounts_to_docker_params)"
+        verbosity::print_info
+        verbosity::print_info "Mounting necessary host volumes to Docker"
+        verbosity::print_info
+        read -r -a EXTRA_DOCKER_FLAGS <<<"$(local_mounts::convert_local_mounts_to_docker_params)"
     else
-        print_info
-        print_info "Skip mounting host volumes to Docker"
-        print_info
+        verbosity::print_info
+        verbosity::print_info "Skip mounting host volumes to Docker"
+        verbosity::print_info
     fi
 
     if [[ ${MOUNT_FILES} == "true" ]]; then
-        print_info
-        print_info "Mounting files folder to Docker"
-        print_info
+        verbosity::print_info
+        verbosity::print_info "Mounting files folder to Docker"
+        verbosity::print_info
         EXTRA_DOCKER_FLAGS+=(
             "-v" "${AIRFLOW_SOURCES}/files:/files"
         )
@@ -197,7 +197,7 @@ function initialize_mount_variables() {
 }
 
 # Determine values of force settings
-function initialize_force_variables() {
+function initialization::initialize_force_variables() {
     # Whether necessary for airflow run local sources are mounted to docker
     export FORCE_PULL_IMAGES=${FORCE_PULL_IMAGES:="false"}
 
@@ -219,7 +219,7 @@ function initialize_force_variables() {
 }
 
 # Determine information about the host
-function initialize_host_variables() {
+function initialization::initialize_host_variables() {
     # Set host user id to current user. This is used to set the ownership properly when exiting
     # The container on Linux - all files created inside docker are created with root user
     # but they should be restored back to the host user
@@ -252,7 +252,7 @@ function initialize_host_variables() {
 }
 
 # Determine image augmentation parameters
-function initialize_image_build_variables() {
+function initialization::initialize_image_build_variables() {
     # Default extras used for building CI image
     export DEFAULT_CI_EXTRAS="devel_ci"
 
@@ -292,7 +292,7 @@ function initialize_image_build_variables() {
 }
 
 # Determine version suffixes used to build backport packages
-function initialize_version_suffixes_for_package_building() {
+function initialization::initialize_version_suffixes_for_package_building() {
     # Version suffix for PyPI packaging
     export VERSION_SUFFIX_FOR_PYPI=""
     # Artifact name suffix for SVN packaging
@@ -300,7 +300,7 @@ function initialize_version_suffixes_for_package_building() {
 }
 
 # Determine versions of kubernetes cluster and tools used
-function initialize_kubernetes_variables() {
+function initialization::initialize_kubernetes_variables() {
     # By default we assume the kubernetes cluster is not being started
     export ENABLE_KIND_CLUSTER=${ENABLE_KIND_CLUSTER:="false"}
     # Default Kubernetes version
@@ -331,13 +331,13 @@ function initialize_kubernetes_variables() {
     readonly KUBECTL_BINARY_PATH
 }
 
-function initialize_git_variables() {
+function initialization::initialize_git_variables() {
     # SHA of the commit for the current sources
     COMMIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo "Unknown")"
     export COMMIT_SHA
 }
 
-function initialize_github_variables() {
+function initialization::initialize_github_variables() {
     # Defaults for interacting with GitHub
     export USE_GITHUB_REGISTRY=${USE_GITHUB_REGISTRY:="false"}
 
@@ -358,24 +358,24 @@ function initialize_github_variables() {
 }
 
 # Common environment that is initialized by both Breeze and CI scripts
-function initialize_common_environment() {
-    create_directories
-    initialize_base_variables
-    initialize_branch_variables
-    initialize_available_integrations
-    initialize_files_for_rebuild_check
-    initialize_dockerhub_variables
-    initialize_mount_variables
-    initialize_force_variables
-    initialize_host_variables
-    initialize_image_build_variables
-    initialize_version_suffixes_for_package_building
-    initialize_kubernetes_variables
-    initialize_git_variables
-    initialize_github_variables
+function initialization::initialize_common_environment() {
+    initialization::create_directories
+    initialization::initialize_base_variables
+    initialization::initialize_branch_variables
+    initialization::initialize_available_integrations
+    initialization::initialize_files_for_rebuild_check
+    initialization::initialize_dockerhub_variables
+    initialization::initialize_mount_variables
+    initialization::initialize_force_variables
+    initialization::initialize_host_variables
+    initialization::initialize_image_build_variables
+    initialization::initialize_version_suffixes_for_package_building
+    initialization::initialize_kubernetes_variables
+    initialization::initialize_git_variables
+    initialization::initialize_github_variables
 }
 
-function set_default_python_version_if_empty() {
+function initialization::set_default_python_version_if_empty() {
     # default version of python used to tag the "master" and "latest" images in DockerHub
     export DEFAULT_PYTHON_MAJOR_MINOR_VERSION=3.6
 
@@ -384,7 +384,7 @@ function set_default_python_version_if_empty() {
 
 }
 
-function summarize_ci_environment() {
+function initialization::summarize_ci_environment() {
     cat <<EOF
 
 Configured build variables:
@@ -476,7 +476,7 @@ EOF
 # (This makes it easy to move between different CI systems)
 # This function maps CI-specific variables into a generic ones (prefixed with CI_) that
 # we used in other scripts
-function get_environment_for_builds_on_ci() {
+function initialization::get_environment_for_builds_on_ci() {
     if [[ ${GITHUB_ACTIONS:=} == "true" ]]; then
         export CI_TARGET_REPO="${GITHUB_REPOSITORY}"
         export CI_TARGET_BRANCH="${GITHUB_BASE_REF:="master"}"
@@ -494,12 +494,12 @@ function get_environment_for_builds_on_ci() {
             BRANCH_EXISTS=$(git ls-remote --heads \
                 "https://github.com/${CI_SOURCE_REPO}.git" "${CI_SOURCE_BRANCH}" || true)
             if [[ -z ${BRANCH_EXISTS=} ]]; then
-                print_info
-                print_info "https://github.com/${CI_SOURCE_REPO}.git Branch ${CI_SOURCE_BRANCH} does not exist"
-                print_info
-                print_info
-                print_info "Fallback to https://github.com/${CI_TARGET_REPO}.git Branch ${CI_TARGET_BRANCH}"
-                print_info
+                verbosity::print_info
+                verbosity::print_info "https://github.com/${CI_SOURCE_REPO}.git Branch ${CI_SOURCE_BRANCH} does not exist"
+                verbosity::print_info
+                verbosity::print_info
+                verbosity::print_info "Fallback to https://github.com/${CI_TARGET_REPO}.git Branch ${CI_TARGET_BRANCH}"
+                verbosity::print_info
                 # Fallback to the target repository if the repo does not exist
                 export CI_SOURCE_REPO="${CI_TARGET_REPO}"
                 export CI_SOURCE_BRANCH="${CI_TARGET_BRANCH}"
@@ -522,7 +522,7 @@ function get_environment_for_builds_on_ci() {
     fi
 
     if [[ ${VERBOSE} == "true" && ${PRINT_INFO_FROM_SCRIPTS} == "true" ]]; then
-        summarize_ci_environment
+        initialization::summarize_ci_environment
     fi
 }
 
@@ -530,7 +530,7 @@ function get_environment_for_builds_on_ci() {
 
 # By the time this method is run, nearly all constants have been already set to the final values
 # so we can set them as readonly.
-function make_constants_read_only() {
+function initialization::make_constants_read_only() {
     # Set the arguments as read-only
     readonly PYTHON_MAJOR_MINOR_VERSION
 

--- a/scripts/ci/libraries/_local_mounts.sh
+++ b/scripts/ci/libraries/_local_mounts.sh
@@ -20,7 +20,7 @@
 # By default not the whole airflow sources directory is mounted because there are often
 # artifacts created there (for example .egg-info files) that are breaking the capability
 # of running different python versions in Breeze. So we only mount what is needed by default.
-function generate_local_mounts_list {
+function local_mounts::generate_local_mounts_list {
     local prefix="$1"
     LOCAL_MOUNTS=(
         "$prefix".bash_aliases:/root/.bash_aliases:cached
@@ -59,8 +59,8 @@ function generate_local_mounts_list {
 # Converts the local mounts that we defined above to the right set of -v
 # volume mappings in docker-compose file. This is needed so that we only
 # maintain the volumes in one place (above)
-function convert_local_mounts_to_docker_params() {
-    generate_local_mounts_list "${AIRFLOW_SOURCES}/"
+function local_mounts::convert_local_mounts_to_docker_params() {
+    local_mounts::generate_local_mounts_list "${AIRFLOW_SOURCES}/"
     # Bash can't "return" arrays, so we need to quote any special characters
     printf -- '-v %q ' "${LOCAL_MOUNTS[@]}"
 }

--- a/scripts/ci/libraries/_parameters.sh
+++ b/scripts/ci/libraries/_parameters.sh
@@ -17,12 +17,12 @@
 # under the License.
 
 # Reads environment variable passed as first parameter from the .build cache file
-function read_from_file {
+function parameters::read_from_file {
     cat "${BUILD_CACHE_DIR}/.$1" 2>/dev/null || true
 }
 
 # Saves environment variable passed as first parameter to the .build cache file
-function save_to_file {
+function parameters::save_to_file {
     # shellcheck disable=SC2005
     echo "$(eval echo "\$$1")" > "${BUILD_CACHE_DIR}/.$1"
 }
@@ -31,7 +31,7 @@ function save_to_file {
 # and if it is, it saves it to .build cache file. In case the parameter is wrong, the
 # saved variable is removed (so that bad value is not used again in case it comes from there)
 # and exits with an error
-function check_and_save_allowed_param {
+function parameters::check_and_save_allowed_param {
     _VARIABLE_NAME="${1}"
     _VARIABLE_DESCRIPTIVE_NAME="${2}"
     _FLAG="${3}"
@@ -54,5 +54,5 @@ function check_and_save_allowed_param {
         fi
         exit 1
     fi
-    save_to_file "${_VARIABLE_NAME}"
+    parameters::save_to_file "${_VARIABLE_NAME}"
 }

--- a/scripts/ci/libraries/_permissions.sh
+++ b/scripts/ci/libraries/_permissions.sh
@@ -32,28 +32,28 @@
 # Since we can't (easily) tell what dockerignore would restrict, we'll just to
 # it to "all" files in the git repo, making sure to exclude the www/static/docs
 # symlink which is broken until the docs are built.
-function filterout_deleted_files {
+function permissions::filterout_deleted_files {
   # Take NUL-separated stdin, return only files that exist on stdout NUL-separated
   # This is to cope with users deleting files or folders locally but not doing `git rm`
   xargs -0 "$STAT_BIN" --printf '%n\0' 2>/dev/null || true;
 }
 
-# Fixes permissions for groups for all the files that are quickly filtered using the filterout_deleted_files
-function fix_group_permissions() {
+# Fixes permissions for groups for all the files that are quickly filtered using the permissions::filterout_deleted_files
+function permissions::fix_group_permissions() {
     if [[ ${PERMISSIONS_FIXED:=} == "true" ]]; then
-        print_info
-        print_info "Permissions already fixed"
-        print_info
+        verbosity::print_info
+        verbosity::print_info "Permissions already fixed"
+        verbosity::print_info
         return
     fi
-    print_info
+    verbosity::print_info
     pushd "${AIRFLOW_SOURCES}" >/dev/null  || exit 1
     # This deals with files
-    git ls-files -z -- ./ | filterout_deleted_files | xargs -0 chmod og-w
+    git ls-files -z -- ./ | permissions::filterout_deleted_files | xargs -0 chmod og-w
     # and this deals with directories
-    git ls-tree -z -r -d --name-only HEAD | filterout_deleted_files | xargs -0 chmod og-w,og+x
+    git ls-tree -z -r -d --name-only HEAD | permissions::filterout_deleted_files | xargs -0 chmod og-w,og+x
     popd >/dev/null || exit 1
-    print_info "Fixed group permissions"
-    print_info
+    verbosity::print_info "Fixed group permissions"
+    verbosity::print_info
     export PERMISSIONS_FIXED="true"
 }

--- a/scripts/ci/libraries/_push_pull_remove_images.sh
+++ b/scripts/ci/libraries/_push_pull_remove_images.sh
@@ -20,7 +20,7 @@
 # Should be run with set +e
 # Parameters:
 #   $1 -> image to pull
-function pull_image_if_not_present_or_forced() {
+function push_pull_remove_images::pull_image_if_not_present_or_forced() {
     local IMAGE_TO_PULL="${1}"
     local IMAGE_HASH
     IMAGE_HASH=$(docker images -q "${IMAGE_TO_PULL}" 2> /dev/null || true)
@@ -46,22 +46,22 @@ function pull_image_if_not_present_or_forced() {
 # Parameters:
 #   $1 -> DockerHub image to pull
 #   $2 -> GitHub image to try to pull first
-function pull_image_github_dockerhub() {
+function push_pull_remove_images::pull_image_github_dockerhub() {
     local DOCKERHUB_IMAGE="${1}"
     local GITHUB_IMAGE="${2}"
 
     set +e
-    if pull_image_if_not_present_or_forced "${GITHUB_IMAGE}"; then
+    if push_pull_remove_images::pull_image_if_not_present_or_forced "${GITHUB_IMAGE}"; then
         # Tag the image to be the DockerHub one
         docker tag "${GITHUB_IMAGE}" "${DOCKERHUB_IMAGE}"
     else
-        pull_image_if_not_present_or_forced "${DOCKERHUB_IMAGE}"
+        push_pull_remove_images::pull_image_if_not_present_or_forced "${DOCKERHUB_IMAGE}"
     fi
     set -e
 }
 
 # Pulls CI image in case caching strategy is "pulled" and the image needs to be pulled
-function pull_ci_images_if_needed() {
+function push_pull_remove_images::pull_ci_images_if_needed() {
 
     if [[ "${DOCKER_CACHE}" == "pulled" ]]; then
         if [[ "${FORCE_PULL_IMAGES}" == "true" ]]; then
@@ -78,23 +78,23 @@ Docker pulling ${PYTHON_BASE_IMAGE}.
                 if [[ ${GITHUB_REGISTRY_PULL_IMAGE_TAG} != "latest" ]]; then
                     PYTHON_TAG_SUFFIX="-${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
                 fi
-                pull_image_github_dockerhub "${PYTHON_BASE_IMAGE}" "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
+                push_pull_remove_images::pull_image_github_dockerhub "${PYTHON_BASE_IMAGE}" "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
             else
                 docker pull "${PYTHON_BASE_IMAGE}"
             fi
             echo
         fi
         if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
-            pull_image_github_dockerhub "${AIRFLOW_CI_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_CI_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
         else
-            pull_image_if_not_present_or_forced "${AIRFLOW_CI_IMAGE}"
+            push_pull_remove_images::pull_image_if_not_present_or_forced "${AIRFLOW_CI_IMAGE}"
         fi
     fi
 }
 
 
 # Pulls PROD image in case caching strategy is "pulled" and the image needs to be pulled
-function pull_prod_images_if_needed() {
+function push_pull_remove_images::pull_prod_images_if_needed() {
     if [[ "${DOCKER_CACHE}" == "pulled" ]]; then
         if [[ "${FORCE_PULL_IMAGES}" == "true" ]]; then
             echo
@@ -105,7 +105,7 @@ function pull_prod_images_if_needed() {
                 if [[ ${GITHUB_REGISTRY_PULL_IMAGE_TAG} != "latest" ]]; then
                     PYTHON_TAG_SUFFIX="-${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
                 fi
-                pull_image_github_dockerhub "${PYTHON_BASE_IMAGE}" "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
+                push_pull_remove_images::pull_image_github_dockerhub "${PYTHON_BASE_IMAGE}" "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
             else
                 docker pull "${PYTHON_BASE_IMAGE}"
             fi
@@ -113,18 +113,18 @@ function pull_prod_images_if_needed() {
         fi
         if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
             # "Build" segment of production image
-            pull_image_github_dockerhub "${AIRFLOW_PROD_BUILD_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_PROD_BUILD_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
             # "Main" segment of production image
-            pull_image_github_dockerhub "${AIRFLOW_PROD_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_PROD_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
         else
-            pull_image_if_not_present_or_forced "${AIRFLOW_PROD_BUILD_IMAGE}"
-            pull_image_if_not_present_or_forced "${AIRFLOW_PROD_IMAGE}"
+            push_pull_remove_images::pull_image_if_not_present_or_forced "${AIRFLOW_PROD_BUILD_IMAGE}"
+            push_pull_remove_images::pull_image_if_not_present_or_forced "${AIRFLOW_PROD_IMAGE}"
         fi
     fi
 }
 
 # Pushes Ci images and the manifest to the registry in DockerHub.
-function push_ci_images_to_dockerhub() {
+function push_pull_remove_images::push_ci_images_to_dockerhub() {
     docker push "${AIRFLOW_CI_IMAGE}"
     docker tag "${AIRFLOW_CI_LOCAL_MANIFEST_IMAGE}" "${AIRFLOW_CI_REMOTE_MANIFEST_IMAGE}"
     docker push "${AIRFLOW_CI_REMOTE_MANIFEST_IMAGE}"
@@ -135,7 +135,7 @@ function push_ci_images_to_dockerhub() {
 }
 
 # Pushes Ci images and their tags to registry in GitHub
-function push_ci_images_to_github() {
+function push_pull_remove_images::push_ci_images_to_github() {
     # Push image to GitHub registry with chosen push tag
     # the PUSH tag might be:
     #     "${GITHUB_RUN_ID}" - in case of pull-request triggered 'workflow_run' builds
@@ -159,16 +159,16 @@ function push_ci_images_to_github() {
 
 
 # Pushes Ci image and it's manifest to the registry.
-function push_ci_images() {
+function push_pull_remove_images::push_ci_images() {
     if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
-        push_ci_images_to_github
+        push_pull_remove_images::push_ci_images_to_github
     else
-        push_ci_images_to_dockerhub
+        push_pull_remove_images::push_ci_images_to_dockerhub
     fi
 }
 
 # Pushes PROD image to registry in DockerHub
-function push_prod_images_to_dockerhub () {
+function push_pull_remove_images::push_prod_images_to_dockerhub () {
     # Prod image
     docker push "${AIRFLOW_PROD_IMAGE}"
     if [[ -n ${DEFAULT_PROD_IMAGE=} ]]; then
@@ -181,7 +181,7 @@ function push_prod_images_to_dockerhub () {
 
 
 # Pushes PROD image to and their tags to registry in GitHub
-function push_prod_images_to_github () {
+function push_pull_remove_images::push_prod_images_to_github () {
     # Push image to GitHub registry with chosen push tag
     # the PUSH tag might be:
     #     "${GITHUB_RUN_ID}" - in case of pull-request triggered 'workflow_run' builds
@@ -204,16 +204,16 @@ function push_prod_images_to_github () {
 
 # Pushes PROD image to the registry. In case the image was taken from cache registry
 # it is also pushed to the cache, not to the main registry
-function push_prod_images() {
+function push_pull_remove_images::push_prod_images() {
     if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
-        push_prod_images_to_github
+        push_pull_remove_images::push_prod_images_to_github
     else
-        push_prod_images_to_dockerhub
+        push_pull_remove_images::push_prod_images_to_dockerhub
     fi
 }
 
 # Removes airflow CI and base images
-function remove_all_images() {
+function push_pull_remove_images::remove_all_images() {
     echo
     "${AIRFLOW_SOURCES}/confirm" "Removing all local images ."
     echo
@@ -229,7 +229,7 @@ function remove_all_images() {
 }
 
 # waits for an image to be available in the github registry
-function wait_for_github_registry_image() {
+function push_pull_remove_images::wait_for_github_registry_image() {
     GITHUB_API_ENDPOINT="https://${GITHUB_REGISTRY}/v2/${GITHUB_REPOSITORY_LOWERCASE}"
     IMAGE_NAME="${1}"
     IMAGE_TAG=${2}

--- a/scripts/ci/libraries/_pylint.sh
+++ b/scripts/ci/libraries/_pylint.sh
@@ -17,7 +17,7 @@
 # under the License.
 
 # In case of the pylint checks we filter out some files which are still in pylint_todo.txt list
-function filter_out_files_from_pylint_todo_list() {
+function pylint::filter_out_files_from_pylint_todo_list() {
   FILTERED_FILES=()
   set +e
   for FILE in "$@"

--- a/scripts/ci/libraries/_runs.sh
+++ b/scripts/ci/libraries/_runs.sh
@@ -17,7 +17,7 @@
 # under the License.
 
 # Docker command to build documentation
-function run_docs() {
+function runs::run_docs() {
     docker run "${EXTRA_DOCKER_FLAGS[@]}" -t \
             --entrypoint "/usr/local/bin/dumb-init"  \
             "${AIRFLOW_CI_IMAGE}" \
@@ -26,7 +26,7 @@ function run_docs() {
 
 
 # Docker command to generate constraint files.
-function run_generate_constraints() {
+function runs::run_generate_constraints() {
     docker run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         "${AIRFLOW_CI_IMAGE}" \
@@ -34,7 +34,7 @@ function run_generate_constraints() {
 }
 
 # Docker command to prepare backport packages
-function run_prepare_backport_packages() {
+function runs::run_prepare_backport_packages() {
     docker run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         -t \
@@ -44,7 +44,7 @@ function run_prepare_backport_packages() {
 }
 
 # Docker command to generate release notes for backport packages
-function run_prepare_backport_readme() {
+function runs::run_prepare_backport_readme() {
     docker run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         -t \

--- a/scripts/ci/libraries/_script_init.sh
+++ b/scripts/ci/libraries/_script_init.sh
@@ -24,18 +24,18 @@ readonly AIRFLOW_SOURCES
 # shellcheck source=scripts/ci/libraries/_all_libs.sh
 . "${AIRFLOW_SOURCES}/scripts/ci/libraries/_all_libs.sh"
 
-initialize_common_environment
+initialization::initialize_common_environment
 
-basic_sanity_checks
+sanity_checks::basic_sanity_checks
 
-script_start
+start_end::script_start
 
-determine_docker_cache_strategy
+build_images::determine_docker_cache_strategy
 
-get_environment_for_builds_on_ci
+initialization::get_environment_for_builds_on_ci
 
-get_docker_image_names
+build_images::get_docker_image_names
 
-make_constants_read_only
+initialization::make_constants_read_only
 
-add_trap script_end EXIT HUP INT TERM
+traps::add_trap start_end::script_end EXIT HUP INT TERM

--- a/scripts/ci/libraries/_spinner.sh
+++ b/scripts/ci/libraries/_spinner.sh
@@ -19,7 +19,7 @@
 # Function to spin ASCII spinner during pull and build in pre-commits to give the user indication that
 # Pull/Build is happening. It only spins if the output log changes, so if pull/build is stalled
 # The spinner will not move.
-function spin() {
+function spinner::spin() {
     local FILE_TO_MONITOR=${1}
     local SPIN=("-" "\\" "|" "/")
     echo -n "

--- a/scripts/ci/libraries/_start_end.sh
+++ b/scripts/ci/libraries/_start_end.sh
@@ -21,24 +21,24 @@
 # If VERBOSE_COMMANDS variable is set to true, it enables verbose output of commands executed
 # Also prints some useful diagnostics information at start of the script if VERBOSE is set to true
 #
-function script_start {
-    print_info
-    print_info "Running $(basename "$0")"
-    print_info
-    print_info "Log is redirected to ${OUTPUT_LOG}"
-    print_info
+function start_end::script_start {
+    verbosity::print_info
+    verbosity::print_info "Running $(basename "$0")"
+    verbosity::print_info
+    verbosity::print_info "Log is redirected to ${OUTPUT_LOG}"
+    verbosity::print_info
     if [[ ${VERBOSE_COMMANDS:="false"} == "true" ]]; then
-        print_info
-        print_info "Variable VERBOSE_COMMANDS Set to \"true\""
-        print_info "You will see a lot of output"
-        print_info
+        verbosity::print_info
+        verbosity::print_info "Variable VERBOSE_COMMANDS Set to \"true\""
+        verbosity::print_info "You will see a lot of output"
+        verbosity::print_info
         set -x
     else
-        print_info "You can increase verbosity by running 'export VERBOSE_COMMANDS=\"true\""
+        verbosity::print_info "You can increase verbosity by running 'export VERBOSE_COMMANDS=\"true\""
         if [[ ${SKIP_CACHE_DELETION:=} != "true" ]]; then
-            print_info "And skip deleting the output file with 'export SKIP_CACHE_DELETION=\"true\""
+            verbosity::print_info "And skip deleting the output file with 'export SKIP_CACHE_DELETION=\"true\""
         fi
-        print_info
+        verbosity::print_info
         set +x
     fi
     START_SCRIPT_TIME=$(date +%s)
@@ -50,7 +50,7 @@ function script_start {
 # command verbosity and in case the script was not run from Breeze (so via ci scripts) it displays
 # total time spent in the script so that we can easily see it.
 #
-function script_end {
+function start_end::script_end {
     #shellcheck disable=2181
     EXIT_CODE=$?
     if [[ ${EXIT_CODE} != 0 ]]; then
@@ -58,9 +58,9 @@ function script_end {
         if [[ -f "${OUTPUT_LOG}" ]]; then
             cat "${OUTPUT_LOG}"
         fi
-        print_info "###########################################################################################"
-        print_info "                   EXITING WITH STATUS CODE ${EXIT_CODE}"
-        print_info "###########################################################################################"
+        verbosity::print_info "###########################################################################################"
+        verbosity::print_info "                   EXITING WITH STATUS CODE ${EXIT_CODE}"
+        verbosity::print_info "###########################################################################################"
     fi
     if [[ ${VERBOSE_COMMANDS:="false"} == "true" ]]; then
         set +x
@@ -73,10 +73,10 @@ function script_end {
     END_SCRIPT_TIME=$(date +%s)
     RUN_SCRIPT_TIME=$((END_SCRIPT_TIME-START_SCRIPT_TIME))
     if [[ ${BREEZE:=} != "true" ]]; then
-        print_info
-        print_info "Finished the script $(basename "$0")"
-        print_info "Elapsed time spent in the script: ${RUN_SCRIPT_TIME} seconds"
-        print_info "Exit code ${EXIT_CODE}"
-        print_info
+        verbosity::print_info
+        verbosity::print_info "Finished the script $(basename "$0")"
+        verbosity::print_info "Elapsed time spent in the script: ${RUN_SCRIPT_TIME} seconds"
+        verbosity::print_info "Exit code ${EXIT_CODE}"
+        verbosity::print_info
     fi
 }

--- a/scripts/ci/libraries/_traps.sh
+++ b/scripts/ci/libraries/_traps.sh
@@ -24,7 +24,7 @@
 #      trap to set
 #      .... list of signals to handle
 #######################################################################################################
-function add_trap() {
+function traps::add_trap() {
     trap="${1}"
     shift
     for signal in "${@}"

--- a/scripts/ci/libraries/_verbosity.sh
+++ b/scripts/ci/libraries/_verbosity.sh
@@ -16,13 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # In case "VERBOSE_COMMANDS" is set to "true" set -x is used to enable debugging
-function check_verbose_setup {
-    if [[ ${VERBOSE_COMMANDS:="false"} == "true" ]]; then
-        set -x
-    else
-        set +x
-    fi
-}
 
 DOCKER_BINARY_PATH="${DOCKER_BINARY_PATH:=$(command -v docker || echo "/bin/docker")}"
 export DOCKER_BINARY_PATH
@@ -108,13 +101,13 @@ function kind {
 }
 
 # Prints verbose information in case VERBOSE variable is set
-function print_info() {
+function verbosity::print_info() {
     if [[ ${VERBOSE:="false"} == "true" && ${PRINT_INFO_FROM_SCRIPTS} == "true" ]]; then
         echo "$@"
     fi
 }
 
-function set_verbosity() {
+function verbosity::set_verbosity() {
     # whether verbose output should be produced
     export VERBOSE=${VERBOSE:="false"}
 
@@ -125,4 +118,4 @@ function set_verbosity() {
     export PRINT_INFO_FROM_SCRIPTS=${PRINT_INFO_FROM_SCRIPTS:="true"}
 }
 
-set_verbosity
+verbosity::set_verbosity

--- a/scripts/ci/pre_commit/pre_commit_ci_build.sh
+++ b/scripts/ci/pre_commit/pre_commit_ci_build.sh
@@ -23,8 +23,8 @@ export SKIP_CHECK_REMOTE_IMAGE="true"
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-forget_last_answer
+build_images::forget_last_answer
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed_and_confirmed
+build_images::rebuild_ci_image_if_needed_and_confirmed

--- a/scripts/ci/pre_commit/pre_commit_local_yml_mounts.sh
+++ b/scripts/ci/pre_commit/pre_commit_local_yml_mounts.sh
@@ -24,16 +24,16 @@ export SKIP_CHECK_REMOTE_IMAGE="true"
 TMP_OUTPUT=$(mktemp)
 
 # Remove temp file if it's hanging around
-add_trap "rm -rf -- '${TMP_OUTPUT}' 2>/dev/null" EXIT HUP INT TERM
+traps::add_trap "rm -rf -- '${TMP_OUTPUT}' 2>/dev/null" EXIT HUP INT TERM
 
 LOCAL_YML_FILE="${AIRFLOW_SOURCES}/scripts/ci/docker-compose/local.yml"
 
 LEAD='      # START automatically generated volumes from LOCAL_MOUNTS in _local_mounts.sh'
 TAIL='      # END automatically generated volumes from LOCAL_MOUNTS in _local_mounts.sh'
 
-generate_local_mounts_list "      - ../../../"
+local_mounts::generate_local_mounts_list "      - ../../../"
 
-sed -ne "0,/$LEAD/ p" "${LOCAL_YML_FILE}" > "${TMP_OUTPUT}"
+sed "/$LEAD/q" "${LOCAL_YML_FILE}" > "${TMP_OUTPUT}"
 
 printf '%s\n' "${LOCAL_MOUNTS[@]}" >> "${TMP_OUTPUT}"
 sed -ne "/$TAIL/,\$ p" "${LOCAL_YML_FILE}" >> "${TMP_OUTPUT}"

--- a/scripts/ci/pre_commit/pre_commit_mermaid.sh
+++ b/scripts/ci/pre_commit/pre_commit_mermaid.sh
@@ -43,7 +43,7 @@ else
 fi
 
 # shellcheck disable=SC2064
-add_trap "rm -rf '${tmp_file}'" EXIT HUP INT TERM
+traps::add_trap "rm -rf '${tmp_file}'" EXIT HUP INT TERM
 
 for file in "${@}"
 do

--- a/scripts/ci/static_checks/flake8.sh
+++ b/scripts/ci/static_checks/flake8.sh
@@ -34,8 +34,8 @@ function run_flake8() {
     fi
 }
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
 run_flake8 "$@"

--- a/scripts/ci/static_checks/mypy.sh
+++ b/scripts/ci/static_checks/mypy.sh
@@ -31,8 +31,8 @@ function run_mypy() {
         "--" "/opt/airflow/scripts/in_container/run_mypy.sh" "${FILES[@]}"
 }
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
 run_mypy "$@"

--- a/scripts/ci/static_checks/pylint.sh
+++ b/scripts/ci/static_checks/pylint.sh
@@ -33,12 +33,12 @@ function run_pylint() {
     fi
 }
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
 if [[ "${#@}" != "0" ]]; then
-    filter_out_files_from_pylint_todo_list "$@"
+    pylint::filter_out_files_from_pylint_todo_list "$@"
 
     if [[ "${#FILTERED_FILES[@]}" == "0" ]]; then
         echo "Filtered out all files. Skipping pylint."

--- a/scripts/ci/static_checks/refresh_pylint_todo.sh
+++ b/scripts/ci/static_checks/refresh_pylint_todo.sh
@@ -26,8 +26,8 @@ function refresh_pylint_todo() {
         /opt/airflow/scripts/in_container/refresh_pylint_todo.sh
 }
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
 refresh_pylint_todo

--- a/scripts/ci/static_checks/run_static_checks.sh
+++ b/scripts/ci/static_checks/run_static_checks.sh
@@ -25,9 +25,9 @@ if [[ -f ${BUILD_CACHE_DIR}/.skip_tests ]]; then
     exit
 fi
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
 python -m pip install pre-commit \
   --constraint "https://raw.githubusercontent.com/apache/airflow/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt"

--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -73,9 +73,9 @@ function run_airflow_testing_in_docker() {
     return "${EXIT_CODE}"
 }
 
-prepare_ci_build
+build_images::prepare_ci_build
 
-rebuild_ci_image_if_needed
+build_images::rebuild_ci_image_if_needed
 
 # Test environment
 export BACKEND=${BACKEND:="sqlite"}

--- a/tests/bats/bats_utils.bash
+++ b/tests/bats/bats_utils.bash
@@ -28,6 +28,6 @@ export SKIP_IN_CONTAINER_CHECK="true"
 # shellcheck source=scripts/ci/libraries/_all_libs.sh
 source "scripts/ci/libraries/_all_libs.sh"
 
-initialize_common_environment
+initialization::initialize_common_environment
 
-basic_sanity_checks
+sanity_checks::basic_sanity_checks

--- a/tests/bats/test_breeze_params.bats
+++ b/tests/bats/test_breeze_params.bats
@@ -30,7 +30,7 @@ teardown() {
 
 @test "Test missing value for a parameter" {
   export _BREEZE_ALLOWED_TEST_PARAMS="a b c"
-  run check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
+  run parameters::check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
   diff <(echo "${output}") - <<EOF
 
 ERROR:  Allowed Test Param: [ a b c ]. Is: ''.
@@ -44,7 +44,7 @@ EOF
   export _BREEZE_ALLOWED_TEST_PARAMS="a b c"
   export TEST_PARAM=x
   echo "a" > "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
-  run check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
+  run parameters::check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
   diff <(echo "${output}") - <<EOF
 
 ERROR:  Allowed Test Param: [ a b c ]. Is: 'x'.
@@ -60,7 +60,7 @@ EOF
   export _BREEZE_ALLOWED_TEST_PARAMS="a b c"
   export TEST_PARAM=x
   echo "x" > "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
-  run check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
+  run parameters::check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
   diff <(echo "${output}") - <<EOF
 
 ERROR:  Allowed Test Param: [ a b c ]. Is: 'x'.
@@ -77,7 +77,7 @@ EOF
 @test "Test correct value for a parameter" {
   export _BREEZE_ALLOWED_TEST_PARAMS="a b c"
   export TEST_PARAM=a
-  run check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
+  run parameters::check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
   diff <(echo "${output}") <(echo "")
   [ -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
   diff <(echo "a") <(cat "${AIRFLOW_SOURCES}/.build/.TEST_PARAM")
@@ -93,7 +93,7 @@ EOF
 )
   export _BREEZE_ALLOWED_TEST_PARAMS
   export TEST_PARAM=a
-  run check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
+  run parameters::check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
   diff <(echo "${output}") <(echo "")
   [ -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
   diff <(echo "a") <(cat "${AIRFLOW_SOURCES}/.build/.TEST_PARAM")
@@ -102,7 +102,7 @@ EOF
 
 
 @test "Test read_parameter from missing file" {
-  run read_from_file TEST_PARAM
+  run parameters::read_from_file TEST_PARAM
   [ -z "${TEST_FILE}" ]
   diff <(echo "${output}") <(echo "")
   [ ! -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
@@ -111,7 +111,7 @@ EOF
 
 @test "Test read_parameter from file" {
   echo "a" > "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
-  run read_from_file TEST_PARAM
+  run parameters::read_from_file TEST_PARAM
   diff <(echo "${output}") <(echo "a")
   [ -f "${AIRFLOW_SOURCES}/.build/.TEST_PARAM" ]
   [ "${status}" == "0" ]

--- a/tests/bats/test_local_mounts.bats
+++ b/tests/bats/test_local_mounts.bats
@@ -21,7 +21,7 @@
 @test "convert volume list to docker params" {
   load bats_utils
 
-  read -r -a RES <<< "$(convert_local_mounts_to_docker_params)"
+  read -r -a RES <<< "$(local_mounts::convert_local_mounts_to_docker_params)"
 
   [[ ${#RES[@]} -gt 0 ]] # Array should be non-zero length
   [[ $((${#RES[@]} % 2)) == 0 ]] # Array should be even length


### PR DESCRIPTION
[Re-added after reverting it]

Inspired by the Google Shell Guide where they mentioned
separating package names with :: I realized that this was
one of the missing pieces in the bash scripts of ours.

While we already had packages (in libraries folders)
it's been difficult to realise which function is where.

With introducing packages - equal to the library file name
we are *almost* at a level of a structured language - and
it's easier to find the functions if you are looking for them.

Way easier in fact.

Part of #10576

(cherry picked from commit cc551ba)
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
