### PR TITLE
Fix an error of type ingore

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -69,7 +69,7 @@ class DagRun(Base, LoggingMixin):
 
     task_instances = relationship(
         TI,
-        primaryjoin=and_(TI.dag_id == dag_id, TI.execution_date == execution_date),  # type: ignore
+        primaryjoin=and_(TI.dag_id == dag_id, TI.execution_date == execution_date),
         foreign_keys=(dag_id, execution_date),
         backref=backref('dag_run', uselist=False),
     )


### PR DESCRIPTION
```
Run mypy..........................................................................................................................Failed
- hook id: mypy
- exit code: 1

airflow/models/dagrun.py:72: error: unused 'type: ignore' comment
            primaryjoin=and_(TI.dag_id == dag_id, TI.execution_date == exe...
            ^
Found 1 error in 1 file (checked 2408 source files)
```



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
