### PR TITLE
Detect orphaned task instances by SchedulerJob id and heartbeat

### DIFF
--- a/airflow/migrations/versions/b247b1e3d1ed_add_queued_by_job_id_to_ti.py
+++ b/airflow/migrations/versions/b247b1e3d1ed_add_queued_by_job_id_to_ti.py
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add queued by Job ID to TI
+
+Revision ID: b247b1e3d1ed
+Revises: e38be357a868
+Create Date: 2020-09-04 11:53:00.978882
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'b247b1e3d1ed'
+down_revision = 'e38be357a868'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply Add queued by Job ID to TI"""
+    with op.batch_alter_table('task_instance') as batch_op:
+        batch_op.add_column(sa.Column('queued_by_job_id', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    """Unapply Add queued by Job ID to TI"""
+    with op.batch_alter_table('task_instance') as batch_op:
+        batch_op.drop_column('queued_by_job_id')

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -23,7 +23,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import synonym
+from sqlalchemy.orm import backref, relationship, synonym
 from sqlalchemy.orm.session import Session
 
 from airflow.exceptions import AirflowException
@@ -65,6 +65,13 @@ class DagRun(Base, LoggingMixin):
         Index('dag_id_state', dag_id, _state),
         UniqueConstraint('dag_id', 'execution_date'),
         UniqueConstraint('dag_id', 'run_id'),
+    )
+
+    task_instances = relationship(
+        TI,
+        primaryjoin=and_(TI.dag_id == dag_id, TI.execution_date == execution_date),  # type: ignore
+        foreign_keys=(dag_id, execution_date),
+        backref=backref('dag_run', uselist=False),
     )
 
     def __init__(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -219,6 +219,7 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
     priority_weight = Column(Integer)
     operator = Column(String(1000))
     queued_dttm = Column(UtcDateTime)
+    queued_by_job_id = Column(Integer)
     pid = Column(Integer)
     executor_config = Column(PickleType(pickler=dill))
     # If adding new fields here then remember to add them to
@@ -1926,3 +1927,15 @@ class SimpleTaskInstance:
         else:
             ti = qry.first()
         return ti
+
+
+STATICA_HACK = True
+globals()['kcah_acitats'[::-1].upper()] = False
+if STATICA_HACK:  # pragma: no cover
+    # Let pylint know about these relationships, without introducing an import cycle
+    from sqlalchemy.orm import relationship
+
+    from airflow.job.base_job import BaseJob
+    from airflow.models.dagrun import DagRun
+    TaskInstance.dag_run = relationship(DagRun)
+    TaskInstance.queued_by_job = relationship(BaseJob)


### PR DESCRIPTION
Once HA mode for scheduler lands, we can no longer reset orphaned
task by looking at the tasks in (the memory of) the current executor.

This changes it to keep track of which (Scheduler)Job queued/scheduled a
TaskInstance (the new "queued_by_job_id" column stored against
TaskInstance table), and then we can use the existing heartbeat
mechanism for jobs to notice when a TI should be reset.

As part of this the existing implementation of
`reset_state_for_orphaned_tasks` has been moved out of BaseJob in to
BackfillJob -- as only this and SchedulerJob had these methods, and the
SchedulerJob version now operates differently