### PR TITLE
Fixed wrong "-e" on md5 file status check

### DIFF
--- a/scripts/ci/libraries/_md5sum.sh
+++ b/scripts/ci/libraries/_md5sum.sh
@@ -92,7 +92,7 @@ function md5sum::calculate_md5sum_for_all_files() {
             FILES_MODIFIED="true"
         fi
     done
-    set +e
+    set -e
 }
 
 #


### PR DESCRIPTION
The "-e" flag was not reset properly in the md5 status check
which could lead in some cases to removing output of flake check.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
