### PR TITLE
Always return a list from s3 list methods.

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1598,6 +1598,12 @@ of this provider.
 This section describes the changes that have been made, and what you need to do to update your if
 you use any code located in `airflow.providers` package.
 
+#### Changed return type of `list_prefixes` and `list_keys` methods in `S3Hook`
+
+Previously, the `list_prefixes` and `list_keys` methods returned `None` when there were no
+results. The behavior has been changed to return an empty list instead of `None` in this
+case.
+
 #### Removed Hipchat integration
 
 Hipchat has reached end of life and is no longer available.

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -108,7 +108,7 @@ class TestAwsS3Hook:
         bucket.put_object(Key='a', Body=b'a')
         bucket.put_object(Key='dir/b', Body=b'b')
 
-        assert hook.list_prefixes(s3_bucket, prefix='non-existent/') is None
+        assert [] == hook.list_prefixes(s3_bucket, prefix='non-existent/')
         assert ['dir/'] == hook.list_prefixes(s3_bucket, delimiter='/')
         assert ['a'] == hook.list_keys(s3_bucket, delimiter='/')
         assert ['dir/b'] == hook.list_keys(s3_bucket, prefix='dir/')
@@ -131,7 +131,7 @@ class TestAwsS3Hook:
         bucket.put_object(Key='a', Body=b'a')
         bucket.put_object(Key='dir/b', Body=b'b')
 
-        assert hook.list_keys(s3_bucket, prefix='non-existent/') is None
+        assert [] == hook.list_keys(s3_bucket, prefix='non-existent/')
         assert ['a', 'dir/b'] == hook.list_keys(s3_bucket)
         assert ['a'] == hook.list_keys(s3_bucket, delimiter='/')
         assert ['dir/b'] == hook.list_keys(s3_bucket, prefix='dir/')


### PR DESCRIPTION
The `list_prefixes` and `list_keys` methods of the s3 hook return lists if the result isn't empty, and `None` otherwise. Some operators that use these methods break when the result is empty, because they expect to receive a list and not `None`. We could change the operators to handle `None`, but I think it makes more sense to return an empty list when the prefix or key list is empty instead. This matches the behavior of the aws sdk, and I think an empty list is a more reasonable return value than `None` if no prefixes or keys match the query.