### PR TITLE
Make sure pgbouncer-exporter docker image is linux/amd64

### DIFF
--- a/chart/dockerfiles/pgbouncer-exporter/build_and_push.sh
+++ b/chart/dockerfiles/pgbouncer-exporter/build_and_push.sh
@@ -35,44 +35,10 @@ readonly COMMIT_SHA
 
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 
-current_go_version=$("go${EXPECTED_GO_VERSION}" version 2>/dev/null | awk '{ print $3 }' 2>/dev/null || true)
-
-if [[ ${current_go_version} == "" ]]; then
-  current_go_version=$(go version 2>/dev/null | awk '{ print $3 }' 2>/dev/null)
-  GO_BIN=$(command -v go 2>/dev/null || true)
-else
-  GO_BIN=$(command -v go${EXPECTED_GO_VERSION} 2>/dev/null)
-fi
-readonly GO_BIN
-
-if [[ ${current_go_version} == "" ]]; then
-  echo "ERROR! You have no go installed"
-  echo
-  echo "Please install go${EXPECTED_GO_VERSION} to build the package"
-  echo
-  echo "You need to have golang installed. Follow https://golang.org/doc/install"
-  echo
-fi
-
-if [[ ${current_go_version} != "go${EXPECTED_GO_VERSION}" ]]; then
-  echo "ERROR! You have unexpected version of go in the path ${current_go_version}"
-  echo
-  echo "Make sure you have go${EXPECTED_GO_VERSION} installed:"
-  echo
-  echo "   go get golang.org/dl/go${EXPECTED_GO_VERSION}"
-  echo
-  echo "   go${EXPECTED_GO_VERSION} download"
-  echo
-  echo "You might need to add ${HOME}/go/bin to your PATH"
-  echo
-  exit 1
-fi
-
 PGBOUNCER_EXPORTER_DIR="$(pwd)/pgbouncer_exporter-${PGBOUNCER_EXPORTER_VERSION}"
 readonly  PGBOUNCER_EXPORTER_DIR
 
 # Needs to be set for alpine images to run net package of GO
-export CGO_ENABLED=0
 rm -rf "$(pwd)/pgbouncer_exporter*"
 mkdir -pv "${PGBOUNCER_EXPORTER_DIR}"
 
@@ -80,17 +46,17 @@ curl -L "https://github.com/jbub/pgbouncer_exporter/archive/v${PGBOUNCER_EXPORTE
 
 cd "${PGBOUNCER_EXPORTER_DIR}"
 
-"${GO_BIN}" get ./...
-"${GO_BIN}" build
+docker run --rm -e CGO_ENABLED=0 -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:${EXPECTED_GO_VERSION} go build -v
 
 tag="${DOCKERHUB_USER}/${DOCKERHUB_REPO}:airflow-pgbouncer-exporter-${AIRFLOW_PGBOUNCER_EXPORTER_VERSION}-${PGBOUNCER_EXPORTER_VERSION}"
 
+cd ..
 docker build . \
     --pull \
     --build-arg "PGBOUNCER_EXPORTER_VERSION=${PGBOUNCER_EXPORTER_VERSION}" \
     --build-arg "AIRFLOW_PGBOUNCER_EXPORTER_VERSION=${AIRFLOW_PGBOUNCER_EXPORTER_VERSION}"\
     --build-arg "COMMIT_SHA=${COMMIT_SHA}" \
-    --build-arg "GO_VERSION=${current_go_version}" \
+    --build-arg "GO_VERSION=${EXPECTED_GO_VERSION}" \
     --tag "${tag}"
 
 docker push "${tag}"


### PR DESCRIPTION
Previously if the `./build_and_push.sh` was executed from a macOS machine it will upload a docker image containing a macOS executable. This image will fail to run  with 

```
docker run -it --rm apache/airflow:airflow-pgbouncer-exporter-2020.09.05-0.5.0
standard_init_linux.go:211: exec user process caused "exec format error"
```

Now the `./build_and_push.sh` does NOT use the local go compiler instead it compiles using the golang Docker image so that the generated executable is linux/amd64. This also removes the need to have a specific go version installed in the build machine. 

Closes #11145
