### PR TITLE
UX Enhancement: Add button to clear search query from DAG search

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -416,3 +416,18 @@ label[for="timezone-other"],
   top: 15px;
   right: 15px;
 }
+
+.search-input {
+  position: relative;
+}
+
+.search-input__input {
+  padding-right: 40px;
+}
+
+.search-input__clear-btn {
+  position: absolute;
+  right: 2px;
+  top: 2px;
+  border: 0;
+}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -64,7 +64,7 @@
               <label for="dag_query" class="sr-only">Search DAGs</label>
               <input type="search" id="dag_query" class="typeahead form-control search-input__input" data-provide="typeahead" style="width:100%;" value="{{search_query}}" autocomplete="off" placeholder="Search DAGs">
               {% if search_query %}
-                <button type="reset" class="btn btn-default btn-sm material-icons search-input__clear-btn">cancel</button>
+                <button type="reset" aria-label="Clear DAG Search Term" class="btn btn-default btn-sm material-icons search-input__clear-btn">cancel</button>
               {% endif %}
             </div>
           </form>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -319,6 +319,7 @@
     $('#search_form').on('reset', function() {
       var query = new URLSearchParams(window.location.search);
       query.delete('search');
+      query.set('page', '0');
       window.location = DAGS_INDEX + "?" + query;
     });
 

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -319,7 +319,7 @@
     $('#search_form').on('reset', function() {
       var query = new URLSearchParams(window.location.search);
       query.delete('search');
-      query.set('page', '0');
+      query.delete('page');
       window.location = DAGS_INDEX + "?" + query;
     });
 

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -60,9 +60,12 @@
         </div>
         <div class="col-sm-4">
           <form id="search_form" class="form-inline">
-            <div class="form-group" style="width: 100%;">
+            <div class="form-group search-input" style="width: 100%;">
               <label for="dag_query" class="sr-only">Search DAGs</label>
-              <input type="search" id="dag_query" class="typeahead form-control" data-provide="typeahead" style="width:100%;" value="{{search_query}}" autocomplete="off" placeholder="Search DAGs">
+              <input type="search" id="dag_query" class="typeahead form-control search-input__input" data-provide="typeahead" style="width:100%;" value="{{search_query}}" autocomplete="off" placeholder="Search DAGs">
+              {% if search_query %}
+                <button type="reset" class="btn btn-default btn-sm material-icons search-input__clear-btn">cancel</button>
+              {% endif %}
             </div>
           </form>
         </div>
@@ -311,6 +314,12 @@
           window.location = DAGS_INDEX + "?" + query;
         }
       }
+    });
+
+    $('#search_form').on('reset', function() {
+      var query = new URLSearchParams(window.location.search);
+      query.delete('search');
+      window.location = DAGS_INDEX + "?" + query;
     });
 
     $('#main_content').show(250);


### PR DESCRIPTION
Currently there is no easy way to reset the DAGs view (home) after performing a search—leaving users stranded. This update adds a button (X) that only displays when a search query is present. This button removes the search param from the page and refreshes the page (while retaining other url params).

![Screen Recording 2020-10-16 at 11 09 53 AM](https://user-images.githubusercontent.com/3267/96275799-2e3f0c80-0fa0-11eb-9feb-a98935d12135.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
