### PR TITLE
KubernetesPodOperator template fix

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -362,7 +362,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     def create_pod_request_obj(self) -> k8s.V1Pod:
         """
         Creates a V1Pod based on user parameters. Note that a `pod` or `pod_template_file`
-        will supercede all other values.
+        will supersede all other values.
 
         """
         pod = pod_generator.PodGenerator(

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -424,22 +424,21 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
             )
             self.labels.update(labels)
             self.pod.metadata.labels = self.labels
-        pod = self.pod
-        self.log.debug("Starting pod:\n%s", yaml.safe_dump(pod.to_dict()))
+        self.log.debug("Starting pod:\n%s", yaml.safe_dump(self.pod.to_dict()))
         try:
             launcher.start_pod(
                 self.pod,
                 startup_timeout=self.startup_timeout_seconds)
-            final_state, result = launcher.monitor_pod(pod=pod, get_logs=self.get_logs)
+            final_state, result = launcher.monitor_pod(pod=self.pod, get_logs=self.get_logs)
         except AirflowException:
             if self.log_events_on_failure:
-                for event in launcher.read_pod_events(pod).items:
+                for event in launcher.read_pod_events(self.pod).items:
                     self.log.error("Pod Event: %s - %s", event.reason, event.message)
             raise
         finally:
             if self.is_delete_operator_pod:
-                launcher.delete_pod(pod)
-        return final_state, pod, result
+                launcher.delete_pod(self.pod)
+        return final_state, self.pod, result
 
     def monitor_launched_pod(self, launcher, pod) -> Tuple[State, Optional[str]]:
         """

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -364,7 +364,6 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         Creates a V1Pod based on user parameters. Note that a `pod` or `pod_template_file`
         will supercede all other values.
 
-        @return:
         """
         pod = pod_generator.PodGenerator(
             image=self.image,

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -241,8 +241,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.name = self._set_name(name)
         self.termination_grace_period = termination_grace_period
         self.client: CoreV1Api = None
-
-        self.pod: k8s.V1Pod = self.create_pod()
+        self.pod: k8s.V1Pod = None
 
     @staticmethod
     def create_labels_for_pod(context) -> dict:
@@ -278,6 +277,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                 client = kube_client.get_kube_client(cluster_context=self.cluster_context,
                                                      config_file=self.config_file)
 
+            self.pod = self.create_pod_request_obj()
             self.client = client
 
             # Add combination of labels to uniquely identify a running pod
@@ -359,7 +359,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         validate_key(name, max_length=220)
         return re.sub(r'[^a-z0-9.-]+', '-', name.lower())
 
-    def create_pod(self) -> k8s.V1Pod:
+    def create_pod_request_obj(self) -> k8s.V1Pod:
         """
         Creates a V1Pod based on user parameters. Note that a `pod` or `pod_template_file`
         will supercede all other values.

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import textwrap
 import unittest
 from unittest import mock
@@ -684,6 +685,20 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             }
         ]
         self.assertEqual(self.expected_pod, actual_pod)
+
+    def test_pod_template_file_system(self):
+        fixture = sys.path[0] + '/tests/kubernetes/basic_pod.yaml'
+        k = KubernetesPodOperator(
+            task_id="task" + self.get_current_task_name(),
+            in_cluster=False,
+            pod_template_file=fixture,
+            do_xcom_push=True
+        )
+
+        context = create_context(k)
+        result = k.execute(context)
+        self.assertIsNotNone(result)
+        self.assertDictEqual(result, {"hello": "world"})
 
     def test_init_container(self):
         # GIVEN

--- a/tests/kubernetes/basic_pod.yaml
+++ b/tests/kubernetes/basic_pod.yaml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+  name: test-pod
+spec:
+  containers:
+    - name: base
+      image: perl
+      command: ["/bin/bash"]
+      args: ["-c", 'echo {\"hello\" : \"world\"} | cat > /airflow/xcom/return.json']
+  restartPolicy: Never


### PR DESCRIPTION


Fixes a bug where users who run K8sPodOperator could not run because
the operator was expecting a namespace parameter. Also adds integration test for the pod_template_file

ticket here: https://github.com/apache/airflow/issues/10037

 I tried to create a job in my DAG using the [KubernetesPodOperator](https://airflow.apache.org/docs/stable/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html), and configuring it with a `.yaml` file (with the `pod_template_file` argument).

When specifying the `namespace` argument for the `KubernetesPodOperator`, I got the following error : 
```
[2020-07-28 13:27:02,689] {taskinstance.py:1150} ERROR - Pod Launching failed: Cannot configure pod and pass either `pod` or `pod_template_file`. Fields ['namespace'] passed.
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/contrib/operators/kubernetes_pod_operator.py", line 291, in execute
    final_state, _, result = self.create_new_pod_for_operator(labels, launcher)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/contrib/operators/kubernetes_pod_operator.py", line 338, in create_new_pod_for_operator
    pod = pod_generator.PodGenerator(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/kubernetes/pod_generator.py", line 205, in __init__
    self.validate_pod_generator_args(locals())
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/kubernetes/pod_generator.py", line 553, in validate_pod_generator_args
    raise AirflowConfigException(
airflow.exceptions.AirflowConfigException: Cannot configure pod and pass either `pod` or `pod_template_file`. Fields ['namespace'] passed.
```

When not specifying the argument on the other hand, I got the following error:
```
[2020-07-28 13:13:24,938] {taskinstance.py:1150} ERROR - Missing the required parameter `namespace` when calling `list_namespaced_pod`
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 984, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/contrib/operators/kubernetes_pod_operator.py", line 271, in execute
    pod_list = client.list_namespaced_pod(self.namespace, label_selector=label_selector)
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/client/api/core_v1_api.py", line 12803, in list_namespaced_pod
    (data) = self.list_namespaced_pod_with_http_info(namespace, **kwargs)  # noqa: E501
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/client/api/core_v1_api.py", line 12850, in list_namespaced_pod_with_http_info
    raise ValueError("Missing the required parameter `namespace` when calling `list_namespaced_pod`")  # noqa: E501
ValueError: Missing the required parameter `namespace` when calling `list_namespaced_pod`
```
(note that this error comes from the k8s python api, not from airflow)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
