### PR TITLE
Added support for encrypted private keys in SSHHook

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -107,11 +107,12 @@ class SSHHook(BaseHook):
 
                 private_key = extra_options.get('private_key')
                 private_key_passphrase = extra_options.get('private_key_passphrase')
-                if private_key:
-                    if private_key_passphrase:
-                        self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key), password=private_key_passphrase)
-                    else:
-                        self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key))
+                if private_key and private_key_passphrase:
+                    self.pkey = paramiko.RSAKey.from_private_key(
+                        StringIO(private_key), password=private_key_passphrase
+                    )
+                elif private_key and not private_key_passphrase:
+                    self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key))
 
                 if "timeout" in extra_options:
                     self.timeout = int(extra_options["timeout"], 10)

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -107,10 +107,11 @@ class SSHHook(BaseHook):
 
                 private_key = extra_options.get('private_key')
                 private_key_passphrase = extra_options.get('private_key_passphrase')
-                if private_key and not private_key_passphrase:
-                    self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key))
-                elif private_key and private_key_passphrase:
-                    self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key),password=private_key_passphrase)
+                if private_key:
+                    if private_key_passphrase:
+                        self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key), password=private_key_passphrase)
+                    else:
+                        self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key))
 
                 if "timeout" in extra_options:
                     self.timeout = int(extra_options["timeout"], 10)

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -106,8 +106,11 @@ class SSHHook(BaseHook):
                     self.key_file = extra_options.get("key_file")
 
                 private_key = extra_options.get('private_key')
-                if private_key:
+                private_key_passphrase = extra_options.get('private_key_passphrase')
+                if private_key and not private_key_passphrase:
                     self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key))
+                elif private_key and private_key_passphrase:
+                    self.pkey = paramiko.RSAKey.from_private_key(StringIO(private_key),password=private_key_passphrase)
 
                 if "timeout" in extra_options:
                     self.timeout = int(extra_options["timeout"], 10)

--- a/docs/howto/connection/ssh.rst
+++ b/docs/howto/connection/ssh.rst
@@ -44,6 +44,7 @@ Extra (optional)
 
     * ``key_file`` - Full Path of the private SSH Key file that will be used to connect to the remote_host.
     * ``private_key`` - Content of the private key used to connect to the remote_host.
+    * ``private_key_passphrase`` - Content of the private key passphrase used to decrypt the private key.
     * ``timeout`` - An optional timeout (in seconds) for the TCP connect. Default is ``10``.
     * ``compress`` - ``true`` to ask the remote client/server to compress traffic; ``false`` to refuse compression. Default is ``true``.
     * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -337,4 +337,3 @@ class TestSSHHook(unittest.TestCase):
                 sock=None,
                 look_for_keys=True,
             )
-            

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -337,3 +337,4 @@ class TestSSHHook(unittest.TestCase):
                 sock=None,
                 look_for_keys=True,
             )
+            

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -69,7 +69,7 @@ class TestSSHHook(unittest.TestCase):
         with create_session() as session:
             conns_to_reset = [
                 cls.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
-                cls.CONN_SSH_WITH_PRIVATE_KEY_PASSPHRASE_EXTRA
+                cls.CONN_SSH_WITH_PRIVATE_KEY_PASSPHRASE_EXTRA,
             ]
             connections = session.query(Connection).filter(Connection.conn_id.in_(conns_to_reset))
             connections.delete(synchronize_session=False)

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -19,6 +19,9 @@ import json
 import unittest
 from io import StringIO
 
+from typing import Optional
+import random
+import string
 import mock
 import paramiko
 
@@ -26,10 +29,6 @@ from airflow.models import Connection
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.utils import db
 from airflow.utils.session import create_session
-
-from typing import Optional
-import random
-import string
 
 HELLO_SERVER_CMD = """
 import socket, sys
@@ -57,6 +56,7 @@ TEST_PRIVATE_KEY = generate_key_string(pkey=TEST_PKEY)
 
 PASSPHRASE = ''.join(random.choice(string.ascii_letters) for i in range(10))
 TEST_ENCRYPTED_PRIVATE_KEY = generate_key_string(pkey=TEST_PKEY, passphrase=PASSPHRASE)
+
 
 class TestSSHHook(unittest.TestCase):
     CONN_SSH_WITH_PRIVATE_KEY_EXTRA = 'ssh_with_private_key_extra'
@@ -112,9 +112,7 @@ class TestSSHHook(unittest.TestCase):
                 host='localhost',
                 conn_type='ssh',
                 extra=json.dumps(
-                    {   "private_key": TEST_ENCRYPTED_PRIVATE_KEY,
-                        "private_key_passphrase": PASSPHRASE
-                    }
+                    {"private_key": TEST_ENCRYPTED_PRIVATE_KEY, "private_key_passphrase": PASSPHRASE}
                 ),
             )
         )
@@ -237,6 +235,7 @@ class TestSSHHook(unittest.TestCase):
                 host_pkey_directories=[],
                 logger=hook.log,
             )
+
     @mock.patch('airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder')
     def test_tunnel_with_private_key_passphrase(self, ssh_mock):
         hook = SSHHook(

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -27,6 +27,10 @@ from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.utils import db
 from airflow.utils.session import create_session
 
+from typing import Optional
+import random
+import string
+
 HELLO_SERVER_CMD = """
 import socket, sys
 listener = socket.socket()
@@ -40,9 +44,9 @@ conn.sendall(b'hello')
 """
 
 
-def generate_key_string(pkey: paramiko.PKey):
+def generate_key_string(pkey: paramiko.PKey, passphrase: Optional[str] = None):
     key_fh = StringIO()
-    pkey.write_private_key(key_fh)
+    pkey.write_private_key(key_fh, password=passphrase)
     key_fh.seek(0)
     key_str = key_fh.read()
     return key_str
@@ -51,9 +55,12 @@ def generate_key_string(pkey: paramiko.PKey):
 TEST_PKEY = paramiko.RSAKey.generate(4096)
 TEST_PRIVATE_KEY = generate_key_string(pkey=TEST_PKEY)
 
+PASSPHRASE = ''.join(random.choice(string.ascii_letters) for i in range(10))
+TEST_ENCRYPTED_PRIVATE_KEY = generate_key_string(pkey=TEST_PKEY, passphrase=PASSPHRASE)
 
 class TestSSHHook(unittest.TestCase):
     CONN_SSH_WITH_PRIVATE_KEY_EXTRA = 'ssh_with_private_key_extra'
+    CONN_SSH_WITH_PRIVATE_KEY_PASSPHRASE_EXTRA = 'ssh_with_private_key_passphrase_extra'
     CONN_SSH_WITH_EXTRA = 'ssh_with_extra'
     CONN_SSH_WITH_EXTRA_FALSE_LOOK_FOR_KEYS = 'ssh_with_extra_false_look_for_keys'
 
@@ -62,6 +69,7 @@ class TestSSHHook(unittest.TestCase):
         with create_session() as session:
             conns_to_reset = [
                 cls.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
+                cls.CONN_SSH_WITH_PRIVATE_KEY_PASSPHRASE_EXTRA
             ]
             connections = session.query(Connection).filter(Connection.conn_id.in_(conns_to_reset))
             connections.delete(synchronize_session=False)
@@ -94,6 +102,18 @@ class TestSSHHook(unittest.TestCase):
                 extra=json.dumps(
                     {
                         "private_key": TEST_PRIVATE_KEY,
+                    }
+                ),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=cls.CONN_SSH_WITH_PRIVATE_KEY_PASSPHRASE_EXTRA,
+                host='localhost',
+                conn_type='ssh',
+                extra=json.dumps(
+                    {   "private_key": TEST_ENCRYPTED_PRIVATE_KEY,
+                        "private_key_passphrase": PASSPHRASE
                     }
                 ),
             )
@@ -217,6 +237,28 @@ class TestSSHHook(unittest.TestCase):
                 host_pkey_directories=[],
                 logger=hook.log,
             )
+    @mock.patch('airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder')
+    def test_tunnel_with_private_key_passphrase(self, ssh_mock):
+        hook = SSHHook(
+            ssh_conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_PASSPHRASE_EXTRA,
+            remote_host='remote_host',
+            port='port',
+            username='username',
+            timeout=10,
+        )
+
+        with hook.get_tunnel(1234):
+            ssh_mock.assert_called_once_with(
+                'remote_host',
+                ssh_port='port',
+                ssh_username='username',
+                ssh_pkey=TEST_PKEY,
+                ssh_proxy=None,
+                local_bind_address=('localhost',),
+                remote_bind_address=('localhost', 1234),
+                host_pkey_directories=[],
+                logger=hook.log,
+            )
 
     def test_ssh_connection(self):
         hook = SSHHook(ssh_conn_id='ssh_default')
@@ -256,6 +298,28 @@ class TestSSHHook(unittest.TestCase):
     def test_ssh_connection_with_private_key_extra(self, ssh_mock):
         hook = SSHHook(
             ssh_conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
+            remote_host='remote_host',
+            port='port',
+            username='username',
+            timeout=10,
+        )
+
+        with hook.get_conn():
+            ssh_mock.return_value.connect.assert_called_once_with(
+                hostname='remote_host',
+                username='username',
+                pkey=TEST_PKEY,
+                timeout=10,
+                compress=True,
+                port='port',
+                sock=None,
+                look_for_keys=True,
+            )
+
+    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
+    def test_ssh_connection_with_private_key_passphrase_extra(self, ssh_mock):
+        hook = SSHHook(
+            ssh_conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_PASSPHRASE_EXTRA,
             remote_host='remote_host',
             port='port',
             username='username',


### PR DESCRIPTION

Hello, I am fairly new to contributing to larger repositories so I want to apologize in advance if there are any mistakes in my Pull Request. 

I am submitting a change that will allow the `airflow.providers.ssh.hooks.ssh` to handle encrypted RSA keys. Currently, when the SSHHook attempts to run `get_conn()` on an encrypted RSA key it throws the error `paramiko.PasswordRequiredException: Private key file is encrypted`. 

I haven't submitted any tests yet as I just want to make sure that this change is valid and adds value to the airflow community.

---



