### PR TITLE
Mark task as failed when it fails "sending" in Celery

### DIFF
--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -159,13 +159,14 @@ class TestCeleryExecutor(unittest.TestCase):
                 dag=DAG(dag_id='id'),
                 start_date=datetime.datetime.now()
             )
+            when = datetime.datetime.now()
             value_tuple = 'command', 1, None, \
                 SimpleTaskInstance(ti=TaskInstance(task=task, execution_date=datetime.datetime.now()))
-            key = ('fail', 'fake_simple_ti', datetime.datetime.now(), 0)
+            key = ('fail', 'fake_simple_ti', when, 0)
             executor.queued_tasks[key] = value_tuple
             executor.heartbeat()
-        self.assertEqual(1, len(executor.queued_tasks))
-        self.assertEqual(executor.queued_tasks[key], value_tuple)
+        self.assertEqual(0, len(executor.queued_tasks), "Task should no longer be queued")
+        self.assertEqual(executor.event_buffer[('fail', 'fake_simple_ti', when, 0)][0], State.FAILED)
 
     @pytest.mark.backend("mysql", "postgres")
     def test_exception_propagation(self):


### PR DESCRIPTION
If a task failed hard on celery, _before_ being able to execute the
airflow code the task would end up stuck in queued state. This change
makes it get retried.

This was discovered in load testing the HA work (but unrelated to HA
changes), where I swamped the kube-dns pod, meaning the worker was
sometimes unable to resolve the db name via DNS, so the state in the DB
was never updated.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
