### PR TITLE
[AIRFLOW-6585] Fixed Timestamp bug in RefreshKubeConfigLoader

### DIFF
--- a/airflow/kubernetes/refresh_config.py
+++ b/airflow/kubernetes/refresh_config.py
@@ -59,6 +59,8 @@ class RefreshKubeConfigLoader(KubeConfigLoader):
             self.token = "Bearer %s" % status['token']  # pylint: disable=W0201
             ts_str = status.get('expirationTimestamp')
             if ts_str:
+                if ts_str[-1] == 'Z':
+                    ts_str = ts_str[:-1] + '+0000'
                 self.api_key_expire_ts = calendar.timegm(
                     datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S%z").timetuple(),
                 )

--- a/airflow/kubernetes/refresh_config.py
+++ b/airflow/kubernetes/refresh_config.py
@@ -33,7 +33,7 @@ from kubernetes.config.exec_provider import ExecProvider
 from kubernetes.config.kube_config import KUBE_CONFIG_DEFAULT_LOCATION, KubeConfigLoader
 
 
-def _parse_timestamp(ts_str: str) -> time.struct_time:
+def _parse_timestamp(ts_str: str) -> int:
     return calendar.timegm(pendulum.parse(ts_str).timetuple())
 
 

--- a/airflow/kubernetes/refresh_config.py
+++ b/airflow/kubernetes/refresh_config.py
@@ -24,7 +24,7 @@ import calendar
 import logging
 import os
 import time
-from typing import Optional
+from typing import Optional, cast
 
 import pendulum
 import yaml
@@ -34,10 +34,8 @@ from kubernetes.config.kube_config import KUBE_CONFIG_DEFAULT_LOCATION, KubeConf
 
 
 def _parse_timestamp(ts_str: str) -> int:
-    parsed_dt = pendulum.parse(ts_str)
-    if isinstance(parsed_dt, pendulum.DateTime):
-        return calendar.timegm(parsed_dt.timetuple())
-    raise ValueError(f"timestamp string '{ts_str}' could not be parsed to DateTime.")
+    parsed_dt = cast(pendulum.DateTime, pendulum.parse(ts_str))
+    return calendar.timegm(parsed_dt.timetuple())
 
 
 class RefreshKubeConfigLoader(KubeConfigLoader):

--- a/airflow/kubernetes/refresh_config.py
+++ b/airflow/kubernetes/refresh_config.py
@@ -34,7 +34,10 @@ from kubernetes.config.kube_config import KUBE_CONFIG_DEFAULT_LOCATION, KubeConf
 
 
 def _parse_timestamp(ts_str: str) -> int:
-    return calendar.timegm(pendulum.parse(ts_str).timetuple())
+    dt = pendulum.parse(ts_str)
+    if isinstance(dt, pendulum.DateTime):
+        return calendar.timegm(dt.timetuple())
+    raise ValueError(f"timestamp string '{ts_str}' could not be parsed to DateTime.")
 
 
 class RefreshKubeConfigLoader(KubeConfigLoader):

--- a/airflow/kubernetes/refresh_config.py
+++ b/airflow/kubernetes/refresh_config.py
@@ -33,6 +33,15 @@ from kubernetes.config.exec_provider import ExecProvider
 from kubernetes.config.kube_config import KUBE_CONFIG_DEFAULT_LOCATION, KubeConfigLoader
 
 
+def _parse_timestamp(ts_str: str) -> int:
+    if ts_str[-1] == 'Z':
+        ts_str = ts_str[:-1] + '+0000'
+    expire_ts = calendar.timegm(
+        datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S%z").timetuple()
+    )
+    return expire_ts
+
+
 class RefreshKubeConfigLoader(KubeConfigLoader):
     """
     Patched KubeConfigLoader, this subclass takes expirationTimestamp into
@@ -59,11 +68,7 @@ class RefreshKubeConfigLoader(KubeConfigLoader):
             self.token = "Bearer %s" % status['token']  # pylint: disable=W0201
             ts_str = status.get('expirationTimestamp')
             if ts_str:
-                if ts_str[-1] == 'Z':
-                    ts_str = ts_str[:-1] + '+0000'
-                self.api_key_expire_ts = calendar.timegm(
-                    datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S%z").timetuple(),
-                )
+                self.api_key_expire_ts = _parse_timestamp(ts_str)
             return True
         except Exception as e:  # pylint: disable=W0703
             logging.error(str(e))

--- a/airflow/kubernetes/refresh_config.py
+++ b/airflow/kubernetes/refresh_config.py
@@ -34,9 +34,9 @@ from kubernetes.config.kube_config import KUBE_CONFIG_DEFAULT_LOCATION, KubeConf
 
 
 def _parse_timestamp(ts_str: str) -> int:
-    dt = pendulum.parse(ts_str)
-    if isinstance(dt, pendulum.DateTime):
-        return calendar.timegm(dt.timetuple())
+    parsed_dt = pendulum.parse(ts_str)
+    if isinstance(parsed_dt, pendulum.DateTime):
+        return calendar.timegm(parsed_dt.timetuple())
     raise ValueError(f"timestamp string '{ts_str}' could not be parsed to DateTime.")
 
 

--- a/airflow/kubernetes/refresh_config.py
+++ b/airflow/kubernetes/refresh_config.py
@@ -24,22 +24,17 @@ import calendar
 import logging
 import os
 import time
-from datetime import datetime
 from typing import Optional
 
+import pendulum
 import yaml
 from kubernetes.client import Configuration
 from kubernetes.config.exec_provider import ExecProvider
 from kubernetes.config.kube_config import KUBE_CONFIG_DEFAULT_LOCATION, KubeConfigLoader
 
 
-def _parse_timestamp(ts_str: str) -> int:
-    if ts_str[-1] == 'Z':
-        ts_str = ts_str[:-1] + '+0000'
-    expire_ts = calendar.timegm(
-        datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S%z").timetuple()
-    )
-    return expire_ts
+def _parse_timestamp(ts_str: str) -> time.struct_time:
+    return calendar.timegm(pendulum.parse(ts_str).timetuple())
 
 
 class RefreshKubeConfigLoader(KubeConfigLoader):

--- a/tests/kubernetes/test_refresh_config.py
+++ b/tests/kubernetes/test_refresh_config.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from unittest import TestCase
 
 from airflow.kubernetes.refresh_config import _parse_timestamp

--- a/tests/kubernetes/test_refresh_config.py
+++ b/tests/kubernetes/test_refresh_config.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from airflow.kubernetes.refresh_config import _parse_timestamp
+
+
+class TestRefreshKubeConfigLoader(TestCase):
+
+    def test_parse_timestamp_should_convert_Z_timezone_to_unix_timestamp(self):
+        ts = _parse_timestamp("2020-01-13T13:42:20Z")
+        self.assertEqual(1578922940, ts)
+
+    def test_parse_timestamp_should_convert_regular_timezone_to_unix_timestamp(self):
+        ts = _parse_timestamp("2020-01-13T13:42:20+0600")
+        self.assertEqual(1578922940, ts)

--- a/tests/kubernetes/test_refresh_config.py
+++ b/tests/kubernetes/test_refresh_config.py
@@ -5,7 +5,7 @@ from airflow.kubernetes.refresh_config import _parse_timestamp
 
 class TestRefreshKubeConfigLoader(TestCase):
 
-    def test_parse_timestamp_should_convert_Z_timezone_to_unix_timestamp(self):
+    def test_parse_timestamp_should_convert_z_timezone_to_unix_timestamp(self):
         ts = _parse_timestamp("2020-01-13T13:42:20Z")
         self.assertEqual(1578922940, ts)
 

--- a/tests/kubernetes/test_refresh_config.py
+++ b/tests/kubernetes/test_refresh_config.py
@@ -17,6 +17,8 @@
 
 from unittest import TestCase
 
+from pendulum.parsing import ParserError
+
 from airflow.kubernetes.refresh_config import _parse_timestamp
 
 
@@ -29,3 +31,7 @@ class TestRefreshKubeConfigLoader(TestCase):
     def test_parse_timestamp_should_convert_regular_timezone_to_unix_timestamp(self):
         ts = _parse_timestamp("2020-01-13T13:42:20+0600")
         self.assertEqual(1578922940, ts)
+
+    def test_parse_timestamp_should_throw_exception(self):
+        with self.assertRaises(ParserError):
+            _parse_timestamp("foobar")


### PR DESCRIPTION
# Jira
https://issues.apache.org/jira/browse/AIRFLOW-6585

# Description
This is basically #7153 which I extended by using pendulum to parse time strings as asked in https://github.com/apache/airflow/pull/7153#pullrequestreview-389880157 . Since that PR is closed I opened a new one.
**Original description:**
When using the KubernetesPodOperator on an aws kubernetes cluster, the aws-iam-authenticator is used to obtain kubernetes authentication tokens. The aws tokens contain ISO-8601 formatted timestamps, which couldn't be parsed in case of a "Z" (Zulu Time) timezone.