### PR TITLE
Users can specify sub-secrets and paths k8spodop

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -294,8 +294,9 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                 self.log.info("creating pod with labels %s and launcher %s", labels, launcher)
                 final_state, _, result = self.create_new_pod_for_operator(labels, launcher)
             if final_state != State.SUCCESS:
+                status = self.client.read_namespaced_pod(self.name, self.namespace)
                 raise AirflowException(
-                    'Pod returned a failure: {state}'.format(state=final_state))
+                    'Pod returned a failure: {state}'.format(state=status))
             return result
         except AirflowException as ex:
             raise AirflowException('Pod Launching failed: {error}'.format(error=ex))

--- a/tests/kubernetes/models/test_secret.py
+++ b/tests/kubernetes/models/test_secret.py
@@ -65,6 +65,29 @@ class TestSecret(unittest.TestCase):
         ))
 
     @mock.patch('uuid.uuid4')
+    def test_only_mount_sub_secret(self, mock_uuid):
+        mock_uuid.return_value = '0'
+        items = [k8s.V1KeyToPath(
+            key="my-username",
+            path="/extra/path"
+        )
+        ]
+        secret = Secret('volume', '/etc/foo', 'secret_b', items=items)
+        self.assertEqual(secret.to_volume_secret(), (
+            k8s.V1Volume(
+                name='secretvol0',
+                secret=k8s.V1SecretVolumeSource(
+                    secret_name='secret_b',
+                    items=items)
+            ),
+            k8s.V1VolumeMount(
+                mount_path='/etc/foo',
+                name='secretvol0',
+                read_only=True
+            )
+        ))
+
+    @mock.patch('uuid.uuid4')
     def test_attach_to_pod(self, mock_uuid):
         static_uuid = uuid.UUID('cf4a56d2-8101-4217-b027-2af6216feb48')
         mock_uuid.return_value = static_uuid


### PR DESCRIPTION
Allows users to specify items for specific key path projections
when using the airflow.kubernetes.secret.Secret class

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
