### PR TITLE
Teardown of webserver tests is not picky about processes.

### DIFF
--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -227,7 +227,7 @@ class TestCliWebServer(unittest.TestCase):
         self._check_processes()
         self._clean_pidfiles()
 
-    def _check_processes(self):
+    def _check_processes(self, ignore_running=False):
         # Confirm that webserver hasn't been launched.
         # pgrep returns exit status 1 if no process matched.
         exit_code_pgrep_webserver = subprocess.Popen(["pgrep", "-c", "-f", "airflow webserver"]).wait()
@@ -238,13 +238,13 @@ class TestCliWebServer(unittest.TestCase):
                 subprocess.Popen(["pkill", "-9", "-f", "airflow webserver"]).wait()
             if exit_code_pgrep_gunicorn != 1:
                 subprocess.Popen(["pkill", "-9", "-f", "gunicorn"]).wait()
-
-            raise AssertionError(
-                "Background processes are running that prevent the test from passing successfully."
-            )
+            if not ignore_running:
+                raise AssertionError(
+                    "Background processes are running that prevent the test from passing successfully."
+                )
 
     def tearDown(self) -> None:
-        self._check_processes()
+        self._check_processes(ignore_running=True)
         self._clean_pidfiles()
 
     def _clean_pidfiles(self):


### PR DESCRIPTION
Fixes random failure when processes are still running
on teardown of some webserver tests. We simply ignor that
after we send sigkill to those processes.

Fixes #11615

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
