### PR TITLE
Fix gitSync user in the helm Chart

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -105,6 +105,8 @@
 {{- define "git_sync_container"}}
 - name: {{ .Values.dags.gitSync.containerName }}
   image: "{{ .Values.dags.gitSync.containerRepository }}:{{ .Values.dags.gitSync.containerTag }}"
+  securityContext:
+    runAsUser: {{ .Values.dags.gitSync.uid }}
   env:
     {{- if .Values.dags.gitSync.sshKeySecret }}
     - name: GIT_SSH_KEY_FILE

--- a/chart/tests/git-sync-scheduler_test.yaml
+++ b/chart/tests/git-sync-scheduler_test.yaml
@@ -54,6 +54,8 @@ tests:
           path: spec.template.spec.containers[1]
           value:
             name: git-sync-test
+            securityContext:
+              runAsUser: 65533
             image: test-registry/test-repo:test-tag
             env:
               - name: GIT_SYNC_REV

--- a/chart/tests/pod-template-file_test.yaml
+++ b/chart/tests/pod-template-file_test.yaml
@@ -55,6 +55,8 @@ tests:
           path: spec.initContainers[0]
           value:
             name: git-sync-test
+            securityContext:
+              runAsUser: 65533
             image: test-registry/test-repo:test-tag
             env:
               - name: GIT_SYNC_REV

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -616,3 +616,4 @@ dags:
     containerRepository: k8s.gcr.io/git-sync
     containerTag: v3.1.6
     containerName: git-sync
+    uid: 65533


### PR DESCRIPTION
There was a problem with user in Git Sync mode of the Helm Chart
in connection with the git sync image and official Airflow
image. Since we are using the official image, most of the
containers are run with the "50000" user, but the git-sync image
used by the git sync user is 65533 so we have to set it as
default. We also exposed that value as parameter, so that
another image could be used here as well.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
