### PR TITLE
Fix Kubernetes Executor logs for long dag names 

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -117,14 +117,26 @@ class FileTaskHandler(logging.Handler):
             except Exception as e:  # pylint: disable=broad-except
                 log = "*** Failed to load local log file: {}\n".format(location)
                 log += "*** {}\n".format(str(e))
-        elif conf.get('core', 'executor') == 'KubernetesExecutor':
-            log += '*** Trying to get logs (last 100 lines) from worker pod {} ***\n\n'\
-                .format(ti.hostname)
-
+        elif conf.get('core', 'executor') == 'KubernetesExecutor':   # pylint: disable=too-many-nested-blocks
             try:
                 from airflow.kubernetes.kube_client import get_kube_client
 
                 kube_client = get_kube_client()
+
+                if len(ti.hostname) >= 63:
+                    # Kubernetes takes the pod name and truncates it for the hostname. This trucated hostname
+                    # is returned for the fqdn to comply with the 63 character limit imposed by DNS standards
+                    # on any label of a FQDN.
+                    pod_list = kube_client.list_namespaced_pod(conf.get('kubernetes', 'namespace'))
+                    matches = [pod.metadata.name for pod in pod_list.items
+                               if pod.metadata.name.startswith(ti.hostname)]
+                    if len(matches) == 1:
+                        if len(matches[0]) > len(ti.hostname):
+                            ti.hostname = matches[0]
+
+                log += '*** Trying to get logs (last 100 lines) from worker pod {} ***\n\n'\
+                    .format(ti.hostname)
+
                 res = kube_client.read_namespaced_pod_log(
                     name=ti.hostname,
                     namespace=conf.get('kubernetes', 'namespace'),


### PR DESCRIPTION
closes: #10292

When using the KubernetesExecutor, if the generated pod name is longer than 63 bytes, the host name inside the pod will be truncated to 63 bytes to comply with the DNS label RFC. This truncated pod name is saved in the database as the `ti.hostname`. Currently, when using the KubernetesExecutor, it assumes a pod with a `name==ti.hostname` exists and tries fetching the logs for it. In the case with long pod names, it fails.

This patch uses the Kubernetes client to resolve the full name of the pod from the partial host name in the database if the `ti.hostname` is long enough that it *may* be truncated and there is only 1 match for what is assumed to be a partial hostname.
