### PR TITLE
Tail out all logs when retrieving from pod

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -171,7 +171,7 @@ class PodLauncher(LoggingMixin):
         wait=tenacity.wait_exponential(),
         reraise=True
     )
-    def read_pod_logs(self, pod: V1Pod, tail_lines: int = 10):
+    def read_pod_logs(self, pod: V1Pod):
         """Reads log from the POD"""
         try:
             return self._client.read_namespaced_pod_log(
@@ -179,7 +179,6 @@ class PodLauncher(LoggingMixin):
                 namespace=pod.metadata.namespace,
                 container='base',
                 follow=True,
-                tail_lines=tail_lines,
                 _preload_content=False
             )
         except BaseHTTPError as e:

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -49,8 +49,7 @@ class TestPodLauncher(unittest.TestCase):
                 container='base',
                 follow=True,
                 name=mock.sentinel.metadata.name,
-                namespace=mock.sentinel.metadata.namespace,
-                tail_lines=10
+                namespace=mock.sentinel.metadata.namespace
             ),
             mock.call(
                 _preload_content=False,
@@ -58,7 +57,6 @@ class TestPodLauncher(unittest.TestCase):
                 follow=True,
                 name=mock.sentinel.metadata.name,
                 namespace=mock.sentinel.metadata.namespace,
-                tail_lines=10
             )
         ])
 
@@ -74,24 +72,6 @@ class TestPodLauncher(unittest.TestCase):
             self.pod_launcher.read_pod_logs,
             mock.sentinel
         )
-
-    def test_read_pod_logs_successfully_with_tail_lines(self):
-        mock.sentinel.metadata = mock.MagicMock()
-        self.mock_kube_client.read_namespaced_pod_log.side_effect = [
-            mock.sentinel.logs
-        ]
-        logs = self.pod_launcher.read_pod_logs(mock.sentinel, 100)
-        self.assertEqual(mock.sentinel.logs, logs)
-        self.mock_kube_client.read_namespaced_pod_log.assert_has_calls([
-            mock.call(
-                _preload_content=False,
-                container='base',
-                follow=True,
-                name=mock.sentinel.metadata.name,
-                namespace=mock.sentinel.metadata.namespace,
-                tail_lines=100
-            ),
-        ])
 
     def test_read_pod_events_successfully_returns_events(self):
         mock.sentinel.metadata = mock.MagicMock()


### PR DESCRIPTION
<!--

closes: https://github.com/apache/airflow/issues/10586

--->

Remove the inaccessible tail_lines parameter which was causing log truncation in the event of a k8sPodOperator pod. 

I'm in the process of testing this with Breeze.
