### PR TITLE
Get Airflow configs with sensitive data from CloudSecretManagerBackend

### DIFF
--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -57,6 +57,8 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
     :type connections_prefix: str
     :param variables_prefix: Specifies the prefix of the secret to read to get Variables.
     :type variables_prefix: str
+    :param config_prefix: Specifies the prefix of the secret to read to get Variables.
+    :type config_prefix: str
     :param gcp_key_path: Path to Google Cloud Service Account key file (JSON). Mutually exclusive with
         gcp_keyfile_dict. use default credentials in the current environment if not provided.
     :type gcp_key_path: str
@@ -75,6 +77,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         self,
         connections_prefix: str = "airflow-connections",
         variables_prefix: str = "airflow-variables",
+        config_prefix: str = "airflow-config",
         gcp_keyfile_dict: Optional[dict] = None,
         gcp_key_path: Optional[str] = None,
         gcp_scopes: Optional[str] = None,
@@ -85,6 +88,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         super().__init__(**kwargs)
         self.connections_prefix = connections_prefix
         self.variables_prefix = variables_prefix
+        self.config_prefix = config_prefix
         self.sep = sep
         if not self._is_valid_prefix_and_sep():
             raise AirflowException(
@@ -128,6 +132,15 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         :return: Variable Value
         """
         return self._get_secret(self.variables_prefix, key)
+
+    def get_config(self, key: str) -> Optional[str]:
+        """
+        Get Airflow Configuration
+
+        :param key: Configuration Option Key
+        :return: Configuration Option Value
+        """
+        return self._get_secret(self.config_prefix, key)
 
     def _get_secret(self, path_prefix: str, secret_id: str) -> Optional[str]:
         """

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -57,7 +57,8 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
     :type connections_prefix: str
     :param variables_prefix: Specifies the prefix of the secret to read to get Variables.
     :type variables_prefix: str
-    :param config_prefix: Specifies the prefix of the secret to read to get Variables.
+    :param config_prefix: Specifies the prefix of the secret to read to get Airflow Configurations
+        containing secrets.
     :type config_prefix: str
     :param gcp_key_path: Path to Google Cloud Service Account key file (JSON). Mutually exclusive with
         gcp_keyfile_dict. use default credentials in the current environment if not provided.

--- a/docs/security/secrets/secrets-backend/google-cloud-secret-manager-backend.rst
+++ b/docs/security/secrets/secrets-backend/google-cloud-secret-manager-backend.rst
@@ -116,11 +116,13 @@ The name of the secret must fit the following formats:
 
  * for connection: ``[variable_prefix][sep][connection_name]``
  * for variable: ``[connections_prefix][sep][variable_name]``
+ * for Airflow config: ``[config_prefix][sep][config_name]``
 
 where:
 
  * ``connections_prefix`` - fixed value defined in the ``connections_prefix`` parameter in backend configuration. Default: ``airflow-connections``.
  * ``variable_prefix`` - fixed value defined in the ``variable_prefix`` parameter in backend configuration. Default: ``airflow-variables``.
+ * ``config_prefix`` - fixed value defined in the ``config_prefix`` parameter in backend configuration. Default: ``airflow-config``.
  * ``sep`` - fixed value defined in the ``sep`` parameter in backend configuration. Default: ``-``.
 
 The Cloud Secrets Manager secret name should follow the pattern ``^[a-zA-Z0-9-_]*$``.

--- a/docs/security/secrets/secrets-backend/index.rst
+++ b/docs/security/secrets/secrets-backend/index.rst
@@ -31,6 +31,9 @@ such as :ref:`Google Cloud Secret Manager<google_cloud_secret_manager_backend>`,
     The Airflow UI only shows connections and variables stored in the Metadata DB and not via any other method.
     If you use an alternative secrets backend, check inside your backend to view the values of your variables and connections.
 
+You can also get Airflow configurations with sensitive data from the Secrets Backend.
+See :doc:`../../howto/set-config` for more details.
+
 Search path
 ^^^^^^^^^^^
 When looking up a connection/variable, by default Airflow will search environment variables first and metastore

--- a/docs/security/secrets/secrets-backend/index.rst
+++ b/docs/security/secrets/secrets-backend/index.rst
@@ -32,7 +32,7 @@ such as :ref:`Google Cloud Secret Manager<google_cloud_secret_manager_backend>`,
     If you use an alternative secrets backend, check inside your backend to view the values of your variables and connections.
 
 You can also get Airflow configurations with sensitive data from the Secrets Backend.
-See :doc:`../../howto/set-config` for more details.
+See :doc:`../../../howto/set-config` for more details.
 
 Search path
 ^^^^^^^^^^^


### PR DESCRIPTION
Adds support to Google Cloud CloudSecretManagerBackend for feature added in https://github.com/apache/airflow/pull/9645

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
