### PR TITLE
Add pypirc initialization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -58,6 +58,7 @@
 !NOTICE
 !.github
 !empty
+!.pypirc
 
 # Avoid triggering context change on README change (new companies using Airflow)
 # So please do not uncomment this line ;)

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ Chart.lock
 
 # Might be generated when you build wheels
 pip-wheel-metadata
+
+.pypirc

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -34,6 +34,12 @@ function initialization::create_directories() {
     export FILES_DIR="${AIRFLOW_SOURCES}/files"
     readonly FILES_DIR
 
+    # Create an empty .pypirc file that you can customise. It is .gitignored so it will never
+    # land in the repository - it is only added to the "build image" of production image
+    # So you can keep your credentials safe as long as you do not push the build image.
+    # The final image does not contain it.
+    touch "${AIRFLOW_SOURCES}/.pypirc"
+
     # Directory where all the build cache is stored - we keep there status of all the docker images
     # As well as hashes of the important files, but also we generate build scripts there that are
     # Used to execute the commands for breeze


### PR DESCRIPTION
This PR needs to be merged first in order to handle the #11385
which requires .pypirc to be created before dockerfile gets build.

This means that the script change needs to be merged to master
first in this PR;

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
