### PR TITLE
Make test_trigger_rule_dep tests re-runnable

### DIFF
--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -30,6 +30,7 @@ from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule
 from tests.models import DEFAULT_DATE
+from tests.test_utils.db import clear_db_runs
 
 
 class TestTriggerRuleDep(unittest.TestCase):
@@ -521,6 +522,7 @@ class TestTriggerRuleDep(unittest.TestCase):
             op4.set_upstream([op3, op2])  # op3, op2 >> op4
             op5.set_upstream([op2, op3, op4])  # (op2, op3, op4) >> op5
 
+        clear_db_runs()
         dag.clear()
         dr = dag.create_dagrun(run_id='test_dagrun_with_pre_tis',
                                state=State.RUNNING,


### PR DESCRIPTION
If we run this test (`TestTriggerRuleDep::test_get_states_count_upstream_ti` specifically) more than once without clearing the DB in between it would fail due to a
unique constraint violation.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->