### PR TITLE
Refactor Elasticsearch provider to support 1.10.x

### DIFF
--- a/scripts/ci/provider_packages/ci_prepare_provider_readme.sh
+++ b/scripts/ci/provider_packages/ci_prepare_provider_readme.sh
@@ -17,7 +17,7 @@
 # under the License.
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
-
+#
 build_images::prepare_ci_build
 
 build_images::rebuild_ci_image_if_needed


### PR DESCRIPTION
Resolves #11479

In order to properly read logs from Elasticsearch in 1.10.x with the latest Elasticsearch backport provider, we need to use the newer `FileTaskHandler` base class