### PR TITLE
Add note on GKE metadata server Workload Identity

### DIFF
--- a/docs/howto/connection/gcp.rst
+++ b/docs/howto/connection/gcp.rst
@@ -32,7 +32,13 @@ There are three ways to connect to Google Cloud using Airflow.
 
 1. Use `Application Default Credentials
    <https://google-auth.readthedocs.io/en/latest/reference/google.auth.html#google.auth.default>`_,
-   such as via the metadata server when running on Google Compute Engine.
+   such as via the metadata server when running on Google Compute Engine or the GKE metadata server
+   when running on GKE which allows mapping Kubernetes Service Accounts to GCP service accounts
+   `Workload Identity
+   <https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity>`_. This can be useful
+   when managing minimum permissions for multiple Airflow deployments on a single GKE cluster which
+   each have a different IAM footprint. It has the benefit of not storing google service account
+   keys on disk nor in the Airflow database.
 2. Use a `service account
    <https://cloud.google.com/docs/authentication/#service_accounts>`_ key
    file (JSON format) on disk - ``Keyfile Path``.

--- a/docs/howto/connection/gcp.rst
+++ b/docs/howto/connection/gcp.rst
@@ -47,7 +47,7 @@ All hooks and operators related to Google Cloud use ``google_cloud_default`` by 
 
 
 Note On Application Default Credentials
----------------------------------------  
+---------------------------------------
 Application Default Credentials are inferred by the GCE metadata server when running
 Airflow on Google Compute Engine or the GKE metadata server
 when running on GKE which allows mapping Kubernetes Service Accounts to GCP service accounts
@@ -60,7 +60,7 @@ From a security perspective it has the benefit of not storing Google Service Acc
 keys  on disk nor in the Airflow database, making it impossible
 to leak the sensitive long lived credential key material.
 
-From an Airflow perspective Application Default Credentials can be used for 
+From an Airflow perspective Application Default Credentials can be used for
 a connection by specifying an empty URI.
     For example:
 

--- a/docs/howto/connection/gcp.rst
+++ b/docs/howto/connection/gcp.rst
@@ -32,13 +32,6 @@ There are three ways to connect to Google Cloud using Airflow.
 
 1. Use `Application Default Credentials
    <https://google-auth.readthedocs.io/en/latest/reference/google.auth.html#google.auth.default>`_,
-   such as via the metadata server when running on Google Compute Engine or the GKE metadata server
-   when running on GKE which allows mapping Kubernetes Service Accounts to GCP service accounts
-   `Workload Identity
-   <https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity>`_. This can be useful
-   when managing minimum permissions for multiple Airflow deployments on a single GKE cluster which
-   each have a different IAM footprint. It has the benefit of not storing google service account
-   keys on disk nor in the Airflow database.
 2. Use a `service account
    <https://cloud.google.com/docs/authentication/#service_accounts>`_ key
    file (JSON format) on disk - ``Keyfile Path``.
@@ -51,6 +44,29 @@ Default Connection IDs
 ----------------------
 
 All hooks and operators related to Google Cloud use ``google_cloud_default`` by default.
+
+
+Note On Application Default Credentials
+---------------------------------------  
+Application Default Credentials are inferred by the GCE metadata server when running
+Airflow on Google Compute Engine or the GKE metadata server
+when running on GKE which allows mapping Kubernetes Service Accounts to GCP service accounts
+`Workload Identity
+<https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity>`_.
+This can be useful when managing minimum permissions for multiple Airflow instances on a single GKE cluster which
+each have a different IAM footprint. Simply assign KSAs for your worker / webserver deployments and workload identity
+will map them to separate GCP Service Accounts (rather than sharing a cluster-level GCE service account).
+From a security perspective it has the benefit of not storing Google Service Account
+keys  on disk nor in the Airflow database, making it impossible
+to leak the sensitive long lived credential key material.
+
+From an Airflow perspective Application Default Credentials can be used for 
+a connection by specifying an empty URI.
+    For example:
+
+    .. code-block:: bash
+
+       export AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT='google-cloud-platform://'
 
 Configuring the Connection
 --------------------------


### PR DESCRIPTION
Workload Identity is the recommended way of managing authorization to GCP services from GKE.
While it is notably not used by Cloud Composer, I think a note like this could be useful for those who run airflow on GKE themselves, especially those interested in multi-tenancy :)

cc: @mik-laj @potiuk @turbaszek 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
