### PR TITLE
Fix doc preview error in editor for google operators doc

### DIFF
--- a/docs/apache-airflow-providers-google/operators/ads.rst
+++ b/docs/apache-airflow-providers-google/operators/ads.rst
@@ -27,7 +27,7 @@ businesses to advertise on Google Search, YouTube and other sites across the web
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleAdsToGcsOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/automl.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/automl.rst
@@ -31,7 +31,7 @@ and then integrate those models into your applications and web sites.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudAutoMLDocuments:

--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
@@ -33,7 +33,7 @@ data.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 Manage datasets
 ^^^^^^^^^^^^^^^

--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery_dts.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery_dts.rst
@@ -33,7 +33,7 @@ gain access to data connectors that allow you to easily transfer data from Terad
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:BigQueryDTSDocuments:

--- a/docs/apache-airflow-providers-google/operators/cloud/bigtable.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigtable.rst
@@ -27,7 +27,7 @@ Google Cloud Bigtable Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:BigtableCreateInstanceOperator:

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_build.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_build.rst
@@ -33,7 +33,7 @@ artifacts such as Docker containers or Java archives.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudBuildBuild:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_memorystore.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_memorystore.rst
@@ -32,7 +32,7 @@ of managing complex Redis deployments.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudMemorystoreInstance:

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_sql.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_sql.rst
@@ -27,7 +27,7 @@ Google Cloud SQL Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudSQLCreateInstanceDatabaseOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_storage_transfer_service.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_storage_transfer_service.rst
@@ -27,7 +27,7 @@ Google Cloud Transfer Service Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudDataTransferServiceCreateJobOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/compute.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/compute.rst
@@ -27,7 +27,7 @@ Google Compute Engine Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:ComputeEngineStartInstanceOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/data_loss_prevention.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/data_loss_prevention.rst
@@ -27,7 +27,7 @@ elements to help you better manage the data that you collect, store, or use for 
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 Info-Types
 ^^^^^^^^^^

--- a/docs/apache-airflow-providers-google/operators/cloud/datacatalog.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/datacatalog.rst
@@ -36,7 +36,7 @@ Google Cloud. It offers:
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudDataCatalogEntryOperators:

--- a/docs/apache-airflow-providers-google/operators/cloud/datafusion.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/datafusion.rst
@@ -33,7 +33,7 @@ and action.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudDataFusionRestartInstanceOperator:

--- a/docs/apache-airflow-providers-google/operators/cloud/dataprep.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataprep.rst
@@ -49,7 +49,7 @@ Set values for these fields:
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:DataprepRunJobGroupOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
@@ -32,7 +32,7 @@ For more information about the service visit `Dataproc production documentation 
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:DataprocCreateClusterOperator:

--- a/docs/apache-airflow-providers-google/operators/cloud/datastore.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/datastore.rst
@@ -31,7 +31,7 @@ For more information about the service visit
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudDatastoreExportEntitiesOperator:

--- a/docs/apache-airflow-providers-google/operators/cloud/functions.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/functions.rst
@@ -27,7 +27,7 @@ Google Cloud Functions Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudFunctionDeleteFunctionOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
@@ -27,7 +27,7 @@ Google Cloud Storage Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToBigQueryOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/kubernetes_engine.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/kubernetes_engine.rst
@@ -31,7 +31,7 @@ consists of multiple machines (specifically, Compute Engine instances) grouped t
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 Manage GKE cluster
 ^^^^^^^^^^^^^^^^^^

--- a/docs/apache-airflow-providers-google/operators/cloud/life_sciences.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/life_sciences.rst
@@ -31,7 +31,7 @@ and biomedical data at scale.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 Pipeline Configuration

--- a/docs/apache-airflow-providers-google/operators/cloud/natural_language.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/natural_language.rst
@@ -35,7 +35,7 @@ messaging app.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudNaturalLanguageDocuments:

--- a/docs/apache-airflow-providers-google/operators/cloud/pubsub.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/pubsub.rst
@@ -35,7 +35,7 @@ By decoupling senders and receivers Google Cloud PubSub allows developers to com
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:PubSubCreateTopicOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/spanner.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/spanner.rst
@@ -27,7 +27,7 @@ Google Cloud Spanner Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:SpannerDeployInstanceOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/speech_to_text.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/speech_to_text.rst
@@ -22,7 +22,7 @@ Google Cloud Speech to Text Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudSpeechToTextRecognizeSpeechOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/stackdriver.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/stackdriver.rst
@@ -27,7 +27,7 @@ Google Cloud Stackdriver Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:StackdriverListAlertPoliciesOperator:

--- a/docs/apache-airflow-providers-google/operators/cloud/text_to_speech.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/text_to_speech.rst
@@ -22,7 +22,7 @@ Google Cloud Text to Speech Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudTextToSpeechSynthesizeOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/translate.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/translate.rst
@@ -27,7 +27,7 @@ Google Cloud Translate Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudTranslateTextOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/translate_speech.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/translate_speech.rst
@@ -25,7 +25,7 @@ Google Cloud Speech Translate Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudTranslateSpeechOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/video_intelligence.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/video_intelligence.rst
@@ -15,23 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-..  Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-..  http://www.apache.org/licenses/LICENSE-2.0
-
-..  Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
 Google Cloud Video Intelligence Operators
 =========================================
 
@@ -42,7 +25,7 @@ Google Cloud Video Intelligence Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudVideoIntelligenceDetectVideoLabelsOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/vision.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/vision.rst
@@ -27,7 +27,7 @@ Google Cloud Vision Operators
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:CloudVisionAddProductToProductSetOperator:
 

--- a/docs/apache-airflow-providers-google/operators/firebase/firestore.rst
+++ b/docs/apache-airflow-providers-google/operators/firebase/firestore.rst
@@ -34,7 +34,7 @@ Cloud Functions.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 .. _howto/operator:CloudFirestoreExportDatabaseOperator:

--- a/docs/apache-airflow-providers-google/operators/marketing_platform/analytics.rst
+++ b/docs/apache-airflow-providers-google/operators/marketing_platform/analytics.rst
@@ -30,7 +30,7 @@ For more information about the Google Analytics 360 API check
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleAnalyticsListAccountsOperator:
 

--- a/docs/apache-airflow-providers-google/operators/marketing_platform/campaign_manager.rst
+++ b/docs/apache-airflow-providers-google/operators/marketing_platform/campaign_manager.rst
@@ -30,7 +30,7 @@ reports. For more information about the Campaign Manager API check
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleCampaignManagerDeleteReportOperator:
 

--- a/docs/apache-airflow-providers-google/operators/marketing_platform/display_video.rst
+++ b/docs/apache-airflow-providers-google/operators/marketing_platform/display_video.rst
@@ -27,7 +27,7 @@ campaign management features you need.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleDisplayVideo360CreateReportOperator:
 

--- a/docs/apache-airflow-providers-google/operators/marketing_platform/search_ads.rst
+++ b/docs/apache-airflow-providers-google/operators/marketing_platform/search_ads.rst
@@ -28,7 +28,7 @@ For more information check `Google Search Ads <https://developers.google.com/sea
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleSearchAdsInsertReportOperator:
 

--- a/docs/apache-airflow-providers-google/operators/suite/sheets.rst
+++ b/docs/apache-airflow-providers-google/operators/suite/sheets.rst
@@ -39,7 +39,7 @@ For more information check `official documentation <https://developers.google.co
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleSheetsCreateSpreadsheetOperator:
 

--- a/docs/apache-airflow-providers-google/operators/transfer/facebook_ads_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/facebook_ads_to_gcs.rst
@@ -27,7 +27,7 @@ Facebook Ads To GCS Operators
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:FacebookAdsReportToGcsOperator:
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
@@ -61,7 +61,7 @@ In the next section they will be described.
 Prerequisite Tasks
 ------------------
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 
 Operators

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gdrive.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gdrive.rst
@@ -33,7 +33,7 @@ document editor, file sharing mechanisms.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToGoogleDriveOperator:
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_local.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_local.rst
@@ -29,7 +29,7 @@ This page shows how to download data from GCS to local filesystem.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToLocalFilesystemOperator:
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_sftp.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_sftp.rst
@@ -32,7 +32,7 @@ It runs over the SSH protocol. It supports the full security and authentication 
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToSFTPOperator:
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_sheets.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_sheets.rst
@@ -32,7 +32,7 @@ common spreadsheet tasks.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GCSToGoogleSheets:
 

--- a/docs/apache-airflow-providers-google/operators/transfer/local_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/local_to_gcs.rst
@@ -29,7 +29,7 @@ This page shows how to upload data from local filesystem to GCS.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:LocalFilesystemToGCSOperator:
 

--- a/docs/apache-airflow-providers-google/operators/transfer/sftp_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/sftp_to_gcs.rst
@@ -32,7 +32,7 @@ It runs over the SSH protocol. It supports the full security and authentication 
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:SFTPToGCSOperator:
 

--- a/docs/apache-airflow-providers-google/operators/transfer/sheets_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/sheets_to_gcs.rst
@@ -32,7 +32,7 @@ common spreadsheet tasks.
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
-.. include:: /operators/_partials/prerequisite_tasks.rst
+.. include::/operators/_partials/prerequisite_tasks.rst
 
 .. _howto/operator:GoogleSheetsToGCSOperator:
 


### PR DESCRIPTION
When I open the documentation for google operators in my editor, I receive an error instead of a preview. 
Here's the error:
```
No preview available.


Error output:
:34: (SEVERE/4) Problems with "include" directive path: InputError: [Errno 2] No such file or directory: '/howto/operator/google/_partials/prerequisite_tasks.rst'. Exiting due to level-4 (SEVERE) system message.
```
This PR addresses it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
