### PR TITLE
Update the name of static check without pylint in CI.rst

### DIFF
--- a/CI.rst
+++ b/CI.rst
@@ -536,7 +536,7 @@ This workflow is a regular workflow that performs all checks of Airflow code.
 +---------------------------+----------------------------------------------+-------+-------+------+
 | CI Images                 | Waits for CI Images (3)                      | Yes   | Yes   | Yes  |
 +---------------------------+----------------------------------------------+-------+-------+------+
-| Static checks: no pylint  | Performs static checks without pylint        | Yes   | Yes   | Yes  |
+| Static checks             | Performs static checks without pylint        | Yes   | Yes   | Yes  |
 +---------------------------+----------------------------------------------+-------+-------+------+
 | Static checks: pylint     | Performs pylint static checks                | Yes   | Yes   | Yes  |
 +---------------------------+----------------------------------------------+-------+-------+------+


### PR DESCRIPTION
We changed the name of the static check without pylint in https://github.com/apache/airflow/commit/a1032805bc2ac96a507660a813a3a304cf4a2f8c#diff-e9f950f17198d3d5e3122a44230a09b9, this commit updates it's name in the docs

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
