### PR TITLE
Add capability of customising PyPI sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,6 +164,8 @@ RUN mkdir -p /root/.local/bin
 ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
 ENV AIRFLOW_PRE_CACHED_PIP_PACKAGES=${AIRFLOW_PRE_CACHED_PIP_PACKAGES}
 
+COPY .pypirc /root/.pypirc
+
 # In case of Production build image segment we want to pre-install master version of airflow
 # dependencies from github so that we do not have to always reinstall it from the scratch.
 RUN if [[ ${AIRFLOW_PRE_CACHED_PIP_PACKAGES} == "true" ]]; then \
@@ -384,6 +386,8 @@ RUN chmod a+x /entrypoint /clean-logs
 # Make /etc/passwd root-group-writeable so that user can be dynamically added by OpenShift
 # See https://github.com/apache/airflow/issues/9248
 RUN chmod g=u /etc/passwd
+
+COPY .pypirc ${AIRFLOW_USER_HOME_DIR}/.pypirc
 
 ENV PATH="${AIRFLOW_USER_HOME_DIR}/.local/bin:${PATH}"
 ENV GUNICORN_CMD_ARGS="--worker-tmp-dir /dev/shm"

--- a/docs/production-deployment.rst
+++ b/docs/production-deployment.rst
@@ -262,6 +262,14 @@ You can combine both - customizing & extending the image. You can build the imag
 ``customize`` method (either with docker command or with ``breeze`` and then you can ``extend``
 the resulting image using ``FROM`` any dependencies you want.
 
+Customizing PYPI installation
+.............................
+
+You can customize PYPI sources used during image build by modifying .pypirc file that should be
+placed in the root of Airflow Directory. The .pypirc will never be committed to the repository
+and it will not be present in the final production image. It is added and used only in the build
+segment of the image so it is never copied to the final image.
+
 External sources for dependencies
 ---------------------------------
 
@@ -622,3 +630,8 @@ Keytab secret and both containers in the same Pod share the volume, where tempor
 the side-care container and read by the worker container.
 
 This concept is implemented in the development version of the Helm Chart that is part of Airflow source code.
+
+
+.. spelling::
+
+   pypirc

--- a/docs/production-deployment.rst
+++ b/docs/production-deployment.rst
@@ -266,7 +266,7 @@ Customizing PYPI installation
 .............................
 
 You can customize PYPI sources used during image build by modifying .pypirc file that should be
-placed in the root of Airflow Directory. The .pypirc will never be committed to the repository
+placed in the root of Airflow Directory. This .pypirc will never be committed to the repository
 and it will not be present in the final production image. It is added and used only in the build
 segment of the image so it is never copied to the final image.
 

--- a/docs/production-deployment.rst
+++ b/docs/production-deployment.rst
@@ -267,7 +267,7 @@ Customizing PYPI installation
 
 You can customize PYPI sources used during image build by modifying .pypirc file that should be
 placed in the root of Airflow Directory. This .pypirc will never be committed to the repository
-and it will not be present in the final production image. It is added and used only in the build
+and will not be present in the final production image. It is added and used only in the build
 segment of the image so it is never copied to the final image.
 
 External sources for dependencies


### PR DESCRIPTION
This change adds capability of customising installation of PyPI
modules via custom .pypirc file. This might allow to install
dependencies from in-house, vetted registry of PyPI


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
