### PR TITLE
Fix DagBag bug when a Dag has invalid schedule_interval

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -352,9 +352,9 @@ class DagBag(BaseDagBag, LoggingMixin):
                     dag.fileloc = filepath
             try:
                 dag.is_subdag = False
-                self.bag_dag(dag=dag, root_dag=dag)
                 if isinstance(dag.normalized_schedule_interval, str):
                     croniter(dag.normalized_schedule_interval)
+                self.bag_dag(dag=dag, root_dag=dag)
                 found_dags.append(dag)
                 found_dags += dag.subdags
             except (CroniterBadCronError,

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -174,6 +174,7 @@ class TestDagBag(unittest.TestCase):
         for file in invalid_dag_files:
             dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, file))
         self.assertEqual(len(dagbag.import_errors), len(invalid_dag_files))
+        self.assertEqual(len(dagbag.dags), 0)
 
     @patch.object(DagModel, 'get_current')
     def test_get_dag_without_refresh(self, mock_dagmodel):


### PR DESCRIPTION
When a DAG has the wrong schedule_interval, it should be treated as a broken dag, but it would be appearing on UI, and people can trigger it as well and wait for to get process, which would eventually never going to happen. The issue is in dagbag.py where it is being added into dagbag.dags even if the schedule_interval is incorrect. 

To reproduce, put some garbage interval in a test dag. 
