### PR TITLE
Don't over-queue tasks in the executors

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -17,6 +17,7 @@
 """
 Base executor - this is the base class for all the implemented executors.
 """
+import sys
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -264,6 +265,16 @@ class BaseExecutor(LoggingMixin):
         This method is called when the daemon receives a SIGTERM
         """
         raise NotImplementedError()
+
+    @property
+    def slots_available(self):
+        """
+        Number of new tasks this executor can accept
+        """
+        if self.parallelism:
+            return self.parallelism - len(self.running) - len(self.queued_tasks)
+        else:
+            return sys.maxsize
 
     @staticmethod
     def validate_command(command: List[str]) -> None:

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1477,7 +1477,8 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
             session.commit()
             return result + len(simple_tis_with_state_changed)
 
-        return helpers.reduce_in_chunks(query, executable_tis, 0, self.max_tis_per_query)
+        chunk_size = min(self.max_tis_per_query, self.executor.slots_available)
+        return helpers.reduce_in_chunks(query, executable_tis, 0, chunk_size)
 
     @provide_session
     def _change_state_for_tasks_failed_to_execute(self, session: Session = None):


### PR DESCRIPTION
This is a small change, but a bigger change in behaviour, and used more in future HA PRs.

Previously the flow was to set as many tasks as possible to queued, try to
enqueue as many as possible ("over-filling" the executor in the
process), and then via `_change_state_for_tasks_failed_to_execute` we
change them back to scheduled.

(For now that method is still called, but will be removed as part of
future work -- it's just does less now)

