### PR TITLE
Allow upgrade rules to return None or str

### DIFF
--- a/airflow/upgrade/problem.py
+++ b/airflow/upgrade/problem.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from __future__ import absolute_import
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Iterable
 
 from airflow.upgrade.rules.base_rule import BaseRule
 
@@ -36,11 +36,10 @@ class RuleStatus(NamedTuple(
     @classmethod
     def from_rule(cls, rule):
         # type: (BaseRule) -> RuleStatus
+        messages = []  # type: List[str]
         result = rule.check()
-        if not result:
-            messages = []
-        elif isinstance(result, str):
+        if isinstance(result, str):
             messages = [result]
-        else:
+        elif isinstance(result, Iterable):
             messages = list(result)
         return cls(rule=rule, messages=messages)

--- a/airflow/upgrade/problem.py
+++ b/airflow/upgrade/problem.py
@@ -36,5 +36,11 @@ class RuleStatus(NamedTuple(
     @classmethod
     def from_rule(cls, rule):
         # type: (BaseRule) -> RuleStatus
-        messages = rule.check()
-        return cls(rule=rule, messages=list(messages))
+        result = rule.check()
+        if not result:
+            messages = []
+        elif isinstance(result, str):
+            messages = [result]
+        else:
+            messages = list(result)
+        return cls(rule=rule, messages=messages)


### PR DESCRIPTION
This allows us to return None, str or iterable in `check` method of upgrade rules.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
