### PR TITLE
Update node installation cmd

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -790,7 +790,7 @@ To install yarn on macOS:
 
 .. code-block:: bash
 
-    brew install node --without-npm
+    brew install node
     brew install yarn
     yarn config set prefix ~/.yarn
 


### PR DESCRIPTION
In CONTRIBUTING.rst, we have brew install node --without-npm for installing node in macOS. The --without-npm flag is outdated and running this command will throw Error: invalid option: --without-npm.

closes: #10743 
