### PR TITLE
Add missing "example" tag on example DAG

### DIFF
--- a/airflow/example_dags/example_nested_branch_dag.py
+++ b/airflow/example_dags/example_nested_branch_dag.py
@@ -27,7 +27,12 @@ from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.utils.dates import days_ago
 
-with DAG(dag_id="example_nested_branch_dag", start_date=days_ago(2), schedule_interval="@daily") as dag:
+with DAG(
+    dag_id="example_nested_branch_dag",
+    start_date=days_ago(2),
+    schedule_interval="@daily",
+    tags=['example']
+) as dag:
     branch_1 = BranchPythonOperator(task_id="branch_1", python_callable=lambda: "true_1")
     join_1 = DummyOperator(task_id="join_1", trigger_rule="none_failed_or_skipped")
     true_1 = DummyOperator(task_id="true_1")

--- a/airflow/example_dags/example_nested_branch_dag.py
+++ b/airflow/example_dags/example_nested_branch_dag.py
@@ -31,7 +31,7 @@ with DAG(
     dag_id="example_nested_branch_dag",
     start_date=days_ago(2),
     schedule_interval="@daily",
-    tags=['example']
+    tags=["example"]
 ) as dag:
     branch_1 = BranchPythonOperator(task_id="branch_1", python_callable=lambda: "true_1")
     join_1 = DummyOperator(task_id="join_1", trigger_rule="none_failed_or_skipped")

--- a/airflow/example_dags/example_task_group.py
+++ b/airflow/example_dags/example_task_group.py
@@ -25,7 +25,7 @@ from airflow.utils.dates import days_ago
 from airflow.utils.task_group import TaskGroup
 
 # [START howto_task_group]
-with DAG(dag_id="example_task_group", start_date=days_ago(2)) as dag:
+with DAG(dag_id="example_task_group", start_date=days_ago(2), tags=['example']) as dag:
     start = DummyOperator(task_id="start")
 
     # [START howto_task_group_section_1]

--- a/airflow/example_dags/example_task_group.py
+++ b/airflow/example_dags/example_task_group.py
@@ -25,7 +25,7 @@ from airflow.utils.dates import days_ago
 from airflow.utils.task_group import TaskGroup
 
 # [START howto_task_group]
-with DAG(dag_id="example_task_group", start_date=days_ago(2), tags=['example']) as dag:
+with DAG(dag_id="example_task_group", start_date=days_ago(2), tags=["example"]) as dag:
     start = DummyOperator(task_id="start")
 
     # [START howto_task_group_section_1]


### PR DESCRIPTION
`example_task_group` and `example_nested_branch_dag` didn't have the example tag while all the other ones do have it

![image](https://user-images.githubusercontent.com/8811558/94988514-aac7f900-0565-11eb-9020-ba6f19f5c049.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
