### PR TITLE
Prevent text-selection of scheduler interval when selecting DAG ID

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -55,11 +55,11 @@
         <span class="text-muted">ROOT:</span> {{ root }}
       {% endif %}
     </h3>
-    <h4 class="pull-right">
+    <h4 class="pull-right" style="user-select: none;-moz-user-select: auto;">
       {% if state_token is defined and state_token %}
         {{ state_token }}
       {% endif %}
-      <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}" style="user-select: none;-moz-user-select: auto;">
+      <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
         schedule: {{ dag.schedule_interval }}
       </a>
     </h4>


### PR DESCRIPTION
Resolves #11500.

An adjustment to the previous fix in #8912. The scheduler interval was moved so we need to include it in the "unselectable" text grouping.

**Before:**

![Screen Recording 2020-10-13 at 09 54 23 AM](https://user-images.githubusercontent.com/3267/95874913-6d225780-0d3f-11eb-8673-c4c8164024ed.gif)



**After:**

![Screen Recording 2020-10-13 at 09 55 22 AM](https://user-images.githubusercontent.com/3267/95874890-6398ef80-0d3f-11eb-85e5-42320bde9583.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
