### PR TITLE
Add some tasks using BashOperator in TaskGroup example dag

### DIFF
--- a/airflow/example_dags/example_task_group.py
+++ b/airflow/example_dags/example_task_group.py
@@ -19,6 +19,7 @@
 """Example DAG demonstrating the usage of the TaskGroup."""
 
 from airflow.models.dag import DAG
+from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
 from airflow.utils.task_group import TaskGroup
@@ -30,7 +31,7 @@ with DAG(dag_id="example_task_group", start_date=days_ago(2)) as dag:
     # [START howto_task_group_section_1]
     with TaskGroup("section_1", tooltip="Tasks for section_1") as section_1:
         task_1 = DummyOperator(task_id="task_1")
-        task_2 = DummyOperator(task_id="task_2")
+        task_2 = BashOperator(task_id="task_2", bash_command='echo 1')
         task_3 = DummyOperator(task_id="task_3")
 
         task_1 >> [task_2, task_3]
@@ -42,7 +43,7 @@ with DAG(dag_id="example_task_group", start_date=days_ago(2)) as dag:
 
         # [START howto_task_group_inner_section_2]
         with TaskGroup("inner_section_2", tooltip="Tasks for inner_section2") as inner_section_2:
-            task_2 = DummyOperator(task_id="task_2")
+            task_2 = BashOperator(task_id="task_2", bash_command='echo 1')
             task_3 = DummyOperator(task_id="task_3")
             task_4 = DummyOperator(task_id="task_4")
 


### PR DESCRIPTION
Previously all the tasks in airflow/example_dags/example_task_group.py were using DummyOperator which does not go to executor and is marked as success in Scheduler itself so it would be good to have some tasks that aren't dummy operator to properly test TaskGroup functionality

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
