### PR TITLE
Add type annotations to ZendeskHook, update unit test

### DIFF
--- a/airflow/providers/zendesk/hooks/zendesk.py
+++ b/airflow/providers/zendesk/hooks/zendesk.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import time
+from typing import Optional
 
 from zdesk import RateLimitError, Zendesk, ZendeskError
 
@@ -40,7 +41,7 @@ class ZendeskHook(BaseHook):
             zdesk_url=self.__url, zdesk_email=conn.login, zdesk_password=conn.password, zdesk_token=True
         )
 
-    def __handle_rate_limit_exception(self, rate_limit_exception) -> None:
+    def __handle_rate_limit_exception(self, rate_limit_exception: ZendeskError) -> None:
         """
         Sleep for the time specified in the exception. If not specified, wait
         for 60 seconds.
@@ -48,8 +49,15 @@ class ZendeskHook(BaseHook):
         retry_after = int(rate_limit_exception.response.headers.get('Retry-After', 60))
         self.log.info("Hit Zendesk API rate limit. Pausing for %s seconds", retry_after)
         time.sleep(retry_after)
+        return None
 
-    def call(self, path, query=None, get_all_pages: bool = True, side_loading: bool = False) -> dict:
+    def call(
+        self,
+        path: str,
+        query: Optional[dict] = None,
+        get_all_pages: bool = True,
+        side_loading: bool = False,
+    ) -> dict:
         """
         Call Zendesk API and return results
 
@@ -64,12 +72,13 @@ class ZendeskHook(BaseHook):
                to load. For more information on side-loading see
                https://developer.zendesk.com/rest_api/docs/core/side_loading
         """
+        query_params = query or {}
         zendesk = self.get_conn()
         first_request_successful = False
 
         while not first_request_successful:
             try:
-                results = zendesk.call(path, query)
+                results = zendesk.call(path, query_params)
                 first_request_successful = True
             except RateLimitError as rle:
                 self.__handle_rate_limit_exception(rle)
@@ -78,7 +87,7 @@ class ZendeskHook(BaseHook):
         keys = [path.split("/")[-1].split(".json")[0]]
         next_page = results['next_page']
         if side_loading:
-            keys += query['include'].split(',')
+            keys += query_params['include'].split(',')
         results = {key: results[key] for key in keys}
 
         # pylint: disable=too-many-nested-blocks

--- a/airflow/providers/zendesk/hooks/zendesk.py
+++ b/airflow/providers/zendesk/hooks/zendesk.py
@@ -49,7 +49,6 @@ class ZendeskHook(BaseHook):
         retry_after = int(rate_limit_exception.response.headers.get('Retry-After', 60))
         self.log.info("Hit Zendesk API rate limit. Pausing for %s seconds", retry_after)
         time.sleep(retry_after)
-        return None
 
     def call(
         self,

--- a/tests/providers/zendesk/hooks/test_zendesk.py
+++ b/tests/providers/zendesk/hooks/test_zendesk.py
@@ -58,7 +58,7 @@ class TestZendeskHook(unittest.TestCase):
         mock_conn.call = mock_call
         zendesk_hook.get_conn = mock.Mock(return_value=mock_conn)
         zendesk_hook.call("path", get_all_pages=False)
-        mock_call.assert_called_once_with("path", None)
+        mock_call.assert_called_once_with("path", {})
 
     @mock.patch("airflow.providers.zendesk.hooks.zendesk.Zendesk")
     def test_returns_multiple_pages_if_get_all_pages_true(self, _):


### PR DESCRIPTION
### What

* Add correct type annotations to ZendeskHook and each method
* Update one unit test to call an empty dictionary rather than a
NoneType since the argument should be a dictionary

### Why

* Building out type annotations is good for the code base
* The query parameter is accessed with an index at one point, which means that it cannot be a `None` type, but should rather be defaulted to an empty dictionary if not provided

related: #9708

@mik-laj or others 😅

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
