### PR TITLE
Add support to set lifecycle on K8s pods

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -217,6 +217,7 @@ class PodGenerator:
         pod_template_file: Optional[str] = None,
         extract_xcom: bool = False,
         priority_class_name: Optional[str] = None,
+        lifecycle: Optional[Union[k8s.V1Lifecycle, dict]] = None,
     ):
         self.validate_pod_generator_args(locals())
 
@@ -266,6 +267,7 @@ class PodGenerator:
         self.container.ports = ports or []
         self.container.resources = resources
         self.container.volume_mounts = volume_mounts or []
+        self.container.lifecycle = lifecycle
 
         # Pod Spec
         self.spec = k8s.V1PodSpec(containers=[])

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -16,7 +16,7 @@
 # under the License.
 """Executes task in a Kubernetes POD"""
 import re
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import yaml
 from kubernetes.client import models as k8s

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -195,6 +195,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                  pod_template_file: Optional[str] = None,
                  priority_class_name: Optional[str] = None,
                  termination_grace_period: Optional[int] = None,
+                 lifecycle: Optional[Union[k8s.V1Lifecycle, dict]] = None,
                  **kwargs):
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'do_xcom_push' instead")
@@ -237,6 +238,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.init_containers = init_containers or []
         self.log_events_on_failure = log_events_on_failure
         self.priority_class_name = priority_class_name
+        self.lifecycle = lifecycle
         self.pod_template_file = pod_template_file
         self.name = self._set_name(name)
         self.termination_grace_period = termination_grace_period
@@ -397,6 +399,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
             init_containers=self.init_containers,
             restart_policy='Never',
             priority_class_name=self.priority_class_name,
+            lifecycle=self.lifecycle,
             pod_template_file=self.pod_template_file,
             pod=self.full_pod_spec,
         ).gen_pod()


### PR DESCRIPTION
I'm using `pod_mutation_hook` to modify the worker pods before sending them to k8s, but couldn't set the `lifecycle` policy on it, so adding support for that.

PS: Not able to test changes on the master yet, as we are on 1.10.4 as of now. 

https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/