### PR TITLE
Combine back multiple test types into single jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,28 +345,21 @@ jobs:
 
   tests-postgres:
     timeout-minutes: 60
-    name: "${{matrix.test-type}}:Pg${{matrix.postgres-version}},Py${{matrix.python-version}}"
+    name: "Postgres${{matrix.postgres-version}},Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
         postgres-version: ${{ fromJson(needs.build-info.outputs.postgresVersions) }}
-        test-type: ${{ fromJson(needs.build-info.outputs.testTypes) }}
         exclude: ${{ fromJson(needs.build-info.outputs.postgresExclude) }}
-        # Additionally include all postgres-only tests but only for default versions
-        # in case the regular tests are excluded in the future
-        include:
-          - python_version: ${{ needs.build-info.outputs.defaultPythonVersion }}
-            postgres-version: ${{ needs.build-info.outputs.defaultPostgresVersion }}
-            test-type: "Postgres"
       fail-fast: false
     env:
       BACKEND: postgres
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       POSTGRES_VERSION: ${{ matrix.postgres-version }}
       RUN_TESTS: true
-      TEST_TYPE: ${{ matrix.test-type }}
+      TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
         (github.repository == 'apache/airflow' || github.event_name != 'schedule')
@@ -398,14 +391,13 @@ jobs:
 
   tests-mysql:
     timeout-minutes: 60
-    name: "${{matrix.test-type}}:MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}"
+    name: "MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
         mysql-version: ${{ fromJson(needs.build-info.outputs.mysqlVersions) }}
-        test-type: ${{ fromJson(needs.build-info.outputs.testTypes) }}
         exclude: ${{ fromJson(needs.build-info.outputs.mysqlExclude) }}
         # Additionally include all mysql-only tests but only for default versions
         # in case the regular tests are excluded in the future
@@ -419,7 +411,7 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       MYSQL_VERSION: ${{ matrix.mysql-version }}
       RUN_TESTS: true
-      TEST_TYPE: ${{ matrix.test-type }}
+      TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
         (github.repository == 'apache/airflow' || github.event_name != 'schedule')
@@ -450,7 +442,7 @@ jobs:
 
   tests-sqlite:
     timeout-minutes: 60
-    name: "${{matrix.test-type}}:Sqlite Py${{matrix.python-version}}"
+    name: "Sqlite Py${{matrix.python-version}}"
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     strategy:
@@ -463,7 +455,7 @@ jobs:
       BACKEND: sqlite
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       RUN_TESTS: true
-      TEST_TYPE: ${{ matrix.test-type }}
+      TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
         (github.repository == 'apache/airflow' || github.event_name != 'schedule')
@@ -510,7 +502,7 @@ jobs:
       MYSQL_VERSION: ${{needs.build-info.outputs.defaultMySQLVersion}}
       POSTGRES_VERSION: ${{needs.build-info.outputs.defaultPostgresVersion}}
       RUN_TESTS: true
-      TEST_TYPE: Quarantined
+      TEST_TYPES: "Quarantined"
       NUM_RUNS: 10
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     if: >
@@ -661,7 +653,7 @@ jobs:
       - name: "Cache virtualenv for kubernetes testing"
         uses: actions/cache@v2
         env:
-          cache-name: cache-kubernetes-tests-virtualenv-v4
+          cache-name: cache-kubernetes-tests-virtualenv-v6
         with:
           path: .build/.kubernetes_venv
           key: "${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('setup.py') }}"

--- a/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
@@ -83,9 +83,10 @@ fi
 
 . "${virtualenv_path}/bin/activate"
 
+pip install --upgrade pip==20.2.3
+
 pip install pytest freezegun pytest-cov \
   --constraint "https://raw.githubusercontent.com/apache/airflow/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt"
-
 
 pip install -e ".[kubernetes]" \
   --constraint "https://raw.githubusercontent.com/apache/airflow/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt"

--- a/scripts/ci/selective_tests.sh
+++ b/scripts/ci/selective_tests.sh
@@ -61,14 +61,13 @@ function output_all_basic_variables() {
 function set_outputs_run_all_tests() {
     initialization::ga_output run-tests "true"
     initialization::ga_output run-kubernetes-tests "true"
-    initialization::ga_output test-types \
-        '["Core", "Other", "API", "CLI", "Providers", "WWW", "Integration", "Heisentests"]'
+    initialization::ga_output test-types "Core Other API CLI Providers WWW Integration Heisentests"
 }
 
 function set_output_skip_all_tests() {
     initialization::ga_output run-tests "false"
     initialization::ga_output run-kubernetes-tests "false"
-    initialization::ga_output test-types '[]'
+    initialization::ga_output test-types ""
 }
 
 function initialize_git_repo() {
@@ -312,27 +311,27 @@ function calculate_test_types_to_run() {
             echo
             echo "Adding API to selected files as ${COUNT_API_CHANGED_FILES} API files changed"
             echo
-            SELECTED_TESTS="${SELECTED_TESTS}, \"API\""
+            SELECTED_TESTS="${SELECTED_TESTS} API"
         fi
         if [[ ${COUNT_CLI_CHANGED_FILES} != "0" ]]; then
             echo
             echo "Adding CLI to selected files as ${COUNT_CLI_CHANGED_FILES} CLI files changed"
             echo
-            SELECTED_TESTS="${SELECTED_TESTS}, \"CLI\""
+            SELECTED_TESTS="${SELECTED_TESTS} CLI"
         fi
         if [[ ${COUNT_PROVIDERS_CHANGED_FILES} != "0" ]]; then
             echo
             echo "Adding Providers to selected files as ${COUNT_PROVIDERS_CHANGED_FILES} Provider files changed"
             echo
-            SELECTED_TESTS="${SELECTED_TESTS}, \"Providers\""
+            SELECTED_TESTS="${SELECTED_TESTS} Providers"
         fi
         if [[ ${COUNT_WWW_CHANGED_FILES} != "0" ]]; then
             echo
             echo "Adding WWW to selected files as ${COUNT_WWW_CHANGED_FILES} WWW files changed"
             echo
-            SELECTED_TESTS="${SELECTED_TESTS}, \"WWW\""
+            SELECTED_TESTS="${SELECTED_TESTS} WWW"
         fi
-        initialization::ga_output test-types "[ \"Integration\", \"Heisentests\" ${SELECTED_TESTS} ]"
+        initialization::ga_output test-types "Integration Heisentests ${SELECTED_TESTS}"
     fi
 }
 


### PR DESCRIPTION
Seems that by splitting the tests into many small jobs has a bad
effect - since we only have queue size = 180 for the whole Apache
organisation, we are competing with other projects for the jobs
and with the jobs being so short we got starved much more than if
we had long jobs. Therefore we are re-combining the test types into
single jobs per Python version/Database version and run all the
tests sequentially on those machines.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
