### PR TITLE
Allow loading plugins on Airflow start-up

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -57,6 +57,11 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
+if not settings.LAZY_LOAD_PLUGINS:
+    from airflow import plugins_manager
+    plugins_manager.ensure_plugins_loaded()
+
+
 # This is never executed, but tricks static analyzers (PyDev, PyCharm,
 # pylint, etc.) into knowing the types of these symbols, and what
 # they contain.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -400,6 +400,14 @@
       type: string
       example: "path.to.CustomXCom"
       default: "airflow.models.xcom.BaseXCom"
+    - name: lazy_load_plugins
+      description: |
+        By default Airflow plugins are lazily-loaded (only loaded when required). Set it to ``False``,
+        if you want to load plugins whenever 'airflow' is invoked via cli or loaded from module.
+      version_added: 2.0.0
+      type: boolean
+      example: ~
+      default: "True"
 
 - name: logging
   description: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -230,6 +230,10 @@ check_slas = True
 # Example: xcom_backend = path.to.CustomXCom
 xcom_backend = airflow.models.xcom.BaseXCom
 
+# By default Airflow plugins are lazily-loaded (only loaded when required). Set it to ``False``,
+# if you want to load plugins whenever 'airflow' is invoked via cli or loaded from module.
+lazy_load_plugins = True
+
 [logging]
 # The folder where airflow should store its log files
 # This path must be absolute

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -393,3 +393,7 @@ CHECK_SLAS = conf.getboolean('core', 'check_slas', fallback=True)
 MAX_DB_RETRIES = conf.getint('core', 'max_db_retries', fallback=3)
 
 USE_JOB_SCHEDULE = conf.getboolean('scheduler', 'use_job_schedule', fallback=True)
+
+# By default Airflow plugins are lazily-loaded (only loaded when required). Set it to False,
+# if you want to load plugins whenever 'airflow' is invoked via cli or loaded from module.
+LAZY_LOAD_PLUGINS = conf.getboolean('core', 'lazy_load_plugins', fallback=True)

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -71,7 +71,8 @@ Airflow has many components that can be reused when building an application:
 When are plugins (re)loaded?
 ----------------------------
 
-Plugins are loaded once at the start of every Airflow process, and never reloaded.
+Plugins are by default lazily loaded and once loaded, there are never reloaded. To load them at the
+start of each Airflow process, set ``[core] lazy_load_plugins = False`` in ``airflow.cfg``.
 
 This means that if you make any changes to plugins and you want the webserver or scheduler to use that new
 code you will need to restart those processes.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -71,7 +71,8 @@ Airflow has many components that can be reused when building an application:
 When are plugins (re)loaded?
 ----------------------------
 
-Plugins are by default lazily loaded and once loaded, there are never reloaded. To load them at the
+Plugins are by default lazily loaded and once loaded, they are never reloaded (except the UI plugins are
+automatically loaded in Webserver). To load them at the
 start of each Airflow process, set ``[core] lazy_load_plugins = False`` in ``airflow.cfg``.
 
 This means that if you make any changes to plugins and you want the webserver or scheduler to use that new


### PR DESCRIPTION
https://github.com/apache/airflow/commit/0be7654fd2ab047c610f44d3c11467f67212a744 commit made an optimization where the plugin are lazy-loaded. However, there are use-cases where you would still want the plugins to be loaded on Airflow start-up.

This PR does not change the current behavior but just provides a way to disable lazy-loading

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
