### PR TITLE
Fixes dependencies to pre-release versions of apache-airflow

### DIFF
--- a/provider_packages/setup_provider_packages.py
+++ b/provider_packages/setup_provider_packages.py
@@ -279,7 +279,7 @@ def do_setup_package_providers(provider_package_id: str,
         airflow_dependency = 'apache-airflow~=1.10' if provider_package_id != 'cncf.kubernetes' \
             else 'apache-airflow>=1.10.12, <2.0.0'
     else:
-        airflow_dependency = 'apache-airflow>=2.0.0'
+        airflow_dependency = 'apache-airflow>=2.0.0a0'
 
     install_requires = [
         airflow_dependency


### PR DESCRIPTION
The dependencies in Alphas are currently >= 2.0.0 and should be
>=2.0.0a0 in order to work with Alphas in cases which are not PEP
440-compliant.

According to https://www.python.org/dev/peps/pep-0440/, >= 2.0.0 should
also work with alpha/beta releases (a1/a2) but in some cases it does not
(https://apache-airflow.slack.com/archives/C0146STM600/p1602774750041800)

Changing to ">=2.0.0a0" should help.

Fixes #11577

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
