### PR TITLE
Add task adoption to CeleryKubernetesExecutor

### DIFF
--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union
 
 from airflow.configuration import conf
 from airflow.executors.base_executor import CommandType, EventBufferValueType, QueuedTaskInstanceType
@@ -130,6 +130,28 @@ class CeleryKubernetesExecutor(LoggingMixin):
         cleared_events_from_kubernetes = self.kubernetes_executor.get_event_buffer(dag_ids)
 
         return {**cleared_events_from_celery, **cleared_events_from_kubernetes}
+
+    def try_adopt_task_instances(self, tis: List[TaskInstance]) -> List[TaskInstance]:
+        """
+        Try to adopt running task instances that have been abandoned by a SchedulerJob dying.
+
+        Anything that is not adopted will be cleared by the scheduler (and then become eligible for
+        re-scheduling)
+
+        :return: any TaskInstances that were unable to be adopted
+        :rtype: list[airflow.models.TaskInstance]
+        """
+        celery_tis = []
+        kubernetes_tis = []
+        abandoned_tis = []
+        for ti in tis:
+            if ti.queue == self.KUBERNETES_QUEUE:
+                kubernetes_tis.append(ti)
+            else:
+                celery_tis.append(ti)
+        abandoned_tis.extend(self.celery_executor.try_adopt_task_instances(celery_tis))
+        abandoned_tis.extend(self.kubernetes_executor.try_adopt_task_instances(kubernetes_tis))
+        return abandoned_tis
 
     def end(self) -> None:
         """

--- a/tests/executors/test_celery_kubernetes_executor.py
+++ b/tests/executors/test_celery_kubernetes_executor.py
@@ -201,6 +201,38 @@ class TestCeleryKubernetesExecutor:
         when_ti_in_k8s_executor()
         when_ti_in_celery_executor()
 
+    def test_adopt_tasks(self):
+        ti = mock.MagicMock
+
+        def when_ti_in_k8s_executor():
+            celery_executor_mock = mock.MagicMock()
+            k8s_executor_mock = mock.MagicMock()
+            ti.queue = "kubernetes"
+            cke = CeleryKubernetesExecutor(celery_executor_mock, k8s_executor_mock)
+
+            celery_executor_mock.try_adopt_task_instances.return_value = []
+            k8s_executor_mock.try_adopt_task_instances.return_value = []
+
+            cke.try_adopt_task_instances([ti])
+            celery_executor_mock.try_adopt_task_instances.assert_called_once_with([])
+            k8s_executor_mock.try_adopt_task_instances.assert_called_once_with([ti])
+
+        def when_ti_in_celery_executor():
+            celery_executor_mock = mock.MagicMock()
+            k8s_executor_mock = mock.MagicMock()
+            ti.queue = "default"
+            cke = CeleryKubernetesExecutor(celery_executor_mock, k8s_executor_mock)
+
+            celery_executor_mock.try_adopt_task_instances.return_value = []
+            k8s_executor_mock.try_adopt_task_instances.return_value = []
+
+            cke.try_adopt_task_instances([ti])
+            celery_executor_mock.try_adopt_task_instances.assert_called_once_with([ti])
+            k8s_executor_mock.try_adopt_task_instances.assert_called_once_with([])
+
+        when_ti_in_k8s_executor()
+        when_ti_in_celery_executor()
+
     def test_get_event_buffer(self):
         celery_executor_mock = mock.MagicMock()
         k8s_executor_mock = mock.MagicMock()


### PR DESCRIPTION
Routes task adoption based on queue name to CeleryExecutor
or KubernetesExecutor

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
