### PR TITLE
Add capability of adding service account annotations to Helm Chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -210,7 +210,9 @@ The following tables lists the configurable parameters of the Airflow chart and 
 | `webserver.defaultUser`                               | Optional default airflow user information                                                                    | `{}`                                              |
 | `dags.persistence.*`                                  | Dag persistence configuration                                                                                | Please refer to `values.yaml`                     |
 | `dags.gitSync.*`                                      | Git sync configuration                                                                                       | Please refer to `values.yaml`                     |
-| `multiNamespaceMode`                                   | Whether the KubernetesExecutor can launch pods in multiple namespaces                                        | `False`                                           |
+| `multiNamespaceMode`                                  | Whether the KubernetesExecutor can launch pods in multiple namespaces                                        | `False`                                           |
+| `serviceAccountAnnottions.*`                          | Map of annotations for worker, webserver, scheduler kubernetes service accounts                              | {}                                                |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/chart/templates/scheduler/scheduler-serviceaccount.yaml
+++ b/chart/templates/scheduler/scheduler-serviceaccount.yaml
@@ -28,6 +28,12 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  {{- with .Values.scheduler.serviceAccountAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+      {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+      {{- end }}
+  {{- end }}
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/chart/templates/webserver/webserver-serviceaccount.yaml
+++ b/chart/templates/webserver/webserver-serviceaccount.yaml
@@ -27,6 +27,12 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  {{- with .Values.webserver.serviceAccountAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+      {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+      {{- end }}
+  {{- end }}
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -28,7 +28,13 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-{{- with .Values.labels }}
+  {{- with .Values.workers.serviceAccountAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+      {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+      {{- end }}
+  {{- end }}
+  {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -467,6 +467,10 @@
                 "safeToEvict": {
                     "description": "This setting tells Kubernetes that it's ok to evict when it wants to scale a node down.",
                     "type": "boolean"
+                },
+                "serviceAccountAnnotations": {
+                  "description": "Annotations to add to the worker kubernetes service account.",
+                  "type": "object"
                 }
             }
         },
@@ -507,6 +511,10 @@
                 "safeToEvict": {
                     "description": "This setting tells Kubernetes that its ok to evict when it wants to scale a node down.",
                     "type": "boolean"
+                },
+                "serviceAccountAnnotations": {
+                  "description": "Annotations to add to the scheduler kubernetes service account.",
+                  "type": "object"
                 }
             }
         },
@@ -631,6 +639,10 @@
                             "type": "object"
                         }
                     }
+                },
+                "serviceAccountAnnotations": {
+                  "description": "Annotations to add to the webserver kubernetes service account.",
+                  "type": "object"
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -233,7 +233,6 @@ kerberos:
       admin_server = admin_server.foo.com
     }
 
-
 # Airflow Worker Config
 workers:
   # Number of airflow celery workers in StatefulSet
@@ -285,6 +284,8 @@ workers:
   # This setting tells kubernetes that its ok to evict
   # when it wants to scale a node down.
   safeToEvict: true
+  # Annotations to add to worker kubernetes service account.
+  serviceAccountAnnotations: {}
 
 # Airflow scheduler settings
 scheduler:
@@ -311,6 +312,9 @@ scheduler:
   # This setting tells kubernetes that its ok to evict
   # when it wants to scale a node down.
   safeToEvict: true
+
+  # Annotations to add to scheduler kubernetes service account.
+  serviceAccountAnnotations: {}
 
 # Airflow webserver settings
 webserver:
@@ -371,6 +375,9 @@ webserver:
     type: ClusterIP
     ## service annotations
     annotations: {}
+
+  # Annotations to add to webserver kubernetes service account.
+  serviceAccountAnnotations: {}
 
 # Flower settings
 flower:


### PR DESCRIPTION
We can now add annotations to the service accounts in a generic
way. This allows for example to add Workflow Identitty in GKE
environment but it is not limited to it.

Co-authored-by: Kamil Breguła <kamil.bregula@polidea.com>


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
