### PR TITLE
Workarounds "unknown blob" issue by introducing retries

### DIFF
--- a/scripts/ci/libraries/_push_pull_remove_images.sh
+++ b/scripts/ci/libraries/_push_pull_remove_images.sh
@@ -16,6 +16,34 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
+# Tries to push the image several times in case we receive an intermittent error on push
+# $1 - tag to push
+function push_pull_remove_images::push_image_with_retries() {
+    for try_num in 1 2 3 4
+    do
+        set +e
+        echo
+        echo "Trying to push the image ${1}. Number of try: ${try_num}"
+        docker push "${1}"
+        local res=$?
+        set -e
+        if [[ ${res} != "0" ]]; then
+            >&2 echo
+            >&2 echo "Error ${res} when pushing image on ${try_num} try"
+            >&2 echo
+            continue
+        else
+            return 0
+        fi
+    done
+    >&2 echo
+    >&2 echo "Error ${res} when pushing image on ${try_num} try. Giving up!"
+    >&2 echo
+    return 1
+}
+
+
 # Pulls image in case it is needed (either has never been pulled or pulling was forced
 # Should be run with set +e
 # Parameters:
@@ -125,12 +153,12 @@ function push_pull_remove_images::pull_prod_images_if_needed() {
 
 # Pushes Ci images and the manifest to the registry in DockerHub.
 function push_pull_remove_images::push_ci_images_to_dockerhub() {
-    docker push "${AIRFLOW_CI_IMAGE}"
+    push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_IMAGE}"
     docker tag "${AIRFLOW_CI_LOCAL_MANIFEST_IMAGE}" "${AIRFLOW_CI_REMOTE_MANIFEST_IMAGE}"
-    docker push "${AIRFLOW_CI_REMOTE_MANIFEST_IMAGE}"
+    push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_REMOTE_MANIFEST_IMAGE}"
     if [[ -n ${DEFAULT_CI_IMAGE=} ]]; then
         # Only push default image to DockerHub registry if it is defined
-        docker push "${DEFAULT_CI_IMAGE}"
+        push_pull_remove_images::push_image_with_retries "${DEFAULT_CI_IMAGE}"
     fi
 }
 
@@ -142,12 +170,12 @@ function push_pull_remove_images::push_ci_images_to_github() {
     #     "latest"           - in case of push builds
     AIRFLOW_CI_TAGGED_IMAGE="${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
     docker tag "${AIRFLOW_CI_IMAGE}" "${AIRFLOW_CI_TAGGED_IMAGE}"
-    docker push "${AIRFLOW_CI_TAGGED_IMAGE}"
+    push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_TAGGED_IMAGE}"
     if [[ -n ${GITHUB_SHA=} ]]; then
         # Also push image to GitHub registry with commit SHA
         AIRFLOW_CI_SHA_IMAGE="${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}:${COMMIT_SHA}"
         docker tag "${AIRFLOW_CI_IMAGE}" "${AIRFLOW_CI_SHA_IMAGE}"
-        docker push "${AIRFLOW_CI_SHA_IMAGE}"
+        push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_SHA_IMAGE}"
     fi
     PYTHON_TAG_SUFFIX=""
     if [[ ${GITHUB_REGISTRY_PUSH_IMAGE_TAG} != "latest" ]]; then
@@ -155,7 +183,7 @@ function push_pull_remove_images::push_ci_images_to_github() {
     fi
     docker tag "${PYTHON_BASE_IMAGE}" "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
     set +e
-    docker push "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
+    push_pull_remove_images::push_image_with_retries "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
     local result=$?
     set -e
     if [[ ${result} != "0" ]]; then
@@ -184,15 +212,14 @@ function push_pull_remove_images::push_ci_images() {
 # Pushes PROD image to registry in DockerHub
 function push_pull_remove_images::push_prod_images_to_dockerhub () {
     # Prod image
-    docker push "${AIRFLOW_PROD_IMAGE}"
+    push_pull_remove_images::push_image_with_retries "${AIRFLOW_PROD_IMAGE}"
     if [[ -n ${DEFAULT_PROD_IMAGE=} ]]; then
-        docker push "${DEFAULT_PROD_IMAGE}"
+        push_pull_remove_images::push_image_with_retries "${DEFAULT_PROD_IMAGE}"
     fi
     # Prod build image
-    docker push "${AIRFLOW_PROD_BUILD_IMAGE}"
+    push_pull_remove_images::push_image_with_retries "${AIRFLOW_PROD_BUILD_IMAGE}"
 
 }
-
 
 # Pushes PROD image to and their tags to registry in GitHub
 function push_pull_remove_images::push_prod_images_to_github () {
@@ -202,18 +229,18 @@ function push_pull_remove_images::push_prod_images_to_github () {
     #     "latest"           - in case of push builds
     AIRFLOW_PROD_TAGGED_IMAGE="${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
     docker tag "${AIRFLOW_PROD_IMAGE}" "${AIRFLOW_PROD_TAGGED_IMAGE}"
-    docker push "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
+    push_pull_remove_images::push_image_with_retries "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
     if [[ -n ${COMMIT_SHA=} ]]; then
         # Also push image to GitHub registry with commit SHA
         AIRFLOW_PROD_SHA_IMAGE="${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${COMMIT_SHA}"
         docker tag "${AIRFLOW_PROD_IMAGE}" "${AIRFLOW_PROD_SHA_IMAGE}"
-        docker push "${AIRFLOW_PROD_SHA_IMAGE}"
+        push_pull_remove_images::push_image_with_retries "${AIRFLOW_PROD_SHA_IMAGE}"
     fi
     # Also push prod build image
     AIRFLOW_PROD_BUILD_TAGGED_IMAGE="${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
     docker tag "${AIRFLOW_PROD_BUILD_IMAGE}" "${AIRFLOW_PROD_BUILD_TAGGED_IMAGE}"
     set +e
-    docker push "${AIRFLOW_PROD_BUILD_TAGGED_IMAGE}"
+    push_pull_remove_images::push_image_with_retries "${AIRFLOW_PROD_BUILD_TAGGED_IMAGE}"
     local result=$?
     set -e
     if [[ ${result} != "0" ]]; then


### PR DESCRIPTION
We have started to experience "unknown_blob" errors intermittently
recently with GitHub Docker registry. We might eventually need
to migrate to GCR (which eventually is going to replace the
Docker Registry for GitHub:

The ticket is opened to the Apache Infrastructure to enable
access to the GCR and to make some statements about Access
Rights management for GCR https://issues.apache.org/jira/projects/INFRA/issues/INFRA-20959
Also a ticket to GitHub Support has been raised about it
https://support.github.com/ticket/personal/0/861667 as we
cannot delete our public images in Docker registry.

But until this happens, the workaround might help us
to handle the situations where we got intermittent errors
while pushing to the registry. This seems to be a common
error, when NGINX proxy is used to proxy Github Registry so
it is likely that retrying will workaround the issue.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
