### PR TITLE
Add reset_dag_run option on dagrun_operator to clear existing dag run

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -73,7 +73,7 @@ def _trigger_dag(
 
     if dag_run:
         raise DagRunAlreadyExists(
-            f"Run id {dag_run.run_id} already exists for dag id {dag_id}"
+            f"Run id {run_id} already exists for dag id {dag_id}"
         )
 
     run_conf = None

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -101,7 +101,8 @@ class TriggerDagRunOperator(BaseOperator):
 
         run_id = DagRun.generate_run_id(DagRunType.MANUAL, execution_date)
         try:
-            # Ignore MyPy type for self.execution_date because it doesn't pick up the timezone.parse() for strings
+            # Ignore MyPy type for self.execution_date
+            # because it doesn't pick up the timezone.parse() for strings
             trigger_dag(
                 dag_id=self.trigger_dag_id,
                 run_id=run_id,

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -50,7 +50,8 @@ class TriggerDagRunOperator(BaseOperator):
     :type conf: dict
     :param execution_date: Execution date for the dag (templated)
     :type execution_date: str or datetime.datetime
-    :param reset_dag_run: whether or not clear existing dag run if already exists
+    :param reset_dag_run: whether or not clear existing dag run if already exists which is especially useful to backfill
+    or rerun an existing dag run.
     :type reset_dag_run: bool
     """
 
@@ -109,13 +110,13 @@ class TriggerDagRunOperator(BaseOperator):
 
         except DagRunAlreadyExists as e:
             if self.reset_dag_run:
-                self.log.info(f"Clearing {self.trigger_dag_id} on {self.execution_date}")
+                self.log.info("Clearing %s on %s", self.trigger_dag_id, self.execution_date)
 
                 # Get target dag object and call clear()
 
                 dag_model = DagModel.get_current(self.trigger_dag_id)
                 if dag_model is None:
-                    raise DagNotFound("Dag id {} not found in DagModel".format(self.trigger_dag_id))
+                    raise DagNotFound(f"Dag id {self.trigger_dag_id} not found in DagModel")
 
                 def read_store_serialized_dags():
                     from airflow.configuration import conf

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -20,6 +20,7 @@ import datetime
 from typing import Dict, Optional, Union
 from urllib.parse import quote
 
+from airflow import settings
 from airflow.api.common.experimental.trigger_dag import trigger_dag
 from airflow.exceptions import DagNotFound, DagRunAlreadyExists
 from airflow.models import BaseOperator, BaseOperatorLink, DagBag, DagModel, DagRun
@@ -121,13 +122,9 @@ class TriggerDagRunOperator(BaseOperator):
                 if dag_model is None:
                     raise DagNotFound(f"Dag id {self.trigger_dag_id} not found in DagModel")
 
-                def read_store_serialized_dags():
-                    from airflow.configuration import conf
-                    return conf.getboolean('core', 'store_serialized_dags')
-
                 dag_bag = DagBag(
                     dag_folder=dag_model.fileloc,
-                    store_serialized_dags=read_store_serialized_dags()
+                    store_serialized_dags=settings.STORE_SERIALIZED_DAGS
                 )
 
                 dag = dag_bag.get_dag(self.trigger_dag_id)

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -101,6 +101,7 @@ class TriggerDagRunOperator(BaseOperator):
 
         run_id = DagRun.generate_run_id(DagRunType.MANUAL, execution_date)
         try:
+            # Ignore MyPy type for self.execution_date because it doesn't pick up the timezone.parse() for strings
             trigger_dag(
                 dag_id=self.trigger_dag_id,
                 run_id=run_id,

--- a/tests/operators/test_dagrun_operator.py
+++ b/tests/operators/test_dagrun_operator.py
@@ -25,6 +25,7 @@ from airflow.models import DAG, DagModel, DagRun, Log, TaskInstance
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
+from airflow.exceptions import DagRunAlreadyExists
 
 DEFAULT_DATE = datetime(2019, 1, 1, tzinfo=timezone.utc)
 TEST_DAG_ID = "testdag"
@@ -140,3 +141,32 @@ class TestDagRunOperator(TestCase):
             dagruns = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
             self.assertEqual(len(dagruns), 1)
             self.assertTrue(dagruns[0].conf, {"foo": TEST_DAG_ID})
+
+    def test_trigger_dagrun_with_reset_dag_run_False(self):
+        """Test TriggerDagRunOperator with reset_dag_run."""
+        execution_date = DEFAULT_DATE
+        task = TriggerDagRunOperator(task_id="test_task",
+                                     trigger_dag_id=TRIGGERED_DAG_ID,
+                                     execution_date=execution_date,
+                                     reset_dag_run=False,
+                                     dag=self.dag)
+        task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
+
+        with self.assertRaises(DagRunAlreadyExists):
+            task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
+
+    def test_trigger_dagrun_with_reset_dag_run_True(self):
+        """Test TriggerDagRunOperator with reset_dag_run."""
+        execution_date = DEFAULT_DATE
+        task = TriggerDagRunOperator(task_id="test_task",
+                                     trigger_dag_id=TRIGGERED_DAG_ID,
+                                     execution_date=execution_date,
+                                     reset_dag_run=True,
+                                     dag=self.dag)
+        task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
+        task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
+
+        with create_session() as session:
+            dagruns = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
+            self.assertEqual(len(dagruns), 1)
+            self.assertTrue(dagruns[0].external_trigger)

--- a/tests/operators/test_dagrun_operator.py
+++ b/tests/operators/test_dagrun_operator.py
@@ -21,11 +21,11 @@ import tempfile
 from datetime import datetime
 from unittest import TestCase
 
+from airflow.exceptions import DagRunAlreadyExists
 from airflow.models import DAG, DagModel, DagRun, Log, TaskInstance
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
-from airflow.exceptions import DagRunAlreadyExists
 
 DEFAULT_DATE = datetime(2019, 1, 1, tzinfo=timezone.utc)
 TEST_DAG_ID = "testdag"
@@ -142,7 +142,7 @@ class TestDagRunOperator(TestCase):
             self.assertEqual(len(dagruns), 1)
             self.assertTrue(dagruns[0].conf, {"foo": TEST_DAG_ID})
 
-    def test_trigger_dagrun_with_reset_dag_run_False(self):
+    def test_trigger_dagrun_with_reset_dag_run_false(self):
         """Test TriggerDagRunOperator with reset_dag_run."""
         execution_date = DEFAULT_DATE
         task = TriggerDagRunOperator(task_id="test_task",
@@ -155,7 +155,7 @@ class TestDagRunOperator(TestCase):
         with self.assertRaises(DagRunAlreadyExists):
             task.run(start_date=execution_date, end_date=execution_date, ignore_ti_state=True)
 
-    def test_trigger_dagrun_with_reset_dag_run_True(self):
+    def test_trigger_dagrun_with_reset_dag_run_true(self):
         """Test TriggerDagRunOperator with reset_dag_run."""
         execution_date = DEFAULT_DATE
         task = TriggerDagRunOperator(task_id="test_task",


### PR DESCRIPTION
dagrun operator throws DagRunAlreadyExists if dag has already run on the same execution date.
However, user might need to [backfill with reset_dagruns option](https://airflow.apache.org/docs/stable/cli-ref#backfill).
When user submit backfill with reset_dagruns and want to clear previous dag run, dagrun_operator should clear that dag run.

trigger_dag.py (line76) change is required since "dag_run" can be list and if that is the case, "AttributeError: 'list' object has no attribute 'run_id'" is raised instead of DagRunAlreadyExists.