### PR TITLE
Requirements might get upgraded without setup.py change

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -53,6 +53,7 @@ jobs:
       sourceEvent: ${{ steps.cancel.outputs.sourceEvent }}
       cacheDirective: ${{ steps.cache-directive.outputs.docker-cache }}
       buildImages: ${{ steps.build-images.outputs.buildImages }}
+      upgradeToLatestConstraints: ${{ steps.upgrade-constraints.upgradeToLatestConstraints }}
     if: github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule'
     steps:
       - name: "Cancel duplicated 'CI Build' runs"
@@ -140,6 +141,15 @@ jobs:
           else
               echo "::set-output name=docker-cache::pulled"
           fi
+      - name: "Set upgrade to latest constraints"
+        id: upgrade-constraints
+        run: |
+          if [[ ${{ needs.cancel-workflow-runs.outputs.sourceEvent == 'push' ||
+              needs.cancel-workflow-runs.outputs.sourceEvent == 'scheduled' }} == 'true' ]]; then
+              echo "::set-output name=upgradeToLatestConstraints::${{ github.sha }}"
+          else
+              echo "::set-output name=upgradeToLatestConstraints::false"
+          fi
 
   build-info:
     # The name is such long because we are using it to cancel duplicated 'Build Images' runs
@@ -210,9 +220,7 @@ jobs:
       BACKEND: postgres
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       GITHUB_REGISTRY_PUSH_IMAGE_TAG: ${{ github.event.workflow_run.id }}
-      UPGRADE_TO_LATEST_CONSTRAINTS: >
-        ${{ needs.cancel-workflow-runs.outputs.sourceEvent == 'push' ||
-        needs.cancel-workflow-runs.outputs.sourceEvent == 'scheduled' }}
+      UPGRADE_TO_LATEST_CONSTRAINTS: ${{ needs.cancel-workflow-runs.outputs.upgradeToLatestConstraints }}
       DOCKER_CACHE: ${{ needs.cancel-workflow-runs.outputs.cacheDirective }}
     steps:
       - name: >

--- a/CI.rst
+++ b/CI.rst
@@ -200,7 +200,8 @@ You can use those variables when you try to reproduce the build locally.
 |                                         |             |             |            | stored in separated "orphan" branches           |
 |                                         |             |             |            | of the airflow repository                       |
 |                                         |             |             |            | ("constraints-master, "constraints-1-10")       |
-|                                         |             |             |            | but when this flag is set, they are not         |
+|                                         |             |             |            | but when this flag is set to anything but false |
+|                                         |             |             |            | (for example commit SHA), they are not used     |
 |                                         |             |             |            | used and "eager" upgrade strategy is used       |
 |                                         |             |             |            | when installing dependencies. We set it         |
 |                                         |             |             |            | to true in case of direct pushes (merges)       |
@@ -209,6 +210,10 @@ You can use those variables when you try to reproduce the build locally.
 |                                         |             |             |            | in case we determine that the tests pass        |
 |                                         |             |             |            | we automatically push latest set of             |
 |                                         |             |             |            | "tested" constraints to the repository.         |
+|                                         |             |             |            |                                                 |
+|                                         |             |             |            | Setting the value to commit SHA is best way     |
+|                                         |             |             |            | to assure that constraints are upgraded even if |
+|                                         |             |             |            | there is no change to setup.py                  |
 |                                         |             |             |            |                                                 |
 |                                         |             |             |            | This way our constraints are automatically      |
 |                                         |             |             |            | tested and updated whenever new versions        |

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -256,7 +256,7 @@ ENV UPGRADE_TO_LATEST_CONSTRAINTS=${UPGRADE_TO_LATEST_CONSTRAINTS}
 # But in cron job we will install latest versions matching setup.py to see if there is no breaking change
 # and push the constraints if everything is successful
 RUN \
-    if [[ "${UPGRADE_TO_LATEST_CONSTRAINTS}" == "true" ]]; then \
+    if [[ "${UPGRADE_TO_LATEST_CONSTRAINTS}" != "false" ]]; then \
         pip install -e ".[${AIRFLOW_EXTRAS}]" --upgrade --upgrade-strategy eager; \
     else \
         pip install -e ".[${AIRFLOW_EXTRAS}]" \


### PR DESCRIPTION
I noticed that when there is no setup.py changes, the constraints
are not upgraded automatically. This is because of the docker
caching strategy used - it simply does not even know that the
upgrade of pip should happen.

I believe this is really good (from security and incremental updates
POV to attempt to upgrade at every successfull merge (not that
the upgrade will not be committed if any of the tests fail and this
is only happening on every merge to master or scheduled run.

This way we will have more often but smaller constraint changes.

Depends on #10828 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
