### PR TITLE
introduce get_partition_by_name within hive hook

### DIFF
--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -665,7 +665,7 @@ class HiveMetastoreHook(BaseHook):
         """Get a metastore partition object
 
         >>> hh = HiveMetastoreHook()
-        >>> tp = hh.get_table(db_name='org_db', tbl_name='my_year_partitioned_table', part_name='year=2020')
+        >>> tp = hh.get_partition_by_name(db_name='org_db', tbl_name='my_year_partitioned_table', part_name='year=2020')
         >>> tp.parameters.get("totalSize")
         '713263'
         >>> tp.sd.location

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -661,6 +661,19 @@ class HiveMetastoreHook(BaseHook):
                 pnames = [p.name for p in table.partitionKeys]
                 return [dict(zip(pnames, p.values)) for p in parts]
 
+    def get_partition_by_name(self, db_name: str, tbl_name: str, part_name: str) -> Any:
+        """Get a metastore partition object
+
+        >>> hh = HiveMetastoreHook()
+        >>> tp = hh.get_table(db_name='org_db', tbl_name='my_year_partitioned_table', part_name='year=2020')
+        >>> tp.parameters.get("totalSize")
+        '713263'
+        >>> tp.sd.location
+        'hdfs://foo/bar'
+        """
+        with self.metastore as client:
+            return client.get_partition_by_name(db_name=db_name, tbl_name=tbl_name, part_name=part_name)
+
     @staticmethod
     def _get_max_partition_from_part_specs(
         part_specs: List[Any], partition_key: Optional[str], filter_map: Optional[Dict[str, Any]]

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -523,26 +523,30 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
         fake_schema = FakeFieldSchema('ds')
         FakePartition = namedtuple('FakePartition', ['values'])
         fake_partition = FakePartition(['2015-01-01'])
-        FakePartitionDetails = namedtuple('FakePartitionDetails',
-                                          ['partitionKey', 'partitionValue', 'details'])
-        fake_partition_details = \
-            FakePartitionDetails(partitionKey=fake_schema.name,
-                                 partitionValue=fake_partition.values,
-                                 details={'totalSize': 5000,
-                                          'numRows': 30})
+        FakePartitionDetails = namedtuple(
+            'FakePartitionDetails',
+            ['partitionKey', 'partitionValue', 'details']
+        )
+        fake_partition_details = FakePartitionDetails(
+            partitionKey=fake_schema.name,
+            partitionValue=fake_partition.values,
+            details={'totalSize': 5000, 'numRows': 30}
+        )
 
-        self.hook.metastore.__enter__().get_partition_by_name = \
-            mock.MagicMock(return_value=fake_partition_details.details)
-        specific_named_partition = \
-            self.hook.get_partition_by_name(db_name=self.database,
-                                            tbl_name=self.table, part_name='ds=2015-01-01')
-        self.assertEqual(specific_named_partition.get('totalSize'),
-                         5000)
+        self.hook.metastore.__enter__().get_partition_by_name = mock.MagicMock(
+            return_value=fake_partition_details.details
+        )
+        specific_named_partition = self.hook.get_partition_by_name(
+            db_name=self.database,
+            tbl_name=self.table,
+            part_name='ds=2015-01-01'
+        )
+        self.assertEqual(specific_named_partition.get('totalSize'), 5000)
         self.assertEqual(specific_named_partition.get('numRows'), 30)
 
-        self.hook.metastore.__enter__().get_partition_by_name.assert_called_with(dbname=self.database,
-                                                                                 tbl_name=self.table,
-                                                                                 part_name='ds=2015-01-01')
+        self.hook.metastore.__enter__().get_partition_by_name.assert_called_with(
+            dbname=self.database, tbl_name=self.table, part_name='ds=2015-01-01'
+        )
 
     def test_table_exists(self):
         # Test with existent table.

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -529,7 +529,7 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
         fake_partition = FakePartition(['2015-01-01'])
         FakePartitionDetails = namedtuple('FakePartitionDetails', ['partitionKey', 'partitionValue', 'details'])
         fake_partition_details = FakePartitionDetails(
-            [fake_schema.name, fake_partition.values, {'totalSize': 5000, 'numRows': 30}])
+            partitionKey=fake_schema.name, partitionValue=fake_partition.values, details={'totalSize': 5000, 'numRows': 30})
 
         self.hook.metastore.__enter__().get_partition_by_name = mock.MagicMock(return_value=fake_partition_details)
         specific_named_partition = self.hook.get_partition_by_name(db_name=self.database, tbl_name=self.table,

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -528,10 +528,12 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
         FakePartition = namedtuple('FakePartition', ['values'])
         fake_partition = FakePartition(['2015-01-01'])
         FakePartitionDetails = namedtuple('FakePartitionDetails', ['partitionKey', 'partitionValue', 'details'])
-        fake_partition_details = FakePartitionDetails([fake_schema.name, fake_partition.values, {'totalSize': 5000, 'numRows': 30}])
+        fake_partition_details = FakePartitionDetails(
+            [fake_schema.name, fake_partition.values, {'totalSize': 5000, 'numRows': 30}])
 
         self.hook.metastore.__enter__().get_partition_by_name = mock.MagicMock(return_value=fake_partition_details)
-        specific_named_partition = self.hook.get_partition_by_name(db=self.database, table_name=self.table, part_name='ds=2015-01-01')
+        specific_named_partition = self.hook.get_partition_by_name(db_name=self.database, tbl_name=self.table,
+                                                                   part_name='ds=2015-01-01')
         self.assertEqual(specific_named_partition.get('totalSize'), 5000)
         self.assertEqual(specific_named_partition.get('numRows'), 30)
 

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -77,7 +77,6 @@ class TestHiveCliHook(unittest.TestCase):
                 'AIRFLOW_CTX_DAG_EMAIL': 'test@airflow.com',
             },
         ):
-
             hook = MockHiveCliHook()
             hook.run_cli("SHOW DATABASES")
 
@@ -192,7 +191,6 @@ class TestHiveCliHook(unittest.TestCase):
                 dag_run_id_ctx_var_name: 'test_dag_run_id',
             },
         ):
-
             hook = MockHiveCliHook()
             mock_popen.return_value = MockSubProcess(output=mock_output)
 
@@ -425,7 +423,6 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
         metastore.get_partitions_by_filter.assert_called_with(self.database, self.table, missing_partition, 1)
 
     def test_check_for_named_partition(self):
-
         # Check for existing partition.
 
         partition = f"{self.partition_by}={DEFAULT_DATE_DS}"
@@ -449,7 +446,6 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
         )
 
     def test_get_table(self):
-
         self.hook.metastore.__enter__().get_table = mock.MagicMock()
         self.hook.get_table(db=self.database, table_name=self.table)
         self.hook.metastore.__enter__().get_table.assert_called_with(
@@ -527,19 +523,26 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
         fake_schema = FakeFieldSchema('ds')
         FakePartition = namedtuple('FakePartition', ['values'])
         fake_partition = FakePartition(['2015-01-01'])
-        FakePartitionDetails = namedtuple('FakePartitionDetails', ['partitionKey', 'partitionValue', 'details'])
-        fake_partition_details = FakePartitionDetails(
-            partitionKey=fake_schema.name, partitionValue=fake_partition.values, details={'totalSize': 5000, 'numRows': 30})
+        FakePartitionDetails = namedtuple('FakePartitionDetails',
+                                          ['partitionKey', 'partitionValue', 'details'])
+        fake_partition_details = \
+            FakePartitionDetails(partitionKey=fake_schema.name,
+                                 partitionValue=fake_partition.values,
+                                 details={'totalSize': 5000,
+                                          'numRows': 30})
 
-        self.hook.metastore.__enter__().get_partition_by_name = mock.MagicMock(return_value=fake_partition_details)
-        specific_named_partition = self.hook.get_partition_by_name(db_name=self.database, tbl_name=self.table,
-                                                                   part_name='ds=2015-01-01')
-        self.assertEqual(specific_named_partition.get('totalSize'), 5000)
+        self.hook.metastore.__enter__().get_partition_by_name = \
+            mock.MagicMock(return_value=fake_partition_details.details)
+        specific_named_partition = \
+            self.hook.get_partition_by_name(db_name=self.database,
+                                            tbl_name=self.table, part_name='ds=2015-01-01')
+        self.assertEqual(specific_named_partition.get('totalSize'),
+                         5000)
         self.assertEqual(specific_named_partition.get('numRows'), 30)
 
-        self.hook.metastore.__enter__().get_partition_by_name.assert_called_with(
-            dbname=self.database, tbl_name=self.table, part_name='ds=2015-01-01'
-        )
+        self.hook.metastore.__enter__().get_partition_by_name.assert_called_with(dbname=self.database,
+                                                                                 tbl_name=self.table,
+                                                                                 part_name='ds=2015-01-01')
 
     def test_table_exists(self):
         # Test with existent table.

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -524,22 +524,19 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
         FakePartition = namedtuple('FakePartition', ['values'])
         fake_partition = FakePartition(['2015-01-01'])
         FakePartitionDetails = namedtuple(
-            'FakePartitionDetails',
-            ['partitionKey', 'partitionValue', 'details']
+            'FakePartitionDetails', ['partitionKey', 'partitionValue', 'details']
         )
         fake_partition_details = FakePartitionDetails(
             partitionKey=fake_schema.name,
             partitionValue=fake_partition.values,
-            details={'totalSize': 5000, 'numRows': 30}
+            details={'totalSize': 5000, 'numRows': 30},
         )
 
         self.hook.metastore.__enter__().get_partition_by_name = mock.MagicMock(
             return_value=fake_partition_details.details
         )
         specific_named_partition = self.hook.get_partition_by_name(
-            db_name=self.database,
-            tbl_name=self.table,
-            part_name='ds=2015-01-01'
+            db_name=self.database, tbl_name=self.table, part_name='ds=2015-01-01'
         )
         self.assertEqual(specific_named_partition.get('totalSize'), 5000)
         self.assertEqual(specific_named_partition.get('numRows'), 30)


### PR DESCRIPTION
Hello Airflow Maintainers,
This PR is introducing the capability to get partition object by name directly through a hook method. This could be often useful to derive multiple useful statistics for a particular partition.
