### PR TITLE
Improve the Error message in Breeze for invalid params

### DIFF
--- a/scripts/ci/libraries/_parameters.sh
+++ b/scripts/ci/libraries/_parameters.sh
@@ -40,7 +40,7 @@ function parameters::check_and_save_allowed_param {
     _VALUE=${!_VARIABLE_NAME}
     if [[ ${_ALLOWED_VALUES:=} != *" ${_VALUE} "* ]]; then
         echo >&2
-        echo >&2 "ERROR:  Allowed ${_VARIABLE_DESCRIPTIVE_NAME}: [${_ALLOWED_VALUES}]. Is: '${!_VARIABLE_NAME}'."
+        echo >&2 "ERROR:  Allowed ${_VARIABLE_DESCRIPTIVE_NAME}: [${_ALLOWED_VALUES}]. Passed: '${!_VARIABLE_NAME}'."
         echo >&2
         echo >&2 "Switch to supported value with ${_FLAG} flag."
 

--- a/tests/bats/test_breeze_params.bats
+++ b/tests/bats/test_breeze_params.bats
@@ -32,7 +32,7 @@ teardown() {
   export _breeze_allowed_test_params="a b c"
   run parameters::check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
   assert_output "
-ERROR:  Allowed Test Param: [ a b c ]. Is: ''.
+ERROR:  Allowed Test Param: [ a b c ]. Passed: ''.
 
 Switch to supported value with --message flag."
   assert_failure
@@ -44,7 +44,7 @@ Switch to supported value with --message flag."
   echo "a" > "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
   run parameters::check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
   assert_output "
-ERROR:  Allowed Test Param: [ a b c ]. Is: 'x'.
+ERROR:  Allowed Test Param: [ a b c ]. Passed: 'x'.
 
 Switch to supported value with --message flag."
   assert_exist "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
@@ -58,7 +58,7 @@ Switch to supported value with --message flag."
   echo "x" > "${AIRFLOW_SOURCES}/.build/.TEST_PARAM"
   run parameters::check_and_save_allowed_param "TEST_PARAM"  "Test Param" "--message"
   assert_output "
-ERROR:  Allowed Test Param: [ a b c ]. Is: 'x'.
+ERROR:  Allowed Test Param: [ a b c ]. Passed: 'x'.
 
 Switch to supported value with --message flag.
 


### PR DESCRIPTION
Changed `Is` to `Passed`

Before:

```

ERROR:  Allowed backend: [ sqlite mysql postgres ]. Is: 'dpostgres'.

Switch to supported value with --backend flag.
```

After:

```

ERROR:  Allowed backend: [ sqlite mysql postgres ]. Passed: 'dpostgres'.

Switch to supported value with --backend flag.
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
