### PR TITLE
StreamLogWriter: Provide (no-op) close method (backport to v1-10)

### DIFF
--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -95,6 +95,14 @@ class StreamLogWriter(object):
         self.level = level
         self._buffer = str()
 
+    def close(self):
+        """
+        Provide close method, for compatibility with the io.IOBase interface.
+
+        This is a no-op method.
+        """
+        pass
+
     @property
     def closed(self):
         """

--- a/tests/utils/test_logging_mixin.py
+++ b/tests/utils/test_logging_mixin.py
@@ -116,3 +116,10 @@ class TestStreamLogWriter(unittest.TestCase):
 
         log = StreamLogWriter(logger, 1)
         self.assertIsNone(log.encoding)
+
+    def test_iobase_compatibility(self):
+        log = StreamLogWriter(None, 1)
+
+        self.assertFalse(log.closed)
+        # has no specific effect
+        log.close()


### PR DESCRIPTION
Some contexts try to close their reference to the stderr stream at logging shutdown, this ensures these don't break.

related: #10882, #10884

