### PR TITLE
Check response status in Slack webhook hook

### DIFF
--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -151,5 +151,5 @@ class SlackWebhookHook(HttpHook):
             endpoint=self.webhook_token,
             data=slack_message,
             headers={'Content-type': 'application/json'},
-            extra_options={'proxies': proxies},
+            extra_options={'proxies': proxies, 'check_response': True},
         )


### PR DESCRIPTION
The slack webhook hook doesn't check the status code of the http response. I think this isn't the right behavior. For example, if the user enters the wrong webhook token, they'll get a 403, but the hook won't crash. This patch passes `check_response` to the superclass `run` method so that the hook fails on errors.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
