### PR TITLE
Restore description for provider packages.

### DIFF
--- a/backport_packages/setup_backport_packages.py
+++ b/backport_packages/setup_backport_packages.py
@@ -213,7 +213,10 @@ def get_long_description(provider_package_id: str) -> str:
     :return: content of the description (README file)
     """
     package_folder = get_target_providers_package_folder(provider_package_id)
-    with open(os.path.join(package_folder, "README.md"), encoding='utf-8', mode="w+") as file:
+    readme_file = os.path.join(package_folder, "README.md")
+    if not(os.path.exists(readme_file)):
+        return ""
+    with open(os.path.join(package_folder, "README.md"), encoding='utf-8', mode="r") as file:
         readme_contents = file.read()
     copying = True
     long_description = ""


### PR DESCRIPTION
The change #10445 caused empty descriptions for all packages.

This change restores it and also makes sure package creation works
when there is no README.md

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
