### PR TITLE
Increase timeout for waiting for images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         run: ./scripts/ci/openapi/client_codegen_diff.sh
 
   ci-images:
-    timeout-minutes: 50
+    timeout-minutes: 120
     name: "Wait for CI images"
     runs-on: ubuntu-latest
     needs: [build-info]
@@ -547,7 +547,7 @@ jobs:
           directory: "./coverage-files"
 
   prod-images:
-    timeout-minutes: 50
+    timeout-minutes: 120
     name: "Wait for PROD images"
     runs-on: ubuntu-latest
     needs: [build-info]


### PR DESCRIPTION
Now, when we have many more jobs to run, it might happen that
when a lot of PRs are submitted one-after-the-other there might
be longer waiting time for building the image.

There is only one waiting job per image type, so it does not
cost a lot to wait a bit longer, in order to avoid cancellation
after 50 minutes of waiting.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
