### PR TITLE
Show Celery stats in webui

### DIFF
--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -140,6 +140,7 @@ def worker(args):
         'hostname': args.celery_hostname,
         'loglevel': conf.get('logging', 'LOGGING_LEVEL'),
         'pidfile': pid_file_path,
+        'task_events': True,
     }
 
     if conf.has_option("celery", "pool"):

--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -19,6 +19,7 @@ import logging
 from contextlib import suppress
 from typing import Optional
 
+from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
 from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.executor_constants import (
@@ -124,3 +125,6 @@ UNPICKLEABLE_EXECUTORS = (
     SEQUENTIAL_EXECUTOR,
     DASK_EXECUTOR,
 )
+
+CELERY_EXECUTORS = (ExecutorLoader.CELERY_EXECUTOR, ExecutorLoader.CELERY_KUBERNETES_EXECUTOR)
+USING_CELERY_EXECUTOR = conf.get("core", "executor") in CELERY_EXECUTORS

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -94,6 +94,7 @@ def init_appbuilder_views(app):
     appbuilder.add_view(
         views.XComModelView, permissions.RESOURCE_XCOM, category=permissions.RESOURCE_ADMIN_MENU
     )
+    appbuilder.add_view(views.StatsView, "Executor Stats", category="Admin")
     # add_view_no_menu to change item position.
     # I added link in extensions.init_appbuilder_links.init_appbuilder_links
     appbuilder.add_view_no_menu(views.RedocView)

--- a/airflow/www/templates/airflow/stats.html
+++ b/airflow/www/templates/airflow/stats.html
@@ -1,0 +1,96 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+{% extends base_template %}
+{% block page_title %}Airflow Executor Stats{% endblock %}
+
+{% block content %}
+<h2>Airflow Summary</h2>
+<p>If you are interested in more detailed statistics please consider using
+  <a href="https://airflow.apache.org/docs/stable/metrics.html" target="_blank">statsd integration</a>.
+</p>
+<h3>Task instances</h3>
+ <table class="table table-bordered table-striped" style="width: auto; min-width: 50%";>
+  <thead>
+    <tr>
+        <th>{{ State.RUNNING | upper }}</th>
+        <th>{{ State.QUEUED | upper }}</th>
+        <th>{{ State.SCHEDULED | upper }}</th>
+        <th>{{ State.UP_FOR_RESCHEDULE | upper }}</th>
+    </tr>
+  </thead>
+  <tbody>
+      <tr>
+        <td>{{ ti_info.get(State.RUNNING, 0) }}</td>
+        <td>{{ ti_info.get(State.QUEUED, 0) }}</td>
+        <td>{{ ti_info.get(State.SCHEDULED, 0) }}</td>
+        <td>{{ ti_info.get(State.UP_FOR_RESCHEDULE, 0) }}</td>
+      </tr>
+  </tbody>
+</table>
+
+<h3>Dag runs</h3>
+ <table class="table table-bordered table-striped" style="width: 50%">
+  <thead>
+    <tr>
+        <th>{{ State.RUNNING | upper }}</th>
+        <th>{{ State.SUCCESS | upper }}</th>
+        <th>{{ State.FAILED | upper }}</th>
+    </tr>
+  </thead>
+  <tbody>
+      <tr>
+        <td>{{ dr_info.get(State.RUNNING, 0) }}</td>
+        <td>{{ dr_info.get(State.QUEUED, 0) }}</td>
+        <td>{{ dr_info.get(State.SCHEDULED, 0) }}</td>
+      </tr>
+  </tbody>
+</table>
+
+{% if celery %}
+<h2>Celery workers</h2>
+<p>This information is limited. For more insight use
+  <a href="https://airflow.apache.org/docs/stable/cli-ref.html#flower" target="_blank">Flower</a>.
+</p>
+<table class="table table-bordered table-striped">
+  <thead>
+    <tr>
+        <th>Worker Name</th>
+        <th>Active</th>
+        <th>Processed</th>
+        <th>Max concurrency</th>
+        <th>Active queues</th>
+        <th>Uptime</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for worker in workers %}
+      <tr>
+        <td>{{ worker.id }}</td>
+        <td>{{ worker.active_task }}</td>
+        <td>{{ worker.total_task }}</td>
+        <td>{{ worker.max_concurrency }}</td>
+        <td>{{ worker.active_queues }}</td>
+        <td>{{ worker.uptime }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Add simple view showing information about Celery workers.
Closes: #11623

<img width="2560" alt="Screenshot 2020-10-18 at 18 48 17" src="https://user-images.githubusercontent.com/9528307/96374362-98a7a680-1172-11eb-9852-ff1559964365.png">


~~I'm still facing some issue with the stability of getting stats (some missing keys and redis errors like here https://github.com/celery/kombu/issues/1063)~~

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
