### PR TITLE
Fetching databricks host from connection if not supplied in extras.

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -157,7 +157,10 @@ class DatabricksHook(BaseHook):  # noqa
         if 'token' in self.databricks_conn.extra_dejson:
             self.log.info('Using token auth. ')
             auth = _TokenAuth(self.databricks_conn.extra_dejson['token'])
-            host = self._parse_host(self.databricks_conn.extra_dejson['host'])
+            if 'host' in self.databricks_conn.extra_dejson:
+                host = self._parse_host(self.databricks_conn.extra_dejson['host'])
+            else:
+                host = self.databricks_conn.host
         else:
             self.log.info('Using basic auth. ')
             auth = (self.databricks_conn.login, self.databricks_conn.password)

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -457,9 +457,7 @@ class TestDatabricksHookToken(unittest.TestCase):
 class TestDatabricksHookTokenWhenNoHostIsProvidedInExtra(TestDatabricksHookToken):
     @provide_session
     def setUp(self, session=None):
-        conn = session.query(Connection) \
-            .filter(Connection.conn_id == DEFAULT_CONN_ID) \
-            .first()
+        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
         conn.extra = json.dumps({'token': TOKEN})
 
         session.commit()

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -454,6 +454,19 @@ class TestDatabricksHookToken(unittest.TestCase):
         self.assertEqual(kwargs['auth'].token, TOKEN)
 
 
+class TestDatabricksHookTokenWhenNoHostIsProvidedInExtra(TestDatabricksHookToken):
+    @provide_session
+    def setUp(self, session=None):
+        conn = session.query(Connection) \
+            .filter(Connection.conn_id == DEFAULT_CONN_ID) \
+            .first()
+        conn.extra = json.dumps({'token': TOKEN})
+
+        session.commit()
+
+        self.hook = DatabricksHook()
+
+
 class TestRunState(unittest.TestCase):
     def test_is_terminal_true(self):
         terminal_states = ['TERMINATED', 'SKIPPED', 'INTERNAL_ERROR']


### PR DESCRIPTION
Fix for the issue #10726 . Have supported the previous functionality of fetching the host from extras if specified else it is getting fetched from the databricks connection which makes more sense.