### PR TITLE
Reduce "start-up" time for tasks in LocalExecutor

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -208,6 +208,16 @@
       type: string
       example: ~
       default: "{AIRFLOW_HOME}/plugins"
+    - name: execute_tasks_new_python_interpreter
+      description: |
+        Should tasks be executed via forking of the parent process ("False",
+        the speedier option) or by spawning a new python process ("True" slow,
+        but means plugin changes picked up by tasks straight away)
+      default: "False"
+      example: ~
+      version_added: "2.0.0"
+      see_also: ":ref:`plugins:loading`"
+      type: boolean
     - name: fernet_key
       description: |
         Secret key to save connection passwords in the db

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -133,6 +133,11 @@ load_default_connections = True
 # Where your Airflow plugins are stored
 plugins_folder = {AIRFLOW_HOME}/plugins
 
+# Should tasks be executed via forking of the parent process ("False",
+# the speedier option) or by spawning a new python process ("True" slow,
+# but means plugin changes picked up by tasks straight away)
+execute_tasks_new_python_interpreter = False
+
 # Secret key to save connection passwords in the db
 fernet_key = {FERNET_KEY}
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -365,3 +365,11 @@ STORE_DAG_CODE = conf.getboolean("core", "store_dag_code", fallback=STORE_SERIAL
 # to get all the logs from the print & log statements in the DAG files before a task is run
 # The handlers are restored after the task completes execution.
 DONOT_MODIFY_HANDLERS = conf.getboolean('logging', 'donot_modify_handlers', fallback=False)
+
+CAN_FORK = hasattr(os, "fork")
+
+EXECUTE_TASKS_NEW_PYTHON_INTERPRETER = not CAN_FORK or conf.getboolean(
+    'core',
+    'execute_tasks_new_python_interpreter',
+    fallback=False,
+)

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -21,10 +21,9 @@ import os
 import psutil
 from setproctitle import setproctitle  # pylint: disable=no-name-in-module
 
+from airflow.settings import CAN_FORK
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.process_utils import reap_process_group
-
-CAN_FORK = hasattr(os, "fork")
 
 
 class StandardTaskRunner(BaseTaskRunner):

--- a/docs/configurations-ref.rst
+++ b/docs/configurations-ref.rst
@@ -53,6 +53,10 @@ can set in ``airflow.cfg`` file or using environment variables.
     {{ option["description"] }}
     {% endif %}
 
+    {% if option.get("see_also") %}
+    .. seealso:: {{ option["see_also"] }}
+    {% endif %}
+
     :Type: {{ option["type"] }}
     :Default: ``{{ "''" if option["default"] == "" else option["default"] }}``
     :Environment Variable: ``AIRFLOW__{{ section["name"] | upper }}__{{ option["name"] | upper }}``

--- a/docs/modules_management.rst
+++ b/docs/modules_management.rst
@@ -228,6 +228,8 @@ Python PATH: [/home/rootcss/venvs/airflow/bin:/usr/lib/python38.zip:/usr/lib/pyt
 
 Below is the sample output of the ``airflow info`` command:
 
+.. seealso:: :ref:`plugins:loading`
+
 .. code-block:: none
 
     Apache Airflow [1.10.11]

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -66,6 +66,25 @@ Airflow has many components that can be reused when building an application:
 * Airflow is deployed, you can just piggy back on its deployment logistics
 * Basic charting capabilities, underlying libraries and abstractions
 
+.. _plugins:loading:
+
+When are plugins (re)loaded?
+----------------------------
+
+Plugins are loaded once at the start of every Airflow process, and never reloaded.
+
+This means that if you make any changes to plugins and you want the webserver or scheduler to use that new
+code you will need to restart those processes.
+
+By default, task execution will use forking to avoid the slow down of having to create a whole new python
+interpreter and re-parse all of the Airflow code and start up routines -- this is a big benefit for shorter
+running tasks. This does mean that if you use plugins in your tasks, and want them to update you will either
+need to restart the worker (if using CeleryExecutor) or scheduler (Local or Sequential executors). The other
+option is you can accept the speed hit at start up set the ``core.execute_tasks_new_python_interpreter``
+config setting to True, resulting in launching a whole new python interpreter for tasks.
+
+(Modules only imported by DAG files on the other hand do not suffer this problem, as DAG files are not
+loaded/parsed in any long-running Airflow process.)
 
 Interface
 ---------


### PR DESCRIPTION
Spawning a whole new python process and then re-loading all of Airflow
is expensive. All though this time fades to insignificance for long
running tasks, this delay gives a "bad" experience for new users when
they are just trying out Airflow for the first time.

For the LocalExecutor this cuts the "queued time" down from 1.5s to 0.1s
on average.

Data on this for a simple 10-task sequential DAG:

```sql
SELECT execution_date,
    min(start_date - queued_dttm) AS min_quued_delay,
    max(start_date - queued_dttm) AS max_queued_delay
FROM task_instance
WHERE dag_id = 'scenario1_case2_03_1' GROUP BY execution_date;
```

|         execution_date         | min_quued_delay | max_queued_delay  | with change? |
| ------------------------------- | ----------------- | ------------------ | -- | 
| 2020-10-07 02:00:00+01 | 00:00:01.329747 | 00:00:01.475085 | No |
| 2020-10-07 01:00:00+01        | 00:00:00.083668  | 00:00:00.11244 | Yes | 

This was discovered in my general benchmarking and profiling of the scheduler for AIP-15, but it's not tied to any of that work. There are more of these kind of improvements coming, each unrelated but all add up.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
