### PR TITLE
[airflow/providers/cncf/kubernetes] correct hook methods name

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tempfile
+import warnings
 from typing import Generator, Optional, Tuple, Union, Any
 
 import yaml
@@ -113,6 +114,31 @@ class KubernetesHook(BaseHook):
         self, group: str, version: str, plural: str, body: Union[str, dict], namespace: Optional[str] = None
     ):
         """
+        This method is deprecated. Please use `create_custom_object`.
+        Creates custom resource definition object in Kubernetes
+
+        :param group: api group
+        :type group: str
+        :param version: api version
+        :type version: str
+        :param plural: api plural
+        :type plural: str
+        :param body: crd object definition
+        :type body: Union[str, dict]
+        :param namespace: kubernetes namespace
+        :type namespace: str
+        """
+        warnings.warn(
+            "This method is deprecated. Please use `create_custom_object`.", DeprecationWarning, stacklevel=2
+        )
+        return self.create_custom_object(
+            group=group, version=version, plural=plural, body=body, namespace=namespace
+        )
+
+    def create_custom_object(
+        self, group: str, version: str, plural: str, body: Union[str, dict], namespace: Optional[str] = None
+    ):
+        """
         Creates custom resource definition object in Kubernetes
 
         :param group: api group
@@ -138,9 +164,34 @@ class KubernetesHook(BaseHook):
             self.log.debug("Response: %s", response)
             return response
         except client.rest.ApiException as e:
-            raise AirflowException("Exception when calling -> create_custom_resource_definition: %s\n" % e)
+            raise AirflowException("Exception when calling -> create_custom_object: %s\n" % e)
 
     def get_custom_resource_definition(
+        self, group: str, version: str, plural: str, name: str, namespace: Optional[str] = None
+    ):
+        """
+        This method is deprecated. Please use `get_custom_object`.
+        Get custom resource definition object from Kubernetes
+
+        :param group: api group
+        :type group: str
+        :param version: api version
+        :type version: str
+        :param plural: api plural
+        :type plural: str
+        :param name: crd object name
+        :type name: str
+        :param namespace: kubernetes namespace
+        :type namespace: str
+        """
+        warnings.warn(
+            "This method is deprecated. Please use `get_custom_object`.", DeprecationWarning, stacklevel=2
+        )
+        return self.get_custom_object(
+            group=group, version=version, plural=plural, name=name, namespace=namespace
+        )
+
+    def get_custom_object(
         self, group: str, version: str, plural: str, name: str, namespace: Optional[str] = None
     ):
         """
@@ -157,16 +208,16 @@ class KubernetesHook(BaseHook):
         :param namespace: kubernetes namespace
         :type namespace: str
         """
-        custom_resource_definition_api = client.CustomObjectsApi(self.api_client)
+        api = client.CustomObjectsApi(self.api_client)
         if namespace is None:
             namespace = self.get_namespace()
         try:
-            response = custom_resource_definition_api.get_namespaced_custom_object(
+            response = api.get_namespaced_custom_object(
                 group=group, version=version, namespace=namespace, plural=plural, name=name
             )
             return response
         except client.rest.ApiException as e:
-            raise AirflowException("Exception when calling -> get_custom_resource_definition: %s\n" % e)
+            raise AirflowException("Exception when calling -> get_custom_object: %s\n" % e)
 
     def get_namespace(self) -> str:
         """

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import tempfile
-import warnings
 from typing import Generator, Optional, Tuple, Union, Any
 
 import yaml
@@ -110,31 +109,6 @@ class KubernetesHook(BaseHook):
         """Cached Kubernetes API client"""
         return self.get_conn()
 
-    def create_custom_resource_definition(
-        self, group: str, version: str, plural: str, body: Union[str, dict], namespace: Optional[str] = None
-    ):
-        """
-        This method is deprecated. Please use `create_custom_object`.
-        Creates custom resource definition object in Kubernetes
-
-        :param group: api group
-        :type group: str
-        :param version: api version
-        :type version: str
-        :param plural: api plural
-        :type plural: str
-        :param body: crd object definition
-        :type body: Union[str, dict]
-        :param namespace: kubernetes namespace
-        :type namespace: str
-        """
-        warnings.warn(
-            "This method is deprecated. Please use `create_custom_object`.", DeprecationWarning, stacklevel=2
-        )
-        return self.create_custom_object(
-            group=group, version=version, plural=plural, body=body, namespace=namespace
-        )
-
     def create_custom_object(
         self, group: str, version: str, plural: str, body: Union[str, dict], namespace: Optional[str] = None
     ):
@@ -165,31 +139,6 @@ class KubernetesHook(BaseHook):
             return response
         except client.rest.ApiException as e:
             raise AirflowException("Exception when calling -> create_custom_object: %s\n" % e)
-
-    def get_custom_resource_definition(
-        self, group: str, version: str, plural: str, name: str, namespace: Optional[str] = None
-    ):
-        """
-        This method is deprecated. Please use `get_custom_object`.
-        Get custom resource definition object from Kubernetes
-
-        :param group: api group
-        :type group: str
-        :param version: api version
-        :type version: str
-        :param plural: api plural
-        :type plural: str
-        :param name: crd object name
-        :type name: str
-        :param namespace: kubernetes namespace
-        :type namespace: str
-        """
-        warnings.warn(
-            "This method is deprecated. Please use `get_custom_object`.", DeprecationWarning, stacklevel=2
-        )
-        return self.get_custom_object(
-            group=group, version=version, plural=plural, name=name, namespace=namespace
-        )
 
     def get_custom_object(
         self, group: str, version: str, plural: str, name: str, namespace: Optional[str] = None

--- a/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -59,7 +59,7 @@ class SparkKubernetesOperator(BaseOperator):
     def execute(self, context):
         self.log.info("Creating sparkApplication")
         hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
-        response = hook.create_custom_resource_definition(
+        response = hook.create_custom_object(
             group="sparkoperator.k8s.io",
             version="v1beta2",
             plural="sparkapplications",

--- a/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
@@ -85,7 +85,7 @@ class SparkKubernetesSensor(BaseSensorOperator):
 
     def poke(self, context: Dict) -> bool:
         self.log.info("Poking: %s", self.application_name)
-        response = self.hook.get_custom_resource_definition(
+        response = self.hook.get_custom_object(
             group="sparkoperator.k8s.io",
             version="v1beta2",
             plural="sparkapplications",


### PR DESCRIPTION
In Kubernetes world, this one is `CustomResourceDefinition` (CRD)
```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: (unknown)
  creationTimestamp: null
  name: scheduledsparkapplications.sparkoperator.k8s.io
spec:
  group: sparkoperator.k8s.io
  names:
    kind: ScheduledSparkApplication
    listKind: ScheduledSparkApplicationList
    plural: scheduledsparkapplications
    shortNames:
    - scheduledsparkapp
    singular: scheduledsparkapplication
  scope: Namespaced
  versions:
  - name: v1beta2
    schema:
      openAPIV3Schema:
        properties:
          apiVersion:
            type: string
          kind:
            type: string
          metadata:
            type: object
...
```
and this one is `CustomResource` or `CustomObject`
```yaml
apiVersion: "sparkoperator.k8s.io/v1beta2"
kind: SparkApplication
metadata:
  name: spark-pi
  namespace: default
spec:
  type: Scala
  mode: cluster
  image: "gcr.io/spark-operator/spark:v3.0.0"
  imagePullPolicy: Always
  mainClass: org.apache.spark.examples.SparkPi
  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.0.0.jar"
  sparkVersion: "3.0.0"
  restartPolicy:
    type: Never
...
```
In Airflow's kubernetes hook, there are some methods name `custom_resource_definition` but work with `custom_object`.
So this PR correct this issue.