### PR TITLE
Fixes automated upgrade to latest constraints.

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -55,7 +55,7 @@ jobs:
       sourceEvent: ${{ steps.source-run-info.outputs.sourceEvent }}
       cacheDirective: ${{ steps.cache-directive.outputs.docker-cache }}
       buildImages: ${{ steps.build-images.outputs.buildImages }}
-      upgradeToLatestConstraints: ${{ steps.upgrade-constraints.upgradeToLatestConstraints }}
+      upgradeToLatestConstraints: ${{ steps.upgrade-constraints.outputs.upgradeToLatestConstraints }}
     if: github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule'
     steps:
       - name: "Get information about the origin 'CI Build' run"
@@ -157,8 +157,8 @@ jobs:
       - name: "Set upgrade to latest constraints"
         id: upgrade-constraints
         run: |
-          if [[ ${{ needs.cancel-workflow-runs.outputs.sourceEvent == 'push' ||
-              needs.cancel-workflow-runs.outputs.sourceEvent == 'scheduled' }} == 'true' ]]; then
+          if [[ ${{ steps.cancel.outputs.sourceEvent == 'push' ||
+              steps.cancel.outputs.sourceEvent == 'scheduled' }} == 'true' ]]; then
               echo "::set-output name=upgradeToLatestConstraints::${{ github.sha }}"
           else
               echo "::set-output name=upgradeToLatestConstraints::false"


### PR DESCRIPTION
Wrong if query in the GitHub action caused upgrade to latest
constraints did not work for a while.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
