### PR TITLE
Update MySQLToS3Operator's s3_bucket to template_fields

### DIFF
--- a/airflow/providers/amazon/aws/transfers/mysql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mysql_to_s3.py
@@ -35,11 +35,11 @@ class MySQLToS3Operator(BaseOperator):
     Saves data from an specific MySQL query into a file in S3.
 
     :param query: the sql query to be executed. If you want to execute a file, place the absolute path of it,
-        ending with .sql extension.
+        ending with .sql extension. (templated)
     :type query: str
-    :param s3_bucket: bucket where the data will be stored
+    :param s3_bucket: bucket where the data will be stored. (templated)
     :type s3_bucket: str
-    :param s3_key: desired key for the file. It includes the name of the file
+    :param s3_key: desired key for the file. It includes the name of the file. (templated)
     :type s3_key: str
     :param mysql_conn_id: reference to a specific mysql database
     :type mysql_conn_id: str
@@ -64,6 +64,7 @@ class MySQLToS3Operator(BaseOperator):
     """
 
     template_fields = (
+        's3_bucket',
         's3_key',
         'query',
     )


### PR DESCRIPTION
It was inconvenient because the s3_bucket of MySQLToS3Operator is not specified in the template_fields. Also, the documentation has been updated a bit.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
