### PR TITLE
Increase typing coverage for postgres provider

### DIFF
--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -77,7 +77,7 @@ class PostgresHook(DbApiHook):
 
     def get_conn(self) -> connection:
         """
-        Establishes a connection to a postgresql database.
+        Establishes a connection to a postgres database.
         """
         conn_id = getattr(self, self.conn_name_attr)
         conn = self.connection or self.get_connection(conn_id)
@@ -165,7 +165,7 @@ class PostgresHook(DbApiHook):
         """
         return cell
 
-    def get_iam_token(self, conn: connection) -> Tuple[str, str, int]:
+    def get_iam_token(self, conn: Connection) -> Tuple[str, str, int]:
         """
         Uses AWSHook to retrieve a temporary password to connect to Postgres
         or Redshift. Port is required. If none is provided, default is used for

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -27,7 +27,7 @@ from psycopg2.extensions import connection
 from psycopg2.extras import DictCursor, RealDictCursor, NamedTupleCursor
 
 from airflow.hooks.dbapi_hook import DbApiHook
-from airflow.models import Connection
+from airflow.models.connection import Connection
 
 CursorType = Union[DictCursor, RealDictCursor, NamedTupleCursor]
 
@@ -63,7 +63,7 @@ class PostgresHook(DbApiHook):
         super().__init__(*args, **kwargs)
         self.schema: Optional[str] = kwargs.pop("schema", None)
         self.connection: Optional[Connection] = kwargs.pop("connection", None)
-        self.conn: Optional[connection] = None
+        self.conn: connection = None
 
     def _get_cursor(self, raw_cursor: str) -> CursorType:
         _cursor = raw_cursor.lower()

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -18,12 +18,18 @@
 
 import os
 from contextlib import closing
+from typing import Iterable, Optional, Tuple, Union
 
 import psycopg2
 import psycopg2.extensions
 import psycopg2.extras
+from psycopg2.extensions import connection
+from psycopg2.extras import DictCursor, RealDictCursor, NamedTupleCursor
 
 from airflow.hooks.dbapi_hook import DbApiHook
+from airflow.models import Connection
+
+CursorType = Union[DictCursor, RealDictCursor, NamedTupleCursor]
 
 
 class PostgresHook(DbApiHook):
@@ -53,13 +59,13 @@ class PostgresHook(DbApiHook):
     default_conn_name = 'postgres_default'
     supports_autocommit = True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.schema = kwargs.pop("schema", None)
-        self.connection = kwargs.pop("connection", None)
-        self.conn = None
+        self.schema: Optional[str] = kwargs.pop("schema", None)
+        self.connection: Optional[Connection] = kwargs.pop("connection", None)
+        self.conn: Optional[connection] = None
 
-    def _get_cursor(self, raw_cursor):
+    def _get_cursor(self, raw_cursor: str) -> CursorType:
         _cursor = raw_cursor.lower()
         if _cursor == 'dictcursor':
             return psycopg2.extras.DictCursor
@@ -69,8 +75,10 @@ class PostgresHook(DbApiHook):
             return psycopg2.extras.NamedTupleCursor
         raise ValueError('Invalid cursor passed {}'.format(_cursor))
 
-    def get_conn(self):
-
+    def get_conn(self) -> connection:
+        """
+        Establishes a connection to a postgresql database.
+        """
         conn_id = getattr(self, self.conn_name_attr)
         conn = self.connection or self.get_connection(conn_id)
 
@@ -104,7 +112,7 @@ class PostgresHook(DbApiHook):
         self.conn = psycopg2.connect(**conn_args)
         return self.conn
 
-    def copy_expert(self, sql, filename):
+    def copy_expert(self, sql: str, filename: str) -> None:
         """
         Executes SQL using psycopg2 copy_expert method.
         Necessary to execute COPY command without access to a superuser.
@@ -126,13 +134,13 @@ class PostgresHook(DbApiHook):
                     file.truncate(file.tell())
                     conn.commit()
 
-    def bulk_load(self, table, tmp_file):
+    def bulk_load(self, table: str, tmp_file: str) -> None:
         """
         Loads a tab-delimited file into a database table
         """
         self.copy_expert("COPY {table} FROM STDIN".format(table=table), tmp_file)
 
-    def bulk_dump(self, table, tmp_file):
+    def bulk_dump(self, table: str, tmp_file: str) -> None:
         """
         Dumps a database table into a tab-delimited file
         """
@@ -140,7 +148,7 @@ class PostgresHook(DbApiHook):
 
     # pylint: disable=signature-differs
     @staticmethod
-    def _serialize_cell(cell, conn):
+    def _serialize_cell(cell: object, conn: Optional[connection] = None) -> object:
         """
         Postgresql will adapt all arguments to the execute() method internally,
         hence we return cell without any conversion.
@@ -157,7 +165,7 @@ class PostgresHook(DbApiHook):
         """
         return cell
 
-    def get_iam_token(self, conn):
+    def get_iam_token(self, conn: connection) -> Tuple[str, str, int]:
         """
         Uses AWSHook to retrieve a temporary password to connect to Postgres
         or Redshift. Port is required. If none is provided, default is used for
@@ -191,7 +199,9 @@ class PostgresHook(DbApiHook):
         return login, token, port
 
     @staticmethod
-    def _generate_insert_sql(table, values, target_fields, replace, **kwargs):
+    def _generate_insert_sql(
+        table: str, values: Tuple[str, ...], target_fields: Iterable[str], replace: bool, **kwargs
+    ) -> str:
         """
         Static helper method that generate the INSERT SQL statement.
         The REPLACE variant is specific to MySQL syntax.


### PR DESCRIPTION
This PR is about increasing typing coverage for the postgres provider. Part of: #9708

I change this file airflow/providers/postgres/hooks/postgres.py

closes: #9943
related: #9708

---
I go throw this guideline [Step 4: Prepare PR](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#step-4-prepare-pr)


## [Run the unit tests from the IDE or local virtualenv as you see fit.](https://github.com/apache/airflow/blob/master/TESTING.rst#running-unit-tests)

run the command bellow

``` bash
$ pytest tests/providers/postgres/
```
result

``` bash
============================================================ test session starts =============================================================
platform linux -- Python 3.7.0, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /home/salem/.pyenv/versions/3.7.0/envs/airflow-venv-370/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/salem/WorkSpaces/python/airflow, configfile: pytest.ini
plugins: rerunfailures-9.0, forked-1.3.0, flaky-3.7.0, cov-2.10.1, requests-mock-1.8.0, timeouts-1.2.1, instafail-0.4.2, xdist-2.0.0
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 20 items                    

tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn PASSED                                            [  5%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_cursor PASSED                                     [ 10%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_from_connection PASSED                            [ 15%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_from_connection_with_schema PASSED                [ 20%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_non_default_id PASSED                             [ 25%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_rds_iam_postgres PASSED                           [ 30%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_rds_iam_redshift PASSED                           [ 35%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_with_invalid_cursor PASSED                        [ 40%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHook::test_bulk_dump SKIPPED                                              [ 45%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHook::test_bulk_load SKIPPED                                              [ 50%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHook::test_copy_expert SKIPPED                                            [ 55%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHook::test_insert_rows SKIPPED                                            [ 60%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHook::test_insert_rows_replace SKIPPED                                    [ 65%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHook::test_insert_rows_replace_missing_replace_index_arg SKIPPED          [ 70%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHook::test_insert_rows_replace_missing_target_field_arg SKIPPED           [ 75%]
tests/providers/postgres/hooks/test_postgres.py::TestPostgresHook::test_rowcount SKIPPED                                               [ 80%]
tests/providers/postgres/operators/test_postgres.py::TestPostgres::test_overwrite_schema SKIPPED                                       [ 85%]
tests/providers/postgres/operators/test_postgres.py::TestPostgres::test_postgres_operator_test SKIPPED                                 [ 90%]
tests/providers/postgres/operators/test_postgres.py::TestPostgres::test_postgres_operator_test_multi SKIPPED                           [ 95%]
tests/providers/postgres/operators/test_postgres.py::TestPostgres::test_vacuum SKIPPED                                                 [100%]
============================================================== warnings summary ==============================================================
================================================== 8 passed, 12 skipped, 1 warning in 0.91s ==================================================
``` 

## [Run the tests in Breeze.](https://github.com/apache/airflow/blob/master/TESTING.rst#running-tests-for-a-specified-target-using-breeze-from-the-host)

run the command bellow

``` bash
$ sudo ./breeze tests tests/providers/postgres
```

results

``` bash
============================================================== warnings summary ==============================================================
ERROR tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn - Failed: Timeout >10.0s
ERROR tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_cursor - Failed: Timeout >10.0s
ERROR tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_from_connection - Failed: Timeout >10.0s
ERROR tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_from_connection_with_schema - Failed: Timeout >1...
ERROR tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_non_default_id - Failed: Timeout >10.0s
ERROR tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_rds_iam_postgres - Failed: Timeout >10.0s
ERROR tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_rds_iam_redshift - Failed: Timeout >10.0s
ERROR tests/providers/postgres/hooks/test_postgres.py::TestPostgresHookConn::test_get_conn_with_invalid_cursor - Failed: Timeout >10.0s
================================================= 12 skipped, 2 warnings, 8 errors in 15.06s =================================================

Regular tests. NOT Updating Quarantine Issue!

```

## [Running static checks](https://github.com/apache/airflow/blob/master/BREEZE.rst#running-static-checks)

I don't know at this time, which static test should I run for this Issue,  but I used the default one as shown below

``` bash
sudo ./breeze static-check mypy
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).

---
``` bash
    $ pytest tests/providers/postgres/

    $ sudo ./breeze tests tests/providers/postgres

    $ sudo ./breeze static-check pylint -- --all-files

    $ sudo ./breeze static-check pylint -- --files airflow/providers/postgres/

    $ sudo ./breeze static-check mypy

    $ mypy airflow/providers/postgres/hooks/postgres.py


    $ sudo ./breeze static-check pylint --show-diff-on-failure  --files airflow/providers

    $ sudo pre-commit run pylint --show-diff-on-failure --files airflow/providers

    $ sudo ./breeze static-check mypy -- --files airflow/providers/postgres/

```



``` bash
    sudo ./breeze static-check pylint -- --all-files
    sudo ./breeze static-check pylint -- --files airflow/providers/postgres/

    ./breeze static-check mypy -- --all-files
    sudo ./breeze static-check mypy -- --files airflow/providers/postgres/
```

:heart:

``` bash
pre-commit run
pre-commit run --all-files
pre-commit run mypy --all-files
pre-commit run pylint --all-files
```


```
git pull apache master
```

---
# TODO 

## Test fails on this stages

1.  ~~Static checks: except pylint [details](https://github.com/apache/airflow/pull/10864/checks?check_run_id=1116702359)~~
 > ` ./scripts/ci/static_checks/run_static_checks.sh`
2.  ~~Spell check docs [details](https://github.com/apache/airflow/pull/10864/checks?check_run_id=1116702223)~~
> `./scripts/ci/docs/ci_docs.sh --spellcheck-only`
3. CI Build / Core:Pg9.6,Py3.7 [details](https://github.com/apache/airflow/pull/10864/checks?check_run_id=1123482621)
> `./scripts/ci/testing/ci_run_airflow_testing.sh`
