### PR TITLE
added type hints for aws cloud formation

### DIFF
--- a/airflow/providers/amazon/aws/hooks/cloud_formation.py
+++ b/airflow/providers/amazon/aws/hooks/cloud_formation.py
@@ -19,9 +19,10 @@
 """
 This module contains AWS CloudFormation Hook
 """
-from typing import Optional
+from typing import Optional, Union
 
 from botocore.exceptions import ClientError
+from boto3 import client, resource
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
@@ -40,7 +41,7 @@ class AWSCloudFormationHook(AwsBaseHook):
     def __init__(self, *args, **kwargs):
         super().__init__(client_type='cloudformation', *args, **kwargs)
 
-    def get_stack_status(self, stack_name):
+    def get_stack_status(self, stack_name: Union[client, resource]) -> Optional[dict]:
         """
         Get stack status from CloudFormation.
         """


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/9708

Adds type hints to the cloud_formation hook within the AWS provider.

Also just saw https://github.com/apache/airflow/issues/11297, which might be a better way to handle this