### PR TITLE
Introduce TaskMixin

### DIFF
--- a/airflow/example_dags/example_xcomargs.py
+++ b/airflow/example_dags/example_xcomargs.py
@@ -32,7 +32,7 @@ def generate_value():
     return "Bring me a shrubbery!"
 
 
-@task
+@task()
 def print_value(value):
     """Dummy function"""
     ctx = get_current_context()
@@ -63,7 +63,7 @@ with DAG(
 ) as dag2:
     bash_op1 = BashOperator(task_id="c", bash_command="echo c")
     bash_op2 = BashOperator(task_id="d", bash_command="echo c")
-    xcom_args_a = print_value("first!")  # type: ignore
-    xcom_args_b = print_value("second!")  # type: ignore
+    xcom_args_a = print_value("first!")
+    xcom_args_b = print_value("second!")
 
-    bash_op1 >> xcom_args_a >> xcom_args_b >> bash_op2  # type: ignore
+    bash_op1 >> xcom_args_a >> xcom_args_b >> bash_op2

--- a/airflow/example_dags/example_xcomargs.py
+++ b/airflow/example_dags/example_xcomargs.py
@@ -66,4 +66,4 @@ with DAG(
     xcom_args_a = print_value("first!")  # type: ignore
     xcom_args_b = print_value("second!")  # type: ignore
 
-    bash_op1 >> xcom_args_a >> xcom_args_b >> bash_op2
+    bash_op1 >> xcom_args_a >> xcom_args_b >> bash_op2  # type: ignore

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1125,11 +1125,9 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
                        upstream: bool = False) -> None:
         """Sets relatives for the task or task list."""
 
-        try:
-            # Check if this is sequence
-            len(task_or_task_list)
+        if isinstance(task_or_task_list, Sequence):
             task_like_object_list = task_or_task_list
-        except TypeError:
+        else:
             task_like_object_list = [task_or_task_list]
 
         task_list: List["BaseOperator"] = [t.operator for t in task_like_object_list]

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1126,11 +1126,13 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         """Sets relatives for the task or task list."""
 
         try:
-            task_list = len(task_or_task_list)  # type: ignore
+            # Check if this is sequence
+            len(task_or_task_list)
+            task_like_object_list = task_or_task_list
         except TypeError:
-            task_list = [task_or_task_list]  # type: ignore
+            task_like_object_list = [task_or_task_list]
 
-        task_list: List["BaseOperator"] = [t.operator for t in task_list]
+        task_list: List["BaseOperator"] = [t.operator for t in task_like_object_list]
 
         for task in task_list:
             if not isinstance(task, BaseOperator):

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from abc import abstractmethod
+from typing import Sequence, Union
 
 
 class TaskMixin:
@@ -28,45 +29,43 @@ class TaskMixin:
     """
 
     @abstractmethod
-    def set_upstream(self, other):
+    def set_upstream(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
         """
         Set a task or a task list to be directly upstream from the current task.
         """
         raise NotImplementedError()
 
     @abstractmethod
-    def set_downstream(self, other):
+    def set_downstream(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
         """
         Set a task or a task list to be directly downstream from the current task.
         """
         raise NotImplementedError()
 
-    def __lshift__(self, other):
+    def __lshift__(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
         """
         Implements Task << Task
         """
         self.set_upstream(other)
         return other
 
-    def __rshift__(self, other):
+    def __rshift__(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
         """
         Implements Task >> Task
         """
         self.set_downstream(other)
         return other
 
-    def __rrshift__(self, other):
+    def __rrshift__(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
         """
-        Called for Task >> [Task] because list don't have
-        __rshift__ operators.
+        Called for Task >> [Task] because list don't have __rshift__ operators.
         """
         self.__lshift__(other)
         return self
 
-    def __rlshift__(self, other):
+    def __rlshift__(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
         """
-        Called for Task >> [Task] because list don't have
-        __lshift__ operators.
+        Called for Task << [Task] because list don't have __lshift__ operators.
         """
         self.__rshift__(other)
         return self

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -29,10 +29,8 @@ class TaskMixin:
     """
 
     @property
-    def operator(self):
-        """
-        Returns underlying operator
-        """
+    def roots(self):
+        """Should return list of root operator List[BaseOperator]"""
         raise NotImplementedError()
 
     @abstractmethod

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import abstractmethod
+
+
+class TaskMixin:
+    """
+    Mixing implementing common chain methods like >> and <<.
+
+    In the following functions we use:
+    Task = Union[BaseOperator, XComArg]
+    No type annotations due to cyclic imports.
+    """
+
+    @abstractmethod
+    def set_upstream(self, other):
+        """
+        Set a task or a task list to be directly upstream from the current task.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def set_downstream(self, other):
+        """
+        Set a task or a task list to be directly downstream from the current task.
+        """
+        raise NotImplementedError()
+
+    def __lshift__(self, other):
+        """
+        Implements Task << Task
+        """
+        self.set_upstream(other)
+        return other
+
+    def __rshift__(self, other):
+        """
+        Implements Task >> Task
+        """
+        self.set_downstream(other)
+        return other
+
+    def __rrshift__(self, other):
+        """
+        Called for Task >> [Task] because list don't have
+        __rshift__ operators.
+        """
+        self.__lshift__(other)
+        return self
+
+    def __rlshift__(self, other):
+        """
+        Called for Task >> [Task] because list don't have
+        __lshift__ operators.
+        """
+        self.__rshift__(other)
+        return self

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -28,6 +28,13 @@ class TaskMixin:
     No type annotations due to cyclic imports.
     """
 
+    @property
+    def operator(self):
+        """
+        Returns underlying operator
+        """
+        raise NotImplementedError()
+
     @abstractmethod
     def set_upstream(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
         """

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Sequence
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator  # pylint: disable=R0401
@@ -94,7 +94,7 @@ class XComArg(TaskMixin):
 
     @property
     def operator(self) -> BaseOperator:
-        """Returns operator of this XComArg"""
+        """Returns operator of this XComArg. Required by TaskMixin"""
         return self._operator
 
     @property
@@ -102,17 +102,15 @@ class XComArg(TaskMixin):
         """Returns keys of this XComArg"""
         return self._key
 
-    def set_upstream(self, task_or_task_list: Union[BaseOperator, List[BaseOperator]]):
+    def set_upstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]]):
         """
-        Proxy to underlying operator set_upstream method
+        Proxy to underlying operator set_upstream method. Required by TaskMixin.
         """
         self.operator.set_upstream(task_or_task_list)
 
-    def set_downstream(
-        self, task_or_task_list: Union[BaseOperator, List[BaseOperator]]
-    ):
+    def set_downstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]]):
         """
-        Proxy to underlying operator set_downstream method
+        Proxy to underlying operator set_downstream method. Required by TaskMixin.
         """
         self.operator.set_downstream(task_or_task_list)
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, Sequence, Union
+from typing import Any, Dict, List, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator  # pylint: disable=R0401
@@ -94,8 +94,13 @@ class XComArg(TaskMixin):
 
     @property
     def operator(self) -> BaseOperator:
-        """Returns operator of this XComArg. Required by TaskMixin"""
+        """Returns operator of this XComArg."""
         return self._operator
+
+    @property
+    def roots(self) -> List[BaseOperator]:
+        """Required by TaskMixin"""
+        return [self._operator]
 
     @property
     def key(self) -> str:

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -19,10 +19,11 @@ from typing import Any, Dict, List, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator  # pylint: disable=R0401
+from airflow.models.taskmixin import TaskMixin
 from airflow.models.xcom import XCOM_RETURN_KEY
 
 
-class XComArg:
+class XComArg(TaskMixin):
     """
     Class that represents a XCom push from a previous operator.
     Defaults to "return_value" as only key.
@@ -64,36 +65,6 @@ class XComArg:
     def __eq__(self, other):
         return (self.operator == other.operator
                 and self.key == other.key)
-
-    def __lshift__(self, other):
-        """
-        Implements XComArg << op
-        """
-        self.set_upstream(other)
-        return other
-
-    def __rshift__(self, other):
-        """
-        Implements XComArg >> op
-        """
-        self.set_downstream(other)
-        return other
-
-    def __rrshift__(self, other):
-        """
-        Called for XComArg >> [XComArg] because list don't have
-        __rshift__ operators.
-        """
-        self.__lshift__(other)
-        return self
-
-    def __rlshift__(self, other):
-        """
-        Called for XComArg >> [XComArg] because list don't have
-        __lshift__ operators.
-        """
-        self.__rshift__(other)
-        return self
 
     def __getitem__(self, item):
         """

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, List, Union, Sequence
+from typing import Any, Dict, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator  # pylint: disable=R0401

--- a/pylintrc
+++ b/pylintrc
@@ -570,7 +570,7 @@ max-branches=22
 max-locals=24
 
 # Maximum number of parents for a class (see R0901).
-max-parents=7
+max-parents=8
 
 # Maximum number of public methods for a class (see R0904).
 # BasPH: choose 27 because this was 50% of the sorted list of 30 number of public methods above 20 (Pylint default)


### PR DESCRIPTION
Both BaseOperator and XComArgs implement bit shift operators
used to chain tasks in DAGs. By extracting this logic to new
mixin we reduce code duplication and make it easier to implement
it in the future.

Closes: #10926

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
