### PR TITLE
improve error messaging for duplicate task_ids in a DAG (#11125)

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1335,10 +1335,10 @@ class DAG(BaseDag, LoggingMixin):
         if task.task_id in self.task_dict and self.task_dict[task.task_id] is not task:
             # TODO: raise an error in Airflow 2.0
             warnings.warn(
-                'The requested task could not be added to the DAG because a '
+                'The requested task could not be added to the DAG with dag_id {} because a '
                 'task with task_id {} is already in the DAG. Starting in '
                 'Airflow 2.0, trying to overwrite a task will raise an '
-                'exception.'.format(task.task_id),
+                'exception.'.format(self.dag_id, task.task_id),
                 category=PendingDeprecationWarning)
         else:
             self.task_dict[task.task_id] = task

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -918,9 +918,9 @@ class DagTest(unittest.TestCase):
     def test_duplicate_task_ids_raise_warning_with_dag_context_manager(self):
         """Verify tasks with Duplicate task_id show warning"""
 
-        deprecation_msg = "The requested task could not be added to the DAG because a task with " \
-                          "task_id t1 is already in the DAG. Starting in Airflow 2.0, trying to " \
-                          "overwrite a task will raise an exception."
+        deprecation_msg = "The requested task could not be added to the DAG with dag_id test_dag because" \
+                          "a task with task_id t1 is already in the DAG. Starting in Airflow 2.0, trying " \
+                          "to overwrite a task will raise an exception."
 
         with pytest.warns(PendingDeprecationWarning) as record:
             with DAG("test_dag", start_date=DEFAULT_DATE) as dag:
@@ -937,8 +937,8 @@ class DagTest(unittest.TestCase):
     def test_duplicate_task_ids_raise_warning(self):
         """Verify tasks with Duplicate task_id show warning"""
 
-        deprecation_msg = "The requested task could not be added to the DAG because a task with " \
-                          "task_id t1 is already in the DAG. Starting in Airflow 2.0, trying to " \
+        deprecation_msg = "The requested task could not be added to the DAG with dag_id test_dag because " \
+                          "a task with task_id t1 is already in the DAG. Starting in Airflow 2.0, trying to " \
                           "overwrite a task will raise an exception."
 
         with pytest.warns(PendingDeprecationWarning) as record:

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -918,7 +918,7 @@ class DagTest(unittest.TestCase):
     def test_duplicate_task_ids_raise_warning_with_dag_context_manager(self):
         """Verify tasks with Duplicate task_id show warning"""
 
-        deprecation_msg = "The requested task could not be added to the DAG with dag_id test_dag because" \
+        deprecation_msg = "The requested task could not be added to the DAG with dag_id test_dag because " \
                           "a task with task_id t1 is already in the DAG. Starting in Airflow 2.0, trying " \
                           "to overwrite a task will raise an exception."
 
@@ -937,9 +937,9 @@ class DagTest(unittest.TestCase):
     def test_duplicate_task_ids_raise_warning(self):
         """Verify tasks with Duplicate task_id show warning"""
 
-        deprecation_msg = "The requested task could not be added to the DAG with dag_id test_dag because " \
-                          "a task with task_id t1 is already in the DAG. Starting in Airflow 2.0, trying to " \
-                          "overwrite a task will raise an exception."
+        deprecation_msg = "The requested task could not be added to the DAG with dag_id test_dag " \
+                          "because a task with task_id t1 is already in the DAG. Starting in Airflow 2.0, " \
+                          "trying to overwrite a task will raise an exception."
 
         with pytest.warns(PendingDeprecationWarning) as record:
             dag = DAG("test_dag", start_date=DEFAULT_DATE)


### PR DESCRIPTION
Improves the deprecation warning for duplicate task_ids by adding the dag_id to the message
closes: #11125