### PR TITLE
Breeze: Fix issue with pulling an image via ID

### DIFF
--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -352,7 +352,7 @@ function build_images::prepare_ci_build() {
     if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
         if [[ -n ${GITHUB_TOKEN=} ]]; then
             echo "${GITHUB_TOKEN}" | docker login \
-                --username "${GITHUB_USERNAME}" \
+                --username "${GITHUB_USERNAME:-apache}" \
                 --password-stdin \
                 "${GITHUB_REGISTRY}"
         fi


### PR DESCRIPTION
Error:

```
❯ ./breeze --github-image-id 285629517

GitHub image id: 285629517

Force pulling the image, using github registry and skip mounting local sources.
This is in order to get the exact same version as used in CI environment for SHA/RUN_ID!.

Must provide --username with --password-stdin
```

After the fix from the PR it works fine.

```
❯ ./breeze --github-image-id 285629517

GitHub image id: 285629517

Force pulling the image, using github registry and skip mounting local sources.
This is in order to get the exact same version as used in CI environment for SHA/RUN_ID!.

Login Succeeded

Force pull base image python:3.6-slim-buster

Pulling the image docker.pkg.github.com/apache/airflow/python:3.6-slim-buster-285629517

```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
