### PR TITLE
Fix syntax error in Dockerfile 'maintainer' Label

### DIFF
--- a/scripts/ci/dockerfiles/apache-rat/Dockerfile
+++ b/scripts/ci/dockerfiles/apache-rat/Dockerfile
@@ -51,7 +51,7 @@ LABEL org.apache.airflow.component="apache-rat"
 LABEL org.apache.airflow.apache_rat.version="${APACHERAT_VERSION}"
 LABEL org.apache.airflow.airflow_apache_rat.version="${AIRFLOW_APACHERAT_VERSION}"
 LABEL org.apache.airflow.commit_sha="${COMMIT_SHA}"
-LABEL maintainer "Apache Airflow Community <dev@airflow.apache.org>"
+LABEL maintainer="Apache Airflow Community <dev@airflow.apache.org>"
 
 ENTRYPOINT ["java", "-jar", "apache-rat.jar" ]
 

--- a/scripts/ci/dockerfiles/krb5-kdc-server/Dockerfile
+++ b/scripts/ci/dockerfiles/krb5-kdc-server/Dockerfile
@@ -55,7 +55,7 @@ WORKDIR /app
 LABEL org.apache.airflow.component="krb5-kdc-server"
 LABEL org.apache.airflow.airflow_krb5_kdc_server.version="${AIRFLOW_KRB5KDCSERVER_VERSION}"
 LABEL org.apache.airflow.commit_sha="${COMMIT_SHA}"
-LABEL maintainer "Apache Airflow Community <dev@airflow.apache.org>"
+LABEL maintainer="Apache Airflow Community <dev@airflow.apache.org>"
 
 RUN chmod a+x /entrypoint
 

--- a/scripts/ci/dockerfiles/stress/Dockerfile
+++ b/scripts/ci/dockerfiles/stress/Dockerfile
@@ -29,6 +29,6 @@ LABEL org.apache.airflow.component="stress"
 LABEL org.apache.airflow.stress.version="${STRESS_VERSION}"
 LABEL org.apache.airflow.airflow_stress.version="${AIRFLOW_STRESS_VERSION}"
 LABEL org.apache.airflow.commit_sha="${COMMIT_SHA}"
-LABEL maintainer "Apache Airflow Community <dev@airflow.apache.org>"
+LABEL maintainer="Apache Airflow Community <dev@airflow.apache.org>"
 
 CMD ["/usr/local/bin/stress"]


### PR DESCRIPTION
I think this was an error in one of the earlier PRs, LABEL expects key=value

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
