### PR TITLE
[airflow/providers/cncf/kubernetes] change pod labels follow k8s convention

### DIFF
--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -79,11 +79,11 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 'labels': {
                     'foo': 'bar',
                     'kubernetes_pod_operator': 'True',
-                    'airflow_version': airflow_version.replace('+', '-'),
-                    'execution_date': '2016-01-01T0100000100-a2f50a31f',
-                    'dag_id': 'dag',
-                    'task_id': ANY,
-                    'try_number': '1',
+                    'airflow.apache.org/version': airflow_version.replace('+', '-'),
+                    'airflow.apache.org/execution_date': '2016-01-01T0100000100-a2f50a31f',
+                    'airflow.apache.org/dag_id': 'dag',
+                    'airflow.apache.org/task_id': ANY,
+                    'airflow.apache.org/try_number': '1',
                 },
             },
             'spec': {
@@ -990,7 +990,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         with pytest.raises(AirflowException):
             k.execute(context)
         pod = client.read_namespaced_pod(name=name, namespace=namespace)
-        assert pod.metadata.labels["already_checked"] == "True"
+        assert pod.metadata.labels["airflow.apache.org/already_checked"] == "True"
         with mock.patch(
             "airflow.providers.cncf.kubernetes"
             ".operators.kubernetes_pod.KubernetesPodOperator"


### PR DESCRIPTION
In k8s, it's highly recommended to prefix labels/annotations by domains name. like [recommended app labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  labels:
    app.kubernetes.io/name: mysql
    app.kubernetes.io/instance: mysql-abcxzy
    app.kubernetes.io/version: "5.7.21"
    app.kubernetes.io/component: database
    app.kubernetes.io/part-of: wordpress
    app.kubernetes.io/managed-by: helm
```
Or in helm, we have `helm.sh/chart: NAME-VERSION`.

So, in Airflow's `KubernetesPodOperator`, I also suggest that prefix all airflow managed labels with `airflow.apache.org/`:
```
dag_id          -> airflow.apache.org/dag_id
task_id         -> airflow.apache.org/task_id
execution_date  -> airflow.apache.org/execution_date
try_number      -> airflow.apache.org/try_number
parent_dag_id   -> airflow.apache.org/parent_dag_id
```