### PR TITLE
Mutual SSL added in PGBouncer configuration in the Chart

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -223,6 +223,10 @@
 {{ .Release.Name }}-pgbouncer-config
 {{- end }}
 
+{{ define "pgbouncer_certificates_secret" -}}
+{{ .Release.Name }}-pgbouncer-certificates
+{{- end }}
+
 {{ define "pgbouncer_stats_secret" -}}
 {{ .Release.Name }}-pgbouncer-stats
 {{- end }}
@@ -262,6 +266,20 @@ max_client_conn = {{ .Values.pgbouncer.maxClientConn }}
 verbose = {{ .Values.pgbouncer.verbose }}
 log_disconnections = {{ .Values.pgbouncer.logDisconnections }}
 log_connections = {{ .Values.pgbouncer.logConnections }}
+
+server_tls_sslmode = {{ .Values.pgbouncer.sslmode }}
+server_tls_ciphers = {{ .Values.pgbouncer.ciphers }}
+
+{{- if .Values.pgbouncer.ssl.ca }}
+server_tls_ca_file = /etc/pgbouncer/root.crt
+{{- end }}
+{{- if .Values.pgbouncer.ssl.cert }}
+server_tls_cert_file = /etc/pgbouncer/server.crt
+{{- end }}
+{{- if .Values.pgbouncer.ssl.key }}
+server_tls_key_file = /etc/pgbouncer/server.key
+{{- end }}
+
 {{- end }}
 
 {{ define "pgbouncer_users" }}

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -54,6 +54,7 @@ spec:
 {{- end }}
       annotations:
         checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
+        checksum/pgbouncer-certificates-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-certificates-secret.yaml") . | sha256sum }}
     spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
@@ -91,6 +92,24 @@ spec:
               subPath: users.txt
               mountPath: /etc/pgbouncer/users.txt
               readOnly: true
+{{- if .Values.pgbouncer.ssl.ca }}
+            - name: pgbouncer-certificates
+              subPath: root.crt
+              mountPath: /etc/pgbouncer/root.crt
+              readOnly: true
+{{- end }}
+{{- if .Values.pgbouncer.ssl.cert }}
+            - name: pgbouncer-certificates
+              subPath: server.crt
+              mountPath: /etc/pgbouncer/server.crt
+              readOnly: true
+{{- end }}
+{{- if .Values.pgbouncer.ssl.key }}
+            - name: pgbouncer-certificates
+              subPath: server.key
+              mountPath: /etc/pgbouncer/server.key
+              readOnly: true
+{{- end }}
           lifecycle:
             preStop:
               exec:
@@ -125,4 +144,7 @@ spec:
         - name: pgbouncer-config
           secret:
             secretName: {{ template "pgbouncer_config_secret" . }}
+        - name: pgbouncer-certificates
+          secret:
+            secretName: {{ template "pgbouncer_certificates_secret" . }}
 {{- end }}

--- a/chart/templates/secrets/pgbouncer-certificates-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-certificates-secret.yaml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+################################
+## Pgbouncer Certificate Secret
+#################################
+{{- if or .Values.pgbouncer.ssl.ca .Values.pgbouncer.ssl.cert .Values.pgbouncer.ssl.key }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "pgbouncer_certificates_secret" . }}
+  labels:
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+type: Opaque
+data:
+{{- if .Values.pgbouncer.ssl.ca }}
+  root.crt: {{ .Values.pgbouncer.ssl.ca | b64enc }}
+{{- end }}
+{{- if .Values.pgbouncer.ssl.cert }}
+  server.crt: {{ .Values.pgbouncer.ssl.cert | b64enc }}
+{{- end }}
+{{- if .Values.pgbouncer.ssl.key }}
+  server.key: {{ .Values.pgbouncer.ssl.key | b64enc }}
+{{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -764,6 +764,33 @@
                 "logConnections": {
                     "description": "Log successful logins.",
                     "type": "integer"
+                },
+                "sslmode": {
+                    "description": "SSL mode for pgbouncer.",
+                    "type": "string",
+                    "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+                },
+                "ciphers": {
+                    "description": "The allowed ciphers, might be 'fast', 'normal' or list ciphers separated with ':'.",
+                    "type": "string"
+                },
+                "ssl": {
+                    "description": "SSL certificates for pgbouncer connection.",
+                    "type": "object",
+                    "properties": {
+                        "ca": {
+                            "description": "Certificate Authority for server side",
+                            "type": ["string", "null"]
+                        },
+                        "cert": {
+                            "description": "Server Certificate for server side",
+                            "type": ["string", "null"]
+                        },
+                        "key": {
+                            "description": "Private key used to authenticate with the server",
+                            "type": ["string", "null"]
+                        }
+                    }
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -448,6 +448,14 @@ pgbouncer:
   logDisconnections: 0
   logConnections: 0
 
+  sslmode: "prefer"
+  ciphers: "normal"
+
+  ssl:
+    ca: ~
+    cert: ~
+    key: ~
+
 redis:
   terminationGracePeriodSeconds: 600
 


### PR DESCRIPTION
Adds SSL configuration for PGBouncer in the Helm Chart. PGBouncer
is crucial to handle the big number of connections that airflow
opens for the database, but often the database is outside of the
Kubernetes Cluster or generally the environment where Airflow is
installed and PGBouncer needs to connect securely to such database.

This PR adds capability of seting CA/Certificate and Private Key
in the PGBouncer configuration that allows for mTLS authentication
(both client and server are authenticated) and secure connection
even over public network.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
