### PR TITLE
Add Plugins View in web UI

### DIFF
--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -49,6 +49,7 @@ PLUGINS_ATTRIBUTES_TO_DUMP = [
     "appbuilder_menu_items",
     "global_operator_extra_links",
     "operator_extra_links",
+    "source",
 ]
 
 

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -55,6 +55,7 @@ def init_appbuilder_views(app):
     appbuilder.add_view(views.TaskRescheduleModelView, "Task Reschedules", category="Browse")
     appbuilder.add_view(views.ConfigurationView, "Configurations", category="Admin", category_icon="fa-user")
     appbuilder.add_view(views.ConnectionModelView, "Connections", category="Admin")
+    appbuilder.add_view(views.PluginView, "Plugins", category="Admin")
     appbuilder.add_view(views.PoolModelView, "Pools", category="Admin")
     appbuilder.add_view(views.VariableModelView, "Variables", category="Admin")
     appbuilder.add_view(views.XComModelView, "XComs", category="Admin")

--- a/airflow/www/templates/airflow/plugin.html
+++ b/airflow/www/templates/airflow/plugin.html
@@ -1,0 +1,56 @@
+{#
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+#}
+
+{% extends base_template %}
+
+
+{% block title %}
+
+  {{ title }}
+
+{% endblock %}
+
+
+{% block content %}
+
+  <div>
+
+    <h2>{{ title }}</h2>
+
+    {% for plugin in plugins %}
+      <h4>{{ plugin["plugin_no"] }}. {{ plugin["plugin_name"] }}</h4>
+
+      <table class="table table-striped table-bordered">
+        <tr>
+          <th>Attribute</th>
+          <th>Value</th>
+        </tr>
+        {% for attr, value in plugin["attrs"].items() %}
+          <tr>
+            <td>{{ attr }}</td>
+            <td class='code'>{{ value }}</td>
+          </tr>
+        {% endfor %}
+      </table>
+
+    {% endfor %}
+
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR adds a link to view details of Plugins loaded into the Airflow.

closes: https://github.com/apache/airflow/issues/9185

<img width="772" alt="Screenshot 2020-09-07 at 12 19 00 AM" src="https://user-images.githubusercontent.com/4328561/92333025-bd066280-f09f-11ea-9248-a250b912b049.png">

<img width="1217" alt="Screenshot 2020-09-17 at 10 30 15 PM" src="https://user-images.githubusercontent.com/4328561/93503250-6e758580-f935-11ea-8f72-b1bec08d0d53.png">



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
