### PR TITLE
Switches to better BATS asserts

### DIFF
--- a/scripts/ci/dockerfiles/bats/Dockerfile
+++ b/scripts/ci/dockerfiles/bats/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:buster-slim
+
+ARG BATS_VERSION
+ARG BATS_SUPPORT_VERSION
+ARG BATS_ASSERT_VERSION
+ARG BATS_FILE_VERSION
+ARG AIRFLOW_BATS_VERSION
+ARG COMMIT_SHA
+
+MAINTAINER "Apache Airflow Community <dev@airflow.apache.org>"
+
+# Install curl and gnupg2 - needed to download nodejs in the next step
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+           curl \
+           ca-certificates \
+    && apt-get autoremove -yqq --purge \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz -o /tmp/bats.tgz \
+    && tar -zxf /tmp/bats.tgz -C /tmp \
+    && /bin/bash /tmp/bats-core-${BATS_VERSION}/install.sh /opt/bats/  && rm -rf
+
+RUN mkdir -p /opt/bats/lib/bats-support \
+    && curl -sSL https://github.com/bats-core/bats-support/archive/v${BATS_SUPPORT_VERSION}.tar.gz -o /tmp/bats-support.tgz \
+    && tar -zxf /tmp/bats-support.tgz -C /opt/bats/lib/bats-support --strip 1 && rm -rf /tmp/*
+
+RUN mkdir -p /opt/bats/lib/bats-assert \
+    && curl -sSL https://github.com/bats-core/bats-assert/archive/v${BATS_ASSERT_VERSION}.tar.gz -o /tmp/bats-assert.tgz \
+    && tar -zxf /tmp/bats-assert.tgz -C /opt/bats/lib/bats-assert --strip 1 && rm -rf /tmp/*
+
+RUN mkdir -p /opt/bats/lib/bats-file \
+    && curl -sSL https://github.com/bats-core/bats-file/archive/v${BATS_FILE_VERSION}.tar.gz -o /tmp/bats-file.tgz \
+    && tar -zxf /tmp/bats-file.tgz -C /opt/bats/lib/bats-file --strip 1 && rm -rf /tmp/*
+
+COPY load.bash /opt/bats/lib/
+RUN chmod a+x /opt/bats/lib/load.bash
+
+LABEL org.apache.airflow.component="bats"
+LABEL org.apache.airflow.bats.core.version="${BATS_VERSION}"
+LABEL org.apache.airflow.bats.support.version="${BATS_SUPPORT_VERSION}"
+LABEL org.apache.airflow.bats.assert.version="${BATS_ASSERT_VERSION}"
+LABEL org.apache.airflow.bats.file.version="${BATS_FILE_VERSION}"
+LABEL org.apache.airflow.airflow_bats.version="${AIRFLOW_BATS_VERSION}"
+LABEL org.apache.airflow.commit_sha="${COMMIT_SHA}"
+
+ENTRYPOINT ["/opt/bats/bin/bats"]
+CMD ["--help"]

--- a/scripts/ci/dockerfiles/bats/build_and_push.sh
+++ b/scripts/ci/dockerfiles/bats/build_and_push.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bats
-
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,10 +15,29 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+set -euo pipefail
+DOCKERHUB_USER=${DOCKERHUB_USER:="apache"}
+DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
+BATS_VERSION="1.2.1"
+BATS_ASSERT_VERSION="2.0.0"
+BATS_SUPPORT_VERSION="0.3.0"
+BATS_FILE_VERSION="0.3.0"
 
-@test "empty test" {
-  load bats_utils
+AIRFLOW_BATS_VERSION="2020.09.03"
 
-  run pwd
-  assert_success
-}
+COMMIT_SHA=$(git rev-parse HEAD)
+
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
+
+TAG="${DOCKERHUB_USER}/${DOCKERHUB_REPO}:bats-${AIRFLOW_BATS_VERSION}-${BATS_VERSION}"
+
+docker build . \
+    --pull \
+    --build-arg "BATS_VERSION=${BATS_VERSION}" \
+    --build-arg "BATS_SUPPORT_VERSION=${BATS_SUPPORT_VERSION}" \
+    --build-arg "BATS_FILE_VERSION=${BATS_FILE_VERSION}" \
+    --build-arg "BATS_ASSERT_VERSION=${BATS_ASSERT_VERSION}" \
+    --build-arg "COMMIT_SHA=${COMMIT_SHA}" \
+    --tag "${TAG}"
+
+docker push "${TAG}"

--- a/scripts/ci/dockerfiles/bats/load.bash
+++ b/scripts/ci/dockerfiles/bats/load.bash
@@ -1,5 +1,3 @@
-#!/usr/bin/env bats
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,10 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-@test "empty test" {
-  load bats_utils
-
-  run pwd
-  assert_success
-}
+# shellcheck disable=SC1091
+source "/opt/bats/lib/bats-support/load.bash"
+# shellcheck disable=SC1091
+source "/opt/bats/lib/bats-assert/load.bash"
+# shellcheck disable=SC1091
+source "/opt/bats/lib/bats-file/load.bash"

--- a/scripts/ci/pre_commit/pre_commit_bat_tests.sh
+++ b/scripts/ci/pre_commit/pre_commit_bat_tests.sh
@@ -26,5 +26,5 @@ else
     PARAMS=("${@}")
 fi
 
-# shellcheck source=scripts/ci/static_checks/bat_tests.sh
-. "$( dirname "${BASH_SOURCE[0]}" )/../static_checks/bat_tests.sh" "${PARAMS[@]}"
+# shellcheck source=scripts/ci/static_checks/bats_tests.sh
+. "$( dirname "${BASH_SOURCE[0]}" )/../static_checks/bats_tests.sh" "${PARAMS[@]}"

--- a/scripts/ci/static_checks/bats_tests.sh
+++ b/scripts/ci/static_checks/bats_tests.sh
@@ -20,10 +20,10 @@ function run_bats_tests() {
     FILES=("$@")
     if [[ "${#FILES[@]}" == "0" ]]; then
         docker run --workdir /airflow -v "$(pwd):/airflow" --rm \
-            bats/bats:latest --tap -r /airflow/tests/bats
+            apache/airflow:bats-2020.09.03-1.2.1 --tap -r /airflow/tests/bats
     else
         docker run --workdir /airflow -v "$(pwd):/airflow" --rm \
-            bats/bats:latest --tap -r "${FILES[@]}"
+            apache/airflow:bats-2020.09.03-1.2.1 --tap "${FILES[@]}"
     fi
 }
 

--- a/tests/bats/bats_utils.bash
+++ b/tests/bats/bats_utils.bash
@@ -30,4 +30,5 @@ source "scripts/ci/libraries/_all_libs.sh"
 
 initialization::initialize_common_environment
 
-sanity_checks::basic_sanity_checks
+# shellcheck disable=SC1091
+source "/opt/bats/lib/load.bash"

--- a/tests/bats/test_local_mounts.bats
+++ b/tests/bats/test_local_mounts.bats
@@ -23,16 +23,16 @@
 
   read -r -a RES <<< "$(local_mounts::convert_local_mounts_to_docker_params)"
 
-  [[ ${#RES[@]} -gt 0 ]] # Array should be non-zero length
-  [[ $((${#RES[@]} % 2)) == 0 ]] # Array should be even length
+  assert [ "${#RES[@]}" -gt 0 ] # Array should be non-zero length
+  assert [ "$((${#RES[@]} % 2))" == 0 ] # Array should be even length
 
   for i in "${!RES[@]}"; do
     if [[ $((i % 2)) == 0 ]]; then
       # Every other value should be `-v`
-      [[ ${RES[$i]} == "-v" ]]
+      assert [ "${RES[$i]}" == "-v" ]
     else
       # And the options should be of form <src>:<dest>:cached
-      [[ ${RES[$i]} = *:*:cached ]]
+      assert bash -c "[[ ${RES[$i]} == *:*:cached ]]"
     fi
   done
 }


### PR DESCRIPTION
BATS has additional libraries of asserts that are much more
straightforward and nicer to write tests for bash scripts

There is no dockerfile from BATS that contains those, so we
had to build our own (but it follows the same structure
as #9652 - where we keep our dev docker image
sources inside our repository and the generated docker images
in "apache/airflow:<tool>-CALVER-TOOLVER format.

We have more BATS unit test to add - following #10576
and this change will be of great help.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
