### PR TITLE
Fix interpolation issue in conf_vars in tests

### DIFF
--- a/tests/test_utils/config.py
+++ b/tests/test_utils/config.py
@@ -51,6 +51,7 @@ def conf_vars(overrides):
     finally:
         for (section, key), value in original.items():
             if value is not None:
+                value = value.replace("%(", "%%(")  # Hack to make interpolation work
                 conf.set(section, key, value)
             else:
                 conf.remove_option(section, key)


### PR DESCRIPTION
It seems that using conf_vars for strings with interpolation
breaks config parser because proper string is replaced by already
interpolated string. This fix errors from v1-10-test

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
