### PR TITLE
Rename "functional DAGs" to "Decorated Flows"

### DIFF
--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -34,7 +34,7 @@ class XComArg(TaskMixin):
         op >> xcomarg   (by BaseOperator code)
         op << xcomarg   (by BaseOperator code)
 
-    **Example**: The moment you get a result from any operator (functional or regular) you can ::
+    **Example**: The moment you get a result from any operator (decorated or regular) you can ::
 
         any_op = AnyOperator()
         xcomarg = XComArg(any_op)

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -151,7 +151,7 @@ class PythonOperator(BaseOperator):
         return self.python_callable(*self.op_args, **self.op_kwargs)
 
 
-class _PythonFunctionalOperator(BaseOperator):
+class _PythonDecoratedOperator(BaseOperator):
     """
     Wraps a Python callable and captures args/kwargs when called for execution.
 
@@ -279,16 +279,16 @@ def task(
     """
     def wrapper(f: T):
         """
-        Python wrapper to generate PythonFunctionalOperator out of simple python functions.
-        Used for Airflow functional interface
+        Python wrapper to generate PythonDecoratedOperator out of simple python functions.
+        Used for Airflow Decorated interface
         """
-        _PythonFunctionalOperator.validate_python_callable(f)
+        _PythonDecoratedOperator.validate_python_callable(f)
         kwargs.setdefault('task_id', f.__name__)
 
         @functools.wraps(f)
         def factory(*args, **f_kwargs):
-            op = _PythonFunctionalOperator(python_callable=f, op_args=args, op_kwargs=f_kwargs,
-                                           multiple_outputs=multiple_outputs, **kwargs)
+            op = _PythonDecoratedOperator(python_callable=f, op_args=args, op_kwargs=f_kwargs,
+                                          multiple_outputs=multiple_outputs, **kwargs)
             return XComArg(op)
         return cast(T, factory)
     if callable(python_callable):

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -124,7 +124,9 @@ Decorated Flows
 .. versionadded:: 2.0.0
 
 Airflow 2.0 adds a new style of authoring dags called Decorated Flows which removes a lot of the boilerplate
-around creating PythonOperators, managing dependencies between task and accessing XCom values.
+around creating PythonOperators, managing dependencies between task and accessing XCom values. (During
+development this feature was called "Functional DAGs", so if you see or hear any references to that, it's the
+same thing)
 
 Outputs and inputs are sent between tasks using :ref:`XCom values <concepts:xcom>`. In addition, you can wrap
 functions as tasks using the :ref:`task decorator <concepts:task_decorator>`. Airflow will also automatically

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -116,17 +116,21 @@ DAGs can be used as context managers to automatically assign new operators to th
 
     op.dag is dag # True
 
-.. _concepts:functional_dags:
+.. _concepts:decorated_flows:
 
-Functional DAGs
+Decorated Flows
 ---------------
 
-DAGs can be defined using functional abstractions. Outputs and inputs are sent between tasks using
-:ref:`XCom values <concepts:xcom>`. In addition, you can wrap functions as tasks using the
-:ref:`task decorator <concepts:task_decorator>`. Airflow will also automatically add dependencies between
-tasks to ensure that XCom messages are available when operators are executed.
+.. versionadded:: 2.0.0
 
-Example DAG with functional abstraction
+Airflow 2.0 adds a new style of authoring dags called Decorated Flows which removes a lot of the boilerplate
+around creating PythonOperators, managing dependencies between task and accessing XCom values.
+
+Outputs and inputs are sent between tasks using :ref:`XCom values <concepts:xcom>`. In addition, you can wrap
+functions as tasks using the :ref:`task decorator <concepts:task_decorator>`. Airflow will also automatically
+add dependencies between tasks to ensure that XCom messages are available when operators are executed.
+
+Example DAG with decorated style
 
 .. code-block:: python
 
@@ -227,9 +231,10 @@ When a DAG Run is created, task_1 will start running and task_2 waits for task_1
 Python task decorator
 ---------------------
 
+.. versionadded:: 2.0.0
+
 Airflow ``task`` decorator converts any Python function to an Airflow operator.
 The decorated function can be called once to set the arguments and key arguments for operator execution.
-
 
 .. code-block:: python
 
@@ -250,10 +255,10 @@ The decorated function can be called once to set the arguments and key arguments
 
       hello_name('Airflow users')
 
-Task decorator captures returned values and sends them to the :ref:`XCom backend <concepts:xcom>`. By default, returned
-value is saved as a single XCom value. You can set ``multiple_outputs`` key argument to ``True`` to unroll dictionaries,
-lists or tuples into separate XCom values. This can be used with regular operators to create
-:ref:`functional DAGs <concepts:functional_dags>`.
+Task decorator captures returned values and sends them to the :ref:`XCom backend <concepts:xcom>`. By default,
+the returned value is saved as a single XCom value. You can set ``multiple_outputs`` key argument to ``True``
+to unroll dictionaries, lists or tuples into separate XCom values. This can be used with regular operators to
+create :ref:`decorated DAGs <concepts:decorated_flows>`.
 
 Calling a decorated function returns an ``XComArg`` instance. You can use it to set templated fields on downstream
 operators.


### PR DESCRIPTION
Functional DAGs were so called because the DAG is "made up of funcitons"
but this AIP adds much more than just the task decorator change -- it
adds nicer XCom use, and in many cases automatic dependencies between
tasks.

"Functional" also invokes "functional programming" which this isn't.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
