### PR TITLE
Add missing states in TaskGroup state

### DIFF
--- a/airflow/www/static/css/graph.css
+++ b/airflow/www/static/css/graph.css
@@ -105,6 +105,10 @@ g.node.skipped rect {
   stroke: pink;
 }
 
+g.node.removed rect {
+  stroke: black;
+}
+
 .svg-wrapper {
   border-radius: 4px;
   background-color: #f0f0f0;

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -620,7 +620,9 @@
         // In this order, if any of these states appeared in children_states, return it as
         // the group state.
         var priority = ["failed", "upstream_failed", "up_for_retry","up_for_reschedule",
-                        "queued", "no_status", "success", "skipped"]
+                        "queued", "scheduled", "sensing", "running", "shutdown", "removed",
+                        "no_status", "success", "skipped"]
+
         for(const state of priority) {
           if (children_states.has(state))
             return state


### PR DESCRIPTION
These states were not applied to `TaskGroup` in Graph View. This PR adds them: removed, scheduled, running, shutdown and sensing

E.g if some tasks in a `TaskGroup` are running, (others are success or skipped), the `TaskGroup` should be shown as `running` when it's collapsed.
