### PR TITLE
JIRA - point client to correct server URL

### DIFF
--- a/airflow/providers/jira/hooks/jira.py
+++ b/airflow/providers/jira/hooks/jira.py
@@ -69,7 +69,7 @@ class JiraHook(BaseHook):
 
             try:
                 self.client = JIRA(
-                    conn.host,
+                    conn.get_uri(),
                     options=extra_options,
                     basic_auth=(conn.login, conn.password),
                     get_server_info=get_server_info,

--- a/tests/providers/jira/hooks/test_jira.py
+++ b/tests/providers/jira/hooks/test_jira.py
@@ -46,3 +46,4 @@ class TestJiraHook(unittest.TestCase):
         self.assertTrue(jira_mock.called)
         self.assertIsInstance(jira_hook.client, Mock)
         self.assertEqual(jira_hook.client.name, jira_mock.return_value.name)  # pylint: disable=no-member
+        self.assertEqual(jira_hook.get_conn()._options['server'], 'https://localhost/jira')

--- a/tests/providers/jira/hooks/test_jira.py
+++ b/tests/providers/jira/hooks/test_jira.py
@@ -46,4 +46,3 @@ class TestJiraHook(unittest.TestCase):
         self.assertTrue(jira_mock.called)
         self.assertIsInstance(jira_hook.client, Mock)
         self.assertEqual(jira_hook.client.name, jira_mock.return_value.name)  # pylint: disable=no-member
-        self.assertEqual(jira_hook.get_conn()._options['server'], 'https://localhost/jira')


### PR DESCRIPTION
closes: #11133 

JiraHook passes the `conn.host` instead of `conn.get_uri()`. The JIRA client expects the URL to the server and requires the scheme as well (`https://`).
