### PR TITLE
Fix rules auto-detection for upgrade check

### DIFF
--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -20,9 +20,9 @@ from typing import List
 
 from airflow.upgrade.formatters import BaseFormatter
 from airflow.upgrade.problem import RuleStatus
-from airflow.upgrade.rules.base_rule import BaseRule, RULES
+from airflow.upgrade.rules import get_rules
 
-ALL_RULES = [cls() for cls in RULES]  # type: List[BaseRule]
+ALL_RULES = [cls() for cls in get_rules()]  # type: List[BaseRule]
 
 
 def check_upgrade(formatter):

--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -21,6 +21,7 @@ from typing import List
 from airflow.upgrade.formatters import BaseFormatter
 from airflow.upgrade.problem import RuleStatus
 from airflow.upgrade.rules import get_rules
+from airflow.upgrade.rules.base_rule import BaseRule
 
 ALL_RULES = [cls() for cls in get_rules()]  # type: List[BaseRule]
 

--- a/airflow/upgrade/problem.py
+++ b/airflow/upgrade/problem.py
@@ -31,7 +31,7 @@ class RuleStatus(NamedTuple(
 
     @property
     def is_success(self):
-        return bool(self.messages)
+        return len(self.messages) == 0
 
     @classmethod
     def from_rule(cls, rule):

--- a/airflow/upgrade/rules/__init__.py
+++ b/airflow/upgrade/rules/__init__.py
@@ -14,3 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import os
+
+
+def get_rules():
+    """Automatically discover all rules"""
+    rule_classes = []
+    path = os.path.dirname(os.path.abspath(__file__))
+    for file in os.listdir(path):
+        if not file.endswith(".py") or file in ("__init__.py", "base_rule.py"):
+            continue
+        py_file = file[:-3]
+        mod = __import__(".".join([__name__, py_file]), fromlist=[py_file])
+        classes = [getattr(mod, x) for x in dir(mod) if isinstance(getattr(mod, x), type)]
+        for cls in classes:
+            bases = [b.__name__ for b in cls.__bases__]
+            if cls.__name__ != "BaseRule" and "BaseRule" in bases:
+                rule_classes.append(cls)
+    return rule_classes

--- a/airflow/upgrade/rules/base_rule.py
+++ b/airflow/upgrade/rules/base_rule.py
@@ -15,24 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from abc import ABCMeta, abstractmethod
-
-from six import add_metaclass
-
-RULES = []
+from abc import abstractmethod
 
 
-class BaseRuleMeta(ABCMeta):
-    def __new__(cls, clsname, bases, attrs):
-        clazz = super(BaseRuleMeta, cls).__new__(cls, clsname, bases, attrs)
-        if clsname != "BaseRule":
-            RULES.append(clazz)
-        return clazz
-
-
-@add_metaclass(BaseRuleMeta)
 class BaseRule(object):
-
     @property
     @abstractmethod
     def title(self):

--- a/tests/upgrade/rules/test_base_rule.py
+++ b/tests/upgrade/rules/test_base_rule.py
@@ -15,12 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.upgrade.rules.base_rule import BaseRule, RULES
+from airflow.upgrade.rules import get_rules
+from airflow.upgrade.rules.conn_type_is_not_nullable import ConnTypeIsNotNullableRule
+from airflow.upgrade.rules.base_rule import BaseRule
 
 
 class TestBaseRule:
-    def test_if_custom_rule_is_registered(self):
-        class CustomRule(BaseRule):
-            pass
-
-        assert CustomRule in list(RULES)
+    def test_rules_are_registered(self):
+        rule_classes = get_rules()
+        assert BaseRule not in rule_classes
+        assert ConnTypeIsNotNullableRule in rule_classes

--- a/tests/upgrade/rules/test_conn_type_is_not_nullable.py
+++ b/tests/upgrade/rules/test_conn_type_is_not_nullable.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from unittest import TestCase
 
 from airflow.models import Connection
 from airflow.upgrade.rules.conn_type_is_not_nullable import ConnTypeIsNotNullableRule
@@ -21,7 +22,7 @@ from airflow.utils.db import create_session
 from tests.test_utils.db import clear_db_connections
 
 
-class TestConnTypeIsNotNullableRule:
+class TestConnTypeIsNotNullableRule(TestCase):
     def tearDown(self):
         clear_db_connections()
 

--- a/tests/upgrade/test_problem.py
+++ b/tests/upgrade/test_problem.py
@@ -22,8 +22,8 @@ from airflow.upgrade.problem import RuleStatus
 
 class TestRuleStatus:
     def test_is_success(self):
-        assert RuleStatus(rule=mock.MagicMock(), messages=[]).is_success is False
-        assert RuleStatus(rule=mock.MagicMock(), messages=["aaa"]).is_success is True
+        assert RuleStatus(rule=mock.MagicMock(), messages=[]).is_success is True
+        assert RuleStatus(rule=mock.MagicMock(), messages=["aaa"]).is_success is False
 
     def test_rule_status_from_rule(self):
         msgs = ["An interesting problem to solve"]


### PR DESCRIPTION
The rules are auto-registered using metaclass but first
we need to load modules that include the classes.

```
root@20b59d3c91ff:/opt/airflow# airflow upgrade_check

=========================================== STATUS ==========================================

Connection.conn_type is not nullable..................................................SUCCESS
Found 0 problems.

====================================== RECOMMENDATIONS ======================================

Connection.conn_type is not nullable
------------------------------------
The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced by application logic, but was not enforced by the database schema.

If you made any modifications to the table directly, make sure you don't have null in the conn_type column.
```
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
