### PR TITLE
Bug Fix: Ensure target_dedicated_nodes or enable_auto_scale is set in AzureBatchOperator

### DIFF
--- a/airflow/providers/microsoft/azure/operators/azure_batch.py
+++ b/airflow/providers/microsoft/azure/operators/azure_batch.py
@@ -234,7 +234,7 @@ class AzureBatchOperator(BaseOperator):
                 )
         if not self.target_dedicated_nodes and not self.enable_auto_scale:
             raise AirflowException(
-                "Either target_dedicated_nodes or enable_auto_scale " "must be set. None was set"
+                "Either target_dedicated_nodes or enable_auto_scale must be set. None was set"
             )
         if self.enable_auto_scale:
             if self.target_dedicated_nodes or self.target_low_priority_nodes:

--- a/airflow/providers/microsoft/azure/operators/azure_batch.py
+++ b/airflow/providers/microsoft/azure/operators/azure_batch.py
@@ -232,6 +232,10 @@ class AzureBatchOperator(BaseOperator):
                         self.vm_publisher, self.vm_offer, self.sku_starts_with
                     )
                 )
+        if not self.target_dedicated_nodes and not self.enable_auto_scale:
+            raise AirflowException(
+                "Either target_dedicated_nodes or enable_auto_scale " "must be set. None was set"
+            )
         if self.enable_auto_scale:
             if self.target_dedicated_nodes or self.target_low_priority_nodes:
                 raise AirflowException(
@@ -243,7 +247,7 @@ class AzureBatchOperator(BaseOperator):
                     )
                 )
             if not self.auto_scale_formula:
-                raise AirflowException("The auto_scale_formula is required when enable_auto_scale is" " set")
+                raise AirflowException("The auto_scale_formula is required when enable_auto_scale is set")
         if self.batch_job_release_task and not self.batch_job_preparation_task:
             raise AirflowException(
                 "A batch_job_release_task cannot be specified without also "

--- a/tests/providers/microsoft/azure/operators/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_batch.py
@@ -32,9 +32,14 @@ BATCH_POOL_ID = "MyPool"
 BATCH_JOB_ID = "MyJob"
 BATCH_TASK_ID = "MyTask"
 BATCH_VM_SIZE = "Standard"
+FORMULA = """$curTime = time();
+             $workHours = $curTime.hour >= 8 && $curTime.hour < 18;
+             $isWeekday = $curTime.weekday >= 1 && $curTime.weekday <= 5;
+             $isWorkingWeekdayHour = $workHours && $isWeekday;
+             $TargetDedicated = $isWorkingWeekdayHour ? 20:10;"""
 
 
-class TestAzureBatchOperator(unittest.TestCase):
+class TestAzureBatchOperator(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
     # set up the test environment
     @mock.patch("airflow.providers.microsoft.azure.hooks.azure_batch.AzureBatchHook")
     @mock.patch("airflow.providers.microsoft.azure.hooks.azure_batch.BatchServiceClient")
@@ -96,6 +101,40 @@ class TestAzureBatchOperator(unittest.TestCase):
             batch_task_id=BATCH_TASK_ID,
             batch_task_command_line="echo hello",
             azure_batch_conn_id=self.test_vm_conn_id,
+            target_dedicated_nodes=1,
+            timeout=2,
+        )
+        self.operator2_pass = AzureBatchOperator(
+            task_id=TASK_ID,
+            batch_pool_id=BATCH_POOL_ID,
+            batch_pool_vm_size=BATCH_VM_SIZE,
+            batch_job_id=BATCH_JOB_ID,
+            batch_task_id=BATCH_TASK_ID,
+            batch_task_command_line="echo hello",
+            azure_batch_conn_id=self.test_vm_conn_id,
+            enable_auto_scale=True,
+            auto_scale_formula=FORMULA,
+            timeout=2,
+        )
+        self.operator2_no_formula = AzureBatchOperator(
+            task_id=TASK_ID,
+            batch_pool_id=BATCH_POOL_ID,
+            batch_pool_vm_size=BATCH_VM_SIZE,
+            batch_job_id=BATCH_JOB_ID,
+            batch_task_id=BATCH_TASK_ID,
+            batch_task_command_line="echo hello",
+            azure_batch_conn_id=self.test_vm_conn_id,
+            enable_auto_scale=True,
+            timeout=2,
+        )
+        self.operator_fail = AzureBatchOperator(
+            task_id=TASK_ID,
+            batch_pool_id=BATCH_POOL_ID,
+            batch_pool_vm_size=BATCH_VM_SIZE,
+            batch_job_id=BATCH_JOB_ID,
+            batch_task_id=BATCH_TASK_ID,
+            batch_task_command_line="echo hello",
+            azure_batch_conn_id=self.test_vm_conn_id,
             timeout=2,
         )
         self.batch_client = mock_batch.return_value
@@ -105,6 +144,15 @@ class TestAzureBatchOperator(unittest.TestCase):
     def test_execute_without_failures(self, wait_mock):
         wait_mock.return_value = True  # No wait
         self.operator.execute(None)
+        # test pool creation
+        self.batch_client.pool.add.assert_called()
+        self.batch_client.job.add.assert_called()
+        self.batch_client.task.add.assert_called()
+
+    @mock.patch.object(AzureBatchHook, 'wait_for_all_node_state')
+    def test_execute_without_failures_2(self, wait_mock):
+        wait_mock.return_value = True  # No wait
+        self.operator2_pass.execute(None)
         # test pool creation
         self.batch_client.pool.add.assert_called()
         self.batch_client.job.add.assert_called()
@@ -129,3 +177,20 @@ class TestAzureBatchOperator(unittest.TestCase):
         self.operator.execute(None)
         mock_clean.assert_called()
         mock_clean.assert_called_once_with(job_id=BATCH_JOB_ID)
+
+    @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
+    def test_operator_fails(self, wait_mock):
+        wait_mock.return_value = True
+        with self.assertRaises(AirflowException) as e:
+            self.operator_fail.execute(None)
+        self.assertEqual(
+            str(e.exception),
+            "Either target_dedicated_nodes or enable_auto_scale " "must be set. None was set",
+        )
+
+    @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
+    def test_operator_fails_no_formula(self, wait_mock):
+        wait_mock.return_value = True
+        with self.assertRaises(AirflowException) as e:
+            self.operator2_no_formula.execute(None)
+        self.assertEqual(str(e.exception), "The auto_scale_formula is required when enable_auto_scale is set")


### PR DESCRIPTION
Currently, If target_dedicated_nodes or enable_auto_scale is not set in AzureBatchOperator, the operator times out waiting for its created tasks to complete. This is because the node that should run the task is not set. This PR adds an exception if target_dedicated_nodes or enable_auto_scale is not set. 
I also added more unit tests for the operator.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
