### PR TITLE
Allow customization of navigation bar title text

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -957,6 +957,13 @@
       type: string
       example: ~
       default: "#007A87"
+    - name: navbar_title
+      description: |
+        Define the title text used in the navigation bar
+      version_added: ~
+      type: string
+      example: ~
+      default: "Airflow"
     - name: default_dag_run_display_number
       description: |
         Default dagrun to show in UI

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -483,6 +483,9 @@ page_size = 100
 # Define the color of navigation bar
 navbar_color = #007A87
 
+# Define the title text used in the navigation bar
+navbar_title = Airflow
+
 # Default dagrun to show in UI
 default_dag_run_display_number = 25
 

--- a/airflow/config_templates/default_webserver_config.py
+++ b/airflow/config_templates/default_webserver_config.py
@@ -31,7 +31,7 @@ from airflow.configuration import conf
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 # The SQLAlchemy connection string.
-SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
+SQLALCHEMY_DATABASE_URI = conf.get("core", "SQL_ALCHEMY_CONN")
 
 # Flask-WTF flag for CSRF
 WTF_CSRF_ENABLED = True
@@ -99,7 +99,7 @@ AUTH_TYPE = AUTH_DB
 # Flask App Builder comes up with a number of predefined themes
 # that you can use for Apache Airflow.
 # http://flask-appbuilder.readthedocs.io/en/latest/customizing.html#changing-themes
-# Please make sure to remove "navbar_color" configuration from airflow.cfg
+# Please make sure to remove "navbar_color" and "navbar_title" configuration from airflow.cfg
 # in order to fully utilize the theme. (or use that property in conjunction with theme)
 # APP_THEME = "bootstrap-theme.css"  # default bootstrap
 # APP_THEME = "amelia.css"

--- a/airflow/www/extensions/init_jinja_globals.py
+++ b/airflow/www/extensions/init_jinja_globals.py
@@ -25,13 +25,13 @@ from airflow.settings import STATE_COLORS
 
 def init_jinja_globals(app):
     """Add extra globals variable to Jinja context"""
-    server_timezone = conf.get('core', 'default_timezone')
+    server_timezone = conf.get("core", "default_timezone")
     if server_timezone == "system":
         server_timezone = pendulum.local_timezone().name
     elif server_timezone == "utc":
         server_timezone = "UTC"
 
-    default_ui_timezone = conf.get('webserver', 'default_ui_timezone')
+    default_ui_timezone = conf.get("webserver", "default_ui_timezone")
     if default_ui_timezone == "system":
         default_ui_timezone = pendulum.local_timezone().name
     elif default_ui_timezone == "utc":
@@ -39,26 +39,27 @@ def init_jinja_globals(app):
     if not default_ui_timezone:
         default_ui_timezone = server_timezone
 
-    expose_hostname = conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
-    hosstname = socket.getfqdn() if expose_hostname else 'redact'
+    expose_hostname = conf.getboolean("webserver", "EXPOSE_HOSTNAME", fallback=True)
+    hosstname = socket.getfqdn() if expose_hostname else "redact"
 
     def prepare_jinja_globals():
         extra_globals = {
-            'server_timezone': server_timezone,
-            'default_ui_timezone': default_ui_timezone,
-            'hostname': hosstname,
-            'navbar_color': conf.get('webserver', 'NAVBAR_COLOR'),
-            'log_fetch_delay_sec': conf.getint('webserver', 'log_fetch_delay_sec', fallback=2),
-            'log_auto_tailing_offset': conf.getint('webserver', 'log_auto_tailing_offset', fallback=30),
-            'log_animation_speed': conf.getint('webserver', 'log_animation_speed', fallback=1000),
-            'state_color_mapping': STATE_COLORS
+            "server_timezone": server_timezone,
+            "default_ui_timezone": default_ui_timezone,
+            "hostname": hosstname,
+            "navbar_color": conf.get("webserver", "NAVBAR_COLOR"),
+            "navbar_title": conf.get("webserver", "NAVBAR_TITLE"),
+            "log_fetch_delay_sec": conf.getint("webserver", "log_fetch_delay_sec", fallback=2),
+            "log_auto_tailing_offset": conf.getint("webserver", "log_auto_tailing_offset", fallback=30),
+            "log_animation_speed": conf.getint("webserver", "log_animation_speed", fallback=1000),
+            "state_color_mapping": STATE_COLORS,
         }
 
-        if 'analytics_tool' in conf.getsection('webserver'):
+        if "analytics_tool" in conf.getsection("webserver"):
             extra_globals.update(
                 {
-                    'analytics_tool': conf.get('webserver', 'ANALYTICS_TOOL'),
-                    'analytics_id': conf.get('webserver', 'ANALYTICS_ID'),
+                    "analytics_tool": conf.get("webserver", "ANALYTICS_TOOL"),
+                    "analytics_id": conf.get("webserver", "ANALYTICS_ID"),
                 }
             )
 

--- a/airflow/www/templates/appbuilder/navbar.html
+++ b/airflow/www/templates/appbuilder/navbar.html
@@ -33,7 +33,7 @@
                    src="{{ url_for("static", filename="pin_100.png") }}"
                    title="{{ current_user.username }}">
               <span>
-                Airflow
+                {{ navbar_title }}
               </span>
           </a>
         </div>

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -96,6 +96,7 @@ class TemplateWithContext(NamedTuple):
             'default_ui_timezone',
             'hostname',
             'navbar_color',
+            'navbar_title',
             'log_fetch_delay_sec',
             'log_auto_tailing_offset',
             'log_animation_speed',


### PR DESCRIPTION
For organizations who may run more than one airflow instance,
this will allow for quick visual distinguishing between for
example a "production" and "test" airflow instance.

Signed-off-by: Nathan J. Mehl <n@oden.io>
