### PR TITLE
StreamLogWriter: Provide (no-op) close method.

### DIFF
--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -90,6 +90,14 @@ class StreamLogWriter:
         self.level = level
         self._buffer = ''
 
+    def close(self):
+        """
+        Provide close method, for compatibility with the io.IOBase interface.
+
+        This is a no-op method.
+        """
+        pass
+
     @property
     def closed(self):   # noqa: D402
         """

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -96,7 +96,6 @@ class StreamLogWriter:
 
         This is a no-op method.
         """
-        pass
 
     @property
     def closed(self):   # noqa: D402

--- a/tests/utils/test_logging_mixin.py
+++ b/tests/utils/test_logging_mixin.py
@@ -96,3 +96,10 @@ class TestStreamLogWriter(unittest.TestCase):
 
         log = StreamLogWriter(logger, 1)
         self.assertIsNone(log.encoding)
+
+    def test_iobase_compatibility(self):
+        log = StreamLogWriter(None, 1)
+
+        self.assertFalse(log.closed)
+        # has no specific effect
+        log.close()


### PR DESCRIPTION
Some contexts try to close their reference to the stderr stream at logging shutdown, this ensures these don't break.

closes: #10882 

