### PR TITLE
Disables --warn-unused-ignore flag for mypy

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -69,7 +69,7 @@ class DagRun(Base, LoggingMixin):
 
     task_instances = relationship(
         TI,
-        primaryjoin=and_(TI.dag_id == dag_id, TI.execution_date == execution_date),
+        primaryjoin=and_(TI.dag_id == dag_id, TI.execution_date == execution_date),  # type: ignore
         foreign_keys=(dag_id, execution_date),
         backref=backref('dag_run', uselist=False),
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ packages = airflow
 ignore_missing_imports = True
 no_implicit_optional = True
 warn_redundant_casts = True
-warn_unused_ignores = True
+warn_unused_ignores = False
 plugins =
   airflow.mypy.plugin.decorators
 pretty = True


### PR DESCRIPTION
There is a problem with MyPy's implementation of
--warn-unused-ignore flag, that depending on it's incremental
or full run it will sometimes throw an "unused ignore" error
(entirely randomly it seems). The problem is described
(but only workarounded) in
https://github.com/python/mypy/issues/2960.

The workaround is to disable --warn-unused-ignore flag.
There is little harm in having unused ignores and we can
clean them up from time to time easily.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
