### PR TITLE
Add CustomOperatorUsesMetaclassRule (#11038)

### DIFF
--- a/airflow/upgrade/rules/customoperator_uses_metaclass.py
+++ b/airflow/upgrade/rules/customoperator_uses_metaclass.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.models import BaseOperator
+from airflow.models.baseoperator import BaseOperatorMeta
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class CustomOperatorUsesMetaclassRule(BaseRule):
+
+    title = "BaseOperator uses metaclass"
+
+    description = """\
+BaseOperator class uses a BaseOperatorMeta as a metaclass. This metaclass is based on abc.ABCMeta.
+
+If your custom operator uses different metaclass then you will have to adjust it."""
+
+    def check(self):
+        if not isinstance(BaseOperator, BaseOperatorMeta):
+            return (
+                "BaseOperator class uses `BaseOperatorMeta` as a metaclass by default. "
+                "As your custom operator uses different metaclass, it would have to be adjusted."
+            )

--- a/tests/upgrade/rules/test_customoperator_uses_metaclass.py
+++ b/tests/upgrade/rules/test_customoperator_uses_metaclass.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.models.baseoperator import BaseOperatorMeta
+from tests.test_utils.mock_operators import MockOperator
+from airflow.upgrade.rules.customoperator_uses_metaclass import CustomOperatorUsesMetaclassRule
+
+
+class TestCustomOperatorUsesMetaclassRule(TestCase):
+    def test_check(self):
+        rule = CustomOperatorUsesMetaclassRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        mock_operator = MockOperator()
+
+        assert isinstance(mock_operator, BaseOperatorMeta)
+
+        msgs = rule.check()
+        assert [m for m in msgs if "CustomOperatorUsesMetaclassRule" in m], \
+            "CustomOperatorUsesMetaclassRule not in warning messages"


### PR DESCRIPTION
closes: #11038 
related: #8765

Added CustomOperatorUsesMetaclassRule which corresponds to

> BaseOperator uses metaclass

entry in UPDATING.md. This rule should allow users to check if their current configuration needs any adjusting
before migration to Airflow 2.0.

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
