### PR TITLE
The verbose functions will not exit immediately if not asked to

### DIFF
--- a/breeze
+++ b/breeze
@@ -2588,9 +2588,18 @@ function breeze::make_sure_precommit_is_installed() {
 #
 #######################################################################################################
 function breeze::remove_images() {
-    docker rmi "${PYTHON_BASE_IMAGE}"  || true
-    docker rmi "${AIRFLOW_CI_IMAGE}"   || true
-    docker rmi "${AIRFLOW_PROD_IMAGE}" || true
+    set +e
+    docker rmi "${PYTHON_BASE_IMAGE}"  2>/dev/null >/dev/null
+    docker rmi "${AIRFLOW_CI_IMAGE}"   2>/dev/null >/dev/null
+    docker rmi "${AIRFLOW_PROD_IMAGE}" 2>/dev/null >/dev/null
+    set -e
+    echo
+    echo "###################################################################"
+    echo "NOTE!! Removed Airflow images for Python version ${PYTHON_MAJOR_MINOR_VERSION}."
+    echo "       But the disk space in docker will be reclaimed only after"
+    echo "       running 'docker system prune' command."
+    echo "###################################################################"
+    echo
     rm -f "${BUILT_CI_IMAGE_FLAG_FILE}"
 }
 

--- a/scripts/ci/libraries/_push_pull_remove_images.sh
+++ b/scripts/ci/libraries/_push_pull_remove_images.sh
@@ -212,22 +212,6 @@ function push_pull_remove_images::push_prod_images() {
     fi
 }
 
-# Removes airflow CI and base images
-function push_pull_remove_images::remove_all_images() {
-    echo
-    "${AIRFLOW_SOURCES}/confirm" "Removing all local images ."
-    echo
-    docker rmi "${PYTHON_BASE_IMAGE}" || true
-    docker rmi "${AIRFLOW_CI_IMAGE}" || true
-    echo
-    echo "###################################################################"
-    echo "NOTE!! Removed Airflow images for Python version ${PYTHON_MAJOR_MINOR_VERSION}."
-    echo "       But the disk space in docker will be reclaimed only after"
-    echo "       running 'docker system prune' command."
-    echo "###################################################################"
-    echo
-}
-
 # waits for an image to be available in the github registry
 function push_pull_remove_images::wait_for_github_registry_image() {
     GITHUB_API_ENDPOINT="https://${GITHUB_REGISTRY}/v2/${GITHUB_REPOSITORY_LOWERCASE}"
@@ -247,9 +231,6 @@ function push_pull_remove_images::wait_for_github_registry_image() {
         fi
         sleep 10
     done
-    echo
-    echo
-    echo "Found ${IMAGE_NAME}:${IMAGE_TAG} image"
-    echo "Digest: '${digest}'"
-    echo
+    verbosity::print_info "Found ${IMAGE_NAME}:${IMAGE_TAG} image"
+    verbosity::print_info "Digest: '${digest}'"
 }

--- a/scripts/ci/libraries/_start_end.sh
+++ b/scripts/ci/libraries/_start_end.sh
@@ -54,8 +54,9 @@ function start_end::script_end {
     #shellcheck disable=2181
     EXIT_CODE=$?
     if [[ ${EXIT_CODE} != 0 ]]; then
-        # Cat output log in case we exit with error
-        if [[ -f "${OUTPUT_LOG}" ]]; then
+        # Cat output log in case we exit with error but only if we do not PRINT_INFO_FROM_SCRIPTS
+        # Because it will be printed immediately by "tee"
+        if [[ -f "${OUTPUT_LOG}" && ${PRINT_INFO_FROM_SCRIPTS} == "false" ]]; then
             cat "${OUTPUT_LOG}"
         fi
         verbosity::print_info "###########################################################################################"


### PR DESCRIPTION
The docker(), helm(), kubectl() functions replace the real tools
to get verbose behaviour (we can print the exact command being
executed for those. But when 'set +e' was set before the command
was called - indicating that error in those functions should be
ignored - this did not happen. The functions set 'set -e' just
before returning the non-zero value, effectively exiting the
script right after. This caused first time experience to be not
good.

The fix also fixes behaviour of stdout and stderr for those
functions - previously they were joined to be able to be
printed to OUTPUT_FILE but this lost the stderr/stdout
distinction. Now both stdout and stderr are printed to the
output file but they are also redirected to stdout/stderr
respectively, so that 2>/dev/null works as expected.



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
