### PR TITLE
fix task instance modal open performance issue

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -478,7 +478,7 @@
                   "&dag_id=" + encodeURIComponent(dag_id) +
                   "&execution_date=" + encodeURIComponent(execution_date) +
                   "&link_name=" + encodeURIComponent(link);
-          var external_link = $('<a href="#" data-toggle="tooltip" class="btn btn-primary disabled" target="_blank"></a>')
+          var external_link = $('<a href="#" class="btn btn-primary disabled" target="_blank"></a>')
           var link_tooltip = $('<span class="tool-tip" data-toggle="tooltip" style="padding-right: 2px; padding-left: 3px" data-placement="top" ' +
             'title="link not yet available"></span>');
           link_tooltip.append(external_link)
@@ -500,9 +500,10 @@
           markupArr.push(link_tooltip)
         });
 
-        $('#extra_links').prev('hr').show();
-        $('#extra_links').append(markupArr).show();
-        $('[data-toggle="tooltip"]').tooltip();
+        var extra_links_span = $('#extra_links');
+        extra_links_span.prev('hr').show();
+        extra_links_span.append(markupArr).show();
+        extra_links_span.find('[data-toggle="tooltip"]').tooltip();
       }
     }
 


### PR DESCRIPTION
This reduces the task instance modal open wait time for large DAGs with extra links from minutes to 6 ms, an order of 10000 times speed up.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
