### PR TITLE
Helm chart fixes in pod template

### DIFF
--- a/chart/files/pod-template-file.yaml
+++ b/chart/files/pod-template-file.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
 {{- if .Values.dags.gitSync.enabled }}
   initContainers:
-{{- include "git_sync_container" . | indent 8 }}
+{{- include "git_sync_container" (dict "Values" .Values "is_init" "true") | indent 8 }}
 {{- end }}
   containers:
     - args: []
@@ -32,7 +32,7 @@ spec:
         value: LocalExecutor
 {{- include "standard_airflow_environment" . | indent 4 }}
       envFrom: []
-      image: dummy_image
+      image: {{ template "pod_template_image" . }}
       imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
       name: base
       ports: []
@@ -51,7 +51,7 @@ spec:
 {{- end }}
 {{- if or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
         - mountPath: {{ include "airflow_dags_mount_path" . }}
-          name: airflow-dags
+          name: dags
           readOnly: true
 {{- if .Values.dags.persistence.enabled }}
           subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -152,6 +152,10 @@
       value: {{ .Values.dags.gitSync.wait | quote }}
     - name: GIT_SYNC_MAX_SYNC_FAILURES
       value: {{ .Values.dags.gitSync.maxFailures | quote }}
+    {{- if .is_init }}
+    - name: GIT_SYNC_ONE_TIME
+      value: "true"
+    {{- end }}
   volumeMounts:
   - name: dags
     mountPath: {{ .Values.dags.gitSync.root }}
@@ -172,6 +176,10 @@
 # This helper will change when customers deploy a new image.
 {{ define "airflow_image" -}}
 {{ printf "%s:%s" (.Values.images.airflow.repository | default .Values.defaultAirflowRepository) (.Values.images.airflow.tag | default .Values.defaultAirflowTag) }}
+{{- end }}
+
+{{ define "pod_template_image" -}}
+{{ printf "%s:%s" (.Values.images.pod_template.repository | default .Values.defaultAirflowRepository) (.Values.images.pod_template.tag | default .Values.defaultAirflowTag) }}
 {{- end }}
 
 # This helper is used for airflow containers that do not need the users code.

--- a/chart/tests/pod-template-file_test.yaml
+++ b/chart/tests/pod-template-file_test.yaml
@@ -22,9 +22,8 @@ tests:
     asserts:
       - isKind:
           of: Pod
-      - equal:
+      - isNotNull:
           path: spec.containers[0].image
-          value: dummy_image
       - equal:
           path: spec.containers[0].name
           value: base
@@ -77,6 +76,8 @@ tests:
                 value: "66"
               - name: GIT_SYNC_MAX_SYNC_FAILURES
                 value: "70"
+              - name: GIT_SYNC_ONE_TIME
+                value: "true"
             volumeMounts:
               - mountPath: /git-root
                 name: dags
@@ -149,3 +150,18 @@ tests:
             name: dags
             persistentVolumeClaim:
               claimName: test-claim
+  - it: should set a custom image in pod_template
+    set:
+      images:
+        pod_template:
+          repository: dummy_image
+          tag: latest
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: spec.containers[0].image
+          value: dummy_image:latest
+      - equal:
+          path: spec.containers[0].name
+          value: base

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -123,6 +123,10 @@ images:
     repository: ~
     tag: ~
     pullPolicy: IfNotPresent
+  pod_template:
+    repository: ~
+    tag: ~
+    pullPolicy: IfNotPresent
   flower:
     repository: ~
     tag: ~


### PR DESCRIPTION
I came with some little issues while testing the chart in this repo locally, here I'm bundling some fixes to them:

- default pod_template image to `defaultAirflowRepository:defaultAirflowTag`
- fix never-ending git-sync init containers
- fix broken reference to volume

