### PR TITLE
Single/Multi-Namespace mode for helm chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -201,7 +201,7 @@ The following tables lists the configurable parameters of the Airflow chart and 
 | `webserver.defaultUser`                               | Optional default airflow user information                                                                    | `{}`                                              |
 | `dags.persistence.*`                                  | Dag persistence configutation                                                                                | Please refer to `values.yaml`                     |
 | `dags.gitSync.*`                                      | Git sync configuration                                                                                       | Please refer to `values.yaml`                     |
-
+| `multiNamespaceMode`                                   | Whether the KubernetesExecutor can launch pods in multiple namespaces                                        | `False`                                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -27,6 +27,9 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-pod-launcher-role
+{{- if not .Values.multiNamespaceMode }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     tier: airflow
     release: {{ .Release.Name }}

--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -19,7 +19,11 @@
 ## Airflow Pod Launcher Role
 #################################
 {{- if and .Values.rbacEnabled .Values.allowPodLaunching }}
+{{- if .Values.multiNamespaceMode }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-pod-launcher-role

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -28,6 +28,9 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if not .Values.multiNamespaceMode }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
   name: {{ .Release.Name }}-pod-launcher-rolebinding
   labels:
     tier: airflow

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -21,7 +21,11 @@
 {{- if and .Values.rbacEnabled .Values.allowPodLaunching }}
 {{- $grantScheduler := or (eq .Values.executor "LocalExecutor") (eq .Values.executor "SequentialExecutor") (eq .Values.executor "KubernetesExecutor") }}
 {{- $grantWorker := or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "KubernetesExecutor") }}
+{{- if .Values.multiNamespaceMode }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-pod-launcher-rolebinding

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -23,6 +23,10 @@
             "description": "Default airflow tag to deploy.",
             "type": "string"
         },
+        "multi_namespaceMode": {
+          "description": "Whether the KubernetesExecutor can launch workers in multiple namespaces",
+          "type": "boolean"
+        },
         "nodeSelector": {
             "description": "Select certain nodes for airflow pods.",
             "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -545,7 +545,10 @@ config:
     worker_container_repository: '{{ .Values.images.airflow.repository | default .Values.defaultAirflowRepository }}'
     worker_container_tag: '{{ .Values.images.airflow.tag | default .Values.defaultAirflowTag }}'
     delete_worker_pods: 'True'
+    multi_namespace_mode: '{{ .Values.multiNamespaceMode }}'
 # yamllint enable rule:line-length
+
+multiNamespaceMode: 'False'
 
 podTemplate: ~
 


### PR DESCRIPTION
Users should not REQUIRE a ClusterRole/ClusterRolebinding
to run airflow via helm. This change will allow "single" and "multi"
namespace modes so users can add airflow to managed kubernetes clusters

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
