### PR TITLE
Remove redundant curly brace from breeze echo message

### DIFF
--- a/breeze
+++ b/breeze
@@ -979,7 +979,7 @@ function breeze::parse_arguments() {
             ;;
         -s | --github-image-id)
             echo
-            echo "GitHub image id: ${2}}"
+            echo "GitHub image id: ${2}"
             echo
             echo "Force pulling the image, using github registry and skip mounting local sources."
             echo "This is in order to get the exact same version as used in CI environment for SHA/RUN_ID!."


### PR DESCRIPTION
Before:

```
❯ ./breeze --github-image-id 260274893

GitHub image id: 260274893}
```

After:

```
❯ ./breeze --github-image-id 260274893

GitHub image id: 260274893
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
