### PR TITLE
Adds dependencies between test jobs to avoid cancel starvation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
     timeout-minutes: 60
     name: "${{matrix.test-type}}:MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
-    needs: [build-info, ci-images]
+    needs: [build-info, ci-images, tests-postgres]
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
@@ -415,7 +415,7 @@ jobs:
     timeout-minutes: 60
     name: "${{matrix.test-type}}:Sqlite Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
-    needs: [build-info, ci-images]
+    needs: [build-info, ci-images, tests-mysql]
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}


### PR DESCRIPTION
This PR adds dependencies between postgres/mysql/sqlite jobs
which is the simplest way to avoid starvation of job cancelling.

Currently several PRs with > 120 jobs might easily saturate the
queue of requests and it means that when there are many PRs
queueing, they might starve "workflow_run" jobs - those jobs
are responsible for cancelling other duplicate/failed requests,
so if they are not run for a while the jobs that should be
cancelled might be cancelled much later than they should,
probably already when they used a lot of build time.

By adding dependencies between the different database tests,
we are adding a bit artifficial delays between the steps - this
means that a single PR mght run slower, but it also means that
it will not starve cancel jobs from the new PRs and they might
have a chance to clean the duplicate/failed jobs more efficiently.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
