### PR TITLE
Correctly redirect to DAG pages after login

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -116,7 +116,8 @@ def has_dag_access(**dag_kwargs) -> Callable[[T], T]:
                 if self.appbuilder.sm.can_read_dag(dag_id):
                     return f(self, *args, **kwargs)
             flash("Access is Denied", "danger")
-            return redirect(url_for(self.appbuilder.sm.auth_view.__class__.__name__ + ".login"))
+            return redirect(url_for(self.appbuilder.sm.auth_view.__class__.__name__ + ".login",
+                                    next=request.url))
 
         return cast(T, wrapper)
 

--- a/tests/www/test_decorators.py
+++ b/tests/www/test_decorators.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import Mock
+
+from flask_appbuilder import BaseView
+
+from airflow.www import app
+from airflow.www.decorators import has_dag_access
+
+
+class TestDecorators():
+
+    def test_has_dag_access_redirection(self):
+        class DummyView(BaseView):
+
+            def __init__(self, appbuilder):
+                BaseView.__init__(self)
+                self.appbuilder = appbuilder
+
+            @has_dag_access(can_dag_edit=True)
+            def dummy_function(self):
+                pass
+
+        testing_app = app.create_app(testing=True)
+        appbuilder = Mock()
+        appbuilder.sm.can_edit_dag.return_value = False
+        appbuilder.sm.auth_view.__class__.__name__ = 'AuthDBView'
+        view = DummyView(appbuilder)
+
+        with testing_app.test_request_context('/landingpage'):
+            response = view.dummy_function()
+            assert response.headers['Location'] == '/login/?next=http%3A%2F%2Flocalhost%2Flandingpage'


### PR DESCRIPTION
Unauthenticated access with RBAC to URL has_dag_access results lose redirection. Fixes #11591

When unauthenticated user visit an airflow page, it will be redirected to login page.
Normally after user enter credentials and logged in, they will be redirected to the original airflow page they wanted to visit.
However for pages marked having "has_dag_access" this redirection is not storing the original page url, this PR adds url as  "next" parameter to the /login page so that after user login, it'll go to the original page it intended.

This change make it consistent with the "has_access" decorator from flask_appbuilder: 
https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/security/decorators.py#L120


