### PR TITLE
Fix sort-in-the-wild pre-commit on Mac

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_sort_in_the_wild.sh
+++ b/scripts/ci/pre_commit/pre_commit_sort_in_the_wild.sh
@@ -25,7 +25,7 @@ readonly INTHEWILD
 export LC_ALL=C
 
 temp_file=$(mktemp)
-sed '/1\./q' "${INTHEWILD}" | tail -r | tail -n +2 | tail -r >"${temp_file}"
+sed '/1\./q' "${INTHEWILD}" | awk 'n>=4 { print a[n%1] } { a[n%1]=$0; n=n+1 }' >"${temp_file}"
 sed -n '/1\./p' "${INTHEWILD}" | sort >> "${temp_file}"
 
 cat "${temp_file}" > "${INTHEWILD}"

--- a/scripts/ci/pre_commit/pre_commit_sort_in_the_wild.sh
+++ b/scripts/ci/pre_commit/pre_commit_sort_in_the_wild.sh
@@ -25,7 +25,7 @@ readonly INTHEWILD
 export LC_ALL=C
 
 temp_file=$(mktemp)
-sed '/1\./q' "${INTHEWILD}" | head -n -1 >"${temp_file}"
+sed '/1\./q' "${INTHEWILD}" | tail -r | tail -n +2 | tail -r >"${temp_file}"
 sed -n '/1\./p' "${INTHEWILD}" | sort >> "${temp_file}"
 
 cat "${temp_file}" > "${INTHEWILD}"

--- a/scripts/ci/pre_commit/pre_commit_sort_in_the_wild.sh
+++ b/scripts/ci/pre_commit/pre_commit_sort_in_the_wild.sh
@@ -25,7 +25,7 @@ readonly INTHEWILD
 export LC_ALL=C
 
 temp_file=$(mktemp)
-sed '/1\./q' "${INTHEWILD}" | awk 'n>=4 { print a[n%1] } { a[n%1]=$0; n=n+1 }' >"${temp_file}"
+sed '/1\./q' "${INTHEWILD}" | awk 'n>=1 { print a[n%1] } { a[n%1]=$0; n=n+1 }' >"${temp_file}"
 sed -n '/1\./p' "${INTHEWILD}" | sort >> "${temp_file}"
 
 cat "${temp_file}" > "${INTHEWILD}"


### PR DESCRIPTION
Previosuly sort-in-the-wild pre-commit failed on Mac with the following error:

```
❯ pre-commit run sort-in-the-wild -a
Sort INTHEWILD.md alphabetically.........................................Failed
- hook id: sort-in-the-wild
- exit code: 1

head: illegal line count -- -1
```

This PR makes the code portable and works on Mac too.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
