### PR TITLE
Add operator link to access DAG triggered by TriggerDagRunOperator

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -18,19 +18,25 @@
 
 import datetime
 from typing import Dict, Optional, Union
+from urllib.parse import quote
 
 from airflow.api.common.experimental.trigger_dag import trigger_dag
-from airflow.models import BaseOperator, DagRun, BaseOperatorLink
+from airflow.models import BaseOperator, BaseOperatorLink, DagRun
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.types import DagRunType
 
 
 class TriggerDagRunLink(BaseOperatorLink):
+    """
+    Operator link for TriggerDagRunOperator. It allows users to access
+    DAG triggered by task using TriggerDagRunOperator.
+    """
+    
     name = 'Triggered DAG'
 
-    def get_link(self, operator: "TriggerDagRunOperator", dttm):
-        return f"/graph?dag_id={operator.trigger_dag_id}&root=&execution_date={dttm}"
+    def get_link(self, operator, dttm):
+        return f"/graph?dag_id={operator.trigger_dag_id}&root=&execution_date={quote(dttm.isoformat())}"
 
 
 class TriggerDagRunOperator(BaseOperator):

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -32,7 +32,7 @@ class TriggerDagRunLink(BaseOperatorLink):
     Operator link for TriggerDagRunOperator. It allows users to access
     DAG triggered by task using TriggerDagRunOperator.
     """
-    
+
     name = 'Triggered DAG'
 
     def get_link(self, operator, dttm):

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -20,10 +20,17 @@ import datetime
 from typing import Dict, Optional, Union
 
 from airflow.api.common.experimental.trigger_dag import trigger_dag
-from airflow.models import BaseOperator, DagRun
+from airflow.models import BaseOperator, DagRun, BaseOperatorLink
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.types import DagRunType
+
+
+class TriggerDagRunLink(BaseOperatorLink):
+    name = 'Triggered DAG'
+
+    def get_link(self, operator: "TriggerDagRunOperator", dttm):
+        return f"/graph?dag_id={operator.trigger_dag_id}&root=&execution_date={dttm}"
 
 
 class TriggerDagRunOperator(BaseOperator):
@@ -40,6 +47,13 @@ class TriggerDagRunOperator(BaseOperator):
 
     template_fields = ("trigger_dag_id", "execution_date", "conf")
     ui_color = "#ffefeb"
+
+    @property
+    def operator_extra_links(self):
+        """
+        Return operator extra links
+        """
+        return [TriggerDagRunLink()]
 
     @apply_defaults
     def __init__(

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -53,7 +53,8 @@ BUILTIN_OPERATOR_EXTRA_LINKS: List[str] = [
     "airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink",
     "airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink",
     "airflow.providers.google.cloud.operators.mlengine.AIPlatformConsoleLink",
-    "airflow.providers.qubole.operators.qubole.QDSLink"
+    "airflow.providers.qubole.operators.qubole.QDSLink",
+    "airflow.operators.dagrun_operator.TriggerDagRunLink",
 ]
 
 


### PR DESCRIPTION
This commit adds TriggerDagRunLink which allows users to access
easily access in Web UI a DAG triggered by TriggerDagRunOperator

<img width="585" alt="Screenshot 2020-10-03 at 13 21 13" src="https://user-images.githubusercontent.com/9528307/94990398-04d3b900-057c-11eb-97b5-d14384904da3.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
