### PR TITLE
Fix for pydocstyle D202

### DIFF
--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -50,7 +50,6 @@ def check_authorization(
     permissions: Optional[Sequence[Tuple[str, str]]] = None, dag_id: Optional[int] = None
 ) -> None:
     """Checks that the logged in user has the specified permissions."""
-
     if not permissions:
         return
     appbuilder = current_app.appbuilder

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -291,7 +291,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
     @provide_session
     def get_accessible_dags(self, user_action, user, session=None):
         """Generic function to get readable or writable DAGs for authenticated user."""
-
         if user.is_anonymous:
             return set()
 


### PR DESCRIPTION
D202 check was added in https://github.com/apache/airflow/pull/11032, then two lines conflicting D202 were introduced in the following commit of https://github.com/apache/airflow/pull/10594 (rebase was missed, which is understandable given the two PRs were merged in a row back to back).

This is failing the CI `Static checks` part. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
