### PR TITLE
Fix migration for Sqlite3

### DIFF
--- a/airflow/migrations/versions/98271e7606e2_add_scheduling_decision_to_dagrun_and_.py
+++ b/airflow/migrations/versions/98271e7606e2_add_scheduling_decision_to_dagrun_and_.py
@@ -64,7 +64,7 @@ def upgrade():
     # Set it to true here as it makes us take the slow/more complete path, and when it's next parsed by the
     # DagParser it will get set to correct value.
     op.execute(
-        "UPDATE dag SET concurrency={}, has_task_concurrency_limits=true where concurrency IS NULL".format(
+        "UPDATE dag SET concurrency={}, has_task_concurrency_limits=1 where concurrency IS NULL".format(
             concurrency
         )
     )

--- a/airflow/migrations/versions/98271e7606e2_add_scheduling_decision_to_dagrun_and_.py
+++ b/airflow/migrations/versions/98271e7606e2_add_scheduling_decision_to_dagrun_and_.py
@@ -39,6 +39,7 @@ def upgrade():
     """Apply Add scheduling_decision to DagRun and DAG"""
     conn = op.get_bind()  # pylint: disable=no-member
     is_mysql = bool(conn.dialect.name == "mysql")
+    is_sqlite = bool(conn.dialect.name == "sqlite")
     timestamp = sa.TIMESTAMP(timezone=True) if not is_mysql else mysql.TIMESTAMP(fsp=6, timezone=True)
 
     with op.batch_alter_table('dag_run', schema=None) as batch_op:
@@ -64,8 +65,8 @@ def upgrade():
     # Set it to true here as it makes us take the slow/more complete path, and when it's next parsed by the
     # DagParser it will get set to correct value.
     op.execute(
-        "UPDATE dag SET concurrency={}, has_task_concurrency_limits=1 where concurrency IS NULL".format(
-            concurrency
+        "UPDATE dag SET concurrency={}, has_task_concurrency_limits={} where concurrency IS NULL".format(
+            concurrency, 1 if is_sqlite else sa.true()
         )
     )
     with op.batch_alter_table('dag', schema=None) as batch_op:


### PR DESCRIPTION
While setting up SQLite DB with Airflow 2.0, got the below error. Not sure how this was hidden from @ashb or CI, or maybe something wrong with my setup only?

`sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such column: true`
`[SQL: UPDATE dag SET concurrency=16, has_task_concurrency_limits=true where concurrency IS NULL]`