### PR TITLE
Fix documentation glitches

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -564,10 +564,18 @@ def get_current_context() -> Dict[str, Any]:
     Obtain the execution context for the currently executing operator without
     altering user method's signature.
     This is the simplest method of retrieving the execution context dictionary.
-    ** Old style:
+
+    **Old style:**
+
+    .. code:: python
+
         def my_task(**context):
             ti = context["ti"]
-    ** New style:
+
+    **New style:**
+
+    .. code:: python
+
         from airflow.task.context import get_current_context
         def my_task():
             context = get_current_context()

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -48,7 +48,7 @@ def get_connection_parameter_names() -> Set[str]:
 
 def _parse_env_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyntaxError]]:
     """
-    Parse a file in the ``.env '' format.
+    Parse a file in the ``.env`` format.
 
     .. code-block:: text
 


### PR DESCRIPTION
In trialing an upgrade of sphinx-autoapi to 1.5.1 (it has otherproblem with metaclasses right now, so we cant use it just yet) I noticed these cases of new warnings being issued that would become errors if we upgraded.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
