### PR TITLE
Stop running Doc tests with Spelling tests

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -741,13 +741,6 @@ args = parser.parse_args()
 
 clean_files()
 
-check_guide_links_in_operator_descriptions()
-check_class_links_in_operators_and_hooks_ref()
-check_guide_links_in_operators_and_hooks_ref()
-check_enforce_code_block()
-check_exampleinclude_for_example_dags()
-check_google_guides()
-
 CHANNEL_INVITATION = """\
 If you need help, write to #documentation channel on Airflow's Slack.
 Channel link: https://apache-airflow.slack.com/archives/CJ1LVREHX
@@ -762,4 +755,10 @@ if not args.docs_only:
 
 if not args.spellcheck_only:
     build_sphinx_docs()
+    check_guide_links_in_operator_descriptions()
+    check_class_links_in_operators_and_hooks_ref()
+    check_guide_links_in_operators_and_hooks_ref()
+    check_enforce_code_block()
+    check_exampleinclude_for_example_dags()
+    check_google_guides()
     print_build_errors_and_exit("The documentation has errors.")


### PR DESCRIPTION
Currently we run the following tests too when checking spell-check errors

- check_guide_links_in_operator_descriptions()
- check_class_links_in_operators_and_hooks_ref()
- check_guide_links_in_operators_and_hooks_ref()
- check_enforce_code_block()
- check_exampleinclude_for_example_dags()
- check_google_guides()

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
