### PR TITLE
The entrypoints in Docker Image should be owned by Airflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -349,8 +349,8 @@ RUN mkdir -pv "${AIRFLOW_HOME}"; \
 
 COPY --chown=airflow:root --from=airflow-build-image /root/.local "${AIRFLOW_USER_HOME_DIR}/.local"
 
-COPY scripts/in_container/prod/entrypoint_prod.sh /entrypoint
-COPY scripts/in_container/prod/clean-logs.sh /clean-logs
+COPY --chown=airflow:root scripts/in_container/prod/entrypoint_prod.sh /entrypoint
+COPY --chown=airflow:root scripts/in_container/prod/clean-logs.sh /clean-logs
 RUN chmod a+x /entrypoint /clean-logs
 
 # Make /etc/passwd root-group-writeable so that user can be dynamically added by OpenShift


### PR DESCRIPTION

Since we are running the airflow image as airflow user, the
entrypoint and clear-logs scripts should also be set as airflow.
    
This had no impact if you actually run this as root user or
when your group was root (which was recommended).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
