### PR TITLE
Fix `breeze -i` error

### DIFF
--- a/breeze
+++ b/breeze
@@ -724,14 +724,14 @@ function breeze::parse_arguments() {
             shift 2
             ;;
         -i | --integration)
-            local integration=${2}
+            local INTEGRATION=${2}
             parameters::check_and_save_allowed_param "INTEGRATION" "integration" "--integration"
-            echo "Integration: ${integration}"
-            if [[ ${integration} == "all" ]]; then
-                for integration in ${_BREEZE_ALLOWED_INTEGRATIONS}; do
-                    if [[ ${integration} != "all" ]]; then
-                        echo "${integration}"
-                        INTEGRATIONS+=("${integration}")
+            echo "Integration: ${INTEGRATION}"
+            if [[ ${INTEGRATION} == "all" ]]; then
+                for INTEGRATION in ${_BREEZE_ALLOWED_INTEGRATIONS}; do
+                    if [[ ${INTEGRATION} != "all" ]]; then
+                        echo "${INTEGRATION}"
+                        INTEGRATIONS+=("${INTEGRATION}")
                     fi
                 done
             else


### PR DESCRIPTION
It was erroring with "unbound" variable, expecting INTEGRATION to be a
pre-defined variable.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).