### PR TITLE
Don't include kubernetes_tests/ and backport_packages/ in our wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -748,7 +748,7 @@ def do_setup():
         long_description_content_type='text/markdown',
         license='Apache License 2.0',
         version=version,
-        packages=find_packages(exclude=['tests*']),
+        packages=find_packages(include=['airflow', 'airflow.*']),
         package_data={
             'airflow': ['py.typed'],
             '': ['airflow/alembic.ini', "airflow/git_version", "*.ipynb",


### PR DESCRIPTION
Since 1.10.x we have added some new top-level folders that were getting
included in the build wheel!

Example of the old wheel:

```
root@4b81e5a580e6:/# pip uninstall apache-airflow
Found existing installation: apache-airflow 2.0.0.dev0
Uninstalling apache-airflow-2.0.0.dev0:
  Would remove:
    /usr/local/bin/airflow
    /usr/local/lib/python3.7/site-packages/airflow/*
    /usr/local/lib/python3.7/site-packages/apache_airflow-2.0.0.dev0.dist-info/*
    /usr/local/lib/python3.7/site-packages/backport_packages/*
    /usr/local/lib/python3.7/site-packages/kubernetes_tests/*
```

New:

```
root@4b81e5a580e6:/# pip uninstall apache-airflow
Found existing installation: apache-airflow 2.0.0.dev0
Uninstalling apache-airflow-2.0.0.dev0:
  Would remove:
    /usr/local/bin/airflow
    /usr/local/lib/python3.7/site-packages/airflow/*
    /usr/local/lib/python3.7/site-packages/apache_airflow-2.0.0.dev0.dist-info/*
```