### PR TITLE
Starting breeze will run an init script after the environment is setup

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1957,6 +1957,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
           available for the usual use cases. In case the database is not initialized it will
           run also 'airflow db init' and create an Admin user with credentials admin/admin.
 
+  --init-script <INIT_SCRIPT_FILE>
+          Initialization script name - Sourced from files/airflow-breeze-config. Default value
+          init.sh. I will be executed after the environment is configured and started (in case
+          --start-airflow is used).
+
   ****************************************************************************************************
    Kind kubernetes and Kubernetes tests configuration(optional)
 

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1959,7 +1959,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   --init-script <INIT_SCRIPT_FILE>
           Initialization script name - Sourced from files/airflow-breeze-config. Default value
-          init.sh. I will be executed after the environment is configured and started (in case
+          init.sh. It will be executed after the environment is configured and started (in case
           --start-airflow is used).
 
   ****************************************************************************************************

--- a/breeze
+++ b/breeze
@@ -1000,6 +1000,12 @@ function breeze::parse_arguments() {
             export START_AIRFLOW="true"
             shift
             ;;
+        --init-script)
+            export INIT_SCRIPT_FILE="${2}"
+            echo "The initialization file is in ${INIT_SCRIPT_FILE}"
+            echo
+            shift 2
+            ;;
         -S | --version-suffix-for-pypi)
             if [[ -n ${VERSION_SUFFIX_FOR_SVN=} ]]; then
                 echo
@@ -1965,6 +1971,11 @@ ${FORMATTED_INTEGRATIONS}
         Starts the Airflow Scheduler and Webserver in two tmux panes, a third one will be
         available for the usual use cases. In case the database is not initialized it will
         run also 'airflow db init' and create an Admin user with credentials admin/admin.
+
+--init-script <INIT_SCRIPT_FILE>
+        Initialization script name - Sourced from files/airflow-breeze-config. Default value
+        init.sh. I will be executed after the environment is configured and started (in case
+        --start-airflow is used).
 
 "
 }

--- a/breeze
+++ b/breeze
@@ -1974,7 +1974,7 @@ ${FORMATTED_INTEGRATIONS}
 
 --init-script <INIT_SCRIPT_FILE>
         Initialization script name - Sourced from files/airflow-breeze-config. Default value
-        init.sh. I will be executed after the environment is configured and started (in case
+        init.sh. It will be executed after the environment is configured and started (in case
         --start-airflow is used).
 
 "

--- a/breeze-complete
+++ b/breeze-complete
@@ -138,7 +138,7 @@ _breeze_long_options="
 help python: backend: integration:
 kubernetes-mode: kubernetes-version: helm-version: kind-version:
 skip-mounting-local-sources install-airflow-version: install-airflow-reference: db-reset
-verbose assume-yes assume-no assume-quit forward-credentials start-airflow
+verbose assume-yes assume-no assume-quit forward-credentials start-airflow init-script:
 force-build-images force-pull-images production-image extras: force-clean-images skip-rebuild-check
 build-cache-local build-cache-pulled build-cache-disabled
 dockerhub-user: dockerhub-repo: github-registry github-repository: github-image-id:

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -59,6 +59,7 @@ services:
       - HOST_AIRFLOW_SOURCES=${AIRFLOW_SOURCES}
       - HOST_OS
       - PYTHONDONTWRITEBYTECODE
+      - INIT_SCRIPT_FILE
     volumes:
       # Pass docker to inside of the container so that Kind and Moto tests can use it.
       - /var/run/docker.sock:/var/run/docker.sock

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -90,6 +90,10 @@ function initialization::initialize_base_variables() {
     # If set to true, the database will be initialized, a user created and webserver and scheduler started
     export START_AIRFLOW=${START_AIRFLOW:="false"}
 
+    # If set the specified file will be used to initialized Airflow after the environment is created,
+    # otherwise it will use files/airflow-breeze-config/init.sh
+    export INIT_SCRIPT_FILE=${INIT_SCRIPT_FILE:=""}
+
     # Read airflow version from the version.py
     AIRFLOW_VERSION=$(grep version "${AIRFLOW_SOURCES}/airflow/version.py" | awk '{print $3}' | sed "s/['+]//g")
     export AIRFLOW_VERSION
@@ -469,6 +473,10 @@ Detected CI build environment:
     CI_SOURCE_REPO=${CI_SOURCE_REPO}
     CI_SOURCE_BRANCH=${CI_SOURCE_BRANCH}
 
+Initialization variables:
+
+    INIT_SCRIPT_FILE: ${INIT_SCRIPT_FILE}
+
 EOF
 
 }
@@ -621,4 +629,6 @@ function initialization::make_constants_read_only() {
     readonly AIRFLOW_PROD_IMAGE_KUBERNETES
     readonly AIRFLOW_PROD_IMAGE_DEFAULT
     readonly BUILT_CI_IMAGE_FLAG_FILE
+    readonly INIT_SCRIPT_FILE
+
 }

--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -106,6 +106,8 @@ function startairflow_if_requested() {
         airflow db init
         airflow users create -u admin -p admin -f Thor -l Adminstra -r Admin -e dummy@dummy.email
 
+        . "$( dirname "${BASH_SOURCE[0]}" )/run_init_script.sh"
+
         #this is because I run docker in WSL - Hi Bill!
         export TMUX_TMPDIR=~/.tmux/tmp
         mkdir -p ~/.tmux/tmp

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -156,6 +156,9 @@ ssh-keyscan -H localhost >> ~/.ssh/known_hosts 2>/dev/null
 # shellcheck source=scripts/in_container/configure_environment.sh
 . "${IN_CONTAINER_DIR}/configure_environment.sh"
 
+# shellcheck source=scripts/in_container/run_init_script.sh
+. "$( dirname "${BASH_SOURCE[0]}" )/run_init_script.sh"
+
 cd "${AIRFLOW_SOURCES}"
 
 set +u

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -157,7 +157,7 @@ ssh-keyscan -H localhost >> ~/.ssh/known_hosts 2>/dev/null
 . "${IN_CONTAINER_DIR}/configure_environment.sh"
 
 # shellcheck source=scripts/in_container/run_init_script.sh
-. "$( dirname "${BASH_SOURCE[0]}" )/run_init_script.sh"
+. "${IN_CONTAINER_DIR}/run_init_script.sh"
 
 cd "${AIRFLOW_SOURCES}"
 

--- a/scripts/in_container/run_init_script.sh
+++ b/scripts/in_container/run_init_script.sh
@@ -16,14 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-if [ -z ${FILES_DIR+x} ]; then
+if [ -z "${FILES_DIR+x}" ]; then
     export FILES_DIR="/files"
 fi
-if [ -z ${AIRFLOW_BREEZE_CONFIG_DIR+x} ]; then
+if [ -z "${AIRFLOW_BREEZE_CONFIG_DIR+x}" ]; then
     export AIRFLOW_BREEZE_CONFIG_DIR="${FILES_DIR}/airflow-breeze-config"
 fi
 
-if [ -z ${INIT_SCRIPT_FILE} ]; then
+if [ -z "${INIT_SCRIPT_FILE}" ]; then
     export INIT_SCRIPT_FILE="init.sh"
 fi
 

--- a/scripts/in_container/run_init_script.sh
+++ b/scripts/in_container/run_init_script.sh
@@ -15,10 +15,24 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# shellcheck source=scripts/in_container/configure_environment.sh
-. "$( dirname "${BASH_SOURCE[0]}" )/configure_environment.sh"
 
-# shellcheck source=scripts/in_container/run_init_script.sh
-. "$( dirname "${BASH_SOURCE[0]}" )/run_init_script.sh"
+export FILES_DIR="/files"
+export AIRFLOW_BREEZE_CONFIG_DIR="${FILES_DIR}/airflow-breeze-config"
+INIT_SCRIPT_FILE="init.sh"
 
-exec /bin/bash "${@}"
+
+if [[ -d "${AIRFLOW_BREEZE_CONFIG_DIR}" && \
+    -f "${AIRFLOW_BREEZE_CONFIG_DIR}/${INIT_SCRIPT_FILE}" ]]; then
+    pushd "${AIRFLOW_BREEZE_CONFIG_DIR}" >/dev/null 2>&1 || exit 1
+    echo
+    echo "Sourcing the initialization script from ${INIT_SCRIPT_FILE} in ${AIRFLOW_BREEZE_CONFIG_DIR}"
+    echo
+     # shellcheck disable=1090
+    source "${INIT_SCRIPT_FILE}"
+    popd >/dev/null 2>&1 || exit 1
+else
+    echo
+    echo "You can add ${AIRFLOW_BREEZE_CONFIG_DIR} directory and place ${INIT_SCRIPT_FILE}"
+    echo "In it to make breeze source an initialization script automatically for you"
+    echo
+fi

--- a/scripts/in_container/run_init_script.sh
+++ b/scripts/in_container/run_init_script.sh
@@ -16,20 +16,27 @@
 # specific language governing permissions and limitations
 # under the License.
 
-export FILES_DIR="/files"
-export AIRFLOW_BREEZE_CONFIG_DIR="${FILES_DIR}/airflow-breeze-config"
-INIT_SCRIPT_FILE="init.sh"
+if [ -z ${FILES_DIR+x} ]; then
+    export FILES_DIR="/files"
+fi
+if [ -z ${AIRFLOW_BREEZE_CONFIG_DIR+x} ]; then
+    export AIRFLOW_BREEZE_CONFIG_DIR="${FILES_DIR}/airflow-breeze-config"
+fi
 
+if [ -z ${INIT_SCRIPT_FILE} ]; then
+    export INIT_SCRIPT_FILE="init.sh"
+fi
 
 if [[ -d "${AIRFLOW_BREEZE_CONFIG_DIR}" && \
     -f "${AIRFLOW_BREEZE_CONFIG_DIR}/${INIT_SCRIPT_FILE}" ]]; then
-    pushd "${AIRFLOW_BREEZE_CONFIG_DIR}" >/dev/null 2>&1 || exit 1
-    echo
-    echo "Sourcing the initialization script from ${INIT_SCRIPT_FILE} in ${AIRFLOW_BREEZE_CONFIG_DIR}"
-    echo
-     # shellcheck disable=1090
-    source "${INIT_SCRIPT_FILE}"
-    popd >/dev/null 2>&1 || exit 1
+
+        pushd "${AIRFLOW_BREEZE_CONFIG_DIR}" >/dev/null 2>&1 || exit 1
+        echo
+        echo "Sourcing the initialization script from ${INIT_SCRIPT_FILE} in ${AIRFLOW_BREEZE_CONFIG_DIR}"
+        echo
+         # shellcheck disable=1090
+        source "${INIT_SCRIPT_FILE}"
+        popd >/dev/null 2>&1 || exit 1
 else
     echo
     echo "You can add ${AIRFLOW_BREEZE_CONFIG_DIR} directory and place ${INIT_SCRIPT_FILE}"


### PR DESCRIPTION
Starting automatically Airflow with --start-airflow made me realize the necessity to run some additional commands to complete the setup of my development or testing environment: using variables.env was not nice, but also it was wrong, because that file is sourced before --start-airflow initialize the db (so no way to create a connection or a pool before the database is up).

For these reasons I gave Airflow the possibility to run an init script (`init.sh`) from `files/airflow-breeze-config`. The flag `--init-script` is added as commodity to change the name of the script (the folder should stay the same).

The init script is executed after the environment is setup, but before other command (like the `exec` command or tests). The only exception is the `--start-airflow` flag, in this case the script is executed after the db initialization, but before the tmux session is created.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
