### PR TITLE
Update SendGridEmail with None return type

### DIFF
--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -36,5 +36,3 @@ The SendGrid module `airflow.contrib.utils.sendgrid` was moved to `airflow.provi
             msg = "Email backend option uses airflow.contrib Sendgrid module. " \
                   + "Please use new module: {}".format(email_provider_path)
             return [msg]
-        else:
-            return None

--- a/airflow/upgrade/rules/send_grid_moved.py
+++ b/airflow/upgrade/rules/send_grid_moved.py
@@ -37,4 +37,4 @@ The SendGrid module `airflow.contrib.utils.sendgrid` was moved to `airflow.provi
                   + "Please use new module: {}".format(email_provider_path)
             return [msg]
         else:
-            return []
+            return None

--- a/tests/upgrade/rules/test_send_grid_moved.py
+++ b/tests/upgrade/rules/test_send_grid_moved.py
@@ -42,6 +42,6 @@ class TestSendGridEmailerMovedRule(TestCase):
         assert isinstance(rule.description, str)
         assert isinstance(rule.title, str)
 
-        msg = []
+        msg = None
         response = rule.check()
         assert response == msg


### PR DESCRIPTION
As a result of #11081 I am updating the `SendGridEmail` rule to return `None` instead of `[]`.

Part of #11067 
