### PR TITLE
Add link on External Task Sensor to navigate to target dag.

### DIFF
--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -19,16 +19,28 @@
 import datetime
 import os
 from typing import FrozenSet, Optional, Union
+from urllib.parse import quote
 
 from sqlalchemy import func
 
 from airflow.exceptions import AirflowException
-from airflow.models import DagBag, DagModel, DagRun, TaskInstance
+from airflow.models import DagBag, DagModel, DagRun, TaskInstance, BaseOperatorLink
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
+
+class ExternalTaskSensorLink(BaseOperatorLink):
+    """
+    Operator link for ExternalTaskSensor. It allows users to access
+    DAG waited with ExternalTaskSensor.
+    """
+
+    name = 'External DAG'
+
+    def get_link(self, operator, dttm):
+        return f"/graph?dag_id={operator.external_dag_id}&root=&execution_date={quote(dttm.isoformat())}"
 
 
 class ExternalTaskSensor(BaseSensorOperator):
@@ -65,6 +77,13 @@ class ExternalTaskSensor(BaseSensorOperator):
 
     template_fields = ['external_dag_id', 'external_task_id']
     ui_color = '#19647e'
+
+    @property
+    def operator_extra_links(self):
+        """
+        Return operator extra links
+        """
+        return [ExternalTaskSensorLink()]
 
     @apply_defaults
     def __init__(self, *,

--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -24,12 +24,13 @@ from urllib.parse import quote
 from sqlalchemy import func
 
 from airflow.exceptions import AirflowException
-from airflow.models import DagBag, DagModel, DagRun, TaskInstance, BaseOperatorLink
+from airflow.models import BaseOperatorLink, DagBag, DagModel, DagRun, TaskInstance
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
+
 
 class ExternalTaskSensorLink(BaseOperatorLink):
     """

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -55,6 +55,7 @@ BUILTIN_OPERATOR_EXTRA_LINKS: List[str] = [
     "airflow.providers.google.cloud.operators.mlengine.AIPlatformConsoleLink",
     "airflow.providers.qubole.operators.qubole.QDSLink",
     "airflow.operators.dagrun_operator.TriggerDagRunLink",
+    "airflow.sensors.external_task_sensor.ExternalTaskSensorLink",
 ]
 
 


### PR DESCRIPTION
External Task Sensor waits for target dag completion but currently there is no easy way to directly navigate to target dag on UI.
This change adds "External Dag" link on External Task Sensor as below.

<img width="509" alt="ExternalTaskSensorImage" src="https://user-images.githubusercontent.com/72407579/95796593-27fc1800-0ca2-11eb-885b-3065b9253d44.png">

