### PR TITLE
Breeze start-airflow command wasn't able to initialize the db in 1.10.x

### DIFF
--- a/breeze
+++ b/breeze
@@ -3110,6 +3110,8 @@ breeze::setup_default_breeze_constants
 
 initialization::initialize_common_environment
 
+initialization::intialize_airflow_variables
+
 breeze::determine_python_version_to_use_in_breeze
 
 sanity_checks::basic_sanity_checks

--- a/breeze
+++ b/breeze
@@ -3110,8 +3110,6 @@ breeze::setup_default_breeze_constants
 
 initialization::initialize_common_environment
 
-initialization::intialize_airflow_variables
-
 breeze::determine_python_version_to_use_in_breeze
 
 sanity_checks::basic_sanity_checks

--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -107,8 +107,12 @@ function startairflow_if_requested() {
         . "$( dirname "${BASH_SOURCE[0]}" )/configure_environment.sh"
 
         # initialize db and create the admin user if it's a new run
-        airflow db init
-        airflow users create -u admin -p admin -f Thor -l Adminstra -r Admin -e dummy@dummy.email
+        if [[ ${RUN_AIRFLOW_1_10} == "true" ]]; then
+            airflow initdb
+        else
+            airflow db init
+            airflow users create -u admin -p admin -f Thor -l Adminstra -r Admin -e dummy@dummy.email
+        fi
 
         . "$( dirname "${BASH_SOURCE[0]}" )/run_init_script.sh"
 

--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -109,6 +109,7 @@ function startairflow_if_requested() {
         # initialize db and create the admin user if it's a new run
         if [[ ${RUN_AIRFLOW_1_10} == "true" ]]; then
             airflow initdb
+            airflow create_user -u admin -p admin -f Thor -l Adminstra -r Admin -e dummy@dummy.email || true
         else
             airflow db init
             airflow users create -u admin -p admin -f Thor -l Adminstra -r Admin -e dummy@dummy.email


### PR DESCRIPTION
The database initialization needs a different cli command (the old `initdb`).

Also it is not necessary to create a dummy user in version 1.10.x to allow people to login in the Web UI.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
