### PR TITLE
All files in providers package have unit tests

### DIFF
--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -20,15 +20,12 @@ import itertools
 import mmap
 import os
 import unittest
-from typing import Set
 
 from parameterized import parameterized
 
 ROOT_FOLDER = os.path.realpath(
     os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir)
 )
-
-MISSING_TEST_FILES: Set[str] = set()  # add missing test files in providers package here.
 
 
 class TestProjectStructure(unittest.TestCase):
@@ -88,22 +85,7 @@ class TestProjectStructure(unittest.TestCase):
         current_test_files = set(current_test_files)
 
         missing_tests_files = expected_test_files - expected_test_files.intersection(current_test_files)
-        self.assertEqual(set(), missing_tests_files - MISSING_TEST_FILES)
-
-    def test_keep_missing_test_files_update(self):
-        new_test_files = []
-        for test_file in MISSING_TEST_FILES:
-            if os.path.isfile(f"{ROOT_FOLDER}/{test_file}"):
-                new_test_files.append(test_file)
-        if new_test_files:
-            new_files_text = '\n'.join(new_test_files)
-            self.fail(
-                "You've added a test file currently listed as missing:\n"
-                f"{new_files_text}"
-                "\n"
-                "Thank you very much.\n"
-                "Can you remove it from the list of missing tests, please?"
-            )
+        self.assertEqual(set(), missing_tests_files)
 
 
 class TestGoogleProviderProjectStructure(unittest.TestCase):


### PR DESCRIPTION
To improve test coverage as well as engage new contributors, I created a ticket about missing unit tests in providers package.
Close: https://github.com/apache/airflow/issues/8278
The goal was met and we already have at least one test for each file in the provider package. I hope it will make keeping this code in good condition much easier. 🎉 

The lucky guy who added the last test is @ephraimbuddy : https://github.com/apache/airflow/pull/10765

Thanks to everyone who participated in this task.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
