### PR TITLE
All versions in CI yamls are not hard-coded any more

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -32,7 +32,6 @@ env:
   DB_RESET: "true"
   VERBOSE: "true"
   UPGRADE_TO_LATEST_CONSTRAINTS: false
-  PYTHON_MAJOR_MINOR_VERSION: 3.6
   USE_GITHUB_REGISTRY: "true"
   GITHUB_REPOSITORY: ${{ github.repository }}
   GITHUB_USERNAME: ${{ github.actor }}
@@ -160,10 +159,16 @@ jobs:
     needs: [cancel-workflow-runs]
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
+    outputs:
+      pythonVersions: ${{ steps.versions.outputs.python-versions }}
+      allPythonVersions: ${{ steps.versions.outputs.all-python-versions }}
+      defaultPythonVersion: ${{ steps.versions.outputs.default-python-version }}
     if: >
       needs.cancel-workflow-runs.outputs.buildImages == 'true' &&
       (github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule')
     steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2
       - name: >
           Event: ${{ needs.cancel-workflow-runs.outputs.sourceEvent }}
           Repo: ${{ needs.cancel-workflow-runs.outputs.sourceHeadRepo }}
@@ -174,15 +179,28 @@ jobs:
           Source Sha: ${{ needs.cancel-workflow-runs.outputs.sourceHeadSha }}
         run: |
           printenv
+      - name: Set versions
+        id: versions
+        run: |
+          . ./scripts/ci/libraries/_script_init.sh
+
+          initialization::ga_output python-versions \
+              "$(initialization::parameters_to_json "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[@]}")"
+          initialization::ga_output default-python-version "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[0]}"
+
+          initialization::ga_output all-python-versions \
+              "$(initialization::parameters_to_json "${ALL_PYTHON_MAJOR_MINOR_VERSIONS[@]}")"
 
   build-images:
     timeout-minutes: 80
     name: "Build ${{matrix.image-type}} images ${{matrix.python-version}}"
     runs-on: ubuntu-latest
-    needs: [cancel-workflow-runs]
+    needs: [build-info, cancel-workflow-runs]
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+      # We need to attempt to build all possible versions here because workflow_run
+      # event is run from master for both master and v1-10-tests
+        python-version: ${{ fromJson(needs.build-info.outputs.allPythonVersions) }}
         image-type: [CI, PROD]
       fail-fast: true
     if: >
@@ -239,7 +257,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ needs.build-info.outputs.defaultPythonVersion }}
         if: steps.defaults.outputs.proceed == 'true'
       - name: "Override 'scripts/ci' with the ${{ github.ref }} version so that the PR cannot override it."
         # We should not override those scripts which become part of the image as they will not be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ env:
   VERBOSE: "true"
   UPGRADE_TO_LATEST_CONSTRAINTS: ${{ github.event_name == 'push' || github.event_name == 'scheduled' }}
   DOCKER_CACHE: "pulled"
-  PYTHON_MAJOR_MINOR_VERSION: 3.6
   USE_GITHUB_REGISTRY: "true"
   GITHUB_REPOSITORY: ${{ github.repository }}
   GITHUB_USERNAME: ${{ github.actor }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_REGISTRY_PULL_IMAGE_TAG: "${{ github.run_id }}"
   GITHUB_REGISTRY_PUSH_IMAGE_TAG: "latest"
+  TEST_TYPES: '["Core", "Integration", "Heisentests"]'
 
   # You can switch between building the image in "Build Images" workflow or building them in CI workflow
   # Separately for each job.
@@ -70,8 +70,29 @@ jobs:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
       waitForImage: ${{ steps.wait-for-image.outputs.wait-for-image }}
+      pythonVersions: ${{ steps.versions.outputs.python-versions }}
+      defaultPythonVersion: ${{ steps.versions.outputs.default-python-version }}
+      kubernetesVersions: ${{ steps.versions.outputs.kubernetes-versions }}
+      defaultKubernetesVersion: ${{ steps.versions.outputs.default-kubernetes-version }}
+      kubernetesModes: ${{ steps.versions.outputs.kubernetes-modes }}
+      defaultKubernetesMode: ${{ steps.versions.outputs.default-kubernetes-mode }}
+      postgresVersions: ${{ steps.versions.outputs.postgres-versions }}
+      defaultPostgresVersion: ${{ steps.versions.outputs.default-postgres-version }}
+      mysqlVersions: ${{ steps.versions.outputs.mysql-versions }}
+      defaultMysqlVersion: ${{ steps.versions.outputs.default-mysql-version }}
+      helmVersions: ${{ steps.versions.outputs.helm-versions }}
+      defaultHelmVersion: ${{ steps.versions.outputs.default-helm-version }}
+      kindVersions: ${{ steps.versions.outputs.kind-versions }}
+      defaultKindVersion: ${{ steps.versions.outputs.default-kind-version }}
+      testTypes: ${{ steps.versions.outputs.test-types }}
+      postgresExclude: ${{ steps.versions.outputs.postgres-exclude }}
+      mysqlExclude: ${{ steps.versions.outputs.mysql-exclude }}
+      sqliteExclude: ${{ steps.versions.outputs.sqlite-exclude }}
+      kubernetesExclude: ${{ steps.versions.outputs.kubernetes-exclude }}
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2
       - name: >
           Event: ${{ github.event_name }}
           Repo: ${{ github.repository }}
@@ -88,6 +109,48 @@ jobs:
           else
               echo "::set-output name=wait-for-image::false"
           fi
+      - name: Set versions
+        id: versions
+        run: |
+          . ./scripts/ci/libraries/_script_init.sh
+
+          initialization::ga_output python-versions \
+              "$(initialization::parameters_to_json "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[@]}")"
+          initialization::ga_output default-python-version "${DEFAULT_PYTHON_MAJOR_MINOR_VERSION}"
+
+          initialization::ga_output kubernetes-versions \
+              "$(initialization::parameters_to_json "${CURRENT_KUBERNETES_VERSIONS[@]}")"
+          initialization::ga_output default-kubernetes-version "${KUBERNETES_VERSION}"
+
+          initialization::ga_output kubernetes-modes \
+              "$(initialization::parameters_to_json "${CURRENT_KUBERNETES_MODES[@]}")"
+          initialization::ga_output default-kubernetes-mode "${KUBERNETES_MODE}"
+
+          initialization::ga_output postgres-versions \
+              "$(initialization::parameters_to_json "${CURRENT_POSTGRES_VERSIONS[@]}")"
+          initialization::ga_output default-postgres-version "${POSTGRES_VERSION}"
+
+          initialization::ga_output mysql-versions \
+              "$(initialization::parameters_to_json "${CURRENT_MYSQL_VERSIONS[@]}")"
+          initialization::ga_output default-mysql-version "${MYSQL_VERSION}"
+
+          initialization::ga_output kind-versions \
+              "$(initialization::parameters_to_json "${CURRENT_KIND_VERSIONS[@]}")"
+          initialization::ga_output default-kind-version "${KIND_VERSION}"
+
+          initialization::ga_output helm-versions \
+              "$(initialization::parameters_to_json "${CURRENT_HELM_VERSIONS[@]}")"
+          initialization::ga_output default-helm-version "${HELM_VERSION}"
+
+          initialization::ga_output test-types "${TEST_TYPES}"
+
+          initialization::ga_output postgres-exclude '[{ "python-version": "3.6" }]'
+
+          initialization::ga_output mysql-exclude '[{ "python-version": "3.7" }]'
+
+          initialization::ga_output sqlite-exclude '[{ "python-version": "3.8" }]'
+
+          initialization::ga_output kubernetes-exclude '[]'
 
   trigger-tests:
     timeout-minutes: 5
@@ -127,11 +190,10 @@ jobs:
   ci-images:
     name: "Wait for CI images"
     runs-on: ubuntu-latest
-    needs: [build-info, helm-tests, test-openapi-client-generation]
+    needs: [build-info]
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     env:
-      BACKEND: postgres
-      POSTGRES_VERSION: ${{ matrix.postgres-version }}
+      BACKEND: sqlite
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -139,12 +201,14 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
         if: needs.build-info.outputs.waitForImage == 'true'
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
         if: needs.build-info.outputs.waitForImage == 'true'
-      - name: Wait for CI images [3.6, 3.7, 3.8]:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}
+      - name: >
+          Wait for CI images
+          ${{ needs.build-info.outputs.pythonVersions }}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         # We wait for the images to be available either from the build-ci-image step or from
         # "build-images-workflow-run.yml' run as pull_request_target (it has the write
         # permissions in case pull_request from fork is run.
@@ -157,10 +221,11 @@ jobs:
     timeout-minutes: 30
     name: "Static checks"
     runs-on: ubuntu-latest
-    needs: [ci-images]
+    needs: [build-info, ci-images]
     env:
       SKIP: "pylint"
       MOUNT_LOCAL_SOURCES: "true"
+      PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
       # We want to make sure we have latest sources as only in_container scripts are added
     # to the image but we want to static-check all of them
@@ -170,7 +235,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
       - name: Cache pre-commit env
         uses: actions/cache@v2
         env:
@@ -191,19 +256,20 @@ jobs:
     timeout-minutes: 30
     name: "Pylint"
     runs-on: ubuntu-latest
-    needs: [ci-images]
+    needs: [build-info, ci-images]
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     env:
       # We want to make sure we have latest sources as only in_container scripts are added
       # to the image but we want to static-check all of them
       MOUNT_LOCAL_SOURCES: "true"
+      PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
       - name: "Cache pre-commit env"
         uses: actions/cache@v2
         env:
@@ -244,7 +310,9 @@ jobs:
     timeout-minutes: 30
     name: "Spell check docs"
     runs-on: ubuntu-latest
-    needs: [ci-images]
+    needs: [build-info, ci-images]
+    env:
+      PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -258,10 +326,10 @@ jobs:
     timeout-minutes: 30
     name: "Backport packages"
     runs-on: ubuntu-latest
-    needs: [ci-images]
+    needs: [build-info, ci-images]
     env:
       INSTALL_AIRFLOW_VERSION: "1.10.12"
-      PYTHON_MAJOR_MINOR_VERSION: 3.6
+      PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -269,7 +337,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -293,12 +361,13 @@ jobs:
     timeout-minutes: 60
     name: "${{matrix.test-type}}:Pg${{matrix.postgres-version}},Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
-    needs: [trigger-tests, ci-images]
+    needs: [build-info, trigger-tests, ci-images]
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
-        postgres-version: [9.6, 10]
-        test-type: [Core, Integration, Heisentests]
+        python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
+        postgres-version: ${{ fromJson(needs.build-info.outputs.postgresVersions) }}
+        test-type: ${{ fromJson(needs.build-info.outputs.testTypes) }}
+        exclude: ${{ fromJson(needs.build-info.outputs.postgresExclude) }}
       fail-fast: false
     env:
       BACKEND: postgres
@@ -315,7 +384,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -339,12 +408,13 @@ jobs:
     timeout-minutes: 60
     name: "${{matrix.test-type}}:MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
-    needs: [trigger-tests, ci-images]
+    needs: [build-info, trigger-tests, ci-images]
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
-        mysql-version: [5.7]
-        test-type: [Core, Integration, Heisentests]
+        python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
+        mysql-version: ${{ fromJson(needs.build-info.outputs.mysqlVersions) }}
+        test-type: ${{ fromJson(needs.build-info.outputs.testTypes) }}
+        exclude: ${{ fromJson(needs.build-info.outputs.mysqlExclude) }}
       fail-fast: false
     env:
       BACKEND: mysql
@@ -361,7 +431,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -384,11 +454,12 @@ jobs:
     timeout-minutes: 60
     name: "${{matrix.test-type}}:Sqlite Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
-    needs: [trigger-tests, ci-images]
+    needs: [build-info, trigger-tests, ci-images]
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
-        test-type: [Core, Integration, Heisentests]
+        python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
+        test-type: ${{ fromJson(needs.build-info.outputs.testTypes) }}
+        exclude: ${{ fromJson(needs.build-info.outputs.sqliteExclude) }}
       fail-fast: false
     env:
       BACKEND: sqlite
@@ -403,7 +474,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -427,16 +498,11 @@ jobs:
     name: "Quarantined tests"
     runs-on: ubuntu-latest
     continue-on-error: true
-    needs: [trigger-tests, ci-images]
-    strategy:
-      matrix:
-        python-version: [3.6]
-        postgres-version: [9.6]
-      fail-fast: false
+    needs: [build-info, trigger-tests, ci-images]
     env:
+      PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
       BACKEND: postgres
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
-      POSTGRES_VERSION: ${{ matrix.postgres-version }}
+      POSTGRES_VERSION: ${{needs.build-info.outputs.defaultPostgresVersion}}
       RUN_TESTS: true
       TEST_TYPE: Quarantined
       NUM_RUNS: 10
@@ -450,7 +516,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Set issue id for master"
         if: github.ref == 'refs/heads/master'
         run: |
@@ -516,8 +582,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     env:
-      BACKEND: postgres
-      POSTGRES_VERSION: ${{ matrix.postgres-version }}
+      BACKEND: sqlite
+      PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -526,30 +592,28 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
         if: needs.build-info.outputs.waitForImage == 'true'
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
         if: needs.build-info.outputs.waitForImage == 'true'
-      - name: "Wait for PROD images [3.6, 3.7, 3.8]:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
+      - name: >
+          Wait for PROD images
+          ${{ needs.build-info.outputs.pythonVersions }}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_wait_for_all_prod_images.sh
         if: needs.build-info.outputs.waitForImage == 'true'
 
   tests-kubernetes:
     timeout-minutes: 50
-    name: "K8s: ${{matrix.kube-mode}} ${{matrix.python-version}} ${{matrix.kubernetes-version}}"
+    name: "K8s: ${{matrix.python-version}} ${{matrix.kubernetes-version}} ${{matrix.kubernetes-mode}}"
     runs-on: ubuntu-latest
-    needs: [trigger-tests, prod-images]
+    needs: [build-info, trigger-tests, prod-images]
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
-        kube-mode:
-          - image
-        kubernetes-version: [v1.18.6, v1.17.5, v1.16.9]
-        kind-version:
-          - "v0.8.0"
-        helm-version:
-          - "v3.2.4"
+        python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
+        kubernetes-version: ${{ fromJson(needs.build-info.outputs.kubernetesVersions) }}
+        kubernetes-mode: ${{ fromJson(needs.build-info.outputs.kubernetesModes) }}
+        exclude: ${{ fromJson(needs.build-info.outputs.kubernetesExclude) }}
       fail-fast: false
     env:
       BACKEND: postgres
@@ -558,10 +622,10 @@ jobs:
       RUNTIME: "kubernetes"
       ENABLE_KIND_CLUSTER: "true"
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python-version }}"
-      KUBERNETES_MODE: "${{ matrix.kube-mode }}"
+      KUBERNETES_MODE: "${{ matrix.kubernetes-mode }}"
       KUBERNETES_VERSION: "${{ matrix.kubernetes-version }}"
-      KIND_VERSION: "${{ matrix.kind-version }}"
-      HELM_VERSION: "${{ matrix.helm-version }}"
+      KIND_VERSION: "${{ needs.build-info.outputs.defaultKindVersion }}"
+      HELM_VERSION: "${{ needs.build-info.outputs.defaultHelmVersion }}"
     if: >
       (needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request') &&
       (github.repository == 'apache/airflow' || github.event_name != 'schedule')
@@ -571,13 +635,13 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-      - name: "Setup Kind Cluster ${{ matrix.kind-version }}"
+      - name: "Setup Kind Cluster ${{ env.KIND_VERSION }}"
         uses: engineerd/setup-kind@v0.4.0
         with:
-          version: "${{ matrix.kind-version }}"
+          version: "${{ env.KIND_VERSION }}"
           name: airflow-python-${{matrix.python-version}}-${{matrix.kubernetes-version}}
           config: "scripts/ci/kubernetes/kind-cluster-conf.yaml"
       - name: "Prepare PROD Image"
@@ -600,12 +664,14 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: kind-logs-${{matrix.kube-mode}}-${{matrix.python-version}}-${{matrix.kubernetes-version}}
+          name: >
+            kind-logs-${{matrix.kubernetes-mode}}-${{matrix.python-version}}-${{matrix.kubernetes-version}}
           path: /tmp/kind_logs_*
       - name: "Upload artifact for coverage"
         uses: actions/upload-artifact@v2
         with:
-          name: coverage-k8s-${{matrix.kube-mode}}-${{matrix.python-version}}-${{matrix.kubernetes-version}}
+          name: >
+            coverage-k8s-${{matrix.kubernetes-mode}}-${{matrix.python-version}}-${{matrix.kubernetes-version}}
           path: "./files/coverage.xml"
 
   push-prod-images-to-github-registry:
@@ -613,6 +679,7 @@ jobs:
     name: "Push PROD images"
     runs-on: ubuntu-latest
     needs:
+      - build-info
       - static-checks
       - static-checks-pylint
       - tests-sqlite
@@ -628,7 +695,7 @@ jobs:
       github.event_name != 'schedule'
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
     env:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       GITHUB_REGISTRY_PUSH_IMAGE_TAG: "latest"
@@ -638,7 +705,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -651,6 +718,7 @@ jobs:
     name: "Push CI images"
     runs-on: ubuntu-latest
     needs:
+      - build-info
       - static-checks
       - static-checks-pylint
       - tests-sqlite
@@ -666,7 +734,7 @@ jobs:
       github.event_name != 'schedule'
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
     env:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       GITHUB_REGISTRY_PUSH_IMAGE_TAG: "latest"
@@ -676,7 +744,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -690,9 +758,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
       fail-fast: false
     needs:
+      - build-info
       - static-checks
       - static-checks-pylint
       - tests-sqlite
@@ -711,7 +780,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ github.sha }}"
@@ -728,7 +797,7 @@ jobs:
     timeout-minutes: 10
     name: "Constraints push"
     runs-on: ubuntu-latest
-    needs: [constraints]
+    needs: [build-info, constraints]
     if: >
       (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' ) &&
       github.event_name != 'pull' &&
@@ -748,7 +817,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: 'artifacts'
-      - name: "Commit changed constraint files"
+      - name: "Commit changed constraint files for ${{needs.build-info.outputs.pythonVersions}}"
         run: ./scripts/ci/constraints/ci_commit_constraints.sh
       - name: "Push changes"
         uses: ad-m/github-push-action@master

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1601,7 +1601,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --mysql-version <MYSQL_VERSION>
           Mysql version used. One of:
 
-                 5.7 8
+                 5.7
 
   -v, --verbose
           Show verbose information about executed docker, kind, kubectl, helm commands. Useful for
@@ -1926,7 +1926,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --mysql-version <MYSQL_VERSION>
           Mysql version used. One of:
 
-                 5.7 8
+                 5.7
 
   ****************************************************************************************************
    Enable production image
@@ -1971,7 +1971,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           Kubernetes mode - only used in case one of kind-cluster commands is used.
           One of:
 
-                 image git
+                 image
 
           Default: image
 

--- a/breeze-complete
+++ b/breeze-complete
@@ -18,29 +18,32 @@
 # under the License.
 
 # Allowed values for the commands & flags used
-# Those cannot be made reaad-only as the breeze-complete must be re-sourceable
+# The values here should be synchronized with the ones in
+# the ./scripts/ci/libraries/_initialization.sh and it is verified
+# by the BATS tests automatically during pre-commit and CI
+# Those cannot be made read-only as the breeze-complete must be re-sourceable
 
 _breeze_allowed_python_major_minor_versions="2.7 3.5 3.6 3.7 3.8"
 _breeze_allowed_backends="sqlite mysql postgres"
 _breeze_allowed_integrations="cassandra kerberos mongo openldap presto rabbitmq redis all"
-_breeze_allowed_kubernetes_modes="image git"
+_breeze_allowed_kubernetes_modes="image"
 _breeze_allowed_kubernetes_versions="v1.18.6 v1.17.5 v1.16.9"
 _breeze_allowed_helm_versions="v3.2.4"
 _breeze_allowed_kind_versions="v0.8.0"
-_breeze_allowed_mysql_versions="5.7 8"
+_breeze_allowed_mysql_versions="5.7"
 _breeze_allowed_postgres_versions="9.6 10"
 _breeze_allowed_kind_operations="start stop restart status deploy test shell"
 
 # shellcheck disable=SC2034
 {
     # Default values for the commands & flags used
-    _breeze_default_backend="sqlite"
-    _breeze_default_kubernetes_mode="image"
-    _breeze_default_kubernetes_version="v1.18.6"
-    _breeze_default_kind_version="v0.8.0"
-    _breeze_default_helm_version="v3.2.4"
-    _breeze_default_postgres_version="9.6"
-    _breeze_default_mysql_version="5.7"
+    _breeze_default_backend=$(echo "${_breeze_allowed_backends}" | awk '{print $1}')
+    _breeze_default_kubernetes_mode=$(echo "${_breeze_allowed_kubernetes_modes}" | awk '{print $1}')
+    _breeze_default_kubernetes_version=$(echo "${_breeze_allowed_kubernetes_versions}" | awk '{print $1}')
+    _breeze_default_helm_version=$(echo "${_breeze_allowed_helm_versions}" | awk '{print $1}')
+    _breeze_default_kind_version=$(echo "${_breeze_allowed_kind_versions}" | awk '{print $1}')
+    _breeze_default_postgres_version=$(echo "${_breeze_allowed_postgres_versions}" | awk '{print $1}')
+    _breeze_default_mysql_version=$(echo "${_breeze_allowed_mysql_versions}" | awk '{print $1}')
 }
 
 _breeze_allowed_install_airflow_versions=$(cat <<-EOF

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -19,6 +19,13 @@
 # Needs to be declared outside function in MacOS
 # shellcheck disable=SC2034
 CURRENT_PYTHON_MAJOR_MINOR_VERSIONS=()
+CURRENT_KUBERNETES_VERSIONS=()
+CURRENT_KUBERNETES_MODES=()
+CURRENT_POSTGRES_VERSIONS=()
+CURRENT_MYSQL_VERSIONS=()
+CURRENT_KIND_VERSIONS=()
+CURRENT_HELM_VERSIONS=()
+ALL_PYTHON_MAJOR_MINOR_VERSIONS=()
 
 # Creates directories for Breeze
 function initialization::create_directories() {
@@ -66,10 +73,6 @@ function initialization::initialize_base_variables() {
     export POSTGRES_HOST_PORT=${POSTGRES_HOST_PORT:="25433"}
     export MYSQL_HOST_PORT=${MYSQL_HOST_PORT:="23306"}
 
-    # Default MySQL/Postgres versions
-    export POSTGRES_VERSION=${POSTGRES_VERSION:="9.6"}
-    export MYSQL_VERSION=${MYSQL_VERSION:="5.7"}
-
     # The SQLite URL used for sqlite runs
     export SQLITE_URL="sqlite:////root/airflow/airflow.db"
 
@@ -80,9 +83,27 @@ function initialization::initialize_base_variables() {
     # By default we build CI images but we can switch to production image with PRODUCTION_IMAGE="true"
     export PRODUCTION_IMAGE="false"
 
+    # All supported major/minor versions of python in all versions of Airflow
+    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("2.7" "3.5" "3.6" "3.7" "3.8")
+    export ALL_PYTHON_MAJOR_MINOR_VERSIONS
+
     # Currently supported major/minor versions of python
     CURRENT_PYTHON_MAJOR_MINOR_VERSIONS+=("3.6" "3.7" "3.8")
     export CURRENT_PYTHON_MAJOR_MINOR_VERSIONS
+
+    # Currently supported versions of Postgres
+    CURRENT_POSTGRES_VERSIONS+=("9.6" "10")
+    export CURRENT_POSTGRES_VERSIONS
+
+   # Currently supported versions of MySQL
+    CURRENT_MYSQL_VERSIONS+=("5.7")
+    export CURRENT_MYSQL_VERSIONS
+
+    # Default Postgres versions
+    export POSTGRES_VERSION=${CURRENT_POSTGRES_VERSIONS[0]}
+
+    # Default MySQL versions
+    export MYSQL_VERSION=${CURRENT_MYSQL_VERSIONS[0]}
 
     # If set to true, the database will be reset at entry. Works for Postgres and MySQL
     export DB_RESET=${DB_RESET:="false"}
@@ -311,17 +332,32 @@ function initialization::initialize_version_suffixes_for_package_building() {
 function initialization::initialize_kubernetes_variables() {
     # By default we assume the kubernetes cluster is not being started
     export ENABLE_KIND_CLUSTER=${ENABLE_KIND_CLUSTER:="false"}
+    # Currently supported versions of Kubernetes
+    CURRENT_KUBERNETES_VERSIONS+=("v1.18.6" "v1.17.5" "v1.16.9")
+    export CURRENT_KUBERNETES_VERSIONS
+    # Currently supported modes of Kubernetes
+    CURRENT_KUBERNETES_MODES+=("image")
+    export CURRENT_KUBERNETES_MODES
+    # Currently supported versions of Kind
+    CURRENT_KIND_VERSIONS+=("v0.8.0")
+    export CURRENT_KIND_VERSIONS
+    # Currently supported versions of Helm
+    CURRENT_HELM_VERSIONS+=("v3.2.4")
+    export CURRENT_HELM_VERSIONS
     # Default Kubernetes version
-    export DEFAULT_KUBERNETES_VERSION="v1.18.6"
-    readonly DEFAULT_KUBERNETES_VERSION
+    export DEFAULT_KUBERNETES_VERSION="${CURRENT_KUBERNETES_VERSIONS[0]}"
+    # Default Kubernetes mode
+    export DEFAULT_KUBERNETES_MODE="${CURRENT_KUBERNETES_MODES[0]}"
     # Default KinD version
-    export DEFAULT_KIND_VERSION="v0.8.0"
-    readonly DEFAULT_KIND_VERSION
+    export DEFAULT_KIND_VERSION="${CURRENT_KIND_VERSIONS[0]}"
     # Default Helm version
-    export DEFAULT_HELM_VERSION="v3.2.4"
-    readonly DEFAULT_HELM_VERSION
+    export DEFAULT_HELM_VERSION="${CURRENT_HELM_VERSIONS[0]}"
     # Namespace where airflow is installed via helm
     export HELM_AIRFLOW_NAMESPACE="airflow"
+    # Kubernetes version
+    export KUBERNETES_VERSION=${KUBERNETES_VERSION:=${DEFAULT_KUBERNETES_VERSION}}
+    # Kubernetes mode
+    export KUBERNETES_MODE=${KUBERNETES_MODE:=${DEFAULT_KUBERNETES_MODE}}
     # Kind version
     export KIND_VERSION=${KIND_VERSION:=${DEFAULT_KIND_VERSION}}
     # Helm version
@@ -631,4 +667,25 @@ function initialization::make_constants_read_only() {
     readonly BUILT_CI_IMAGE_FLAG_FILE
     readonly INIT_SCRIPT_FILE
 
+}
+
+
+# converts parameters to json array
+function initialization::parameters_to_json() {
+    echo -n "["
+    local separator=""
+    local var
+    for var in "${@}"
+    do
+        echo -n "${separator}\"${var}\""
+        separator=","
+    done
+    echo "]"
+}
+
+
+# output parameter name and value - both to stdout and to be set by GitHub Actions
+function initialization::ga_output() {
+    echo "::set-output name=${1}::${2}"
+    echo "${1}=${2}"
 }

--- a/tests/bats/test_breeze_complete.bats
+++ b/tests/bats/test_breeze_complete.bats
@@ -149,3 +149,108 @@
 
   assert_equal "${COMPREPLY[*]}" "build-docs build-image"
 }
+
+@test "Test allowed python versions are same as ALL" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_allowed_python_major_minor_versions}" "${ALL_PYTHON_MAJOR_MINOR_VERSIONS[*]}"
+}
+
+@test "Test allowed Kubernetes versions same as CURRENT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_allowed_kubernetes_versions}" "${CURRENT_KUBERNETES_VERSIONS[*]}"
+}
+
+@test "Test default Kubernetes version same as DEFAULT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_default_kubernetes_version}" "${DEFAULT_KUBERNETES_VERSION}"
+}
+
+@test "Test allowed Kubernetes modes same as CURRENT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_allowed_kubernetes_modes}" "${CURRENT_KUBERNETES_MODES[*]}"
+}
+
+@test "Test default Kubernetes mode same as DEFAULT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_default_kubernetes_mode}" "${DEFAULT_KUBERNETES_MODE}"
+}
+
+
+@test "Test allowed Helm versions same as CURRENT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_allowed_helm_versions}" "${CURRENT_HELM_VERSIONS[*]}"
+}
+
+@test "Test default Helm version same as DEFAULT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_default_helm_version}" "${DEFAULT_HELM_VERSION}"
+}
+
+@test "Test allowed Kind versions same as CURRENT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_allowed_kind_versions}" "${CURRENT_KIND_VERSIONS[*]}"
+}
+
+@test "Test default Kind version same as DEFAULT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_default_kind_version}" "${DEFAULT_KIND_VERSION}"
+}
+
+@test "Test allowed MySQL versions same as CURRENT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_allowed_mysql_versions}" "${CURRENT_MYSQL_VERSIONS[*]}"
+}
+
+@test "Test default MySQL version same as MYSQL_VERSION" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_default_mysql_version}" "${MYSQL_VERSION}"
+}
+
+@test "Test allowed Postgres versions same as CURRENT" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_allowed_postgres_versions}" "${CURRENT_POSTGRES_VERSIONS[*]}"
+}
+
+@test "Test default Postgres version same as POSTGRES_VERSION" {
+  load bats_utils
+  #shellcheck source=breeze-complete
+  source "${AIRFLOW_SOURCES}/breeze-complete"
+
+  assert_equal "${_breeze_default_postgres_version}" "${POSTGRES_VERSION}"
+}


### PR DESCRIPTION
GitHub Actions allow to use `fromJson` method to read arrays
or even more complex json objects into the CI workflow yaml files.

This, connected with set::output commands, allows to read the
list of allowed versions as well as default ones from the
environment variables configured in
./scripts/ci/libraries/initialization.sh

This means that we can have one plece in which versions are
configured. We also need to do it in "breeze-complete" as this is
a standalone script that should not source anything we added
BATS tests to verify if the versions in breeze-complete
correspond with those defined in the initialization.sh

Also we do not limit tests any more in regular PRs now - we run
all combinations of available versions. Our tests run quite a
bit faster now so we should be able to run more complete
matrixes. We can still exclude individual values of the matrixes
if this is too much.

MySQL 8 is disabled from breeze for now. I plan a separate follow
up PR where we will run MySQL 8 tests (they were not run so far)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
