### PR TITLE
Optionally tags image when building with Breeze

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1182,7 +1182,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Flags:
 
-  -p, --python <PYTHON_MAJOR_MINOR_VERSION>
+  -p, --python PYTHON_MAJOR_MINOR_VERSION
           Python version used for the image. This is always major/minor version.
 
           Note that versions 2.7 and 3.5 are only valid when installing Airflow 1.10 with
@@ -1192,14 +1192,14 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  2.7 3.5 3.6 3.7 3.8
 
-  -a, --install-airflow-version <INSTALL_AIRFLOW_VERSION>
+  -a, --install-airflow-version INSTALL_AIRFLOW_VERSION
           If specified, installs Airflow directly from PIP released version. This happens at
           image building time in production image and at container entering time for CI image. One of:
 
                  1.10.12 1.10.11 1.10.10 1.10.9 1.10.8 1.10.7 1.10.6 1.10.5 1.10.4 1.10.3 1.10.2
                  master v1-10-test
 
-  -t, --install-airflow-reference <INSTALL_AIRFLOW_REFERENCE>
+  -t, --install-airflow-reference INSTALL_AIRFLOW_REFERENCE
           If specified, installs Airflow directly from reference in GitHub. This happens at
           image building time in production image and at container entering time for CI image.
 
@@ -1216,7 +1216,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           images are pulled by default only for the first time you run the
           environment, later the locally build images are used as cache.
 
-  -E, --extras
+  -E, --extras EXTRAS
           Extras to pass to build images The default are different for CI and production images:
 
           CI image:
@@ -1226,16 +1226,19 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  async,aws,azure,celery,dask,elasticsearch,gcp,kubernetes,mysql,postgres,redis,slack,
                  ssh,statsd,virtualenv
 
-  --additional-extras
+  --image-tag TAG
+          Additional tag in the image.
+
+  --additional-extras ADDITIONAL_EXTRAS
           Additional extras to pass to build images The default is no additional extras.
 
-  --additional-python-deps
+  --additional-python-deps ADDITIONAL_PYTHON_DEPS
           Additional python dependencies to use when building the images.
 
-  --additional-dev-deps
+  --additional-dev-deps ADDITIONAL_DEV_DEPS
           Additional apt dev dependencies to use when building the images.
 
-  --additional-runtime-deps
+  --additional-runtime-deps ADDITIONAL_RUNTIME_DEPS
           Additional apt runtime dependencies to use when building the images.
 
   --disable-pip-cache
@@ -1279,24 +1282,24 @@ This is the current syntax for  `./breeze <./breeze>`_:
           This strategy is used by default for both Production and CI images for the scheduled
           (nightly) builds in CI.
 
-  -D, --dockerhub-user
+  -D, --dockerhub-user DOCKERHUB_USER
           DockerHub user used to pull, push and build images. Default: apache.
 
-  -H, --dockerhub-repo
+  -H, --dockerhub-repo DOCKERHUB_REPO
           DockerHub repository used to pull, push, build images. Default: airflow.
 
-  -c, --github-registry
+  -c, --github-registry GITHUB_REGISTRY
           If GitHub registry is enabled, pulls and pushes are done from the GitHub registry not
           DockerHub. You need to be logged in to the registry in order to be able to pull/push from
           and you need to be committer to push to Apache Airflow' GitHub registry.
 
-  -g, --github-repository
+  -g, --github-repository GITHUB_REPOSITORY
           GitHub repository used to pull, push images when cache is used.
           Default: apache/airflow.
 
           If you use this flag, automatically --github-registry flag is enabled.
 
-  -s, --github-image-id <COMMIT_SHA>|<RUN_ID>
+  -s, --github-image-id COMMIT_SHA|RUN_ID
           <RUN_ID> or <COMMIT_SHA> of the image. Images in GitHub registry are stored with those
           to be able to easily find the image for particular CI runs. Once you know the
           <RUN_ID> or <COMMIT_SHA>, you can specify it in github-image-id flag and Breeze will
@@ -1330,7 +1333,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Flags:
 
-  -p, --python <PYTHON_MAJOR_MINOR_VERSION>
+  -p, --python PYTHON_MAJOR_MINOR_VERSION
           Python version used for the image. This is always major/minor version.
 
           Note that versions 2.7 and 3.5 are only valid when installing Airflow 1.10 with
@@ -1384,7 +1387,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Flags:
 
-  -p, --python <PYTHON_MAJOR_MINOR_VERSION>
+  -p, --python PYTHON_MAJOR_MINOR_VERSION
           Python version used for the image. This is always major/minor version.
 
           Note that versions 2.7 and 3.5 are only valid when installing Airflow 1.10 with
@@ -1438,24 +1441,24 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Flags:
 
-  -D, --dockerhub-user
+  -D, --dockerhub-user DOCKERHUB_USER
           DockerHub user used to pull, push and build images. Default: apache.
 
-  -H, --dockerhub-repo
+  -H, --dockerhub-repo DOCKERHUB_REPO
           DockerHub repository used to pull, push, build images. Default: airflow.
 
-  -c, --github-registry
+  -c, --github-registry GITHUB_REGISTRY
           If GitHub registry is enabled, pulls and pushes are done from the GitHub registry not
           DockerHub. You need to be logged in to the registry in order to be able to pull/push from
           and you need to be committer to push to Apache Airflow' GitHub registry.
 
-  -g, --github-repository
+  -g, --github-repository GITHUB_REPOSITORY
           GitHub repository used to pull, push images when cache is used.
           Default: apache/airflow.
 
           If you use this flag, automatically --github-registry flag is enabled.
 
-  -s, --github-image-id <COMMIT_SHA>|<RUN_ID>
+  -s, --github-image-id COMMIT_SHA|RUN_ID
           <RUN_ID> or <COMMIT_SHA> of the image. Images in GitHub registry are stored with those
           to be able to easily find the image for particular CI runs. Once you know the
           <RUN_ID> or <COMMIT_SHA>, you can specify it in github-image-id flag and Breeze will
@@ -1491,7 +1494,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Flags:
 
-  -p, --python <PYTHON_MAJOR_MINOR_VERSION>
+  -p, --python PYTHON_MAJOR_MINOR_VERSION
           Python version used for the image. This is always major/minor version.
 
           Note that versions 2.7 and 3.5 are only valid when installing Airflow 1.10 with
@@ -1609,7 +1612,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Flags:
 
-  -p, --python <PYTHON_MAJOR_MINOR_VERSION>
+  -p, --python PYTHON_MAJOR_MINOR_VERSION
           Python version used for the image. This is always major/minor version.
 
           Note that versions 2.7 and 3.5 are only valid when installing Airflow 1.10 with
@@ -1619,7 +1622,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  2.7 3.5 3.6 3.7 3.8
 
-  -b, --backend <BACKEND>
+  -b, --backend BACKEND
           Backend to use for tests - it determines which database is used.
           One of:
 
@@ -1627,12 +1630,12 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           Default: sqlite
 
-  --postgres-version <POSTGRES_VERSION>
+  --postgres-version POSTGRES_VERSION
           Postgres version used. One of:
 
                  9.6 10
 
-  --mysql-version <MYSQL_VERSION>
+  --mysql-version MYSQL_VERSION
           Mysql version used. One of:
 
                  5.7
@@ -1665,7 +1668,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Flags:
 
-  -p, --python <PYTHON_MAJOR_MINOR_VERSION>
+  -p, --python PYTHON_MAJOR_MINOR_VERSION
           Python version used for the image. This is always major/minor version.
 
           Note that versions 2.7 and 3.5 are only valid when installing Airflow 1.10 with
@@ -1685,7 +1688,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           images are pulled by default only for the first time you run the
           environment, later the locally build images are used as cache.
 
-  -E, --extras
+  -E, --extras EXTRAS
           Extras to pass to build images The default are different for CI and production images:
 
           CI image:
@@ -1695,16 +1698,19 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  async,aws,azure,celery,dask,elasticsearch,gcp,kubernetes,mysql,postgres,redis,slack,
                  ssh,statsd,virtualenv
 
-  --additional-extras
+  --image-tag TAG
+          Additional tag in the image.
+
+  --additional-extras ADDITIONAL_EXTRAS
           Additional extras to pass to build images The default is no additional extras.
 
-  --additional-python-deps
+  --additional-python-deps ADDITIONAL_PYTHON_DEPS
           Additional python dependencies to use when building the images.
 
-  --additional-dev-deps
+  --additional-dev-deps ADDITIONAL_DEV_DEPS
           Additional apt dev dependencies to use when building the images.
 
-  --additional-runtime-deps
+  --additional-runtime-deps ADDITIONAL_RUNTIME_DEPS
           Additional apt runtime dependencies to use when building the images.
 
   --disable-pip-cache
@@ -1823,11 +1829,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Flags:
 
-  -S, --version-suffix-for-pypi
+  -S, --version-suffix-for-pypi SUFFIX
           Adds optional suffix to the version in the generated backport package. It can be used
           to generate rc1/rc2 ... versions of the packages to be uploaded to PyPI.
 
-  -N, --version-suffix-for-svn
+  -N, --version-suffix-for-svn SUFFIX
           Adds optional suffix to the generated names of package. It can be used to generate
           rc1/rc2 ... versions of the packages to be uploaded to SVN.
 
@@ -1938,7 +1944,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
   ****************************************************************************************************
    Choose Airflow variant
 
-  -p, --python <PYTHON_MAJOR_MINOR_VERSION>
+  -p, --python PYTHON_MAJOR_MINOR_VERSION
           Python version used for the image. This is always major/minor version.
 
           Note that versions 2.7 and 3.5 are only valid when installing Airflow 1.10 with
@@ -1951,7 +1957,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
   ****************************************************************************************************
    Choose backend to run for Airflow
 
-  -b, --backend <BACKEND>
+  -b, --backend BACKEND
           Backend to use for tests - it determines which database is used.
           One of:
 
@@ -1959,12 +1965,12 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           Default: sqlite
 
-  --postgres-version <POSTGRES_VERSION>
+  --postgres-version POSTGRES_VERSION
           Postgres version used. One of:
 
                  9.6 10
 
-  --mysql-version <MYSQL_VERSION>
+  --mysql-version MYSQL_VERSION
           Mysql version used. One of:
 
                  5.7
@@ -1985,7 +1991,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           ready to start Airflow webserver/scheduler/worker. Without the switch, the database
           does not have any tables and you need to run reset db manually.
 
-  -i, --integration <INTEGRATION>
+  -i, --integration INTEGRATION
           Integration to start during tests - it determines which integrations are started
           for integration tests. There can be more than one integration started, or all to
           start all integrations. Selected integrations are not saved for future execution.
@@ -1993,7 +1999,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  cassandra kerberos mongo openldap presto rabbitmq redis all
 
-  --init-script <INIT_SCRIPT_FILE>
+  --init-script INIT_SCRIPT_FILE
           Initialization script name - Sourced from files/airflow-breeze-config. Default value
           init.sh. It will be executed after the environment is configured and started.
 
@@ -2011,7 +2017,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   Configuration for the KinD Kubernetes cluster and tests:
 
-  -K, --kubernetes-mode <KUBERNETES_MODE>
+  -K, --kubernetes-mode KUBERNETES_MODE
           Kubernetes mode - only used in case one of kind-cluster commands is used.
           One of:
 
@@ -2019,7 +2025,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           Default: image
 
-  -V, --kubernetes-version <KUBERNETES_VERSION>
+  -V, --kubernetes-version KUBERNETES_VERSION
           Kubernetes version - only used in case one of kind-cluster commands is used.
           One of:
 
@@ -2027,7 +2033,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           Default: v1.18.6
 
-  --kind-version <KIND_VERSION>
+  --kind-version KIND_VERSION
           Kind version - only used in case one of kind-cluster commands is used.
           One of:
 
@@ -2035,7 +2041,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           Default: v0.8.0
 
-  --helm-version <HELM_VERSION>
+  --helm-version HELM_VERSION
           Helm version - only used in case one of kind-cluster commands is used.
           One of:
 
@@ -2065,14 +2071,14 @@ This is the current syntax for  `./breeze <./breeze>`_:
   ****************************************************************************************************
    Choose different Airflow version to install or run
 
-  -a, --install-airflow-version <INSTALL_AIRFLOW_VERSION>
+  -a, --install-airflow-version INSTALL_AIRFLOW_VERSION
           If specified, installs Airflow directly from PIP released version. This happens at
           image building time in production image and at container entering time for CI image. One of:
 
                  1.10.12 1.10.11 1.10.10 1.10.9 1.10.8 1.10.7 1.10.6 1.10.5 1.10.4 1.10.3 1.10.2
                  master v1-10-test
 
-  -t, --install-airflow-reference <INSTALL_AIRFLOW_REFERENCE>
+  -t, --install-airflow-reference INSTALL_AIRFLOW_REFERENCE
           If specified, installs Airflow directly from reference in GitHub. This happens at
           image building time in production image and at container entering time for CI image.
 
@@ -2096,7 +2102,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           images are pulled by default only for the first time you run the
           environment, later the locally build images are used as cache.
 
-  -E, --extras
+  -E, --extras EXTRAS
           Extras to pass to build images The default are different for CI and production images:
 
           CI image:
@@ -2106,16 +2112,19 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  async,aws,azure,celery,dask,elasticsearch,gcp,kubernetes,mysql,postgres,redis,slack,
                  ssh,statsd,virtualenv
 
-  --additional-extras
+  --image-tag TAG
+          Additional tag in the image.
+
+  --additional-extras ADDITIONAL_EXTRAS
           Additional extras to pass to build images The default is no additional extras.
 
-  --additional-python-deps
+  --additional-python-deps ADDITIONAL_PYTHON_DEPS
           Additional python dependencies to use when building the images.
 
-  --additional-dev-deps
+  --additional-dev-deps ADDITIONAL_DEV_DEPS
           Additional apt dev dependencies to use when building the images.
 
-  --additional-runtime-deps
+  --additional-runtime-deps ADDITIONAL_RUNTIME_DEPS
           Additional apt runtime dependencies to use when building the images.
 
   --disable-pip-cache
@@ -2162,24 +2171,24 @@ This is the current syntax for  `./breeze <./breeze>`_:
   ****************************************************************************************************
    Flags for pulling/pushing Docker images (both CI and production)
 
-  -D, --dockerhub-user
+  -D, --dockerhub-user DOCKERHUB_USER
           DockerHub user used to pull, push and build images. Default: apache.
 
-  -H, --dockerhub-repo
+  -H, --dockerhub-repo DOCKERHUB_REPO
           DockerHub repository used to pull, push, build images. Default: airflow.
 
-  -c, --github-registry
+  -c, --github-registry GITHUB_REGISTRY
           If GitHub registry is enabled, pulls and pushes are done from the GitHub registry not
           DockerHub. You need to be logged in to the registry in order to be able to pull/push from
           and you need to be committer to push to Apache Airflow' GitHub registry.
 
-  -g, --github-repository
+  -g, --github-repository GITHUB_REPOSITORY
           GitHub repository used to pull, push images when cache is used.
           Default: apache/airflow.
 
           If you use this flag, automatically --github-registry flag is enabled.
 
-  -s, --github-image-id <COMMIT_SHA>|<RUN_ID>
+  -s, --github-image-id COMMIT_SHA|RUN_ID
           <RUN_ID> or <COMMIT_SHA> of the image. Images in GitHub registry are stored with those
           to be able to easily find the image for particular CI runs. Once you know the
           <RUN_ID> or <COMMIT_SHA>, you can specify it in github-image-id flag and Breeze will
@@ -2193,11 +2202,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
   ****************************************************************************************************
    Flags for generation of the backport packages
 
-  -S, --version-suffix-for-pypi
+  -S, --version-suffix-for-pypi SUFFIX
           Adds optional suffix to the version in the generated backport package. It can be used
           to generate rc1/rc2 ... versions of the packages to be uploaded to PyPI.
 
-  -N, --version-suffix-for-svn
+  -N, --version-suffix-for-svn SUFFIX
           Adds optional suffix to the generated names of package. It can be used to generate
           rc1/rc2 ... versions of the packages to be uploaded to SVN.
 

--- a/breeze
+++ b/breeze
@@ -960,6 +960,11 @@ function breeze::parse_arguments() {
             echo "Install MySQL client: ${INSTALL_MYSQL_CLIENT}"
             shift
             ;;
+        --image-tag)
+            export IMAGE_TAG="${2}"
+            echo "Tag to add to the image: ${IMAGE_TAG}"
+            shift 2
+            ;;
         -D | --dockerhub-user)
             export DOCKERHUB_USER="${2}"
             echo "Dockerhub user ${DOCKERHUB_USER}"
@@ -1926,7 +1931,7 @@ Run '${CMDNAME} flags' to see all applicable flags.
 #######################################################################################################
 function breeze::flag_airflow_variants() {
     echo "
--p, --python <PYTHON_MAJOR_MINOR_VERSION>
+-p, --python PYTHON_MAJOR_MINOR_VERSION
         Python version used for the image. This is always major/minor version.
 
         Note that versions 2.7 and 3.5 are only valid when installing Airflow 1.10 with
@@ -1952,7 +1957,7 @@ ${FORMATTED_PYTHON_MAJOR_MINOR_VERSIONS}
 #######################################################################################################
 function breeze::flag_backend_variants() {
     echo "
--b, --backend <BACKEND>
+-b, --backend BACKEND
         Backend to use for tests - it determines which database is used.
         One of:
 
@@ -1960,12 +1965,12 @@ ${FORMATTED_BACKENDS}
 
         Default: ${_breeze_default_backend:=}
 
---postgres-version <POSTGRES_VERSION>
+--postgres-version POSTGRES_VERSION
         Postgres version used. One of:
 
 ${FORMATTED_POSTGRES_VERSIONS}
 
---mysql-version <MYSQL_VERSION>
+--mysql-version MYSQL_VERSION
         Mysql version used. One of:
 
 ${FORMATTED_MYSQL_VERSIONS}
@@ -2006,7 +2011,7 @@ function breeze::flag_breeze_actions() {
         ready to start Airflow webserver/scheduler/worker. Without the switch, the database
         does not have any tables and you need to run reset db manually.
 
--i, --integration <INTEGRATION>
+-i, --integration INTEGRATION
         Integration to start during tests - it determines which integrations are started
         for integration tests. There can be more than one integration started, or all to
         start all integrations. Selected integrations are not saved for future execution.
@@ -2014,7 +2019,7 @@ function breeze::flag_breeze_actions() {
 
 ${FORMATTED_INTEGRATIONS}
 
---init-script <INIT_SCRIPT_FILE>
+--init-script INIT_SCRIPT_FILE
         Initialization script name - Sourced from files/airflow-breeze-config. Default value
         init.sh. It will be executed after the environment is configured and started.
 
@@ -2039,7 +2044,7 @@ function breeze::flag_kubernetes_configuration() {
     echo "
 Configuration for the KinD Kubernetes cluster and tests:
 
--K, --kubernetes-mode <KUBERNETES_MODE>
+-K, --kubernetes-mode KUBERNETES_MODE
         Kubernetes mode - only used in case one of kind-cluster commands is used.
         One of:
 
@@ -2047,7 +2052,7 @@ ${FORMATTED_KUBERNETES_MODES}
 
         Default: ${_breeze_default_kubernetes_mode:=}
 
--V, --kubernetes-version <KUBERNETES_VERSION>
+-V, --kubernetes-version KUBERNETES_VERSION
         Kubernetes version - only used in case one of kind-cluster commands is used.
         One of:
 
@@ -2055,7 +2060,7 @@ ${FORMATTED_KUBERNETES_VERSIONS}
 
         Default: ${_breeze_default_kubernetes_version:=}
 
---kind-version <KIND_VERSION>
+--kind-version KIND_VERSION
         Kind version - only used in case one of kind-cluster commands is used.
         One of:
 
@@ -2063,7 +2068,7 @@ ${FORMATTED_KIND_VERSIONS}
 
         Default: ${_breeze_default_kind_version:=}
 
---helm-version <HELM_VERSION>
+--helm-version HELM_VERSION
         Helm version - only used in case one of kind-cluster commands is used.
         One of:
 
@@ -2102,13 +2107,13 @@ function breeze::flag_local_file_mounting() {
 #######################################################################################################
 function breeze::flag_choose_different_airflow_version() {
     echo "
--a, --install-airflow-version <INSTALL_AIRFLOW_VERSION>
+-a, --install-airflow-version INSTALL_AIRFLOW_VERSION
         If specified, installs Airflow directly from PIP released version. This happens at
         image building time in production image and at container entering time for CI image. One of:
 
 ${FORMATTED_INSTALL_AIRFLOW_VERSIONS}
 
--t, --install-airflow-reference <INSTALL_AIRFLOW_REFERENCE>
+-t, --install-airflow-reference INSTALL_AIRFLOW_REFERENCE
         If specified, installs Airflow directly from reference in GitHub. This happens at
         image building time in production image and at container entering time for CI image.
 "
@@ -2205,7 +2210,7 @@ function breeze::flag_build_docker_images() {
         images are pulled by default only for the first time you run the
         environment, later the locally build images are used as cache.
 
--E, --extras
+-E, --extras EXTRAS
         Extras to pass to build images The default are different for CI and production images:
 
         CI image:
@@ -2214,16 +2219,19 @@ ${FORMATTED_DEFAULT_CI_EXTRAS}
         Production image:
 ${FORMATTED_DEFAULT_PROD_EXTRAS}
 
---additional-extras
+--image-tag TAG
+        Additional tag in the image.
+
+--additional-extras ADDITIONAL_EXTRAS
         Additional extras to pass to build images The default is no additional extras.
 
---additional-python-deps
+--additional-python-deps ADDITIONAL_PYTHON_DEPS
         Additional python dependencies to use when building the images.
 
---additional-dev-deps
+--additional-dev-deps ADDITIONAL_DEV_DEPS
         Additional apt dev dependencies to use when building the images.
 
---additional-runtime-deps
+--additional-runtime-deps ADDITIONAL_RUNTIME_DEPS
         Additional apt runtime dependencies to use when building the images.
 
 --disable-pip-cache
@@ -2285,24 +2293,24 @@ ${FORMATTED_DEFAULT_PROD_EXTRAS}
 #######################################################################################################
 function breeze::flag_pull_push_docker_images() {
     echo "
--D, --dockerhub-user
+-D, --dockerhub-user DOCKERHUB_USER
         DockerHub user used to pull, push and build images. Default: ${_breeze_default_dockerhub_user:=}.
 
--H, --dockerhub-repo
+-H, --dockerhub-repo DOCKERHUB_REPO
         DockerHub repository used to pull, push, build images. Default: ${_breeze_default_dockerhub_repo:=}.
 
--c, --github-registry
+-c, --github-registry GITHUB_REGISTRY
         If GitHub registry is enabled, pulls and pushes are done from the GitHub registry not
         DockerHub. You need to be logged in to the registry in order to be able to pull/push from
         and you need to be committer to push to Apache Airflow' GitHub registry.
 
--g, --github-repository
+-g, --github-repository GITHUB_REPOSITORY
         GitHub repository used to pull, push images when cache is used.
         Default: ${_breeze_default_github_repository:=}.
 
         If you use this flag, automatically --github-registry flag is enabled.
 
--s, --github-image-id <COMMIT_SHA>|<RUN_ID>
+-s, --github-image-id COMMIT_SHA|RUN_ID
         <RUN_ID> or <COMMIT_SHA> of the image. Images in GitHub registry are stored with those
         to be able to easily find the image for particular CI runs. Once you know the
         <RUN_ID> or <COMMIT_SHA>, you can specify it in github-image-id flag and Breeze will
@@ -2325,11 +2333,11 @@ function breeze::flag_pull_push_docker_images() {
 #######################################################################################################
 function breeze::flag_version_suffix() {
     echo "
--S, --version-suffix-for-pypi
+-S, --version-suffix-for-pypi SUFFIX
         Adds optional suffix to the version in the generated backport package. It can be used
         to generate rc1/rc2 ... versions of the packages to be uploaded to PyPI.
 
--N, --version-suffix-for-svn
+-N, --version-suffix-for-svn SUFFIX
         Adds optional suffix to the generated names of package. It can be used to generate
         rc1/rc2 ... versions of the packages to be uploaded to SVN.
 "

--- a/breeze-complete
+++ b/breeze-complete
@@ -148,7 +148,7 @@ build-cache-local build-cache-pulled build-cache-disabled disable-pip-cache
 dockerhub-user: dockerhub-repo: github-registry github-repository: github-image-id:
 postgres-version: mysql-version:
 version-suffix-for-pypi: version-suffix-for-svn:
-additional-extras: additional-python-deps: additional-dev-deps: additional-runtime-deps:
+additional-extras: additional-python-deps: additional-dev-deps: additional-runtime-deps: image-tag:
 disable-mysql-client-installation
 load-default-connections load-example-dags
 "

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -571,7 +571,12 @@ Docker building ${AIRFLOW_CI_IMAGE}.
         . -f Dockerfile.ci
     set -u
     if [[ -n "${DEFAULT_CI_IMAGE=}" ]]; then
+        echo "Tagging additionally image ${AIRFLOW_CI_IMAGE} with ${DEFAULT_CI_IMAGE}"
         docker tag "${AIRFLOW_CI_IMAGE}" "${DEFAULT_CI_IMAGE}"
+    fi
+    if [[ -n "${IMAGE_TAG:=}" ]]; then
+        echo "Tagging additionally image ${AIRFLOW_CI_IMAGE} with ${IMAGE_TAG}"
+        docker tag "${AIRFLOW_CI_IMAGE}" "${IMAGE_TAG}"
     fi
     if [[ -n ${SPIN_PID=} ]]; then
         kill -HUP "${SPIN_PID}" || true
@@ -719,7 +724,12 @@ function build_images::build_prod_images() {
         . -f Dockerfile
     set -u
     if [[ -n "${DEFAULT_PROD_IMAGE:=}" ]]; then
+        echo "Tagging additionally image ${AIRFLOW_PROD_IMAGE} with ${DEFAULT_PROD_IMAGE}"
         docker tag "${AIRFLOW_PROD_IMAGE}" "${DEFAULT_PROD_IMAGE}"
+    fi
+    if [[ -n "${IMAGE_TAG:=}" ]]; then
+        echo "Tagging additionally image ${AIRFLOW_PROD_IMAGE} with ${IMAGE_TAG}"
+        docker tag "${AIRFLOW_PROD_IMAGE}" "${IMAGE_TAG}"
     fi
 }
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -322,6 +322,8 @@ function initialization::initialize_image_build_variables() {
     export AIRFLOW_PRE_CACHED_PIP_PACKAGES="${AIRFLOW_PRE_CACHED_PIP_PACKAGES:="true"}"
     # by default install mysql client
     export INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT:="true"}
+    # additional tag for the image
+    export IMAGE_TAG=${IMAGE_TAG:=""}
 }
 
 # Determine version suffixes used to build backport packages
@@ -637,6 +639,7 @@ function initialization::make_constants_read_only() {
     readonly ADDITIONAL_DEV_DEPS
     readonly ADDITIONAL_RUNTIME_DEPS
     readonly AIRFLOW_PRE_CACHED_PIP_PACKAGES
+    readonly IMAGE_TAG
 
     readonly DOCKERHUB_USER
     readonly DOCKERHUB_REPO


### PR DESCRIPTION
Breeze tags the image based on the default python version,
branch, type of the image, but you might want to tag the image
in the same command especially in automated cases of building
the image via CI scripts or security teams that tag the imge
based on external factors (build time, person etc.).

This is part of #11171 which makes the image easier to build in
corporate environments.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
