### PR TITLE
Bug fix: Job not deleted because pool_id is supplied as arg instead of job_id

### DIFF
--- a/airflow/providers/microsoft/azure/operators/azure_batch.py
+++ b/airflow/providers/microsoft/azure/operators/azure_batch.py
@@ -350,7 +350,7 @@ class AzureBatchOperator(BaseOperator):
         """
         if job_id:
             self.log.info("Deleting job: %s", job_id)
-            self.hook.connection.job.delete(pool_id)
+            self.hook.connection.job.delete(job_id)
         if pool_id:
             self.log.info("Deleting pool: %s", pool_id)
             self.hook.connection.pool.delete(pool_id)


### PR DESCRIPTION
Job is not being deleted in AzureBatchOperator because pool_id is supplied to delete function instead of job_id. This PR corrects that and adds a unit test to that effect.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
