### PR TITLE
Proposal: remove -serviceaccount suffix from KSA names in helm chart

### DIFF
--- a/chart/files/pod-template-file.yaml
+++ b/chart/files/pod-template-file.yaml
@@ -76,7 +76,7 @@ spec:
     {{ toYaml .Values.affinity | indent 8 }}
   tolerations:
     {{ toYaml .Values.tolerations | indent 8 }}
-  serviceAccountName: '{{ .Release.Name }}-worker-serviceaccount'
+  serviceAccountName: '{{ .Release.Name }}-worker'
   volumes:
   {{- if .Values.dags.persistence.enabled }}
   - name: dags

--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
 {{ toYaml .Values.affinity | indent 12 }}
           tolerations:
 {{ toYaml .Values.tolerations | indent 12 }}
-          serviceAccountName: {{ .Release.Name }}-cleanup-serviceaccount
+          serviceAccountName: {{ .Release.Name }}-cleanup
           {{- if or .Values.registry.secretName .Values.registry.connection }}
           imagePullSecrets:
             - name: {{ template "registry_secret" . }}

--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -22,7 +22,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-cleanup-serviceaccount
+  name: {{ .Release.Name }}-cleanup
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/rbac/pod-cleanup-rolebinding.yaml
+++ b/chart/templates/rbac/pod-cleanup-rolebinding.yaml
@@ -37,6 +37,6 @@ roleRef:
   name: {{ .Release.Name }}-cleanup-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-cleanup-serviceaccount
+    name: {{ .Release.Name }}-cleanup
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -40,12 +40,12 @@ roleRef:
 subjects:
 {{- if $grantScheduler }}
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-scheduler-serviceaccount
+    name: {{ .Release.Name }}-scheduler
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- if $grantWorker }}
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-worker-serviceaccount
+    name: {{ .Release.Name }}-worker
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -83,7 +83,7 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ .Release.Name }}-scheduler-serviceaccount
+      serviceAccountName: {{ .Release.Name }}-scheduler
       securityContext:
         runAsUser: {{ .Values.uid }}
         fsGroup: {{ .Values.gid }}

--- a/chart/templates/scheduler/scheduler-serviceaccount.yaml
+++ b/chart/templates/scheduler/scheduler-serviceaccount.yaml
@@ -22,7 +22,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-scheduler-serviceaccount
+  name: {{ .Release.Name }}-scheduler
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -72,7 +72,7 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       terminationGracePeriodSeconds: {{ .Values.workers.terminationGracePeriodSeconds }}
       restartPolicy: Always
-      serviceAccountName: {{ .Release.Name }}-worker-serviceaccount
+      serviceAccountName: {{ .Release.Name }}-worker
       securityContext:
         runAsUser: {{ .Values.uid }}
         fsGroup: {{ .Values.gid }}

--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -22,7 +22,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-worker-serviceaccount
+  name: {{ .Release.Name }}-worker
   labels:
     tier: airflow
     release: {{ .Release.Name }}


### PR DESCRIPTION
It's quite annoying to have `-serviceaccount` in each service account name as this is a useless 15 characters that provides no additional information about the account's purpose.

"why do you care so much about naming convention Jake?"
Actually there is a practical reason: GCP service accounts have 30 char name limit https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating
For manageability / clarity I'd like to keep KSA and GSA names exactly the same when using workload identity which maps KSA<>GSA 1:1 https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity.
If i have a simple release name like `airflow` I already violate the 30 char limit with `airflow-scheduler-serviceaccount` (32 chars)

R: @ashb 
CC: @potiuk @mik-laj (in our project I'm just going to [truncate GSA names to 30 chars](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/666) as I imagine we may get push back on a PR like this which could have adverse affects for others in the community who may rely on the current SA naming convention)