### PR TITLE
KubernetesPodOperator should retry log tailing in case of interruption

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -156,7 +156,15 @@ class PodLauncher(LoggingMixin):
             time.sleep(2)
         return self._task_status(self.read_pod(pod)), result
 
-    def parse_log_line(self, line):
+    def parse_log_line(self, line: str) -> Tuple[str, str]:
+        """
+        Parse K8s log line and returns the final state
+
+        :param line: k8s log line
+        :type line: str
+        :return: timestamp and log message
+        :rtype: Tuple[str, str]
+        """
         split_at = line.find(' ')
         if split_at == -1:
             raise Exception('Log not in "{{timestamp}} {{log}}" format. Got: {}'.format(line))

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -184,7 +184,10 @@ class PodLauncher(LoggingMixin):
         wait=tenacity.wait_exponential(),
         reraise=True
     )
-    def read_pod_logs(self, pod: V1Pod, tail_lines: Optional[int] = None, since_seconds: Optional[int] = None):
+    def read_pod_logs(self,
+                      pod: V1Pod,
+                      tail_lines: Optional[int] = None,
+                      since_seconds: Optional[int] = None):
         """Reads log from the POD"""
         additional_kwargs = {}
         if since_seconds:

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -404,7 +404,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             )
             context = create_context(k)
             k.execute(context=context)
-            mock_logger.info.assert_any_call(b"retrieved from mount\n")
+            mock_logger.info.assert_any_call('retrieved from mount')
             actual_pod = self.api_client.sanitize_for_serialization(k.pod)
             self.expected_pod['spec']['containers'][0]['args'] = args
             self.expected_pod['spec']['containers'][0]['volumeMounts'] = [{

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -49,16 +49,14 @@ class TestPodLauncher(unittest.TestCase):
                 container='base',
                 follow=True,
                 name=mock.sentinel.metadata.name,
-                namespace=mock.sentinel.metadata.namespace,
-                tail_lines=10
+                namespace=mock.sentinel.metadata.namespace
             ),
             mock.call(
                 _preload_content=False,
                 container='base',
                 follow=True,
                 name=mock.sentinel.metadata.name,
-                namespace=mock.sentinel.metadata.namespace,
-                tail_lines=10
+                namespace=mock.sentinel.metadata.namespace
             )
         ])
 

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -48,6 +48,7 @@ class TestPodLauncher(unittest.TestCase):
                 _preload_content=False,
                 container='base',
                 follow=True,
+                timestamps=False,
                 name=mock.sentinel.metadata.name,
                 namespace=mock.sentinel.metadata.namespace
             ),
@@ -55,6 +56,7 @@ class TestPodLauncher(unittest.TestCase):
                 _preload_content=False,
                 container='base',
                 follow=True,
+                timestamps=False,
                 name=mock.sentinel.metadata.name,
                 namespace=mock.sentinel.metadata.namespace
             )
@@ -85,6 +87,7 @@ class TestPodLauncher(unittest.TestCase):
                 _preload_content=False,
                 container='base',
                 follow=True,
+                timestamps=False,
                 name=mock.sentinel.metadata.name,
                 namespace=mock.sentinel.metadata.namespace,
                 tail_lines=100
@@ -103,6 +106,7 @@ class TestPodLauncher(unittest.TestCase):
                 _preload_content=False,
                 container='base',
                 follow=True,
+                timestamps=False,
                 name=mock.sentinel.metadata.name,
                 namespace=mock.sentinel.metadata.namespace,
                 since_seconds=2
@@ -177,4 +181,15 @@ class TestPodLauncher(unittest.TestCase):
             AirflowException,
             self.pod_launcher.read_pod,
             mock.sentinel
+        )
+
+    def test_parse_log_line(self):
+        timestamp, message = self.pod_launcher.parse_log_line('2020-10-08T14:16:17.793417674Z Valid message\n')
+
+        self.assertEqual(timestamp, '2020-10-08T14:16:17.793417674Z')
+        self.assertEqual(message, 'Valid message')
+
+        self.assertRaises(
+            Exception,
+            self.pod_launcher.parse_log_line('2020-10-08T14:16:17.793417674ZInvalid message\n'),
         )

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -80,7 +80,7 @@ class TestPodLauncher(unittest.TestCase):
         self.mock_kube_client.read_namespaced_pod_log.side_effect = [
             mock.sentinel.logs
         ]
-        logs = self.pod_launcher.read_pod_logs(mock.sentinel, 100)
+        logs = self.pod_launcher.read_pod_logs(mock.sentinel, tail_lines=100)
         self.assertEqual(mock.sentinel.logs, logs)
         self.mock_kube_client.read_namespaced_pod_log.assert_has_calls([
             mock.call(
@@ -90,6 +90,24 @@ class TestPodLauncher(unittest.TestCase):
                 name=mock.sentinel.metadata.name,
                 namespace=mock.sentinel.metadata.namespace,
                 tail_lines=100
+            ),
+        ])
+
+    def test_read_pod_logs_successfully_with_since_seconds(self):
+        mock.sentinel.metadata = mock.MagicMock()
+        self.mock_kube_client.read_namespaced_pod_log.side_effect = [
+            mock.sentinel.logs
+        ]
+        logs = self.pod_launcher.read_pod_logs(mock.sentinel, since_seconds=2)
+        self.assertEqual(mock.sentinel.logs, logs)
+        self.mock_kube_client.read_namespaced_pod_log.assert_has_calls([
+            mock.call(
+                _preload_content=False,
+                container='base',
+                follow=True,
+                name=mock.sentinel.metadata.name,
+                namespace=mock.sentinel.metadata.namespace,
+                since_seconds=2
             ),
         ])
 

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -184,7 +184,8 @@ class TestPodLauncher(unittest.TestCase):
         )
 
     def test_parse_log_line(self):
-        timestamp, message = self.pod_launcher.parse_log_line('2020-10-08T14:16:17.793417674Z Valid message\n')
+        timestamp, message = \
+            self.pod_launcher.parse_log_line('2020-10-08T14:16:17.793417674Z Valid message\n')
 
         self.assertEqual(timestamp, '2020-10-08T14:16:17.793417674Z')
         self.assertEqual(message, 'Valid message')


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds ability for KubernetesPodOperator to retry log tailing in case of interruption, described in #11324.
I've also included fix for #10586. I've tested introducted changes to be stable when running modified version for several days.

Closes #11324  #10586


