### PR TITLE
Enable serialization by default

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -348,7 +348,7 @@
       version_added: 1.10.7
       type: string
       example: ~
-      default: "False"
+      default: "True"
     - name: min_serialized_dag_update_interval
       description: |
         Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -199,7 +199,7 @@ default_task_retries = 0
 # Whether to serialise DAGs and persist them in DB.
 # If set to True, Webserver reads from DB instead of parsing DAG files
 # More details: https://airflow.apache.org/docs/stable/dag-serialization.html
-store_serialized_dags = False
+store_serialized_dags = True
 
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.
 min_serialized_dag_update_interval = 30

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -45,6 +45,8 @@ killed_task_cleanup_time = 5
 hostname_callable = socket.getfqdn
 worker_precheck = False
 default_task_retries = 0
+# This is a hack, too many tests assume DAGs are already in the DB. We need to fix those tests instead
+store_serialized_dags = False
 
 [logging]
 base_log_folder = {AIRFLOW_HOME}/logs


### PR DESCRIPTION
We actually need to make serialization the default, but this is an
interim measure for Airflow2.0.0.alpha1 reease


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).