### PR TITLE
Adds missing schema for kerberos sidecar configuration

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -796,6 +796,15 @@
                         }
                     }
                 },
+                "kerberosSidecar": {
+                    "description": "Run a side car in each worker pod to refresh kerberos ccache with `airflow kerberos` according to the airflow secuirty configuration",
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable kerberos side car on worker pods."
+                        }
+                    }
+                },
                 "resources": {
                     "type": "object"
                 },
@@ -1066,6 +1075,44 @@
                     }
                 }
             }
+        },
+        "kerberos": {
+            "description": "Kerberos configurations for airflow",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enable kerberos.",
+                    "type": "boolean"
+                },
+                "ccacheMountPath": {
+                    "description": "Path to mount shared volume for kerberos credentials cache.",
+                    "type": "string"
+                },
+                "ccacheFileName": {
+                    "description": "Name for kerberos credentials cache file.",
+                    "type": "string"
+                },
+                "configPath":{
+                    "description": "Path to mount krb5.conf kerberos configuration file.",
+                    "type": "string"
+                },
+                "keytabPath":{
+                    "description": "Path to mount the keytab for refreshing credentials in the kerberos sidecar.",
+                    "type": "string"
+                },
+                "principal":{
+                    "description": "Principal to use when refreshing kerberos credentials.",
+                    "type": "string"
+                },
+                "reinitFrequency": {
+                    "description": "How often (in seconds) airflow kerberos will reinitialize the credentials cache.",
+                    "type": "integer"
+                },
+                "config": {
+                    "description": "Contents of krb5.conf.",
+                    "type": "string"
+                }
+              }
         }
     }
 }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -797,11 +797,12 @@
                     }
                 },
                 "kerberosSidecar": {
-                    "description": "Run a side car in each worker pod to refresh kerberos ccache with `airflow kerberos` according to the airflow secuirty configuration",
+                    "description": "Run a side car in each worker pod to refresh Kerberos ccache with `airflow kerberos` according to the airflow security configuration",
                     "type": "object",
                     "properties": {
                         "enabled": {
-                            "description": "Enable kerberos side car on worker pods."
+                            "description": "Enable Kerberos side car on worker pods.",
+                            "type": "boolean"
                         }
                     }
                 },


### PR DESCRIPTION
The kerberos support added in #11130 did not have schema added
to the values.yml. This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
