### PR TITLE
Avoid redundant SET conversion

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+from typing import Set
+
 from flask import current_app, g
 from flask_appbuilder.security.sqla import models as sqla_models
 from flask_appbuilder.security.sqla.manager import SecurityManager
@@ -307,7 +309,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
         return session.query(DagModel).filter(DagModel.dag_id.in_(resources))
 
-    def get_accessible_dag_ids(self, username=None):
+    def get_accessible_dag_ids(self, username=None) -> Set[str]:
         """
         Return a set of dags that user has access to(either read or write).
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -588,7 +588,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
     @provide_session
     def task_stats(self, session=None):
         """Task Statistics"""
-        allowed_dag_ids = set(current_app.appbuilder.sm.get_accessible_dag_ids())
+        allowed_dag_ids = current_app.appbuilder.sm.get_accessible_dag_ids()
 
         if not allowed_dag_ids:
             return wwwutils.json_response({})


### PR DESCRIPTION
In this case, `get_accessible_dag_ids()` itself returns a SET, so no need to apply `set()` again.

https://github.com/apache/airflow/blob/fbd994a4cff32be42474c5a121ec6fb888d05cd8/airflow/www/security.py#L310-L330

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
