### PR TITLE
Fix tcp keepalive parameters parsing

### DIFF
--- a/airflow/kubernetes/kube_client.py
+++ b/airflow/kubernetes/kube_client.py
@@ -78,9 +78,9 @@ def _enable_tcp_keepalive() -> None:
 
     from urllib3.connection import HTTPConnection, HTTPSConnection
 
-    tcp_keep_idle = conf.get('kubernetes', 'tcp_keep_idle', fallback=120)
-    tcp_keep_intvl = conf.get('kubernetes', 'tcp_keep_intvl', fallback=30)
-    tcp_keep_cnt = conf.get('kubernetes', 'tcp_keep_cnt', fallback=6)
+    tcp_keep_idle = conf.getint('kubernetes', 'tcp_keep_idle', fallback=120)
+    tcp_keep_intvl = conf.getint('kubernetes', 'tcp_keep_intvl', fallback=30)
+    tcp_keep_cnt = conf.getint('kubernetes', 'tcp_keep_cnt', fallback=6)
 
     socket_options = [
         (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),

--- a/tests/kubernetes/test_client.py
+++ b/tests/kubernetes/test_client.py
@@ -15,11 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import socket
 import unittest
 
 import mock
+from urllib3.connection import HTTPConnection, HTTPSConnection
 
-from airflow.kubernetes.kube_client import RefreshConfiguration, get_kube_client
+from airflow.kubernetes.kube_client import RefreshConfiguration, _enable_tcp_keepalive, get_kube_client
 
 
 class TestClient(unittest.TestCase):
@@ -34,3 +36,18 @@ class TestClient(unittest.TestCase):
     def test_load_file_config(self, _, _2):
         client = get_kube_client(in_cluster=False)
         assert isinstance(client.api_client.configuration, RefreshConfiguration)
+
+    def test_enable_tcp_keepalive(self):
+        socket_options = [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 120),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 6),
+        ]
+        expected_http_connection_options = HTTPConnection.default_socket_options + socket_options
+        expected_https_connection_options = HTTPSConnection.default_socket_options + socket_options
+
+        _enable_tcp_keepalive()
+
+        self.assertEqual(HTTPConnection.default_socket_options, expected_http_connection_options)
+        self.assertEqual(HTTPSConnection.default_socket_options, expected_https_connection_options)


### PR DESCRIPTION
In #11406 I’ve introduced a params parsing bug when moving code from an internal repo. I’ve added a test as a remedy 😉 