### PR TITLE
Fix rendering of code-block in operator/kubernetes.rst

### DIFF
--- a/docs/howto/operator/kubernetes.rst
+++ b/docs/howto/operator/kubernetes.rst
@@ -56,6 +56,7 @@ How to use cluster ConfigMaps, Secrets, and Volumes with Pod?
 
 To add ConfigMaps, Volumes, and other Kubernetes native objects, we recommend that you import the Kubernetes model API
 like this:
+
 .. code-block:: python
 
   from kubernetes.client import models as k8s


### PR DESCRIPTION
Docs were rendered incorrectly because of a missing blank line
![image](https://user-images.githubusercontent.com/8811558/96323468-25d4e900-1015-11eb-9e79-1a277672569d.png)

https://airflow.readthedocs.io/en/latest/howto/operator/kubernetes.html#difference-between-kubernetespodoperator-and-kubernetes-object-spec

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
