### PR TITLE
Re-use existing paramiko connection in SSHHook instead of recreating

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -86,7 +86,6 @@ class SSHHook(BaseHook):
         self.host_proxy = None
         self.look_for_keys = True
 
-        # Placeholder for deprecated __enter__
         self.client = None
 
         # Use connection to override defaults
@@ -174,6 +173,10 @@ class SSHHook(BaseHook):
 
         :rtype: paramiko.client.SSHClient
         """
+
+        if self.client is not None:
+            return self.client
+
         self.log.debug('Creating SSH client for conn_id: %s', self.ssh_conn_id)
         client = paramiko.SSHClient()
 

--- a/tests/providers/zendesk/hooks/test_zendesk.py
+++ b/tests/providers/zendesk/hooks/test_zendesk.py
@@ -58,7 +58,7 @@ class TestZendeskHook(unittest.TestCase):
         mock_conn.call = mock_call
         zendesk_hook.get_conn = mock.Mock(return_value=mock_conn)
         zendesk_hook.call("path", get_all_pages=False)
-        mock_call.assert_called_once_with("path", None)
+        mock_call.assert_called_once_with("path", {})
 
     @mock.patch("airflow.providers.zendesk.hooks.zendesk.Zendesk")
     def test_returns_multiple_pages_if_get_all_pages_true(self, _):


### PR DESCRIPTION
SSHHook was creating the paramiko client every time execute() method was called. This PR makes change to re-use the previously established connection.

closes: https://github.com/apache/airflow/issues/10874
