### PR TITLE
Replace Airflow Slack Invite old link to short link

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -221,7 +221,7 @@ firstPRWelcomeComment: >
 
   Mailing List: dev@airflow.apache.org
 
-  Slack: https://apache-airflow-slack.herokuapp.com/
+  Slack: https://s.apache.org/airflow-slack/
 
 # Comment to be posted to congratulate user on their first merged PR
 firstPRMergeComment: >

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -308,7 +308,7 @@ In case the problems are not solved, you can set the VERBOSE_COMMANDS variable t
 
 
 Then run the failed command, copy-and-paste the output from your terminal to the
-`Airflow Slack <https://apache-airflow-slack.herokuapp.com/>`_  #airflow-breeze channel and
+`Airflow Slack <https://s.apache.org/airflow-slack/>`_  #airflow-breeze channel and
 describe your problem.
 
 Other uses of the Airflow Breeze environment

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -175,7 +175,7 @@ In general, your contribution includes the following stages:
    If you want to add more changes in the future, set up your fork and enable GitHub Actions.
 
 3. Join `devlist <https://lists.apache.org/list.html?dev@airflow.apache.org>`__
-   and set up a `Slack account <https://apache-airflow-slack.herokuapp.com>`__.
+   and set up a `Slack account <https://s.apache.org/airflow-slack>`__.
 
 4. Make the change and create a `Pull Request from your fork <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork>`__.
 
@@ -1080,7 +1080,7 @@ You can join the channels via links at the `Airflow Community page <https://airf
 **IMPORTANT**
 We don't create new issues on JIRA anymore. The reason we still look at JIRA issues is that there are valuable tickets inside of it. However, each new PR should be created on `GitHub issues <https://github.com/apache/airflow/issues>`_ as stated in `Contribution Workflow Example <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example>`_
 
-* The `Apache Airflow Slack <https://apache-airflow-slack.herokuapp.com/>`_ for:
+* The `Apache Airflow Slack <https://s.apache.org/airflow-slack/>`_ for:
    * ad-hoc questions related to development (#development channel)
    * asking for review (#development channel)
    * asking for help with PRs (#how-to-pr channel)

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -745,7 +745,7 @@ clean_files()
 CHANNEL_INVITATION = """\
 If you need help, write to #documentation channel on Airflow's Slack.
 Channel link: https://apache-airflow.slack.com/archives/CJ1LVREHX
-Invitation link: https://apache-airflow-slack.herokuapp.com/\
+Invitation link: https://s.apache.org/airflow-slack/\
 """
 
 print_build_errors_and_exit("The documentation has errors. Fix them to build documentation.")

--- a/docs/project.rst
+++ b/docs/project.rst
@@ -86,7 +86,7 @@ Resources & links
   * Airflow users mailing list: users-subscribe@airflow.apache.org
 
 * `Issues on GitHub <https://github.com/apache/airflow/issues>`_
-* `Slack (chat) Channel <https://apache-airflow-slack.herokuapp.com/>`_
+* `Slack (chat) Channel <https://s.apache.org/airflow-slack/>`_
 * `More resources and links to Airflow related content on the Wiki <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Links>`_
 
 


### PR DESCRIPTION
Follow up to https://github.com/apache/airflow/pull/10034

https://apache-airflow-slack.herokuapp.com/ to https://s.apache.org/airflow-slack/

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
