### PR TITLE
[Airflow-10505] Change to pass all extra connection paramaters to psycopg2

### DIFF
--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -96,7 +96,6 @@ class PostgresHook(DbApiHook):
         raw_cursor = conn.extra_dejson.get('cursor', False)
         if raw_cursor:
             conn_args['cursor_factory'] = self._get_cursor(raw_cursor)
-        # check for ssl parameters in conn.extra
 
         for arg_name, arg_val in conn.extra_dejson.items():
             if arg_name not in [

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -97,15 +97,12 @@ class PostgresHook(DbApiHook):
         if raw_cursor:
             conn_args['cursor_factory'] = self._get_cursor(raw_cursor)
         # check for ssl parameters in conn.extra
+
         for arg_name, arg_val in conn.extra_dejson.items():
-            if arg_name in [
-                'sslmode',
-                'sslcert',
-                'sslkey',
-                'sslrootcert',
-                'sslcrl',
-                'application_name',
-                'keepalives_idle',
+            if arg_name not in [
+                'iam',
+                'redshift',
+                'cursor',
             ]:
                 conn_args[arg_name] = arg_val
 

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -105,6 +105,14 @@ class TestPostgresHookConn(unittest.TestCase):
         )
 
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
+    def test_get_conn_extra(self, mock_connect):
+        self.connection.extra = '{"connect_timeout": 3}'
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(
+            user='login', password='password', host='host', dbname='schema', port=None, connect_timeout=3
+        )
+
+    @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
     @mock.patch('airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.get_client_type')
     def test_get_conn_rds_iam_redshift(self, mock_client, mock_connect):
         self.connection.extra = '{"iam":true, "redshift":true}'


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #6991

Allows the use of extra parameters while connecting to Postgres. The prior implementation only allowed passing ['sslmode', 'sslcert', 'sslkey','sslrootcert', 'sslcrl', 'application_name','keepalives_idle'] as extra parameters. With the new implementation, any parameter deemed extra can be passed without any restrictions. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
