### PR TITLE
Add type hints to  aws provider

### DIFF
--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -103,9 +103,9 @@ class AwsBatchProtocol(Protocol):
         jobName: str,
         jobQueue: str,
         jobDefinition: str,
-        arrayProperties: Dict,
-        parameters: Dict,
-        containerOverrides: Dict,
+        arrayProperties: Optional[Dict],
+        parameters: Optional[Dict],
+        containerOverrides: Optional[Dict],
     ) -> Dict:
         """
         Submit a batch job
@@ -120,13 +120,13 @@ class AwsBatchProtocol(Protocol):
         :type jobDefinition: str
 
         :param arrayProperties: the same parameter that boto3 will receive
-        :type arrayProperties: Dict
+        :type arrayProperties: Optional[Dict]
 
         :param parameters: the same parameter that boto3 will receive
-        :type parameters: Dict
+        :type parameters: Optional[Dict]
 
         :param containerOverrides: the same parameter that boto3 will receive
-        :type containerOverrides: Dict
+        :type containerOverrides: Optional[Dict]
 
         :return: an API response
         :rtype: Dict

--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -103,9 +103,9 @@ class AwsBatchProtocol(Protocol):
         jobName: str,
         jobQueue: str,
         jobDefinition: str,
-        arrayProperties: Optional[Dict],
-        parameters: Optional[Dict],
-        containerOverrides: Optional[Dict],
+        arrayProperties: Dict,
+        parameters: Dict,
+        containerOverrides: Dict,
     ) -> Dict:
         """
         Submit a batch job

--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -120,13 +120,13 @@ class AwsBatchProtocol(Protocol):
         :type jobDefinition: str
 
         :param arrayProperties: the same parameter that boto3 will receive
-        :type arrayProperties: Optional[Dict]
+        :type arrayProperties: Dict
 
         :param parameters: the same parameter that boto3 will receive
-        :type parameters: Optional[Dict]
+        :type parameters: Dict
 
         :param containerOverrides: the same parameter that boto3 will receive
-        :type containerOverrides: Optional[Dict]
+        :type containerOverrides: Dict
 
         :return: an API response
         :rtype: Dict

--- a/airflow/providers/amazon/aws/hooks/elasticache_replication_group.py
+++ b/airflow/providers/amazon/aws/hooks/elasticache_replication_group.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
 
 from time import sleep
 
@@ -40,15 +41,21 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
     TERMINAL_STATES = frozenset({"available", "create-failed", "deleting"})
 
     def __init__(
-        self, max_retries=10, exponential_back_off_factor=1, initial_poke_interval=60, *args, **kwargs
+        self,
+        max_retries: int = 10,
+        exponential_back_off_factor: float = 1,
+        initial_poke_interval: float = 60,
+        *args,
+        **kwargs,
     ):
         self.max_retries = max_retries
         self.exponential_back_off_factor = exponential_back_off_factor
         self.initial_poke_interval = initial_poke_interval
 
-        super().__init__(client_type='elasticache', *args, **kwargs)
+        kwargs["client_type"] = "elasticache"
+        super().__init__(*args, **kwargs)
 
-    def create_replication_group(self, config):
+    def create_replication_group(self, config: dict) -> dict:
         """
         Call ElastiCache API for creating a replication group
 
@@ -59,7 +66,7 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
         """
         return self.conn.create_replication_group(**config)
 
-    def delete_replication_group(self, replication_group_id):
+    def delete_replication_group(self, replication_group_id: str) -> dict:
         """
         Call ElastiCache API for deleting a replication group
 
@@ -70,7 +77,7 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
         """
         return self.conn.delete_replication_group(ReplicationGroupId=replication_group_id)
 
-    def describe_replication_group(self, replication_group_id):
+    def describe_replication_group(self, replication_group_id: str) -> dict:
         """
         Call ElastiCache API for describing a replication group
 
@@ -81,7 +88,7 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
         """
         return self.conn.describe_replication_groups(ReplicationGroupId=replication_group_id)
 
-    def get_replication_group_status(self, replication_group_id):
+    def get_replication_group_status(self, replication_group_id: str) -> str:
         """
         Get current status of replication group
 
@@ -92,7 +99,7 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
         """
         return self.describe_replication_group(replication_group_id)['ReplicationGroups'][0]['Status']
 
-    def is_replication_group_available(self, replication_group_id):
+    def is_replication_group_available(self, replication_group_id: str) -> bool:
         """
         Helper for checking if replication group is available or not
 
@@ -105,10 +112,10 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
 
     def wait_for_availability(
         self,
-        replication_group_id,
-        initial_sleep_time=None,
-        exponential_back_off_factor=None,
-        max_retries=None,
+        replication_group_id: str,
+        initial_sleep_time: Optional[float] = None,
+        exponential_back_off_factor: Optional[float] = None,
+        max_retries: Optional[int] = None,
     ):
         """
         Check if replication group is available or not by performing a describe over it
@@ -164,10 +171,10 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
 
     def wait_for_deletion(
         self,
-        replication_group_id,
-        initial_sleep_time=None,
-        exponential_back_off_factor=None,
-        max_retries=None,
+        replication_group_id: str,
+        initial_sleep_time: Optional[float] = None,
+        exponential_back_off_factor: Optional[float] = None,
+        max_retries: Optional[int] = None,
     ):
         """
         Helper for deleting a replication group ensuring it is either deleted or can't be deleted
@@ -244,10 +251,10 @@ class ElastiCacheReplicationGroupHook(AwsBaseHook):
 
     def ensure_delete_replication_group(
         self,
-        replication_group_id,
-        initial_sleep_time=None,
-        exponential_back_off_factor=None,
-        max_retries=None,
+        replication_group_id: str,
+        initial_sleep_time: Optional[float] = None,
+        exponential_back_off_factor: Optional[float] = None,
+        max_retries: Optional[int] = None,
     ):
         """
         Delete a replication group ensuring it is either deleted or can't be deleted

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -93,14 +93,14 @@ class AwsGlueJobHook(AwsBaseHook):
             self.log.error("Failed to create aws glue job, error: %s", general_error)
             raise
 
-    def initialize_job(self, script_arguments: Optional[List] = None) -> Dict[str, str]:
+    def initialize_job(self, script_arguments: Optional[dict] = None) -> Dict[str, str]:
         """
         Initializes connection with AWS Glue
         to run job
         :return:
         """
         glue_client = self.get_conn()
-        script_arguments = script_arguments or []
+        script_arguments = script_arguments or {}
 
         try:
             job_name = self.get_or_create_glue_job()

--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -39,7 +39,7 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
     :type filename_template: str
     """
 
-    def __init__(self, base_log_folder, log_group_arn, filename_template):
+    def __init__(self, base_log_folder: str, log_group_arn: str, filename_template: str):
         super().__init__(base_log_folder, filename_template)
         split_arn = log_group_arn.split(':')
 
@@ -99,7 +99,7 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
             {'end_of_log': True},
         )
 
-    def get_cloudwatch_logs(self, stream_name):
+    def get_cloudwatch_logs(self, stream_name: str) -> str:
         """
         Return all logs from the given log stream.
 

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -31,7 +31,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
     uploads to and reads from S3 remote storage.
     """
 
-    def __init__(self, base_log_folder, s3_log_folder, filename_template):
+    def __init__(self, base_log_folder: str, s3_log_folder: str, filename_template: str):
         super().__init__(base_log_folder, filename_template)
         self.remote_base = s3_log_folder
         self.log_relative_path = ''
@@ -119,11 +119,12 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         else:
             return super()._read(ti, try_number)
 
-    def s3_log_exists(self, remote_log_location):
+    def s3_log_exists(self, remote_log_location: str) -> bool:
         """
         Check if remote_log_location exists in remote storage
 
         :param remote_log_location: log's location in remote storage
+        :type remote_log_location: str
         :return: True if location exists else False
         """
         try:
@@ -132,7 +133,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             pass
         return False
 
-    def s3_read(self, remote_log_location, return_error=False):
+    def s3_read(self, remote_log_location: str, return_error: bool = False) -> str:
         """
         Returns the log found at the remote_log_location. Returns '' if no
         logs are found or there is an error.
@@ -142,6 +143,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         :param return_error: if True, returns a string error message if an
             error occurs. Otherwise returns '' when an error occurs.
         :type return_error: bool
+        :return the log found at the remote_log_location
         """
         try:
             return self.hook.read_key(remote_log_location)
@@ -151,8 +153,9 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             # return error if needed
             if return_error:
                 return msg
+        return ''
 
-    def s3_write(self, log, remote_log_location, append=True):
+    def s3_write(self, log: str, remote_log_location: str, append: bool = True):
         """
         Writes the log to the remote_log_location. Fails silently if no hook
         was created.

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -143,7 +143,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         :param return_error: if True, returns a string error message if an
             error occurs. Otherwise returns '' when an error occurs.
         :type return_error: bool
-        :return the log found at the remote_log_location
+        :return: the log found at the remote_log_location
         """
         try:
             return self.hook.read_key(remote_log_location)

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -26,7 +26,7 @@ An Airflow operator for AWS Batch services
     - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
     - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
 """
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -48,13 +48,13 @@ class AwsBatchOperator(BaseOperator):
     :type job_queue: str
 
     :param overrides: the `containerOverrides` parameter for boto3 (templated)
-    :type overrides: Dict
+    :type overrides: Optional[dict]
 
     :param array_properties: the `arrayProperties` parameter for boto3
-    :type array_properties: Dict
+    :type array_properties: Optional[dict]
 
     :param parameters: the `parameters` for boto3 (templated)
-    :type parameters: Dict
+    :type parameters: Optional[dict]
 
     :param job_id: the job ID, usually unknown (None) until the
         submit_job operation gets the jobId defined by AWS Batch
@@ -101,18 +101,18 @@ class AwsBatchOperator(BaseOperator):
     def __init__(
         self,
         *,
-        job_name,
-        job_definition,
-        job_queue,
-        overrides,
-        array_properties=None,
-        parameters=None,
-        job_id=None,
-        waiters=None,
-        max_retries=None,
-        status_retries=None,
-        aws_conn_id=None,
-        region_name=None,
+        job_name: str,
+        job_definition: str,
+        job_queue: str,
+        overrides: dict,
+        array_properties: Optional[dict] = None,
+        parameters: Optional[dict] = None,
+        job_id: Optional[str] = None,
+        waiters: Optional[Any] = None,
+        max_retries: Optional[int] = None,
+        status_retries: Optional[int] = None,
+        aws_conn_id: Optional[str] = None,
+        region_name: Optional[str] = None,
         **kwargs,
     ):  # pylint: disable=too-many-arguments
 
@@ -181,6 +181,9 @@ class AwsBatchOperator(BaseOperator):
 
         :raises: AirflowException
         """
+        if not self.job_id:
+            raise AirflowException('AWS Batch job - job_id was not found')
+
         try:
             if self.waiters:
                 self.waiters.wait_for_job(self.job_id)

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -121,9 +121,9 @@ class AwsBatchOperator(BaseOperator):
         self.job_name = job_name
         self.job_definition = job_definition
         self.job_queue = job_queue
-        self.overrides = overrides
+        self.overrides = overrides or {}
         self.array_properties = array_properties or {}
-        self.parameters = parameters
+        self.parameters = parameters or {}
         self.waiters = waiters
         self.hook = AwsBatchClientHook(
             max_retries=max_retries,

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains CloudFormation create/delete stack operators."""
-from typing import List
+from typing import List, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.cloud_formation import AWSCloudFormationHook
@@ -43,7 +43,7 @@ class CloudFormationCreateStackOperator(BaseOperator):
     ui_color = '#6b9659'
 
     @apply_defaults
-    def __init__(self, *, stack_name, params, aws_conn_id='aws_default', **kwargs):
+    def __init__(self, *, stack_name: str, params: dict, aws_conn_id: str = 'aws_default', **kwargs):
         super().__init__(**kwargs)
         self.stack_name = stack_name
         self.params = params
@@ -77,11 +77,12 @@ class CloudFormationDeleteStackOperator(BaseOperator):
     ui_fgcolor = '#FFF'
 
     @apply_defaults
-    def __init__(self, *, stack_name, params=None, aws_conn_id='aws_default', **kwargs):
+    def __init__(
+        self, *, stack_name: str, params: Optional[dict] = None, aws_conn_id: str = 'aws_default', **kwargs
+    ):
         super().__init__(**kwargs)
         self.params = params or {}
         self.stack_name = stack_name
-        self.params = params
         self.aws_conn_id = aws_conn_id
 
     def execute(self, context):

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -18,6 +18,7 @@
 from __future__ import unicode_literals
 
 import os.path
+from typing import Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook
@@ -61,24 +62,24 @@ class AwsGlueJobOperator(BaseOperator):
     def __init__(
         self,
         *,
-        job_name='aws_glue_default_job',
-        job_desc='AWS Glue Job with Airflow',
-        script_location=None,
-        concurrent_run_limit=None,
-        script_args=None,
-        retry_limit=None,
-        num_of_dpus=6,
-        aws_conn_id='aws_default',
-        region_name=None,
-        s3_bucket=None,
-        iam_role_name=None,
+        job_name: str = 'aws_glue_default_job',
+        job_desc: str = 'AWS Glue Job with Airflow',
+        script_location: Optional[str] = None,
+        concurrent_run_limit: Optional[int] = None,
+        script_args: Optional[dict] = None,
+        retry_limit: Optional[int] = None,
+        num_of_dpus: int = 6,
+        aws_conn_id: str = 'aws_default',
+        region_name: Optional[str] = None,
+        s3_bucket: Optional[str] = None,
+        iam_role_name: Optional[str] = None,
         **kwargs,
     ):  # pylint: disable=too-many-arguments
         super(AwsGlueJobOperator, self).__init__(**kwargs)
         self.job_name = job_name
         self.job_desc = job_desc
         self.script_location = script_location
-        self.concurrent_run_limit = concurrent_run_limit
+        self.concurrent_run_limit = concurrent_run_limit or 1
         self.script_args = script_args or {}
         self.retry_limit = retry_limit
         self.num_of_dpus = num_of_dpus
@@ -87,7 +88,7 @@ class AwsGlueJobOperator(BaseOperator):
         self.s3_bucket = s3_bucket
         self.iam_role_name = iam_role_name
         self.s3_protocol = "s3://"
-        self.s3_artifcats_prefix = 'artifacts/glue-scripts/'
+        self.s3_artifacts_prefix = 'artifacts/glue-scripts/'
 
     def execute(self, context):
         """
@@ -98,7 +99,7 @@ class AwsGlueJobOperator(BaseOperator):
         if self.script_location and not self.script_location.startswith(self.s3_protocol):
             s3_hook = S3Hook(aws_conn_id=self.aws_conn_id)
             script_name = os.path.basename(self.script_location)
-            s3_hook.load_file(self.script_location, self.s3_bucket, self.s3_artifcats_prefix + script_name)
+            s3_hook.load_file(self.script_location, self.s3_bucket, self.s3_artifacts_prefix + script_name)
         glue_job = AwsGlueJobHook(
             job_name=self.job_name,
             desc=self.job_desc,

--- a/airflow/providers/amazon/aws/operators/s3_bucket.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket.py
@@ -43,7 +43,7 @@ class S3CreateBucketOperator(BaseOperator):
     def __init__(
         self,
         *,
-        bucket_name,
+        bucket_name: str,
         aws_conn_id: Optional[str] = "aws_default",
         region_name: Optional[str] = None,
         **kwargs,
@@ -81,7 +81,7 @@ class S3DeleteBucketOperator(BaseOperator):
 
     def __init__(
         self,
-        bucket_name,
+        bucket_name: str,
         force_delete: bool = False,
         aws_conn_id: Optional[str] = "aws_default",
         **kwargs,

--- a/airflow/providers/amazon/aws/operators/s3_copy_object.py
+++ b/airflow/providers/amazon/aws/operators/s3_copy_object.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -70,13 +71,13 @@ class S3CopyObjectOperator(BaseOperator):
     def __init__(
         self,
         *,
-        source_bucket_key,
-        dest_bucket_key,
-        source_bucket_name=None,
-        dest_bucket_name=None,
-        source_version_id=None,
-        aws_conn_id='aws_default',
-        verify=None,
+        source_bucket_key: str,
+        dest_bucket_key: str,
+        source_bucket_name: Optional[str] = None,
+        dest_bucket_name: Optional[str] = None,
+        source_version_id: Optional[str] = None,
+        aws_conn_id: str = 'aws_default',
+        verify: Optional[Union[str, bool]] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -62,7 +63,16 @@ class S3DeleteObjectsOperator(BaseOperator):
     template_fields = ('keys', 'bucket', 'prefix')
 
     @apply_defaults
-    def __init__(self, *, bucket, keys=None, prefix=None, aws_conn_id='aws_default', verify=None, **kwargs):
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        keys: Optional[Union[str, list]] = None,
+        prefix: Optional[str] = None,
+        aws_conn_id: str = 'aws_default',
+        verify: Optional[Union[str, bool]] = None,
+        **kwargs,
+    ):
 
         if not bool(keys) ^ bool(prefix):
             raise ValueError("Either keys or prefix should be set.")

--- a/airflow/providers/amazon/aws/operators/s3_list.py
+++ b/airflow/providers/amazon/aws/operators/s3_list.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Iterable
+from typing import Iterable, Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -70,7 +70,16 @@ class S3ListOperator(BaseOperator):
     ui_color = '#ffd700'
 
     @apply_defaults
-    def __init__(self, *, bucket, prefix='', delimiter='', aws_conn_id='aws_default', verify=None, **kwargs):
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str = '',
+        delimiter: str = '',
+        aws_conn_id: str = 'aws_default',
+        verify: Optional[Union[str, bool]] = None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.bucket = bucket
         self.prefix = prefix

--- a/airflow/providers/amazon/aws/operators/sagemaker_base.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_base.py
@@ -19,6 +19,8 @@
 import json
 from typing import Iterable
 
+from cached_property import cached_property
+
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
 from airflow.utils.decorators import apply_defaults
@@ -41,12 +43,11 @@ class SageMakerBaseOperator(BaseOperator):
     integer_fields = []  # type: Iterable[Iterable[str]]
 
     @apply_defaults
-    def __init__(self, *, config, aws_conn_id='aws_default', **kwargs):
+    def __init__(self, *, config: dict, aws_conn_id: str = 'aws_default', **kwargs):
         super().__init__(**kwargs)
 
         self.aws_conn_id = aws_conn_id
         self.config = config
-        self.hook = None
 
     def parse_integer(self, config, field):
         """Recursive method for parsing string fields holding integer values to integers."""
@@ -84,7 +85,6 @@ class SageMakerBaseOperator(BaseOperator):
     def preprocess_config(self):
         """Process the config into a usable form."""
         self.log.info('Preprocessing the config and doing required s3_operations')
-        self.hook = SageMakerHook(aws_conn_id=self.aws_conn_id)
 
         self.hook.configure_s3_resources(self.config)
         self.parse_config_integers()
@@ -97,3 +97,8 @@ class SageMakerBaseOperator(BaseOperator):
 
     def execute(self, context):
         raise NotImplementedError('Please implement execute() in sub class!')
+
+    @cached_property
+    def hook(self):
+        """Return SageMakerHook"""
+        return SageMakerHook(aws_conn_id=self.aws_conn_id)

--- a/airflow/providers/amazon/aws/operators/sagemaker_endpoint.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_endpoint.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
 
 from botocore.exceptions import ClientError
 
@@ -74,11 +75,11 @@ class SageMakerEndpointOperator(SageMakerBaseOperator):
     def __init__(
         self,
         *,
-        config,
-        wait_for_completion=True,
-        check_interval=30,
-        max_ingestion_time=None,
-        operation='create',
+        config: dict,
+        wait_for_completion: bool = True,
+        check_interval: int = 30,
+        max_ingestion_time: Optional[int] = None,
+        operation: str = 'create',
         **kwargs,
     ):
         super().__init__(config=config, **kwargs)
@@ -92,12 +93,12 @@ class SageMakerEndpointOperator(SageMakerBaseOperator):
             raise ValueError('Invalid value! Argument operation has to be one of "create" and "update"')
         self.create_integer_fields()
 
-    def create_integer_fields(self):
+    def create_integer_fields(self) -> None:
         """Set fields which should be casted to integers."""
         if 'EndpointConfig' in self.config:
             self.integer_fields = [['EndpointConfig', 'ProductionVariants', 'InitialInstanceCount']]
 
-    def expand_role(self):
+    def expand_role(self) -> None:
         if 'Model' not in self.config:
             return
         hook = AwsBaseHook(self.aws_conn_id, client_type='iam')
@@ -105,7 +106,7 @@ class SageMakerEndpointOperator(SageMakerBaseOperator):
         if 'ExecutionRoleArn' in config:
             config['ExecutionRoleArn'] = hook.expand_role(config['ExecutionRoleArn'])
 
-    def execute(self, context):
+    def execute(self, context) -> dict:
         self.preprocess_config()
 
         model_info = self.config.get('Model')

--- a/airflow/providers/amazon/aws/operators/sagemaker_endpoint_config.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_endpoint_config.py
@@ -38,12 +38,12 @@ class SageMakerEndpointConfigOperator(SageMakerBaseOperator):
     integer_fields = [['ProductionVariants', 'InitialInstanceCount']]
 
     @apply_defaults
-    def __init__(self, *, config, **kwargs):
+    def __init__(self, *, config: dict, **kwargs):
         super().__init__(config=config, **kwargs)
 
         self.config = config
 
-    def execute(self, context):
+    def execute(self, context) -> dict:
         self.preprocess_config()
 
         self.log.info('Creating SageMaker Endpoint Config %s.', self.config['EndpointConfigName'])

--- a/airflow/providers/amazon/aws/operators/sagemaker_model.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_model.py
@@ -42,12 +42,12 @@ class SageMakerModelOperator(SageMakerBaseOperator):
 
         self.config = config
 
-    def expand_role(self):
+    def expand_role(self) -> None:
         if 'ExecutionRoleArn' in self.config:
             hook = AwsBaseHook(self.aws_conn_id, client_type='iam')
             self.config['ExecutionRoleArn'] = hook.expand_role(self.config['ExecutionRoleArn'])
 
-    def execute(self, context):
+    def execute(self, context) -> dict:
         self.preprocess_config()
 
         self.log.info('Creating SageMaker Model %s.', self.config['ModelName'])

--- a/airflow/providers/amazon/aws/operators/sagemaker_processing.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_processing.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -55,12 +56,12 @@ class SageMakerProcessingOperator(SageMakerBaseOperator):
     def __init__(
         self,
         *,
-        config,
-        aws_conn_id,
-        wait_for_completion=True,
-        print_log=True,
-        check_interval=30,
-        max_ingestion_time=None,
+        config: dict,
+        aws_conn_id: str,
+        wait_for_completion: bool = True,
+        print_log: bool = True,
+        check_interval: int = 30,
+        max_ingestion_time: Optional[int] = None,
         action_if_job_exists: str = "increment",  # TODO use typing.Literal for this in Python 3.8
         **kwargs,
     ):
@@ -78,7 +79,7 @@ class SageMakerProcessingOperator(SageMakerBaseOperator):
         self.max_ingestion_time = max_ingestion_time
         self._create_integer_fields()
 
-    def _create_integer_fields(self):
+    def _create_integer_fields(self) -> None:
         """Set fields which should be casted to integers."""
         self.integer_fields = [
             ['ProcessingResources', 'ClusterConfig', 'InstanceCount'],
@@ -87,12 +88,12 @@ class SageMakerProcessingOperator(SageMakerBaseOperator):
         if 'StoppingCondition' in self.config:
             self.integer_fields += [['StoppingCondition', 'MaxRuntimeInSeconds']]
 
-    def expand_role(self):
+    def expand_role(self) -> None:
         if 'RoleArn' in self.config:
             hook = AwsBaseHook(self.aws_conn_id, client_type='iam')
             self.config['RoleArn'] = hook.expand_role(self.config['RoleArn'])
 
-    def execute(self, context):
+    def execute(self, context) -> dict:
         self.preprocess_config()
 
         processing_job_name = self.config["ProcessingJobName"]

--- a/airflow/providers/amazon/aws/operators/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_training.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -61,11 +62,11 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
     def __init__(
         self,
         *,
-        config,
-        wait_for_completion=True,
-        print_log=True,
-        check_interval=30,
-        max_ingestion_time=None,
+        config: dict,
+        wait_for_completion: bool = True,
+        print_log: bool = True,
+        check_interval: int = 30,
+        max_ingestion_time: Optional[int] = None,
         action_if_job_exists: str = "increment",  # TODO use typing.Literal for this in Python 3.8
         **kwargs,
     ):
@@ -84,12 +85,12 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
                 f"Provided value: '{action_if_job_exists}'."
             )
 
-    def expand_role(self):
+    def expand_role(self) -> None:
         if 'RoleArn' in self.config:
             hook = AwsBaseHook(self.aws_conn_id, client_type='iam')
             self.config['RoleArn'] = hook.expand_role(self.config['RoleArn'])
 
-    def execute(self, context):
+    def execute(self, context) -> dict:
         self.preprocess_config()
 
         training_job_name = self.config["TrainingJobName"]

--- a/airflow/providers/amazon/aws/operators/sagemaker_transform.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_transform.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional, List
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -63,7 +64,13 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
 
     @apply_defaults
     def __init__(
-        self, *, config, wait_for_completion=True, check_interval=30, max_ingestion_time=None, **kwargs
+        self,
+        *,
+        config: dict,
+        wait_for_completion: bool = True,
+        check_interval: int = 30,
+        max_ingestion_time: Optional[int] = None,
+        **kwargs,
     ):
         super().__init__(config=config, **kwargs)
         self.config = config
@@ -72,9 +79,9 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
         self.max_ingestion_time = max_ingestion_time
         self.create_integer_fields()
 
-    def create_integer_fields(self):
+    def create_integer_fields(self) -> None:
         """Set fields which should be casted to integers."""
-        self.integer_fields = [
+        self.integer_fields: List[List[str]] = [
             ['Transform', 'TransformResources', 'InstanceCount'],
             ['Transform', 'MaxConcurrentTransforms'],
             ['Transform', 'MaxPayloadInMB'],
@@ -83,7 +90,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
             for field in self.integer_fields:
                 field.pop(0)
 
-    def expand_role(self):
+    def expand_role(self) -> None:
         if 'Model' not in self.config:
             return
         config = self.config['Model']
@@ -91,7 +98,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
             hook = AwsBaseHook(self.aws_conn_id, client_type='iam')
             config['ExecutionRoleArn'] = hook.expand_role(config['ExecutionRoleArn'])
 
-    def execute(self, context):
+    def execute(self, context) -> dict:
         self.preprocess_config()
 
         model_config = self.config.get('Model')

--- a/airflow/providers/amazon/aws/operators/sagemaker_tuning.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_tuning.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -56,7 +57,13 @@ class SageMakerTuningOperator(SageMakerBaseOperator):
 
     @apply_defaults
     def __init__(
-        self, *, config, wait_for_completion=True, check_interval=30, max_ingestion_time=None, **kwargs
+        self,
+        *,
+        config: dict,
+        wait_for_completion: bool = True,
+        check_interval: int = 30,
+        max_ingestion_time: Optional[int] = None,
+        **kwargs,
     ):
         super().__init__(config=config, **kwargs)
         self.config = config
@@ -64,14 +71,14 @@ class SageMakerTuningOperator(SageMakerBaseOperator):
         self.check_interval = check_interval
         self.max_ingestion_time = max_ingestion_time
 
-    def expand_role(self):
+    def expand_role(self) -> None:
         if 'TrainingJobDefinition' in self.config:
             config = self.config['TrainingJobDefinition']
             if 'RoleArn' in config:
                 hook = AwsBaseHook(self.aws_conn_id, client_type='iam')
                 config['RoleArn'] = hook.expand_role(config['RoleArn'])
 
-    def execute(self, context):
+    def execute(self, context) -> dict:
         self.preprocess_config()
 
         self.log.info(

--- a/airflow/providers/amazon/aws/operators/sns.py
+++ b/airflow/providers/amazon/aws/operators/sns.py
@@ -17,6 +17,7 @@
 # under the License.
 
 """Publish message to SNS queue"""
+from typing import Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.sns import AwsSnsHook
@@ -47,11 +48,11 @@ class SnsPublishOperator(BaseOperator):
     def __init__(
         self,
         *,
-        target_arn,
-        message,
-        aws_conn_id='aws_default',
-        subject=None,
-        message_attributes=None,
+        target_arn: str,
+        message: str,
+        aws_conn_id: str = 'aws_default',
+        subject: Optional[str] = None,
+        message_attributes: Optional[dict] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/operators/sqs.py
+++ b/airflow/providers/amazon/aws/operators/sqs.py
@@ -16,6 +16,7 @@
 # under the License.
 
 """Publish message to SQS queue"""
+from typing import Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.sqs import SQSHook
@@ -46,11 +47,11 @@ class SQSPublishOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sqs_queue,
-        message_content,
-        message_attributes=None,
-        delay_seconds=0,
-        aws_conn_id='aws_default',
+        sqs_queue: str,
+        message_content: str,
+        message_attributes: Optional[dict] = None,
+        delay_seconds: int = 0,
+        aws_conn_id: str = 'aws_default',
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/operators/step_function_get_execution_output.py
+++ b/airflow/providers/amazon/aws/operators/step_function_get_execution_output.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import json
+from typing import Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.step_function import StepFunctionHook
@@ -42,7 +43,14 @@ class StepFunctionGetExecutionOutputOperator(BaseOperator):
     ui_color = '#f9c915'
 
     @apply_defaults
-    def __init__(self, *, execution_arn: str, aws_conn_id='aws_default', region_name=None, **kwargs):
+    def __init__(
+        self,
+        *,
+        execution_arn: str,
+        aws_conn_id: str = 'aws_default',
+        region_name: Optional[str] = None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.execution_arn = execution_arn
         self.aws_conn_id = aws_conn_id

--- a/airflow/providers/amazon/aws/operators/step_function_start_execution.py
+++ b/airflow/providers/amazon/aws/operators/step_function_start_execution.py
@@ -55,8 +55,8 @@ class StepFunctionStartExecutionOperator(BaseOperator):
         state_machine_arn: str,
         name: Optional[str] = None,
         state_machine_input: Union[dict, str, None] = None,
-        aws_conn_id='aws_default',
-        region_name=None,
+        aws_conn_id: str = 'aws_default',
+        region_name: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/sensors/emr_base.py
+++ b/airflow/providers/amazon/aws/sensors/emr_base.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Iterable
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.emr import EmrHook
@@ -42,17 +42,19 @@ class EmrBaseSensor(BaseSensorOperator):
     ui_color = '#66c3ff'
 
     @apply_defaults
-    def __init__(self, *, aws_conn_id='aws_default', **kwargs):
+    def __init__(self, *, aws_conn_id: str = 'aws_default', **kwargs):
         super().__init__(**kwargs)
         self.aws_conn_id = aws_conn_id
-        self.target_states = None  # will be set in subclasses
-        self.failed_states = None  # will be set in subclasses
-        self.hook = None
+        self.target_states: Optional[Iterable[str]] = None  # will be set in subclasses
+        self.failed_states: Optional[Iterable[str]] = None  # will be set in subclasses
+        self.hook: Optional[EmrHook] = None
 
-    def get_hook(self):
+    def get_hook(self) -> EmrHook:
         """Get EmrHook"""
-        if not self.hook:
-            self.hook = EmrHook(aws_conn_id=self.aws_conn_id)
+        if self.hook:
+            return self.hook
+
+        self.hook = EmrHook(aws_conn_id=self.aws_conn_id)
         return self.hook
 
     def poke(self, context):

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -36,7 +36,7 @@ class AwsGlueJobSensor(BaseSensorOperator):
     template_fields = ('job_name', 'run_id')
 
     @apply_defaults
-    def __init__(self, *, job_name, run_id, aws_conn_id='aws_default', **kwargs):
+    def __init__(self, *, job_name: str, run_id: str, aws_conn_id: str = 'aws_default', **kwargs):
         super().__init__(**kwargs)
         self.job_name = job_name
         self.run_id = run_id

--- a/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
+++ b/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
 
 from airflow.providers.amazon.aws.hooks.glue_catalog import AwsGlueCatalogHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -59,12 +60,12 @@ class AwsGlueCatalogPartitionSensor(BaseSensorOperator):
     def __init__(
         self,
         *,
-        table_name,
-        expression="ds='{{ ds }}'",
-        aws_conn_id='aws_default',
-        region_name=None,
-        database_name='default',
-        poke_interval=60 * 3,
+        table_name: str,
+        expression: str = "ds='{{ ds }}'",
+        aws_conn_id: str = 'aws_default',
+        region_name: Optional[str] = None,
+        database_name: str = 'default',
+        poke_interval: int = 60 * 3,
         **kwargs,
     ):
         super().__init__(poke_interval=poke_interval, **kwargs)
@@ -73,7 +74,7 @@ class AwsGlueCatalogPartitionSensor(BaseSensorOperator):
         self.table_name = table_name
         self.expression = expression
         self.database_name = database_name
-        self.hook = None
+        self.hook: Optional[AwsGlueCatalogHook] = None
 
     def poke(self, context):
         """Checks for existence of the partition in the AWS Glue Catalog table"""
@@ -85,8 +86,10 @@ class AwsGlueCatalogPartitionSensor(BaseSensorOperator):
 
         return self.get_hook().check_for_partition(self.database_name, self.table_name, self.expression)
 
-    def get_hook(self):
+    def get_hook(self) -> AwsGlueCatalogHook:
         """Gets the AwsGlueCatalogHook"""
-        if not self.hook:
-            self.hook = AwsGlueCatalogHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
+        if self.hook:
+            return self.hook
+
+        self.hook = AwsGlueCatalogHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
         return self.hook

--- a/airflow/providers/amazon/aws/sensors/redshift.py
+++ b/airflow/providers/amazon/aws/sensors/redshift.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
 
 from airflow.providers.amazon.aws.hooks.redshift import RedshiftHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -34,19 +35,28 @@ class AwsRedshiftClusterSensor(BaseSensorOperator):
     template_fields = ('cluster_identifier', 'target_status')
 
     @apply_defaults
-    def __init__(self, *, cluster_identifier, target_status='available', aws_conn_id='aws_default', **kwargs):
+    def __init__(
+        self,
+        *,
+        cluster_identifier: str,
+        target_status: str = 'available',
+        aws_conn_id: str = 'aws_default',
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.cluster_identifier = cluster_identifier
         self.target_status = target_status
         self.aws_conn_id = aws_conn_id
-        self.hook = None
+        self.hook: Optional[RedshiftHook] = None
 
     def poke(self, context):
         self.log.info('Poking for status : %s\nfor cluster %s', self.target_status, self.cluster_identifier)
         return self.get_hook().cluster_status(self.cluster_identifier) == self.target_status
 
-    def get_hook(self):
+    def get_hook(self) -> RedshiftHook:
         """Create and return a RedshiftHook"""
-        if not self.hook:
-            self.hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
+        if self.hook:
+            return self.hook
+
+        self.hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
         return self.hook

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -15,8 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-
+from typing import Optional, Union
 from urllib.parse import urlparse
 
 from airflow.exceptions import AirflowException
@@ -62,11 +61,11 @@ class S3KeySensor(BaseSensorOperator):
     def __init__(
         self,
         *,
-        bucket_key,
-        bucket_name=None,
-        wildcard_match=False,
-        aws_conn_id='aws_default',
-        verify=None,
+        bucket_key: str,
+        bucket_name: Optional[str] = None,
+        wildcard_match: bool = False,
+        aws_conn_id: str = 'aws_default',
+        verify: Optional[Union[str, bool]] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -91,7 +90,7 @@ class S3KeySensor(BaseSensorOperator):
         self.wildcard_match = wildcard_match
         self.aws_conn_id = aws_conn_id
         self.verify = verify
-        self.hook = None
+        self.hook: Optional[S3Hook] = None
 
     def poke(self, context):
         self.log.info('Poking for key : s3://%s/%s', self.bucket_name, self.bucket_key)
@@ -99,8 +98,10 @@ class S3KeySensor(BaseSensorOperator):
             return self.get_hook().check_for_wildcard_key(self.bucket_key, self.bucket_name)
         return self.get_hook().check_for_key(self.bucket_key, self.bucket_name)
 
-    def get_hook(self):
+    def get_hook(self) -> S3Hook:
         """Create and return an S3Hook"""
-        if not self.hook:
-            self.hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
+        if self.hook:
+            return self.hook
+
+        self.hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
         return self.hook

--- a/airflow/providers/amazon/aws/sensors/s3_prefix.py
+++ b/airflow/providers/amazon/aws/sensors/s3_prefix.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional, Union
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -56,7 +57,14 @@ class S3PrefixSensor(BaseSensorOperator):
 
     @apply_defaults
     def __init__(
-        self, *, bucket_name, prefix, delimiter='/', aws_conn_id='aws_default', verify=None, **kwargs
+        self,
+        *,
+        bucket_name: str,
+        prefix: str,
+        delimiter: str = '/',
+        aws_conn_id: str = 'aws_default',
+        verify: Optional[Union[str, bool]] = None,
+        **kwargs,
     ):
         super().__init__(**kwargs)
         # Parse
@@ -66,7 +74,7 @@ class S3PrefixSensor(BaseSensorOperator):
         self.full_url = "s3://" + bucket_name + '/' + prefix
         self.aws_conn_id = aws_conn_id
         self.verify = verify
-        self.hook = None
+        self.hook: Optional[S3Hook] = None
 
     def poke(self, context):
         self.log.info('Poking for prefix : %s in bucket s3://%s', self.prefix, self.bucket_name)
@@ -74,8 +82,10 @@ class S3PrefixSensor(BaseSensorOperator):
             prefix=self.prefix, delimiter=self.delimiter, bucket_name=self.bucket_name
         )
 
-    def get_hook(self):
+    def get_hook(self) -> S3Hook:
         """Create and return an S3Hook"""
-        if not self.hook:
-            self.hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
+        if self.hook:
+            return self.hook
+
+        self.hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
         return self.hook

--- a/airflow/providers/amazon/aws/sensors/sagemaker_base.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_base.py
@@ -15,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional, Set
+
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -32,15 +34,17 @@ class SageMakerBaseSensor(BaseSensorOperator):
     ui_color = '#ededed'
 
     @apply_defaults
-    def __init__(self, *, aws_conn_id='aws_default', **kwargs):
+    def __init__(self, *, aws_conn_id: str = 'aws_default', **kwargs):
         super().__init__(**kwargs)
         self.aws_conn_id = aws_conn_id
-        self.hook = None
+        self.hook: Optional[SageMakerHook] = None
 
-    def get_hook(self):
+    def get_hook(self) -> SageMakerHook:
         """Get SageMakerHook"""
-        if not self.hook:
-            self.hook = SageMakerHook(aws_conn_id=self.aws_conn_id)
+        if self.hook:
+            return self.hook
+
+        self.hook = SageMakerHook(aws_conn_id=self.aws_conn_id)
         return self.hook
 
     def poke(self, context):
@@ -62,22 +66,22 @@ class SageMakerBaseSensor(BaseSensorOperator):
             raise AirflowException('Sagemaker job failed for the following reason: %s' % failed_reason)
         return True
 
-    def non_terminal_states(self):
+    def non_terminal_states(self) -> Set[str]:
         """Placeholder for returning states with should not terminate."""
         raise NotImplementedError('Please implement non_terminal_states() in subclass')
 
-    def failed_states(self):
+    def failed_states(self) -> Set[str]:
         """Placeholder for returning states with are considered failed."""
         raise NotImplementedError('Please implement failed_states() in subclass')
 
-    def get_sagemaker_response(self):
+    def get_sagemaker_response(self) -> Optional[dict]:
         """Placeholder for checking status of a SageMaker task."""
         raise NotImplementedError('Please implement get_sagemaker_response() in subclass')
 
-    def get_failed_reason_from_response(self, response):  # pylint: disable=unused-argument
+    def get_failed_reason_from_response(self, response: dict) -> str:  # pylint: disable=unused-argument
         """Placeholder for extracting the reason for failure from an AWS response."""
         return 'Unknown'
 
-    def state_from_response(self, response):
+    def state_from_response(self, response: dict) -> str:
         """Placeholder for extracting the state from an AWS response."""
         raise NotImplementedError('Please implement state_from_response() in subclass')

--- a/airflow/providers/amazon/aws/sensors/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_training.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
 
 import time
 
@@ -44,13 +45,13 @@ class SageMakerTrainingSensor(SageMakerBaseSensor):
         self.print_log = print_log
         self.positions = {}
         self.stream_names = []
-        self.instance_count = None
-        self.state = None
+        self.instance_count: Optional[int] = None
+        self.state: Optional[int] = None
         self.last_description = None
         self.last_describe_job_call = None
         self.log_resource_inited = False
 
-    def init_log_resource(self, hook):
+    def init_log_resource(self, hook: SageMakerHook) -> None:
         """Set tailing LogState for associated training job."""
         description = hook.describe_training_job(self.job_name)
         self.instance_count = description['ResourceConfig']['InstanceCount']

--- a/airflow/providers/amazon/aws/sensors/sagemaker_transform.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_transform.py
@@ -35,7 +35,7 @@ class SageMakerTransformSensor(SageMakerBaseSensor):
     template_ext = ()
 
     @apply_defaults
-    def __init__(self, *, job_name, **kwargs):
+    def __init__(self, *, job_name: str, **kwargs):
         super().__init__(**kwargs)
         self.job_name = job_name
 

--- a/airflow/providers/amazon/aws/sensors/sagemaker_tuning.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_tuning.py
@@ -35,7 +35,7 @@ class SageMakerTuningSensor(SageMakerBaseSensor):
     template_ext = ()
 
     @apply_defaults
-    def __init__(self, *, job_name, **kwargs):
+    def __init__(self, *, job_name: str, **kwargs):
         super().__init__(**kwargs)
         self.job_name = job_name
 

--- a/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/airflow/providers/amazon/aws/sensors/sqs.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Reads and then deletes the message from SQS queue"""
+from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sqs import SQSHook
@@ -43,14 +44,20 @@ class SQSSensor(BaseSensorOperator):
 
     @apply_defaults
     def __init__(
-        self, *, sqs_queue, aws_conn_id='aws_default', max_messages=5, wait_time_seconds=1, **kwargs
+        self,
+        *,
+        sqs_queue,
+        aws_conn_id: str = 'aws_default',
+        max_messages: int = 5,
+        wait_time_seconds: int = 1,
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.sqs_queue = sqs_queue
         self.aws_conn_id = aws_conn_id
         self.max_messages = max_messages
         self.wait_time_seconds = wait_time_seconds
-        self.hook = None
+        self.hook: Optional[SQSHook] = None
 
     def poke(self, context):
         """
@@ -90,8 +97,10 @@ class SQSSensor(BaseSensorOperator):
 
         return False
 
-    def get_hook(self):
+    def get_hook(self) -> SQSHook:
         """Create and return an SQSHook"""
-        if not self.hook:
-            self.hook = SQSHook(aws_conn_id=self.aws_conn_id)
+        if self.hook:
+            return self.hook
+
+        self.hook = SQSHook(aws_conn_id=self.aws_conn_id)
         return self.hook

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -86,7 +86,7 @@ class TestAwsBatchOperator(unittest.TestCase):
         self.assertEqual(self.batch.waiters, None)
         self.assertEqual(self.batch.hook.max_retries, self.MAX_RETRIES)
         self.assertEqual(self.batch.hook.status_retries, self.STATUS_RETRIES)
-        self.assertEqual(self.batch.parameters, None)
+        self.assertEqual(self.batch.parameters, {})
         self.assertEqual(self.batch.overrides, {})
         self.assertEqual(self.batch.array_properties, {})
         self.assertEqual(self.batch.hook.region_name, "eu-west-1")
@@ -121,7 +121,7 @@ class TestAwsBatchOperator(unittest.TestCase):
             containerOverrides={},
             jobDefinition="hello-world",
             arrayProperties={},
-            parameters=None,
+            parameters={},
         )
 
         self.assertEqual(self.batch.job_id, JOB_ID)
@@ -140,7 +140,7 @@ class TestAwsBatchOperator(unittest.TestCase):
             containerOverrides={},
             jobDefinition="hello-world",
             arrayProperties={},
-            parameters=None,
+            parameters={},
         )
 
     @mock.patch.object(AwsBatchClientHook, "check_job_success")


### PR DESCRIPTION
This PR is about increasing typing coverage for the aws provider. Part of: #9708
I added type hints to the rest modules of amazon provider.

The typing coverage of amazon provider becomes 77.7.

This PR relates to #11434 and #11612.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
