### PR TITLE
Remove Unnecessary comprehension in 'any' builtin function

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -368,7 +368,7 @@ class DagFileProcessor(LoggingMixin):
         We are assuming that the scheduler runs often, so we only check for
         tasks that should have succeeded in the past hour.
         """
-        if not any([isinstance(ti.sla, timedelta) for ti in dag.tasks]):
+        if not any(isinstance(ti.sla, timedelta) for ti in dag.tasks):
             self.log.info("Skipping SLA check for %s because no tasks in DAG have SLAs", dag)
             return
 

--- a/setup.py
+++ b/setup.py
@@ -640,8 +640,7 @@ devel_all = list(set(devel +
                      [req for req_list in EXTRAS_REQUIREMENTS.values() for req in req_list] +
                      [req for req_list in PROVIDERS_REQUIREMENTS.values() for req in req_list]))
 
-PACKAGES_EXCLUDED_FOR_ALL = [
-]
+PACKAGES_EXCLUDED_FOR_ALL = []
 
 if PY3:
     PACKAGES_EXCLUDED_FOR_ALL.extend([
@@ -663,11 +662,12 @@ PACKAGES_EXCLUDED_FOR_CI = [
 def is_package_excluded(package: str, exclusion_list: List[str]):
     """
     Checks if package should be excluded.
+
     :param package: package name (beginning of it)
     :param exclusion_list: list of excluded packages
     :return: true if package should be excluded
     """
-    return any([package.startswith(excluded_package) for excluded_package in exclusion_list])
+    return any(package.startswith(excluded_package) for excluded_package in exclusion_list)
 
 
 devel_all = [package for package in devel_all if not is_package_excluded(


### PR DESCRIPTION
The inbuilt functions `any()` support short-circuiting (evaluation stops as soon as the overall return value of the function is known), but this behavior is lost if you use comprehension. This affects performance.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
