### PR TITLE
Bugfix: Fix REST API DAGs Schema does not allow "None" for schedule_interval

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2372,6 +2372,7 @@ components:
       properties:
         __type: {type: string}
         value: {type: string}
+      nullable: true
 
     Timezone:
       type: string

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -121,6 +121,35 @@ class TestGetDag(TestDagEndpoint):
             current_response,
         )
 
+    @provide_session
+    def test_should_response_200_with_schedule_interval_none(self, session=None):
+        dag_model = DagModel(
+            dag_id="TEST_DAG_1",
+            fileloc="/tmp/dag_1.py",
+            schedule_interval=None,
+        )
+        session.add(dag_model)
+        session.commit()
+        response = self.client.get("/api/v1/dags/TEST_DAG_1", environ_overrides={'REMOTE_USER': "test"})
+        assert response.status_code == 200
+
+        current_response = response.json
+        current_response["fileloc"] = "/tmp/test-dag.py"
+        self.assertEqual(
+            {
+                "dag_id": "TEST_DAG_1",
+                "description": None,
+                "fileloc": "/tmp/test-dag.py",
+                "is_paused": False,
+                "is_subdag": False,
+                "owners": [],
+                "root_dag_id": None,
+                "schedule_interval": None,
+                "tags": [],
+            },
+            current_response,
+        )
+
     def test_should_response_200_with_granular_dag_access(self):
         self._create_dag_models(1)
         response = self.client.get(


### PR DESCRIPTION
Closes: #11506 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
