### PR TITLE
Change job submission template from underscores to dashes to conform with k8s naming convention for Dataproc on GKE

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -59,7 +59,7 @@ class DataProcJobBuilder:
         job_type: str,
         properties: Optional[Dict[str, str]] = None,
     ) -> None:
-        name = task_id + "_" + str(uuid.uuid4())[:8]
+        name = task_id + "-" + str(uuid.uuid4())[:8]
         self.job_type = job_type
         self.job = {
             "job": {
@@ -193,7 +193,7 @@ class DataProcJobBuilder:
         :param name: Job name.
         :type name: str
         """
-        self.job["job"]["reference"]["job_id"] = name + "_" + str(uuid.uuid4())[:8]
+        self.job["job"]["reference"]["job_id"] = name + "-" + str(uuid.uuid4())[:8]
 
     def build(self) -> Dict:
         """
@@ -288,7 +288,7 @@ class DataprocHook(GoogleBaseHook):
         :type metadata: Sequence[Tuple[str, str]]
         """
         # Dataproc labels must conform to the following regex:
-        # [a-z]([-a-z0-9]*[a-z0-9])? (current airflow version string follows
+        # [a-z]([-a-z0-9]*[a-z0-9]) (current airflow version string follows
         # semantic versioning spec: x.y.z).
         labels = labels or {}
         labels.update({'airflow-version': 'v' + airflow_version.replace('.', '-').replace('+', '-')})

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -918,7 +918,7 @@ class DataprocJobBaseOperator(BaseOperator):
     def __init__(
         self,
         *,
-        job_name: str = '{{task.task_id}}_{{ds_nodash}}',
+        job_name: str = '{{task.task_id}}-{{ds_nodash}}',
         cluster_name: str = "cluster-1",
         dataproc_properties: Optional[Dict] = None,
         dataproc_jars: Optional[List[str]] = None,
@@ -1461,7 +1461,7 @@ class DataprocSubmitPySparkJobOperator(DataprocJobBaseOperator):
     @staticmethod
     def _generate_temp_filename(filename):
         date = time.strftime('%Y%m%d%H%M%S')
-        return "{}_{}_{}".format(date, str(uuid.uuid4())[:8], ntpath.basename(filename))
+        return "{}-{}-{}".format(date, str(uuid.uuid4())[:8], ntpath.basename(filename))
 
     def _upload_file_temp(self, bucket, local_file):
         """

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -323,7 +323,7 @@ class TestDataProcJobBuilder(unittest.TestCase):
             "job": {
                 "labels": {"airflow-version": AIRFLOW_VERSION},
                 "placement": {"cluster_name": CLUSTER_NAME},
-                "reference": {"job_id": TASK_ID + "_uuid", "project_id": GCP_PROJECT},
+                "reference": {"job_id": TASK_ID + "-uuid", "project_id": GCP_PROJECT},
                 "test": {"properties": properties},
             }
         }
@@ -408,7 +408,7 @@ class TestDataProcJobBuilder(unittest.TestCase):
         mock_uuid.return_value = uuid
         name = "name"
         self.builder.set_job_name(name)
-        name += "_" + uuid[:8]
+        name += "-" + uuid[:8]
         self.assertEqual(name, self.builder.job["job"]["reference"]["job_id"])
 
     def test_build(self):


### PR DESCRIPTION
Change job submission template from underscores to dashes to conform with k8s naming convention [1] for Dataproc on GKE 

Rn, if you submit a job with the `DataProcPySparkOperator` to a Dataproc cluster running on GKE, the job fails to launch due to this issue

[1] https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
