### PR TITLE
Move latest_only_operator.py to latest_only.py (#11178)

### DIFF
--- a/airflow/example_dags/example_latest_only.py
+++ b/airflow/example_dags/example_latest_only.py
@@ -22,7 +22,7 @@ import datetime as dt
 
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.utils.dates import days_ago
 
 dag = DAG(

--- a/airflow/example_dags/example_latest_only_with_trigger.py
+++ b/airflow/example_dags/example_latest_only_with_trigger.py
@@ -24,7 +24,7 @@ import datetime as dt
 
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.utils.dates import days_ago
 from airflow.utils.trigger_rule import TriggerRule
 

--- a/airflow/operators/latest_only.py
+++ b/airflow/operators/latest_only.py
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This module contains an operator to run downstream tasks only for the
+latest scheduled DagRun
+"""
+from typing import Dict, Iterable, Union
+
+import pendulum
+
+from airflow.operators.branch_operator import BaseBranchOperator
+
+
+class LatestOnlyOperator(BaseBranchOperator):
+    """
+    Allows a workflow to skip tasks that are not running during the most
+    recent schedule interval.
+
+    If the task is run outside of the latest schedule interval (i.e. external_trigger),
+    all directly downstream tasks will be skipped.
+
+    Note that downstream tasks are never skipped if the given DAG_Run is
+    marked as externally triggered.
+    """
+
+    ui_color = '#e9ffdb'  # nyanza
+
+    def choose_branch(self, context: Dict) -> Union[str, Iterable[str]]:
+        # If the DAG Run is externally triggered, then return without
+        # skipping downstream tasks
+        if context['dag_run'] and context['dag_run'].external_trigger:
+            self.log.info(
+                "Externally triggered DAG_Run: allowing execution to proceed.")
+            return list(context['task'].get_direct_relative_ids(upstream=False))
+
+        now = pendulum.now('UTC')
+        left_window = context['dag'].following_schedule(
+            context['execution_date'])
+        right_window = context['dag'].following_schedule(left_window)
+        self.log.info(
+            'Checking latest only with left_window: %s right_window: %s now: %s',
+            left_window, right_window, now
+        )
+
+        if not left_window < now <= right_window:
+            self.log.info('Not latest execution, skipping downstream.')
+            # we return an empty list, thus the parent BaseBranchOperator
+            # won't exclude any downstream tasks from skipping.
+            return []
+        else:
+            self.log.info('Latest, allowing execution to proceed.')
+            return list(context['task'].get_direct_relative_ids(upstream=False))

--- a/airflow/operators/latest_only_operator.py
+++ b/airflow/operators/latest_only_operator.py
@@ -16,52 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-This module contains an operator to run downstream tasks only for the
-latest scheduled DagRun
+This module is deprecated. Please use `airflow.operators.latest_only`.
 """
-from typing import Dict, Iterable, Union
+import warnings
 
-import pendulum
+# pylint: disable=unused-import
+from airflow.operators.latest_only import LatestOnlyOperator  # noqa
 
-from airflow.operators.branch_operator import BaseBranchOperator
-
-
-class LatestOnlyOperator(BaseBranchOperator):
-    """
-    Allows a workflow to skip tasks that are not running during the most
-    recent schedule interval.
-
-    If the task is run outside of the latest schedule interval (i.e. external_trigger),
-    all directly downstream tasks will be skipped.
-
-    Note that downstream tasks are never skipped if the given DAG_Run is
-    marked as externally triggered.
-    """
-
-    ui_color = '#e9ffdb'  # nyanza
-
-    def choose_branch(self, context: Dict) -> Union[str, Iterable[str]]:
-        # If the DAG Run is externally triggered, then return without
-        # skipping downstream tasks
-        if context['dag_run'] and context['dag_run'].external_trigger:
-            self.log.info(
-                "Externally triggered DAG_Run: allowing execution to proceed.")
-            return list(context['task'].get_direct_relative_ids(upstream=False))
-
-        now = pendulum.now('UTC')
-        left_window = context['dag'].following_schedule(
-            context['execution_date'])
-        right_window = context['dag'].following_schedule(left_window)
-        self.log.info(
-            'Checking latest only with left_window: %s right_window: %s now: %s',
-            left_window, right_window, now
-        )
-
-        if not left_window < now <= right_window:
-            self.log.info('Not latest execution, skipping downstream.')
-            # we return an empty list, thus the parent BaseBranchOperator
-            # won't exclude any downstream tasks from skipping.
-            return []
-        else:
-            self.log.info('Latest, allowing execution to proceed.')
-            return list(context['task'].get_direct_relative_ids(upstream=False))
+warnings.warn(
+    "This module is deprecated. Please use `airflow.operators.latest_only`.",
+    DeprecationWarning, stacklevel=2
+)

--- a/docs/operators-and-hooks-ref.rst
+++ b/docs/operators-and-hooks-ref.rst
@@ -73,7 +73,7 @@ Fundamentals
    * - :mod:`airflow.operators.generic_transfer`
      -
 
-   * - :mod:`airflow.operators.latest_only_operator`
+   * - :mod:`airflow.operators.latest_only`
      -
 
    * - :mod:`airflow.operators.python`

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1339,6 +1339,10 @@ OPERATORS = [
         "airflow.providers.google.cloud.operators.text_to_speech.CloudTextToSpeechSynthesizeOperator",
         "airflow.contrib.operators.gcp_text_to_speech_operator.GcpTextToSpeechSynthesizeOperator",
     ),
+    (
+        "airflow.operators.latest_only.LatestOnlyOperator",
+        "airflow.operators.latest_only_operator.LatestOnlyOperator",
+    ),
 ]
 
 SECRETS = [

--- a/tests/operators/test_latest_only_operator.py
+++ b/tests/operators/test_latest_only_operator.py
@@ -25,7 +25,7 @@ from airflow import settings
 from airflow.models import DagRun, TaskInstance
 from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This change is related to #11178 for `latest_only_operator`.

I tried running the unit test in breeze, they passed with some warnings. I'm not sure what to make of it, but if I'm supposed to be doing something please let me know.

```
root@b20475852b92:/opt/airflow# pytest tests/operators/test_latest_only_operator.py 
========================================================================= test session starts =========================================================================
platform linux -- Python 3.6.12, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/airflow, configfile: pytest.ini
plugins: timeouts-1.2.1, forked-1.3.0, rerunfailures-9.0, requests-mock-1.8.0, flaky-3.7.0, xdist-2.0.0, cov-2.10.1, celery-4.4.7, instafail-0.4.2
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 3 items                                                                                                                                                     

tests/operators/test_latest_only_operator.py::TestLatestOnlyOperator::test_not_skipping_external 



PASSED                                                         [ 33%]
tests/operators/test_latest_only_operator.py::TestLatestOnlyOperator::test_run PASSED                                                                           [ 66%]
tests/operators/test_latest_only_operator.py::TestLatestOnlyOperator::test_skipping_non_latest PASSED                                                           [100%]

========================================================================== warnings summary ===========================================================================
tests/operators/test_latest_only_operator.py::TestLatestOnlyOperator::test_not_skipping_external
tests/operators/test_latest_only_operator.py::TestLatestOnlyOperator::test_not_skipping_external
  /usr/local/lib/python3.6/site-packages/alembic/ddl/sqlite.py:41: UserWarning: Skipping unsupported ALTER for creation of implicit constraintPlease refer to the batch mode feature which allows for SQLite migrations using a copy-and-move strategy.
    "Skipping unsupported ALTER for "

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================================== 3 passed, 2 warnings in 30.69s ====================================================================
Exception ignored in: <function _ConnectionRecord.checkout.<locals>.<lambda> at 0x7f077fd61e18>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/pool/base.py", line 506, in <lambda>
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/pool/base.py", line 714, in _finalize_fairy
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/pool/base.py", line 531, in checkin
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/pool/base.py", line 388, in _return_conn
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/pool/impl.py", line 236, in _do_return_conn
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/pool/base.py", line 543, in close
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/pool/base.py", line 645, in __close
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/pool/base.py", line 267, in _close_connection
  File "/usr/local/lib/python3.6/logging/__init__.py", line 1295, in debug
  File "/usr/local/lib/python3.6/logging/__init__.py", line 1548, in isEnabledFor
TypeError: '>=' not supported between instances of 'int' and 'NoneType'
```

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
