### PR TITLE
Fix: add support for no-menu plugin views (#10788)

### DIFF
--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -73,8 +73,12 @@ def init_plugins(app):
     appbuilder = app.appbuilder
 
     for view in plugins_manager.flask_appbuilder_views:
-        log.debug("Adding view %s", view["name"])
-        appbuilder.add_view(view["view"], view["name"], category=view["category"])
+        try:
+            log.debug("Adding view %s with menu", view["name"])
+            appbuilder.add_view(view["view"], view["name"], category=view["category"])
+        except KeyError:
+            log.debug("Adding view %s without menu", str(type(view["view"])))
+            appbuilder.add_view_no_menu(view["view"])
 
     for menu_link in sorted(plugins_manager.flask_appbuilder_menu_links, key=lambda x: x["name"]):
         log.debug("Adding menu link %s", menu_link["name"])


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #10788

---

Adds support in Airflow to add custom views from plugins without associating a menu entry. If "name" key is missing in the given plugin view, then it adds the view without menu, otherwise it behaves as usual by adding a view with menu.

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
