### PR TITLE
Adds timeout in CI/PROD waiting jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
         run: ./scripts/ci/openapi/client_codegen_diff.sh
 
   ci-images:
+    timeout-minutes: 50
     name: "Wait for CI images"
     runs-on: ubuntu-latest
     needs: [build-info]
@@ -578,6 +579,7 @@ jobs:
           directory: "./coverage-files"
 
   prod-images:
+    timeout-minutes: 50
     name: "Wait for PROD images"
     runs-on: ubuntu-latest
     needs: [build-info]


### PR DESCRIPTION
In very rare cases, the waiting job might not be cancelled when
the "Build Image" job fails or gets cancelled on its own.

In the "Build Image" workflow we have this step:

- name: "Canceling the CI Build source workflow in case of failure!"
  if: cancelled() || failure()
  uses: potiuk/cancel-workflow-runs@v2
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    cancelMode: self
    sourceRunId: ${{ github.event.workflow_run.id }}

But when this step fails or gets cancelled on its own before
cancel is triggered, the "wait for image" steps could
run for up to 6 hours.

This change sets 50 minutes timeout for those jobs.

Fixes #11114


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
