### PR TITLE
Remove usage of deprecated operators from check_operators.py in Airflow code

### DIFF
--- a/airflow/providers/apache/druid/operators/druid_check.py
+++ b/airflow/providers/apache/druid/operators/druid_check.py
@@ -18,12 +18,12 @@
 from typing import Any, Dict, Optional
 
 from airflow.exceptions import AirflowException
-from airflow.operators.check_operator import CheckOperator
+from airflow.operators.sql import SQLCheckOperator
 from airflow.providers.apache.druid.hooks.druid import DruidDbApiHook
 from airflow.utils.decorators import apply_defaults
 
 
-class DruidCheckOperator(CheckOperator):
+class DruidCheckOperator(SQLCheckOperator):
     """
     Performs checks against Druid. The ``DruidCheckOperator`` expects
     a sql query that will return a single row. Each value on that

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -35,7 +35,7 @@ from google.cloud.bigquery import TableReference
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.models.taskinstance import TaskInstance
-from airflow.operators.check_operator import CheckOperator, IntervalCheckOperator, ValueCheckOperator
+from airflow.operators.sql import SQLCheckOperator, SQLIntervalCheckOperator, SQLValueCheckOperator
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, BigQueryJob
 from airflow.providers.google.cloud.hooks.gcs import GCSHook, _parse_gcs_url
 from airflow.utils.decorators import apply_defaults
@@ -92,7 +92,7 @@ class BigQueryConsoleIndexableLink(BaseOperatorLink):
         return BIGQUERY_JOB_DETAILS_LINK_FMT.format(job_id=job_id)
 
 
-class BigQueryCheckOperator(CheckOperator):
+class BigQueryCheckOperator(SQLCheckOperator):
     """
     Performs checks against BigQuery. The ``BigQueryCheckOperator`` expects
     a sql query that will return a single row. Each value on that
@@ -188,7 +188,7 @@ class BigQueryCheckOperator(CheckOperator):
         )
 
 
-class BigQueryValueCheckOperator(ValueCheckOperator):
+class BigQueryValueCheckOperator(SQLValueCheckOperator):
     """
     Performs a simple value check using sql code.
 
@@ -263,7 +263,7 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
         )
 
 
-class BigQueryIntervalCheckOperator(IntervalCheckOperator):
+class BigQueryIntervalCheckOperator(SQLIntervalCheckOperator):
     """
     Checks that the values of metrics given as SQL expressions are within
     a certain tolerance of the ones from days_back before.

--- a/airflow/providers/qubole/operators/qubole_check.py
+++ b/airflow/providers/qubole/operators/qubole_check.py
@@ -19,13 +19,13 @@
 from typing import Iterable
 
 from airflow.exceptions import AirflowException
-from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
+from airflow.operators.sql import SQLCheckOperator, SQLValueCheckOperator
 from airflow.providers.qubole.hooks.qubole_check import QuboleCheckHook
 from airflow.providers.qubole.operators.qubole import QuboleOperator
 from airflow.utils.decorators import apply_defaults
 
 
-class QuboleCheckOperator(CheckOperator, QuboleOperator):
+class QuboleCheckOperator(SQLCheckOperator, QuboleOperator):
     """
     Performs checks against Qubole Commands. ``QuboleCheckOperator`` expects
     a command that will be executed on QDS.
@@ -70,11 +70,13 @@ class QuboleCheckOperator(CheckOperator, QuboleOperator):
             which the checks have to be performed.
 
     .. note:: All fields in common with template fields of
-        QuboleOperator and CheckOperator are template-supported.
+        QuboleOperator and SQLCheckOperator are template-supported.
 
     """
 
-    template_fields: Iterable[str] = set(QuboleOperator.template_fields) | set(CheckOperator.template_fields)
+    template_fields: Iterable[str] = set(QuboleOperator.template_fields) | set(
+        SQLCheckOperator.template_fields
+    )
     template_ext = QuboleOperator.template_ext
     ui_fgcolor = '#000'
 
@@ -117,7 +119,7 @@ class QuboleCheckOperator(CheckOperator, QuboleOperator):
             object.__setattr__(self, name, value)
 
 
-class QuboleValueCheckOperator(ValueCheckOperator, QuboleOperator):
+class QuboleValueCheckOperator(SQLValueCheckOperator, QuboleOperator):
     """
     Performs a simple value check using Qubole command.
     By default, each value on the first row of this
@@ -152,10 +154,10 @@ class QuboleValueCheckOperator(ValueCheckOperator, QuboleOperator):
 
 
     .. note:: All fields in common with template fields of
-            QuboleOperator and ValueCheckOperator are template-supported.
+            QuboleOperator and SQLValueCheckOperator are template-supported.
     """
 
-    template_fields = set(QuboleOperator.template_fields) | set(ValueCheckOperator.template_fields)
+    template_fields = set(QuboleOperator.template_fields) | set(SQLValueCheckOperator.template_fields)
     template_ext = QuboleOperator.template_ext
     ui_fgcolor = '#000'
 


### PR DESCRIPTION
This change seeks to remove usages of CheckOperator, ValueCheckOperator, and IntervalCheckOperator from Airflow code(since they are deprecated) and replace it with their equivalents: SQLCheckOperator, SQLValueCheckOperator, and SQLIntervalCheckOperator from airflow.operators.sql.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
