### PR TITLE
Fix user in helm chart pgbouncer deployment

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -69,7 +69,7 @@ spec:
           command:
             - pgbouncer
             - -u
-            - pgbouncer
+            - nobody
             - /etc/pgbouncer/pgbouncer.ini
           resources:
 {{ toYaml .Values.pgbouncer.resources | indent 12 }}


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The current helm chart does not work when `pgbouncer.enabled=true`  because it tries to run `pgbouncer -u pgbouncer /etc/pgbouncer/pgbouncer.ini` and there is no user `pgbouncer` in the docker image  `apache/airflow:airflow-pgbouncer-2020.09.05-1.14.0`.  The original docker image entrypoint uses user `nobody` as seen [here](https://github.com/apache/airflow/blob/master/chart/dockerfiles/pgbouncer/Dockerfile#L73). 

    docker run -it --rm  --entrypoint="" apache/airflow:airflow-pgbouncer-2020.09.05-1.14.0 pgbouncer -u pgbouncer /etc/pgbouncer/pgbouncer.ini
    2020-09-25 06:57:15.244 UTC [1] FATAL could not find user 'pgbouncer' to switch to

This PR changes the user to `nobody` although it would be possible to remove the whole `command:` section and use the default entrypoint from the Dockerfile. 
