### PR TITLE
spark-on-k8s sensor logs - properly pass defined namespace to pod log call

### DIFF
--- a/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
@@ -697,7 +697,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
             task_id="test_task_id",
         )
         self.assertRaises(AirflowException, sensor.poke, None)
-        mock_log_call.assert_called_once_with("spark_pi-driver")
+        mock_log_call.assert_called_once_with("spark-pi-driver", namespace="default")
         error_log_call.assert_called_once_with(TEST_POD_LOG_RESULT)
 
     @patch(
@@ -719,7 +719,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
             task_id="test_task_id",
         )
         sensor.poke(None)
-        mock_log_call.assert_called_once_with("spark_pi-driver")
+        mock_log_call.assert_called_once_with("spark-pi-2020-02-24-1-driver", namespace="default")
         log_info_call = info_log_call.mock_calls[1]
         log_value = log_info_call[1][0]
         self.assertEqual(log_value, TEST_POD_LOG_RESULT)


### PR DESCRIPTION
This is a follow up to #10023 - it seems that passing the defined namespace to the log call was missed in one of the rebases done during the PR. 
Without this fix, logging will fail when the k8s connection uses a different namespace than the one SparkApplication(s) are actually submitted to.