### PR TITLE
Fixes versioning for pre-release provider packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,7 @@ jobs:
       INSTALL_AIRFLOW_VERSION: "1.10.12"
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
       BACKPORT_PACKAGES: "true"
+      VERSION_SUFFIX_FOR_SVN: "rc1"
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -315,6 +316,8 @@ jobs:
     env:
       INSTALL_AIRFLOW_VERSION: "2.0.0-dev"   # Note that this causes local installation
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
+      VERSION_SUFFIX_FOR_PYPI: "a0"
+      VERSION_SUFFIX_FOR_SVN: "a0"
     if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1911,7 +1911,8 @@ This is the current syntax for  `./breeze <./breeze>`_:
         Prepares backport packages. You can provide (after --) optional list of packages to prepare.
         If no packages are specified, readme for all packages are generated. You can specify optional
         --version-suffix-for-svn flag to generate rc candidate packages to upload to SVN or
-        --version-suffix-for-pypi flag to generate rc candidates for PyPI packages.
+        --version-suffix-for-pypi flag to generate rc candidates for PyPI packages. You can also
+        provide both suffixes in case you prepare alpha/beta versions.
 
         Examples:
 
@@ -1919,6 +1920,8 @@ This is the current syntax for  `./breeze <./breeze>`_:
         'breeze prepare-provider-packages google' or
         'breeze prepare-provider-packages --version-suffix-for-svn rc1 http google amazon' or
         'breeze prepare-provider-packages --version-suffix-for-pypi rc1 http google amazon'
+        'breeze prepare-provider-packages --version-suffix-for-pypi a1
+                                              --version-suffix-for-svn a1 http google amazon'
 
         General form:
 

--- a/breeze
+++ b/breeze
@@ -1090,24 +1090,12 @@ function breeze::parse_arguments() {
             shift 2
             ;;
         -S | --version-suffix-for-pypi)
-            if [[ -n ${VERSION_SUFFIX_FOR_SVN=} ]]; then
-                echo
-                echo "You can only set one version suffix - either for PyPI or for SVN"
-                echo
-                exit 1
-            fi
             export VERSION_SUFFIX_FOR_PYPI="${2}"
             echo "Version suffix for PyPI ${VERSION_SUFFIX_FOR_PYPI}"
             echo
             shift 2
             ;;
         -N | --version-suffix-for-svn)
-            if [[ -n ${VERSION_SUFFIX_FOR_PYPI=} ]]; then
-                echo
-                echo "You can only set one version suffix - either for PyPI or for SVN"
-                echo
-                exit 1
-            fi
             export VERSION_SUFFIX_FOR_SVN="${2}"
             echo "Version suffix for SVN ${VERSION_SUFFIX_FOR_SVN}"
             echo
@@ -1709,7 +1697,8 @@ ${CMDNAME} prepare-provider-packages [FLAGS] [PACKAGE_ID ...]
       Prepares backport packages. You can provide (after --) optional list of packages to prepare.
       If no packages are specified, readme for all packages are generated. You can specify optional
       --version-suffix-for-svn flag to generate rc candidate packages to upload to SVN or
-      --version-suffix-for-pypi flag to generate rc candidates for PyPI packages.
+      --version-suffix-for-pypi flag to generate rc candidates for PyPI packages. You can also
+      provide both suffixes in case you prepare alpha/beta versions.
 
       Examples:
 
@@ -1717,6 +1706,8 @@ ${CMDNAME} prepare-provider-packages [FLAGS] [PACKAGE_ID ...]
       '${CMDNAME} prepare-provider-packages google' or
       '${CMDNAME} prepare-provider-packages --version-suffix-for-svn rc1 http google amazon' or
       '${CMDNAME} prepare-provider-packages --version-suffix-for-pypi rc1 http google amazon'
+      '${CMDNAME} prepare-provider-packages --version-suffix-for-pypi a1
+                                            --version-suffix-for-svn a1 http google amazon'
 
       General form:
 


### PR DESCRIPTION
When we prepare pre-release versions, they are not intended to be
converted to final release versions, so there is no need to replace
version number for them artificially,

For release candidates on the other hand, we should internally use the
"final" version because those packages might be simply renamed to the
final "production" versions.

Fixes #11585

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
