### PR TITLE
Refactor celery worker command

### DIFF
--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -24,7 +24,6 @@ import daemon
 import psutil
 import sqlalchemy.exc
 from celery import maybe_patch_concurrency
-from celery.bin import worker as worker_bin
 from daemon.pidfile import TimeoutPIDLockFile
 from flower.command import FlowerCommand
 from lockfile.pidlockfile import read_pid_from_pidfile, remove_existing_pidfile
@@ -132,7 +131,6 @@ def worker(args):
     # Setup Celery worker
     options = {
         'optimization': 'fair',
-        'O': 'fair',
         'queues': args.queues,
         'concurrency': args.concurrency,
         'autoscale': autoscale,
@@ -140,7 +138,6 @@ def worker(args):
         'loglevel': conf.get('logging', 'LOGGING_LEVEL'),
         'pidfile': pid_file_path,
     }
-    worker_instance = celery_app.Worker(**options)
 
     if conf.has_option("celery", "pool"):
         pool = conf.get("celery", "pool")
@@ -152,6 +149,8 @@ def worker(args):
         # executed.
         maybe_patch_concurrency(['-P', pool])
 
+    worker_instance = celery_app.Worker(**options)
+    
     if args.daemon:
         # Run Celery worker as daemon
         handle = setup_logging(log_file)

--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -130,7 +130,6 @@ def worker(args):
             pass
 
     # Setup Celery worker
-    worker_instance = worker_bin.worker(app=celery_app)
     options = {
         'optimization': 'fair',
         'O': 'fair',
@@ -141,6 +140,7 @@ def worker(args):
         'loglevel': conf.get('logging', 'LOGGING_LEVEL'),
         'pidfile': pid_file_path,
     }
+    worker_instance = celery_app.Worker(**options)
 
     if conf.has_option("celery", "pool"):
         pool = conf.get("celery", "pool")
@@ -169,14 +169,14 @@ def worker(args):
         )
         with ctx:
             sub_proc = _serve_logs(skip_serve_logs)
-            worker_instance.run(**options)
+            worker_instance.start()
 
         stdout.close()
         stderr.close()
     else:
         # Run Celery worker in the same process
         sub_proc = _serve_logs(skip_serve_logs)
-        worker_instance.run(**options)
+        worker_instance.start()
 
     if sub_proc:
         sub_proc.terminate()

--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -150,7 +150,7 @@ def worker(args):
         maybe_patch_concurrency(['-P', pool])
 
     worker_instance = celery_app.Worker(**options)
-    
+
     if args.daemon:
         # Run Celery worker as daemon
         handle = setup_logging(log_file)

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -70,7 +70,8 @@ else:
 
 app = Celery(
     conf.get('celery', 'CELERY_APP_NAME'),
-    config_source=celery_configuration)
+    config_source=celery_configuration
+)
 
 
 @app.task

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -189,3 +189,4 @@ class TestWorkerStart(unittest.TestCase):
             hostname=celery_hostname,
             loglevel=conf.get('logging', 'LOGGING_LEVEL'),
         )
+        mock_worker.return_value.start.assert_called_once_with()

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -69,7 +69,7 @@ class TestWorkerServeLogs(unittest.TestCase):
     def setUpClass(cls):
         cls.parser = cli_parser.get_parser()
 
-    @mock.patch('airflow.cli.commands.celery_command.worker_bin')
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
     @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_serve_logs_on_worker_start(self, mock_worker):
         with mock.patch('airflow.cli.commands.celery_command.Process') as mock_process:
@@ -80,7 +80,7 @@ class TestWorkerServeLogs(unittest.TestCase):
                 celery_command.worker(args)
                 mock_process.assert_called()
 
-    @mock.patch('airflow.cli.commands.celery_command.worker_bin')
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
     @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_skip_serve_logs_on_worker_start(self, mock_worker):
         with mock.patch('airflow.cli.commands.celery_command.Process') as mock_popen:
@@ -119,7 +119,7 @@ class TestCeleryStopCommand(unittest.TestCase):
                 mock_process.return_value.terminate.assert_called_once_with()
 
     @mock.patch("airflow.cli.commands.celery_command.read_pid_from_pidfile")
-    @mock.patch("airflow.cli.commands.celery_command.worker_bin.worker")
+    @mock.patch("airflow.cli.commands.celery_command.celery_app.Worker")
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
     @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_same_pid_file_is_used_in_start_and_stop(
@@ -135,10 +135,9 @@ class TestCeleryStopCommand(unittest.TestCase):
         # Call worker
         worker_args = self.parser.parse_args(['celery', 'worker', '--skip-serve-logs'])
         celery_command.worker(worker_args)
-        run_mock = mock_celery_worker.return_value.run
-        assert run_mock.call_args
-        assert 'pidfile' in run_mock.call_args.kwargs
-        assert run_mock.call_args.kwargs['pidfile'] == pid_file
+        assert mock_celery_worker.call_args
+        assert 'pidfile' in mock_celery_worker.call_args.kwargs
+        assert mock_celery_worker.call_args.kwargs['pidfile'] == pid_file
 
         # Call stop
         stop_args = self.parser.parse_args(['celery', 'stop'])
@@ -154,7 +153,7 @@ class TestWorkerStart(unittest.TestCase):
 
     @mock.patch("airflow.cli.commands.celery_command.setup_locations")
     @mock.patch('airflow.cli.commands.celery_command.Process')
-    @mock.patch('airflow.cli.commands.celery_command.worker_bin')
+    @mock.patch('airflow.cli.commands.celery_command.celery_app.Worker')
     @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_worker_started_with_required_arguments(self, mock_worker, mock_popen, mock_locations):
         pid_file = "pid_file"
@@ -180,10 +179,9 @@ class TestWorkerStart(unittest.TestCase):
             mock_privil.return_value = 0
             celery_command.worker(args)
 
-        mock_worker.worker.return_value.run.assert_called_once_with(
+        mock_worker.assert_called_once_with(
             pool='prefork',
             optimization='fair',
-            O='fair',  # noqa
             queues=queues,
             pidfile=pid_file,
             concurrency=int(concurrency),


### PR DESCRIPTION
This commit does small refactor of the way we star celery worker.
In this way it will be easier to migrate to Celery 5.0.

Running with currently used Celery version:
```
root@1e7421e00701:/opt/airflow# airflow celery worker
/usr/local/lib/python3.7/site-packages/celery/platforms.py:801: RuntimeWarning: You're running the worker with superuser privileges: this is
absolutely not recommended!

Please specify a different user using the --uid option.

User information: uid=0 euid=0 gid=0 egid=0

  uid=uid, euid=euid, gid=gid, egid=egid,
Starting flask
 * Serving Flask app "airflow.utils.serve_logs" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
[2020-10-07 20:44:47,384: INFO/Process-1]  * Running on http://0.0.0.0:8793/ (Press CTRL+C to quit)

 -------------- celery@1e7421e00701 v4.4.7 (cliffs)
--- ***** -----
-- ******* ---- Linux-4.19.76-linuxkit-x86_64-with-debian-10.5 2020-10-07 20:44:47
- *** --- * ---
- ** ---------- [config]
- ** ---------- .> app:         airflow.executors.celery_executor:0x7f401d0d2a10
- ** ---------- .> transport:   redis://redis:6379/0
- ** ---------- .> results:     postgresql://postgres:**@postgres/airflow
- *** --- * --- .> concurrency: 8 (prefork)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** -----
 -------------- [queues]
                .> default          exchange=default(direct) key=default


[tasks]
  . airflow.executors.celery_executor.execute_command

[2020-10-07 20:44:47,988: INFO/MainProcess] Connected to redis://redis:6379/0
[2020-10-07 20:44:47,998: INFO/MainProcess] mingle: searching for neighbors
[2020-10-07 20:44:49,024: INFO/MainProcess] mingle: all alone
[2020-10-07 20:44:49,045: INFO/MainProcess] celery@1e7421e00701 ready.
^C
worker: Hitting Ctrl+C again will terminate all running tasks!

worker: Warm shutdown (MainProcess)
```

Running with Celery 5.0:
```
root@5257c48ec87e:/opt/airflow# airflow celery worker
/usr/local/lib/python3.7/site-packages/celery/platforms.py:798: RuntimeWarning: You're running the worker with superuser privileges: this is
absolutely not recommended!

Please specify a different user using the --uid option.

User information: uid=0 euid=0 gid=0 egid=0

  uid=uid, euid=euid, gid=gid, egid=egid,
Starting flask
 * Serving Flask app "airflow.utils.serve_logs" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
[2020-10-07 20:40:27,110: INFO/Process-1]  * Running on http://0.0.0.0:8793/ (Press CTRL+C to quit)

 -------------- celery@5257c48ec87e v5.0.0 (singularity)
--- ***** -----
-- ******* ---- Linux-4.19.76-linuxkit-x86_64-with-debian-10.5 2020-10-07 20:40:27
- *** --- * ---
- ** ---------- [config]
- ** ---------- .> app:         airflow.executors.celery_executor:0x7fb3e65b5dd0
- ** ---------- .> transport:   redis://redis:6379/0
- ** ---------- .> results:     postgresql://postgres:**@postgres/airflow
- *** --- * --- .> concurrency: 8 (prefork)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** -----
 -------------- [queues]
                .> default          exchange=default(direct) key=default


[tasks]
  . airflow.executors.celery_executor.execute_command

[2020-10-07 20:40:27,701: INFO/MainProcess] Connected to redis://redis:6379/0
[2020-10-07 20:40:27,711: INFO/MainProcess] mingle: searching for neighbors
[2020-10-07 20:40:28,737: INFO/MainProcess] mingle: all alone
[2020-10-07 20:40:28,762: INFO/MainProcess] celery@5257c48ec87e ready.
^C
worker: Hitting Ctrl+C again will terminate all running tasks!

worker: Warm shutdown (MainProcess)
```

Related to #11301

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
