### PR TITLE
[Doc] Correct description for macro task_instance_key_str

### DIFF
--- a/docs/macros-ref.rst
+++ b/docs/macros-ref.rst
@@ -68,7 +68,7 @@ Variable                                Description
                                         with deserialized JSON object, append the path to the
                                         key within the JSON object
 ``{{ task_instance_key_str }}``         a unique, human-readable key to the task instance
-                                        formatted ``{dag_id}_{task_id}_{ds}``
+                                        formatted ``{dag_id}__{task_id}__{ds_nodash}``
 ``{{ conf }}``                          the full configuration object located at
                                         ``airflow.configuration.conf`` which
                                         represents the content of your


### PR DESCRIPTION
The description of macro variable `task_instance_key_str` states its format is `{dag_id}_{task_id}_{ds}`, but it's actually `{dag_id}__{task_id}__{ds_nodash}`.

Related codes:

https://github.com/apache/airflow/blob/master/airflow/models/taskinstance.py#L1474-L1475

This can be easily reproduced by task “runme_0” in the example DAG “example_bash_operator”.

![image001](https://user-images.githubusercontent.com/11539188/93800077-5311bf80-fc40-11ea-8eba-baf1d85264f7.jpg)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
