### PR TITLE
Add CeleryKubernetesExecutor to helm chart

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -24,14 +24,14 @@ Your release is named {{ .Release.Name }}.
 You can now access your dashboard(s) by following defined Ingress urls:
 
 Airflow dashboard:     http{{ if .Values.ingress.web.tls.enabled }}s{{ end }}://{{ .Values.ingress.web.host }}{{ .Values.ingress.web.path }}/
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 Flower dashboard:      http{{ if .Values.ingress.flower.tls.enabled }}s{{ end }}://{{ .Values.ingress.flower.host }}{{ .Values.ingress.flower.path }}/
 {{- end }}
 {{- else }}
 You can now access your dashboard(s) by executing the following command(s) and visiting the corresponding port at localhost in your browser:
 
 Airflow dashboard:        kubectl port-forward svc/{{ .Release.Name }}-webserver {{ .Values.ports.airflowUI }}:{{ .Values.ports.airflowUI }} --namespace {{ .Release.Namespace }}
-{{- if eq .Values.executor "CeleryExecutor"}}
+{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")}}
 Flower dashboard:         kubectl port-forward svc/{{ .Release.Name }}-flower {{ .Values.ports.flowerUI }}:{{ .Values.ports.flowerUI }} --namespace {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -33,7 +33,7 @@
       secretKeyRef:
         name: {{ template "airflow_metadata_secret" . }}
         key: connection
-  {{- if eq .Values.executor "CeleryExecutor" }}
+  {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
   - name: AIRFLOW__CELERY__CELERY_RESULT_BACKEND
     valueFrom:
       secretKeyRef:
@@ -72,7 +72,7 @@
   {{- range $i, $config := .Values.env }}
   - name: {{ $config.name }}
     value: {{ $config.value | quote }}
-    {{- if eq $.Values.executor "KubernetesExecutor" }}
+    {{- if or (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}
   - name: AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__{{ $config.name }}
     value: {{ $config.value | quote }}
     {{- end }}
@@ -85,7 +85,7 @@
         name: {{ $config.secretName }}
         key: {{ default "value" $config.secretKey }}
   {{- end }}
-  {{- if eq .Values.executor "KubernetesExecutor" }}
+    {{- if or (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}
     {{- range $i, $config := .Values.secret }}
   - name: AIRFLOW__KUBERNETES_SECRETS__{{ $config.envName }}
     value: {{ printf "%s=%s" $config.secretName $config.secretKey }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -55,7 +55,7 @@ data:
   known_hosts: |
     {{ .Values.dags.gitSync.knownHosts | nindent 4 }}
 {{- end }}
-{{- if eq .Values.executor "KubernetesExecutor" }}
+{{- if or (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}
   pod_template_file.yaml: |-
 {{- if .Values.podTemplate }}
     {{ .Values.podTemplate | nindent 4 }}

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Flower Deployment
 #################################
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Flower Ingress
 #################################
-{{- if and .Values.ingress.enabled (eq .Values.executor "CeleryExecutor") }}
+{{- if and .Values.ingress.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:

--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Flower Service Component
 #################################
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -19,8 +19,8 @@
 ## Airflow Pod Launcher Role Binding
 #################################
 {{- if and .Values.rbacEnabled .Values.allowPodLaunching }}
-{{- $grantScheduler := or (eq .Values.executor "LocalExecutor") (eq .Values.executor "SequentialExecutor") (eq .Values.executor "KubernetesExecutor") }}
-{{- $grantWorker := or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "KubernetesExecutor") }}
+{{- $grantScheduler := or (eq .Values.executor "LocalExecutor") (eq .Values.executor "SequentialExecutor") (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "CeleryKubernetesExecutor")}}
+{{- $grantWorker := or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "CeleryKubernetesExecutor")  }}
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRoleBinding
 {{- else }}

--- a/chart/templates/redis/redis-networkpolicy.yaml
+++ b/chart/templates/redis/redis-networkpolicy.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Redis NetworkPolicy
 #################################
-{{- if (and .Values.networkPolicies.enabled (eq .Values.executor "CeleryExecutor")) }}
+{{- if (and .Values.networkPolicies.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor"))) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/redis/redis-service.yaml
+++ b/chart/templates/redis/redis-service.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Redis Service
 #################################
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Redis StatefulSet
 #################################
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -21,8 +21,6 @@
 
 # Are we using a local/sequenial executor?
 {{- $local := or (eq .Values.executor "LocalExecutor") (eq .Values.executor "SequentialExecutor") }}
-# Are we using the kubernetes executor?
-{{- $kube := eq .Values.executor "KubernetesExecutor" }}
 # Is persistence enabled on the _workers_?
 # This is important because in $local mode, the scheduler assumes the role of the worker
 {{- $persistence := .Values.workers.persistence.enabled }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -19,7 +19,7 @@
 ## Airflow Worker Deployment
 #################################
 {{- $persistence := .Values.workers.persistence.enabled }}
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
 metadata:

--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Worker KEDA Scaler
 #################################
-{{- if (and .Values.workers.keda.enabled (eq .Values.executor "CeleryExecutor")) }}
+{{- if (and .Values.workers.keda.enabled ( or (eq .Values.executor "CeleryExecutor"))  (eq .Values.executor "CeleryKubernetesExecutor")) }}
 apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:

--- a/chart/templates/workers/worker-networkpolicy.yaml
+++ b/chart/templates/workers/worker-networkpolicy.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Worker NetworkPolicy
 #################################
-{{- if (and .Values.networkPolicies.enabled (eq .Values.executor "CeleryExecutor")) }}
+{{- if (and .Values.networkPolicies.enabled ( or (eq .Values.executor "CeleryExecutor"))  (eq .Values.executor "CeleryKubernetesExecutor")) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/tests/celery-kubernetes-executor_test.yaml
+++ b/chart/tests/celery-kubernetes-executor_test.yaml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+templates:
+  - workers/worker-deployment.yaml
+tests:
+  - it: should create a worker deployment with the CeleryExecuto
+    set:
+      executor: CeleryExecutor
+      dags:
+        persistence:
+          enabled: true
+        gitSync:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: config
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: dags
+  - it: should create a worker deployment with the CeleryKubernetesExecutor
+    set:
+      executor: CeleryKubernetesExecutor
+      dags:
+        gitSync:
+          enabled: true
+        persistence:
+          enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: config
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: dags

--- a/chart/tests/celery-kubernetes-pod-launcher-role.yaml
+++ b/chart/tests/celery-kubernetes-pod-launcher-role.yaml
@@ -15,32 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-################################
-## Airflow Worker Service
-#################################
-{{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-kind: Service
-apiVersion: v1
-metadata:
-  name: {{ .Release.Name }}-worker
-  labels:
-    tier: airflow
-    component: worker
-    release: {{ .Release.Name }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: {{ .Release.Service }}
-{{- with .Values.labels }}
-{{ toYaml . | indent 4 }}
-{{- end }}
-spec:
-  clusterIP: None
-  selector:
-    tier: airflow
-    component: worker
-    release: {{ .Release.Name }}
-  ports:
-    - name: worker-logs
-      protocol: TCP
-      port: {{ .Values.ports.workerLogs }}
-      targetPort: {{ .Values.ports.workerLogs }}
-{{- end }}
+---
+templates:
+  - workers/worker-deployment.yaml
+  - rbac/pod-launcher-rolebinding.yaml
+tests:
+  - it: should allow both scheduler pod launching and worker pod launching
+    set:
+      executor: CeleryKubernetesExecutor
+    asserts:
+      - matchRegex:
+          path: subjects[0].name
+          pattern: ^.*-worker$


### PR DESCRIPTION
Users of the CeleryKubernetesExecutor will require both
Celery and Kubernetes features to launch tasks.

This PR will also serve as the basis for integration tests for this
executor

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
