### PR TITLE
Clarify breeze docs --install-airflow-version/-reference

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1197,11 +1197,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
           image building time in production image and at container entering time for CI image. One of:
 
                  1.10.12 1.10.11 1.10.10 1.10.9 1.10.8 1.10.7 1.10.6 1.10.5 1.10.4 1.10.3 1.10.2
-                 master v1-10-test
 
   -t, --install-airflow-reference INSTALL_AIRFLOW_REFERENCE
           If specified, installs Airflow directly from reference in GitHub. This happens at
           image building time in production image and at container entering time for CI image.
+          This can be a GitHub branch like master or v1-10-test, or a tag like 2.0.0a1.
 
   --no-rbac-ui
           Disables RBAC UI when Airflow 1.10.* is installed.
@@ -2183,11 +2183,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
           image building time in production image and at container entering time for CI image. One of:
 
                  1.10.12 1.10.11 1.10.10 1.10.9 1.10.8 1.10.7 1.10.6 1.10.5 1.10.4 1.10.3 1.10.2
-                 master v1-10-test
 
   -t, --install-airflow-reference INSTALL_AIRFLOW_REFERENCE
           If specified, installs Airflow directly from reference in GitHub. This happens at
           image building time in production image and at container entering time for CI image.
+          This can be a GitHub branch like master or v1-10-test, or a tag like 2.0.0a1.
 
   --no-rbac-ui
           Disables RBAC UI when Airflow 1.10.* is installed.

--- a/breeze
+++ b/breeze
@@ -2207,6 +2207,7 @@ ${FORMATTED_INSTALL_AIRFLOW_VERSIONS}
 -t, --install-airflow-reference INSTALL_AIRFLOW_REFERENCE
         If specified, installs Airflow directly from reference in GitHub. This happens at
         image building time in production image and at container entering time for CI image.
+        This can be a GitHub branch like master or v1-10-test, or a tag like 2.0.0a1.
 
 --no-rbac-ui
         Disables RBAC UI when Airflow 1.10.* is installed.

--- a/breeze-complete
+++ b/breeze-complete
@@ -60,8 +60,6 @@ _breeze_allowed_install_airflow_versions=$(cat <<-EOF
 1.10.4
 1.10.3
 1.10.2
-master
-v1-10-test
 EOF
 )
 


### PR DESCRIPTION
The breeze docs did say that you can install an airflow version such as master or v1-10-test through the `--install-airflow-version` flag. But this does not work - instead use the `--install-airflow-reference` flag.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
