### PR TITLE
Fix Recent Tasks UI Overlap

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -138,7 +138,7 @@
             </td>
 
             <!-- Column 6: Recent Tasks -->
-            <td style="padding:0; width:200px; height:10px;">
+            <td style="padding:0; width:323px; height:10px;">
               <svg height="10" width="10" id='task-run-{{ dag.safe_dag_id }}' style="display: block;"></svg>
             </td>
 
@@ -467,7 +467,7 @@
     function drawTaskStatsForDag(dag_id, states) {
       g = d3.select('svg#task-run-' + dag_id.replace(/\./g, '__dot__'))
         .attr('height', diameter + (stroke_width_hover * 2))
-        .attr('width', '300px')
+        .attr('width', (states.length * (diameter + circle_margin)) + circle_margin)
         .selectAll("g")
         .data(states)
         .enter()


### PR DESCRIPTION
Resolves apache/airflow#10935.

Prevents the "Recent Tasks" UI from being overlapped. The math simply did not add up. I replaced the hard-coded value with the math to hopefully avoid this discrepancy with future changes.

Each circle is 25px wide. Spacing is 4px.

```
11*25 = 275 (circles)
12*4 = 48 (spaces)
275+48 = 323
```

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/3267/93105366-fc731700-f67c-11ea-88b0-a1a511629b76.png)  | ![image](https://user-images.githubusercontent.com/3267/93105391-0432bb80-f67d-11ea-94f7-a519861a1f2d.png)  |
