### PR TITLE
Remove unknown pytest.ini setting

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -29,5 +29,4 @@ norecursedirs =
     tests/dags_corrupted
     tests/dags
 faulthandler_timeout = 480
-log_print = True
 log_level = INFO


### PR DESCRIPTION
This was added when we first migrated to pytest, but pytest is now
complaining that this setting is unknown.

Since it doesn't do anything, lets remove it

```
/usr/local/lib/python3.7/site-packages/_pytest/config/__init__.py:1148
  /usr/local/lib/python3.7/site-packages/_pytest/config/__init__.py:1148: PytestConfigWarning: Unknown config ini key: log_print
  
    self._warn_or_fail_if_strict("Unknown config ini key: {}\n".format(key))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).