### PR TITLE
Bump tenacity to 6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -735,7 +735,7 @@ INSTALL_REQUIREMENTS = [
     'sqlalchemy>=1.3.18, <2',
     'sqlalchemy_jsonfield~=0.9',
     'tabulate>=0.7.5, <0.9',
-    'tenacity>=4.12.0, <5.2',
+    'tenacity~=6.2.0',
     'termcolor>=1.1.0',
     'thrift>=0.9.2',
     'typing;python_version<"3.6"',


### PR DESCRIPTION
There is no reason to limit tenacity. One of my upcoming PRs (or a commit in scheduler-ha PR) will use a new feature available in the newer version.

One of the reasons for creating a separate PR for this is so that [constraints](https://github.com/apache/airflow/tree/constraints-master) are updated and when I create new PR (or merge to scheduler-ha PR) it will run against a newer version of tenacity because of the upgraded constraints, without it, it will error.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
