### PR TITLE
Fix logo issues due to generic scripting selector use

### DIFF
--- a/airflow/www/templates/airflow/circles.html
+++ b/airflow/www/templates/airflow/circles.html
@@ -33,7 +33,7 @@
             id="div_svg"
             class="centered text-center"
             style="border: 1px solid #ccc;padding:0;margin:0;">
-        <svg></svg>
+        <svg id="circles-svg"></svg>
 
     </div>
     <script src="{{ url_for_asset('d3.min.js') }}"></script>
@@ -68,7 +68,7 @@
     sclx = d3.scale.linear().domain([-1, points]).range([0, width]);
     scly = d3.scale.linear().domain([-1, points]).range([0, height]);
 
-    circles = d3.select("svg")
+    circles = d3.select("#circles-svg")
     .attr('width', "100%")
 
     .attr('height', height)

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -84,7 +84,7 @@
 </button>
 <div id="svg_container">
 
-  <svg width="{{ width }}" height="{{ height }}">
+  <svg id="graph-svg" width="{{ width }}" height="{{ height }}">
     <g id='dig' transform="translate(20,20)"></g>
     <filter id="blur-effect-1">
       <feGaussianBlur stdDeviation="3"></feGaussianBlur>
@@ -155,8 +155,8 @@
       .setDefaultEdgeLabel(function() { return { lineInterpolate: 'basis' } });
 
     var render = dagreD3.render(),
-      svg = d3.select("svg"),
-      innerSvg = d3.select("svg g");
+      svg = d3.select("#graph-svg"),
+      innerSvg = d3.select("#graph-svg g");
 
     // Update the page to show the latest DAG.
     function draw() {

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -67,7 +67,7 @@
 <hr/>
 <div id="svg_container">
   <img id='loading' width="50" src="{{ url_for('static', filename='loading.gif') }}">
-  <svg class='tree' width="100%">
+  <svg id="tree-svg" class='tree' width="100%">
     <filter id="blur-effect-1">
       <feGaussianBlur stdDeviation="3"></feGaussianBlur>
     </filter>
@@ -183,7 +183,7 @@ const taskTip = d3.tip()
     return toolTipHtml;
 });
 
-var svg = d3.select("svg")
+var svg = d3.select("#tree-svg")
     //.attr("width", width + margin.left + margin.right)
   .append("g")
   .attr("class", "level")
@@ -208,7 +208,7 @@ var svg = d3.select("svg")
     (num_square * square_size) + ((num_square-1) * square_spacing) - (square_size/2)
   ]);
 
-  d3.select("svg")
+  d3.select("#tree-svg")
   .insert("g")
   .attr("transform",
     "translate("+ (square_x + margin.left) +", " + axisHeight + ")")
@@ -245,7 +245,7 @@ function update(source) {
 
   var height = Math.max(500, nodes.length * barHeight + margin.top + margin.bottom);
   var width = square_x + (num_square * (square_size + square_spacing)) + margin.left + margin.right + 50;
-  d3.select("svg").transition()
+  d3.select("#tree-svg").transition()
       .duration(duration)
       .attr("height", height)
       .attr("width", width);


### PR DESCRIPTION
Resolves #11025 

In certain views, the recently added SVG brand logo (#11018) was being manipulated due to scripting on those pages generically selecting the first SVG element it could find. I replaced all of the generic selectors with explicit IDs so the scripting now knows which is the intended SVG.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/3267/93667231-3021b880-fa52-11ea-92db-f3d390890572.png)  | ![image](https://user-images.githubusercontent.com/3267/93667192-de792e00-fa51-11ea-9efd-100e0b83d5db.png) |

| Before | After |
|---|---|
| <img width="138" alt="Image 2020-09-19 at 8 05 41 AM" src="https://user-images.githubusercontent.com/3267/93667212-11bbbd00-fa52-11ea-8bbb-1a805d63c396.png">  |  ![image](https://user-images.githubusercontent.com/3267/93667197-f355c180-fa51-11ea-96ab-dbdb33690f47.png) |

