### PR TITLE
Fix airflow_local_settings.py showing up as directory

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -47,8 +47,8 @@ data:
     {{- .Values.webserver.webserverConfig | nindent 4 }}
 {{- end }}
 
-{{- if .Values.scheduler.airflowLocalSettings }}
   airflow_local_settings.py: |
+{{- if .Values.scheduler.airflowLocalSettings }}
     {{ .Values.scheduler.airflowLocalSettings | nindent 4 }}
 {{- end }}
 {{- if and .Values.dags.gitSync.enabled  .Values.dags.gitSync.knownHosts }}


### PR DESCRIPTION
Fixes a bug where the airflow_local_settings.py mounts as a volume
if there is no value (this causes k8sExecutor pods to fail)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
