### PR TITLE
Fix autocommit property for snowflake connection

### DIFF
--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -134,3 +134,7 @@ class SnowflakeHook(DbApiHook):
 
     def set_autocommit(self, conn, autocommit):
         conn.autocommit(autocommit)
+        conn._autocommit = autocommit
+
+    def get_autocommit(self, conn):
+        return getattr(conn, '_autocommit', False)


### PR DESCRIPTION

When using the Snowflake hook with auto commit disabled, transactions get closed without committing the changes.
The get_autocommit function in the DbApiHook looks for a autocommit property which does not exist for Snowflake connections, this change adds an additional property to the connection to store this information.
