### PR TITLE
Add test for Health Endpoint when there is an exception

### DIFF
--- a/tests/api_connexion/endpoints/test_health_endpoint.py
+++ b/tests/api_connexion/endpoints/test_health_endpoint.py
@@ -16,6 +16,7 @@
 # under the License.
 import unittest
 from datetime import timedelta
+from unittest import mock
 
 from airflow.jobs.base_job import BaseJob
 from airflow.utils import timezone
@@ -87,4 +88,11 @@ class TestGetHeath(TestHealthTestBase):
         resp_json = self.client.get("/api/v1/health").json
         self.assertEqual("healthy", resp_json["metadatabase"]["status"])
         self.assertEqual("unhealthy", resp_json["scheduler"]["status"])
-        self.assertIsNone(None, resp_json["scheduler"]["latest_scheduler_heartbeat"])
+        self.assertIsNone(resp_json["scheduler"]["latest_scheduler_heartbeat"])
+
+    @mock.patch("airflow.api_connexion.endpoints.health_endpoint.SchedulerJob.most_recent_job")
+    def test_unhealthy_metadatabase_status(self, mock_scheduler_most_recent_job):
+        mock_scheduler_most_recent_job.side_effect = Exception
+        resp_json = self.client.get("/api/v1/health").json
+        self.assertEqual("unhealthy", resp_json["metadatabase"]["status"])
+        self.assertIsNone(resp_json["scheduler"]["latest_scheduler_heartbeat"])


### PR DESCRIPTION
We did not have any test to verify that if there is an exception, the API will still return a response and say Metadatabase is unhealthy.

Also fixed a bug where we had assertNone but still passed None as the first argument

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
