### PR TITLE
Fix autocommit property for snowflake connection

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -133,7 +133,7 @@ class SnowflakeHook(DbApiHook):
 
     def set_autocommit(self, conn, autocommit):
         conn.autocommit(autocommit)
-        conn._autocommit = autocommit
+        conn.autocommit_mode = autocommit
 
     def get_autocommit(self, conn):
-        return getattr(conn, '_autocommit', False)
+        return getattr(conn, 'autocommit_mode', False)

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -133,3 +133,7 @@ class SnowflakeHook(DbApiHook):
 
     def set_autocommit(self, conn, autocommit):
         conn.autocommit(autocommit)
+        conn._autocommit = autocommit
+
+    def get_autocommit(self, conn):
+        return getattr(conn, '_autocommit', False)


### PR DESCRIPTION
When using the Snowflake hook with auto commit disabled, transactions get closed without committing the changes.
The get_autocommit function in the DbApiHook looks for a autocommit property which does not exist for Snowflake connections, this change adds an additional property to the connection to store this information.