### PR TITLE
Prints nicer message in case of git push errors

### DIFF
--- a/scripts/ci/libraries/_push_pull_remove_images.sh
+++ b/scripts/ci/libraries/_push_pull_remove_images.sh
@@ -154,7 +154,21 @@ function push_pull_remove_images::push_ci_images_to_github() {
         PYTHON_TAG_SUFFIX="-${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
     fi
     docker tag "${PYTHON_BASE_IMAGE}" "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
+    set +e
     docker push "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
+    local result=$?
+    set -e
+    if [[ ${result} != "0" ]]; then
+        >&2 echo
+        >&2 echo "There was an unexpected error when pushing images to the GitHub Registry"
+        >&2 echo
+        >&2 echo "If you see 'unknown blob' or similar kind of error it means that it was a transient error"
+        >&2 echo "And it will likely be gone next time"
+        >&2 echo
+        >&2 echo "Please rebase your change or 'git commit --amend; git push --force' and try again"
+        >&2 echo
+        exit "${result}"
+    fi
 }
 
 
@@ -198,7 +212,22 @@ function push_pull_remove_images::push_prod_images_to_github () {
     # Also push prod build image
     AIRFLOW_PROD_BUILD_TAGGED_IMAGE="${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
     docker tag "${AIRFLOW_PROD_BUILD_IMAGE}" "${AIRFLOW_PROD_BUILD_TAGGED_IMAGE}"
+    set +e
     docker push "${AIRFLOW_PROD_BUILD_TAGGED_IMAGE}"
+    local result=$?
+    set -e
+    if [[ ${result} != "0" ]]; then
+        >&2 echo
+        >&2 echo "There was an unexpected error when pushing images to the GitHub Registry"
+        >&2 echo
+        >&2 echo "If you see 'unknown blob' or similar kind of error it means that it was a transient error"
+        >&2 echo "And it will likely be gone next time"
+        >&2 echo
+        >&2 echo "Please rebase your change or 'git commit --amend; git push --force' and try again"
+        >&2 echo
+        exit "${result}"
+    fi
+
 }
 
 


### PR DESCRIPTION
We started to get more often "unknown blob" kind of errors when
pushing the images to GitHub Registry. While this is clearly a
GitHub issue, it's frequency of occurence and unclear message
make it a good candidate to write additional message with
instructions to the users, especially that now they have
an easy way to get to that information via status checks and
links leading to the log file, when this problem happens during
image building process.

This way users will know that they should simply rebase or
amend/force-push their change to fix it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
