### PR TITLE
Guard against kubernetes not being installed

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -25,14 +25,6 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Union
 import cattr
 import pendulum
 from dateutil import relativedelta
-
-try:
-    from kubernetes.client import models as k8s
-    from airflow.kubernetes.pod_generator import PodGenerator
-    has_kubernetes = True
-except ImportError:
-    has_kubernetes = False
-
 from pendulum.tz.timezone import Timezone
 
 from airflow.exceptions import AirflowException
@@ -46,6 +38,16 @@ from airflow.settings import json
 from airflow.utils.code_utils import get_python_source
 from airflow.utils.module_loading import import_string
 from airflow.utils.task_group import TaskGroup
+
+try:
+    # isort: off
+    from kubernetes.client import models as k8s
+    from airflow.kubernetes.pod_generator import PodGenerator
+    # isort: on
+    has_kubernetes = True
+except ImportError:
+    has_kubernetes = False
+
 
 log = logging.getLogger(__name__)
 FAILED = 'serialization_failed'

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -878,10 +878,10 @@ class TestStringifiedDAGs(unittest.TestCase):
 def test_kubernetes_optional():
     """Serialisation / deserialisation continues to work without kubernetes installed"""
 
-    def mock__import__(name, globals=None, locals=None, fromlist=(), level=0):
+    def mock__import__(name, globals_=None, locals_=None, fromlist=(), level=0):
         if level == 0 and name.partition('.')[0] == 'kubernetes':
             raise ImportError("No module named 'kubernetes'")
-        return importlib.__import__(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
+        return importlib.__import__(name, globals=globals_, locals=locals_, fromlist=fromlist, level=level)
 
     with mock.patch('builtins.__import__', side_effect=mock__import__) as import_mock:
         # load module from scratch, this does not replace any already imported

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -18,6 +18,8 @@
 
 """Unit tests for stringified DAGs."""
 
+import importlib
+import importlib.util
 import multiprocessing
 import os
 import unittest
@@ -871,3 +873,38 @@ class TestStringifiedDAGs(unittest.TestCase):
                 check_task_group(child)
 
         check_task_group(serialized_dag.task_group)
+
+
+def test_kubernetes_optional():
+    """Serialisation / deserialisation continues to work without kubernetes installed"""
+
+    def mock__import__(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 0 and name.partition('.')[0] == 'kubernetes':
+            raise ImportError("No module named 'kubernetes'")
+        return importlib.__import__(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
+
+    with mock.patch('builtins.__import__', side_effect=mock__import__) as import_mock:
+        # load module from scratch, this does not replace any already imported
+        # airflow.serialization.serialized_objects module in sys.modules
+        spec = importlib.util.find_spec("airflow.serialization.serialized_objects")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        # if we got this far, the module did not try to load kubernetes, but
+        # did it try to access airflow.kubernetes.*?
+        imported_airflow = {
+            c.args[0].split('.', 2)[1] for c in import_mock.call_args_list if c.args[0].startswith("airflow.")
+        }
+        assert "kubernetes" not in imported_airflow
+
+        # pod loading is not supported when kubernetes is not available
+        pod_override = {
+            '__type': 'k8s.V1Pod',
+            '__var': PodGenerator.serialize_pod(executor_config_pod),
+        }
+
+        with pytest.raises(RuntimeError):
+            module.BaseSerialization.from_dict(pod_override)
+
+        # basic serialization should succeed
+        module.SerializedDAG.to_dict(make_simple_dag()["simple_dag"])


### PR DESCRIPTION
If the `kubernetes.client` import fails, then `airflow.kubernetes.pod_generator` also can't be imported, and there won't be attributes on `k8s` to use in `isinstance()` calls.

Instead of setting `k8s` to `None`, use an explicit flag so later code can disable kubernetes-specific branches explicitly.

closes: #11556 