### PR TITLE
Remove errors raised during initialiation of virtualenv

### DIFF
--- a/breeze
+++ b/breeze
@@ -240,11 +240,24 @@ function breeze::initialize_virtualenv() {
         echo
         echo "Resetting AIRFLOW sqlite database"
         echo
-        AIRFLOW__CORE__UNIT_TEST_MODE="False" airflow db reset -y
+        AIRFLOW__CORE__LOAD_EXAMPLES="False" \
+            AIRFLOW__CORE__UNIT_TEST_MODE="False" \
+            AIRFLOW__CORE__SQL_ALCHEMY_POOL_ENABLED="False" \
+            AIRFLOW__CORE__DAGS_FOLDER="${AIRFLOW_SOURCES}/empty" \
+            AIRFLOW__CORE__PLUGINS_FOLDER="${AIRFLOW_SOURCES}/empty" \
+            airflow db reset -y
         echo
         echo "Resetting AIRFLOW sqlite unit test database"
         echo
-        AIRFLOW__CORE__UNIT_TEST_MODE="True" airflow db reset -y
+        AIRFLOW__CORE__LOAD_EXAMPLES="False" \
+            AIRFLOW__CORE__UNIT_TEST_MODE="True" \
+            AIRFLOW__CORE__SQL_ALCHEMY_POOL_ENABLED="False" \
+            AIRFLOW__CORE__DAGS_FOLDER="${AIRFLOW_SOURCES}/empty" \
+            AIRFLOW__CORE__PLUGINS_FOLDER="${AIRFLOW_SOURCES}/empty" \
+            airflow db reset -y
+        echo
+        echo "Initialization of virtualenv was successful! Go ahead and develop Airflow!"
+        echo
         exit 0
     fi
 }


### PR DESCRIPTION
Our migration scripts are written in the way that if you
are running them to reset the db and you have some files in
example_dags or dags, or some plugins in your plugins folder,
you will get various kinds of errors.

Those errors are printed to the user and even if they are
ultimately ignored by the SqlAlchemy migration process,
they are confusing whether the database reset
(and thus the whole initialize-virtualenv) were successful
or not.

This change disables any DAGs that could be loaded during the
DB reset (in case of running './breeze initialize-virtualenv'.

Fixes #10894

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
