### PR TITLE
Rename (confusing) dag.sub_dag method to dag.partial_subset

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -103,7 +103,7 @@ def dag_backfill(args, dag=None):
     args.start_date = args.start_date or args.end_date
 
     if args.task_regex:
-        dag = dag.sub_dag(
+        dag = dag.partial_subset(
             task_regex=args.task_regex,
             include_upstream=not args.ignore_dependencies)
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -411,7 +411,7 @@ def task_clear(args):
 
         if args.task_regex:
             for idx, dag in enumerate(dags):
-                dags[idx] = dag.sub_dag(
+                dags[idx] = dag.partial_subset(
                     task_regex=args.task_regex,
                     include_downstream=args.downstream,
                     include_upstream=args.upstream)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1347,8 +1347,18 @@ class DAG(BaseDag, LoggingMixin):
             result._log = self._log
         return result
 
-    def sub_dag(self, task_regex, include_downstream=False,
-                include_upstream=True):
+    def sub_dag(self, *args, **kwargs):
+        """This method is deprecated in favor of partial_subset"""
+        warnings.warn(
+            "This method is deprecated and will be removed in a future version. Please use partial_subset",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.partial_subset(*args, **kwargs)
+
+    def partial_subset(
+        self, task_regex, include_downstream=False, include_upstream=True
+    ):
         """
         Returns a subset of the current dag as a deep copy of the current dag
         based on a regex that should match one or many tasks, and includes


### PR DESCRIPTION
There was a method on the DAG class called `sub_dag()` that had nothing
to do with Sub-DAGs or the SubDagOperator - It instead created a new
"partial" dag that contained only a selected subset of tasks.

To remove this confusion when seeing `dag.sub_dag()` used in code I have
renamed this function, and included a compat shim in case anyone is
using it outside of Airflow core.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).