### PR TITLE
do not fail breeze when force deleting local-airflow-manifest

### DIFF
--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -206,7 +206,7 @@ function build_images::get_local_image_info() {
     TMP_MANIFEST_LOCAL_SHA=$(mktemp)
     set +e
     # Remove the container just in case
-    docker rm --force "local-airflow-manifest"
+    docker rm --force "local-airflow-manifest" || true
     # Create manifest from the local manifest image
     if ! docker create --name "local-airflow-manifest" "${AIRFLOW_CI_LOCAL_MANIFEST_IMAGE}"; then
         echo


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This fixes the following error:

```
22:59:35 ❯ ./breeze  --backend mysql
Backend: mysql


Checking if the remote image needs to be pulled

master-python3.6-ci-manifest: Pulling from apache/airflow
Digest: sha256:f8e98d54dcfb41a26d74c2ccc3828b8c8efb8e45f651bc62d379bed766c83237
Status: Image is up to date for apache/airflow:master-python3.6-ci-manifest
docker.io/apache/airflow:master-python3.6-ci-manifest
dab057dc69ef8caad343d214f6616dd720c19d84fdcba37cd156d371b886e065
dab057dc69ef8caad343d214f6616dd720c19d84fdcba37cd156d371b886e065
Error: No such container: local-airflow-manifest
Error: No such container: local-airflow-manifest
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
