### PR TITLE
Add loggingconfig rule

### DIFF
--- a/airflow/upgrade/rules/logging_configuration.py
+++ b/airflow/upgrade/rules/logging_configuration.py
@@ -28,4 +28,24 @@ class LoggingConfigurationRule(BaseRule):
 
     def check(self):
         if not conf.has_option("logging", "logging_level"):
-            return "The logging configurations have been to moved from [core] to the new [logging] section."
+            return (
+                "The following configurations have been to moved from [core] to the new [logging] section. \n"
+                "- base_log_folder \n"
+                "- remote_logging \n"
+                "- remote_log_conn_id \n"
+                "- remote_base_log_folder \n"
+                "- encrypt_s3_logs \n"
+                "- logging_level \n"
+                "- fab_logging_level \n"
+                "- logging_config_class \n"
+                "- colored_console_log \n"
+                "- colored_log_format \n"
+                "- colored_formatter_class \n"
+                "- log_format \n"
+                "- simple_log_format \n"
+                "- task_log_prefix_template \n"
+                "- log_filename_template \n"
+                "- log_processor_filename_template \n"
+                "- dag_processor_manager_log_location \n"
+                "- task_log_reader \n"
+            )

--- a/airflow/upgrade/rules/logging_configuration.py
+++ b/airflow/upgrade/rules/logging_configuration.py
@@ -28,4 +28,4 @@ class LoggingConfigurationRule(BaseRule):
 
     def check(self):
         if not conf.has_option("logging", "logging_level"):
-            return "The logging configuration has been to moved from [core] to the new [logging] section."
+            return "The logging configurations have been to moved from [core] to the new [logging] section."

--- a/airflow/upgrade/rules/logging_configuration.py
+++ b/airflow/upgrade/rules/logging_configuration.py
@@ -17,7 +17,7 @@
 
 from __future__ import absolute_import
 
-from airflow.configuration import conf
+from airflow.configuration import conf, AIRFLOW_HOME
 from airflow.upgrade.rules.base_rule import BaseRule
 
 
@@ -27,25 +27,57 @@ class LoggingConfigurationRule(BaseRule):
     description = "The logging configurations have been moved from [core] to the new [logging] section."
 
     def check(self):
-        if not conf.has_option("logging", "logging_level"):
-            return (
-                "The following configurations have been to moved from [core] to the new [logging] section. \n"
-                "- base_log_folder \n"
-                "- remote_logging \n"
-                "- remote_log_conn_id \n"
-                "- remote_base_log_folder \n"
-                "- encrypt_s3_logs \n"
-                "- logging_level \n"
-                "- fab_logging_level \n"
-                "- logging_config_class \n"
-                "- colored_console_log \n"
-                "- colored_log_format \n"
-                "- colored_formatter_class \n"
-                "- log_format \n"
-                "- simple_log_format \n"
-                "- task_log_prefix_template \n"
-                "- log_filename_template \n"
-                "- log_processor_filename_template \n"
-                "- dag_processor_manager_log_location \n"
-                "- task_log_reader \n"
-            )
+        logging_configs = [
+            ("base_log_folder", "{}/logs".format(AIRFLOW_HOME)),
+            ("remote_logging", "False"),
+            ("remote_log_conn_id", ""),
+            ("remote_base_log_folder", ""),
+            ("encrypt_s3_logs", "False"),
+            ("logging_level", "INFO"),
+            ("fab_logging_level", "WARN"),
+            ("logging_config_class", ""),
+            ("colored_console_log", "True"),
+            (
+                "colored_log_format",
+                "[%(blue)s%(asctime)s%(reset)s] {%(blue)s%(filename)s:%(reset)s%(lineno)d} "
+                "%(log_color)s%(levelname)s%(reset)s - %(log_color)s%(message)s%(reset)s",
+            ),
+            (
+                "colored_formatter_class",
+                "airflow.utils.log.colored_log.CustomTTYColoredFormatter",
+            ),
+            (
+                "log_format",
+                "[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+            ),
+            ("simple_log_format", "%(asctime)s %(levelname)s - %(message)s"),
+            ("task_log_prefix_template", ""),
+            (
+                "log_filename_template",
+                "{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log",
+            ),
+            ("log_processor_filename_template", "{{ filename }}.log"),
+            (
+                "dag_processor_manager_log_location",
+                "{}/logs/dag_processor_manager/dag_processor_manager.log".format(
+                    AIRFLOW_HOME
+                ),
+            ),
+            ("task_log_reader", "task"),
+        ]
+
+        mismatches = []
+        for logging_config, default in logging_configs:
+            if not conf.has_option("logging", logging_config) and conf.has_option(
+                "core", logging_config
+            ):
+                existing_config = conf.get("core", logging_config)
+                if existing_config != default:
+                    mismatches.append(
+                        "{} has been moved from [core] to a the new [logging] section.\n".format(
+                            logging_config
+                        )
+                    )
+
+        if mismatches:
+            return "".join(mismatches)

--- a/airflow/upgrade/rules/logging_configuration.py
+++ b/airflow/upgrade/rules/logging_configuration.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.configuration import conf
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class LoggingConfigurationRule(BaseRule):
+    title = "Logging configuration has been moved to new section"
+
+    description = "The logging configurations have been moved from [core] to the new [logging] section."
+
+    def check(self):
+        if not conf.has_option("logging", "logging_level"):
+            return "The logging configuration has been to moved from [core] to the new [logging] section."

--- a/airflow/upgrade/rules/logging_configuration.py
+++ b/airflow/upgrade/rules/logging_configuration.py
@@ -74,10 +74,9 @@ class LoggingConfigurationRule(BaseRule):
                 existing_config = conf.get("core", logging_config)
                 if existing_config != default:
                     mismatches.append(
-                        "{} has been moved from [core] to a the new [logging] section.\n".format(
+                        "{} has been moved from [core] to a the new [logging] section.".format(
                             logging_config
                         )
                     )
 
-        if mismatches:
-            return "".join(mismatches)
+        return mismatches

--- a/tests/upgrade/rules/test_logging_configuration.py
+++ b/tests/upgrade/rules/test_logging_configuration.py
@@ -22,7 +22,23 @@ from tests.test_utils.config import conf_vars
 
 
 class TestLoggingConfigurationRule(TestCase):
-    @conf_vars({("core", "logging_level"): "INFO"})
+    @conf_vars(
+        {
+            ("core", "base_log_folder"): "DUMMY",
+            ("core", "remote_logging"): "DUMMY",
+            ("core", "remote_log_conn_id"): "DUMMY",
+            ("core", "remote_base_log_folder"): "DUMMY",
+            ("core", "encrypt_s3_logs"): "DUMMY",
+            ("core", "logging_level"): "DUMMY",
+            ("core", "fab_logging_level"): "DUMMY",
+            ("core", "logging_config_class"): "DUMMY",
+            ("core", "colored_console_log"): "DUMMY",
+            ("core", "simple_log_format"): "DUMMY",
+            ("core", "task_log_prefix_template"): "DUMMY",
+            ("core", "log_processor_filename_template"): "DUMMY",
+            ("core", "task_log_reader"): "DUMMY",
+        }
+    )
     def test_invalid_check(self):
         rule = LoggingConfigurationRule()
 
@@ -30,35 +46,56 @@ class TestLoggingConfigurationRule(TestCase):
         assert isinstance(rule.title, str)
 
         # Remove the fallback option
+        conf.remove_option("logging", "base_log_folder")
+        conf.remove_option("logging", "remote_logging")
+        conf.remove_option("logging", "remote_log_conn_id")
+        conf.remove_option("logging", "remote_base_log_folder")
+        conf.remove_option("logging", "encrypt_s3_logs")
         conf.remove_option("logging", "logging_level")
+        conf.remove_option("logging", "fab_logging_level")
+        conf.remove_option("logging", "logging_config_class")
+        conf.remove_option("logging", "colored_console_log")
+        conf.remove_option("logging", "simple_log_format")
+        conf.remove_option("logging", "task_log_prefix_template")
+        conf.remove_option("logging", "log_processor_filename_template")
+        conf.remove_option("logging", "task_log_reader")
         msg = (
-            "The following configurations have been to moved from [core] to the new [logging] section. \n"
-            "- base_log_folder \n"
-            "- remote_logging \n"
-            "- remote_log_conn_id \n"
-            "- remote_base_log_folder \n"
-            "- encrypt_s3_logs \n"
-            "- logging_level \n"
-            "- fab_logging_level \n"
-            "- logging_config_class \n"
-            "- colored_console_log \n"
-            "- colored_log_format \n"
-            "- colored_formatter_class \n"
-            "- log_format \n"
-            "- simple_log_format \n"
-            "- task_log_prefix_template \n"
-            "- log_filename_template \n"
-            "- log_processor_filename_template \n"
-            "- dag_processor_manager_log_location \n"
-            "- task_log_reader \n"
+            "base_log_folder has been moved from [core] to a the new [logging] section.\n"
+            "remote_logging has been moved from [core] to a the new [logging] section.\n"
+            "remote_log_conn_id has been moved from [core] to a the new [logging] section.\n"
+            "remote_base_log_folder has been moved from [core] to a the new [logging] section.\n"
+            "encrypt_s3_logs has been moved from [core] to a the new [logging] section.\n"
+            "logging_level has been moved from [core] to a the new [logging] section.\n"
+            "fab_logging_level has been moved from [core] to a the new [logging] section.\n"
+            "logging_config_class has been moved from [core] to a the new [logging] section.\n"
+            "colored_console_log has been moved from [core] to a the new [logging] section.\n"
+            "simple_log_format has been moved from [core] to a the new [logging] section.\n"
+            "task_log_prefix_template has been moved from [core] to a the new [logging] section.\n"
+            "log_processor_filename_template has been moved from [core] to a the new [logging] section.\n"
+            "task_log_reader has been moved from [core] to a the new [logging] section.\n"
         )
         response = rule.check()
         assert response == msg
 
-    @conf_vars({("logging", "logging_level"): "INFO"})
+    @conf_vars(
+        {
+            ("logging", "base_log_folder"): "DUMMY",
+            ("logging", "remote_logging"): "DUMMY",
+            ("logging", "remote_log_conn_id"): "DUMMY",
+            ("logging", "remote_base_log_folder"): "DUMMY",
+            ("logging", "encrypt_s3_logs"): "DUMMY",
+            ("logging", "logging_level"): "DUMMY",
+            ("logging", "fab_logging_level"): "DUMMY",
+            ("logging", "logging_config_class"): "DUMMY",
+            ("logging", "colored_console_log"): "DUMMY",
+            ("logging", "simple_log_format"): "DUMMY",
+            ("logging", "task_log_prefix_template"): "DUMMY",
+            ("logging", "log_processor_filename_template"): "DUMMY",
+            ("logging", "task_log_reader"): "DUMMY",
+        }
+    )
     def test_valid_check(self):
         rule = LoggingConfigurationRule()
-
         assert isinstance(rule.description, str)
         assert isinstance(rule.title, str)
 

--- a/tests/upgrade/rules/test_logging_configuration.py
+++ b/tests/upgrade/rules/test_logging_configuration.py
@@ -31,7 +31,27 @@ class TestLoggingConfigurationRule(TestCase):
 
         # Remove the fallback option
         conf.remove_option("logging", "logging_level")
-        msg = "The logging configurations have been to moved from [core] to the new [logging] section."
+        msg = (
+            "The following configurations have been to moved from [core] to the new [logging] section. \n"
+            "- base_log_folder \n"
+            "- remote_logging \n"
+            "- remote_log_conn_id \n"
+            "- remote_base_log_folder \n"
+            "- encrypt_s3_logs \n"
+            "- logging_level \n"
+            "- fab_logging_level \n"
+            "- logging_config_class \n"
+            "- colored_console_log \n"
+            "- colored_log_format \n"
+            "- colored_formatter_class \n"
+            "- log_format \n"
+            "- simple_log_format \n"
+            "- task_log_prefix_template \n"
+            "- log_filename_template \n"
+            "- log_processor_filename_template \n"
+            "- dag_processor_manager_log_location \n"
+            "- task_log_reader \n"
+        )
         response = rule.check()
         assert response == msg
 

--- a/tests/upgrade/rules/test_logging_configuration.py
+++ b/tests/upgrade/rules/test_logging_configuration.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.upgrade.rules.logging_configuration import LoggingConfigurationRule
+from airflow.configuration import conf
+from tests.test_utils.config import conf_vars
+
+
+class TestLoggingConfigurationRule(TestCase):
+    @conf_vars({("core", "logging_level"): "INFO"})
+    def test_invalid_check(self):
+        rule = LoggingConfigurationRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        # Remove the fallback option
+        conf.remove_option("logging", "logging_level")
+        msg = "Logging configuration has been to moved from [core] to the new [logging] section."
+        response = rule.check()
+        assert response == msg
+
+    @conf_vars({("logging", "logging_level"): "INFO"})
+    def test_valid_check(self):
+        rule = LoggingConfigurationRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        response = rule.check()
+        assert response is None

--- a/tests/upgrade/rules/test_logging_configuration.py
+++ b/tests/upgrade/rules/test_logging_configuration.py
@@ -39,7 +39,7 @@ class TestLoggingConfigurationRule(TestCase):
             ("core", "task_log_reader"): "DUMMY",
         }
     )
-    def test_invalid_check(self):
+    def test_check(self):
         rule = LoggingConfigurationRule()
 
         assert isinstance(rule.description, str)
@@ -76,28 +76,3 @@ class TestLoggingConfigurationRule(TestCase):
         ]
         response = rule.check()
         assert response == msg
-
-    @conf_vars(
-        {
-            ("logging", "base_log_folder"): "DUMMY",
-            ("logging", "remote_logging"): "DUMMY",
-            ("logging", "remote_log_conn_id"): "DUMMY",
-            ("logging", "remote_base_log_folder"): "DUMMY",
-            ("logging", "encrypt_s3_logs"): "DUMMY",
-            ("logging", "logging_level"): "DUMMY",
-            ("logging", "fab_logging_level"): "DUMMY",
-            ("logging", "logging_config_class"): "DUMMY",
-            ("logging", "colored_console_log"): "DUMMY",
-            ("logging", "simple_log_format"): "DUMMY",
-            ("logging", "task_log_prefix_template"): "DUMMY",
-            ("logging", "log_processor_filename_template"): "DUMMY",
-            ("logging", "task_log_reader"): "DUMMY",
-        }
-    )
-    def test_valid_check(self):
-        rule = LoggingConfigurationRule()
-        assert isinstance(rule.description, str)
-        assert isinstance(rule.title, str)
-
-        response = rule.check()
-        assert response == []

--- a/tests/upgrade/rules/test_logging_configuration.py
+++ b/tests/upgrade/rules/test_logging_configuration.py
@@ -59,21 +59,21 @@ class TestLoggingConfigurationRule(TestCase):
         conf.remove_option("logging", "task_log_prefix_template")
         conf.remove_option("logging", "log_processor_filename_template")
         conf.remove_option("logging", "task_log_reader")
-        msg = (
-            "base_log_folder has been moved from [core] to a the new [logging] section.\n"
-            "remote_logging has been moved from [core] to a the new [logging] section.\n"
-            "remote_log_conn_id has been moved from [core] to a the new [logging] section.\n"
-            "remote_base_log_folder has been moved from [core] to a the new [logging] section.\n"
-            "encrypt_s3_logs has been moved from [core] to a the new [logging] section.\n"
-            "logging_level has been moved from [core] to a the new [logging] section.\n"
-            "fab_logging_level has been moved from [core] to a the new [logging] section.\n"
-            "logging_config_class has been moved from [core] to a the new [logging] section.\n"
-            "colored_console_log has been moved from [core] to a the new [logging] section.\n"
-            "simple_log_format has been moved from [core] to a the new [logging] section.\n"
-            "task_log_prefix_template has been moved from [core] to a the new [logging] section.\n"
-            "log_processor_filename_template has been moved from [core] to a the new [logging] section.\n"
-            "task_log_reader has been moved from [core] to a the new [logging] section.\n"
-        )
+        msg = [
+            "base_log_folder has been moved from [core] to a the new [logging] section.",
+            "remote_logging has been moved from [core] to a the new [logging] section.",
+            "remote_log_conn_id has been moved from [core] to a the new [logging] section.",
+            "remote_base_log_folder has been moved from [core] to a the new [logging] section.",
+            "encrypt_s3_logs has been moved from [core] to a the new [logging] section.",
+            "logging_level has been moved from [core] to a the new [logging] section.",
+            "fab_logging_level has been moved from [core] to a the new [logging] section.",
+            "logging_config_class has been moved from [core] to a the new [logging] section.",
+            "colored_console_log has been moved from [core] to a the new [logging] section.",
+            "simple_log_format has been moved from [core] to a the new [logging] section.",
+            "task_log_prefix_template has been moved from [core] to a the new [logging] section.",
+            "log_processor_filename_template has been moved from [core] to a the new [logging] section.",
+            "task_log_reader has been moved from [core] to a the new [logging] section.",
+        ]
         response = rule.check()
         assert response == msg
 
@@ -100,4 +100,4 @@ class TestLoggingConfigurationRule(TestCase):
         assert isinstance(rule.title, str)
 
         response = rule.check()
-        assert response is None
+        assert response == []

--- a/tests/upgrade/rules/test_logging_configuration.py
+++ b/tests/upgrade/rules/test_logging_configuration.py
@@ -31,7 +31,7 @@ class TestLoggingConfigurationRule(TestCase):
 
         # Remove the fallback option
         conf.remove_option("logging", "logging_level")
-        msg = "Logging configuration has been to moved from [core] to the new [logging] section."
+        msg = "The logging configurations have been to moved from [core] to the new [logging] section."
         response = rule.check()
         assert response == msg
 


### PR DESCRIPTION
Closes: #11046

Adds LoggingConfigurationRule rule to upgrade/rules as per:

https://github.com/apache/airflow/blob/master/UPDATING.md#logging-configuration-has-been-moved-to-new-section

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
