### PR TITLE
Use Sphinx Auto Typehints for docstrings

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -635,6 +635,7 @@ def check_spelling() -> None:
         "sphinxcontrib.spelling",
         "exampleinclude",
         "sphinx.ext.autodoc",
+        "sphinx_autodoc_typehints",
         "sphinx.ext.coverage",
         "sphinx.ext.viewcode",
         "sphinx.ext.graphviz",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,6 +125,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinx.ext.graphviz',
+    'sphinx_autodoc_typehints',
     'sphinxarg.ext',
     'sphinxcontrib.httpdomain',
     'sphinxcontrib.jinja',

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ doc = [
     'sphinx>=2.1.2',
     'sphinx-argparse>=0.1.13',
     'sphinx-autoapi==1.0.0',
+    'sphinx-autodoc-typehints',
     'sphinx-copybutton',
     'sphinx-jinja~=1.1',
     'sphinx-rtd-theme>=0.1.6',


### PR DESCRIPTION
https://pypi.org/project/sphinx-autodoc-typehints/

This extension allows you to use Python 3 annotations for documenting acceptable argument types and return value types of functions. This allows you to use type hints in a very natural fashion, allowing you to migrate from this:

```
def format_unit(value, unit):
    """
    Formats the given value as a human readable string using the given units.

    :param float|int value: a numeric value
    :param str unit: the unit for the value (kg, m, etc.)
    :rtype: str
    """
    return '{} {}'.format(value, unit)
```

to

```
from typing import Union

def format_unit(value: Union[float, int], unit: str) -> str:
    """
    Formats the given value as a human readable string using the given units.

    :param value: a numeric value
    :param unit: the unit for the value (kg, m, etc.)
    """
    return '{} {}'.format(value, unit)
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
