### PR TITLE
Add GCP Service Account rule

### DIFF
--- a/airflow/upgrade/rules/gcp_service_account_keys_rule.py
+++ b/airflow/upgrade/rules/gcp_service_account_keys_rule.py
@@ -24,17 +24,16 @@ from airflow.upgrade.rules.base_rule import BaseRule
 class GCPServiceAccountKeyRule(BaseRule):
     title = "GCP service account key deprecation"
 
-    description = """
-Option has been removed because it is no longer supported by the Google Kubernetes Engine."""
+    description = """Option has been removed because it is no longer \
+supported by the Google Kubernetes Engine."""
 
     def check(self):
         gcp_option = conf.get(section="kubernetes", key="gcp_service_account_keys")
-        if gcp_option != "":
-            msg = """
-This option has been removed because it is no longer \
+        if gcp_option:
+            msg = """This option has been removed because it is no longer \
 supported by the Google Kubernetes Engine. The new recommended \
 service account keys for the Google Cloud management method is \
 Workload Identity."""
             return [msg]
         else:
-            return []
+            return None

--- a/airflow/upgrade/rules/gcp_service_account_keys_rule.py
+++ b/airflow/upgrade/rules/gcp_service_account_keys_rule.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.configuration import conf
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class GCPServiceAccountKeyRule(BaseRule):
+    title = "GCP service account key deprecation"
+
+    description = """
+Option has been removed because it is no longer supported by the Google Kubernetes Engine.
+    """
+
+    def check(self):
+        gcp_option = conf.get(section="kubernetes", key="gcp_service_account_keys")
+        if gcp_option != "":
+            msg = "This option has been removed because it is no longer \
+                supported by the Google Kubernetes Engine. The new recommended \
+                service account keys for the Google Cloud management method is \
+                Workload Identity."
+            return [msg]
+        else:
+            return []

--- a/airflow/upgrade/rules/gcp_service_account_keys_rule.py
+++ b/airflow/upgrade/rules/gcp_service_account_keys_rule.py
@@ -25,8 +25,7 @@ class GCPServiceAccountKeyRule(BaseRule):
     title = "GCP service account key deprecation"
 
     description = """
-Option has been removed because it is no longer supported by the Google Kubernetes Engine.
-    """
+Option has been removed because it is no longer supported by the Google Kubernetes Engine."""
 
     def check(self):
         gcp_option = conf.get(section="kubernetes", key="gcp_service_account_keys")

--- a/airflow/upgrade/rules/gcp_service_account_keys_rule.py
+++ b/airflow/upgrade/rules/gcp_service_account_keys_rule.py
@@ -31,10 +31,11 @@ Option has been removed because it is no longer supported by the Google Kubernet
     def check(self):
         gcp_option = conf.get(section="kubernetes", key="gcp_service_account_keys")
         if gcp_option != "":
-            msg = "This option has been removed because it is no longer \
-                supported by the Google Kubernetes Engine. The new recommended \
-                service account keys for the Google Cloud management method is \
-                Workload Identity."
+            msg = """
+This option has been removed because it is no longer \
+supported by the Google Kubernetes Engine. The new recommended \
+service account keys for the Google Cloud management method is \
+Workload Identity."""
             return [msg]
         else:
             return []

--- a/tests/upgrade/rules/test_gcp_service_account_key_rule.py
+++ b/tests/upgrade/rules/test_gcp_service_account_key_rule.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.upgrade.rules.send_grid_moved import GCPServiceAccountKeyRule
+from tests.test_utils.config import conf_vars
+
+
+class TestGCPServiceAccountKeyRule(TestCase):
+
+    @conf_vars({("kubernetes", "gcp_service_account_keys"): "key_name:key_path"})
+    def test_invalid_check(self):
+        rule = GCPServiceAccountKeyRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        msg = "This option has been removed because it is no longer \
+            supported by the Google Kubernetes Engine. The new recommended \
+            service account keys for the Google Cloud management method is \
+            Workload Identity."
+        response = rule.check()
+        assert response == [msg]
+
+    @conf_vars({("kubernetes", "gcp_service_account_keys"): ""})
+    def test_valid_check(self):
+        rule = GCPServiceAccountKeyRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        msg = []
+        response = rule.check()
+        assert response == msg

--- a/tests/upgrade/rules/test_gcp_service_account_key_rule.py
+++ b/tests/upgrade/rules/test_gcp_service_account_key_rule.py
@@ -16,7 +16,7 @@
 # under the License.
 from unittest import TestCase
 
-from airflow.upgrade.rules.send_grid_moved import GCPServiceAccountKeyRule
+from airflow.upgrade.rules.gcp_service_account_keys_rule import GCPServiceAccountKeyRule
 from tests.test_utils.config import conf_vars
 
 
@@ -29,10 +29,11 @@ class TestGCPServiceAccountKeyRule(TestCase):
         assert isinstance(rule.description, str)
         assert isinstance(rule.title, str)
 
-        msg = "This option has been removed because it is no longer \
-            supported by the Google Kubernetes Engine. The new recommended \
-            service account keys for the Google Cloud management method is \
-            Workload Identity."
+        msg = """
+This option has been removed because it is no longer \
+supported by the Google Kubernetes Engine. The new recommended \
+service account keys for the Google Cloud management method is \
+Workload Identity."""
         response = rule.check()
         assert response == [msg]
 

--- a/tests/upgrade/rules/test_gcp_service_account_key_rule.py
+++ b/tests/upgrade/rules/test_gcp_service_account_key_rule.py
@@ -29,8 +29,7 @@ class TestGCPServiceAccountKeyRule(TestCase):
         assert isinstance(rule.description, str)
         assert isinstance(rule.title, str)
 
-        msg = """
-This option has been removed because it is no longer \
+        msg = """This option has been removed because it is no longer \
 supported by the Google Kubernetes Engine. The new recommended \
 service account keys for the Google Cloud management method is \
 Workload Identity."""
@@ -44,6 +43,6 @@ Workload Identity."""
         assert isinstance(rule.description, str)
         assert isinstance(rule.title, str)
 
-        msg = []
+        msg = None
         response = rule.check()
         assert response == msg


### PR DESCRIPTION
Adds GCP Service Account rule check for Kubernetes configuration.

Related: #8765
Closes: #11047