### PR TITLE
Add example to use cluster policy - Maintenance mode for conn

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1181,14 +1181,19 @@ that no tasks run for more than 48 hours. Here's an example of what this
 may look like inside your ``airflow_local_settings.py``:
 
 
-.. code-block:: python
+.. exampleinclude:: /../tests/cluster_policies/task_mutation_queue_timeout.py
+      :language: python
+      :start-after: [START task_mutation_queue_timeout]
+      :end-before: [END task_mutation_queue_timeout]
 
-    def policy(task):
-        if task.__class__.__name__ == 'HivePartitionSensor':
-            task.queue = "sensor_queue"
-        if task.timeout > timedelta(hours=48):
-            task.timeout = timedelta(hours=48)
+Another example, you can set a pool based on a connection ID to be able to restrict new tasks
+from starting if the server described by the connection is under maintenance.
 
+
+.. exampleinclude:: /../tests/cluster_policies/task_mutation_connection.py
+      :language: python
+      :start-after: [START task_mutation_connection]
+      :end-before: [END task_mutation_connection]
 
 Please note, cluster policy will have precedence over task
 attributes defined in DAG meaning if ``task.sla`` is defined
@@ -1226,7 +1231,7 @@ security controls.
 
 For example, don't run tasks without airflow owners:
 
-.. literalinclude:: /../tests/cluster_policies/__init__.py
+.. exampleinclude:: /../tests/cluster_policies/task_checks.py
       :language: python
       :start-after: [START example_cluster_policy_rule]
       :end-before: [END example_cluster_policy_rule]
@@ -1239,7 +1244,7 @@ the UI (and import errors table in the database).
 
 For Example in ``airflow_local_settings.py``:
 
-.. literalinclude:: /../tests/cluster_policies/__init__.py
+.. exampleinclude:: /../tests/cluster_policies/task_checks.py
       :language: python
       :start-after: [START example_list_of_cluster_policy_rules]
       :end-before: [END example_list_of_cluster_policy_rules]

--- a/tests/cluster_policies/task_checks.py
+++ b/tests/cluster_policies/task_checks.py
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Callable, List
+
+from airflow.configuration import conf
+from airflow.exceptions import AirflowClusterPolicyViolation
+from airflow.models.baseoperator import BaseOperator
+
+
+# [START example_cluster_policy_rule]
+def task_must_have_owners(task: BaseOperator):
+    if not task.owner or task.owner.lower() == conf.get('operators',
+                                                        'default_owner'):
+        raise AirflowClusterPolicyViolation(
+            f'''Task must have non-None non-default owner. Current value: {task.owner}''')
+# [END example_cluster_policy_rule]
+
+
+# [START example_list_of_cluster_policy_rules]
+TASK_RULES: List[Callable[[BaseOperator], None]] = [
+    task_must_have_owners,
+]
+
+
+def _check_task_rules(current_task: BaseOperator):
+    """Check task rules for given task."""
+    notices = []
+    for rule in TASK_RULES:
+        try:
+            rule(current_task)
+        except AirflowClusterPolicyViolation as ex:
+            notices.append(str(ex))
+    if notices:
+        notices_list = " * " + "\n * ".join(notices)
+        raise AirflowClusterPolicyViolation(
+            f"DAG policy violation (DAG ID: {current_task.dag_id}, Path: {current_task.dag.filepath}):\n"
+            f"Notices:\n"
+            f"{notices_list}")
+
+
+def cluster_policy(task: BaseOperator):
+    """Ensure Tasks have non-default owners."""
+    _check_task_rules(task)
+# [END example_list_of_cluster_policy_rules]

--- a/tests/cluster_policies/task_mutation_connection.py
+++ b/tests/cluster_policies/task_mutation_connection.py
@@ -14,3 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from airflow.models.pool import Pool
+
+
+# [START task_mutation_connection]
+def policy(task):
+    if task.pool == Pool.DEFAULT_POOL_NAME:
+        conn_id = getattr(task, 'conn_id') or getattr(task, 'gcp_conn_id')
+        if conn_id:
+            task.pool = f"conn_{conn_id}"
+# [START task_mutation_connection]

--- a/tests/cluster_policies/task_mutation_queue_timeout.py
+++ b/tests/cluster_policies/task_mutation_queue_timeout.py
@@ -14,3 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from datetime import timedelta
+
+
+# [START task_mutation_queue_timeout]
+def policy(task):
+    if task.__class__.__name__ == 'HivePartitionSensor':
+        task.queue = "sensor_queue"
+    if task.timeout > timedelta(hours=48):
+        task.timeout = timedelta(hours=48)
+# [END task_mutation_queue_timeout]

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -32,7 +32,7 @@ from airflow.models import DagBag, DagModel
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils.dates import timezone as tz
 from airflow.utils.session import create_session
-from tests import cluster_policies
+from tests.cluster_policies import task_checks
 from tests.models import TEST_DAGS_FOLDER
 from tests.test_utils import db
 from tests.test_utils.asserts import assert_queries_count
@@ -721,7 +721,7 @@ class TestDagBag(unittest.TestCase):
             self.assertEqual(serialized_dag.dag_id, dag.dag_id)
             self.assertEqual(set(serialized_dag.task_dict), set(dag.task_dict))
 
-    @patch("airflow.settings.policy", cluster_policies.cluster_policy)
+    @patch("airflow.settings.policy", task_checks.cluster_policy)
     def test_cluster_policy_violation(self):
         """test that file processing results in import error when task does not
         obey cluster policy.
@@ -741,7 +741,7 @@ class TestDagBag(unittest.TestCase):
         }
         self.assertEqual(expected_import_errors, dagbag.import_errors)
 
-    @patch("airflow.settings.policy", cluster_policies.cluster_policy)
+    @patch("airflow.settings.policy", task_checks.cluster_policy)
     def test_cluster_policy_obeyed(self):
         """test that dag successfully imported without import errors when tasks
         obey cluster policy.


### PR DESCRIPTION
Users tell us they need to restrict the launch of new tasks based on the connection. This is not officially supported by Airflow, so I am adding an example workaround for this and I hope some users will find it helpful.

Part of: https://github.com/apache/airflow/issues/9755
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
