### PR TITLE
Remove Edit Button from DagModel View

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -319,9 +319,6 @@
         </div>
         <div class="modal-body">
           <form method="POST">
-            <a id="btn_edit_dagrun" class="btn btn-primary" href="{{ url_for('DagModelView.edit', pk=dag.dag_id) }}">
-              Edit
-            </a>
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             <input name="dag_id" type="hidden" value="{{ dag.dag_id }}">
             <input name="execution_date" type="hidden">


### PR DESCRIPTION
We don't allow Editing DagModel so it will fail with Permissions anyway so the button is useless.

Error:

```
[2020-09-18 14:42:15,160] {decorators.py:111} WARNING - Access is Denied for: can_edit on: DagModelView
```

**Before**
![image](https://user-images.githubusercontent.com/8811558/93656700-1cf7f400-fa24-11ea-970e-4d7f28a4d129.png)

**After**:

![image](https://user-images.githubusercontent.com/8811558/93656794-e9699980-fa24-11ea-898a-695dde9709dd.png)


closes: https://github.com/apache/airflow/issues/11014


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
