### PR TITLE
Fix regression in DataflowTemplatedJobStartOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -281,6 +281,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
     :param job_name: The 'jobName' to use when executing the DataFlow template
         (templated).
     :param options: Map of job runtime environment options.
+        It will update environment argument if passed.
 
         .. seealso::
             For more information on possible configurations, look at the API documentation
@@ -316,6 +317,13 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :type impersonation_chain: Union[str, Sequence[str]]
+    :type environment: Optional, Map of job runtime environment options.
+
+        .. seealso::
+            For more information on possible configurations, look at the API documentation
+            `https://cloud.google.com/dataflow/pipelines/specifying-exec-params
+            <https://cloud.google.com/dataflow/docs/reference/rest/v1b3/RuntimeEnvironment>`__
+    :type environment: Optional[dict]
 
     It's a good practice to define dataflow_* parameters in the default_args of the dag
     like the project, zone and staging location.
@@ -373,6 +381,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
         'location',
         'gcp_conn_id',
         'impersonation_chain',
+        'environment',
     ]
     ui_color = '#0273d4'
 
@@ -391,6 +400,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
         delegate_to: Optional[str] = None,
         poll_sleep: int = 10,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        environment: Optional[Dict] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -407,6 +417,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
         self.job_id = None
         self.hook: Optional[DataflowHook] = None
         self.impersonation_chain = impersonation_chain
+        self.environment = environment
 
     def execute(self, context):
         self.hook = DataflowHook(
@@ -421,7 +432,6 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
 
         options = self.dataflow_default_options
         options.update(self.options)
-
         job = self.hook.start_template_dataflow(
             job_name=self.job_name,
             variables=options,
@@ -430,6 +440,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
             on_new_job_id_callback=set_current_job_id,
             project_id=self.project_id,
             location=self.location,
+            environment=self.environment,
         )
 
         return job

--- a/tests/providers/google/cloud/operators/test_dataflow.py
+++ b/tests/providers/google/cloud/operators/test_dataflow.py
@@ -261,6 +261,7 @@ class TestDataflowTemplateOperator(unittest.TestCase):
             dataflow_default_options={"EXTRA_OPTION": "TEST_A"},
             poll_sleep=POLL_SLEEP,
             location=TEST_LOCATION,
+            environment={"maxWorkers": 2},
         )
 
     @mock.patch('airflow.providers.google.cloud.operators.dataflow.DataflowHook')
@@ -287,4 +288,5 @@ class TestDataflowTemplateOperator(unittest.TestCase):
             on_new_job_id_callback=mock.ANY,
             project_id=None,
             location=TEST_LOCATION,
+            environment={'maxWorkers': 2},
         )


### PR DESCRIPTION
- fix regression which caused that system test with example DAG not worked anymore (https://github.com/apache/airflow/pull/8531)
- add `environment` arguments for more clear passing runtime environment configuration (it keeps backward compatibility)

---

not working example:

Log:
```
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/taskinstance.py", line 1076, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/opt/airflow/airflow/models/taskinstance.py", line 1198, in _prepare_and_execute_task_with_callbacks
    result = self._execute_task(context, task_copy)
  File "/opt/airflow/airflow/models/taskinstance.py", line 1243, in _execute_task
    result = task_copy.execute(context=context)
  File "/opt/airflow/airflow/providers/google/cloud/operators/dataflow.py", line 432, in execute
    location=self.location,
  File "/opt/airflow/airflow/providers/google/cloud/hooks/dataflow.py", line 85, in inner_wrapper
    return func(self, *args, **kwargs)
  File "/opt/airflow/airflow/providers/google/cloud/hooks/dataflow.py", line 85, in inner_wrapper
    return func(self, *args, **kwargs)
  File "/opt/airflow/airflow/providers/google/common/hooks/base_google.py", line 373, in inner_wrapper
    return func(self, *args, **kwargs)
  File "/opt/airflow/airflow/providers/google/cloud/hooks/dataflow.py", line 575, in start_template_dataflow
    response = request.execute(num_retries=self.num_retries)
  File "/usr/local/lib/python3.7/site-packages/googleapiclient/_helpers.py", line 134, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/googleapiclient/http.py", line 907, in execute
    raise HttpError(resp, content, uri=self.uri)
googleapiclient.errors.HttpError: <HttpError 400 when requesting https://dataflow.googleapis.com/v1b3/projects/polidea-airflow/locations/europe-west3/templates:launch?gcsPath=gs%3A%2F%2Fdataflow-templates%2Flatest%2FWord_Count&alt=json returned "Invalid JSON payload received. Unknown name "stagingLocation" at 'launch_parameters.environment': Cannot find field.". Details: "[{'@type': 'type.googleapis.com/google.rpc.BadRequest', 'fieldViolations': [{'field': 'launch_parameters.environment', 'description': 'Invalid JSON payload received. Unknown name "stagingLocation" at \'launch_parameters.environment\': Cannot find field.'}]}]">
```
