### PR TITLE
Add Hacktoberfest topic to the repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,7 @@ github:
     - python
     - scheduler
     - workflow
+    - hactoberfest
   features:
     # Enable issues management
     issues: true

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,7 +27,7 @@ github:
     - python
     - scheduler
     - workflow
-    - hactoberfest
+    - hacktoberfest
   features:
     # Enable issues management
     issues: true


### PR DESCRIPTION
According to https://hacktoberfest.digitalocean.com/hacktoberfest-update as of today projects must add hacktoberfest topic to opt-in. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
