### PR TITLE
Don't commit when explicitly passed a session to TI.set_state

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -361,7 +361,7 @@ class BackfillJob(BaseJob):
             for ti in dag_run.get_task_instances():
                 # all tasks part of the backfill are scheduled to run
                 if ti.state == State.NONE:
-                    ti.set_state(State.SCHEDULED, session=session, commit=False)
+                    ti.set_state(State.SCHEDULED, session=session)
                 if ti.state != State.REMOVED:
                     tasks_to_run[ti.key] = ti
             session.commit()

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -596,24 +596,20 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         return TaskInstanceKey(self.dag_id, self.task_id, self.execution_date, self.try_number)
 
     @provide_session
-    def set_state(self, state: str, session=None, commit: bool = True):
+    def set_state(self, state: str, session=None):
         """
-        Set TaskInstance state
+        Set TaskInstance state.
 
         :param state: State to set for the TI
         :type state: str
         :param session: SQLAlchemy ORM Session
         :type session: Session
-        :param commit: Whether or not to commit session
-        :type commit: bool
         """
         self.log.debug("Setting task state for %s to %s", self, state)
         self.state = state
         self.start_date = timezone.utcnow()
         self.end_date = timezone.utcnow()
         session.merge(self)
-        if commit:
-            session.commit()
 
     @property
     def is_premature(self):


### PR DESCRIPTION
The `@provide_session` wrapper will already commit the transaction when returned, unless an explicit session is passed in -- removing this parameter changes the behaviour to be:

- If session explicitly passed in: don't commit (caller's responsibility)
- If no session passed in, `@provide_session` will commit for us already.

(This is prep work for scheduler HA, where we need to be more careful about when exactly we commit session, as we use 'SELECT ... FOR UPDATE' so we tighter control over when the lock is released.)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).