### PR TITLE
Unpin 'tornado' dep pulled in by flower

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,6 @@ cassandra = [
 celery = [
     'celery~=4.4.2',
     'flower>=0.7.3, <1.0',
-    'tornado>=4.2.0, <6.0',  # Dep of flower. Pin to a version that works on Py3.5.2
     'vine~=1.3',  # https://stackoverflow.com/questions/32757259/celery-no-module-named-five
 ]
 cgroups = [


### PR DESCRIPTION
'tornado' version was pinned in https://github.com/apache/airflow/pull/4815

The underlying [issue](https://github.com/tornadoweb/tornado/issues/2604) is fixed for Py 3.5.2 so that is not a problem. Also since Airflow Master is already Py 3.6+ this does not apply to us.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
