### PR TITLE
Legacy ui deprecated rule fix

### DIFF
--- a/airflow/upgrade/rules/legacy_ui_deprecated.py
+++ b/airflow/upgrade/rules/legacy_ui_deprecated.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.configuration import conf
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class LegacyUIDeprecated(BaseRule):
+    title = "Legacy UI is deprecated by default"
+
+    description = "Legacy UI is deprecated. FAB RBAC is enabled by default in order to increase security."
+
+    def check(self):
+        if conf.has_option("webserver", "rbac"):
+            rbac = conf.get("webserver", "rbac")
+            if rbac == "false":
+                return (
+                    "rbac in airflow.cfg must be explicitly set empty as"
+                    " RBAC mechanism is enabled by default."
+                )

--- a/tests/upgrade/rules/test_legacy_ui_deprecated.py
+++ b/tests/upgrade/rules/test_legacy_ui_deprecated.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.upgrade.rules.legacy_ui_deprecated import LegacyUIDeprecated
+from tests.test_utils.config import conf_vars
+
+
+class TestLegacyUIDeprecated(TestCase):
+    @conf_vars({("webserver", "rbac"): "false"})
+    def test_invalid_check(self):
+        rule = LegacyUIDeprecated()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        msg = (
+            "rbac in airflow.cfg must be explicitly set empty as"
+            " RBAC mechanism is enabled by default."
+        )
+        response = rule.check()
+        assert response == msg
+
+    @conf_vars({("webserver", "rbac"): ""})
+    def test_valid_check(self):
+        rule = LegacyUIDeprecated()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        response = rule.check()
+        assert response is None


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Adds LegacyUIDeprecated rule to upgrade/rules as per:

https://github.com/apache/airflow/blob/master/UPDATING.md#drop-legacy-ui-in-favor-of-fab-rbac-ui

Closes: #11050 
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
