### PR TITLE
Reduce "start-up" time for tasks in CeleryExecutor

### DIFF
--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -225,18 +225,20 @@ class TestCeleryExecutor(unittest.TestCase):
         [['airflow', 'version'], ValueError],
         [['airflow', 'tasks', 'run'], None]
     ))
-    @mock.patch('subprocess.check_output')
-    def test_command_validation(self, command, expected_exception, mock_check_output):
+    def test_command_validation(self, command, expected_exception):
         # Check that we validate _on the receiving_ side, not just sending side
-        if expected_exception:
-            with pytest.raises(expected_exception):
+        with mock.patch('airflow.executors.celery_executor._execute_in_subprocees') as mock_subproc, \
+             mock.patch('airflow.executors.celery_executor._execute_in_fork') as mock_fork:
+            if expected_exception:
+                with pytest.raises(expected_exception):
+                    celery_executor.execute_command(command)
+                mock_subproc.assert_not_called()
+                mock_fork.assert_not_called()
+            else:
                 celery_executor.execute_command(command)
-            mock_check_output.assert_not_called()
-        else:
-            celery_executor.execute_command(command)
-            mock_check_output.assert_called_once_with(
-                command, stderr=mock.ANY, close_fds=mock.ANY, env=mock.ANY,
-            )
+                # One of these should be called.
+                assert mock_subproc.call_args == ((command,),) or \
+                    mock_fork.call_args == ((command,),)
 
     @pytest.mark.backend("mysql", "postgres")
     def test_try_adopt_task_instances_none(self):


### PR DESCRIPTION
This is similar to #11327, but for Celery this time.

The impact is not quite as pronounced here (for simple dags at least)
but takes the average queued to start delay from 1.5s to 0.4s

Closes #6905 - the config option added for LocalExecutor is used here too.

Data on this for a simple 10-task sequential DAG:

```sql
SELECT execution_date,
    min(start_date - queued_dttm) AS min_quued_delay,
    max(start_date - queued_dttm) AS max_queued_delay,
    avg(start_date - queued_dttm) AS avg
FROM task_instance
WHERE dag_id = 'scenario1_case2_03_1' GROUP BY execution_date;
```

|         execution_date         | min_quued_delay | max_queued_delay  | avg | with change? |
| ------------------------------- | ----------------- | ------------------ | -- | -- |
 2020-10-08 01:00:00+01 | 00:00:00.348837 | 00:00:00.473693  | 00:00:00.396751 | Yes |
 2020-10-08 02:00:00+01 | 00:00:01.432304 | 00:00:01.574801  | 00:00:01.478422 | No |


This was discovered in my general benchmarking and profiling of the scheduler for AIP-15, but it's not tied to any of that work. There are more of these kind of improvements coming, each unrelated but all add up.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
