### PR TITLE
Add fernetenabled rule and unittest

### DIFF
--- a/airflow/upgrade/rules/fernet_enabled.py
+++ b/airflow/upgrade/rules/fernet_enabled.py
@@ -24,15 +24,15 @@ from airflow.upgrade.rules.base_rule import BaseRule
 class FernetEnabledRule(BaseRule):
     title = "Fernet is enabled by default"
 
-    description = """
-The fernet mechanism is enabled by default to increase the security of the default installation.
-"""
+    description = (
+        "The fernet mechanism is enabled by default "
+        + "to increase the security of the default installation."
+    )
 
     def check(self):
         fernet_key = conf.get("core", "fernet_key")
         if not fernet_key:
-            return"""
-        fernet_key must be explicitly set empty as fernet mechanism is enabled by default
+            return """fernet_key in airflow.cfg must be explicitly set empty as fernet mechanism is enabled by default
         this means that the apache-airflow[crypto] extra-packages are always installed.
         However, this requires that your operating system has libffi-dev installed.
         """

--- a/airflow/upgrade/rules/fernet_enabled.py
+++ b/airflow/upgrade/rules/fernet_enabled.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.configuration import conf
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class FernetEnabledRule(BaseRule):
+    title = "Fernet is enabled by default"
+
+    description = """
+The fernet mechanism is enabled by default to increase the security of the default installation.
+"""
+
+    def check(self):
+        fernet_key = conf.get("core", "fernet_key")
+        if not fernet_key:
+            return"""
+        fernet_key must be explicitly set empty as fernet mechanism is enabled by default
+        this means that the apache-airflow[crypto] extra-packages are always installed.
+        However, this requires that your operating system has libffi-dev installed.
+        """

--- a/airflow/upgrade/rules/fernet_enabled.py
+++ b/airflow/upgrade/rules/fernet_enabled.py
@@ -26,13 +26,14 @@ class FernetEnabledRule(BaseRule):
 
     description = (
         "The fernet mechanism is enabled by default "
-        + "to increase the security of the default installation."
+        "to increase the security of the default installation."
     )
 
     def check(self):
         fernet_key = conf.get("core", "fernet_key")
         if not fernet_key:
-            return """fernet_key in airflow.cfg must be explicitly set empty as fernet mechanism is enabled by default
-        this means that the apache-airflow[crypto] extra-packages are always installed.
-        However, this requires that your operating system has libffi-dev installed.
-        """
+            return (
+                "fernet_key in airflow.cfg must be explicitly set empty as fernet mechanism is enabled"
+                "by default. This means that the apache-airflow[crypto] extra-packages are always installed."
+                "However, this requires that your operating system has libffi-dev installed."
+            )

--- a/tests/upgrade/rules/test_fernet_enabled.py
+++ b/tests/upgrade/rules/test_fernet_enabled.py
@@ -29,8 +29,7 @@ class TestFernetEnabledRule(TestCase):
         assert isinstance(rule.description, str)
         assert isinstance(rule.title, str)
 
-        msg = """
-        fernet_key must be explicitly set empty as fernet mechanism is enabled by default
+        msg = """fernet_key in airflow.cfg must be explicitly set empty as fernet mechanism is enabled by default
         this means that the apache-airflow[crypto] extra-packages are always installed.
         However, this requires that your operating system has libffi-dev installed.
         """

--- a/tests/upgrade/rules/test_fernet_enabled.py
+++ b/tests/upgrade/rules/test_fernet_enabled.py
@@ -21,7 +21,6 @@ from tests.test_utils.config import conf_vars
 
 
 class TestFernetEnabledRule(TestCase):
-
     @conf_vars({("core", "fernet_key"): ""})
     def test_invalid_check(self):
         rule = FernetEnabledRule()
@@ -29,10 +28,11 @@ class TestFernetEnabledRule(TestCase):
         assert isinstance(rule.description, str)
         assert isinstance(rule.title, str)
 
-        msg = """fernet_key in airflow.cfg must be explicitly set empty as fernet mechanism is enabled by default
-        this means that the apache-airflow[crypto] extra-packages are always installed.
-        However, this requires that your operating system has libffi-dev installed.
-        """
+        msg = (
+            "fernet_key in airflow.cfg must be explicitly set empty as fernet mechanism is enabled"
+            "by default. This means that the apache-airflow[crypto] extra-packages are always installed."
+            "However, this requires that your operating system has libffi-dev installed."
+        )
         response = rule.check()
         assert response == msg
 

--- a/tests/upgrade/rules/test_fernet_enabled.py
+++ b/tests/upgrade/rules/test_fernet_enabled.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.upgrade.rules.fernet_enabled import FernetEnabledRule
+from tests.test_utils.config import conf_vars
+
+
+class TestFernetEnabledRule(TestCase):
+
+    @conf_vars({("core", "fernet_key"): ""})
+    def test_check(self):
+        rule = FernetEnabledRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        msg = """
+        fernet_key must be explicitly set empty as fernet mechanism is enabled by default
+        this means that the apache-airflow[crypto] extra-packages are always installed.
+        However, this requires that your operating system has libffi-dev installed.
+        """
+        response = rule.check()
+        assert response == msg

--- a/tests/upgrade/rules/test_fernet_enabled.py
+++ b/tests/upgrade/rules/test_fernet_enabled.py
@@ -23,7 +23,7 @@ from tests.test_utils.config import conf_vars
 class TestFernetEnabledRule(TestCase):
 
     @conf_vars({("core", "fernet_key"): ""})
-    def test_check(self):
+    def test_invalid_check(self):
         rule = FernetEnabledRule()
 
         assert isinstance(rule.description, str)
@@ -36,3 +36,13 @@ class TestFernetEnabledRule(TestCase):
         """
         response = rule.check()
         assert response == msg
+
+    @conf_vars({("core", "fernet_key"): "dummyfernet"})
+    def test_valid_check(self):
+        rule = FernetEnabledRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        response = rule.check()
+        assert response is None


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adds FernetEnabled rule to `upgrade/rules` as per:

https://github.com/apache/airflow/blob/master/UPDATING.md#fernet-is-enabled-by-default

Closes: #11048

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
