### PR TITLE
Bugfix: Error in SSHOperator when command is None

### DIFF
--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -78,7 +78,7 @@ class SSHOperator(BaseOperator):
         self.command = command
         self.timeout = timeout
         self.environment = environment
-        self.get_pty = self.command.startswith('sudo') or get_pty  # type: ignore[union-attr]
+        self.get_pty = (self.command.startswith('sudo') or get_pty) if self.command else get_pty
 
     def execute(self, context) -> Union[bytes, str, bool]:
         try:

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -191,6 +191,7 @@ class TestSSHOperator(unittest.TestCase):
             (COMMAND, True, True),
             (COMMAND_WITH_SUDO, False, True),
             (COMMAND_WITH_SUDO, True, True),
+            (None, True, True),
         ]
     )
     def test_get_pyt_set_correctly(self, command, get_pty_in, get_pty_out):


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/10656

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
