### PR TITLE
[WIP] sketch import error alert emails

### DIFF
--- a/airflow/models/errors.py
+++ b/airflow/models/errors.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy import Boolean, Column, Integer, String, Text
 
 from airflow.models.base import Base
 from airflow.utils.sqlalchemy import UtcDateTime
@@ -32,3 +32,4 @@ class ImportError(Base):  # pylint: disable=redefined-builtin
     timestamp = Column(UtcDateTime)
     filename = Column(String(1024))
     stacktrace = Column(Text)
+    email_sent = Column(Boolean, default=False)


### PR DESCRIPTION
This PR is a conversation piece that came from pondering how to support import error alert emails in #10968.
This is a feature will be especially useful for admins who use `ClusterPolicyViolation` or those who have pesky folks that push bad DAGs cluttering the UI with notifications that should be triaged to the on-call w/o human intervention.

I believe that the `import_errors` is a sad place in the airflow codebase and now might be the time to refactor this.
I've left TODO comments with questions about how to best keep track of import_error emails we have sent (as to not spam the recipients with emails every scheduler loop).

It seems to me we can either keep history of import errors in the existing table or create a new table (e.g. `import_error_history` which has a bool field for email_sent) for this purpose.

cc: @mik-laj 