### PR TITLE
Access task type via the property, not dundervars

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1111,7 +1111,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             return self.downstream_list
 
     def __repr__(self):
-        return "<Task({self.__class__.__name__}): {self.task_id}>".format(
+        return "<Task({self.task_type}): {self.task_id}>".format(
             self=self)
 
     @property

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -485,7 +485,7 @@ class DagRun(Base, LoggingMixin):
 
             if task.task_id not in task_ids:
                 Stats.incr(
-                    "task_instance_created-{}".format(task.__class__.__name__),
+                    "task_instance_created-{}".format(task.task_type),
                     1, 1)
                 ti = TI(task, self.execution_date)
                 task_instance_mutation_hook(ti)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1205,7 +1205,7 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         Stats.timing('dag.{dag_id}.{task_id}.duration'.format(dag_id=task_copy.dag_id,
                                                               task_id=task_copy.task_id),
                      duration)
-        Stats.incr('operator_successes_{}'.format(self.task.__class__.__name__), 1, 1)
+        Stats.incr('operator_successes_{}'.format(self.task.task_type), 1, 1)
         Stats.incr('ti_successes')
 
     @provide_session
@@ -1338,7 +1338,7 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         task = self.task
         self.end_date = timezone.utcnow()
         self.set_duration()
-        Stats.incr('operator_failures_{}'.format(task.__class__.__name__), 1, 1)
+        Stats.incr('operator_failures_{}'.format(task.task_type), 1, 1)
         Stats.incr('ti_failures')
         if not test_mode:
             session.add(Log(State.FAILED, self))

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1184,7 +1184,7 @@ may look like inside your ``airflow_local_settings.py``:
 .. code-block:: python
 
     def policy(task):
-        if task.__class__.__name__ == 'HivePartitionSensor':
+        if task.task_type == 'HivePartitionSensor':
             task.queue = "sensor_queue"
         if task.timeout > timedelta(hours=48):
             task.timeout = timedelta(hours=48)

--- a/tests/api/common/experimental/test_mark_tasks.py
+++ b/tests/api/common/experimental/test_mark_tasks.py
@@ -104,7 +104,7 @@ class TestMarkTasks(unittest.TestCase):
         self.assertTrue(len(tis) > 0)
 
         for ti in tis:  # pylint: disable=too-many-nested-blocks
-            self.assertEqual(ti.operator, dag.get_task(ti.task_id).__class__.__name__)
+            self.assertEqual(ti.operator, dag.get_task(ti.task_id).task_type)
             if ti.task_id in task_ids and ti.execution_date in execution_dates:
                 self.assertEqual(ti.state, state)
                 if state in State.finished():


### PR DESCRIPTION
We don't currently create TIs form serialized dags, but we are about to
start -- at which point some of these cases would have just shown
"SerializedBaseOperator", rather than the _real_ class name.

The other changes are just for "consistency" -- we should always get the
task type from this property, not via `__class__.__name__`.

I haven't set up a pre-commit rule for this as using this dunder
property is used elsewhere on things that are not BaseOperator
instances, and detecting that is hard to do in a pre-commit rule.


---


Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
