### PR TITLE
Merge Airflow and Backport Packages preparation instructions

### DIFF
--- a/backport_packages/README.md
+++ b/backport_packages/README.md
@@ -1,0 +1,173 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# Backport packages
+
+# What the backport packages are
+
+The Backport Provider packages are packages (per provider) that make it possible to easily use Hooks,
+Operators, Sensors, and Secrets from the 2.0 version of Airflow in the 1.10.* series.
+
+The release manager prepares backport packages separately from the main Airflow Release, using
+`breeze` commands and accompanying scripts. This document provides an overview of the command line tools
+needed to prepare backport packages.
+
+# Content of the release notes
+
+Each of the backport packages contains Release notes in the form of the README.md file that is
+automatically generated from history of the changes and code of the provider.
+
+The script generates all the necessary information:
+
+* summary of requirements for each backport package
+* list of dependencies (including extras to install them) when package
+  depends on other providers packages
+* table of new hooks/operators/sensors/protocols/secrets
+* table of moved hooks/operators/sensors/protocols/secrets with the
+  information where they were moved from
+* changelog of all the changes to the provider package. This will be
+  automatically updated with an incremental changelog whenever we decide to
+  release separate packages.
+
+The script generates two types of files:
+
+* PROVIDERS_CHANGES_YYYY.MM.DD.md which keeps information about changes (commits) in a particular
+  version of the provider package. The file for latest release gets updated when you iterate with
+  the same new date/version, but it never changes automatically for already released packages.
+  This way - just before the final release, you can manually correct the changes file if you
+  want to remove some changes from the file.
+
+* README.md which is regenerated every time you run the script (unless there are no changes since
+  the last time you generated the release notes
+
+Note that our CI system builds the release notes for backport packages automatically with every build and
+current date - this way you might be sure the automated generation of the release notes continues to
+work. You can also preview the generated readme files (by downloading artifacts from GitHub Actions).
+The script does not modify the README and CHANGES files if there is no change in the repo for that provider.
+
+
+## Generating release notes
+
+When you want to prepare release notes for a package, you need to run:
+
+```
+./breeze prepare-backport-readme [YYYY.MM.DD] <PACKAGE_ID> ...
+```
+
+
+* YYYY.MM.DD - is the CALVER version of the package to prepare. Note that this date cannot be earlier
+  than the already released version (the script will fail if it will be). It can be set in the future
+  anticipating the future release date. If you do not specify date, the date will be taken from the last
+  generated readme - the last generated CHANGES file will be updated.
+
+* <PACKAGE_ID> is usually directory in the `airflow/providers` folder (for example `google` but in several
+  cases, it might be one level deeper separated with `.` for example `apache.hive`
+
+You can run the script with multiple package names if you want to prepare several packages at the same time.
+Before you specify a new version, the last released version is update in case you have any bug fixes
+merged in the master recently, they will be automatically taken into account.
+
+Typically, the first time you run release before release, you run it with target release.date:
+
+```
+./breeze prepare-backport-readme 2020.05.20 google
+```
+
+Then while you iterate with merges and release candidates you update the release date without providing
+the date (to update the existing release notes)
+
+```
+./breeze prepare-backport-readme google
+```
+
+
+Whenever you are satisfied with the release notes generated you can commit generated changes/new files
+to the repository.
+
+## Preparing backport packages
+
+As part of preparation to Airflow 2.0 we decided to prepare backport of providers package that will be
+possible to install in the Airflow 1.10.*, Python 3.6+ environment.
+Some of those packages will be soon (after testing) officially released via PyPi, but you can build and
+prepare such packages on your own easily.
+
+You build those packages in the breeze environment, so you do not have to worry about common environment.
+
+Note that readme release notes have to be generated first, so that the package preparation script reads
+the latest version from the latest version of release notes prepared.
+
+* The provider package ids PACKAGE_ID are subdirectories in the ``providers`` directory. Sometimes they
+are one level deeper (`apache/hive` folder for example, in which case PACKAGE_ID uses "." to separate
+the folders (for example Apache Hive's PACKAGE_ID is `apache.hive` ). You can see the list of all available
+providers by running:
+
+```bash
+./breeze prepare-backport-packages -- --help
+```
+
+The examples below show how you can build selected packages, but you can also build all packages by
+omitting the package ids altogether.
+
+* To build the release candidate packages for SVN Apache upload run the following command:
+
+```bash
+./breeze prepare-backport-packages --version-suffix-for-svn=rc1 [PACKAGE_ID] ...
+```
+
+for example:
+
+```bash
+./breeze prepare-backport-packages --version-suffix-for-svn=rc1 http ...
+```
+
+* To build the release candidate packages for PyPI upload run the following command:
+
+```bash
+./breeze prepare-backport-packages --version-suffix-for-pypi=rc1 [PACKAGE_ID] ...
+```
+
+for example:
+
+```bash
+./breeze prepare-backport-packages --version-suffix-for-pypi=rc1 http ...
+```
+
+
+* To build the final release packages run the following command:
+
+```bash
+./breeze prepare-backport-packages [PACKAGE_ID] ...
+```
+for example:
+
+```bash
+./breeze prepare-backport-packages http ...
+```
+
+* For each package, this creates a wheel package and source distribution package in your `dist` folder with
+  names following the patterns:
+
+  * `apache_airflow_backport_providers_<PROVIDER>_YYYY.[M]M.[D]D[suffix]-py3-none-any.whl`
+  * `apache-airflow-backport-providers-<PROVIDER>-YYYY.[M]M.[D]D[suffix].tar.gz`
+
+Note! Even if we always use the two-digit month and day when generating the readme files,
+the version in PyPI does not contain the leading 0s in version name - therefore the artifacts generated
+also do not container the leading 0s.
+
+* You can install the .whl packages with `pip install <PACKAGE_FILE>`

--- a/backport_packages/remove_old_releases.py
+++ b/backport_packages/remove_old_releases.py
@@ -1,0 +1,96 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Removes older releases of backport packages from the folder using svn rm.
+
+It iterates over the folder specified as first parameter and removes all but latest releases of
+packages found in that directory.
+
+"""
+import argparse
+import glob
+import os
+import subprocess
+from collections import defaultdict
+from distutils.version import LooseVersion
+from typing import Dict, List, NamedTuple
+
+
+class VersionedFile(NamedTuple):
+    base: str
+    version: str
+    suffix: str
+    type: str
+    comparable_version: LooseVersion
+
+
+def split_version_and_suffix(file_name: str, suffix: str) -> VersionedFile:
+    no_suffix_file = file_name[:-len(suffix)]
+    no_version_file, version = no_suffix_file.rsplit("-", 1)
+    return VersionedFile(base=no_version_file + "-",
+                         version=version,
+                         suffix=suffix,
+                         type=no_version_file + "-" + suffix,
+                         comparable_version=LooseVersion(version))
+
+
+def process_all_files(directory: str, suffix: str, execute: bool):
+    package_types_dicts: Dict[str, List[VersionedFile]] = defaultdict(list)
+    os.chdir(directory)
+
+    for file in glob.glob("*" + suffix):
+        versioned_file = split_version_and_suffix(file, suffix)
+        package_types_dicts[versioned_file.type].append(versioned_file)
+
+    for package_types in package_types_dicts.values():
+        package_types.sort(key=lambda x: x.comparable_version)
+
+    for package_types in package_types_dicts.values():
+        if len(package_types) == 1:
+            versioned_file = package_types[0]
+            print("Leaving the only version: "
+                  f"${versioned_file.base + versioned_file.version + versioned_file.suffix}")
+        # Leave only last version from each type
+        for versioned_file in package_types[:-1]:
+            command = ["svn", "rm", versioned_file.base + versioned_file.version + versioned_file.suffix]
+            if not execute:
+                print(command)
+            else:
+                subprocess.run(command, check=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Removes old releases.')
+    parser.add_argument('--directory', dest='directory', action='store', required=True,
+                        help='Directory to remove old releases in')
+    parser.add_argument('--execute', dest='execute', action='store_true',
+                        help='Execute the removal rather than dry run')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    process_all_files(args.directory, "-bin.tar.gz", args.execute)
+    process_all_files(args.directory, "-bin.tar.gz.sha512", args.execute)
+    process_all_files(args.directory, "-bin.tar.gz.asc", args.execute)
+    process_all_files(args.directory, "-source.tar.gz", args.execute)
+    process_all_files(args.directory, "-source.tar.gz.sha512", args.execute)
+    process_all_files(args.directory, "-source.tar.gz.asc", args.execute)
+    process_all_files(args.directory, "-py3-none-any.whl", args.execute)
+    process_all_files(args.directory, "-py3-none-any.whl.sha512", args.execute)
+    process_all_files(args.directory, "-py3-none-any.whl.asc", args.execute)

--- a/dev/README.md
+++ b/dev/README.md
@@ -20,232 +20,194 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of contents**
 
-- [Development Tools](#development-tools)
-  - [Airflow release signing tool](#airflow-release-signing-tool)
-- [Verifying the release candidate by PMCs (legal)](#verifying-the-release-candidate-by-pmcs-legal)
-  - [PMC voting](#pmc-voting)
-  - [SVN check](#svn-check)
-  - [Verifying the licences](#verifying-the-licences)
-  - [Verifying the signatures](#verifying-the-signatures)
-  - [Verifying the SHA512 sum](#verifying-the-sha512-sum)
-- [Verifying if the release candidate "works" by Contributors](#verifying-if-the-release-candidate-works-by-contributors)
-- [Building an RC](#building-an-rc)
-- [PyPI Snapshots](#pypi-snapshots)
-- [Make sure your public key is on id.apache.org and in KEYS](#make-sure-your-public-key-is-on-idapacheorg-and-in-keys)
-- [Voting on an RC](#voting-on-an-rc)
-- [Publishing release](#publishing-release)
-- [Publishing to PyPi](#publishing-to-pypi)
-- [Updating CHANGELOG.md](#updating-changelogmd)
-- [Notifying developers of release](#notifying-developers-of-release)
+- [Apache Airflow source releases](#apache-airflow-source-releases)
+  - [Apache Airflow Package](#apache-airflow-package)
+  - [Backport Provider packages](#backport-provider-packages)
+- [Prerequisites for the release manager preparing the release](#prerequisites-for-the-release-manager-preparing-the-release)
+  - [Upload Public keys to id.apache.org](#upload-public-keys-to-idapacheorg)
+  - [Configure PyPI uploads](#configure-pypi-uploads)
+  - [Hardware used to prepare and verify the packages](#hardware-used-to-prepare-and-verify-the-packages)
+- [Apache Airflow packages](#apache-airflow-packages)
+  - [Prepare the Apache Airflow Package RC](#prepare-the-apache-airflow-package-rc)
+  - [Vote and verify the Apache Airflow release candidate](#vote-and-verify-the-apache-airflow-release-candidate)
+  - [Publish the final Apache Airflow release](#publish-the-final-apache-airflow-release)
+- [Backport Provider Packages](#backport-provider-packages)
+  - [Decide when to release](#decide-when-to-release)
+  - [Prepare the Backport Provider Packages RC](#prepare-the-backport-provider-packages-rc)
+  - [Vote and verify the Backport Providers release candidate](#vote-and-verify-the-backport-providers-release-candidate)
+  - [Publish the final releases of backport packages](#publish-the-final-releases-of-backport-packages)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Development Tools
+# Apache Airflow source releases
 
-## Airflow release signing tool
+The Apache Airflow releases are one of the two types:
 
-The release signing tool can be used to create the SHA512/MD5 and ASC files that required for Apache releases.
+* Releases of the Apache Airflow package
+* Releases of the Backport Providers Packages
 
-### Execution
+## Apache Airflow Package
 
-To create a release tarball execute following command from Airflow's root.
+This package contains sources that allow the user building fully-functional Apache Airflow 2.0 package.
+They contain sources for:
 
-```bash
-python setup.py compile_assets sdist --formats=gztar
-```
+ * "apache-airflow" python package that installs "airflow" Python package and includes
+   all the assets required to release the webserver UI coming with Apache Airflow
+ * Dockerfile and corresponding scripts that build and use an official DockerImage
+ * Breeze development environment that helps with building images and testing locally
+   apache airflow built from sources
 
-*Note: `compile_assets` command build the frontend assets (JS and CSS) files for the
-Web UI using webpack and yarn. Please make sure you have `yarn` installed on your local machine globally.
-Details on how to install `yarn` can be found in CONTRIBUTING.rst file.*
+In the future (Airflow 2.0) this package will be split into separate "core" and "providers" packages that
+will be distributed separately, following the mechanisms introduced in Backport Package Providers. We also
+plan to release the official Helm Chart sources that will allow the user to install Apache Airflow
+via helm 3.0 chart in a distributed fashion.
 
-After that navigate to relative directory i.e., `cd dist` and sign the release files.
+The Source releases are the only "official" Apache Software Foundation releases, and they are distributed
+via [Official Apache Download sources](https://downloads.apache.org/)
 
-```bash
-../dev/sign.sh <the_created_tar_ball.tar.gz
-```
+Following source releases Apache Airflow release manager also distributes convenience packages:
 
-Signing files will be created in the same directory.
+* PyPI packages released via https://pypi.org/project/apache-airflow/
+* Docker Images released via https://hub.docker.com/repository/docker/apache/airflow
 
+Those convenience packages are not "official releases" of Apache Airflow, but the users who
+cannot or do not want to build the packages themselves can use them as a convenient way of installing
+Apache Airflow, however they are not considered as "official source releases". You can read more
+details about it in the [ASF Release Policy](http://www.apache.org/legal/release-policy.html).
 
-# Verifying the release candidate by PMCs (legal)
+This document describes the process of releasing both - official source packages and convenience
+packages for Apache Airflow packages.
 
-## PMC voting
+## Backport Provider packages
 
-The PMCs should verify the releases in order to make sure the release is following the
-[Apache Legal Release Policy](http://www.apache.org/legal/release-policy.html).
+The Backport Provider packages are packages (per provider) that make it possible to easily use Hooks,
+Operators, Sensors, and Secrets from the 2.0 version of Airflow in the 1.10.* series.
 
-At least 3 (+1) votes should be recorded in accordance to
-[Votes on Package Releases](https://www.apache.org/foundation/voting.html#ReleaseVotes)
-
-The legal checks include:
-
-* checking if the packages are present in the right dist folder on svn
-* verifying if all the sources have correct licences
-* verifying if release manager signed the releases with the right key
-* verifying if all the checksums are valid for the release
-
-## SVN check
-
-The files should be present in the sub-folder of
-[Airflow dist](https://dist.apache.org/repos/dist/dev/airflow/)
-
-The following files should be present (9 files):
-
-* -bin-tar.gz + .asc + .sha512
-* -source.tar.gz + .asc + .sha512
-* -.whl + .asc + .sha512
-
-As a PMC you should be able to clone the SVN repository:
-
-```bash
-svn co https://dist.apache.org/repos/dist/dev/airflow
-```
-
-Or update it if you already checked it out:
-
-```bash
-svn update .
-```
-
-## Verifying the licences
-
-This can be done with the Apache RAT tool.
-
-* Download the latest jar from https://creadur.apache.org/rat/download_rat.cgi (unpack the sources,
-  the jar is inside)
-* Unpack the -source.tar.gz to a folder
-* Enter the folder and run the check (point to the place where you extracted the .jar)
-
-```bash
-java -jar ../../apache-rat-0.13/apache-rat-0.13.jar -E .rat-excludes -d .
-```
-
-## Verifying the signatures
-
-Make sure you have the key of person signed imported in your GPG. You can find the valid keys in
-[KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS).
-
-You can import the whole KEYS file:
-
-```bash
-gpg --import KEYS
-```
-
-You can also import the keys individually from a keyserver. The below one uses Kaxil's key and
-retrieves it from the default GPG keyserver
-[OpenPGP.org](https://keys.openpgp.org):
-
-```bash
-gpg --receive-keys 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
-```
-
-You should choose to import the key when asked.
-
-Note that by being default, the OpenPGP server tends to be overloaded often and might respond with
-errors or timeouts. Many of the release managers also uploaded their keys to the
-[GNUPG.net](https://keys.gnupg.net) keyserver, and you can retrieve it from there.
-
-```bash
-gpg --keyserver keys.gnupg.net --receive-keys 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
-```
-
-Once you have the keys, the signatures can be verified by running this:
-
-```bash
-for i in *.asc
-do
-   echo "Checking $i"; gpg --verify `basename $i .sha512 `
-done
-```
-
-This should produce results similar to the below. The "Good signature from ..." is indication
-that the signatures are correct. Do not worry about the "not certified with a trusted signature"
-warning. Most of certificates used by release managers are self signed, that's why you get this
-warning. By importing the server in the previous step and importing it via ID from
-[KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS) page, you know that
-this is a valid Key already.
+Once you release the packages, you can simply install them with:
 
 ```
-Checking apache-airflow-1.10.12rc4-bin.tar.gz.asc
-gpg: assuming signed data in 'apache-airflow-1.10.12rc4-bin.tar.gz'
-gpg: Signature made sob, 22 sie 2020, 20:28:28 CEST
-gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
-gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
-Checking apache_airflow-1.10.12rc4-py2.py3-none-any.whl.asc
-gpg: assuming signed data in 'apache_airflow-1.10.12rc4-py2.py3-none-any.whl'
-gpg: Signature made sob, 22 sie 2020, 20:28:31 CEST
-gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
-gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
-Checking apache-airflow-1.10.12rc4-source.tar.gz.asc
-gpg: assuming signed data in 'apache-airflow-1.10.12rc4-source.tar.gz'
-gpg: Signature made sob, 22 sie 2020, 20:28:25 CEST
-gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
-gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+pip install apache-airflow-backport-providers-<PROVIDER>[<EXTRAS>]
 ```
 
-## Verifying the SHA512 sum
+Where `<PROVIDER>` is the provider id and `<EXTRAS>` are optional extra packages to install.
+You can find the provider packages dependencies and extras in the README.md files in each provider
+package (in `airflow/providers/<PROVIDER>` folder) as well as in the PyPI installation page.
 
-Run this:
+Backport providers are a great way to migrate your DAGs to Airflow-2.0 compatible DAGs. You can
+switch to the new Airflow-2.0 packages in your DAGs, long before you attempt to migrate
+airflow to 2.0 line.
 
-```bash
-for i in *.sha512
-do
-    echo "Checking $i"; gpg --print-md SHA512 `basename $i .sha512 ` | diff - $i
-done
+The sources released in SVN allow to build all the provider packages by the user, following the
+instructions and scripts provided. Those are also "official_source releases" as described in the
+[ASF Release Policy](http://www.apache.org/legal/release-policy.html) and they are available
+via [Official Apache Download sources](https://downloads.apache.org/airflow/backport-providers/).
+
+There are also 50+ convenience packages released as "apache-airflow-backport-providers" separately in
+PyPI. You can find them all by [PyPI query](https://pypi.org/search/?q=apache-airflow-backport-providers)
+
+The document describes the process of releasing both - official source packages and convenience
+packages for Backport Provider Packages.
+
+# Prerequisites for the release manager preparing the release
+
+The person acting as release manager has to fulfill certain pre-requisites. More details and FAQs are
+available in the [ASF Release Policy](http://www.apache.org/legal/release-policy.html) but here some important
+pre-requisites are listed below. Note that release manager does not have to be a PMC - it is enough
+to be committer to assume the release manager role, but there are final steps in the process (uploading
+final releases to SVN) that can only be done by PMC member. If needed, the release manager
+can ask PMC to perform that final step of release.
+
+## Upload Public keys to id.apache.org
+
+Make sure your public key is on id.apache.org and in KEYS. You will need to sign the release artifacts
+with your pgp key. After you have created a key, make sure you:
+
+- Add your GPG pub key to https://dist.apache.org/repos/dist/release/airflow/KEYS , follow the instructions at the top of that file. Upload your GPG public key to https://pgp.mit.edu
+- Add your key fingerprint to https://id.apache.org/ (login with your apache credentials, paste your fingerprint into the pgp fingerprint field and hit save).
+
+```shell script
+# Create PGP Key
+gpg --gen-key
+
+# Checkout ASF dist repo
+svn checkout https://dist.apache.org/repos/dist/release/airflow
+cd airflow
+
+
+# Add your GPG pub key to KEYS file. Replace "Kaxil Naik" with your name
+(gpg --list-sigs "Kaxil Naik" && gpg --armor --export "Kaxil Naik" ) >> KEYS
+
+
+# Commit the changes
+svn commit -m "Add PGP keys of Airflow developers"
 ```
 
-You should get output similar to:
+See this for more detail on creating keys and what is required for signing releases.
+
+http://www.apache.org/dev/release-signing.html#basic-facts
+
+## Configure PyPI uploads
+
+In order to not reveal your password in plain text, it's best if you create and configure API Upload tokens.
+You can add and copy the tokens here:
+
+* [Test PyPI](https://test.pypi.org/manage/account/token/)
+* [Prod PyPI](https://pypi.org/manage/account/token/)
+
+
+Create a ~/.pypirc file:
+
+```shell script
+[distutils]
+index-servers =
+  pypi
+  pypitest
+
+[pypi]
+username=__token__
+password=<API Upload Token>
+
+[pypitest]
+repository=https://test.pypi.org/legacy/
+username=__token__
+password=<API Upload Token>
 
 ```
-Checking apache-airflow-1.10.12rc4-bin.tar.gz.sha512
-Checking apache_airflow-1.10.12rc4-py2.py3-none-any.whl.sha512
-Checking apache-airflow-1.10.12rc4-source.tar.gz.sha512
+
+Set proper permissions for the pypirc file:
+
+```shell script
+$ chmod 600 ~/.pypirc
 ```
 
-# Verifying if the release candidate "works" by Contributors
+- Install [twine](https://pypi.org/project/twine/) if you do not have it already (it can be done
+  in a separate virtual environment).
 
-This can be done (and we encourage to) by any of the Contributors. In fact, it's best if the
-actual users of Apache Airflow test it in their own staging/test installations. Each release candidate
-is available on PyPI apart from SVN packages, so everyone should be able to install
-the release candidate version of Airflow via simply (<VERSION> is 1.10.12 for example, and <X> is
-release candidate number 1,2,3,....).
-
-```bash
-pip install apache-airflow==<VERSION>rc<X>
-```
-Optionally it can be followed with constraints
-
-```bash
-pip install apache-airflow==<VERSION>rc<X> \
-  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-<VERSION>/constraints-3.6.txt"`
+```shell script
+pip install twine
 ```
 
-Note that the constraints contain python version that you are installing it with.
+(more details [here](https://peterdowns.com/posts/first-time-with-pypi.html).)
 
-You can use any of the installation methods you prefer (you can even install it via the binary wheel
-downloaded from the SVN).
+- Set proper permissions for the pypirc file:
+`$ chmod 600 ~/.pypirc`
 
-There is also an easy way of installation with Breeze if you have the latest sources of Apache Airflow.
-Running the following command will use tmux inside breeze, create `admin` user and run Webserver & Scheduler:
-
-```
-./breeze start-airflow --install-airflow-version <VERSION>rc<X> --python 3.7 --backend postgres
-```
-
-Once you install and run Airflow, you should perform any verification you see as necessary to check
-that the Airflow works as you expected.
+- Confirm that airflow/version.py is set properly.
 
 
-# Building an RC
+## Hardware used to prepare and verify the packages
+
+The best way to prepare and verify the releases is to prepare them on a hardware owned and controlled
+by the committer acting as release manager. While strictly speaking, releases must only be verified
+on hardware owned and controlled by the committer, for practical reasons it's best if the packages are
+prepared using such hardware. More information can be found in this
+[FAQ](http://www.apache.org/legal/release-policy.html#owned-controlled-hardware)
+
+# Apache Airflow packages
+
+## Prepare the Apache Airflow Package RC
+
+### Build RC artifacts (both source packages and convenience packages)
 
 The Release Candidate artifacts we vote upon should be the exact ones we vote against, without any modification than renaming – i.e. the contents of the files must be the same between voted release canidate and final release. Because of this the version in the built artifacts that will become the official Apache releases must not include the rcN suffix.
 
@@ -279,7 +241,9 @@ export AIRFLOW_REPO_ROOT=$(pwd)
 `git archive --format=tar.gz ${VERSION} --prefix=apache-airflow-${VERSION}/ -o apache-airflow-${VERSION}-source.tar.gz`
 
 - Generate sdist
+
 NOTE: Make sure your checkout is clean at this stage - any untracked or changed files will otherwise be included in the file produced.
+
 `python setup.py compile_assets sdist bdist_wheel`
 
 - Rename the sdist
@@ -314,57 +278,52 @@ svn add *
 svn commit -m "Add artifacts for Airflow ${VERSION}"
 ```
 
-# PyPI Snapshots
+### Prepare PyPI convenience "snapshot" packages
 
-At this point we have the artefact that we vote on, but as a convenience to developers we also want to publish "snapshots" of the RC builds to pypi for installing via pip. To do this we need to
+At this point we have the artefact that we vote on, but as a convenience to developers we also want to
+publish "snapshots" of the RC builds to pypi for installing via pip. To do this we need to
 
 - Edit the airflow/version.py to include the RC suffix.
-- python setup.py compile_assets sdist bdist_wheel
-- Follow the steps in [here](#Publishing-to-PyPi)
+
+- Build the package:
+`python setup.py compile_assets sdist bdist_wheel`
+
+- Verify the artifacts that would be uploaded:
+`twine check dist/*`
+
+- Upload the package to PyPi's test environment:
+`twine upload -r pypitest dist/*`
+
+- Verify that the test package looks good by downloading it and installing it into a virtual environment. The package download link is available at:
+https://test.pypi.org/project/apache-airflow/#files
+
+- Upload the package to PyPi's production environment:
+`twine upload -r pypi dist/*`
+
+- Again, confirm that the package is available here:
+https://pypi.python.org/pypi/apache-airflow
+
 - Throw away the change - we don't want to commit this: `git checkout airflow/version.py`
 
-It is important to stress that this snapshot is not intended for users.
+It is important to stress that this snapshot should not be named "release", and it
+is not supposed to be used by and advertised to the end-users who do not read the devlist.
 
-# Make sure your public key is on id.apache.org and in KEYS
+## Vote and verify the Apache Airflow release candidate
 
-You will need to sign the release artifacts with your pgp key. After you have created a key, make sure you
-
-- Add your GPG pub key to https://dist.apache.org/repos/dist/release/airflow/KEYS , follow the instructions at the top of that file. Upload your GPG public key to https://pgp.mit.edu
-- Add your key fingerprint to https://id.apache.org/ (login with your apache credentials, paste your fingerprint into the pgp fingerprint field and hit save).
-
-```shell script
-# Create PGP Key
-gpg --gen-key
-
-# Checkout ASF dist repo
-svn checkout https://dist.apache.org/repos/dist/release/airflow
-cd airflow
-
-
-# Add your GPG pub key to KEYS file. Replace "Kaxil Naik" with your name
-(gpg --list-sigs "Kaxil Naik" && gpg --armor --export "Kaxil Naik" ) >> KEYS
-
-
-# Commit the changes
-svn commit -m "Add PGP keys of Airflow developers"
-```
-
-See this for more detail on creating keys and what is required for signing releases.
-
-http://www.apache.org/dev/release-signing.html#basic-facts
-
-# Voting on an RC
-
-- Once the RC is built (both source and binary), put them in the dev SVN repository:
-https://dist.apache.org/repos/dist/dev/airflow/
+### Prepare Vote email on the Apache Airflow release candidate
 
 - Use the dev/airflow-jira script to generate a list of Airflow JIRAs that were closed in the release.
 
 - Send out a vote to the dev@airflow.apache.org mailing list:
 
-<details><summary>[VOTE] Airflow 1.10.2rc3</summary>
-<p>
+Subject:
+```
+[VOTE] Airflow 1.10.2rc3
+```
 
+Body:
+
+```
 Hey all,
 
 I have cut Airflow 1.10.2 RC3. This email is calling a vote on the release,
@@ -380,8 +339,11 @@ with INSTALL instructions.
 Public keys are available at:
 https://dist.apache.org/repos/dist/release/airflow/KEYS
 
-Only votes from PMC members are binding, but members of the community are
-encouraged to test the release and vote with "(non-binding)".
+Only votes from PMC members are binding, but the release manager should encourage members of the community
+to test the release and vote with "(non-binding)".
+
+The test procedure for PMCs and Contributors who would like to test this RC are described in
+https://github.com/apache/airflow/blob/master/dev/README.md#vote-and-verify-the-apache-airflow-release-candidate
 
 Please note that the version number excludes the `rcX` string, so it's now
 simply 1.10.2. This will allow us to rename the artifact without modifying
@@ -414,13 +376,205 @@ Changes since 1.10.2rc2:
 
 Cheers,
 <your name>
-</p>
-</details>
+```
 
-- Once the vote has been passed, you will need to send a result vote to dev@airflow.apache.org:
+### Verify the release candidate by PMCs (legal)
 
-<details><summary>[RESULT][VOTE] Airflow 1.10.2rc3</summary>
-<p>
+#### PMC responsibilities
+
+The PMCs should verify the releases in order to make sure the release is following the
+[Apache Legal Release Policy](http://www.apache.org/legal/release-policy.html).
+
+At least 3 (+1) votes should be recorded in accordance to
+[Votes on Package Releases](https://www.apache.org/foundation/voting.html#ReleaseVotes)
+
+The legal checks include:
+
+* checking if the packages are present in the right dist folder on svn
+* verifying if all the sources have correct licences
+* verifying if release manager signed the releases with the right key
+* verifying if all the checksums are valid for the release
+
+#### SVN check
+
+The files should be present in the sub-folder of
+[Airflow dist](https://dist.apache.org/repos/dist/dev/airflow/)
+
+The following files should be present (9 files):
+
+* -bin-tar.gz + .asc + .sha512
+* -source.tar.gz + .asc + .sha512
+* -.whl + .asc + .sha512
+
+As a PMC you should be able to clone the SVN repository:
+
+```shell script
+svn co https://dist.apache.org/repos/dist/dev/airflow
+```
+
+Or update it if you already checked it out:
+
+```shell script
+svn update .
+```
+
+#### Verify the licences
+
+This can be done with the Apache RAT tool.
+
+* Download the latest jar from https://creadur.apache.org/rat/download_rat.cgi (unpack the sources,
+  the jar is inside)
+* Unpack the -source.tar.gz to a folder
+* Enter the folder and run the check (point to the place where you extracted the .jar)
+
+```shell script
+java -jar ../../apache-rat-0.13/apache-rat-0.13.jar -E .rat-excludes -d .
+```
+
+#### Verify the signatures
+
+Make sure you have the key of person signed imported in your GPG. You can find the valid keys in
+[KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS).
+
+You can import the whole KEYS file:
+
+```shell script
+gpg --import KEYS
+```
+
+You can also import the keys individually from a keyserver. The below one uses Kaxil's key and
+retrieves it from the default GPG keyserver
+[OpenPGP.org](https://keys.openpgp.org):
+
+```shell script
+gpg --receive-keys 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+```
+
+You should choose to import the key when asked.
+
+Note that by being default, the OpenPGP server tends to be overloaded often and might respond with
+errors or timeouts. Many of the release managers also uploaded their keys to the
+[GNUPG.net](https://keys.gnupg.net) keyserver, and you can retrieve it from there.
+
+```shell script
+gpg --keyserver keys.gnupg.net --receive-keys 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+```
+
+Once you have the keys, the signatures can be verified by running this:
+
+```shell script
+for i in *.asc
+do
+   echo "Checking $i"; gpg --verify `basename $i .sha512 `
+done
+```
+
+This should produce results similar to the below. The "Good signature from ..." is indication
+that the signatures are correct. Do not worry about the "not certified with a trusted signature"
+warning. Most of the certificates used by release managers are self signed, that's why you get this
+warning. By importing the server in the previous step and importing it via ID from
+[KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS) page, you know that
+this is a valid Key already.
+
+```
+Checking apache-airflow-1.10.12rc4-bin.tar.gz.asc
+gpg: assuming signed data in 'apache-airflow-1.10.12rc4-bin.tar.gz'
+gpg: Signature made sob, 22 sie 2020, 20:28:28 CEST
+gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+Checking apache_airflow-1.10.12rc4-py2.py3-none-any.whl.asc
+gpg: assuming signed data in 'apache_airflow-1.10.12rc4-py2.py3-none-any.whl'
+gpg: Signature made sob, 22 sie 2020, 20:28:31 CEST
+gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+Checking apache-airflow-1.10.12rc4-source.tar.gz.asc
+gpg: assuming signed data in 'apache-airflow-1.10.12rc4-source.tar.gz'
+gpg: Signature made sob, 22 sie 2020, 20:28:25 CEST
+gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+```
+
+#### Verify the SHA512 sum
+
+Run this:
+
+```shell script
+for i in *.sha512
+do
+    echo "Checking $i"; gpg --print-md SHA512 `basename $i .sha512 ` | diff - $i
+done
+```
+
+You should get output similar to:
+
+```
+Checking apache-airflow-1.10.12rc4-bin.tar.gz.sha512
+Checking apache_airflow-1.10.12rc4-py2.py3-none-any.whl.sha512
+Checking apache-airflow-1.10.12rc4-source.tar.gz.sha512
+```
+
+### Verify if the release candidate "works" by Contributors
+
+This can be done (and we encourage to) by any of the Contributors. In fact, it's best if the
+actual users of Apache Airflow test it in their own staging/test installations. Each release candidate
+is available on PyPI apart from SVN packages, so everyone should be able to install
+the release candidate version of Airflow via simply (<VERSION> is 1.10.12 for example, and <X> is
+release candidate number 1,2,3,....).
+
+```shell script
+pip install apache-airflow==<VERSION>rc<X>
+```
+Optionally it can be followed with constraints
+
+```shell script
+pip install apache-airflow==<VERSION>rc<X> \
+  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-<VERSION>/constraints-3.6.txt"`
+```
+
+Note that the constraints contain python version that you are installing it with.
+
+You can use any of the installation methods you prefer (you can even install it via the binary wheel
+downloaded from the SVN).
+
+There is also an easy way of installation with Breeze if you have the latest sources of Apache Airflow.
+Running the following command will use tmux inside breeze, create `admin` user and run Webserver & Scheduler:
+
+```
+./breeze start-airflow --install-airflow-version <VERSION>rc<X> --python 3.7 --backend postgres
+```
+
+For 1.10 releases you can also use `--no-rbac-ui` flag disable RBAC UI of Airflow:
+
+```
+./breeze start-airflow --install-airflow-version <VERSION>rc<X> --python 3.7 --backend postgres --no-rbac-ui
+```
+
+Once you install and run Airflow, you should perform any verification you see as necessary to check
+that the Airflow works as you expected.
+
+## Publish the final Apache Airflow release
+
+### Summarize the voting for the Apache Airflow release
+
+Once the vote has been passed, you will need to send a result vote to dev@airflow.apache.org:
+
+Subject:
+```
+[RESULT][VOTE] Airflow 1.10.2rc3
+```
+
+Message:
+
+```
 Hello,
 
 Apache Airflow 1.10.2 (based on RC3) has been accepted.
@@ -442,19 +596,18 @@ Apache Airflow 1.10.2 (based on RC3) has been accepted.
 Vote thread:
 https://lists.apache.org/thread.html/736404ca3d2b2143b296d0910630b9bd0f8b56a0c54e3a05f4c8b5fe@%3Cdev.airflow.apache.org%3E
 
-I'll continue with the release process and the release announcement will follow shortly.
+I'll continue with the release process, and the release announcement will follow shortly.
 
 Cheers,
 <your name>
+```
 
-</p>
-</details>
 
-# Publishing release
+### Publish release to SVN
 
-- After both votes pass (see above), you need to migrate the RC artifacts that passed to this repository:
+You need to migrate the RC artifacts that passed to this repository:
 https://dist.apache.org/repos/dist/release/airflow/
-(The migration should including renaming the files so that they no longer have the RC number in their filenames.)
+(The migration should include renaming the files so that they no longer have the RC number in their filenames.)
 
 The best way of doing this is to svn cp  between the two repos (this avoids having to upload the binaries again, and gives a clearer history in the svn commit logs):
 
@@ -481,36 +634,11 @@ svn rm ${PREVIOUS_VERSION}
 svn commit -m "Remove old release: ${PREVIOUS_VERSION}"
 ```
 
-# Publishing to PyPi
+Verify that the packages appear in [airflow](https://dist.apache.org/repos/dist/release/airflow/)
 
-- Create a ~/.pypirc file:
+### Prepare PyPI "release" packages
 
-```shell script
-$ cat ~/.pypirc
-[distutils]
-index-servers =
-pypi
-pypitest
-
-[pypi]
-username=your-username
-password=*********
-
-[pypitest]
-repository=https://test.pypi.org/legacy/
-username=your-username
-password=*********
-```
-
-(more details [here](https://peterdowns.com/posts/first-time-with-pypi.html).)
-
-- Set proper permissions for the pypirc file:
-`$ chmod 600 ~/.pypirc`
-
-- Confirm that airflow/version.py is set properly.
-
-- Install [twine](https://pypi.org/project/twine/) if you do not have it already.
-`pip install twine`
+At this point we release an official package:
 
 - Build the package:
 `python setup.py compile_assets sdist bdist_wheel`
@@ -521,8 +649,8 @@ password=*********
 - Upload the package to PyPi's test environment:
 `twine upload -r pypitest dist/*`
 
-- Verify that the test package looks good by downloading it and installing it into a virtual environment. The package download link is available at:
-https://test.pypi.org/project/apache-airflow/#files
+- Verify that the test package looks good by downloading it and installing it into a virtual environment.
+The package download link is available at: https://test.pypi.org/project/apache-airflow/#files
 
 - Upload the package to PyPi's production environment:
 `twine upload -r pypi dist/*`
@@ -530,26 +658,35 @@ https://test.pypi.org/project/apache-airflow/#files
 - Again, confirm that the package is available here:
 https://pypi.python.org/pypi/apache-airflow
 
-# Updating CHANGELOG.md
+### Update CHANGELOG.md
 
 - Get a diff between the last version and the current version:
 `$ git log 1.8.0..1.9.0 --pretty=oneline`
 - Update CHANGELOG.md with the details, and commit it.
 
-# Notifying developers of release
+### Notify developers of release
 
-- Notify users@airflow.apache.org (cc'ing dev@airflow.apache.org and announce@apache.org) that the artifacts have been published:
+- Notify users@airflow.apache.org (cc'ing dev@airflow.apache.org and announce@apache.org) that
+the artifacts have been published:
 
-<details><summary>Airflow 1.10.2 is released</summary>
-<p>
+Subject:
+```shell script
+cat <<EOF
+Airflow ${VERSION} is released
+EOF
+```
+
+Body:
+```shell script
+cat <<EOF
 Dear Airflow community,
 
-I'm happy to announce that Airflow 1.10.2 was just released.
+I'm happy to announce that Airflow ${VERSION} was just released.
 
 The source release, as well as the binary "sdist" release, are available
 here:
 
-https://dist.apache.org/repos/dist/release/airflow/1.10.2/
+https://dist.apache.org/repos/dist/release/airflow/${VERSION}/
 
 We also made this version available on PyPi for convenience (`pip install apache-airflow`):
 
@@ -567,8 +704,645 @@ https://airflow.apache.org/changelog.html#airflow-1-10-2-2019-01-19
 
 Cheers,
 <your name>
-</p>
-</details>
+EOF
+```
 
-- Update the Announcement page on
-[Airflow Site](https://airflow.apache.org/announcements/)
+### Update Announcements page
+
+Update "Announcements" page at the [Official Airflow website](https://airflow.apache.org/announcements/)
+
+
+-----------------------------------------------------------------------------------------------------------
+
+
+# Backport Provider Packages
+
+You can read more about the command line tools used to generate backport packages in
+[Backport Providers README](../backport_packages/README.md).
+
+## Decide when to release
+
+You can release backport packages separately on an ad-hoc basis, whenever we find that a given provider needs
+to be released - due to new features or due to bug fixes. You can release each backport package
+separately.
+
+We are using the [CALVER](https://calver.org/) versioning scheme for the backport packages. We also have an
+automated way to prepare and build the packages, so it should be very easy to release the packages often and
+separately.
+
+## Prepare the Backport Provider Packages RC
+
+### Generate release notes
+
+Prepare release notes for all the packages you plan to release. Where YYYY.MM.DD is the CALVER
+date for the packages.
+
+```
+./breeze prepare-backport-readme YYYY.MM.DD [packages]
+```
+
+If you iterate with merges and release candidates you can update the release date without providing
+the date (to update the existing release notes)
+
+```
+./breeze prepare-backport-readme google
+```
+
+Generated readme files should be eventually committed to the repository.
+
+### Build an RC release for SVN apache upload
+
+The Release Candidate artifacts we vote upon should be the exact ones we vote against, without any
+modification than renaming i.e. the contents of the files must be the same between voted
+release candidate and final release. Because of this the version in the built artifacts
+that will become the official Apache releases must not include the rcN suffix. They also need
+to be signed and have checksum files. You can generate the checksum/signature files by running
+the "dev/sign.sh" script (assuming you have the right PGP key set-up for signing). The script
+generates corresponding .asc and .sha512 files for each file to sign.
+
+#### Build and sign the source and convenience packages
+
+* Set environment variables (version and root of airflow repo)
+
+```shell script
+export VERSION=2020.5.20rc2
+export AIRFLOW_REPO_ROOT=$(pwd)
+
+```
+
+* Build the source package:
+
+```
+./backport_packages/build_source_package.sh
+
+```
+
+It will generate `apache-airflow-backport-providers-${VERSION}-source.tar.gz`
+
+* Generate the packages - since we are preparing packages for SVN repo, we should use the right switch. Note
+  that this will clean up dist folder before generating the packages, so it will only contain the packages
+  you intended to build.
+
+```shell script
+./breeze prepare-backport-packages --version-suffix-for-svn rc1
+```
+
+if you ony build few packages, run:
+
+```shell script
+./breeze prepare-backport-packages --version-suffix-for-svn rc1 PACKAGE PACKAGE ....
+```
+
+* Move the source tarball to dist folder
+
+```shell script
+mv apache-airflow-backport-providers-${VERSION}-source.tar.gz dist
+```
+
+* Sign all your packages
+
+```shell script
+pushd dist
+../dev/sign.sh *
+popd
+```
+
+* Push tags to Apache repository (assuming that you have apache remote pointing to apache/airflow repo)]
+
+```shell script
+git push apache backport-providers-${VERSION}
+```
+
+#### Commit the source packages to Apache SVN repo
+
+* Push the artifacts to ASF dev dist repo
+
+```shell script
+# First clone the repo if you do not have it
+svn checkout https://dist.apache.org/repos/dist/dev/airflow airflow-dev
+
+# update the repo in case you have it already
+cd airflow-dev
+svn update
+
+# Create a new folder for the release.
+cd airflow-dev/backport-providers
+svn mkdir ${VERSION}
+
+# Move the artifacts to svn folder
+mv ${AIRFLOW_REPO_ROOT}/dist/* ${VERSION}/
+
+# Add and commit
+svn add ${VERSION}/*
+svn commit -m "Add artifacts for Airflow ${VERSION}"
+
+cd ${AIRFLOW_REPO_ROOT}
+```
+
+Verify that the files are available at
+[backport-providers](https://dist.apache.org/repos/dist/dev/airflow/backport-providers/)
+
+### Publish the RC convenience package to PyPI
+
+In order to publish to PyPI you just need to build and release packages. The packages should however
+contain the rcN suffix in the version name as well, so you need to use `--version-suffix-for-pypi` switch
+to prepare those packages. Note that these are different packages than the ones used for SVN upload
+though they should be generated from the same sources.
+
+* Generate the packages with the right RC version (specify the version suffix with PyPI switch). Note that
+this will clean up dist folder before generating the packages, so you will only have the right packages there.
+
+```shell script
+./breeze prepare-backport-packages --version-suffix-for-pypi rc1
+```
+
+if you ony build few packages, run:
+
+```shell script
+./breeze prepare-backport-packages --version-suffix-for-pypi rc1 PACKAGE PACKAGE ....
+```
+
+* Verify the artifacts that would be uploaded:
+
+```shell script
+twine check dist/*
+```
+
+* Upload the package to PyPi's test environment:
+
+```shell script
+twine upload -r pypitest dist/*
+```
+
+* Verify that the test packages look good by downloading it and installing them into a virtual environment.
+Twine prints the package links as output - separately for each package.
+
+* Upload the package to PyPi's production environment:
+
+```shell script
+twine upload -r pypi dist/*
+```
+
+* Copy the list of links to the uploaded packages - they will be useful in preparing VOTE email.
+
+* Again, confirm that the packages are available under the links printed.
+
+## Vote and verify the Backport Providers release candidate
+
+### Prepare voting email for Backport Providers release candidate
+
+Make sure the packages are in https://dist.apache.org/repos/dist/dev/airflow/backport-providers/
+
+Send out a vote to the dev@airflow.apache.org mailing list. Here you can prepare text of the
+email using the ${VERSION} variable you already set in the command line.
+
+subject:
+
+
+```shell script
+cat <<EOF
+[VOTE] Airflow Backport Providers ${VERSION}
+EOF
+```
+
+```shell script
+cat <<EOF
+Hey all,
+
+I have cut Airflow Backport Providers ${VERSION}. This email is calling a vote on the release,
+which will last for 72 hours - which means that it will end on $(date -d '+3 days').
+
+Consider this my (binding) +1.
+
+Airflow Backport Providers ${VERSION} are available at:
+https://dist.apache.org/repos/dist/dev/airflow/backport-providers/${VERSION}/
+
+*apache-airflow-backport-providers-${VERSION}-source.tar.gz* is a source release that comes
+ with INSTALL instructions.
+
+*apache-airflow-backport-providers-<PROVIDER>-${VERSION}-bin.tar.gz* are the binary
+ Python "sdist" release.
+
+The test procedure for PMCs and Contributors who would like to test the RC candidates are described in
+https://github.com/apache/airflow/blob/master/dev/README.md#vote-and-verify-the-backport-providers-release-candidate
+
+
+Public keys are available at:
+https://dist.apache.org/repos/dist/release/airflow/KEYS
+
+Please vote accordingly:
+
+[ ] +1 approve
+[ ] +0 no opinion
+[ ] -1 disapprove with the reason
+
+
+Only votes from PMC members are binding, but members of the community are
+encouraged to test the release and vote with "(non-binding)".
+
+Please note that the version number excludes the 'rcX' string, so it's now
+simply ${VERSION%rc?}. This will allow us to rename the artifact without modifying
+the artifact checksums when we actually release.
+
+Each of the packages contains detailed changelog. Here is the list of links to
+the released packages and changelogs:
+
+TODO: Paste the result of twine upload
+
+Cheers,
+<TODO: Your Name>
+
+EOF
+```
+
+Due to the nature of backport packages, not all packages have to be released as convenience
+packages in the final release. During the voting process
+the voting PMCs might decide to exclude certain packages from the release if some critical
+problems have been found in some packages.
+
+Please modify the message above accordingly to clearly exclude those packages.
+
+### Verify the release
+
+#### SVN check
+
+The files should be present in the sub-folder of
+[Airflow dist](https://dist.apache.org/repos/dist/dev/airflow/backport-providers/)
+
+The following files should be present (9 files):
+
+* -source.tar.gz + .asc + .sha512 (one set of files)
+* -bin-tar.gz + .asc + .sha512 (one set of files per provider)
+* -.whl + .asc + .sha512 (one set of files per provider)
+
+As a PMC you should be able to clone the SVN repository:
+
+```shell script
+svn co https://dist.apache.org/repos/dist/dev/airflow/
+```
+
+Or update it if you already checked it out:
+
+```shell script
+svn update .
+```
+
+#### Verify the licences
+
+This can be done with the Apache RAT tool.
+
+* Download the latest jar from https://creadur.apache.org/rat/download_rat.cgi (unpack the sources,
+  the jar is inside)
+* Unpack the -source.tar.gz to a folder
+* Enter the folder and run the check (point to the place where you extracted the .jar)
+
+```shell script
+java -jar ../../apache-rat-0.13/apache-rat-0.13.jar -E .rat-excludes -d .
+```
+
+#### Verify the signatures
+
+Make sure you have the key of person signed imported in your GPG. You can find the valid keys in
+[KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS).
+
+You can import the whole KEYS file:
+
+```shell script
+gpg --import KEYS
+```
+
+You can also import the keys individually from a keyserver. The below one uses Kaxil's key and
+retrieves it from the default GPG keyserver
+[OpenPGP.org](https://keys.openpgp.org):
+
+```shell script
+gpg --receive-keys 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+```
+
+You should choose to import the key when asked.
+
+Note that by being default, the OpenPGP server tends to be overloaded often and might respond with
+errors or timeouts. Many of the release managers also uploaded their keys to the
+[GNUPG.net](https://keys.gnupg.net) keyserver, and you can retrieve it from there.
+
+```shell script
+gpg --keyserver keys.gnupg.net --receive-keys 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+```
+
+Once you have the keys, the signatures can be verified by running this:
+
+```shell script
+for i in *.asc
+do
+   echo "Checking $i"; gpg --verify `basename $i .sha512 `
+done
+```
+
+This should produce results similar to the below. The "Good signature from ..." is indication
+that the signatures are correct. Do not worry about the "not certified with a trusted signature"
+warning. Most of the certificates used by release managers are self signed, that's why you get this
+warning. By importing the server in the previous step and importing it via ID from
+[KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS) page, you know that
+this is a valid Key already.
+
+```
+Checking apache-airflow-1.10.12rc4-bin.tar.gz.asc
+gpg: assuming signed data in 'apache-airflow-1.10.12rc4-bin.tar.gz'
+gpg: Signature made sob, 22 sie 2020, 20:28:28 CEST
+gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+Checking apache_airflow-1.10.12rc4-py2.py3-none-any.whl.asc
+gpg: assuming signed data in 'apache_airflow-1.10.12rc4-py2.py3-none-any.whl'
+gpg: Signature made sob, 22 sie 2020, 20:28:31 CEST
+gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+Checking apache-airflow-1.10.12rc4-source.tar.gz.asc
+gpg: assuming signed data in 'apache-airflow-1.10.12rc4-source.tar.gz'
+gpg: Signature made sob, 22 sie 2020, 20:28:25 CEST
+gpg:                using RSA key 12717556040EEF2EEAF1B9C275FCCD0A25FA0E4B
+gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+```
+
+#### Verify the SHA512 sum
+
+Run this:
+
+```shell script
+for i in *.sha512
+do
+    echo "Checking $i"; gpg --print-md SHA512 `basename $i .sha512 ` | diff - $i
+done
+```
+
+You should get output similar to:
+
+```
+Checking apache-airflow-1.10.12rc4-bin.tar.gz.sha512
+Checking apache_airflow-1.10.12rc4-py2.py3-none-any.whl.sha512
+Checking apache-airflow-1.10.12rc4-source.tar.gz.sha512
+```
+
+### Verify if the Backport Packages release candidates "work" by Contributors
+
+This can be done (and we encourage to) by any of the Contributors. In fact, it's best if the
+actual users of Apache Airflow test it in their own staging/test installations. Each release candidate
+is available on PyPI apart from SVN packages, so everyone should be able to install
+the release candidate version of Airflow via simply (<VERSION> is 1.10.12 for example, and <X> is
+release candidate number 1,2,3,....).
+
+You have to make sure you have ariflow 1.10.* (the version you want to install providers with).
+
+```shell script
+pip install apache-airflow-backport-providers-<provider>==<VERSION>rc<X>
+```
+Optionally it can be followed with constraints
+
+```shell script
+pip install apache-airflow-backport-providers-<provider>==<VERSION>rc<X> \
+  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-<VERSION>/constraints-3.6.txt"`
+```
+
+Note that the constraints contain python version that you are installing it with.
+
+You can use any of the installation methods you prefer (you can even install it via the binary wheels
+downloaded from the SVN).
+
+There is also an easy way of installation with Breeze if you have the latest sources of Apache Airflow.
+Here is a typical scenario.
+
+First copy all the provider packages .whl files to the `dist` folder.
+
+```shell script
+./breeze start-airflow --install-airflow-version <VERSION>rc<X> \
+    --python 3.7 --backend postgres --instal-wheels
+```
+
+For 1.10 releases you can also use `--no-rbac-ui` flag disable RBAC UI of Airflow:
+
+```shell script
+./breeze start-airflow --install-airflow-version <VERSION>rc<X> \
+    --python 3.7 --backend postgres --install-wheels --no-rbac-ui
+```
+
+Once you install and run Airflow, you should perform any verification you see as necessary to check
+that the Airflow works as you expected.
+
+
+## Publish the final releases of backport packages
+
+### Summarize the voting for the Backport Providers Release
+
+Once the vote has been passed, you will need to send a result vote to dev@airflow.apache.org:
+
+Subject:
+```shell script
+cat <<EOF
+[RESULT][VOTE] Airflow Backport Providers ${VERSION}
+EOF
+```
+
+Body:
+
+```shell script
+cat <<EOF
+
+Hey all,
+
+Airflow Backport Providers ${VERSION} (based on the ${VERSION_RC} candidate) has been accepted.
+
+N "+1" binding votes received:
+- PMC Member  (binding)
+...
+
+N "+1" non-binding votes received:
+
+- COMMITER (non-binding)
+
+Vote thread:
+https://lists.apache.org/thread.html/<TODO:REPLACE_ME_WITH_THE_VOTING_THREAD>@%3Cdev.airflow.apache.org%3E
+
+I'll continue with the release process and the release announcement will follow shortly.
+
+Cheers,
+<TODO: Your Name>
+
+EOF
+
+```
+
+### Publish release to SVN
+
+The best way of doing this is to svn cp  between the two repos (this avoids having to upload the binaries
+again, and gives a clearer history in the svn commit logs.
+
+We also need to archive older releases before copying the new ones
+[Release policy](http://www.apache.org/legal/release-policy.html#when-to-archive)
+
+```shell script
+# Set the variables
+export VERSION_RC=2020.5.20rc2
+export VERSION=${VERSION_RC/rc?/}
+
+# Set AIRFLOW_REPO_ROOT to the path of your git repo
+export AIRFLOW_REPO_ROOT=$(pwd)
+
+# Go to the directory where you have checked out the dev svn release
+# And go to the sub-folder with RC candidates
+cd "<ROOT_OF_YOUR_DEV_REPO>/backport-providers/${VERSION_RC}"
+export SOURCE_DIR=$(pwd)
+
+# Go the folder where you have checked out the release repo
+# Clone it if it's not done yet
+svn checkout https://dist.apache.org/repos/dist/release/airflow airflow-release
+
+# Update to latest version
+svn update
+
+# Create backport-providers folder if it does not exist
+# All latest releases are kept in this one folder without version sub-folder
+mkdir -pv backport-providers
+cd backport-providers
+
+# Move the artifacts to svn folder & remove the rc postfix
+for file in ${SOURCE_DIR}/*${VERSION_RC}*
+do
+  base_file=$(basename ${file})
+  svn cp "${file}" "${base_file/${VERSION_RC}/${VERSION}}"
+done
+
+
+# If some packages have been excluded, remove them now
+# Check the packages
+ls *<provider>*
+# Remove them
+svn rm *<provider>*
+
+# Check which old packages will be removed (you need python 3.6+)
+python ${AIRFLOW_REPO_ROOT}/backport_packages/remove_old_releases.py \
+    --directory .
+
+# Remove those packages
+python ${AIRFLOW_REPO_ROOT}/backport_packages/remove_old_releases.py \
+    --directory . --execute
+
+
+# Commit to SVN
+svn commit -m "Release Airflow Backport Providers ${VERSION} from ${VERSION_RC}"
+```
+
+Verify that the packages appear in
+[backport-providers](https://dist.apache.org/repos/dist/release/airflow/backport-providers)
+
+### Publish the final version convenience package to PyPI
+
+Checkout the RC Version:
+
+```shell script
+git checkout backport-providers-${VERSION_RC}
+```
+
+Tag and push the final version (providing that your apache remote is named 'apache'):
+
+```shell script
+git tag backport-providers-${VERSION}
+git push apache backport-providers-${VERSION}
+```
+
+In order to publish to PyPI you just need to build and release packages.
+
+* Generate the packages.
+
+```shell script
+./breeze prepare-backport-packages
+```
+
+if you ony build few packages, run:
+
+```shell script
+./breeze prepare-backport-packages
+```
+
+In case you decided to remove some of the packages. Remove them from dist folder now:
+
+```shell script
+ls dist/*<provider>*
+rm dist/*<provider>*
+```
+
+
+* Verify the artifacts that would be uploaded:
+
+```shell script
+twine check dist/*
+```
+
+* Upload the package to PyPi's test environment:
+
+```shell script
+twine upload -r pypitest dist/*
+```
+
+* Verify that the test packages look good by downloading it and installing them into a virtual environment.
+Twine prints the package links as output - separately for each package.
+
+* Upload the package to PyPi's production environment:
+
+```shell script
+twine upload -r pypi dist/*
+```
+
+### Notify developers of release
+
+- Notify users@airflow.apache.org (cc'ing dev@airflow.apache.org and announce@apache.org) that
+the artifacts have been published:
+
+### Notify developers of release
+
+- Notify users@airflow.apache.org (cc'ing dev@airflow.apache.org and announce@apache.org) that
+the artifacts have been published:
+
+Subject:
+```shell script
+cat <<EOF
+Airflow Backport Providers ${VERSION} are released
+EOF
+```
+
+Body:
+```shell script
+cat <<EOF
+Dear Airflow community,
+
+I'm happy to announce that Airflow Backport Providers packages ${VERSION} were just released.
+
+The source release, as well as the binary releases, are available here:
+
+https://dist.apache.org/repos/dist/release/airflow/backport-providers/
+
+We also made those versions available on PyPi for convenience ('pip install apache-airflow-backport-providers-*'):
+
+https://pypi.org/search/?q=apache-airflow-backport-providers
+
+The documentation and changelogs are available in the PyPI packages:
+
+<PASTE TWINE UPLOAD LINKS HERE>
+
+
+Cheers,
+<your name>
+EOF
+```
+
+
+### Update Announcements page
+
+Update "Announcements" page at the [Official Airflow website](https://airflow.apache.org/announcements/)


### PR DESCRIPTION
This commit extracts common parts of Apache Airflow package
preparation and Backport Packages preparation.

Common parts were extracted as prerequisites, the release process
has been put in chronological order, some details about preparing
backport packages have been moved to a separate README.md
in the Backport Packages to not confuse release instructions
with tool instructions.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
