### PR TITLE
Fix and unquarantine TestDagFileProcessorAgent.test_parse_once

### DIFF
--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -25,8 +25,6 @@ from tempfile import TemporaryDirectory
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
-import pytest
-
 from airflow.configuration import conf
 from airflow.jobs.local_task_job import LocalTaskJob as LJ
 from airflow.jobs.scheduler_job import DagFileProcessorProcess
@@ -384,7 +382,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
 
             self.assertFalse(os.path.isfile(log_file_loc))
 
-    @pytest.mark.quarantined
+    @conf_vars({('core', 'load_examples'): 'False'})
     def test_parse_once(self):
         test_dag_path = os.path.join(TEST_DAG_FOLDER, 'test_scheduler_dags.py')
         async_mode = 'sqlite' not in conf.get('core', 'sql_alchemy_conn')


### PR DESCRIPTION
The SmartSensor PR #5499 introduces slightly different behaviour onlist_py_files happens when given a file path directly.

Prior to that PR, if given a file path it would not include examples.

After that PR was merged, it would return that path and the example dags
(assuming they were enabled.)

@potiuk I'm not sure what behaviour you were seeing that caused you to quarantine it, but for me _every_ time I ran this test on SQLite it failed. (well hung for ever.) This PR fixes that.

Please let me know if you quarantined it for a different reason, and I can leave it quarantined.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
