### PR TITLE
Perform "mini scheduling run" after task has finished

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -102,7 +102,7 @@ def dag_backfill(args, dag=None):
 
     if args.task_regex:
         dag = dag.partial_subset(
-            task_regex=args.task_regex,
+            task_ids_or_regex=args.task_regex,
             include_upstream=not args.ignore_dependencies)
 
     run_conf = None

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -411,7 +411,7 @@ def task_clear(args):
         if args.task_regex:
             for idx, dag in enumerate(dags):
                 dags[idx] = dag.partial_subset(
-                    task_regex=args.task_regex,
+                    task_ids_or_regex=args.task_regex,
                     include_downstream=args.downstream,
                     include_upstream=args.upstream)
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1617,6 +1617,17 @@
       type: string
       default: ~
       see_also: ":ref:`scheduler:ha:tunables`"
+    - name: schedule_after_task_execution
+      description: |
+        Should the Task supervisor process perform a "mini scheduler" to attempt to schedule more tasks of the
+        same DAG. Leaving this on will mean tasks in the same DAG execute quicker, but might starve out other
+        dags in some circumstances
+
+        Default: True
+      example: ~
+      version_added: 2.0.0
+      type: boolean
+      default: ~
     - name: statsd_on
       description: |
         Statsd (https://github.com/etsy/statsd) integration settings

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -811,6 +811,13 @@ use_row_level_locking = True
 # Default: 20
 # max_dagruns_per_loop_to_schedule =
 
+# Should the Task supervisor process perform a "mini scheduler" to attempt to schedule more tasks of the
+# same DAG. Leaving this on will mean tasks in the same DAG execute quicker, but might starve out other
+# dags in some circumstances
+#
+# Default: True
+# schedule_after_task_execution =
+
 # Statsd (https://github.com/etsy/statsd) integration settings
 statsd_on = False
 statsd_host = localhost

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -102,6 +102,7 @@ sync_parallelism = 0
 
 [scheduler]
 job_heartbeat_sec = 1
+schedule_after_task_execution = False
 scheduler_heartbeat_sec = 5
 scheduler_health_check_threshold = 30
 max_threads = 2

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1014,7 +1014,6 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
     def get_flat_relative_ids(self,
                               upstream: bool = False,
                               found_descendants: Optional[Set[str]] = None,
-                              recurse: bool = True,
                               ) -> Set[str]:
         """Get a flat set of relatives' ids, either upstream or downstream."""
         if not self._dag:
@@ -1028,20 +1027,18 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             if relative_id not in found_descendants:
                 found_descendants.add(relative_id)
                 relative_task = self._dag.task_dict[relative_id]
-
-                if recurse:
-                    relative_task.get_flat_relative_ids(upstream, found_descendants)
+                relative_task.get_flat_relative_ids(upstream, found_descendants)
 
         return found_descendants
 
-    def get_flat_relatives(self, upstream: bool = False, recurse: bool = True):
+    def get_flat_relatives(self, upstream: bool = False):
         """Get a flat list of relatives, either upstream or downstream."""
         if not self._dag:
             return set()
         from airflow.models.dag import DAG
         dag: DAG = self._dag
         return list(map(lambda task_id: dag.task_dict[task_id],
-                        self.get_flat_relative_ids(upstream, recurse=recurse)))
+                        self.get_flat_relative_ids(upstream)))
 
     def run(
             self,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1013,7 +1013,9 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
 
     def get_flat_relative_ids(self,
                               upstream: bool = False,
-                              found_descendants: Optional[Set[str]] = None) -> Set[str]:
+                              found_descendants: Optional[Set[str]] = None,
+                              recurse: bool = True,
+                              ) -> Set[str]:
         """Get a flat set of relatives' ids, either upstream or downstream."""
         if not self._dag:
             return set()
@@ -1026,19 +1028,20 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             if relative_id not in found_descendants:
                 found_descendants.add(relative_id)
                 relative_task = self._dag.task_dict[relative_id]
-                relative_task.get_flat_relative_ids(upstream,
-                                                    found_descendants)
+
+                if recurse:
+                    relative_task.get_flat_relative_ids(upstream, found_descendants)
 
         return found_descendants
 
-    def get_flat_relatives(self, upstream: bool = False):
+    def get_flat_relatives(self, upstream: bool = False, recurse: bool = True):
         """Get a flat list of relatives, either upstream or downstream."""
         if not self._dag:
             return set()
         from airflow.models.dag import DAG
         dag: DAG = self._dag
         return list(map(lambda task_id: dag.task_dict[task_id],
-                        self.get_flat_relative_ids(upstream)))
+                        self.get_flat_relative_ids(upstream, recurse=recurse)))
 
     def run(
             self,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1406,6 +1406,7 @@ class DAG(BaseDag, LoggingMixin):
         task_ids_or_regex: Union[str, PatternType, Iterable[str]],
         include_downstream=False,
         include_upstream=True,
+        include_direct_upstream=False,
     ):
         """
         Returns a subset of the current dag as a deep copy of the current dag
@@ -1442,6 +1443,8 @@ class DAG(BaseDag, LoggingMixin):
                 also_include += t.get_flat_relatives(upstream=False)
             if include_upstream:
                 also_include += t.get_flat_relatives(upstream=True)
+            elif include_direct_upstream:
+                also_include += t.upstream_list
 
         # Compiling the unique list of tasks that made the cut
         # Make sure to not recursively deepcopy the dag while copying the task

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1406,6 +1406,7 @@ class DAG(BaseDag, LoggingMixin):
         task_ids_or_regex: Union[str, PatternType, Iterable[str]],
         include_downstream=False,
         include_upstream=True,
+        include_direct_parents=False,
     ):
         """
         Returns a subset of the current dag as a deep copy of the current dag
@@ -1442,6 +1443,8 @@ class DAG(BaseDag, LoggingMixin):
                 also_include += t.get_flat_relatives(upstream=False)
             if include_upstream:
                 also_include += t.get_flat_relatives(upstream=True)
+            if include_direct_parents and not include_upstream:
+                also_include += t.get_flat_relatives(upstream=True, recurse=False)
 
         # Compiling the unique list of tasks that made the cut
         # Make sure to not recursively deepcopy the dag while copying the task

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1406,7 +1406,6 @@ class DAG(BaseDag, LoggingMixin):
         task_ids_or_regex: Union[str, PatternType, Iterable[str]],
         include_downstream=False,
         include_upstream=True,
-        include_direct_parents=False,
     ):
         """
         Returns a subset of the current dag as a deep copy of the current dag
@@ -1443,8 +1442,6 @@ class DAG(BaseDag, LoggingMixin):
                 also_include += t.get_flat_relatives(upstream=False)
             if include_upstream:
                 also_include += t.get_flat_relatives(upstream=True)
-            if include_direct_parents and not include_upstream:
-                also_include += t.get_flat_relatives(upstream=True, recurse=False)
 
         # Compiling the unique list of tasks that made the cut
         # Make sure to not recursively deepcopy the dag while copying the task

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1180,7 +1180,7 @@ class DAG(BaseDag, LoggingMixin):
 
         if include_parentdag and self.is_subdag and self.parent_dag is not None:
             p_dag = self.parent_dag.sub_dag(
-                task_regex=r"^{}$".format(self.dag_id.split('.')[1]),
+                task_ids_or_regex=r"^{}$".format(self.dag_id.split('.')[1]),
                 include_upstream=False,
                 include_downstream=True)
 
@@ -1253,7 +1253,7 @@ class DAG(BaseDag, LoggingMixin):
                             if not external_dag:
                                 raise AirflowException("Could not find dag {}".format(tii.dag_id))
                             downstream = external_dag.sub_dag(
-                                task_regex=r"^{}$".format(tii.task_id),
+                                task_ids_or_regex=r"^{}$".format(tii.task_id),
                                 include_upstream=False,
                                 include_downstream=True
                             )

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1425,7 +1425,7 @@ class DAG(BaseDag, LoggingMixin):
         task_dict = self.task_dict
         task_group = self._task_group
         self.task_dict = {}
-        self._task_group = None
+        self._task_group = None  # type: ignore
         dag = copy.deepcopy(self)
         self.task_dict = task_dict
         self._task_group = task_group

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -685,7 +685,7 @@ class DagRun(Base, LoggingMixin):
         Any DummyOperator without callbacks is instead set straight to the success state.
 
         All the TIs should belong to this DagRun, but this code is in the hot-path, this is not checked -- it
-        is the caller's responsiblity to call this function only with TIs from a single dag run.
+        is the caller's responsibility to call this function only with TIs from a single dag run.
         """
         # Get list of TIs that do not need to executed, these are
         # tasks using DummyOperator and without on_execute_callback / on_success_callback

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -44,11 +44,7 @@ from airflow.utils.types import DagRunType
 
 
 class TISchedulingDecision(NamedTuple):
-    """
-    Type of return for DagRun.task_instance_scheduling_decisions
-
-    This is only used by type checkers, at run time this is a plain dict.
-    """
+    """Type of return for DagRun.task_instance_scheduling_decisions"""
 
     tis: List[TI]
     schedulable_tis: List[TI]

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -43,7 +43,7 @@ from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 
-class _TISchedulingDecision(NamedTuple):
+class TISchedulingDecision(NamedTuple):
     """
     Type of return for DagRun.task_instance_scheduling_decisions
 
@@ -477,7 +477,7 @@ class DagRun(Base, LoggingMixin):
         return schedulable_tis, callback
 
     @provide_session
-    def task_instance_scheduling_decisions(self, session: Session = None) -> _TISchedulingDecision:
+    def task_instance_scheduling_decisions(self, session: Session = None) -> TISchedulingDecision:
 
         schedulable_tis: List[TI] = []
         changed_tis = False
@@ -496,7 +496,7 @@ class DagRun(Base, LoggingMixin):
                 self, len(scheduleable_tasks))
             schedulable_tis, changed_tis = self._get_ready_tis(scheduleable_tasks, finished_tasks, session)
 
-        return _TISchedulingDecision(
+        return TISchedulingDecision(
             tis=tis,
             schedulable_tis=schedulable_tis,
             changed_tis=changed_tis,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union
 
 from sqlalchemy import (
     Boolean, Column, DateTime, Index, Integer, PickleType, String, UniqueConstraint, and_, func, or_,
@@ -35,12 +35,27 @@ from airflow.settings import task_instance_mutation_hook
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
+from airflow.typing_compat import TypedDict
 from airflow.utils import callback_requests, timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, nulls_first, skip_locked, with_row_locks
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
+
+
+class _TISchedulingDecision(TypedDict):
+    """
+    Type of return for DagRun.task_instance_scheduling_decisions
+
+    This is only used by type checkers, at run time this is a plain dict.
+    """
+
+    tis: List[TI]
+    schedulable_tis: List[TI]
+    changed_tis: bool
+    unfinished_tis: List[TI]
+    finished_tis: List[TI]
 
 
 class DagRun(Base, LoggingMixin):
@@ -380,27 +395,21 @@ class DagRun(Base, LoggingMixin):
         self.last_scheduling_decision = start_dttm
 
         dag = self.get_dag()
-        ready_tis: List[TI] = []
-        tis = list(self.get_task_instances(session=session, state=State.task_states + (State.SHUTDOWN,)))
-        self.log.debug("number of tis tasks for %s: %s task(s)", self, len(tis))
-        for ti in tis:
-            ti.task = dag.get_task(ti.task_id)
+        info = self.task_instance_scheduling_decisions(session)
 
-        unfinished_tasks = [t for t in tis if t.state in State.unfinished]
-        finished_tasks = [t for t in tis if t.state in State.finished]
+        tis = info['tis']
+        schedulable_tis = info['schedulable_tis']
+        changed_tis = info['changed_tis']
+        finished_tasks = info['finished_tasks']
+        unfinished_tasks = info['unfinished_tasks']
+
         none_depends_on_past = all(not t.task.depends_on_past for t in unfinished_tasks)
         none_task_concurrency = all(t.task.task_concurrency is None for t in unfinished_tasks)
-        if unfinished_tasks:
-            scheduleable_tasks = [ut for ut in unfinished_tasks if ut.state in SCHEDULEABLE_STATES]
-            self.log.debug(
-                "number of scheduleable tasks for %s: %s task(s)",
-                self, len(scheduleable_tasks))
-            ready_tis, changed_tis = self._get_ready_tis(scheduleable_tasks, finished_tasks, session)
-            self.log.debug("ready tis length for %s: %s task(s)", self, len(ready_tis))
-            if none_depends_on_past and none_task_concurrency:
-                # small speed up
-                are_runnable_tasks = ready_tis or self._are_premature_tis(
-                    unfinished_tasks, finished_tasks, session) or changed_tis
+
+        if unfinished_tasks and none_depends_on_past and none_task_concurrency:
+            # small speed up
+            are_runnable_tasks = schedulable_tis or self._are_premature_tis(
+                unfinished_tasks, finished_tasks, session) or changed_tis
 
         duration = (timezone.utcnow() - start_dttm)
         Stats.timing("dagrun.dependency-check.{}".format(self.dag_id), duration)
@@ -466,7 +475,35 @@ class DagRun(Base, LoggingMixin):
 
         session.merge(self)
 
-        return ready_tis, callback
+        return schedulable_tis, callback
+
+    @provide_session
+    def task_instance_scheduling_decisions(self, session: Session = None) -> _TISchedulingDecision:
+
+        schedulable_tis: List[TI] = []
+        changed_tis = False
+
+        tis = list(self.get_task_instances(session=session, state=State.task_states + (State.SHUTDOWN,)))
+        self.log.debug("number of tis tasks for %s: %s task(s)", self, len(tis))
+        for ti in tis:
+            ti.task = self.get_dag().get_task(ti.task_id)
+
+        unfinished_tasks = [t for t in tis if t.state in State.unfinished()]
+        finished_tasks = [t for t in tis if t.state in State.finished() + [State.UPSTREAM_FAILED]]
+        if unfinished_tasks:
+            scheduleable_tasks = [ut for ut in unfinished_tasks if ut.state in SCHEDULEABLE_STATES]
+            self.log.debug(
+                "number of scheduleable tasks for %s: %s task(s)",
+                self, len(scheduleable_tasks))
+            schedulable_tis, changed_tis = self._get_ready_tis(scheduleable_tasks, finished_tasks, session)
+
+        return _TISchedulingDecision(
+            tis=tis,
+            schedulable_tis=schedulable_tis,
+            changed_tis=changed_tis,
+            unfinished_tasks=unfinished_tasks,
+            finished_tasks=finished_tasks,
+        )
 
     def _get_ready_tis(
         self,
@@ -638,3 +675,52 @@ class DagRun(Base, LoggingMixin):
             .all()
         )
         return dagruns
+
+    @provide_session
+    def schedule_tis(self, schedulable_tis: Iterable[TI], session: Session = None) -> int:
+        """
+        Set the given task instances in to the scheduled state.
+
+        Each element of ``schedulable_tis`` should have it's ``task`` attribute already set.
+
+        Any DummyOperator without callbacks is instead set straight to the success state.
+
+        All the TIs should belong to this DagRun, but this code is in the hot-path, this is not checked -- it
+        is the caller's responsiblity to call this function only with TIs from a single dag run.
+        """
+        # Get list of TIs that do not need to executed, these are
+        # tasks using DummyOperator and without on_execute_callback / on_success_callback
+        dummy_tis = {
+            ti for ti in schedulable_tis
+            if
+            (
+                ti.task.task_type == "DummyOperator"
+                and not ti.task.on_execute_callback
+                and not ti.task.on_success_callback
+            )
+        }
+
+        schedulable_ti_ids = [ti.task_id for ti in schedulable_tis if ti not in dummy_tis]
+        count = 0
+
+        if schedulable_ti_ids:
+            count += session.query(TI).filter(
+                TI.dag_id == self.dag_id,
+                TI.execution_date == self.execution_date,
+                TI.task_id.in_(schedulable_ti_ids)
+            ).update({TI.state: State.SCHEDULED}, synchronize_session=False)
+
+        # Tasks using DummyOperator should not be executed, mark them as success
+        if dummy_tis:
+            count += session.query(TI).filter(
+                TI.dag_id == self.dag_id,
+                TI.execution_date == self.execution_date,
+                TI.task_id.in_(ti.task_id for ti in dummy_tis)
+            ).update({
+                TI.state: State.SUCCESS,
+                TI.start_date: timezone.utcnow(),
+                TI.end_date: timezone.utcnow(),
+                TI.duration: 0
+            }, synchronize_session=False)
+
+        return count

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, NamedTuple, Optional, Tuple, Union
 
 from sqlalchemy import (
     Boolean, Column, DateTime, Index, Integer, PickleType, String, UniqueConstraint, and_, func, or_,
@@ -35,7 +35,6 @@ from airflow.settings import task_instance_mutation_hook
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
-from airflow.typing_compat import TypedDict
 from airflow.utils import callback_requests, timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
@@ -44,7 +43,7 @@ from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 
-class _TISchedulingDecision(TypedDict):
+class _TISchedulingDecision(NamedTuple):
     """
     Type of return for DagRun.task_instance_scheduling_decisions
 
@@ -54,8 +53,8 @@ class _TISchedulingDecision(TypedDict):
     tis: List[TI]
     schedulable_tis: List[TI]
     changed_tis: bool
-    unfinished_tis: List[TI]
-    finished_tis: List[TI]
+    unfinished_tasks: List[TI]
+    finished_tasks: List[TI]
 
 
 class DagRun(Base, LoggingMixin):
@@ -397,11 +396,11 @@ class DagRun(Base, LoggingMixin):
         dag = self.get_dag()
         info = self.task_instance_scheduling_decisions(session)
 
-        tis = info['tis']
-        schedulable_tis = info['schedulable_tis']
-        changed_tis = info['changed_tis']
-        finished_tasks = info['finished_tasks']
-        unfinished_tasks = info['unfinished_tasks']
+        tis = info.tis
+        schedulable_tis = info.schedulable_tis
+        changed_tis = info.changed_tis
+        finished_tasks = info.finished_tasks
+        unfinished_tasks = info.unfinished_tasks
 
         none_depends_on_past = all(not t.task.depends_on_past for t in unfinished_tasks)
         none_task_concurrency = all(t.task.task_concurrency is None for t in unfinished_tasks)

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -488,8 +488,8 @@ class DagRun(Base, LoggingMixin):
         for ti in tis:
             ti.task = self.get_dag().get_task(ti.task_id)
 
-        unfinished_tasks = [t for t in tis if t.state in State.unfinished()]
-        finished_tasks = [t for t in tis if t.state in State.finished() + [State.UPSTREAM_FAILED]]
+        unfinished_tasks = [t for t in tis if t.state in State.unfinished]
+        finished_tasks = [t for t in tis if t.state in State.finished | {State.UPSTREAM_FAILED}]
         if unfinished_tasks:
             scheduleable_tasks = [ut for ut in unfinished_tasks if ut.state in SCHEDULEABLE_STATES]
             self.log.debug(

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -489,7 +489,7 @@ class DagRun(Base, LoggingMixin):
             ti.task = self.get_dag().get_task(ti.task_id)
 
         unfinished_tasks = [t for t in tis if t.state in State.unfinished]
-        finished_tasks = [t for t in tis if t.state in State.finished | {State.UPSTREAM_FAILED}]
+        finished_tasks = [t for t in tis if t.state in State.finished]
         if unfinished_tasks:
             scheduleable_tasks = [ut for ut in unfinished_tasks if ut.state in SCHEDULEABLE_STATES]
             self.log.debug(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1174,7 +1174,7 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
                     ti for ti in siblings.task_ids if ti not in self.task.downstream_task_ids
                 }
                 schedulable_tis = [
-                    ti for ti in info['schedulable_tis'] if ti.task_id not in skippable_task_ids
+                    ti for ti in info.schedulable_tis if ti.task_id not in skippable_task_ids
                 ]
 
                 for schedulable_ti in schedulable_tis:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -34,6 +34,7 @@ import lazy_object_proxy
 import pendulum
 from jinja2 import TemplateAssertionError, UndefinedError
 from sqlalchemy import Column, Float, Index, Integer, PickleType, String, and_, func, or_
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import reconstructor, relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.elements import BooleanClauseList
@@ -61,7 +62,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
 from airflow.utils.operator_helpers import context_to_airflow_vars
 from airflow.utils.session import provide_session
-from airflow.utils.sqlalchemy import UtcDateTime
+from airflow.utils.sqlalchemy import UtcDateTime, with_row_locks
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 
@@ -1135,7 +1136,43 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         if not test_mode:
             session.add(Log(self.state, self))
             session.merge(self)
+
         session.commit()
+
+        if conf.getboolean('scheduler', 'schedule_after_task_execution', fallback=True):
+            from airflow.models.dagrun import DagRun  # Avoid circular import
+
+            try:
+                # Re-select the row with a lock
+                dag_run = with_row_locks(session.query(DagRun).filter_by(
+                    dag_id=self.dag_id,
+                    execution_date=self.execution_date,
+                )).one()
+
+                # Get a partial dag with just the specific tasks we want to
+                # examine. In order for dep checks to work correctly, we
+                # include ourself (so TriggerRuleDep can check the state of the
+                # task we just executed)
+                partial_dag = self.task.dag.partial_subset(
+                    self.task.downstream_task_ids.union({self.task_id}),
+                    include_upstream=False,
+                )
+                dag_run.dag = partial_dag
+                info = dag_run.task_instance_scheduling_decisions(session)
+                schedulable_tis = info['schedulable_tis']
+
+                for downstream_ti in schedulable_tis:
+                    if not hasattr(downstream_ti, "task"):
+                        downstream_ti.task = self.task.dag.get_task(downstream_ti.task_id)
+
+                num = dag_run.schedule_tis(schedulable_tis)
+                self.log.info("%d downstream tasks scheduled from follow-on schedule check", num)
+
+                session.commit()
+            except OperationalError:
+                # Any kind of DB error here is _non fatal_ as this block is just an optimisation.
+                self.log.info("DB error when checking downstream tasks ignored", exc_info=True)
+                session.rollback()
 
     def _prepare_and_execute_task_with_callbacks(
             self,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1433,7 +1433,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         only_failed = request.form.get('only_failed') == "true"
 
         dag = dag.sub_dag(
-            task_regex=r"^{0}$".format(task_id),
+            task_ids_or_regex=r"^{0}$".format(task_id),
             include_downstream=downstream,
             include_upstream=upstream)
 
@@ -1706,7 +1706,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         root = request.args.get('root')
         if root:
             dag = dag.sub_dag(
-                task_regex=root,
+                task_ids_or_regex=root,
                 include_downstream=False,
                 include_upstream=True)
 
@@ -1876,7 +1876,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         root = request.args.get('root')
         if root:
             dag = dag.sub_dag(
-                task_regex=root,
+                task_ids_or_regex=root,
                 include_upstream=True,
                 include_downstream=False)
 
@@ -1980,7 +1980,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         root = request.args.get('root')
         if root:
             dag = dag.sub_dag(
-                task_regex=root,
+                task_ids_or_regex=root,
                 include_upstream=True,
                 include_downstream=False)
 
@@ -2091,7 +2091,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         root = request.args.get('root')
         if root:
             dag = dag.sub_dag(
-                task_regex=root,
+                task_ids_or_regex=root,
                 include_upstream=True,
                 include_downstream=False)
 
@@ -2161,7 +2161,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         root = request.args.get('root')
         if root:
             dag = dag.sub_dag(
-                task_regex=root,
+                task_ids_or_regex=root,
                 include_upstream=True,
                 include_downstream=False)
 
@@ -2284,7 +2284,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         root = request.args.get('root')
         if root:
             dag = dag.sub_dag(
-                task_regex=root,
+                task_ids_or_regex=root,
                 include_upstream=True,
                 include_downstream=False)
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1056,7 +1056,7 @@ class TestBackfillJob(unittest.TestCase):
                                start_date=DEFAULT_DATE)
 
         executor = MockExecutor()
-        sub_dag = dag.sub_dag(task_regex="leave*",
+        sub_dag = dag.sub_dag(task_ids_or_regex="leave*",
                               include_downstream=False,
                               include_upstream=False)
         job = BackfillJob(dag=sub_dag,
@@ -1226,7 +1226,7 @@ class TestBackfillJob(unittest.TestCase):
         self.assertEqual(ti_downstream.state, State.SUCCESS)
 
         sdag = subdag.sub_dag(
-            task_regex='daily_job_subdag_task',
+            task_ids_or_regex='daily_job_subdag_task',
             include_downstream=True,
             include_upstream=False)
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -23,17 +23,19 @@ from unittest import mock
 from parameterized import parameterized
 
 from airflow import models, settings
+from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import DAG, DagBag, DagModel, TaskInstance as TI, clear_task_instances
 from airflow.models.dagrun import DagRun
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.python import ShortCircuitOperator
+from airflow.operators.python import PythonOperator, ShortCircuitOperator
 from airflow.utils import timezone
 from airflow.utils.callback_requests import DagCallbackRequest
 from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunType
 from tests.models import DEFAULT_DATE
-from tests.test_utils.db import clear_db_pools, clear_db_runs
+from tests.test_utils.config import conf_vars
+from tests.test_utils.db import clear_db_dags, clear_db_pools, clear_db_runs
 
 
 class TestDagRun(unittest.TestCase):
@@ -45,6 +47,7 @@ class TestDagRun(unittest.TestCase):
     def setUp(self):
         clear_db_runs()
         clear_db_pools()
+        clear_db_dags()
 
     def create_dag_run(self, dag,
                        state=State.RUNNING,
@@ -214,6 +217,110 @@ class TestDagRun(unittest.TestCase):
         ti_op4.set_state(state=State.SUCCESS, session=session)
         dr.update_state()
         self.assertEqual(State.SUCCESS, dr.state)
+
+    def validate_ti_states(self, dag_run, ti_state_mapping):
+        for task_id, expected_state in ti_state_mapping.items():
+            task_instance = dag_run.get_task_instance(task_id=task_id)
+            self.assertEqual(task_instance.state, expected_state)
+
+    @conf_vars({('scheduler', 'schedule_after_task_execution'): 'True'})
+    def test_dagrun_fast_follow(self):
+        session = settings.Session()
+
+        dag = DAG(
+            'test_dagrun_fast_follow',
+            start_date=DEFAULT_DATE
+        )
+
+        dag_model = DagModel(
+            dag_id=dag.dag_id,
+            next_dagrun=dag.start_date,
+            is_active=True,
+        )
+        session.add(dag_model)
+        session.flush()
+
+        python_callable = lambda: True
+        with dag:
+            task_a = PythonOperator(task_id='A', python_callable=python_callable)
+            task_b = PythonOperator(task_id='B', python_callable=python_callable)
+            task_c = PythonOperator(task_id='C', python_callable=python_callable)
+            task_a >> task_b
+            task_b >> task_c
+
+        scheduler = SchedulerJob()
+        scheduler.dagbag.bag_dag(dag, root_dag=dag)
+
+        dag_run = dag.create_dagrun(run_id='test_dagrun_fast_follow', state=State.RUNNING)
+
+        task_instance_a = dag_run.get_task_instance(task_id=task_a.task_id)
+        task_instance_a.task = dag.get_task(task_a.task_id)
+
+        task_instance_b = dag_run.get_task_instance(task_id=task_b.task_id)
+        task_instance_b.task = dag.get_task(task_b.task_id)
+
+        schedulable_tis, _ = dag_run.update_state()
+        self.assertEqual(len(schedulable_tis), 1)
+        self.assertEqual(schedulable_tis[0].task_id, task_a.task_id)
+        self.assertEqual(schedulable_tis[0].state, State.NONE)
+
+        dag_run.schedule_tis(schedulable_tis, session)
+        self.validate_ti_states(dag_run, {'A': State.SCHEDULED, 'B': State.NONE, 'C': State.NONE})
+
+        scheduler._critical_section_execute_task_instances(session=session)
+        self.validate_ti_states(dag_run, {'A': State.QUEUED, 'B': State.NONE, 'C': State.NONE})
+
+        task_instance_a.run()
+        self.validate_ti_states(dag_run, {'A': State.SUCCESS, 'B': State.SCHEDULED, 'C': State.NONE})
+
+        scheduler._critical_section_execute_task_instances(session=session)
+        task_instance_b.run()
+        self.validate_ti_states(dag_run, {'A': State.SUCCESS, 'B': State.SUCCESS, 'C': State.SCHEDULED})
+
+    @conf_vars({('scheduler', 'schedule_after_task_execution'): 'False'})
+    def test_dagrun_fast_follow_deactivated(self):
+        session = settings.Session()
+
+        dag = DAG(
+            'test_dagrun_fast_follow_deactivated',
+            start_date=DEFAULT_DATE
+        )
+
+        dag_model = DagModel(
+            dag_id=dag.dag_id,
+            next_dagrun=dag.start_date,
+            is_active=True,
+        )
+        session.add(dag_model)
+        session.flush()
+
+        python_callable = lambda: True
+        with dag:
+            task_a = PythonOperator(task_id='A', python_callable=python_callable)
+            task_b = PythonOperator(task_id='B', python_callable=python_callable)
+            task_a >> task_b
+
+        scheduler = SchedulerJob()
+        scheduler.dagbag.bag_dag(dag, root_dag=dag)
+
+        dag_run = dag.create_dagrun(run_id='test_dagrun_fast_follow_deactivated', state=State.RUNNING)
+
+        task_instance_a = dag_run.get_task_instance(task_id=task_a.task_id)
+        task_instance_a.task = dag.get_task(task_a.task_id)
+
+        schedulable_tis, _ = dag_run.update_state()
+        self.assertEqual(len(schedulable_tis), 1)
+        self.assertEqual(schedulable_tis[0].task_id, task_a.task_id)
+        self.assertEqual(schedulable_tis[0].state, State.NONE)
+
+        dag_run.schedule_tis(schedulable_tis, session)
+        self.validate_ti_states(dag_run, {'A': State.SCHEDULED, 'B': State.NONE})
+
+        scheduler._critical_section_execute_task_instances(session=session)
+        self.validate_ti_states(dag_run, {'A': State.QUEUED, 'B': State.NONE})
+
+        task_instance_a.run()
+        self.validate_ti_states(dag_run, {'A': State.SUCCESS, 'B': State.NONE})
 
     def test_dagrun_deadlock(self):
         session = settings.Session()

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -33,7 +33,7 @@ from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunType
 from tests.models import DEFAULT_DATE
-from tests.test_utils.db import clear_db_dags, clear_db_pools, clear_db_runs
+from tests.test_utils.db import clear_db_pools, clear_db_runs
 
 
 class TestDagRun(unittest.TestCase):
@@ -45,7 +45,6 @@ class TestDagRun(unittest.TestCase):
     def setUp(self):
         clear_db_runs()
         clear_db_pools()
-        clear_db_dags()
 
     def create_dag_run(self, dag,
                        state=State.RUNNING,

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1894,8 +1894,8 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
 
     @parameterized.expand([
         # Expected queries, mark_success
-        (12, False),
-        (7, True),
+        (10, False),
+        (5, True),
     ])
     def test_execute_queries_count(self, expected_query_count, mark_success):
         with create_session() as session:
@@ -1930,7 +1930,7 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
                 session=session,
             )
 
-        with assert_queries_count(12):
+        with assert_queries_count(10):
             ti._run_raw_task()
 
     def test_operator_field_with_serialization(self):

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1798,8 +1798,8 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
 
     @parameterized.expand([
         # Expected queries, mark_success
-        (10, False),
-        (5, True),
+        (12, False),
+        (7, True),
     ])
     def test_execute_queries_count(self, expected_query_count, mark_success):
         with create_session() as session:
@@ -1834,7 +1834,7 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
                 session=session,
             )
 
-        with assert_queries_count(10):
+        with assert_queries_count(12):
             ti._run_raw_task()
 
     def test_operator_field_with_serialization(self):

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -512,7 +512,7 @@ def clear_tasks(dag_bag, dag, task, start_date=DEFAULT_DATE, end_date=DEFAULT_DA
     """
     Clear the task and its downstream tasks recursively for the dag in the given dagbag.
     """
-    subdag = dag.sub_dag(task_regex="^{}$".format(task.task_id), include_downstream=True)
+    subdag = dag.sub_dag(task_ids_or_regex="^{}$".format(task.task_id), include_downstream=True)
     subdag.clear(start_date=start_date, end_date=end_date, dag_bag=dag_bag)
 
 

--- a/tests/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/tests/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -18,13 +18,14 @@
 
 import pendulum
 
-from airflow.models import DAG, TaskInstance
+from airflow.models import DAG, DagRun, TaskInstance
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkippedDep
 from airflow.utils.session import create_session
 from airflow.utils.state import State
+from airflow.utils.types import DagRunType
 
 
 def test_no_parent():
@@ -73,10 +74,10 @@ def test_parent_follow_branch():
     dag = DAG(
         "test_parent_follow_branch_dag", schedule_interval=None, start_date=start_date
     )
+    dag.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING, execution_date=start_date)
     op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op2", dag=dag)
     op2 = DummyOperator(task_id="op2", dag=dag)
     op1 >> op2
-
     TaskInstance(op1, start_date).run()
     ti2 = TaskInstance(op2, start_date)
 
@@ -91,21 +92,24 @@ def test_parent_skip_branch():
     """
     A simple DAG with a BranchPythonOperator that does not follow op2. NotPreviouslySkippedDep is not met.
     """
-    start_date = pendulum.datetime(2020, 1, 1)
-    dag = DAG(
-        "test_parent_skip_branch_dag", schedule_interval=None, start_date=start_date
-    )
-    op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op3", dag=dag)
-    op2 = DummyOperator(task_id="op2", dag=dag)
-    op3 = DummyOperator(task_id="op3", dag=dag)
-    op1 >> [op2, op3]
-
-    TaskInstance(op1, start_date).run()
-    ti2 = TaskInstance(op2, start_date)
-
     with create_session() as session:
+        session.query(DagRun).delete()
+        session.query(TaskInstance).delete()
+        start_date = pendulum.datetime(2020, 1, 1)
+        dag = DAG(
+            "test_parent_skip_branch_dag", schedule_interval=None, start_date=start_date
+        )
+        dag.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING, execution_date=start_date)
+        op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op3", dag=dag)
+        op2 = DummyOperator(task_id="op2", dag=dag)
+        op3 = DummyOperator(task_id="op3", dag=dag)
+        op1 >> [op2, op3]
+        TaskInstance(op1, start_date).run()
+        ti2 = TaskInstance(op2, start_date)
         dep = NotPreviouslySkippedDep()
+
         assert len(list(dep.get_dep_statuses(ti2, session, DepContext()))) == 1
+        session.commit()
         assert not dep.is_met(ti2, session)
         assert ti2.state == State.SKIPPED
 

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -30,6 +30,7 @@ from airflow.utils.log.logging_mixin import set_context
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
+from airflow.utils.types import DagRunType
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 TASK_LOGGER = 'airflow.task'
@@ -66,6 +67,7 @@ class TestFileTaskLogHandler(unittest.TestCase):
         def task_callable(ti, **kwargs):
             ti.log.info("test")
         dag = DAG('dag_for_testing_file_task_handler', start_date=DEFAULT_DATE)
+        dag.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING, execution_date=DEFAULT_DATE)
         task = PythonOperator(
             task_id='task_for_testing_file_log_handler',
             dag=dag,

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -365,7 +365,7 @@ def test_sub_dag_task_group():
         group234 >> group6
         group234 >> task7
 
-    subdag = dag.sub_dag(task_regex="task5", include_upstream=True, include_downstream=False)
+    subdag = dag.sub_dag(task_ids_or_regex="task5", include_upstream=True, include_downstream=False)
 
     assert extract_node_id(task_group_to_dict(subdag.task_group)) == {
         'id': None,


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/11498

In order to further reduce intra-dag task scheduling lag we add an
optimization: when a task has just finished executing (success or
failure) we can look at the downstream tasks of just that task, and then
make scheduling decisions for those tasks there -- we've already got the
dag loaded, and we know they are likely actionable as we just finished.

We should set tasks to scheduled if we can (but no further, i.e. not to
queued, as the scheduler has to make that decision with info about the
Pool usage etc.).

Co-authored-by: Ash Berlin-Taylor <ash_github@firemirror.com>

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
