### PR TITLE
Improve GCSToSFTPOperator paths handling

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_gcs_to_sftp.py
+++ b/airflow/providers/google/cloud/example_dags/example_gcs_to_sftp.py
@@ -27,8 +27,8 @@ from airflow.utils.dates import days_ago
 
 BUCKET_SRC = os.environ.get("GCP_GCS_BUCKET_1_SRC", "test-gcs-sftp")
 OBJECT_SRC_1 = "parent-1.bin"
-OBJECT_SRC_2 = "parent-2.bin"
-OBJECT_SRC_3 = "subdir-1/*"
+OBJECT_SRC_2 = "subdir-1/parent-2.bin"
+OBJECT_SRC_3 = "subdir-2/*"
 DESTINATION_PATH_1 = "/tmp/single-file/"
 DESTINATION_PATH_2 = "/tmp/dirs/"
 

--- a/airflow/providers/google/cloud/example_dags/example_gcs_to_sftp.py
+++ b/airflow/providers/google/cloud/example_dags/example_gcs_to_sftp.py
@@ -23,14 +23,17 @@ import os
 
 from airflow import models
 from airflow.providers.google.cloud.transfers.gcs_to_sftp import GCSToSFTPOperator
+from airflow.providers.sftp.sensors.sftp import SFTPSensor
 from airflow.utils.dates import days_ago
 
+SFTP_CONN_ID = "ssh_default"
 BUCKET_SRC = os.environ.get("GCP_GCS_BUCKET_1_SRC", "test-gcs-sftp")
 OBJECT_SRC_1 = "parent-1.bin"
-OBJECT_SRC_2 = "subdir-1/parent-2.bin"
-OBJECT_SRC_3 = "subdir-2/*"
+OBJECT_SRC_2 = "dir-1/parent-2.bin"
+OBJECT_SRC_3 = "dir-2/*"
 DESTINATION_PATH_1 = "/tmp/single-file/"
-DESTINATION_PATH_2 = "/tmp/dirs/"
+DESTINATION_PATH_2 = "/tmp/dest-dir-1/"
+DESTINATION_PATH_3 = "/tmp/dest-dir-2/"
 
 
 with models.DAG(
@@ -39,15 +42,24 @@ with models.DAG(
     # [START howto_operator_gcs_to_sftp_copy_single_file]
     copy_file_from_gcs_to_sftp = GCSToSFTPOperator(
         task_id="file-copy-gsc-to-sftp",
+        sftp_conn_id=SFTP_CONN_ID,
         source_bucket=BUCKET_SRC,
         source_object=OBJECT_SRC_1,
         destination_path=DESTINATION_PATH_1,
     )
     # [END howto_operator_gcs_to_sftp_copy_single_file]
 
+    check_copy_file_from_gcs_to_sftp = SFTPSensor(
+        task_id="check-file-copy-gsc-to-sftp",
+        sftp_conn_id=SFTP_CONN_ID,
+        timeout=60,
+        path=os.path.join(DESTINATION_PATH_1, OBJECT_SRC_1),
+    )
+
     # [START howto_operator_gcs_to_sftp_move_single_file_destination]
     move_file_from_gcs_to_sftp = GCSToSFTPOperator(
         task_id="file-move-gsc-to-sftp",
+        sftp_conn_id=SFTP_CONN_ID,
         source_bucket=BUCKET_SRC,
         source_object=OBJECT_SRC_2,
         destination_path=DESTINATION_PATH_1,
@@ -55,20 +67,51 @@ with models.DAG(
     )
     # [END howto_operator_gcs_to_sftp_move_single_file_destination]
 
+    check_move_file_from_gcs_to_sftp = SFTPSensor(
+        task_id="check-file-move-gsc-to-sftp",
+        sftp_conn_id=SFTP_CONN_ID,
+        timeout=60,
+        path=os.path.join(DESTINATION_PATH_1, OBJECT_SRC_2),
+    )
+
     # [START howto_operator_gcs_to_sftp_copy_directory]
     copy_dir_from_gcs_to_sftp = GCSToSFTPOperator(
         task_id="dir-copy-gsc-to-sftp",
+        sftp_conn_id=SFTP_CONN_ID,
         source_bucket=BUCKET_SRC,
         source_object=OBJECT_SRC_3,
         destination_path=DESTINATION_PATH_2,
     )
     # [END howto_operator_gcs_to_sftp_copy_directory]
 
+    check_copy_dir_from_gcs_to_sftp = SFTPSensor(
+        task_id="check-dir-copy-gsc-to-sftp",
+        sftp_conn_id=SFTP_CONN_ID,
+        timeout=60,
+        path=os.path.join(DESTINATION_PATH_2, "dir-2", OBJECT_SRC_1),
+    )
+
     # [START howto_operator_gcs_to_sftp_move_specific_files]
     move_dir_from_gcs_to_sftp = GCSToSFTPOperator(
         task_id="dir-move-gsc-to-sftp",
+        sftp_conn_id=SFTP_CONN_ID,
         source_bucket=BUCKET_SRC,
         source_object=OBJECT_SRC_3,
-        destination_path=DESTINATION_PATH_2,
+        destination_path=DESTINATION_PATH_3,
+        keep_directory_structure=False,
     )
     # [END howto_operator_gcs_to_sftp_move_specific_files]
+
+    check_move_dir_from_gcs_to_sftp = SFTPSensor(
+        task_id="check-dir-move-gsc-to-sftp",
+        sftp_conn_id=SFTP_CONN_ID,
+        timeout=60,
+        path=os.path.join(DESTINATION_PATH_3, OBJECT_SRC_1),
+    )
+
+    move_file_from_gcs_to_sftp >> check_move_file_from_gcs_to_sftp
+    copy_dir_from_gcs_to_sftp >> check_copy_file_from_gcs_to_sftp
+
+    copy_dir_from_gcs_to_sftp >> move_dir_from_gcs_to_sftp
+    copy_dir_from_gcs_to_sftp >> check_copy_dir_from_gcs_to_sftp
+    move_dir_from_gcs_to_sftp >> check_move_dir_from_gcs_to_sftp

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -21,9 +21,8 @@ import os
 import unittest
 from unittest import mock
 
-from parameterized import parameterized
-
 import pytest
+from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.transfers.gcs_to_sftp import GCSToSFTPOperator

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -19,6 +19,9 @@
 
 import os
 import unittest
+
+import mock
+from parameterized import parameterized
 from unittest import mock
 
 import pytest
@@ -31,31 +34,31 @@ GCP_CONN_ID = "GCP_CONN_ID"
 SFTP_CONN_ID = "SFTP_CONN_ID"
 DELEGATE_TO = "DELEGATE_TO"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
-
 TEST_BUCKET = "test-bucket"
-SOURCE_OBJECT_WILDCARD_FILENAME = "test_object*.txt"
-SOURCE_OBJECT_NO_WILDCARD = "test_object.txt"
-SOURCE_OBJECT_MULTIPLE_WILDCARDS = "csv/*/test_*.csv"
-
-SOURCE_FILES_LIST = [
-    "test_object/file1.txt",
-    "test_object/file2.txt",
-    "test_object/file3.json",
-]
-
 DESTINATION_SFTP = "destination_path"
 
 
 # pylint: disable=unused-argument
 class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("folder/test_object.txt", "folder/test_object.txt", True),
+            ("folder/subfolder/test_object.txt", "folder/subfolder/test_object.txt", True),
+            ("folder/test_object.txt", "test_object.txt", False),
+            ("folder/subfolder/test_object.txt", "test_object.txt", False),
+        ]
+    )
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.GCSHook")
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.SFTPHook")
-    def test_execute_copy_single_file(self, sftp_hook, gcs_hook):
+    def test_execute_copy_single_file(
+        self, source_object, target_object, keep_directory_structure, sftp_hook_mock, gcs_hook_mock
+    ):
         task = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
-            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            source_object=source_object,
             destination_path=DESTINATION_SFTP,
+            keep_directory_structure=keep_directory_structure,
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
@@ -63,30 +66,42 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute({})
-        gcs_hook.assert_called_once_with(
+        gcs_hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        sftp_hook.assert_called_once_with(SFTP_CONN_ID)
+        sftp_hook_mock.assert_called_once_with(SFTP_CONN_ID)
 
-        args, kwargs = gcs_hook.return_value.download.call_args
-        assert kwargs["bucket_name"] == TEST_BUCKET
-        assert kwargs["object_name"] == SOURCE_OBJECT_NO_WILDCARD
+        gcs_hook_mock.return_value.download.assert_called_with(
+            bucket_name=TEST_BUCKET, object_name=source_object, filename=mock.ANY
+        )
 
-        args, kwargs = sftp_hook.return_value.store_file.call_args
-        assert args[0] == os.path.join(DESTINATION_SFTP, SOURCE_OBJECT_NO_WILDCARD)
+        sftp_hook_mock.return_value.store_file.assert_called_with(
+            os.path.join(DESTINATION_SFTP, target_object), mock.ANY
+        )
 
-        gcs_hook.return_value.delete.assert_not_called()
+        gcs_hook_mock.return_value.delete.assert_not_called()
 
+    @parameterized.expand(
+        [
+            ("folder/test_object.txt", "folder/test_object.txt", True),
+            ("folder/subfolder/test_object.txt", "folder/subfolder/test_object.txt", True),
+            ("folder/test_object.txt", "test_object.txt", False),
+            ("folder/subfolder/test_object.txt", "test_object.txt", False),
+        ]
+    )
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.GCSHook")
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.SFTPHook")
-    def test_execute_move_single_file(self, sftp_hook, gcs_hook):
+    def test_execute_move_single_file(
+        self, source_object, target_object, keep_directory_structure, sftp_hook_mock, gcs_hook_mock
+    ):
         task = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
-            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            source_object=source_object,
             destination_path=DESTINATION_SFTP,
+            keep_directory_structure=keep_directory_structure,
             move_object=True,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
@@ -94,31 +109,91 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         task.execute(None)
-        gcs_hook.assert_called_once_with(
+        gcs_hook_mock.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        sftp_hook.assert_called_once_with(SFTP_CONN_ID)
+        sftp_hook_mock.assert_called_once_with(SFTP_CONN_ID)
 
-        args, kwargs = gcs_hook.return_value.download.call_args
-        assert kwargs["bucket_name"] == TEST_BUCKET
-        assert kwargs["object_name"] == SOURCE_OBJECT_NO_WILDCARD
+        gcs_hook_mock.return_value.download.assert_called_with(
+            bucket_name=TEST_BUCKET, object_name=source_object, filename=mock.ANY
+        )
 
-        args, kwargs = sftp_hook.return_value.store_file.call_args
-        assert args[0] == os.path.join(DESTINATION_SFTP, SOURCE_OBJECT_NO_WILDCARD)
+        sftp_hook_mock.return_value.store_file.assert_called_with(
+            os.path.join(DESTINATION_SFTP, target_object), mock.ANY
+        )
 
-        gcs_hook.return_value.delete.assert_called_once_with(TEST_BUCKET, SOURCE_OBJECT_NO_WILDCARD)
+        gcs_hook_mock.return_value.delete.assert_called_once_with(TEST_BUCKET, source_object)
 
+    @parameterized.expand(
+        [
+            (
+                "folder/test_object*.txt",
+                "folder/test_object",
+                ".txt",
+                [
+                    "folder/test_object/file1.txt",
+                    "folder/test_object/file2.txt",
+                ],
+                ["test_object/file1.txt", "test_object/file2.txt"],
+                False,
+            ),
+            (
+                "folder/test_object/*",
+                "folder/test_object/",
+                "",
+                [
+                    "folder/test_object/file1.txt",
+                    "folder/test_object/file2.txt",
+                ],
+                ["file1.txt", "file2.txt"],
+                False,
+            ),
+            (
+                "folder/test_object*.txt",
+                "folder/test_object",
+                ".txt",
+                [
+                    "folder/test_object/file1.txt",
+                    "folder/test_object/file2.txt",
+                ],
+                ["folder/test_object/file1.txt", "folder/test_object/file2.txt"],
+                True,
+            ),
+            (
+                "folder/test_object/*",
+                "folder/test_object/",
+                "",
+                [
+                    "folder/test_object/file1.txt",
+                    "folder/test_object/file2.txt",
+                ],
+                ["folder/test_object/file1.txt", "folder/test_object/file2.txt"],
+                True,
+            ),
+        ]
+    )
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.GCSHook")
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.SFTPHook")
-    def test_execute_copy_with_wildcard(self, sftp_hook, gcs_hook):
-        gcs_hook.return_value.list.return_value = SOURCE_FILES_LIST[:2]
+    def test_execute_copy_with_wildcard(
+        self,
+        source_object,
+        prefix,
+        delimiter,
+        gcs_files_list,
+        target_objects,
+        keep_directory_structure,
+        sftp_hook_mock,
+        gcs_hook_mock,
+    ):
+        gcs_hook_mock.return_value.list.return_value = gcs_files_list
         operator = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
-            source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
+            source_object=source_object,
             destination_path=DESTINATION_SFTP,
+            keep_directory_structure=keep_directory_structure,
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
@@ -126,24 +201,91 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
         )
         operator.execute(None)
 
-        gcs_hook.return_value.list.assert_called_with(TEST_BUCKET, delimiter=".txt", prefix="test_object")
+        gcs_hook_mock.return_value.list.assert_called_with(TEST_BUCKET, delimiter=delimiter, prefix=prefix)
 
-        call_one, call_two = gcs_hook.return_value.download.call_args_list
-        assert call_one[1]["bucket_name"] == TEST_BUCKET
-        assert call_one[1]["object_name"] == "test_object/file1.txt"
+        gcs_hook_mock.return_value.download.assert_has_calls(
+            [
+                mock.call(bucket_name=TEST_BUCKET, object_name=gcs_file, filename=mock.ANY)
+                for gcs_file in gcs_files_list
+            ]
+        )
+        sftp_hook_mock.return_value.store_file.assert_has_calls(
+            [
+                mock.call(os.path.join(DESTINATION_SFTP, target_object), mock.ANY)
+                for target_object in target_objects
+            ]
+        )
 
-        assert call_two[1]["bucket_name"] == TEST_BUCKET
-        assert call_two[1]["object_name"] == "test_object/file2.txt"
+        gcs_hook_mock.return_value.delete.assert_not_called()
 
+    @parameterized.expand(
+        [
+            (
+                "folder/test_object*.txt",
+                "folder/test_object",
+                ".txt",
+                [
+                    "folder/test_object/file1.txt",
+                    "folder/test_object/file2.txt",
+                ],
+                ["test_object/file1.txt", "test_object/file2.txt"],
+                False,
+            ),
+            (
+                "folder/test_object/*",
+                "folder/test_object/",
+                "",
+                [
+                    "folder/test_object/file1.txt",
+                    "folder/test_object/file2.txt",
+                ],
+                ["file1.txt", "file2.txt"],
+                False,
+            ),
+            (
+                "folder/test_object*.txt",
+                "folder/test_object",
+                ".txt",
+                [
+                    "folder/test_object/file1.txt",
+                    "folder/test_object/file2.txt",
+                ],
+                ["folder/test_object/file1.txt", "folder/test_object/file2.txt"],
+                True,
+            ),
+            (
+                "folder/test_object/*",
+                "folder/test_object/",
+                "",
+                [
+                    "folder/test_object/file1.txt",
+                    "folder/test_object/file2.txt",
+                ],
+                ["folder/test_object/file1.txt", "folder/test_object/file2.txt"],
+                True,
+            ),
+        ]
+    )
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.GCSHook")
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.SFTPHook")
-    def test_execute_move_with_wildcard(self, sftp_hook, gcs_hook):
-        gcs_hook.return_value.list.return_value = SOURCE_FILES_LIST[:2]
+    def test_execute_move_with_wildcard(
+        self,
+        source_object,
+        prefix,
+        delimiter,
+        gcs_files_list,
+        target_objects,
+        keep_directory_structure,
+        sftp_hook_mock,
+        gcs_hook_mock,
+    ):
+        gcs_hook_mock.return_value.list.return_value = gcs_files_list
         operator = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
-            source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
+            source_object=source_object,
             destination_path=DESTINATION_SFTP,
+            keep_directory_structure=keep_directory_structure,
             move_object=True,
             gcp_conn_id=GCP_CONN_ID,
             sftp_conn_id=SFTP_CONN_ID,
@@ -151,20 +293,32 @@ class TestGoogleCloudStorageToSFTPOperator(unittest.TestCase):
         )
         operator.execute(None)
 
-        gcs_hook.return_value.list.assert_called_with(TEST_BUCKET, delimiter=".txt", prefix="test_object")
+        gcs_hook_mock.return_value.list.assert_called_with(TEST_BUCKET, delimiter=delimiter, prefix=prefix)
 
-        call_one, call_two = gcs_hook.return_value.delete.call_args_list
-        assert call_one[0] == (TEST_BUCKET, "test_object/file1.txt")
-        assert call_two[0] == (TEST_BUCKET, "test_object/file2.txt")
+        gcs_hook_mock.return_value.download.assert_has_calls(
+            [
+                mock.call(bucket_name=TEST_BUCKET, object_name=gcs_file, filename=mock.ANY)
+                for gcs_file in gcs_files_list
+            ]
+        )
+        sftp_hook_mock.return_value.store_file.assert_has_calls(
+            [
+                mock.call(os.path.join(DESTINATION_SFTP, target_object), mock.ANY)
+                for target_object in target_objects
+            ]
+        )
+
+        gcs_hook_mock.return_value.delete.assert_has_calls(
+            [mock.call(TEST_BUCKET, gcs_file) for gcs_file in gcs_files_list]
+        )
 
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.GCSHook")
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_sftp.SFTPHook")
-    def test_execute_more_than_one_wildcard_exception(self, sftp_hook, gcs_hook):
-        gcs_hook.return_value.list.return_value = SOURCE_FILES_LIST[:2]
+    def test_execute_more_than_one_wildcard_exception(self, sftp_hook_mock, gcs_hook_mock):
         operator = GCSToSFTPOperator(
             task_id=TASK_ID,
             source_bucket=TEST_BUCKET,
-            source_object=SOURCE_OBJECT_MULTIPLE_WILDCARDS,
+            source_object="csv/*/test_*.csv",
             destination_path=DESTINATION_SFTP,
             move_object=False,
             gcp_conn_id=GCP_CONN_ID,

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -19,10 +19,9 @@
 
 import os
 import unittest
-
-import mock
-from parameterized import parameterized
 from unittest import mock
+
+from parameterized import parameterized
 
 import pytest
 

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp_system.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp_system.py
@@ -43,8 +43,8 @@ class GcsToSftpExampleDagsSystemTest(GoogleSystemTest):
         for bucket_src, object_source in product(
             (
                 BUCKET_SRC,
-                f"{BUCKET_SRC}/subdir-1",
-                f"{BUCKET_SRC}/subdir-2",
+                f"{BUCKET_SRC}/dir-1",
+                f"{BUCKET_SRC}/dir-2",
             ),
             (OBJECT_SRC_1, OBJECT_SRC_2),
         ):

--- a/tests/test_utils/gcp_system_helpers.py
+++ b/tests/test_utils/gcp_system_helpers.py
@@ -165,6 +165,9 @@ class GoogleSystemTest(SystemTest):
         bucket_name = f"gs://{bucket}" if not bucket.startswith("gs://") else bucket
         with TemporaryDirectory(prefix="airflow-gcp") as tmp_dir:
             tmp_path = os.path.join(tmp_dir, filename)
+            tmp_dir_path = os.path.dirname(tmp_path)
+            if tmp_dir_path:
+                os.makedirs(tmp_dir_path, exist_ok=True)
             with open(tmp_path, "w") as file:
                 file.writelines(lines)
                 file.flush()


### PR DESCRIPTION
Improve GCSToSFTPOperator paths handling.

Now for every file on GCS is created separate folder on SFTP.

now:
```
copy_file_from_gcs_to_sftp = GCSToSFTPOperator(
        task_id="file-copy-gsc-to-sftp",
        source_bucket="bucket_name",
        source_object="folder/subfolder/file.txt",
        destination_path="/tmp",
    )
# downloads file to "/tmp/folder/subfolder/file.txt"
```

EDIT:
I made previous behavior default (for backward compatibility) but possible to change it by `ignore_gcs_path_in_destination` argument:
```
copy_file_from_gcs_to_sftp = GCSToSFTPOperator(
        task_id="file-copy-gsc-to-sftp",
        source_bucket="bucket_name",
        source_object="folder/subfolder/file.txt",
        destination_path="/tmp",
        keep_directory_structure=False,
    )
# downloads file to "/tmp/file.txt"
```