### PR TITLE
Enables back duplicate cancelling on push/schedule

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -71,7 +71,6 @@ jobs:
           cancelMode: duplicates
           sourceRunId: ${{ github.event.workflow_run.id }}
           notifyPRCancel: true
-          skipEventTypes: '["schedule", "push"]'
       - name: "Output BUILD_IMAGES"
         id: build-images
         run: |


### PR DESCRIPTION
We disabled duplicate cancelling on push/schedule in #11397
but then it causes a lot of extra strain in case several commits
are merged in quick succession. The master merges are always
full builds and take a lot of time, but if we merge PRs
quickly, the subsequent merge cancels the previous ones.

This has the negative consequence that we might not know who
broke the master build, but this happens rarely enough to suffer
the pain at expense of much less strained queue in GitHub Actions.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
