### PR TITLE
Add creating_job_id to DagRun table

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -280,7 +280,8 @@ class BackfillJob(BaseJob):
                     ti.handle_failure(msg)
 
     @provide_session
-    def _get_dag_run(self, run_date: datetime, dag: DAG, session: Session = None):
+    def _get_dag_run(self, run_date: datetime, dag: DAG, session: Session = None,
+                     supervising_job_id: int = None):
         """
         Returns a dag run for the given run date, which will be matched to an existing
         dag run if available or create a new dag run otherwise. If the max_active_runs
@@ -289,6 +290,7 @@ class BackfillJob(BaseJob):
         :param run_date: the execution date for the dag run
         :param dag: DAG
         :param session: the database session object
+        :param supervising_job_id: id of the supervising job
         :return: a DagRun in state RUNNING or None
         """
         # consider max_active_runs but ignore when running subdags
@@ -333,6 +335,7 @@ class BackfillJob(BaseJob):
         # explicitly mark as backfill and running
         run.state = State.RUNNING
         run.run_id = run.generate_run_id(DagRunType.BACKFILL_JOB, run_date)
+        run.supervising_job_id = supervising_job_id
         run.run_type = DagRunType.BACKFILL_JOB.value
         run.verify_integrity(session=session)
         return run
@@ -719,7 +722,7 @@ class BackfillJob(BaseJob):
         """
         for next_run_date in run_dates:
             for dag in [self.dag] + self.dag.subdags:
-                dag_run = self._get_dag_run(next_run_date, dag, session=session)
+                dag_run = self._get_dag_run(next_run_date, dag, session=session, supervising_job_id=self.id)
                 tis_map = self._task_instances_for_dag_run(dag_run,
                                                            session=session)
                 if dag_run is None:

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -333,7 +333,7 @@ class BackfillJob(BaseJob):
         # explicitly mark as backfill and running
         run.state = State.RUNNING
         run.run_id = run.generate_run_id(DagRunType.BACKFILL_JOB, run_date)
-        run.supervising_job_id = self.id
+        run.creating_job_id = self.id
         run.run_type = DagRunType.BACKFILL_JOB.value
         run.verify_integrity(session=session)
         return run

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -325,6 +325,7 @@ class BackfillJob(BaseJob):
             session=session,
             conf=self.conf,
             run_type=DagRunType.BACKFILL_JOB,
+            creating_job_id=self.id,
         )
 
         # set required transient field
@@ -333,7 +334,6 @@ class BackfillJob(BaseJob):
         # explicitly mark as backfill and running
         run.state = State.RUNNING
         run.run_id = run.generate_run_id(DagRunType.BACKFILL_JOB, run_date)
-        run.creating_job_id = self.id
         run.run_type = DagRunType.BACKFILL_JOB.value
         run.verify_integrity(session=session)
         return run

--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -82,9 +82,9 @@ class BaseJob(Base, LoggingMixin):
 
     dag_runs = relationship(
         DagRun,
-        primaryjoin=id == DagRun.supervising_job_id,
+        primaryjoin=id == DagRun.creating_job_id,
         foreign_keys=id,
-        backref=backref('supervising_job'),
+        backref=backref('creating_job'),
     )
 
     """

--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm.session import make_transient
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
+from airflow.models import DagRun
 from airflow.models.base import ID_LEN, Base
 from airflow.models.taskinstance import TaskInstance
 from airflow.stats import Stats
@@ -78,6 +79,14 @@ class BaseJob(Base, LoggingMixin):
         foreign_keys=id,
         backref=backref('queued_by_job', uselist=False),
     )
+
+    dag_runs = relationship(
+        DagRun,
+        primaryjoin=id == DagRun.supervising_job_id,
+        foreign_keys=id,
+        backref=backref('supervising_job'),
+    )
+
     """
     TaskInstances which have been enqueued by this Job.
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1563,7 +1563,8 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                 state=State.RUNNING,
                 external_trigger=False,
                 session=session,
-                dag_hash=dag_hash
+                dag_hash=dag_hash,
+                creating_job_id=self.id,
             )
 
         self._update_dag_next_dagruns(dag_models, session)
@@ -1657,9 +1658,6 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                     currently_active_runs,
                 )
                 return 0
-
-        # This DagRun will be schedule by this job so we set up the creating_job_id
-        dag_run.creating_job_id = self.id
 
         self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session)
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1658,6 +1658,9 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                 )
                 return 0
 
+        # This DagRun will be schedule by this job so we set up the supervising_job_id
+        dag_run.supervising_job_id = self.id
+
         self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session)
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1658,8 +1658,8 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                 )
                 return 0
 
-        # This DagRun will be schedule by this job so we set up the supervising_job_id
-        dag_run.supervising_job_id = self.id
+        # This DagRun will be schedule by this job so we set up the creating_job_id
+        dag_run.creating_job_id = self.id
 
         self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session)
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?

--- a/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
+++ b/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add supervising_job_id to DagRun table
+
+Revision ID: 364159666cbd
+Revises: 98271e7606e2
+Create Date: 2020-10-10 09:08:07.332456
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '364159666cbd'
+down_revision = '98271e7606e2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply Add supervising_job_id to DagRun table"""
+    op.add_column('dag_run', sa.Column('supervising_job_id', sa.Integer))
+
+
+def downgrade():
+    """Unapply Add job_id to DagRun table"""
+    op.drop_column('dag_run', 'supervising_job_id')

--- a/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
+++ b/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
@@ -19,7 +19,7 @@
 """Add creating_job_id to DagRun table
 
 Revision ID: 364159666cbd
-Revises: 98271e7606e2
+Revises: 849da589634d
 Create Date: 2020-10-10 09:08:07.332456
 
 """

--- a/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
+++ b/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Add supervising_job_id to DagRun table
+"""Add creating_job_id to DagRun table
 
 Revision ID: 364159666cbd
 Revises: 98271e7606e2
@@ -35,10 +35,10 @@ depends_on = None
 
 
 def upgrade():
-    """Apply Add supervising_job_id to DagRun table"""
-    op.add_column('dag_run', sa.Column('supervising_job_id', sa.Integer))
+    """Apply Add creating_job_id to DagRun table"""
+    op.add_column('dag_run', sa.Column('creating_job_id', sa.Integer))
 
 
 def downgrade():
     """Unapply Add job_id to DagRun table"""
-    op.drop_column('dag_run', 'supervising_job_id')
+    op.drop_column('dag_run', 'creating_job_id')

--- a/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
+++ b/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
@@ -29,7 +29,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '364159666cbd'
-down_revision = '98271e7606e2'
+down_revision = '849da589634d'
 branch_labels = None
 depends_on = None
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1655,7 +1655,8 @@ class DAG(BaseDag, LoggingMixin):
         conf=None,
         run_type=None,
         session=None,
-        dag_hash=None
+        dag_hash=None,
+        creating_job_id=None,
     ):
         """
         Creates a dag run from this dag including the tasks associated with this dag.
@@ -1675,6 +1676,8 @@ class DAG(BaseDag, LoggingMixin):
         :type external_trigger: bool
         :param conf: Dict containing configuration/parameters to pass to the DAG
         :type conf: dict
+        :param creating_job_id: id of the job creating this DagRun
+        :type creating_job_id: int
         :param session: database session
         :type session: sqlalchemy.orm.session.Session
         :param dag_hash: Hash of Serialized DAG
@@ -1702,7 +1705,8 @@ class DAG(BaseDag, LoggingMixin):
             conf=conf,
             state=state,
             run_type=run_type.value,
-            dag_hash=dag_hash
+            dag_hash=dag_hash,
+            creating_job_id=creating_job_id
         )
         session.add(run)
         session.flush()

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -58,7 +58,7 @@ class DagRun(Base, LoggingMixin):
     end_date = Column(UtcDateTime)
     _state = Column('state', String(50), default=State.RUNNING)
     run_id = Column(String(ID_LEN))
-    supervising_job_id = Column(Integer)
+    creating_job_id = Column(Integer)
     external_trigger = Column(Boolean, default=True)
     run_type = Column(String(50), nullable=False)
     conf = Column(PickleType)

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -58,6 +58,7 @@ class DagRun(Base, LoggingMixin):
     end_date = Column(UtcDateTime)
     _state = Column('state', String(50), default=State.RUNNING)
     run_id = Column(String(ID_LEN))
+    supervising_job_id = Column(Integer)
     external_trigger = Column(Boolean, default=True)
     run_type = Column(String(50), nullable=False)
     conf = Column(PickleType)

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -99,6 +99,7 @@ class DagRun(Base, LoggingMixin):
         state: Optional[str] = None,
         run_type: Optional[str] = None,
         dag_hash: Optional[str] = None,
+        creating_job_id: Optional[int] = None,
     ):
         self.dag_id = dag_id
         self.run_id = run_id
@@ -109,6 +110,7 @@ class DagRun(Base, LoggingMixin):
         self.state = state
         self.run_type = run_type
         self.dag_hash = dag_hash
+        self.creating_job_id = creating_job_id
         super().__init__()
 
     def __repr__(self):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3505,21 +3505,15 @@ class TestSchedulerJob(unittest.TestCase):
         )
         dagbag.bag_dag(dag=dag, root_dag=dag)
         dagbag.sync_to_db()
-
-        dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
+        dag_model = DagModel.get_dagmodel(dag.dag_id)
 
         scheduler = SchedulerJob(executor=self.null_exec)
         scheduler.processor_agent = mock.MagicMock()
 
-        dr = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.NONE,
-        )
         with create_session() as session:
-            scheduler._schedule_dag_run(dr, 0, session)
+            scheduler._create_dag_runs([dag_model], session)
 
-        assert dr.creating_job_id == scheduler.id
+        assert dag.get_last_dagrun().creating_job_id == scheduler.id
 
 
 @pytest.mark.xfail(reason="Work out where this goes")

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3488,6 +3488,39 @@ class TestSchedulerJob(unittest.TestCase):
                 full_filepath=dag.fileloc, dag_id=dag_id
             )
 
+    def test_scheduler_sets_job_id_on_dag_run(self):
+        dag = DAG(
+            dag_id='test_scheduler_sets_job_id_on_dag_run',
+            start_date=DEFAULT_DATE)
+
+        DummyOperator(
+            task_id='dummy',
+            dag=dag,
+        )
+
+        dagbag = DagBag(
+            dag_folder=os.path.join(settings.DAGS_FOLDER, "no_dags.py"),
+            include_examples=False,
+            read_dags_from_db=True
+        )
+        dagbag.bag_dag(dag=dag, root_dag=dag)
+        dagbag.sync_to_db()
+
+        dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
+
+        scheduler = SchedulerJob(executor=self.null_exec)
+        scheduler.processor_agent = mock.MagicMock()
+
+        dr = dag.create_dagrun(
+            run_type=DagRunType.SCHEDULED,
+            execution_date=DEFAULT_DATE,
+            state=State.NONE,
+        )
+        with create_session() as session:
+            scheduler._schedule_dag_run(dr, 0, session)
+
+        assert dr.creating_job_id == scheduler.id
+
 
 @pytest.mark.xfail(reason="Work out where this goes")
 def test_task_with_upstream_skip_process_task_instances():

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1348,6 +1348,14 @@ class TestDag(unittest.TestCase):
         dr = dag.create_dagrun(run_id="custom_is_set_to_manual", state=State.NONE)
         assert dr.run_type == DagRunType.MANUAL.value
 
+    def test_create_dagrun_job_id_is_set(self):
+        job_id = 42
+        dag = DAG(dag_id="test_create_dagrun_job_id_is_set")
+        dr = dag.create_dagrun(
+            run_id="test_create_dagrun_job_id_is_set", state=State.NONE, creating_job_id=job_id
+        )
+        assert dr.creating_job_id == job_id
+
     @parameterized.expand(
         [
             (State.NONE,),


### PR DESCRIPTION
This PR introduces `supervising_job_id` column in DagRun table that links a DagRun to job that is supervising it.
Part of #11302 

Running this query:
```sql
select 
       dr.dag_id, 
       dr.run_id, 
       dr.state, 
       dr.supervising_job_id, 
       j.id, 
       j.job_type, 
       j.latest_heartbeat, 
       j.state 
from dag_run dr join job j on dr.supervising_job_id = j.id
```
gives the following result:
<img width="1503" alt="Screenshot 2020-10-10 at 12 32 13" src="https://user-images.githubusercontent.com/9528307/95652939-0873bc80-0af5-11eb-8cef-4a6aff61ad2c.png">

The last row represents a BackfillJob that was killed externally and is related to a zombie DagRun that is and will be in a running state unless someone fixes it. In the follow-up PR I would like to address removing such zombies. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
