### PR TITLE
Fix typo in 'Installing with Breeze' doc

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -1173,7 +1173,7 @@ First copy all the provider packages .whl files to the `dist` folder.
 
 ```shell script
 ./breeze start-airflow --install-airflow-version <VERSION>rc<X> \
-    --python 3.7 --backend postgres --instal-wheels
+    --python 3.7 --backend postgres --install-wheels
 ```
 
 For 1.10 releases you can also use `--no-rbac-ui` flag disable RBAC UI of Airflow:


### PR DESCRIPTION
It's not a Hacktoberfest heist. 
Typos are the worst developer enemies. Especially if they are in very important commands, like that one. 
Let's crush them with our PRs.