### PR TITLE
Fix error message when checking literalinclude in docs

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -416,7 +416,7 @@ def check_exampleinclude_for_example_dags():
             file_path=doc_file,
             pattern=r"literalinclude::.+example_dags",
             message=(
-                "literalinclude directive is is prohibited for example DAGs. \n"
+                "literalinclude directive is prohibited for example DAGs. \n"
                 "You should use the exampleinclude directive to include example DAGs."
             )
         )


### PR DESCRIPTION
Before:
```
literalinclude directive is is prohibited for example DAGs
```

After:

```
literalinclude directive is prohibited for example DAGs
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
