### PR TITLE
includes the STS token if STS credentials are used

### DIFF
--- a/airflow/providers/amazon/aws/utils/redshift.py
+++ b/airflow/providers/amazon/aws/utils/redshift.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from botocore.credentials import ReadOnlyCredentials
+
+log = logging.getLogger(__name__)
+
+
+def build_credentials_block(credentials: ReadOnlyCredentials) -> str:
+    """
+    Generate AWS credentials block for Redshift COPY and UNLOAD
+    commands, as noted in AWS docs
+    https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html#copy-credentials
+
+    :param credentials: ReadOnlyCredentials object from `botocore`
+    :return: str
+    """
+    if credentials.token:
+        log.debug("STS token found in credentials, including it in the command")
+        # these credentials are obtained from AWS STS
+        # so the token must be included in the CREDENTIALS clause
+        credentials_line = (
+            f"aws_access_key_id={credentials.access_key};"
+            f"aws_secret_access_key={credentials.secret_key};"
+            f"token={credentials.token}"
+        )
+
+    else:
+        credentials_line = (
+            f"aws_access_key_id={credentials.access_key};" f"aws_secret_access_key={credentials.secret_key}"
+        )
+
+    return credentials_line

--- a/tests/providers/amazon/aws/utils/test_redshift.py
+++ b/tests/providers/amazon/aws/utils/test_redshift.py
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+from unittest import mock
+
+from boto3.session import Session
+
+from airflow.providers.amazon.aws.utils.redshift import build_credentials_block
+
+
+class TestS3ToRedshiftTransfer(unittest.TestCase):
+    @mock.patch("boto3.session.Session")
+    def test_build_credentials_block(self, mock_session):
+        access_key = "aws_access_key_id"
+        secret_key = "aws_secret_access_key"
+        token = "aws_secret_token"
+        mock_session.return_value = Session(access_key, secret_key)
+        mock_session.return_value.access_key = access_key
+        mock_session.return_value.secret_key = secret_key
+        mock_session.return_value.token = None
+
+        credentials_block = build_credentials_block(mock_session.return_value)
+
+        assert access_key in credentials_block
+        assert secret_key in credentials_block
+        assert token not in credentials_block
+
+    @mock.patch("boto3.session.Session")
+    def test_build_credentials_block_sts(self, mock_session):
+        access_key = "ASIA_aws_access_key_id"
+        secret_key = "aws_secret_access_key"
+        token = "aws_secret_token"
+        mock_session.return_value = Session(access_key, secret_key)
+        mock_session.return_value.access_key = access_key
+        mock_session.return_value.secret_key = secret_key
+        mock_session.return_value.token = token
+
+        credentials_block = build_credentials_block(mock_session.return_value)
+
+        assert access_key in credentials_block
+        assert secret_key in credentials_block
+        assert token in credentials_block


### PR DESCRIPTION
Includes the STS token if temporary STS credentials are used, as per AWS docs https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html#copy-credentials

I'm not sure if I updated the tests in the correct way - they are passing but maybe I should have created tests
for the specific functions I added rather than extending the tests for the `execute` functions. I'll split them if requested.

closes: #9970

pinging @potiuk and @turbaszek because you guys were reviewing #10337 which tries to solve the same problem