### PR TITLE
Using new version of setup-kind using new add-path mechanism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,7 +660,7 @@ jobs:
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Setup Kind Cluster ${{ env.KIND_VERSION }}"
-        uses: engineerd/setup-kind@v0.4.0
+        uses: potiuk/setup-kind@7345a7e015d9844bab5f4a8a8cfb4eb3cf7f91ef
         with:
           version: "${{ env.KIND_VERSION }}"
           name: airflow-python-${{matrix.python-version}}-${{matrix.kubernetes-version}}


### PR DESCRIPTION
Add Path was deprecated in
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
and will be removed soon, so this PR changes the mechanism to
the new one.

The path is added to the ${GITHUB_PATH} file instead as described in
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path

For now this was (hopefully) fixed in potiuk's fork but the
plan is to make PR to the original action and use it from
there once it is merged.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
