### PR TITLE
The test_find_not_should_ignore_path is now in heisentests

### DIFF
--- a/tests/plugins/test_plugin_ignore.py
+++ b/tests/plugins/test_plugin_ignore.py
@@ -23,6 +23,8 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 from airflow import settings
 from airflow.utils.file import find_path_from_directory
 
@@ -65,6 +67,8 @@ class TestIgnorePluginFile(unittest.TestCase):
         """
         shutil.rmtree(self.test_dir)
 
+    # See the issue: https://github.com/apache/airflow/issues/10988
+    @pytest.mark.heisentests
     def test_find_not_should_ignore_path(self):
         """
         Test that the .airflowignore work and whether the file is properly ignored.


### PR DESCRIPTION
It seems that the test_find_not_should_ignore_path test has some
dependency on side-effects from other tests.

See #10988 - we are moving this test to heisentests until we
solve the issue.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
