### PR TITLE
Adds capability of installing wheel packages in CI image

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1239,6 +1239,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --image-tag TAG
           Additional tag in the image.
 
+  --skip-installing-airflow-via-pip
+          Skips installing Airflow via PIP. If you use this flag and want to install
+          Airflow, you have to install Airflow from packages placed in
+          'docker-context-files' and use --add-local-pip-files flag.
+
   --additional-extras ADDITIONAL_EXTRAS
           Additional extras to pass to build images The default is no additional extras.
 
@@ -1292,10 +1297,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --disable-pip-cache
           Disables GitHub PIP cache during the build. Useful if github is not reachable during build.
 
-  --install-local-pip-wheels
-          This flag is only used in production image building. If it is used then instead of
-          installing Airflow from PyPI, the packages are installed from the .whl packages placed
-          in the 'docker-context-files' folder. It implies '--disable-pip-cache'
+  --add-local-pip-wheels
+          This flag is used during image building. If it is used additionally to installing
+          Airflow from PyPI, the packages are installed from the .whl packages placed
+          in the 'docker-context-files' folder. The same flag can be used during entering the image in
+          the CI image - in this case also the .whl files
 
   -C, --force-clean-images
           Force build images with cache disabled. This will remove the pulled or build images
@@ -1752,6 +1758,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --image-tag TAG
           Additional tag in the image.
 
+  --skip-installing-airflow-via-pip
+          Skips installing Airflow via PIP. If you use this flag and want to install
+          Airflow, you have to install Airflow from packages placed in
+          'docker-context-files' and use --add-local-pip-files flag.
+
   --additional-extras ADDITIONAL_EXTRAS
           Additional extras to pass to build images The default is no additional extras.
 
@@ -1805,10 +1816,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --disable-pip-cache
           Disables GitHub PIP cache during the build. Useful if github is not reachable during build.
 
-  --install-local-pip-wheels
-          This flag is only used in production image building. If it is used then instead of
-          installing Airflow from PyPI, the packages are installed from the .whl packages placed
-          in the 'docker-context-files' folder. It implies '--disable-pip-cache'
+  --add-local-pip-wheels
+          This flag is used during image building. If it is used additionally to installing
+          Airflow from PyPI, the packages are installed from the .whl packages placed
+          in the 'docker-context-files' folder. The same flag can be used during entering the image in
+          the CI image - in this case also the .whl files
 
   -C, --force-clean-images
           Force build images with cache disabled. This will remove the pulled or build images
@@ -2220,6 +2232,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --image-tag TAG
           Additional tag in the image.
 
+  --skip-installing-airflow-via-pip
+          Skips installing Airflow via PIP. If you use this flag and want to install
+          Airflow, you have to install Airflow from packages placed in
+          'docker-context-files' and use --add-local-pip-files flag.
+
   --additional-extras ADDITIONAL_EXTRAS
           Additional extras to pass to build images The default is no additional extras.
 
@@ -2273,10 +2290,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --disable-pip-cache
           Disables GitHub PIP cache during the build. Useful if github is not reachable during build.
 
-  --install-local-pip-wheels
-          This flag is only used in production image building. If it is used then instead of
-          installing Airflow from PyPI, the packages are installed from the .whl packages placed
-          in the 'docker-context-files' folder. It implies '--disable-pip-cache'
+  --add-local-pip-wheels
+          This flag is used during image building. If it is used additionally to installing
+          Airflow from PyPI, the packages are installed from the .whl packages placed
+          in the 'docker-context-files' folder. The same flag can be used during entering the image in
+          the CI image - in this case also the .whl files
 
   -C, --force-clean-images
           Force build images with cache disabled. This will remove the pulled or build images

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -254,6 +254,12 @@ ENV AIRFLOW_CI_BUILD_EPOCH=${AIRFLOW_CI_BUILD_EPOCH}
 ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
 ENV AIRFLOW_PRE_CACHED_PIP_PACKAGES=${AIRFLOW_PRE_CACHED_PIP_PACKAGES}
 
+ARG AIRFLOW_LOCAL_PIP_WHEELS=""
+ENV AIRFLOW_LOCAL_PIP_WHEELS=${AIRFLOW_LOCAL_PIP_WHEELS}
+
+ARG INSTALL_AIRFLOW_VIA_PIP="true"
+ENV INSTALL_AIRFLOW_VIA_PIP=${INSTALL_AIRFLOW_VIA_PIP}
+
 # In case of CI builds we want to pre-install master version of airflow dependencies so that
 # We do not have to always reinstall it from the scratch.
 # This can be reinstalled from latest master by increasing PIP_DEPENDENCIES_EPOCH_NUMBER.
@@ -295,11 +301,22 @@ ENV UPGRADE_TO_LATEST_CONSTRAINTS=${UPGRADE_TO_LATEST_CONSTRAINTS}
 # Usually we will install versions based on the dependencies in setup.py and upgraded only if needed.
 # But in cron job we will install latest versions matching setup.py to see if there is no breaking change
 # and push the constraints if everything is successful
-RUN \
-    if [[ "${UPGRADE_TO_LATEST_CONSTRAINTS}" != "false" ]]; then \
-        pip install -e ".[${AIRFLOW_EXTRAS}]" --upgrade --upgrade-strategy eager; \
-    else \
-        pip install -e ".[${AIRFLOW_EXTRAS}]" --upgrade --upgrade-strategy only-if-needed; \
+RUN if [[ ${INSTALL_AIRFLOW_VIA_PIP} == "true" ]]; then \
+        if [[ "${UPGRADE_TO_LATEST_CONSTRAINTS}" != "false" ]]; then \
+            pip install -e ".[${AIRFLOW_EXTRAS}]" --upgrade --upgrade-strategy eager; \
+        else \
+            pip install -e ".[${AIRFLOW_EXTRAS}]" --upgrade --upgrade-strategy only-if-needed; \
+        fi; \
+    fi
+
+# If wheel files are found in /docker-context-files sduring installation
+# they are also installed additionally to whatever is installed from Airflow.
+COPY docker-context-files /docker-context-files
+
+RUN if [[ ${AIRFLOW_LOCAL_PIP_WHEELS} != "true" ]]; then \
+        if ls /docker-context-files/*.whl 1> /dev/null 2>&1; then \
+            pip install --no-deps /docker-context-files/*.whl; \
+        fi ; \
     fi
 
 # Copy all the www/ files we need to compile assets. Done as two separate COPY
@@ -319,10 +336,10 @@ RUN chmod a+x /entrypoint
 # add it with ! in .dockerignore next to the airflow, test etc. directories there
 COPY . ${AIRFLOW_SOURCES}/
 
-
-
 # Install autocomplete for airflow
-RUN register-python-argcomplete airflow >> ~/.bashrc
+RUN if command -v airflow; then \
+        register-python-argcomplete airflow >> ~/.bashrc ; \
+    fi
 
 # Install autocomplete for Kubectl
 RUN echo "source /etc/bash_completion" >> ~/.bashrc

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -393,11 +393,18 @@ The following build arguments (``--build-arg`` in docker build command) can be u
 | ``AIRFLOW_LOCAL_PIP_WHEELS``             | ``false``                                | If set to true, Airflow and it's         |
 |                                          |                                          | dependencies are installed from locally  |
 |                                          |                                          | downloaded .whl files placed in the      |
-|                                          |                                          | ``docker-context-files``. Implies        |
-|                                          |                                          | ``AIRFLOW_PRE_CACHED_PIP_PACKAGES``      |
-|                                          |                                          | to be false.                             |
+|                                          |                                          | ``docker-context-files``.                |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``AIRFLOW_EXTRAS``                       | ``all``                                  | extras to install                        |
++------------------------------------------+------------------------------------------+------------------------------------------+
+| ``INSTALL_AIRFLOW_VIA_PIP``              | ``false``                                | If set to true, Airflow is installed via |
+|                                          |                                          | pip install. if you want to install      |
+|                                          |                                          | Airflow from externally provided binary  |
+|                                          |                                          | package you can set it to false, place   |
+|                                          |                                          | the package in ``docker-context-files``  |
+|                                          |                                          | and set ``AIRFLOW_LOCAL_PIP_WHEELS`` to  |
+|                                          |                                          | true. You have to also set to true the   |
+|                                          |                                          | ``AIRFLOW_PRE_CACHED_PIP_PACKAGES`` flag |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``AIRFLOW_PRE_CACHED_PIP_PACKAGES``      | ``true``                                 | Allows to pre-cache airflow PIP packages |
 |                                          |                                          | from the GitHub of Apache Airflow        |

--- a/breeze
+++ b/breeze
@@ -933,6 +933,12 @@ function breeze::parse_arguments() {
             echo
             shift
             ;;
+        --skip-installing-airflow-via-pip)
+            export INSTALL_AIRFLOW_VIA_PIP="false"
+            export AIRFLOW_PRE_CACHED_PIP_PACKAGES="false"
+            echo "Skip installing airflow via PIP"
+            shift
+            ;;
         -E | --extras)
             export AIRFLOW_EXTRAS="${2}"
             echo "Extras : ${AIRFLOW_EXTRAS}"
@@ -1014,10 +1020,9 @@ function breeze::parse_arguments() {
             export AIRFLOW_PRE_CACHED_PIP_PACKAGES="false"
             shift
             ;;
-        --install-local-pip-wheels)
+        --add-local-pip-wheels)
             export AIRFLOW_LOCAL_PIP_WHEELS="true"
-            export AIRFLOW_PRE_CACHED_PIP_PACKAGES="false"
-            echo "Install from local wheels and disable pip cache"
+            echo "Install wheels from local docker-context-files when building image"
             shift
             ;;
         --image-tag)
@@ -1134,7 +1139,7 @@ function breeze::parse_arguments() {
             ;;
         --install-wheels)
             export INSTALL_WHEELS="true"
-            echo "Install wheels found in dist folder"
+            echo "Install wheels found in dist folder during entering breeze."
             echo
             shift
             ;;
@@ -2318,6 +2323,11 @@ ${FORMATTED_DEFAULT_PROD_EXTRAS}
 --image-tag TAG
         Additional tag in the image.
 
+--skip-installing-airflow-via-pip
+        Skips installing Airflow via PIP. If you use this flag and want to install
+        Airflow, you have to install Airflow from packages placed in
+        'docker-context-files' and use --add-local-pip-files flag.
+
 --additional-extras ADDITIONAL_EXTRAS
         Additional extras to pass to build images The default is no additional extras.
 
@@ -2371,10 +2381,11 @@ Build options:
 --disable-pip-cache
         Disables GitHub PIP cache during the build. Useful if github is not reachable during build.
 
---install-local-pip-wheels
-        This flag is only used in production image building. If it is used then instead of
-        installing Airflow from PyPI, the packages are installed from the .whl packages placed
-        in the 'docker-context-files' folder. It implies '--disable-pip-cache'
+--add-local-pip-wheels
+        This flag is used during image building. If it is used additionally to installing
+        Airflow from PyPI, the packages are installed from the .whl packages placed
+        in the 'docker-context-files' folder. The same flag can be used during entering the image in
+        the CI image - in this case also the .whl files
 
 -C, --force-clean-images
         Force build images with cache disabled. This will remove the pulled or build images

--- a/breeze-complete
+++ b/breeze-complete
@@ -152,8 +152,8 @@ dockerhub-user: dockerhub-repo: github-registry github-repository: github-image-
 postgres-version: mysql-version:
 version-suffix-for-pypi: version-suffix-for-svn: backports
 additional-extras: additional-python-deps: additional-dev-deps: additional-runtime-deps: image-tag:
-disable-mysql-client-installation constraints-location: disable-pip-cache install-local-pip-wheels
-additional-extras: additional-python-deps:
+disable-mysql-client-installation constraints-location: disable-pip-cache add-local-pip-wheels
+additional-extras: additional-python-deps: skip-installing-airflow-via-pip
 dev-apt-deps: additional-dev-apt-deps: dev-apt-command: additional-dev-apt-command: additional-dev-apt-env:
 runtime-apt-deps: additional-runtime-apt-deps: runtime-apt-command: additional-runtime-apt-command: additional-runtime-apt-env:
 load-default-connections load-example-dags

--- a/docker-context-files/README.md
+++ b/docker-context-files/README.md
@@ -21,11 +21,12 @@ This folder is par of the Docker context.
 
 Most of other folders in Airflow are not part of the context in order to make the context smaller.
 
-The Production [Dockerfile](../Dockerfile) copies the [docker-context-files](.) folder to the "build"
-stage of the production image (it is not used in the CI image) and content of the folder is available
-in the `/docker-context-file` folder inside the build image. You can store constraint files and wheel
+The Production [Dockerfile](../Dockerfile) and the CI one [Dockerfile.ci](../Dockerfile.ci) copies
+the [docker-context-files](.) folder to the image context - in case of production image it copies it to
+the build segment, co content of the folder is available in the `/docker-context-file` folder inside
+the build image. You can store constraint files and wheel
 packages there that you want to install as PYPI packages and refer to those packages using
-`--constraint-location` flag for constraints or by using `--install-local-pip-wheels` flag.
+`--constraint-location` flag for constraints or by using `--add-local-pip-wheels` flag.
 
 By default, the content of this folder is .gitignored so that any binaries and files you put here are only
 used for local builds and not committed to the repository.

--- a/docs/production-deployment.rst
+++ b/docs/production-deployment.rst
@@ -234,7 +234,7 @@ Building the image (after copying the files downloaded to the "docker-context-fi
 
   ./breeze build-image \
       --production-image --python 3.7 --install-airflow-version=1.10.12 \
-      --disable-mysql-client-installation --disable-pip-cache --install-local-pip-wheels \
+      --disable-mysql-client-installation --disable-pip-cache --add-local-pip-wheels \
       --constraints-location="/docker-context-files/constraints-1-10.txt"
 
 or
@@ -398,6 +398,15 @@ The following build arguments (``--build-arg`` in docker build command) can be u
 | ``AIRFLOW_EXTRAS``                       | (see Dockerfile)                         | Default extras with which airflow is     |
 |                                          |                                          | installed                                |
 +------------------------------------------+------------------------------------------+------------------------------------------+
+| ``INSTALL_AIRFLOW_VIA_PIP``              | ``false``                                | If set to true, Airflow is installed via |
+|                                          |                                          | pip install. if you want to install      |
+|                                          |                                          | Airflow from externally provided binary  |
+|                                          |                                          | package you can set it to false, place   |
+|                                          |                                          | the package in ``docker-context-files``  |
+|                                          |                                          | and set ``AIRFLOW_LOCAL_PIP_WHEELS`` to  |
+|                                          |                                          | true. You have to also set to true the   |
+|                                          |                                          | ``AIRFLOW_PRE_CACHED_PIP_PACKAGES`` flag |
++------------------------------------------+------------------------------------------+------------------------------------------+
 | ``AIRFLOW_PRE_CACHED_PIP_PACKAGES``      | ``true``                                 | Allows to pre-cache airflow PIP packages |
 |                                          |                                          | from the GitHub of Apache Airflow        |
 |                                          |                                          | This allows to optimize iterations for   |
@@ -405,6 +414,12 @@ The following build arguments (``--build-arg`` in docker build command) can be u
 |                                          |                                          | But in some corporate environments it    |
 |                                          |                                          | might be forbidden to download anything  |
 |                                          |                                          | from public repositories.                |
++------------------------------------------+------------------------------------------+------------------------------------------+
+| ``AIRFLOW_LOCAL_PIP_WHEELS``             | ``false``                                | If set to true, Airflow and it's         |
+|                                          |                                          | dependencies are installed during build  |
+|                                          |                                          | from locally downloaded .whl             |
+|                                          |                                          | files placed in the                      |
+|                                          |                                          | ``docker-context-files``.                |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``ADDITIONAL_AIRFLOW_EXTRAS``            |                                          | Optional additional extras with which    |
 |                                          |                                          | airflow is installed                     |

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -599,6 +599,8 @@ Docker building ${AIRFLOW_CI_IMAGE}.
         --build-arg ADDITIONAL_RUNTIME_APT_COMMAND="${ADDITIONAL_RUNTIME_APT_COMMAND}" \
         --build-arg ADDITIONAL_RUNTIME_APT_DEPS="${ADDITIONAL_RUNTIME_APT_DEPS}" \
         --build-arg ADDITIONAL_RUNTIME_APT_ENV="${ADDITIONAL_RUNTIME_APT_ENV}" \
+        --build-arg INSTALL_AIRFLOW_VIA_PIP="${INSTALL_AIRFLOW_VIA_PIP}" \
+        --build-arg AIRFLOW_LOCAL_PIP_WHEELS="${AIRFLOW_LOCAL_PIP_WHEELS}" \
         --build-arg UPGRADE_TO_LATEST_CONSTRAINTS="${UPGRADE_TO_LATEST_CONSTRAINTS}" \
         --build-arg BUILD_ID="${CI_BUILD_ID}" \
         --build-arg COMMIT_SHA="${COMMIT_SHA}" \
@@ -746,6 +748,7 @@ function build_images::build_prod_images() {
         --build-arg ADDITIONAL_DEV_APT_DEPS="${ADDITIONAL_DEV_APT_DEPS}" \
         --build-arg ADDITIONAL_DEV_APT_ENV="${ADDITIONAL_DEV_APT_ENV}" \
         --build-arg AIRFLOW_PRE_CACHED_PIP_PACKAGES="${AIRFLOW_PRE_CACHED_PIP_PACKAGES}" \
+        --build-arg INSTALL_AIRFLOW_VIA_PIP="${INSTALL_AIRFLOW_VIA_PIP}" \
         --build-arg AIRFLOW_LOCAL_PIP_WHEELS="${AIRFLOW_LOCAL_PIP_WHEELS}" \
         --build-arg BUILD_ID="${CI_BUILD_ID}" \
         --build-arg COMMIT_SHA="${COMMIT_SHA}" \
@@ -774,6 +777,7 @@ function build_images::build_prod_images() {
         --build-arg ADDITIONAL_RUNTIME_APT_DEPS="${ADDITIONAL_RUNTIME_APT_DEPS}" \
         --build-arg ADDITIONAL_RUNTIME_APT_ENV="${ADDITIONAL_RUNTIME_APT_ENV}" \
         --build-arg AIRFLOW_PRE_CACHED_PIP_PACKAGES="${AIRFLOW_PRE_CACHED_PIP_PACKAGES}" \
+        --build-arg INSTALL_AIRFLOW_VIA_PIP="${INSTALL_AIRFLOW_VIA_PIP}" \
         --build-arg AIRFLOW_LOCAL_PIP_WHEELS="${AIRFLOW_LOCAL_PIP_WHEELS}" \
         --build-arg AIRFLOW_VERSION="${AIRFLOW_VERSION}" \
         --build-arg AIRFLOW_BRANCH="${AIRFLOW_BRANCH_FOR_PYPI_PRELOADING}" \

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -358,6 +358,10 @@ function initialization::initialize_image_build_variables() {
     # additional tag for the image
     export IMAGE_TAG=${IMAGE_TAG:=""}
 
+    # whether installation of Airflow should be done via PIP. You can set it to false if you have
+    # all the binary packages (including airflow) in the docker-context-files folder and use
+    # AIRFLOW_LOCAL_PIP_WHEELS="true" to install it from there.
+    export INSTALL_AIRFLOW_VIA_PIP="${INSTALL_AIRFLOW_VIA_PIP:="true"}"
     # whether installation should be performed from the local wheel packages in "docker-context-files" folder
     export AIRFLOW_LOCAL_PIP_WHEELS="${AIRFLOW_LOCAL_PIP_WHEELS:="false"}"
     # reference to CONSTRAINTS. they can be overwritten manually or replaced with AIRFLOW_CONSTRAINTS_LOCATION
@@ -689,6 +693,7 @@ function initialization::make_constants_read_only() {
     readonly IMAGE_TAG
 
     readonly AIRFLOW_PRE_CACHED_PIP_PACKAGES
+    readonly INSTALL_AIRFLOW_VIA_PIP
     readonly AIRFLOW_LOCAL_PIP_WHEELS
     readonly AIRFLOW_CONSTRAINTS_REFERENCE
     readonly AIRFLOW_CONSTRAINTS_LOCATION


### PR DESCRIPTION
The production image had the capability of installing images from
wheels (for security teams/air-gaped systems). This capability
might also be useful when building CI image espeically when
we are installing separately core and providers packages and
we do not yet have provider packages available in PyPI.

This is an intermediate step to implement #11490

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
