### PR TITLE
Allways use Airlfow db in FAB

### DIFF
--- a/airflow/config_templates/default_webserver_config.py
+++ b/airflow/config_templates/default_webserver_config.py
@@ -20,8 +20,6 @@ import os
 
 from flask_appbuilder.security.manager import AUTH_DB
 
-from airflow.configuration import conf
-
 # from flask_appbuilder.security.manager import AUTH_LDAP
 # from flask_appbuilder.security.manager import AUTH_OAUTH
 # from flask_appbuilder.security.manager import AUTH_OID
@@ -29,9 +27,6 @@ from airflow.configuration import conf
 
 
 basedir = os.path.abspath(os.path.dirname(__file__))
-
-# The SQLAlchemy connection string.
-SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
 
 # Flask-WTF flag for CSRF
 WTF_CSRF_ENABLED = True

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -71,6 +71,7 @@ def create_app(config=None, testing=False, app_name="Airflow"):
     flask_app.config.from_pyfile(settings.WEBSERVER_CONFIG, silent=True)
     flask_app.config['APP_NAME'] = app_name
     flask_app.config['TESTING'] = testing
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = conf.get('core', 'SQL_ALCHEMY_CONN')
     flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
     flask_app.config['SESSION_COOKIE_HTTPONLY'] = True


### PR DESCRIPTION
We always want to use one database in Airflow and FAB. The existence of this configuration in the default_webserver_config.py file causes problems when the user configures their own webserver_config.py. and fails to add a valid database configuration. By default, SQLite will be used in Airflow 1.10. In Airflow 2.0, this option is likely not taken into account by Airflow, but external plugins can still access it, so it's a good idea to sync it.

@potiuk we encountered this problem with one of our users recently.
Related: https://github.com/apache/airflow/pull/8940
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
