### PR TITLE
Fix integration tests being accidentally excluded

### DIFF
--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -545,8 +545,6 @@ function initialization::make_constants_read_only() {
     readonly HOST_HOME
     readonly HOST_OS
 
-    readonly INTEGRATIONS
-
     readonly ENABLE_KIND_CLUSTER
     readonly KUBERNETES_MODE
     readonly KUBERNETES_VERSION

--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -17,6 +17,9 @@
 # under the License.
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 
+
+. "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
+
 INTEGRATIONS=()
 
 ENABLED_INTEGRATIONS=${ENABLED_INTEGRATIONS:=""}
@@ -39,8 +42,7 @@ do
     INTEGRATIONS+=("${SCRIPTS_CI_DIR}/docker-compose/integration-${_INT}.yml")
 done
 
-
-. "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
+readonly INTEGRATIONS
 
 if [[ -f ${BUILD_CACHE_DIR}/.skip_tests ]]; then
     echo


### PR DESCRIPTION
The change from #10769 accidentally switched Integration tests
into far-longer run unit tests (we effectively run the tests
twice and did not run integration tests.

This fixes the problem by removing readonly status from
INTEGRATIONS and only setting it after the integrations are
set.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
