### PR TITLE
Make the usage of bash 'shift' consistent across Breeze

### DIFF
--- a/breeze
+++ b/breeze
@@ -819,7 +819,7 @@ function breeze::parse_arguments() {
             echo "Resetting the DB!"
             echo
             export DB_RESET="true"
-            shift 1
+            shift
             ;;
         -v | --verbose)
             export VERBOSE="true"
@@ -951,7 +951,7 @@ function breeze::parse_arguments() {
             echo "Forwarding credentials. Be careful as your credentials ar available in the container!"
             echo
             export FORWARD_CREDENTIALS="true"
-            shift 1
+            shift
             ;;
         -c | --github-registry)
             echo
@@ -991,7 +991,7 @@ function breeze::parse_arguments() {
             echo "Starting Airflow"
             echo
             export START_AIRFLOW="true"
-            shift 1
+            shift
             ;;
         -S | --version-suffix-for-pypi)
             if [[ -n ${VERSION_SUFFIX_FOR_SVN=} ]]; then
@@ -1046,7 +1046,7 @@ function breeze::parse_arguments() {
         build-docs)
             last_subcommand="${1}"
             command_to_run="build_docs"
-            shift 1
+            shift
             ;;
         build-image)
             last_subcommand="${1}"


### PR DESCRIPTION
If an argument is not provided to `shift` it by default uses `shift 1`. The commands "shift 1" and "shift" (with no argument) do the same thing. This PR makes the usage consistent as there were occurences of both

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
