### PR TITLE
Add ability to zoom into Graph view from selection in Tree View

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -536,7 +536,6 @@
     }
 
     function call_modal_dag(dag) {
-      id = dag && dag.id;
       execution_date = dag && dag.execution_date;
       dag_id = dag && dag.dag_id
       $('#dagModal').modal({});

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -341,7 +341,10 @@
               </form>
             </span>
             <span class="col-md-4">
-              <a id="btn_dag_graph_view" class="btn" data-base-url="{{ url_for('Airflow.graph') }}" role="button">Show Graph View</a>
+              <a id="btn_dag_graph_view" class="btn" data-base-url="{{ url_for('Airflow.graph') }}" role="button">
+                <span class="material-icons" aria-hidden="true">account_tree</span>
+                Graph View
+              </a>
             </span>
           </div>
         </div>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -340,7 +340,7 @@
                 </button>
               </form>
             </span>
-            <span class="col-md-4">
+            <span class="col-md-4 text-right">
               <a id="btn_dag_graph_view" class="btn" data-base-url="{{ url_for('Airflow.graph') }}" role="button">
                 <span class="material-icons" aria-hidden="true">account_tree</span>
                 Graph View

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -322,21 +322,28 @@
           </h4>
         </div>
         <div class="modal-body">
-          <form method="POST">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
-            <input type="hidden" name="execution_date">
-            <input type="hidden" name="origin" value="{{ request.base_url }}">
-            <button type="button" id="btn_dagrun_clear" class="btn btn-primary" data-action="{{ url_for('Airflow.dagrun_clear') }}">
-              Clear
-            </button>
-            <button type="button" id="btn_dagrun_failed" class="btn btn-primary" data-action="{{ url_for('Airflow.dagrun_failed') }}">
-              Mark Failed
-            </button>
-            <button type="button" id="btn_dagrun_success" class="btn btn-primary" data-action="{{ url_for('Airflow.dagrun_success') }}">
-              Mark Success
-            </button>
-          </form>
+          <div class="row">
+            <span class="btn-group col-md-8">
+              <form method="POST">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
+                <input type="hidden" name="execution_date">
+                <input type="hidden" name="origin" value="{{ request.base_url }}">
+                <button type="button" id="btn_dagrun_clear" class="btn btn-primary" data-action="{{ url_for('Airflow.dagrun_clear') }}">
+                  Clear
+                </button>
+                <button type="button" id="btn_dagrun_failed" class="btn btn-primary" data-action="{{ url_for('Airflow.dagrun_failed') }}">
+                  Mark Failed
+                </button>
+                <button type="button" id="btn_dagrun_success" class="btn btn-primary" data-action="{{ url_for('Airflow.dagrun_success') }}">
+                  Mark Success
+                </button>
+              </form>
+            </span>
+            <span class="col-md-4">
+              <a id="btn_dag_graph_view" class="btn" data-base-url="{{ url_for('Airflow.graph') }}" role="button">Show Graph View</a>
+            </span>
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -531,8 +538,13 @@
     function call_modal_dag(dag) {
       id = dag && dag.id;
       execution_date = dag && dag.execution_date;
+      dag_id = dag && dag.dag_id
       $('#dagModal').modal({});
       $('#dagModal').css('margin-top','0');
+      updateButtonUrl(buttons.dag_graph_view, {
+        dag_id: dag_id,
+        execution_date: execution_date,
+        });
     }
 
     function confirmTriggerDag(link, dag_id){


### PR DESCRIPTION
Adds link to graph view of specific dagrun from tree view, as outlined in issue https://github.com/apache/airflow/issues/11388.

Currently users have to check for execution date, use drop down in graph view to 'zoom in'.

I verified desired functionality via breeze + point/click.

![image](https://user-images.githubusercontent.com/5178938/96326392-32017c00-0ffe-11eb-9c8b-3b079222866e.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
