### PR TITLE
Allow overrides for pod_template_file

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -30,6 +30,7 @@ from airflow.utils.decorators import apply_defaults
 from airflow.utils.helpers import validate_key
 from airflow.utils.state import State
 from airflow.version import version as airflow_version
+from airflow.kubernetes.pod_generator import PodGenerator
 
 
 class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
@@ -266,6 +267,8 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                                                      config_file=self.config_file)
 
             self.pod = self.create_pod_request_obj()
+            self.namespace = self.pod.metadata.namespace
+
             self.client = client
 
             # Add combination of labels to uniquely identify a running pod
@@ -348,53 +351,55 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
 
         """
         if self.pod_template_file:
-            pod = pod_generator.PodGenerator.deserialize_model_file(self.pod_template_file)
-        elif not self.pod:
-            pod = k8s.V1Pod(
-                api_version="v1",
-                kind="Pod",
-                metadata=k8s.V1ObjectMeta(
-                    namespace=self.namespace,
-                    labels=self.labels,
-                    name=self.name,
-                    annotations=self.annotations,
-
-                ),
-                spec=k8s.V1PodSpec(
-                    node_selector=self.node_selectors,
-                    affinity=self.affinity,
-                    tolerations=self.tolerations,
-                    init_containers=self.init_containers,
-                    containers=[
-                        k8s.V1Container(
-                            image=self.image,
-                            name="base",
-                            command=self.cmds,
-                            ports=self.ports,
-                            resources=self.k8s_resources,
-                            volume_mounts=self.volume_mounts,
-                            args=self.arguments,
-                            env=self.env_vars,
-                            env_from=self.env_from,
-                        )
-                    ],
-                    image_pull_secrets=self.image_pull_secrets,
-                    service_account_name=self.service_account_name,
-                    host_network=self.hostnetwork,
-                    security_context=self.security_context,
-                    dns_policy=self.dnspolicy,
-                    scheduler_name=self.schedulername,
-                    restart_policy='Never',
-                    priority_class_name=self.priority_class_name,
-                    volumes=self.volumes,
-                )
-            )
+            pod_template = pod_generator.PodGenerator.deserialize_model_file(self.pod_template_file)
         else:
-            pod = self.pod
+            pod_template = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="name"))
+
+        pod = k8s.V1Pod(
+            api_version="v1",
+            kind="Pod",
+            metadata=k8s.V1ObjectMeta(
+                namespace=self.namespace,
+                labels=self.labels,
+                name=self.name,
+                annotations=self.annotations,
+
+            ),
+            spec=k8s.V1PodSpec(
+                node_selector=self.node_selectors,
+                affinity=self.affinity,
+                tolerations=self.tolerations,
+                init_containers=self.init_containers,
+                containers=[
+                    k8s.V1Container(
+                        image=self.image,
+                        name="base",
+                        command=self.cmds,
+                        ports=self.ports,
+                        resources=self.k8s_resources,
+                        volume_mounts=self.volume_mounts,
+                        args=self.arguments,
+                        env=self.env_vars,
+                        env_from=self.env_from,
+                    )
+                ],
+                image_pull_secrets=self.image_pull_secrets,
+                service_account_name=self.service_account_name,
+                host_network=self.hostnetwork,
+                security_context=self.security_context,
+                dns_policy=self.dnspolicy,
+                scheduler_name=self.schedulername,
+                restart_policy='Never',
+                priority_class_name=self.priority_class_name,
+                volumes=self.volumes,
+            )
+        )
+
+        pod = PodGenerator.reconcile_pods(pod_template, pod)
+
         for secret in self.secrets:
             pod = secret.attach_to_pod(pod)
         if self.do_xcom_push:
-            from airflow.kubernetes.pod_generator import PodGenerator
             pod = PodGenerator.add_xcom_sidecar(pod)
         return pod
 

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -872,7 +872,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                                                   'env': [],
                                                   'envFrom': [],
                                                   'image': 'apache/airflow:stress-2020.07.10-1.0.4',
-                                                  'name': 'memory-demo-ctr',
+                                                  'name': 'base',
                                                   'ports': [],
                                                   'resources': {'limits': {'memory': '200Mi'},
                                                                 'requests': {'memory': '100Mi'}},

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -727,6 +727,24 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertDictEqual(result, {"hello": "world"})
 
+    def test_pod_template_file_with_overrides_system(self):
+        fixture = sys.path[0] + '/tests/kubernetes/basic_pod.yaml'
+        k = KubernetesPodOperator(
+            task_id="task" + self.get_current_task_name(),
+            labels={"foo": "bar", "fizz": "buzz"},
+            env_vars=[k8s.V1EnvVar(name="env_name", value="value")],
+            in_cluster=False,
+            pod_template_file=fixture,
+            do_xcom_push=True
+        )
+
+        context = create_context(k)
+        result = k.execute(context)
+        self.assertIsNotNone(result)
+        self.assertEqual(k.pod.metadata.labels, {'fizz': 'buzz', 'foo': 'bar'})
+        self.assertEqual(k.pod.spec.containers[0].env, [k8s.V1EnvVar(name="env_name", value="value")])
+        self.assertDictEqual(result, {"hello": "world"})
+
     def test_init_container(self):
         # GIVEN
         volume_mounts = [k8s.V1VolumeMount(

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -847,7 +847,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             api_version: v1
             kind: Pod
             metadata:
-              annotations: null
+              annotations: {}
               cluster_name: null
               creation_timestamp: null
               deletion_grace_period_seconds: null\
@@ -855,39 +855,48 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             self.assertTrue(any(line.startswith(expected_line) for line in cm.output))
 
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-        self.assertEqual({
-            'apiVersion': 'v1',
-            'kind': 'Pod',
-            'metadata': {'name': ANY, 'namespace': 'mem-example'},
-            'spec': {
-                'volumes': [{'name': 'xcom', 'emptyDir': {}}],
-                'containers': [{
-                    'args': ['--vm', '1', '--vm-bytes', '150M', '--vm-hang', '1'],
-                    'command': ['stress'],
-                    'image': 'apache/airflow:stress-2020.07.10-1.0.4',
-                    'name': 'memory-demo-ctr',
-                    'resources': {
-                        'limits': {'memory': '200Mi'},
-                        'requests': {'memory': '100Mi'}
-                    },
-                    'volumeMounts': [{
-                        'name': 'xcom',
-                        'mountPath': '/airflow/xcom'
-                    }]
-                }, {
-                    'name': 'airflow-xcom-sidecar',
-                    'image': "alpine",
-                    'command': ['sh', '-c', PodDefaults.XCOM_CMD],
-                    'volumeMounts': [
-                        {
-                            'name': 'xcom',
-                            'mountPath': '/airflow/xcom'
-                        }
-                    ],
-                    'resources': {'requests': {'cpu': '1m'}},
-                }],
-            }
-        }, actual_pod)
+        expected_dict = {'apiVersion': 'v1',
+                         'kind': 'Pod',
+                         'metadata': {'annotations': {},
+                                      'labels': {},
+                                      'name': 'memory-demo',
+                                      'namespace': 'mem-example'},
+                         'spec': {'affinity': {},
+                                  'containers': [{'args': ['--vm',
+                                                           '1',
+                                                           '--vm-bytes',
+                                                           '150M',
+                                                           '--vm-hang',
+                                                           '1'],
+                                                  'command': ['stress'],
+                                                  'env': [],
+                                                  'envFrom': [],
+                                                  'image': 'apache/airflow:stress-2020.07.10-1.0.4',
+                                                  'name': 'memory-demo-ctr',
+                                                  'ports': [],
+                                                  'resources': {'limits': {'memory': '200Mi'},
+                                                                'requests': {'memory': '100Mi'}},
+                                                  'volumeMounts': [{'mountPath': '/airflow/xcom',
+                                                                    'name': 'xcom'}]},
+                                                 {'command': ['sh',
+                                                              '-c',
+                                                              'trap "exit 0" INT; while true; do sleep '
+                                                              '30; done;'],
+                                                  'image': 'alpine',
+                                                  'name': 'airflow-xcom-sidecar',
+                                                  'resources': {'requests': {'cpu': '1m'}},
+                                                  'volumeMounts': [{'mountPath': '/airflow/xcom',
+                                                                    'name': 'xcom'}]}],
+                                  'hostNetwork': False,
+                                  'imagePullSecrets': [],
+                                  'initContainers': [],
+                                  'nodeSelector': {},
+                                  'restartPolicy': 'Never',
+                                  'securityContext': {},
+                                  'serviceAccountName': 'default',
+                                  'tolerations': [],
+                                  'volumes': [{'emptyDir': {}, 'name': 'xcom'}]}}
+        self.assertEqual(expected_dict, actual_pod)
 
     @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
     @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")


### PR DESCRIPTION
A pod_template_file should be treated as a *template* not a steadfast
rule.

This PR ensures that users can override individual values set by the
pod_template_file s.t. the same file can be used for multiple tasks.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
