### PR TITLE
Enables retries of test in case of resource failure (137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,7 @@ jobs:
           path: "./files/airflow-backport-readme*"
 
   tests-postgres:
-    timeout-minutes: 60
+    timeout-minutes: 90
     name: "${{matrix.test-type}}:Pg${{matrix.postgres-version}},Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
     needs: [build-info, trigger-tests, ci-images]
@@ -406,7 +406,7 @@ jobs:
           path: "./files/coverage.xml"
 
   tests-mysql:
-    timeout-minutes: 60
+    timeout-minutes: 90
     name: "${{matrix.test-type}}:MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
     needs: [build-info, trigger-tests, ci-images]
@@ -452,7 +452,7 @@ jobs:
           path: "./files/coverage.xml"
 
   tests-sqlite:
-    timeout-minutes: 60
+    timeout-minutes: 90
     name: "${{matrix.test-type}}:Sqlite Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
     needs: [build-info, trigger-tests, ci-images]
@@ -495,7 +495,7 @@ jobs:
           path: ./files/coverage.xml
 
   tests-quarantined:
-    timeout-minutes: 60
+    timeout-minutes: 90
     name: "Quarantined tests"
     runs-on: ubuntu-latest
     continue-on-error: true


### PR DESCRIPTION
We experienc occasional failures in CI with 137 exit code which
indicates some kind of resource problem (memory/cpu/disk). We do
not have enough information to judge if this is connnected with
particular worker or maybe with some coincidental and temporary
resource starvation, so the best strategy for now is to retry
the test execution several times adding cleaning of the
docker compose and docker between.

In the worst case we will at least see if the problem persist for the
worker. In the best case, those 137 errors will be gone.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
