### PR TITLE
Accessibility Fix: State token contrast

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -233,9 +233,12 @@ def task_instance_link(attr):
 def state_token(state):
     """Returns a formatted string with HTML for a given State"""
     color = State.color(state)
+    fg_color = State.color_fg(state)
     return Markup(  # noqa
-        '<span class="label" style="background-color:{color};" title="Current State: {state}">'
-        '{state}</span>').format(color=color, state=state)
+        """
+        <span class="label" style="color:{fg_color}; background-color:{color};"
+            title="Current State: {state}">{state}</span>
+        """).format(color=color, state=state, fg_color=fg_color)
 
 
 def state_f(attr):


### PR DESCRIPTION
The `state_token` utility that renders the labels depicted below was failing contrast ratio standards for the "success" and "failed" states. There was already a preexisting `color_fg` method in place to handle the foreground color used for these two instances, it just wasn't employed in this utility (until now).

| Before | After |
|---|---|
|  <img width="166" alt="Image 2020-10-16 at 10 07 35 AM" src="https://user-images.githubusercontent.com/3267/96268841-8a516300-0f97-11eb-8205-1fabb5bbe779.png"> | <img width="169" alt="Image 2020-10-16 at 9 55 27 AM" src="https://user-images.githubusercontent.com/3267/96268623-45c5c780-0f97-11eb-9039-6d2f39699dfa.png">  |

| Before | After |
|---|---|
| <img width="118" alt="Image 2020-10-16 at 10 07 46 AM" src="https://user-images.githubusercontent.com/3267/96268858-8f161700-0f97-11eb-9d78-fea8ec34b779.png">  |  <img width="131" alt="Image 2020-10-16 at 9 57 54 AM" src="https://user-images.githubusercontent.com/3267/96268598-4199aa00-0f97-11eb-90b2-cb0e7c1bc4ea.png"> |

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
