### PR TITLE
Fix issue with stale dags not being marked inactive by Scheduler

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1709,6 +1709,13 @@
       type: string
       example: ~
       default: "False"
+    - name: stale_dag_cleanup_timeout
+      description: |
+        Timeout in seconds before Schduler marks a removed DAG as inactive in DB.
+      version_added: ~
+      type: string
+      example: ~
+      default: 600
 - name: ldap
   description: ~
   options:

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3488,6 +3488,10 @@ class TestSchedulerJob(unittest.TestCase):
                 full_filepath=dag.fileloc, dag_id=dag_id
             )
 
+    def test_deactivate_stale_dags(self):
+        """"Test if Scheduler deactivates the deleted DAGs"""
+        pass #TODO
+
 
 @pytest.mark.xfail(reason="Work out where this goes")
 def test_task_with_upstream_skip_process_task_instances():


### PR DESCRIPTION
As of now, the logic to mark DAGs inactive is out of the `_run_scheduler_loop` which never runs unless `num_runs` is configured, so have to move it inside the `_run_scheduler_loop` method.

Also currently, it relies on Scheduler's loop start time to figure out which all DAGs needed to be marked inactive, something which won't work in a Scheduler HA setup, as each Scheduler would be processing a small number of DAGs only. To solve that, I've introduced a timeout config with a default value of 10mins, so a deleted DAG would be visible up to 10mins on UI, but that's better to wrongly mark some active DAGs as inactive or not marking them at all. 

PS: Will write unit tests if the approach looks good. 