### PR TITLE
Fix failing dependencies for FAB and Celery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,7 @@ celery = [
     'celery~=4.4.2',
     'flower>=0.7.3, <1.0',
     'tornado>=4.2.0, <6.0',  # Dep of flower. Pin to a version that works on Py3.5.2
+    'vine~=1.3',  # https://stackoverflow.com/questions/32757259/celery-no-module-named-five
 ]
 cgroups = [
     'cgroupspy>=0.1.4',
@@ -247,7 +248,7 @@ facebook = [
     'facebook-business>=6.0.2',
 ]
 flask_oauth = [
-    'Flask-OAuthlib>=0.9.1',
+    'Flask-OAuthlib>=0.9.1,<0.9.6',  # Flask OAuthLib 0.9.6 requires Flask-Login 0.5.0 - breaks FAB
     'oauthlib!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0,>=1.1.2',
     'requests-oauthlib==1.1.0',
 ]
@@ -703,7 +704,7 @@ INSTALL_REQUIREMENTS = [
     'flask>=1.1.0, <2.0',
     'flask-appbuilder>2.3.4,~=3.0',
     'flask-caching>=1.3.3, <2.0.0',
-    'flask-login>=0.3, <1.0',
+    'flask-login>=0.3, <0.5',
     'flask-swagger==0.2.13',
     'flask-wtf>=0.14.2, <0.15',
     'funcsigs>=1.0.0, <2.0.0',


### PR DESCRIPTION
Recent releases of FAB and Celery caused our installation to
fail. Luckily we have protection so that regular PRs are not
affected, however, we need to update the setup.py to exclude
those dependencies that cause the problem.

Those are:

* vine - which is used by Celery Sensor (via kombu) - 5.0.0
  version breaks celery-vine feature

* Flask-OauthLib and flask-login - combination of the current
  requirements caused a conflict by forcing flask login to
  be 0.5.0 which is not compatible with Flask Application Builder

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
