### PR TITLE
Fix incorrect cloudwatch and wasb taskhandler path in config template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           if [[ ${EVENT_NAME} == "pull_request" ]]; then
             # Run selective checks
-            ./scripts/ci/selective_ci_checks.sh "${MERGE_COMMIT_SHA}"
+            ./scripts/ci/selective_ci_checks.sh "${MERGE_COMMIT_SHA}" "${GITHUB_SHA}"
           else
             # Run all checks
             ./scripts/ci/selective_ci_checks.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,13 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 2
         if: github.event_name  == 'pull_request'
+      - name: >
+          Fetch commit ${{ github.ref }} ( ${{ github.sha }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+        if: github.event_name  == 'pull_request'
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} : merge commit ${{ github.merge_commit_sha }} )"
         uses: actions/checkout@v2
       - name: >

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -186,7 +186,7 @@ if REMOTE_LOGGING:
     elif REMOTE_BASE_LOG_FOLDER.startswith('cloudwatch://'):
         CLOUDWATCH_REMOTE_HANDLERS: Dict[str, Dict[str, str]] = {
             'task': {
-                'class': 'airflow.utils.log.cloudwatch_task_handler.CloudwatchTaskHandler',
+                'class': 'airflow.providers.amazon.aws.log.cloudwatch_task_handler.CloudwatchTaskHandler',
                 'formatter': 'airflow',
                 'base_log_folder': str(os.path.expanduser(BASE_LOG_FOLDER)),
                 'log_group_arn': urlparse(REMOTE_BASE_LOG_FOLDER).netloc,
@@ -212,7 +212,7 @@ if REMOTE_LOGGING:
     elif REMOTE_BASE_LOG_FOLDER.startswith('wasb'):
         WASB_REMOTE_HANDLERS: Dict[str, Dict[str, Union[str, bool]]] = {
             'task': {
-                'class': 'airflow.utils.log.wasb_task_handler.WasbTaskHandler',
+                'class': 'airflow.providers.microsoft.azure.log.wasb_task_handler.WasbTaskHandler',
                 'formatter': 'airflow',
                 'base_log_folder': str(os.path.expanduser(BASE_LOG_FOLDER)),
                 'wasb_log_folder': REMOTE_BASE_LOG_FOLDER,

--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -393,11 +393,28 @@ if (($# < 1)); then
 fi
 
 MERGE_COMMIT_SHA="${1}"
+
+if (($# > 1)); then
+    COMMIT_SHA="${2}"
+    echo
+    echo "Commit SHA : ${COMMIT_SHA}"
+    echo
+    if [[ ${MERGE_COMMIT_SHA} == "" ]]; then
+       MERGE_COMMIT_SHA=${COMMIT_SHA}
+    fi
+fi
 readonly MERGE_COMMIT_SHA
 
 echo
 echo "Merge commit SHA: ${MERGE_COMMIT_SHA}"
 echo
+
+if [[ ${MERGE_COMMIT_SHA} == "" ]] ; then
+    echo
+    echo "Merge commit SHA empty - running all tests!"
+    echo
+    set_outputs_run_everything_and_exit
+fi
 
 image_build_needed="false"
 tests_needed="false"


### PR DESCRIPTION
CloudwatchTaskHandler and WasbTaskHandler were moved to their respective provider packages but their references at airflow_local_settings were not updated. This PR updates it

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
