### PR TITLE
Use only-if-needed upgrade strategy to install deps for PRs

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -292,15 +292,14 @@ ENV UPGRADE_TO_LATEST_CONSTRAINTS=${UPGRADE_TO_LATEST_CONSTRAINTS}
 # The goal of this line is to install the dependencies from the most current setup.py from sources
 # This will be usually incremental small set of packages in CI optimized build, so it will be very fast
 # In non-CI optimized build this will install all dependencies before installing sources.
-# Usually we will install versions constrained to the current constraints file
+# Usually we will install versions based on the dependencies in setup.py and upgraded only if needed.
 # But in cron job we will install latest versions matching setup.py to see if there is no breaking change
 # and push the constraints if everything is successful
 RUN \
     if [[ "${UPGRADE_TO_LATEST_CONSTRAINTS}" != "false" ]]; then \
         pip install -e ".[${AIRFLOW_EXTRAS}]" --upgrade --upgrade-strategy eager; \
     else \
-        pip install -e ".[${AIRFLOW_EXTRAS}]" \
-            --constraint "${AIRFLOW_CONSTRAINTS_URL}" ; \
+        pip install -e ".[${AIRFLOW_EXTRAS}]" --upgrade --upgrade-strategy only-if-needed; \
     fi
 
 # Copy all the www/ files we need to compile assets. Done as two separate COPY


### PR DESCRIPTION
Currently, upgrading dependencies in setup.py still run with previous versions of the package for the PR which fails.

This PR will change it to only upgrade the package if a requirement is not satisfied (i.e. if we change the upper or lower bound of dependency in setup.py).

This will avoid the situation like https://github.com/apache/airflow/pull/11020 and https://github.com/apache/airflow/pull/11313 where we can't test upgrading the package in the PR itself. And we were "deadlocked" even after merging the PR as the constraints won't allow installing the new version of the package, I had to generate new constraints myself and push to constraints-master branch (https://github.com/apache/airflow/commit/e6e840f16c33225bb80cf7836ef6a355262e6594), this is not ideal and won't be possible for just contributors.

Using `only-if-needed` upgrade strategy - packages are only upgraded if they are named in the pip command or a requirement file (i.e, they are direct requirements), or an upgraded parent needs a later version of the dependency than is currently installed.

Example:

**Using `only-if-needed`**:
```
root@822984cd3cf4:/opt/airflow# pip install -e . --upgrade --upgrade-strategy only-if-needed
Obtaining file:///opt/airflow
Requirement already satisfied, skipping upgrade: alembic<2.0,>=1.2 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (1.4.3)
Requirement already satisfied, skipping upgrade: jinja2<2.12.0,>=2.10.1 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (2.11.2)
Requirement already satisfied, skipping upgrade: json-merge-patch==0.2 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (0.2)
Requirement already satisfied, skipping upgrade: tabulate<0.9,>=0.7.5 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (0.8.7)
Requirement already satisfied, skipping upgrade: graphviz>=0.12 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (0.14.1)
Collecting tenacity~=6.2.0
  Downloading tenacity-6.2.0-py2.py3-none-any.whl (24 kB)
...
...
```

vs

**Using `eager`**:
```
root@822984cd3cf4:/opt/airflow# pip install -e . --upgrade --upgrade-strategy eager
Obtaining file:///opt/airflow
Requirement already up-to-date: alembic<2.0,>=1.2 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (1.4.3)
Requirement already up-to-date: argcomplete~=1.10 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (1.12.1)
Requirement already up-to-date: cryptography>=0.9.3 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (3.1.1)
Requirement already up-to-date: dill<0.4,>=0.2.2 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (0.3.2)
Requirement already up-to-date: funcsigs<2.0.0,>=1.0.0 in /usr/local/lib/python3.7/site-packages (from apache-airflow==2.0.0.dev0) (1.0.2)
Collecting graphviz>=0.12
  Downloading graphviz-0.14.2-py2.py3-none-any.whl (18 kB)
....
....
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
