### PR TITLE
Fixes cancelling of too many workflows.

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -124,11 +124,11 @@ jobs:
         # to match the jobs using job name rather than use proper API because that feature
         # is currently missing in GitHub Actions ¯\_(ツ)_/¯.
         id: extract-cancelled-failed-runs
-        if: steps.source-run-info-failed.outputs.cancelledRuns != '[]'
+        if: steps.cancel-failed.outputs.cancelledRuns != '[]'
         run: |
             REGEXP="Source Run id: "
             SEPARATOR=""
-            for run_id in $(echo "${{ steps.source-run-info-failed.outputs.cancelledRuns }}" | jq '.[]')
+            for run_id in $(echo "${{ steps.cancel-failed.outputs.cancelledRuns }}" | jq '.[]')
             do
                 REGEXP="${REGEXP}${SEPARATOR}(${run_id})"
                 SEPARATOR="|"


### PR DESCRIPTION
A problem was introduced in #11397 where a bit too many "Build Image"
jobs is being cancelled by subsequent Build Image run. For now it
cancels all the Build Image jobs that are running :(.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
