### PR TITLE
Add s3 key to template fields for s3/redshift transfer operators

### DIFF
--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -65,7 +65,7 @@ class RedshiftToS3Operator(BaseOperator):
     :type table_as_file_name: bool
     """
 
-    template_fields = ()
+    template_fields = (s3_key, )
     template_ext = ()
     ui_color = '#ededed'
 

--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -65,7 +65,7 @@ class RedshiftToS3Operator(BaseOperator):
     :type table_as_file_name: bool
     """
 
-    template_fields = (s3_key, )
+    template_fields = ('s3_key', )
     template_ext = ()
     ui_color = '#ededed'
 

--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -65,7 +65,7 @@ class RedshiftToS3Operator(BaseOperator):
     :type table_as_file_name: bool
     """
 
-    template_fields = ('s3_key', )
+    template_fields = ('s3_key',)
     template_ext = ()
     ui_color = '#ededed'
 

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -58,7 +58,7 @@ class S3ToRedshiftOperator(BaseOperator):
     :type copy_options: list
     """
 
-    template_fields = ('s3_key', )
+    template_fields = ('s3_key',)
     template_ext = ()
     ui_color = '#ededed'
 

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -58,7 +58,7 @@ class S3ToRedshiftOperator(BaseOperator):
     :type copy_options: list
     """
 
-    template_fields = ()
+    template_fields = (s3_key, )
     template_ext = ()
     ui_color = '#ededed'
 

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -58,7 +58,7 @@ class S3ToRedshiftOperator(BaseOperator):
     :type copy_options: list
     """
 
-    template_fields = (s3_key, )
+    template_fields = ('s3_key', )
     template_ext = ()
     ui_color = '#ededed'
 


### PR DESCRIPTION
Add 's3_key' variable so Jinja templating can be applied for AWS redshift/s3 transfer operators
