### PR TITLE
Set start_date, end_date & duration for tasks failing without DagRun

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1159,11 +1159,22 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
             tis_to_change: List[TI] = query.with_for_update().all()
             for ti in tis_to_change:
                 ti.set_state(new_state, session=session)
-                ti.duration = 0
                 tis_changed += 1
         else:
             subq = query.subquery()
             current_time = timezone.utcnow()
+            ti_prop_update = {
+                models.TaskInstance.state: new_state,
+                models.TaskInstance.start_date: current_time,
+            }
+
+            # Only add end_date and duration if the new_state is 'success', 'failed' or 'skipped'
+            if new_state in State.finished():
+                ti_prop_update.update({
+                    models.TaskInstance.end_date: current_time,
+                    models.TaskInstance.duration: 0,
+                })
+
             tis_changed = session \
                 .query(models.TaskInstance) \
                 .filter(
@@ -1171,12 +1182,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                     models.TaskInstance.task_id == subq.c.task_id,
                     models.TaskInstance.execution_date ==
                     subq.c.execution_date) \
-                .update({
-                    models.TaskInstance.state: new_state,
-                    models.TaskInstance.start_date: current_time,
-                    models.TaskInstance.end_date: current_time,
-                    models.TaskInstance.duration: 0,
-                }, synchronize_session=False)
+                .update(ti_prop_update, synchronize_session=False)
             session.commit()
 
         if tis_changed > 0:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -611,10 +611,11 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         :param session: SQLAlchemy ORM Session
         :type session: Session
         """
+        current_time = timezone.utcnow()
         self.log.debug("Setting task state for %s to %s", self, state)
         self.state = state
-        self.start_date = timezone.utcnow()
-        self.end_date = timezone.utcnow()
+        self.start_date = current_time
+        self.end_date = current_time
         session.merge(self)
 
     @property

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -615,7 +615,9 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         self.log.debug("Setting task state for %s to %s", self, state)
         self.state = state
         self.start_date = current_time
-        self.end_date = current_time
+        if self.state in State.finished():
+            self.end_date = current_time
+            self.duration = 0
         session.merge(self)
 
     @property

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2236,9 +2236,8 @@ class TestSchedulerJob(unittest.TestCase):
         ti3.refresh_from_db(session=session)
         self.assertEqual(ti3.state, State.NONE)
         self.assertIsNotNone(ti3.start_date)
-        self.assertIsNotNone(ti3.end_date)
-        self.assertEqual(ti3.start_date, ti3.end_date)
-        self.assertEqual(ti3.duration, 0.0)
+        self.assertIsNone(ti3.end_date)
+        self.assertIsNone(ti3.duration)
 
         dr1.refresh_from_db(session=session)
         dr1.state = State.FAILED
@@ -2400,6 +2399,11 @@ class TestSchedulerJob(unittest.TestCase):
 
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         self.assertEqual(ti.state, expected_task_state)
+        self.assertIsNotNone(ti.start_date)
+        if expected_task_state in State.finished():
+            self.assertIsNotNone(ti.end_date)
+            self.assertEqual(ti.start_date, ti.end_date)
+            self.assertIsNotNone(ti.duration)
 
     @provide_session
     def evaluate_dagrun(

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2235,6 +2235,10 @@ class TestSchedulerJob(unittest.TestCase):
 
         ti3.refresh_from_db(session=session)
         self.assertEqual(ti3.state, State.NONE)
+        self.assertIsNotNone(ti3.start_date)
+        self.assertIsNotNone(ti3.end_date)
+        self.assertEqual(ti3.start_date, ti3.end_date)
+        self.assertEqual(ti3.duration, 0.0)
 
         dr1.refresh_from_db(session=session)
         dr1.state = State.FAILED


### PR DESCRIPTION
start_date, end_date & duration were not set for tasks that were failing because the DagRun status was marked externally to some state.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
