### PR TITLE
Add SendGrid emailer rule

### DIFF
--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -31,7 +31,8 @@ has been moved to airflow.providers.
 
     def check(self):
         email_conf = conf.get(section="email", key="email_backend")
-        if email_conf.startswith("airflow.contrib"):
+        email_contrib_path = "airflow.contrib.utils.sendgrid"
+        if email_contrib_path in email_conf:
             email_provider_path = "airflow.providers.sendgrid.utils.emailer"
             msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
                 email_provider_path)

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -37,7 +37,5 @@ has been moved to airflow.providers.
             msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
                 email_provider_path)
             return [msg]
-
-
-
-
+        else:
+            return []

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -34,7 +34,7 @@ has been moved to airflow.providers.
         email_contrib_path = "airflow.contrib.utils.sendgrid"
         if email_contrib_path in email_conf:
             email_provider_path = "airflow.providers.sendgrid.utils.emailer"
-            msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
+            msg = "Email backend option uses airflow.contrib Sendgrid module. Please use new module: {}".format(
                 email_provider_path)
             return [msg]
         else:

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -33,5 +33,6 @@ has been moved to airflow.providers.
         email_conf = conf.get(section="email", key="email_backend")
         if email_conf.startswith("airflow.contrib"):
             email_provider_path = "airflow.providers.sendgrid.utils.emailer"
-            return "Email backend option uses airflow.contrib module. Please use new module: {}".format(
+            msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
                 email_provider_path)
+            return [msg]

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.configuration import conf
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class SendGridEmailerMovedRule(BaseRule):
+    title = "SendGrid email uses old airflow.contrib module"
+
+    description = """
+Removes the need for SendGrid email code to be in contrib package. The SendGrid email function \
+has been moved to airflow.providers.
+    """
+
+    def check(self, session=None):
+        email_conf = conf.get(section="email", key="email_backend")
+        if email_conf.startswith("airflow.contrib"):
+            email_backend_path = "airflow.providers.sendgrid.utils.emailer"
+            return "Email backend option uses airflow.contrib module. Please use new module: {}".format(
+                email_backend_path)

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -37,3 +37,4 @@ has been moved to airflow.providers.
             msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
                 email_provider_path)
             return [msg]
+

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -34,8 +34,8 @@ has been moved to airflow.providers.
         email_contrib_path = "airflow.contrib.utils.sendgrid"
         if email_contrib_path in email_conf:
             email_provider_path = "airflow.providers.sendgrid.utils.emailer"
-            msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
-                email_provider_path)
+            msg = "Email backend option uses airflow.contrib module. " \
+                  + "Please use new module: {}".format(email_provider_path)
             return [msg]
         else:
             return []

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -31,7 +31,6 @@ has been moved to airflow.providers.
 
     def check(self):
         email_conf = conf.get(section="email", key="email_backend")
-
         email_contrib_path = "airflow.contrib.utils.sendgrid"
         if email_contrib_path in email_conf:
             email_provider_path = "airflow.providers.sendgrid.utils.emailer"

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -31,10 +31,12 @@ has been moved to airflow.providers.
 
     def check(self):
         email_conf = conf.get(section="email", key="email_backend")
+
         email_contrib_path = "airflow.contrib.utils.sendgrid"
         if email_contrib_path in email_conf:
             email_provider_path = "airflow.providers.sendgrid.utils.emailer"
             msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
                 email_provider_path)
             return [msg]
+
 

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -25,8 +25,7 @@ class SendGridEmailerMovedRule(BaseRule):
     title = "SendGrid email uses old airflow.contrib module"
 
     description = """
-Removes the need for SendGrid email code to be in contrib package. The SendGrid email function \
-has been moved to airflow.providers.
+The SendGrid module `airflow.contrib.utils.sendgrid` was moved to `airflow.providers.sendgrid.utils.emailer`.
     """
 
     def check(self):

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -32,6 +32,6 @@ has been moved to airflow.providers.
     def check(self):
         email_conf = conf.get(section="email", key="email_backend")
         if email_conf.startswith("airflow.contrib"):
-            email_backend_path = "airflow.providers.sendgrid.utils.emailer"
+            email_provider_path = "airflow.providers.sendgrid.utils.emailer"
             return "Email backend option uses airflow.contrib module. Please use new module: {}".format(
-                email_backend_path)
+                email_provider_path)

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -40,3 +40,5 @@ has been moved to airflow.providers.
             return [msg]
 
 
+
+

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -29,7 +29,7 @@ Removes the need for SendGrid email code to be in contrib package. The SendGrid 
 has been moved to airflow.providers.
     """
 
-    def check(self, session=None):
+    def check(self):
         email_conf = conf.get(section="email", key="email_backend")
         if email_conf.startswith("airflow.contrib"):
             email_backend_path = "airflow.providers.sendgrid.utils.emailer"

--- a/tests/upgrade/rules/test_send_grid_moved.py
+++ b/tests/upgrade/rules/test_send_grid_moved.py
@@ -33,7 +33,7 @@ class TestSendGridEmailerMovedRule(TestCase):
         msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
             email_provider_path)
         response = rule.check()
-        assert response, msg
+        assert response, [msg]
 
     @conf_vars({("email", "email_backend"): "airflow.providers.sendgrid.utils.emailer"})
     def test_valid_check(self):

--- a/tests/upgrade/rules/test_send_grid_moved.py
+++ b/tests/upgrade/rules/test_send_grid_moved.py
@@ -30,8 +30,8 @@ class TestSendGridEmailerMovedRule(TestCase):
         assert isinstance(rule.title, str)
 
         email_provider_path = "airflow.providers.sendgrid.utils.emailer"
-        msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
-            email_provider_path)
+        msg = "Email backend option uses airflow.contrib Sendgrid module. " + \
+              "Please use new module: {}".format(email_provider_path)
         response = rule.check()
         assert response == [msg]
 

--- a/tests/upgrade/rules/test_send_grid_moved.py
+++ b/tests/upgrade/rules/test_send_grid_moved.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.upgrade.rules.send_grid_moved import SendGridEmailerMovedRule
+from tests.test_utils.config import conf_vars
+
+
+class TestSendGridEmailerMovedRule(TestCase):
+
+    @conf_vars({("email", "email_backend"): "airflow.contrib.utils.sendgrid"})
+    def test_invalid_check(self):
+        rule = SendGridEmailerMovedRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        email_provider_path = "airflow.providers.sendgrid.utils.emailer"
+        msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
+            email_provider_path)
+        response = rule.check()
+        assert response, msg
+
+    @conf_vars({("email", "email_backend"): "airflow.providers.sendgrid.utils.emailer"})
+    def test_valid_check(self):
+        rule = SendGridEmailerMovedRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        msg = []
+        response = rule.check()
+        assert response, msg

--- a/tests/upgrade/rules/test_send_grid_moved.py
+++ b/tests/upgrade/rules/test_send_grid_moved.py
@@ -33,7 +33,7 @@ class TestSendGridEmailerMovedRule(TestCase):
         msg = "Email backend option uses airflow.contrib module. Please use new module: {}".format(
             email_provider_path)
         response = rule.check()
-        assert response, [msg]
+        assert response == [msg]
 
     @conf_vars({("email", "email_backend"): "airflow.providers.sendgrid.utils.emailer"})
     def test_valid_check(self):
@@ -44,4 +44,4 @@ class TestSendGridEmailerMovedRule(TestCase):
 
         msg = []
         response = rule.check()
-        assert response, msg
+        assert response == msg


### PR DESCRIPTION
Adds SendGrid emailer rule to `upgrade/rules` as per:

https://github.com/apache/airflow/blob/master/UPDATING.md#sendgrid-emailer-has-been-moved

Closes: #11052

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
