### PR TITLE
Support extra_args in S3Hook and through GCSToS3Operator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -109,6 +109,14 @@ class S3Hook(AwsBaseHook):
 
     def __init__(self, *args, **kwargs) -> None:
         kwargs['client_type'] = 's3'
+
+        self.extra_args = {}
+        if 'extra_args' in kwargs:
+            self.extra_args = kwargs['extra_args']
+            if not isinstance(self.extra_args, dict):
+                raise ValueError("extra_args '%r' must be of type %s" % (self.extra_args, dict))
+            del kwargs['extra_args']
+
         super().__init__(*args, **kwargs)
 
     @staticmethod
@@ -485,11 +493,10 @@ class S3Hook(AwsBaseHook):
         if not replace and self.check_for_key(key, bucket_name):
             raise ValueError("The key {key} already exists.".format(key=key))
 
-        extra_args = {}
+        extra_args = self.extra_args
         if encrypt:
             extra_args['ServerSideEncryption'] = "AES256"
         if gzip:
-            filename_gz = ''
             with open(filename, 'rb') as f_in:
                 filename_gz = f_in.name + '.gz'
                 with gz.open(filename_gz, 'wb') as f_out:
@@ -625,7 +632,7 @@ class S3Hook(AwsBaseHook):
         if not replace and self.check_for_key(key, bucket_name):
             raise ValueError("The key {key} already exists.".format(key=key))
 
-        extra_args = {}
+        extra_args = self.extra_args
         if encrypt:
             extra_args['ServerSideEncryption'] = "AES256"
         if acl_policy:

--- a/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -19,7 +19,7 @@
 This module contains Google Cloud Storage to S3 operator.
 """
 import warnings
-from typing import Iterable, Optional, Sequence, Union
+from typing import Iterable, Optional, Sequence, Union, Dict
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -108,6 +108,7 @@ class GCSToS3Operator(BaseOperator):
         dest_verify=None,
         replace=False,
         google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        dest_s3_extra_args: Optional[Dict] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -131,6 +132,7 @@ class GCSToS3Operator(BaseOperator):
         self.dest_verify = dest_verify
         self.replace = replace
         self.google_impersonation_chain = google_impersonation_chain
+        self.dest_s3_extra_args = dest_s3_extra_args or {}
 
     def execute(self, context):
         # list all files in an Google Cloud Storage bucket
@@ -149,7 +151,9 @@ class GCSToS3Operator(BaseOperator):
 
         files = hook.list(bucket_name=self.bucket, prefix=self.prefix, delimiter=self.delimiter)
 
-        s3_hook = S3Hook(aws_conn_id=self.dest_aws_conn_id, verify=self.dest_verify)
+        s3_hook = S3Hook(
+            aws_conn_id=self.dest_aws_conn_id, verify=self.dest_verify, extra_args=self.dest_s3_extra_args
+        )
 
         if not self.replace:
             # if we are not replacing -> list all files in the S3 bucket

--- a/tests/providers/amazon/aws/transfers/test_gcs_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_gcs_to_s3.py
@@ -189,3 +189,54 @@ class TestGCSToS3Operator(unittest.TestCase):
         uploaded_files = operator.execute(None)
         self.assertEqual(sorted(MOCK_FILES), sorted(uploaded_files))
         self.assertEqual(sorted(MOCK_FILES), sorted(hook.list_keys('bucket', delimiter='/')))
+
+    @mock_s3
+    @mock.patch('airflow.providers.google.cloud.operators.gcs.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.transfers.gcs_to_s3.S3Hook')
+    def test_execute_should_handle_with_default_dest_s3_extra_args(self, s3_mock_hook, mock_hook, mock_hook2):
+        mock_hook.return_value.list.return_value = MOCK_FILES
+        mock_hook.return_value.download.return_value = b"testing"
+        mock_hook2.return_value.list.return_value = MOCK_FILES
+        s3_mock_hook.return_value = mock.Mock()
+        s3_mock_hook.parse_s3_url.return_value = mock.Mock()
+
+        operator = GCSToS3Operator(
+            task_id=TASK_ID,
+            bucket=GCS_BUCKET,
+            prefix=PREFIX,
+            delimiter=DELIMITER,
+            dest_aws_conn_id="aws_default",
+            dest_s3_key=S3_BUCKET,
+            replace=True,
+        )
+        operator.execute(None)
+        s3_mock_hook.assert_called_once_with(aws_conn_id='aws_default', extra_args={}, verify=None)
+
+    @mock_s3
+    @mock.patch('airflow.providers.google.cloud.operators.gcs.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSHook')
+    @mock.patch('airflow.providers.amazon.aws.transfers.gcs_to_s3.S3Hook')
+    def test_execute_should_pass_dest_s3_extra_args_to_s3_hook(self, s3_mock_hook, mock_hook, mock_hook2):
+        mock_hook.return_value.list.return_value = MOCK_FILES
+        mock_hook.return_value.download.return_value = b"testing"
+        mock_hook2.return_value.list.return_value = MOCK_FILES
+        s3_mock_hook.return_value = mock.Mock()
+        s3_mock_hook.parse_s3_url.return_value = mock.Mock()
+
+        operator = GCSToS3Operator(
+            task_id=TASK_ID,
+            bucket=GCS_BUCKET,
+            prefix=PREFIX,
+            delimiter=DELIMITER,
+            dest_aws_conn_id="aws_default",
+            dest_s3_key=S3_BUCKET,
+            replace=True,
+            dest_s3_extra_args={
+                "ContentLanguage": "value",
+            },
+        )
+        operator.execute(None)
+        s3_mock_hook.assert_called_once_with(
+            aws_conn_id='aws_default', extra_args={'ContentLanguage': 'value'}, verify=None
+        )


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/10298
related: https://github.com/apache/airflow/pull/8304

S3Hook used ExtraArgs but didn't support extra_args to be passed to the class. GCSToS3Operator used S3Hook internally which didn't support passing the args to S3Hook either. This PR adds dest_s3_extra_args: Dict to GCSToS3Operator and extra_args: Dict to S3Hook.
