### PR TITLE
Pins temporarily moto to 1.3.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -456,7 +456,8 @@ devel = [
     'ipdb',
     'jira',
     'mongomock',
-    'moto>=1.3.14,<2.0.0',
+    'moto==1.3.14',  # TODO - fix Datasync issues to get higher version of moto:
+                     #        See: https://github.com/apache/airflow/issues/10985
     'parameterized',
     'paramiko',
     'pipdeptree',


### PR DESCRIPTION
As described in #10985, moto upgrade causes some AWS tests to fail.
Until we fix it, we pin the version to 1.3.14.

Part of #10985



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
