### PR TITLE
Switched to Run Checks for Building Images.

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -66,11 +66,6 @@ jobs:
           cancelMode: duplicates
           sourceRunId: ${{ github.event.workflow_run.id }}
           notifyPRCancel: true
-          notifyPRMessageStart: |
-            The CI and PROD Docker Images for the build are prepared in a separate "Build Image" workflow,
-            that you will not see in the list of checks (you will see "Wait for images" jobs instead).
-
-            You can checks the status of those images in
       - name: "Output BUILD_IMAGES"
         id: build-images
         run: |
@@ -274,6 +269,21 @@ jobs:
           else
               echo "::set-output name=proceed::false"
           fi
+      - name: Initiate Github Checks for Building image
+        uses: LouisBrunner/checks-action@v1.1.0
+        id: build-image-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Status of image build ${{ matrix.image-type }}: ${{ matrix.python-version }}"
+          status: "in_progress"
+          sha: ${{ needs.cancel-workflow-runs.outputs.sourceHeadSha }}
+          details_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: >
+            {"summary":
+            "Building the image: ${{ matrix.image-type }}: ${{ matrix.python-version }}. See the
+            [Image Build](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            for details" }
+        if: steps.defaults.outputs.proceed == 'true'
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} ) to 'main-airflow' to use main scripts"
         uses: actions/checkout@v2
         with:
@@ -307,6 +317,21 @@ jobs:
       - name: "Push PROD images ${{ matrix.python-version }}:${{ github.event.workflow_run.id }}"
         run: ./scripts/ci/images/ci_push_production_images.sh
         if: matrix.image-type == 'PROD' && steps.defaults.outputs.proceed == 'true'
+      - name: Update Github Checks for Building image with status
+        uses: LouisBrunner/checks-action@v1.1.0
+        if: always() && steps.defaults.outputs.proceed == 'true'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check_id: ${{ steps.build-image-check.outputs.check_id }}
+          status: "completed"
+          sha: ${{ needs.cancel-workflow-runs.outputs.sourceHeadSha }}
+          conclusion: ${{ job.status }}
+          details_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: >
+            {"summary":
+            "Building the image: ${{ matrix.image-type }}: ${{ matrix.python-version }}. See the
+            [Image Build](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            for details" }
 
   cancel-on-build-failure:
     name: "Cancel 'CI Build' jobs on build image failure"


### PR DESCRIPTION
Replaces the annoying comments with "workflow_run" links
with Run Checks. Now we will be able to see the "Build Image"
checks in the "Checks" section including their status and direct
link to the steps running the image builds as "Details" link.

Unfortunately Github Actions do not handle well the links to
details - even if you provide details_url to link to the other
run, the "Build Image" checks appear in the original workflow,
that's why we had to introduce another link in the summary of
the Build Image check that links to the actual workflow.

This is the best I can do now: 

The "Build Image" checks appear in the "checks"  of the PR. You can see their status (in_progress/ok/failed) and when you click such a "Build Image check" you will see the link to the other workflow running the build:

![Screenshot from 2020-10-05 11-17-12](https://user-images.githubusercontent.com/595491/95062023-ada92200-06fc-11eb-8f1d-66b353016940.png)

I think it's a very good solution - much better than the annoying comment.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
