### PR TITLE
Add new lint check to now allow realtive imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -274,6 +274,14 @@ repos:
         entry: "\\|\\s*safe"
         files: \.html$
         pass_filenames: true
+      - id: no-relative-imports
+        language: pygrep
+        name: No relative imports
+        description: Airflow style is to use absolute imports only
+        entry: "^\\s*from\\s+\\."
+        pass_filenames: true
+        files: \.py$
+        exclude: ^tests/
       - id: language-matters
         language: pygrep
         name: Check for language that we do not accept as community

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1813,10 +1813,10 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  debug-statements detect-private-key doctoc dont-use-safe-filter end-of-file-fixer
                  fix-encoding-pragma flake8 forbid-tabs incorrect-use-of-LoggingMixin insert-license
                  isort language-matters lint-dockerfile lint-openapi mermaid mixed-line-ending mypy
-                 pre-commit-descriptions provide-create-sessions pydevd pydocstyle pylint
-                 pylint-tests python-no-log-warn restrict-start_date rst-backticks setup-order
-                 shellcheck stylelint trailing-whitespace update-breeze-file update-extras
-                 update-local-yml-file update-setup-cfg-file yamllint
+                 no-relative-imports pre-commit-descriptions provide-create-sessions pydevd
+                 pydocstyle pylint pylint-tests python-no-log-warn restrict-start_date rst-backticks
+                 setup-order shellcheck stylelint trailing-whitespace update-breeze-file
+                 update-extras update-local-yml-file update-setup-cfg-file yamllint
 
         You can pass extra arguments including options to to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -86,6 +86,8 @@ require Breeze Docker images to be installed locally:
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``dont-use-safe-filter``              Don't use safe in templates.
 ----------------------------------- ---------------------------------------------------------------- ------------
+``no-relative-imports``               Use absolute imports, not realtive
+----------------------------------- ---------------------------------------------------------------- ------------
 ``end-of-file-fixer``                 Makes sure that there is an empty line at the end.
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``fix-encoding-pragma``               Removes encoding header from python files.

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -28,12 +28,11 @@ from kubernetes.stream import stream as kubernetes_stream
 from requests.exceptions import BaseHTTPError
 
 from airflow.exceptions import AirflowException
+from airflow.kubernetes.kube_client import get_kube_client
 from airflow.kubernetes.pod_generator import PodDefaults
 from airflow.settings import pod_mutation_hook
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
-
-from .kube_client import get_kube_client
 
 
 class PodStatus:

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -23,7 +23,7 @@ from random import random  # noqa
 
 import dateutil  # noqa
 
-from . import hive  # noqa
+from airflow.macros import hive  # noqa
 
 
 def ds_add(ds, days):

--- a/breeze-complete
+++ b/breeze-complete
@@ -97,6 +97,7 @@ lint-openapi
 mermaid
 mixed-line-ending
 mypy
+no-relative-imports
 pre-commit-descriptions
 provide-create-sessions
 pydevd


### PR DESCRIPTION
Relative and absolute imports are functionally equivalent, the only
pratical difference is that relative is shorter.

But it is also less obvious what exactly is imported, and harder to find
such imports with simple tools (such as grep).

Thus we have decided that Airflow house style is to use absolute imports
only
