### PR TITLE
The bats script for CI image is now placed in the docker folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,7 +38,6 @@
 # Add those folders to the context so that they are available in the CI container
 !scripts/in_container
 !scripts/docker
-!scripts/ci/dockerfiles/bats
 
 # Add backport packages to the context
 !backport_packages

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -216,7 +216,7 @@ RUN mkdir -p /opt/bats/lib/bats-file \
 RUN echo "export PATH=/opt/bats/bin:${PATH}" >> /root/.bashrc
 
 # Additional scripts for managing BATS addons
-COPY scripts/ci/dockerfiles/bats/load.bash /opt/bats/lib/
+COPY scripts/docker/load.bash /opt/bats/lib/
 RUN chmod a+x /opt/bats/lib/load.bash
 
 

--- a/scripts/docker/load.bash
+++ b/scripts/docker/load.bash
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# shellcheck disable=SC1091
+source "/opt/bats/lib/bats-support/load.bash"
+# shellcheck disable=SC1091
+source "/opt/bats/lib/bats-assert/load.bash"
+# shellcheck disable=SC1091
+source "/opt/bats/lib/bats-file/load.bash"


### PR DESCRIPTION
The script was previously placed in scripts/ci which caused
a bit of a problem in 1-10-test branch where PRs were using
scripts/ci from the v1-10-test HEAD but they were missing
the ci script from the PR.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
