### PR TITLE
Remove breeze help marker from breeze docs

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2398,5 +2398,3 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   -h, --help
           Shows detailed help message for the command specified.
-
- .. END BREEZE HELP MARKER

--- a/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.sh
+++ b/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.sh
@@ -73,7 +73,7 @@ beginning_of_generated_help_line_number=$(grep -n "${lead_marker}" <"${BREEZE_RS
 end_beginning_of_generated_help_line_number=$(grep -n "${tail_marker}" <"${BREEZE_RST_FILE}" | sed 's/\(.*\):.*/\1/g')
 cat <(head -n "${beginning_of_generated_help_line_number}" "${BREEZE_RST_FILE}") \
     "${TMP_FILE}" \
-    <(tail -n +"${end_beginning_of_generated_help_line_number}" "${BREEZE_RST_FILE}") \
+    <(tail -n +$((end_beginning_of_generated_help_line_number + 1)) "${BREEZE_RST_FILE}") \
     >"${TMP_OUTPUT}"
 
 mv "${TMP_OUTPUT}" "${BREEZE_RST_FILE}"


### PR DESCRIPTION
The breeze helper marker which is intended to tell the automated breeze script (which builds the docs) where to start and to end was still in the breeze docs.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
