### PR TITLE
Fix syntax highlightling for concurrency in configurations doc

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -165,7 +165,7 @@
     - name: dag_concurrency
       description: |
         The number of task instances allowed to run concurrently by the scheduler
-        in one DAG. Can be overridden by `concurrency` on DAG level.
+        in one DAG. Can be overridden by ``concurrency`` on DAG level.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -112,7 +112,7 @@ sql_alchemy_schema =
 parallelism = 32
 
 # The number of task instances allowed to run concurrently by the scheduler
-# in one DAG. Can be overridden by `concurrency` on DAG level.
+# in one DAG. Can be overridden by ``concurrency`` on DAG level.
 dag_concurrency = 16
 
 # Are DAGs paused by default at creation


### PR DESCRIPTION
`concurrency` -> ``concurrency`` since it is rendered in rst

PR where this was added: https://github.com/apache/airflow/pull/11300

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
