### PR TITLE
Add pod_override setting for KubernetesExecutor

### DIFF
--- a/airflow/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/example_dags/example_kubernetes_executor_config.py
@@ -20,6 +20,8 @@ This is an example dag for using a Kubernetes Executor Configuration.
 """
 import os
 
+from kubernetes.client import models as k8s
+
 from airflow import DAG
 from airflow.example_dags.libs.helper import print_stuff
 from airflow.operators.python import PythonOperator
@@ -59,27 +61,73 @@ with DAG(
         }
     )
 
-    # You can mount volume or secret to the worker pod
-    second_task = PythonOperator(
-        task_id="four_task",
+    # [START task_with_volume]
+    volume_task = PythonOperator(
+        task_id="task_with_volume",
         python_callable=test_volume_mount,
         executor_config={
-            "KubernetesExecutor": {
-                "volumes": [
-                    {
-                        "name": "example-kubernetes-test-volume",
-                        "hostPath": {"path": "/tmp/"},
-                    },
-                ],
-                "volume_mounts": [
-                    {
-                        "mountPath": "/foo/",
-                        "name": "example-kubernetes-test-volume",
-                    },
-                ]
-            }
+            "pod_override": k8s.V1Pod(
+                spec=k8s.V1PodSpec(
+                    containers=[
+                        k8s.V1Container(
+                            name="base",
+                            volume_mounts=[
+                                k8s.V1VolumeMount(
+                                    mount_path="/foo/",
+                                    name="example-kubernetes-test-volume"
+                                )
+                            ]
+                        )
+                    ],
+                    volumes=[
+                        k8s.V1Volume(
+                            name="example-kubernetes-test-volume",
+                            host_path=k8s.V1HostPathVolumeSource(
+                                path="/tmp/"
+                            )
+                        )
+                    ]
+                )
+            ),
         }
     )
+    # [END task_with_volume]
+
+    # [START task_with_sidecar]
+    sidecar_task = PythonOperator(
+        task_id="task_with_sidecar",
+        python_callable=test_volume_mount,
+        executor_config={
+            "pod_override": k8s.V1Pod(
+                spec=k8s.V1PodSpec(
+                    containers=[
+                        k8s.V1Container(
+                            name="base",
+                            volume_mounts=[k8s.V1VolumeMount(
+                                mount_path="/shared/",
+                                name="shared-empty-dir"
+                            )]
+                        ),
+                        k8s.V1Container(
+                            name="sidecar",
+                            image="ubuntu",
+                            volume_mounts=[k8s.V1VolumeMount(
+                                mount_path="/shared/",
+                                name="shared-empty-dir"
+                            )]
+                        )
+                    ],
+                    volumes=[
+                        k8s.V1Volume(
+                            name="shared-empty-dir",
+                            empty_dir=k8s.V1EmptyDirVolumeSource()
+                        ),
+                    ]
+                )
+            ),
+        }
+    )
+    # [END task_with_sidecar]
 
     # Test that we can add labels to pods
     third_task = PythonOperator(
@@ -107,5 +155,6 @@ with DAG(
         }
     )
 
-    start_task >> second_task >> third_task
+    start_task >> volume_task >> third_task
     start_task >> other_ns_task
+    start_task >> sidecar_task

--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -42,3 +42,4 @@ class DagAttributeTypes(str, Enum):
     DICT = 'dict'
     SET = 'set'
     TUPLE = 'tuple'
+    POD = 'k8s.V1Pod'

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -156,6 +156,44 @@ Example DAG with functional abstraction
         html_content=email_info['body']
     )
 
+.. _concepts:executor_config:
+
+executor_config
+===============
+
+The executor_config is an argument placed into operators that allow airflow users to override tasks
+before launch. Currently this is primarily used by the :class:`KubernetesExecutor`, but will soon be available
+for other overrides.
+
+.. _concepts:pod_override:
+
+pod_override
+------------
+
+When using the KubernetesExecutor, Airflow offers the ability to override system defaults on a per-task basis.
+To utilize this functionality, create a Kubernetes V1pod object and fill in your desired overrides.
+Please note that the scheduler will override the ``metadata.name`` of the V1pod before launching it.
+
+To overwrite the base container of the pod launched by the KubernetesExecutor,
+create a V1pod with a single container, and overwrite the fields as follows:
+
+.. exampleinclude:: /../airflow/example_dags/example_kubernetes_executor_config.py
+    :language: python
+    :start-after: [START task_with_volume]
+    :end-before: [END task_with_volume]
+
+Note that volume mounts environment variables, ports, and devices will all be extended instead of overwritten.
+
+To add a sidecar container to the launched pod, create a V1pod with an empty first container with the
+name ``base`` and a second container containing your desired sidecar.
+
+.. exampleinclude:: /../airflow/example_dags/example_kubernetes_executor_config.py
+    :language: python
+    :start-after: [START task_with_sidecar]
+    :end-before: [END task_with_sidecar]
+
+In the following example, we create a sidecar container that shares a volume_mount for data sharing.
+
 .. _concepts:dagruns:
 
 DAG Runs

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -165,35 +165,6 @@ The executor_config is an argument placed into operators that allow airflow user
 before launch. Currently this is primarily used by the :class:`KubernetesExecutor`, but will soon be available
 for other overrides.
 
-.. _concepts:pod_override:
-
-pod_override
-------------
-
-When using the KubernetesExecutor, Airflow offers the ability to override system defaults on a per-task basis.
-To utilize this functionality, create a Kubernetes V1pod object and fill in your desired overrides.
-Please note that the scheduler will override the ``metadata.name`` of the V1pod before launching it.
-
-To overwrite the base container of the pod launched by the KubernetesExecutor,
-create a V1pod with a single container, and overwrite the fields as follows:
-
-.. exampleinclude:: /../airflow/example_dags/example_kubernetes_executor_config.py
-    :language: python
-    :start-after: [START task_with_volume]
-    :end-before: [END task_with_volume]
-
-Note that volume mounts environment variables, ports, and devices will all be extended instead of overwritten.
-
-To add a sidecar container to the launched pod, create a V1pod with an empty first container with the
-name ``base`` and a second container containing your desired sidecar.
-
-.. exampleinclude:: /../airflow/example_dags/example_kubernetes_executor_config.py
-    :language: python
-    :start-after: [START task_with_sidecar]
-    :end-before: [END task_with_sidecar]
-
-In the following example, we create a sidecar container that shares a volume_mount for data sharing.
-
 .. _concepts:dagruns:
 
 DAG Runs

--- a/docs/executor/kubernetes.rst
+++ b/docs/executor/kubernetes.rst
@@ -41,6 +41,35 @@ The volumes are optional and depend on your configuration. There are two volumes
 To troubleshoot issue with KubernetesExecutor, you can use ``airflow kubernetes generate-dag-yaml`` command.
 This command generates the pods as they will be launched in Kubernetes and dumps them into yaml files for you to inspect.
 
+.. _concepts:pod_override:
+
+pod_override
+############
+
+When using the KubernetesExecutor, Airflow offers the ability to override system defaults on a per-task basis.
+To utilize this functionality, create a Kubernetes V1pod object and fill in your desired overrides.
+Please note that the scheduler will override the ``metadata.name`` of the V1pod before launching it.
+
+To overwrite the base container of the pod launched by the KubernetesExecutor,
+create a V1pod with a single container, and overwrite the fields as follows:
+
+.. exampleinclude:: /../airflow/example_dags/example_kubernetes_executor_config.py
+    :language: python
+    :start-after: [START task_with_volume]
+    :end-before: [END task_with_volume]
+
+Note that volume mounts environment variables, ports, and devices will all be extended instead of overwritten.
+
+To add a sidecar container to the launched pod, create a V1pod with an empty first container with the
+name ``base`` and a second container containing your desired sidecar.
+
+.. exampleinclude:: /../airflow/example_dags/example_kubernetes_executor_config.py
+    :language: python
+    :start-after: [START task_with_sidecar]
+    :end-before: [END task_with_sidecar]
+
+In the following example, we create a sidecar container that shares a volume_mount for data sharing.
+
 KubernetesExecutor Architecture
 ################################
 


### PR DESCRIPTION
Users of the KubernetesExecutor will now have a "podOverride"
option in the executor_config. This option will allow users to
modify the pod launched by the KubernetesExecutor using a
`kubernetes.client.models.V1Pod` class. This is the first step
in deprecating the tradition executor_config.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
