### PR TITLE
 Don't commit when explicitly passed a session to TI.set_state

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -361,7 +361,7 @@ class BackfillJob(BaseJob):
             for ti in dag_run.get_task_instances():
                 # all tasks part of the backfill are scheduled to run
                 if ti.state == State.NONE:
-                    ti.set_state(State.SCHEDULED, session=session, commit=False)
+                    ti.set_state(State.SCHEDULED, session=session)
                 if ti.state != State.REMOVED:
                     tasks_to_run[ti.key] = ti
             session.commit()

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -596,24 +596,20 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         return TaskInstanceKey(self.dag_id, self.task_id, self.execution_date, self.try_number)
 
     @provide_session
-    def set_state(self, state: str, session=None, commit: bool = True):
+    def set_state(self, state: str, session=None):
         """
-        Set TaskInstance state
+        Set TaskInstance state.
 
         :param state: State to set for the TI
         :type state: str
         :param session: SQLAlchemy ORM Session
         :type session: Session
-        :param commit: Whether or not to commit session
-        :type commit: bool
         """
         self.log.debug("Setting task state for %s to %s", self, state)
         self.state = state
         self.start_date = timezone.utcnow()
         self.end_date = timezone.utcnow()
         session.merge(self)
-        if commit:
-            session.commit()
 
     @property
     def is_premature(self):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3579,9 +3579,9 @@ class TestSchedulerJobQueriesCount(unittest.TestCase):
             # One DAG with one task per DAG file
             (13, 1, 1),  # noqa
             # One DAG with five tasks per DAG  file
-            (21, 1, 5),  # noqa
+            (17, 1, 5),  # noqa
             # 10 DAGs with 10 tasks per DAG file
-            (77, 10, 10),  # noqa
+            (46, 10, 10),  # noqa
         ]
     )
     def test_execute_queries_count_with_harvested_dags(self, expected_query_count, dag_count, task_count):

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -71,6 +71,7 @@ class TestDagRun(unittest.TestCase):
             for task_id, task_state in task_states.items():
                 ti = dag_run.get_task_instance(task_id)
                 ti.set_state(task_state, session)
+            session.commit()
             session.close()
 
         return dag_run

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -539,6 +539,8 @@ class TestTriggerRuleDep(unittest.TestCase):
         ti_op4.set_state(state=State.SUCCESS, session=session)
         ti_op5.set_state(state=State.SUCCESS, session=session)
 
+        session.commit()
+
         # check handling with cases that tasks are triggered from backfill with no finished tasks
         finished_tasks = DepContext().ensure_finished_tasks(ti_op2.task.dag, ti_op2.execution_date, session)
         self.assertEqual(get_states_count_upstream_ti(finished_tasks=finished_tasks, ti=ti_op2),


### PR DESCRIPTION
The `@provide_session` wrapper will already commit the transaction when returned, unless an explicit session is passed in -- removing this parameter changes the behaviour to be:

- If session explicitly passed in: don't commit (caller's responsibility)
- If no session passed in, `@provide_session` will commit for us already.