### PR TITLE
Fixes pre-commit failing on build step

### DIFF
--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -509,7 +509,7 @@ function build_images::build_ci_image() {
         spinner::spin "${OUTPUT_LOG}" &
         SPIN_PID=$!
         # shellcheck disable=SC2064
-        traps::add_trap "kill ${SPIN_PID}" INT TERM HUP EXIT
+        traps::add_trap "kill ${SPIN_PID} || true" INT TERM HUP EXIT
     fi
     push_pull_remove_images::pull_ci_images_if_needed
     if [[ "${DOCKER_CACHE}" == "disabled" ]]; then
@@ -537,7 +537,7 @@ function build_images::build_ci_image() {
         spinner::spin "${OUTPUT_LOG}" &
         SPIN_PID=$!
         # shellcheck disable=SC2064
-        traps::add_trap "kill ${SPIN_PID}" EXIT HUP INT TERM
+        traps::add_trap "kill ${SPIN_PID} || true" EXIT HUP INT TERM
     fi
     if [[ -n ${DETECTED_TERMINAL=} ]]; then
         echo -n "

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -235,7 +235,7 @@ EOF
 }
 
 function stop_output_heartbeat() {
-    kill "${HEARTBEAT_PID}"
+    kill "${HEARTBEAT_PID}" || true
     wait "${HEARTBEAT_PID}" || true 2> /dev/null
 }
 


### PR DESCRIPTION
When rebuildig the image during commit, kill command failed to
find the spinner job to kill (this is just preventive measure)
and failed the rebuild step in pre-commit.

This is now fixed.



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
