### PR TITLE
Add kubernetes worker annotation rule

### DIFF
--- a/airflow/upgrade/formatters.py
+++ b/airflow/upgrade/formatters.py
@@ -79,6 +79,7 @@ class ConsoleFormatter(BaseFormatter):
                 print("Problems:")
                 for message_no, message in enumerate(rule_status.messages, 1):
                     print('{:>3}.  {}'.format(message_no, message))
+            print()
 
     def on_next_rule_status(self, rule_status):
         status = "SUCCESS" if rule_status.is_success else "FAIL"

--- a/airflow/upgrade/rules/kubernetes_worker_annotation_rule.py
+++ b/airflow/upgrade/rules/kubernetes_worker_annotation_rule.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow import conf
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class KubernetesWorkerAnnotationRule(BaseRule):
+
+    title = "kubernetes_annotations configuration section has been removed"
+
+    description = ("A new key worker_annotations has been added to existing kubernetes section instead. "
+                   "That is to remove restriction on the character set for k8s annotation keys. "
+                   "All key/value pairs from kubernetes_annotations should now go to worker_annotations "
+                   "as a json."
+                   )
+
+    def check(self):
+        kub_annotations = conf.getsection('kubernetes_annotations')
+        if kub_annotations:
+            return (
+                "For example:\n"
+                "\n"
+                "[kubernetes_annotations]\n"
+                "annotation_key = annotation_value\n"
+                "annotation_key2 = annotation_value2\n"
+                "\n"
+                "Should be written as:\n"
+                "\n"
+                "[kubernetes]\n"
+                'worker_annotations = { "annotation_key" : "annotation_value",'
+                ' "annotation_key2" : "annotation_value2" }'
+            )

--- a/airflow/upgrade/rules/kubernetes_worker_annotation_rule.py
+++ b/airflow/upgrade/rules/kubernetes_worker_annotation_rule.py
@@ -15,39 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-
-import json
-
 from airflow import conf
 from airflow.upgrade.rules.base_rule import BaseRule
 
 
 class KubernetesWorkerAnnotationsRule(BaseRule):
-
     title = "kubernetes_annotations configuration section has been removed"
 
-    description = ("A new key worker_annotations has been added to existing kubernetes section instead. "
-                   "That is to remove restriction on the character set for k8s annotation keys. "
-                   "All key/value pairs from kubernetes_annotations should now go to worker_annotations "
-                   "as a json."
+    description = ("A new key pod_template_file has been added in the kubernetes section. "
+                   "It should point to the YAML pod configuration file. This YAML pod file is "
+                   "where you add the kubernetes annotations key value pairs"
                    )
 
     def check(self):
         kub_annotations = conf.getsection('kubernetes_annotations')
         if kub_annotations:
-            annotations_json = json.dumps(kub_annotations)
             pairs = "\n".join(["%s = %s" % kv for kv in kub_annotations.items()])
-
-            return [
-                "For example:\n"
-                "\n"
-                "[kubernetes_annotations]\n"
-                '{pairs}'
-                "\n"
-                "Should be written as:\n"
-                "\n"
-                "[kubernetes]\n"
-                'worker_annotations = {annotations_json}'.format(pairs=pairs,
-                                                                 annotations_json=annotations_json)
-            ]
+            msg = ("These settings:\n"
+                   "\n[kubernetes_annotaions]\n"
+                   "{pairs}\n\n"
+                   "Should be in your YAML pod configuration file").format(pairs=pairs)
+            return [msg]

--- a/airflow/upgrade/rules/kubernetes_worker_annotation_rule.py
+++ b/airflow/upgrade/rules/kubernetes_worker_annotation_rule.py
@@ -17,11 +17,13 @@
 
 from __future__ import absolute_import
 
+import json
+
 from airflow import conf
 from airflow.upgrade.rules.base_rule import BaseRule
 
 
-class KubernetesWorkerAnnotationRule(BaseRule):
+class KubernetesWorkerAnnotationsRule(BaseRule):
 
     title = "kubernetes_annotations configuration section has been removed"
 
@@ -34,16 +36,18 @@ class KubernetesWorkerAnnotationRule(BaseRule):
     def check(self):
         kub_annotations = conf.getsection('kubernetes_annotations')
         if kub_annotations:
-            return (
+            annotations_json = json.dumps(kub_annotations)
+            pairs = "\n".join(["%s = %s" % kv for kv in kub_annotations.items()])
+
+            return [
                 "For example:\n"
                 "\n"
                 "[kubernetes_annotations]\n"
-                "annotation_key = annotation_value\n"
-                "annotation_key2 = annotation_value2\n"
+                '{pairs}'
                 "\n"
                 "Should be written as:\n"
                 "\n"
                 "[kubernetes]\n"
-                'worker_annotations = { "annotation_key" : "annotation_value",'
-                ' "annotation_key2" : "annotation_value2" }'
-            )
+                'worker_annotations = {annotations_json}'.format(pairs=pairs,
+                                                                 annotations_json=annotations_json)
+            ]

--- a/tests/upgrade/rules/test_kubernetes_worker_annotation_rule.py
+++ b/tests/upgrade/rules/test_kubernetes_worker_annotation_rule.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow.upgrade.rules.kubernetes_worker_annotation_rule import KubernetesWorkerAnnotationsRule
+from tests.test_utils.config import conf_vars
+
+
+class TestKubernetesWorkerAnnotationRule(unittest.TestCase):
+
+    @conf_vars({('kubernetes_annotations', 'test_key'): 'test-value'})
+    def test_check_works(self):
+        rule = KubernetesWorkerAnnotationsRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        msg = rule.check()
+
+        assert msg == \
+               ["For example:\n"
+                "\n"
+                "[kubernetes_annotations]\n"
+                "test_key = test-value\n"
+                "Should be written as:\n"
+                "\n"
+                "[kubernetes]\n"
+                'worker_annotations = {"test_key": "test-value"}'
+                ]

--- a/tests/upgrade/rules/test_kubernetes_worker_annotation_rule.py
+++ b/tests/upgrade/rules/test_kubernetes_worker_annotation_rule.py
@@ -33,12 +33,8 @@ class TestKubernetesWorkerAnnotationRule(unittest.TestCase):
         msg = rule.check()
 
         assert msg == \
-               ["For example:\n"
-                "\n"
-                "[kubernetes_annotations]\n"
-                "test_key = test-value\n"
-                "Should be written as:\n"
-                "\n"
-                "[kubernetes]\n"
-                'worker_annotations = {"test_key": "test-value"}'
+               ["These settings:\n"
+                   "\n[kubernetes_annotaions]\n"
+                   "test_key = test-value\n\n"
+                   "Should be in your YAML pod configuration file"
                 ]


### PR DESCRIPTION
This PR adds upgrade check for KubernetesWorkerAnnotationsRule. 
Changes link: https://github.com/apache/airflow/blob/master/UPDATING.md#changes-to-propagating-kubernetes-worker-annotations
Closes: #11049


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
