### PR TITLE
Remove unnecessary use of comprehension in setup_provider_packages.py

### DIFF
--- a/provider_packages/setup_provider_packages.py
+++ b/provider_packages/setup_provider_packages.py
@@ -1257,7 +1257,7 @@ def get_all_providers() -> List[str]:
     Returns all providers for regular packages.
     :return: list of providers that are considered for provider packages
     """
-    return [prov for prov in PROVIDERS_REQUIREMENTS.keys()]
+    return list(PROVIDERS_REQUIREMENTS.keys())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since we are just iterating without modification, it is simpler to just use `list(PROVIDERS_REQUIREMENTS.keys())`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
