### PR TITLE
PagerdutyHook to use pdpyras instead of pypd

### DIFF
--- a/airflow/providers/pagerduty/README.md
+++ b/airflow/providers/pagerduty/README.md
@@ -49,7 +49,7 @@ You can install this package on top of an existing airflow 2.* installation via
 
 | PIP package   | Version required   |
 |:--------------|:-------------------|
-| pypd          | &gt;=1.1.0            |
+| pdpyras       | &gt;=4.1.2,&lt;5         |
 
 # Provider classes summary
 

--- a/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -15,10 +15,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Hook for creating Pagerduty incidents."""
+"""Hook for sending or receiving data from PagerDuty as well as creating PagerDuty incidents."""
 from typing import Any, Dict, List, Optional
 
-import pypd
+import pdpyras
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
@@ -26,17 +26,18 @@ from airflow.hooks.base_hook import BaseHook
 
 class PagerdutyHook(BaseHook):
     """
-    Takes both Pagerduty API token directly and connection that has Pagerduty API token.
+    Takes both PagerDuty API token directly and connection that has PagerDuty API token.
 
-    If both supplied, Pagerduty API token will be used.
+    If both supplied, PagerDuty API token will be used.
 
-    :param token: Pagerduty API token
-    :param pagerduty_conn_id: connection that has Pagerduty API token in the password field
+    :param token: PagerDuty API token
+    :param pagerduty_conn_id: connection that has PagerDuty API token in the password field
     """
 
     def __init__(self, token: Optional[str] = None, pagerduty_conn_id: Optional[str] = None) -> None:
         super().__init__()
         self.routing_key = None
+        self._session = None
 
         if pagerduty_conn_id is not None:
             conn = self.get_connection(pagerduty_conn_id)
@@ -52,6 +53,19 @@ class PagerdutyHook(BaseHook):
         if self.token is None:
             raise AirflowException('Cannot get token: No valid api token nor pagerduty_conn_id supplied.')
 
+    def get_session(self) -> pdpyras.APISession:
+        """
+        Returns `pdpyras.APISession` for use with sending or receiving data through the PagerDuty REST API.
+
+        The `pdpyras` library supplies a class `pdpyras.APISession` extending `requests.Session` from the
+        Requests HTTP library.
+
+        Documentation on how to use the `APISession` class can be found at:
+        https://pagerduty.github.io/pdpyras/#data-access-abstraction
+        """
+        self._session = pdpyras.APISession(self.token)
+        return self._session
+
     # pylint: disable=too-many-arguments
     def create_event(
         self,
@@ -65,14 +79,15 @@ class PagerdutyHook(BaseHook):
         group: Optional[str] = None,
         component: Optional[str] = None,
         class_type: Optional[str] = None,
-        links: Optional[List[Dict]] = None,
+        images: Optional[List[Any]] = None,
+        links: Optional[List[Any]] = None,
     ) -> Dict:
         """
         Create event for service integration.
 
         :param summary: Summary for the event
         :type summary: str
-        :param severity: Severity for the event, needs to be one of: Info, Warning, Error, Critical
+        :param severity: Severity for the event, needs to be one of: info, warning, error, critical
         :type severity: str
         :param source: Specific human-readable unique identifier, such as a
             hostname, for the system having the problem.
@@ -83,10 +98,12 @@ class PagerdutyHook(BaseHook):
         :param routing_key: Integration key. If not specified, will try to read
             from connection's extra json blob.
         :type routing_key: str
-        :param dedup_key: A string which identifies the alert triggered for the given event
+        :param dedup_key: A string which identifies the alert triggered for the given event.
+            Required for the actions acknowledge and resolve.
         :type dedup_key: str
-        :param custom_details: Free-form details from the event
-        :type custom_details: str
+        :param custom_details: Free-form details from the event. Can be a dictionary or a string.
+            If a dictionary is passed it will show up in PagerDuty as a table.
+        :type custom_details: dict or str
         :param group: A cluster or grouping of sources. For example, sources
             “prod-datapipe-02” and “prod-datapipe-03” might both be part of “prod-datapipe”
         :type group: str
@@ -94,8 +111,19 @@ class PagerdutyHook(BaseHook):
         :type component: str
         :param class_type: The class/type of the event.
         :type class_type: str
-        :param links: List of links to include.
-        :type class_type: list(str)
+        :param images: List of images to include. Each dictionary in the list accepts the following keys:
+            `src`: The source (URL) of the image being attached to the incident. This image must be served via
+            HTTPS.
+            `href`: [Optional] URL to make the image a clickable link.
+            `alt`: [Optional] Alternative text for the image.
+        :type images: list[dict]
+        :param links: List of links to include. Each dictionary in the list accepts the following keys:
+            `href`: URL of the link to be attached.
+            `text`: [Optional] Plain text that describes the purpose of the link, and can be used as the
+            link's text.
+        :type links: list[dict]
+        :return: PagerDuty Events API v2 response.
+        :rtype: dict
         """
         if routing_key is None:
             routing_key = self.routing_key
@@ -115,13 +143,27 @@ class PagerdutyHook(BaseHook):
         if class_type:
             payload["class"] = class_type
 
+        actions = ('trigger', 'acknowledge', 'resolve')
+        if action not in actions:
+            raise ValueError("Event action must be one of: %s" % ', '.join(actions))
         data = {
-            "routing_key": routing_key,
             "event_action": action,
             "payload": payload,
         }
         if dedup_key:
             data["dedup_key"] = dedup_key
+        elif action != 'trigger':
+            raise ValueError(
+                "The dedup_key property is required for event_action=%s events, and it must \
+                be a string."
+                % action
+            )
+        if images is not None:
+            data["images"] = images
         if links is not None:
             data["links"] = links
-        return pypd.EventV2.create(api_key=self.token, data=data)
+
+        session = pdpyras.EventsAPISession(routing_key)
+        resp = session.post('/v2/enqueue', json=data)
+        resp.raise_for_status()
+        return resp.json()

--- a/setup.py
+++ b/setup.py
@@ -340,7 +340,7 @@ oracle = [
     'cx_Oracle>=5.1.2',
 ]
 pagerduty = [
-    'pypd>=1.1.0',
+    'pdpyras>=4.1.2,<5',
 ]
 papermill = [
     'papermill[all]>=1.2.1',


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Updating the "pagerduty" provider's `PagerdutyHook` to no longer use the "pypd" dependency which is now deprecated and instead use the "[pdpyras](https://github.com/PagerDuty/pdpyras)" package which replaced it (both are official PagerDuty python clients).

### PagerdutyHook.create_event
The updated `PagerdutyHook.create_event` method takes the same params as before but with an additional optional `images` param. It returns the same response dictionary as before. It is now using the `pdpyras.EventsAPISession` class which is a session class for submitting events to the PagerDuty Events API v2.

### PagerdutyHook.get_session
There is an additional `PagerdutyHook.get_session()` method which returns a `pdpyras.APISession` for use with sending or receiving data through the PagerDuty REST API (different from the PagerDuty Events API v2). Because the updated `PagerdutyHook.create_event` method does not use the PagerDuty API token at all (it only uses the `routing_key`) I had to find another use of the API token, and the `PagerdutyHook.get_session()` method will actually make use of the API token. When using the method to get an API session you are able to use any of the methods defined in the [pdpyras documentation](https://pagerduty.github.io/pdpyras/).

The intention of this PR is to both update `PagerdutyHook.create_event` to use the newer `pdpyras` package and to have a starting off point for adding additional methods for the PagerDuty REST API to this hook in the future as needed. I did not include other methods because I didn't want to just fully port over all of the `pdpyras.APISession` methods into this hook and I think it is enough for a user of the hook to be able to use the APISession as needed.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
