### PR TITLE
Improvement: Populate 'Configuration JSON' form with DAG default params json in the Trigger-DAG UI

### DIFF
--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -35,7 +35,8 @@ dag = DAG(
     schedule_interval='0 0 * * *',
     start_date=days_ago(2),
     dagrun_timeout=timedelta(minutes=60),
-    tags=['example']
+    tags=['example'],
+    params={"example_key": "example_value"}
 )
 
 run_this_last = DummyOperator(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1241,13 +1241,17 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         """Triggers DAG Run."""
         dag_id = request.values.get('dag_id')
         origin = get_safe_url(request.values.get('origin'))
+        request_conf = request.values.get('conf')
 
         if request.method == 'GET':
-            # Use dag.params as default data in trigger-DagRun UI
+            # Populate conf textarea with conf requests parameter, or dag.params
             default_conf = ''
-            dag = current_app.dag_bag.get_dag(dag_id)
-            if dag.params:
-                default_conf = json.dumps(dag.params, indent=4)
+            if request_conf:
+                default_conf = request_conf
+            else:
+                dag = current_app.dag_bag.get_dag(dag_id)
+                if dag.params:
+                    default_conf = json.dumps(dag.params, indent=4)
             return self.render_template(
                 'airflow/trigger.html',
                 dag_id=dag_id,
@@ -1268,7 +1272,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             return redirect(origin)
 
         run_conf = {}
-        request_conf = request.values.get('conf')
         if request_conf:
             try:
                 run_conf = json.loads(request_conf)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1243,11 +1243,16 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         origin = get_safe_url(request.values.get('origin'))
 
         if request.method == 'GET':
+            # Use dag.params as default data in trigger-DagRun UI
+            default_conf = ''
+            dag = current_app.dag_bag.get_dag(dag_id)
+            if dag.params:
+                default_conf = json.dumps(dag.params, indent=4)
             return self.render_template(
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
-                conf=''
+                conf=default_conf
             )
 
         dag_orm = session.query(models.DagModel).filter(models.DagModel.dag_id == dag_id).first()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1251,7 +1251,10 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             else:
                 dag = current_app.dag_bag.get_dag(dag_id)
                 if dag.params:
-                    default_conf = json.dumps(dag.params, indent=4)
+                    try:
+                        default_conf = json.dumps(dag.params, indent=4)
+                    except TypeError:
+                        flash("Could not pre-populate conf field due to non-JSON-serializable data-types")
             return self.render_template(
                 'airflow/trigger.html',
                 dag_id=dag_id,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1249,12 +1249,11 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             if request_conf:
                 default_conf = request_conf
             else:
-                dag = current_app.dag_bag.get_dag(dag_id)
-                if dag.params:
-                    try:
-                        default_conf = json.dumps(dag.params, indent=4)
-                    except TypeError:
-                        flash("Could not pre-populate conf field due to non-JSON-serializable data-types")
+                try:
+                    dag = current_app.dag_bag.get_dag(dag_id)
+                    default_conf = json.dumps(dag.params, indent=4)
+                except TypeError:
+                    flash("Could not pre-populate conf field due to non-JSON-serializable data-types")
             return self.render_template(
                 'airflow/trigger.html',
                 dag_id=dag_id,

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2519,6 +2519,16 @@ class TestTriggerDag(TestBase):
                 expected_origin),
             resp)
 
+    def test_trigger_dag_params_conf(self):
+        test_dag_id = "example_bash_operator"
+        test_dag_conf = json.dumps({"example_key": "example_value"}, indent=4) \
+            .replace("\"", "&#34;")
+
+        resp = self.client.get('trigger?dag_id={}'.format(test_dag_id))
+        self.check_content_in_response(
+            '<textarea class="form-control" name="conf">{}</textarea>'.format(test_dag_conf),
+            resp)
+
     def test_trigger_endpoint_uses_existing_dagbag(self):
         """
         Test that Trigger Endpoint uses the DagBag already created in views.py

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2519,14 +2519,32 @@ class TestTriggerDag(TestBase):
                 expected_origin),
             resp)
 
-    def test_trigger_dag_params_conf(self):
+    @parameterized.expand([
+        (None, {"example_key": "example_value"}),
+        ({"other": "test_data", "key": 12}, {"other": "test_data", "key": 12}),
+    ])
+    def test_trigger_dag_params_conf(self, request_conf, expected_conf):
+        """
+        Test that textarea in Trigger DAG UI is pre-populated
+        with json config when the conf URL parameter is passed,
+        or if a params dict is passed in the DAG
+
+            1. Conf is not included in URL parameters -> DAG.conf is in textarea
+            2. Conf is passed as a URL parameter -> passed conf json is in textarea
+        """
         test_dag_id = "example_bash_operator"
-        test_dag_conf = json.dumps({"example_key": "example_value"}, indent=4) \
+
+        if not request_conf:
+            resp = self.client.get('trigger?dag_id={}'.format(test_dag_id))
+        else:
+            test_request_conf = json.dumps(request_conf, indent=4)
+            resp = self.client.get('trigger?dag_id={}&conf={}'.format(test_dag_id, test_request_conf))
+
+        expected_dag_conf = json.dumps(expected_conf, indent=4) \
             .replace("\"", "&#34;")
 
-        resp = self.client.get('trigger?dag_id={}'.format(test_dag_id))
         self.check_content_in_response(
-            '<textarea class="form-control" name="conf">{}</textarea>'.format(test_dag_conf),
+            '<textarea class="form-control" name="conf">{}</textarea>'.format(expected_dag_conf),
             resp)
 
     def test_trigger_endpoint_uses_existing_dagbag(self):


### PR DESCRIPTION
This PR populates the **Configuration JSON** text-area in the '**Trigger DAG**' UI with the DAG's `param` dict.

Currently the UI looks like this: 
![Screenshot 2020-09-09 at 17 25 29](https://user-images.githubusercontent.com/17148324/92626182-7db75c00-f2c1-11ea-8099-ddebd9730f0a.png)

When a job can be run with many parameters, it may be easier to provide users with the default values that they can change.

An artist's rendition of the proposed change:
![Screenshot 2020-09-09 at 17 25 29](https://user-images.githubusercontent.com/17148324/92627265-04b90400-f2c3-11ea-833b-01e5ce076c27.png)

Fortunately for me, the `conf` parameter was already present in the template:
https://github.com/apache/airflow/blob/master/airflow/www/templates/airflow/trigger.html#L31


I will add / change some tests for this shortly

---

A minor aside here - I love this addition to the UI, I think I'm going to be using it a lot in the very near future. Huge thanks to @dacohen and all of the reviewers & maintainers involved in this feature 🙌 