### PR TITLE
Fix race conditions in task callback invocations

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -405,6 +405,7 @@ ARG_SHIP_DAG = Arg(
     ("--ship-dag",), help="Pickles (serializes) the DAG and ships it to the worker", action="store_true"
 )
 ARG_PICKLE = Arg(("-p", "--pickle"), help="Serialized pickle object of the entire dag (used internally)")
+ARG_EXCEPTION_FILE = Arg(("--error-file",), help="File to store task failure error")
 ARG_JOB_ID = Arg(("-j", "--job-id"), help=argparse.SUPPRESS)
 ARG_CFG_PATH = Arg(("--cfg-path",), help="Path to config file to use instead of airflow.cfg")
 ARG_MIGRATION_TIMEOUT = Arg(
@@ -962,6 +963,7 @@ TASKS_COMMANDS = (
             ARG_PICKLE,
             ARG_JOB_ID,
             ARG_INTERACTIVE,
+            ARG_EXCEPTION_FILE,
             ARG_SHUT_DOWN_LOGGING,
         ),
     ),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -405,7 +405,7 @@ ARG_SHIP_DAG = Arg(
     ("--ship-dag",), help="Pickles (serializes) the DAG and ships it to the worker", action="store_true"
 )
 ARG_PICKLE = Arg(("-p", "--pickle"), help="Serialized pickle object of the entire dag (used internally)")
-ARG_EXCEPTION_FILE = Arg(("--error-file",), help="File to store task failure error")
+ARG_ERROR_FILE = Arg(("--error-file",), help="File to store task failure error")
 ARG_JOB_ID = Arg(("-j", "--job-id"), help=argparse.SUPPRESS)
 ARG_CFG_PATH = Arg(("--cfg-path",), help="Path to config file to use instead of airflow.cfg")
 ARG_MIGRATION_TIMEOUT = Arg(
@@ -963,7 +963,7 @@ TASKS_COMMANDS = (
             ARG_PICKLE,
             ARG_JOB_ID,
             ARG_INTERACTIVE,
-            ARG_EXCEPTION_FILE,
+            ARG_ERROR_FILE,
             ARG_SHUT_DOWN_LOGGING,
         ),
     ),

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -47,7 +47,7 @@ from airflow.utils.net import get_hostname
 from airflow.utils.session import create_session
 
 
-def _run_task_by_selected_method(args, dag, ti):
+def _run_task_by_selected_method(args, dag: DAG, ti: TaskInstance) -> None:
     """
     Runs the task in one of 3 modes
 
@@ -132,7 +132,7 @@ RAW_TASK_UNSUPPORTED_OPTION = [
 ]
 
 
-def _run_raw_task(args, ti):
+def _run_raw_task(args, ti: TaskInstance) -> None:
     """Runs the main task handling code"""
     unsupported_options = [o for o in RAW_TASK_UNSUPPORTED_OPTION if getattr(args, o)]
 
@@ -149,6 +149,7 @@ def _run_raw_task(args, ti):
         mark_success=args.mark_success,
         job_id=args.job_id,
         pool=args.pool,
+        error_file=args.error_file,
     )
 
 

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -77,7 +77,6 @@ class DebugExecutor(BaseExecutor):
         try:
             params = self.tasks_params.pop(ti.key, {})
             ti._run_raw_task(job_id=ti.job_id, **params)  # pylint: disable=protected-access
-            ti.set_state(State.SUCCESS)
             self.change_state(key, State.SUCCESS)
             ti._run_finished_callback()  # pylint: disable=protected-access
             return True

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -66,7 +66,7 @@ class DebugExecutor(BaseExecutor):
                 self.log.info("Executor is terminated! Stopping %s to %s", ti.key, State.FAILED)
                 ti.set_state(State.FAILED)
                 self.change_state(ti.key, State.FAILED)
-                ti.run_finished_callback()
+                ti._run_finished_callback()  # pylint: disable=protected-access
                 continue
 
             task_succeeded = self._run_task(ti)
@@ -79,12 +79,12 @@ class DebugExecutor(BaseExecutor):
             ti._run_raw_task(job_id=ti.job_id, **params)  # pylint: disable=protected-access
             ti.set_state(State.SUCCESS)
             self.change_state(key, State.SUCCESS)
-            ti.run_finished_callback()
+            ti._run_finished_callback()  # pylint: disable=protected-access
             return True
         except Exception as e:  # pylint: disable=broad-except
             ti.set_state(State.FAILED)
             self.change_state(key, State.FAILED)
-            ti.run_finished_callback()
+            ti._run_finished_callback()  # pylint: disable=protected-access
             self.log.exception("Failed to execute task: %s.", str(e))
             return False
 

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -280,7 +280,7 @@ class BackfillJob(BaseJob):
                     "killed externally? Info: {}".format(ti, state, ti.state, info)
                 )
                 self.log.error(msg)
-                ti.handle_failure(msg)
+                ti.handle_failure_with_callback(error=msg)
 
     @provide_session
     def _get_dag_run(self, run_date: datetime, dag: DAG, session: Session = None):

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -101,6 +101,10 @@ class LocalTaskJob(BaseJob):
             # task callback invocation happens either here or in
             # self.heartbeat() instead of taskinstance._run_raw_task to
             # avoid race conditions
+            #
+            # When self.terminating is set to True by heartbeat_callback, this
+            # loop should not be restarted. Otherwise self.handle_task_exit
+            # will be invoked and we will end up with duplicated callbacks
             while not self.terminating:
                 # Monitor the task to see if it's done. Wait in a syscall
                 # (`os.wait`) for as long as possible so we notice the

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -169,11 +169,7 @@ class LocalTaskJob(BaseJob):
             self.log.warning(
                 "State of this instance has been externally set to %s. " "Terminating instance.", ti.state
             )
-            if ti.state == State.FAILED and ti.task.on_failure_callback:
-                context = ti.get_template_context()
-                ti.task.on_failure_callback(context)
-            if ti.state == State.SUCCESS and ti.task.on_success_callback:
-                context = ti.get_template_context()
-                ti.task.on_success_callback(context)
+            # send sigterm to task process so it can catch the exception and
+            # execute the success/failure callback
             self.task_runner.terminate()
             self.terminating = True

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -590,7 +590,7 @@ class DagFileProcessor(LoggingMixin):
                 ti.state = simple_ti.state
                 ti.test_mode = self.UNIT_TEST_MODE
                 if request.is_failure_callback:
-                    ti.handle_failure(request.msg, ti.test_mode, ti.get_template_context())
+                    ti.handle_failure_with_callback(error=request.msg, test_mode=ti.test_mode)
                     self.log.info('Executed failure callback for %s in state %s', ti, ti.state)
 
     @provide_session
@@ -1729,8 +1729,8 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         pools = models.Pool.slots_stats(session=session)
         for pool_name, slot_stats in pools.items():
             Stats.gauge(f'pool.open_slots.{pool_name}', slot_stats["open"])
-            Stats.gauge(f'pool.queued_slots.{pool_name}', slot_stats[State.QUEUED])
-            Stats.gauge(f'pool.running_slots.{pool_name}', slot_stats[State.RUNNING])
+            Stats.gauge(f'pool.queued_slots.{pool_name}', slot_stats[State.QUEUED])  # type: ignore
+            Stats.gauge(f'pool.running_slots.{pool_name}', slot_stats[State.RUNNING])  # type: ignore
 
     @provide_session
     def heartbeat_callback(self, session: Session = None) -> None:

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1105,14 +1105,11 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
 
         for execution_date in self.dag.date_range(start_date, end_date=end_date):
             ti = TaskInstance(self, execution_date)
-            try:
-                ti.run(
-                    mark_success=mark_success,
-                    ignore_depends_on_past=(execution_date == start_date and ignore_first_depends_on_past),
-                    ignore_ti_state=ignore_ti_state,
-                )
-            finally:
-                ti.run_finished_callback()
+            ti.run(
+                mark_success=mark_success,
+                ignore_depends_on_past=(execution_date == start_date and ignore_first_depends_on_past),
+                ignore_ti_state=ignore_ti_state,
+            )
 
     def dry_run(self) -> None:
         """Performs dry run for the operator - just render template fields."""

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1104,11 +1104,15 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         end_date = end_date or self.end_date or timezone.utcnow()
 
         for execution_date in self.dag.date_range(start_date, end_date=end_date):
-            TaskInstance(self, execution_date).run(
-                mark_success=mark_success,
-                ignore_depends_on_past=(execution_date == start_date and ignore_first_depends_on_past),
-                ignore_ti_state=ignore_ti_state,
-            )
+            ti = TaskInstance(self, execution_date)
+            try:
+                ti.run(
+                    mark_success=mark_success,
+                    ignore_depends_on_past=(execution_date == start_date and ignore_first_depends_on_past),
+                    ignore_ti_state=ignore_ti_state,
+                )
+            finally:
+                ti.run_finished_callback()
 
     def dry_run(self) -> None:
         """Performs dry run for the operator - just render template fields."""

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1104,8 +1104,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         end_date = end_date or self.end_date or timezone.utcnow()
 
         for execution_date in self.dag.date_range(start_date, end_date=end_date):
-            ti = TaskInstance(self, execution_date)
-            ti.run(
+            TaskInstance(self, execution_date).run(
                 mark_success=mark_success,
                 ignore_depends_on_past=(execution_date == start_date and ignore_first_depends_on_past),
                 ignore_ti_state=ignore_ti_state,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -584,7 +584,7 @@ class DAG(LoggingMixin):
         next_run_date = None
         if not date_last_automated_dagrun:
             # First run
-            task_start_dates = [t.start_date for t in self.tasks]
+            task_start_dates = [t.start_date for t in self.tasks if t.start_date]
             if task_start_dates:
                 next_run_date = self.normalize_schedule(min(task_start_dates))
                 self.log.debug("Next run date based on tasks %s", next_run_date)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1397,7 +1397,13 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         self.log.info('Rescheduling task, marking task as UP_FOR_RESCHEDULE')
 
     @provide_session
-    def handle_failure(self, error, test_mode=None, force_fail: bool = False, session=None) -> None:
+    def handle_failure(
+        self,
+        error: Union[str, Exception],
+        test_mode: Optional[bool] = None,
+        force_fail: bool = False,
+        session=None,
+    ) -> None:
         """Handle Failure for the TaskInstance"""
         if test_mode is None:
             test_mode = self.test_mode
@@ -1461,8 +1467,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
     @provide_session
     def handle_failure_with_callback(
         self,
-        error,
-        test_mode=None,
+        error: Union[str, Exception],
+        test_mode: Optional[bool] = None,
         force_fail: bool = False,
         session=None,
     ) -> None:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -109,7 +109,7 @@ def set_current_context(context: Context):
 
 def load_error_file(fd: IO[bytes]) -> Optional[Union[str, Exception]]:
     """Load and return error from error file"""
-    fd.seek(0, 0)
+    fd.seek(0, os.SEEK_SET)
     data = fd.read()
     if not data:
         return None

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1115,9 +1115,10 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             raise
         except AirflowException as e:
             self.refresh_from_db()
-            # for case when task is marked as success/failed externally we need
-            # to invoke callback from within task process to avoid race
-            # conditions
+            # for case when task is marked as success/failed externally,
+            # AirflowException will be raised through registered signal
+            # handler.  we need to invoke callback from within task process to
+            # avoid race conditions
             if self.state == State.SUCCESS:
                 self.log.info('Task marked as SUCCESS externally.')
             else:

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -20,6 +20,7 @@ import getpass
 import os
 import subprocess
 import threading
+from typing import Optional
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
@@ -144,7 +145,7 @@ class BaseTaskRunner(LoggingMixin):
         """Start running the task instance in a subprocess."""
         raise NotImplementedError()
 
-    def return_code(self) -> int:
+    def return_code(self) -> Optional[int]:
         """
         :return: The return code associated with running the task instance or
             None if the task is not yet done.

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -144,7 +144,7 @@ class BaseTaskRunner(LoggingMixin):
         """Start running the task instance in a subprocess."""
         raise NotImplementedError()
 
-    def return_code(self):
+    def return_code(self) -> int:
         """
         :return: The return code associated with running the task instance or
             None if the task is not yet done.
@@ -152,11 +152,11 @@ class BaseTaskRunner(LoggingMixin):
         """
         raise NotImplementedError()
 
-    def terminate(self):
-        """Kill the running task instance."""
+    def terminate(self) -> None:
+        """Force kill the running task instance."""
         raise NotImplementedError()
 
-    def on_finish(self):
+    def on_finish(self) -> None:
         """A callback that should be called when this is done running."""
         if self._cfg_path and os.path.isfile(self._cfg_path):
             if self.run_as_user:

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -18,7 +18,6 @@
 """Base task runner"""
 import getpass
 import os
-import pickle
 import subprocess
 import threading
 from tempfile import NamedTemporaryFile
@@ -26,6 +25,7 @@ from typing import Optional, Union
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
+from airflow.models.taskinstance import load_error_file
 from airflow.utils.configuration import tmp_configuration_copy
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
@@ -102,13 +102,7 @@ class BaseTaskRunner(LoggingMixin):
 
     def deserialize_run_error(self) -> Optional[Union[str, Exception]]:
         """Return task runtime error if its written to provided error file."""
-        data = self._error_file.read()
-        if not data:
-            return None
-        try:
-            return pickle.loads(data)
-        except Exception:  # pylint: disable=broad-except
-            return "Failed to load task run error"
+        return load_error_file(self._error_file)
 
     def _read_task_logs(self, stream):
         while True:

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -18,6 +18,7 @@
 """Standard task runner"""
 import logging
 import os
+from typing import Optional
 
 import psutil
 from setproctitle import setproctitle  # pylint: disable=no-name-in-module
@@ -91,7 +92,7 @@ class StandardTaskRunner(BaseTaskRunner):
                 logging.shutdown()
                 os._exit(return_code)  # pylint: disable=protected-access
 
-    def return_code(self, timeout=0):
+    def return_code(self, timeout: int = 0) -> Optional[int]:
         # We call this multiple times, but we can only wait on the process once
         if self._rc is not None or not self.process:
             return self._rc

--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -44,7 +44,12 @@ log = logging.getLogger(__name__)
 DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM = conf.getint('core', 'KILLED_TASK_CLEANUP_TIME')
 
 
-def reap_process_group(pgid, logger, sig=signal.SIGTERM, timeout=DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM):
+def reap_process_group(
+    pgid: int,
+    logger,
+    sig: signal.Signals = signal.SIGTERM,
+    timeout: int = DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM,
+) -> Dict[int, int]:
     """
     Tries really hard to terminate all processes in the group (including grandchildren). Will send
     sig (SIGTERM) to the process group of pid. If any process is alive after timeout

--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -47,7 +47,7 @@ DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM = conf.getint('core', 'KILLED_TASK_CLEANUP_TI
 def reap_process_group(
     pgid: int,
     logger,
-    sig: signal.Signals = signal.SIGTERM,
+    sig: 'signal.Signals' = signal.SIGTERM,
     timeout: int = DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM,
 ) -> Dict[int, int]:
     """

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -192,6 +192,8 @@ class TestCore(unittest.TestCase):
 
         def check_failure(context, test_case=self):  # pylint: disable=unused-argument
             data['called'] = True
+            error = context.get("exception")
+            test_case.assertIsInstance(error, AirflowException)
 
         op = BashOperator(
             task_id='check_on_failure_callback',

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -190,10 +190,8 @@ class TestCore(unittest.TestCase):
         # Annoying workaround for nonlocal not existing in python 2
         data = {'called': False}
 
-        def check_failure(context, test_case=self):
+        def check_failure(context, test_case=self):  # pylint: disable=unused-argument
             data['called'] = True
-            error = context.get('exception')
-            test_case.assertIsInstance(error, AirflowException)
 
         op = BashOperator(
             task_id='check_on_failure_callback',

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -446,6 +446,7 @@ class TestLocalTaskJob(unittest.TestCase):
         dag = DAG(dag_id='test_mark_success', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
 
         def task_function(ti):
+            # pylint: disable=unused-argument
             time.sleep(60)
             # This should not happen -- the state change should be noticed and the task should get killed
             with shared_mem_lock:
@@ -476,7 +477,7 @@ class TestLocalTaskJob(unittest.TestCase):
         process.start()
         ti.refresh_from_db()
         for _ in range(0, 50):
-            time.sleep(0.1)
+            time.sleep(0.2)
             if ti.state == State.RUNNING:
                 break
             ti.refresh_from_db()

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -318,6 +318,7 @@ class TestLocalTaskJob(unittest.TestCase):
             with failure_callback_called.get_lock():
                 failure_callback_called.value += 1
             assert context['dag_run'].dag_id == 'test_mark_failure'
+            assert context['exception'] == "task marked as failed externally"
 
         def task_function(ti):
             with create_session() as session:
@@ -378,6 +379,7 @@ class TestLocalTaskJob(unittest.TestCase):
             with callback_count_lock:
                 failure_callback_called.value += 1
             assert context['dag_run'].dag_id == 'test_failure_callback_race'
+            assert isinstance(context['exception'], AirflowFailException)
 
         def task_function(ti):
             raise AirflowFailException()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -642,7 +642,7 @@ class TestDagFileProcessor(unittest.TestCase):
             num_scheduled = scheduler._schedule_dag_run(dr3, {dr1.execution_date}, session)
             assert num_scheduled == 0
 
-    @patch.object(TaskInstance, 'handle_failure')
+    @patch.object(TaskInstance, 'handle_failure_with_callback')
     def test_execute_on_failure_callbacks(self, mock_ti_handle_failure):
         dagbag = DagBag(dag_folder="/dev/null", include_examples=True, read_dags_from_db=False)
         dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
@@ -663,7 +663,8 @@ class TestDagFileProcessor(unittest.TestCase):
             ]
             dag_file_processor.execute_callbacks(dagbag, requests)
             mock_ti_handle_failure.assert_called_once_with(
-                "Message", conf.getboolean('core', 'unit_test_mode'), mock.ANY
+                error="Message",
+                test_mode=conf.getboolean('core', 'unit_test_mode'),
             )
 
     def test_process_file_should_failure_callback(self):

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1389,8 +1389,9 @@ class TestTaskInstance(unittest.TestCase):
 
         callback_wrapper.wrap_task_instance(ti)
         ti._run_raw_task()
+        ti.run_finished_callback()
         assert callback_wrapper.callback_ran
-        assert callback_wrapper.task_state_in_callback == State.RUNNING
+        assert callback_wrapper.task_state_in_callback == State.SUCCESS
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
@@ -1618,6 +1619,7 @@ class TestTaskInstance(unittest.TestCase):
         ti1 = TI(task=task1, execution_date=start_date)
         ti1.state = State.FAILED
         ti1.handle_failure("test failure handling")
+        ti1.run_finished_callback()
 
         context_arg_1 = mock_on_failure_1.call_args[0][0]
         assert context_arg_1 and "task_instance" in context_arg_1
@@ -1635,6 +1637,7 @@ class TestTaskInstance(unittest.TestCase):
         ti2 = TI(task=task2, execution_date=start_date)
         ti2.state = State.FAILED
         ti2.handle_failure("test retry handling")
+        ti2.run_finished_callback()
 
         mock_on_failure_2.assert_not_called()
 
@@ -1654,6 +1657,7 @@ class TestTaskInstance(unittest.TestCase):
         ti3 = TI(task=task3, execution_date=start_date)
         ti3.state = State.FAILED
         ti3.handle_failure("test force_fail handling", force_fail=True)
+        ti3.run_finished_callback()
 
         context_arg_3 = mock_on_failure_3.call_args[0][0]
         assert context_arg_3 and "task_instance" in context_arg_3

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1389,7 +1389,7 @@ class TestTaskInstance(unittest.TestCase):
 
         callback_wrapper.wrap_task_instance(ti)
         ti._run_raw_task()
-        ti.run_finished_callback()
+        ti._run_finished_callback()
         assert callback_wrapper.callback_ran
         assert callback_wrapper.task_state_in_callback == State.SUCCESS
         ti.refresh_from_db()
@@ -1619,7 +1619,7 @@ class TestTaskInstance(unittest.TestCase):
         ti1 = TI(task=task1, execution_date=start_date)
         ti1.state = State.FAILED
         ti1.handle_failure("test failure handling")
-        ti1.run_finished_callback()
+        ti1._run_finished_callback()
 
         context_arg_1 = mock_on_failure_1.call_args[0][0]
         assert context_arg_1 and "task_instance" in context_arg_1
@@ -1637,7 +1637,7 @@ class TestTaskInstance(unittest.TestCase):
         ti2 = TI(task=task2, execution_date=start_date)
         ti2.state = State.FAILED
         ti2.handle_failure("test retry handling")
-        ti2.run_finished_callback()
+        ti2._run_finished_callback()
 
         mock_on_failure_2.assert_not_called()
 
@@ -1657,7 +1657,7 @@ class TestTaskInstance(unittest.TestCase):
         ti3 = TI(task=task3, execution_date=start_date)
         ti3.state = State.FAILED
         ti3.handle_failure("test force_fail handling", force_fail=True)
-        ti3.run_finished_callback()
+        ti3._run_finished_callback()
 
         context_arg_3 = mock_on_failure_3.call_args[0][0]
         assert context_arg_3 and "task_instance" in context_arg_3


### PR DESCRIPTION
This race condition resulted in task success and failure callbacks being
called more than once. Here is the order of events that could lead to
this issue:

* task started running within process 2
* (process 1) local_task_job checked for task return code, returns None
* (process 2) task exited with failure state, task state updated as failed in DB
* (process 2) task failure callback invoked through taskinstance.handle_failure method
* (process 1) local_task_job heartbeat noticed task state set to
  failure, mistoken it as state bing updated externally, also invoked task
  failure callback

To avoid this race condition, we need to make sure task callbacks are
only invoked within a single process.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
