### PR TITLE
Fix chain methods for XComArg

### DIFF
--- a/airflow/example_dags/example_xcomargs.py
+++ b/airflow/example_dags/example_xcomargs.py
@@ -63,7 +63,7 @@ with DAG(
 ) as dag2:
     bash_op1 = BashOperator(task_id="c", bash_command="echo c")
     bash_op2 = BashOperator(task_id="d", bash_command="echo c")
-    xcom_args_a = print_value("first!")
-    xcom_args_b = print_value("second!")
+    xcom_args_a = print_value("first!")  # type: ignore
+    xcom_args_b = print_value("second!")  # type: ignore
 
     bash_op1 >> xcom_args_a >> xcom_args_b >> bash_op2

--- a/airflow/example_dags/example_xcomargs.py
+++ b/airflow/example_dags/example_xcomargs.py
@@ -20,6 +20,7 @@
 import logging
 
 from airflow import DAG
+from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator, get_current_context, task
 from airflow.utils.dates import days_ago
 
@@ -43,7 +44,7 @@ with DAG(
     default_args={'owner': 'airflow'},
     start_date=days_ago(2),
     schedule_interval=None,
-    tags=['example']
+    tags=['example'],
 ) as dag:
     task1 = PythonOperator(
         task_id='generate_value',
@@ -51,3 +52,18 @@ with DAG(
     )
 
     print_value(task1.output)
+
+
+with DAG(
+    "example_xcom_args_with_operators",
+    default_args={'owner': 'airflow'},
+    start_date=days_ago(2),
+    schedule_interval=None,
+    tags=['example'],
+) as dag2:
+    bash_op1 = BashOperator(task_id="c", bash_command="echo c")
+    bash_op2 = BashOperator(task_id="d", bash_command="echo c")
+    xcom_args_a = print_value("first!")
+    xcom_args_b = print_value("second!")
+
+    bash_op1 >> xcom_args_a >> xcom_args_b >> bash_op2

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -79,6 +79,22 @@ class XComArg:
         self.set_downstream(other)
         return other
 
+    def __rrshift__(self, other):
+        """
+        Called for XComArg >> [XComArg] because list don't have
+        __rshift__ operators.
+        """
+        self.__lshift__(other)
+        return self
+
+    def __rlshift__(self, other):
+        """
+        Called for XComArg >> [XComArg] because list don't have
+        __lshift__ operators.
+        """
+        self.__rshift__(other)
+        return self
+
     def __getitem__(self, item):
         """
         Implements xcomresult['some_result_key']

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -70,14 +70,14 @@ class XComArg:
         Implements XComArg << op
         """
         self.set_upstream(other)
-        return self
+        return other
 
     def __rshift__(self, other):
         """
         Implements XComArg >> op
         """
         self.set_downstream(other)
-        return self
+        return other
 
     def __getitem__(self, item):
         """

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -78,29 +78,31 @@ class TestXComArgBuild:
         with DAG("test_set_downstream", default_args=DEFAULT_ARGS):
             op_a = BashOperator(task_id="a", bash_command="echo a")
             op_b = BashOperator(task_id="b", bash_command="echo b")
-            bash_op = BashOperator(task_id="c", bash_command="echo c")
+            bash_op1 = BashOperator(task_id="c", bash_command="echo c")
+            bash_op2 = BashOperator(task_id="d", bash_command="echo c")
             xcom_args_a = XComArg(op_a)
             xcom_args_b = XComArg(op_b)
 
-            xcom_args_a >> xcom_args_b >> bash_op
+            bash_op1 >> xcom_args_a >> xcom_args_b >> bash_op2
 
-        assert len(op_a.downstream_list) == 2
+        assert op_a in bash_op1.downstream_list
         assert op_b in op_a.downstream_list
-        assert bash_op in op_a.downstream_list
+        assert bash_op2 in op_b.downstream_list
 
     def test_set_upstream(self):
         with DAG("test_set_upstream", default_args=DEFAULT_ARGS):
             op_a = BashOperator(task_id="a", bash_command="echo a")
             op_b = BashOperator(task_id="b", bash_command="echo b")
-            bash_op = BashOperator(task_id="c", bash_command="echo c")
+            bash_op1 = BashOperator(task_id="c", bash_command="echo c")
+            bash_op2 = BashOperator(task_id="d", bash_command="echo c")
             xcom_args_a = XComArg(op_a)
             xcom_args_b = XComArg(op_b)
 
-            xcom_args_a << xcom_args_b << bash_op
+            bash_op1 << xcom_args_a << xcom_args_b << bash_op2
 
-        assert len(op_a.upstream_list) == 2
+        assert op_a in bash_op1.upstream_list
         assert op_b in op_a.upstream_list
-        assert bash_op in op_a.upstream_list
+        assert bash_op2 in op_b.upstream_list
 
     def test_xcom_arg_property_of_base_operator(self):
         with DAG("test_xcom_arg_property_of_base_operator", default_args=DEFAULT_ARGS):


### PR DESCRIPTION
__lshift__ and __rshift__ methods should return other not self.
This PR fixes XComArg implementation  to support chain like this one:
BaseOprator >> XComArg >> BaseOperator

Related to: #10153

Kudos to @yuqian90 for spotting this issue! 🚀 

<img width="728" alt="Screenshot 2020-09-09 at 12 57 21" src="https://user-images.githubusercontent.com/9528307/92590228-2357d480-f29c-11ea-9dcd-9ad14e18a697.png">
I
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
