### PR TITLE
Dumps more logs in case of CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,10 +469,16 @@ jobs:
         run: ./scripts/ci/testing/ci_run_airflow_testing.sh
       - name: "Upload airflow logs"
         uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
           name: airflow-logs-${{matrix.python-version}}-${{matrix.postgres-version}}
           path: "./files/airflow_logs*"
+      - name: "Upload container logs"
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: container-logs-postgres-${{matrix.python-version}}-${{matrix.postgres-version}}
+          path: "./files/container_logs*"
       - name: "Upload artifact for coverage"
         uses: actions/upload-artifact@v2
         with:
@@ -515,10 +521,16 @@ jobs:
         run: ./scripts/ci/testing/ci_run_airflow_testing.sh
       - name: "Upload airflow logs"
         uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
           name: airflow-logs-${{matrix.python-version}}-${{matrix.mysql-version}}
           path: "./files/airflow_logs*"
+      - name: "Upload container logs"
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: container-logs-mysql-${{matrix.python-version}}-${{matrix.mysql-version}}
+          path: "./files/container_logs*"
       - name: "Upload artifact for coverage"
         uses: actions/upload-artifact@v2
         with:
@@ -558,10 +570,16 @@ jobs:
         run: ./scripts/ci/testing/ci_run_airflow_testing.sh
       - name: "Upload airflow logs"
         uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
           name: airflow-logs-${{matrix.python-version}}
           path: './files/airflow_logs*'
+      - name: "Upload container logs"
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: container-logs-sqlite-${{matrix.python-version}}
+          path: "./files/container_logs*"
       - name: "Upload artifact for coverage"
         uses: actions/upload-artifact@v2
         with:
@@ -625,14 +643,20 @@ jobs:
           path: "files/test_result.xml"
       - name: "Upload airflow logs"
         uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: airflow-logs-quarantined-${{matrix.python-version}}-${{ matrix.postgres-version }}
+          name: airflow-logs-quarantined-${{ matrix.backend }}
           path: "./files/airflow_logs*"
+      - name: "Upload container logs"
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: container-logs-quarantined-${{ matrix.backend }}
+          path: "./files/container_logs*"
       - name: "Upload artifact for coverage"
         uses: actions/upload-artifact@v2
         with:
-          name: coverage-quarantined-${{matrix.python-version}}
+          name: coverage-quarantined-${{ matrix.backend }}
           path: "./files/coverage.xml"
 
   upload-coverage:

--- a/scripts/ci/libraries/_verbosity.sh
+++ b/scripts/ci/libraries/_verbosity.sh
@@ -117,6 +117,7 @@ function kind {
     ${KIND_BINARY_PATH} "${@}"
 }
 
+
 # Prints verbose information in case VERBOSE variable is set
 function verbosity::print_info() {
     if [[ ${VERBOSE:="false"} == "true" && ${PRINT_INFO_FROM_SCRIPTS} == "true" ]]; then

--- a/scripts/ci/mysql/conf.d/airflow.cnf
+++ b/scripts/ci/mysql/conf.d/airflow.cnf
@@ -21,3 +21,4 @@
 explicit_defaults_for_timestamp = 1
 secure_file_priv = "/var/lib/mysql"
 local_infile = 1
+innodb_print_all_deadlocks = 1

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -274,17 +274,17 @@ function setup_kerberos() {
 }
 
 function dump_airflow_logs() {
-    DUMP_FILE=/files/airflow_logs_$(date "+%Y-%m-%d")_${CI_BUILD_ID}_${CI_JOB_ID}.log.tar.gz
+    local dump_file
+    dump_file=/files/airflow_logs_$(date "+%Y-%m-%d")_${CI_BUILD_ID}_${CI_JOB_ID}.log.tar.gz
     echo "###########################################################################################"
     echo "                   Dumping logs from all the airflow tasks"
     echo "###########################################################################################"
     pushd "${AIRFLOW_HOME}" || exit 1
-    tar -czf "${DUMP_FILE}" logs
-    echo "                   Logs dumped to ${DUMP_FILE}"
+    tar -czf "${dump_file}" logs
+    echo "                   Logs dumped to ${dump_file}"
     popd || exit 1
     echo "###########################################################################################"
 }
-
 
 function install_released_airflow_version() {
     pip uninstall -y apache-airflow || true

--- a/scripts/in_container/run_ci_tests.sh
+++ b/scripts/in_container/run_ci_tests.sh
@@ -98,7 +98,12 @@ if [[ ${TEST_TYPE:=} == "Quarantined" ]]; then
 fi
 
 if [[ ${CI:=} == "true" ]]; then
-    dump_airflow_logs
+    if [[ ${RES} != "0" ]]; then
+        echo
+        echo "Dumping logs on error"
+        echo
+        dump_airflow_logs
+    fi
 fi
 
 exit "${RES}"


### PR DESCRIPTION
We do not dump airflow logs on success any more, but we dump them
and all the container logs in case of failure, so that we can
better investigate cases like #11543 - that includes enabling
full deadlock information dumping in our mysql database.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
