### PR TITLE
chore: use `--no-cache-dir` flag to `pip` in dockerfiles, to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,7 +168,7 @@ RUN if [[ ${AIRFLOW_PRE_CACHED_PIP_PACKAGES} == "true" ]]; then \
        if [[ ${INSTALL_MYSQL_CLIENT} != "true" ]]; then \
           AIRFLOW_EXTRAS=${AIRFLOW_EXTRAS/mysql,}; \
        fi; \
-       pip install --user \
+       pip install --no-cache-dir --user \
           "https://github.com/${AIRFLOW_REPO}/archive/${AIRFLOW_BRANCH}.tar.gz#egg=apache-airflow[${AIRFLOW_EXTRAS}]" \
           --constraint "${AIRFLOW_CONSTRAINTS_URL}" && pip uninstall --yes apache-airflow; \
     fi
@@ -205,9 +205,9 @@ WORKDIR /opt/airflow
 RUN if [[ ${INSTALL_MYSQL_CLIENT} != "true" ]]; then \
         AIRFLOW_EXTRAS=${AIRFLOW_EXTRAS/mysql,}; \
     fi; \
-    pip install --user "${AIRFLOW_INSTALL_SOURCES}[${AIRFLOW_EXTRAS}]${AIRFLOW_INSTALL_VERSION}" \
+    pip install --no-cache-dir --user "${AIRFLOW_INSTALL_SOURCES}[${AIRFLOW_EXTRAS}]${AIRFLOW_INSTALL_VERSION}" \
     --constraint "${AIRFLOW_CONSTRAINTS_URL}" && \
-    if [ -n "${ADDITIONAL_PYTHON_DEPS}" ]; then pip install --user ${ADDITIONAL_PYTHON_DEPS} \
+    if [ -n "${ADDITIONAL_PYTHON_DEPS}" ]; then pip install --no-cache-dir --user ${ADDITIONAL_PYTHON_DEPS} \
     --constraint "${AIRFLOW_CONSTRAINTS_URL}"; fi && \
     find /root/.local/ -name '*.pyc' -print0 | xargs -0 rm -r && \
     find /root/.local/ -type d -name '__pycache__' -print0 | xargs -0 rm -r

--- a/scripts/ci/dockerfiles/krb5-kdc-server/Dockerfile
+++ b/scripts/ci/dockerfiles/krb5-kdc-server/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN mkdir /app/
 
 # Supervisord
-RUN pip install supervisor==3.3.4
+RUN pip install --no-cache-dir supervisor==3.3.4
 
 COPY ./krb-conf/server/kdc.conf /etc/krb5kdc/kdc.conf
 COPY ./krb-conf/server/kadm5.acl /etc/krb5kdc/kadm5.acl


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>