### PR TITLE
Remove test dependency in TestApiKerberos

### DIFF
--- a/tests/www/api/experimental/test_kerberos_endpoints.py
+++ b/tests/www/api/experimental/test_kerberos_endpoints.py
@@ -26,20 +26,32 @@ from unittest import mock
 import pytest
 
 from airflow.api.auth.backend.kerberos_auth import CLIENT_AUTH
+from airflow.models import DagBag
 from airflow.www import app as application
 from tests.test_utils.config import conf_vars
+from tests.test_utils.db import clear_db_dags
 
 KRB5_KTNAME = os.environ.get("KRB5_KTNAME")
 
 
 @pytest.mark.integration("kerberos")
 class TestApiKerberos(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        dagbag = DagBag(include_examples=True)
+        for dag in dagbag.dags.values():
+            dag.sync_to_db()
+
     @conf_vars({
         ("api", "auth_backend"): "airflow.api.auth.backend.kerberos_auth",
         ("kerberos", "keytab"): KRB5_KTNAME,
     })
     def setUp(self):
         self.app = application.create_app(testing=True)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        clear_db_dags()
 
     def test_trigger_dag(self):
         with self.app.test_client() as client:


### PR DESCRIPTION
I encountered this while working on https://github.com/apache/airflow/pull/10949 (Test Run: https://github.com/apache/airflow/pull/10949/checks?check_run_id=1117381842)

TestApiKerberos::test_trigger_dag previously was dependent that the `example_bash_operator` exist in the Database.

If one of the other tests didn't write it to the DB or if one of the other tests cleared it from the DB, this test failed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
