### PR TITLE
Improves stability of K8S tests by caching binaries and repeats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,6 +654,16 @@ jobs:
         with:
           path: .build/.kubernetes_venv
           key: "${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('setup.py') }}"
+      - name: "Cache bin folder with tools for kubernetes testing"
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-kubernetes-tests-bin-v6
+        with:
+          path: .build/bin
+          key: "${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('setup.py') }}\
+-${{ needs.build-info.outputs.defaultKindVersion }}\
+-${{ needs.build-info.outputs.defaultHelmVersion }}\
+-$${{ matrix.kubernetes-version }}"
       - name: "Kubernetes Tests"
         run: ./scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
       - name: "Upload KinD logs"

--- a/scripts/ci/libraries/_all_libs.sh
+++ b/scripts/ci/libraries/_all_libs.sh
@@ -28,6 +28,8 @@ readonly SCRIPTS_CI_DIR
 . "${LIBRARIES_DIR}"/_traps.sh
 # shellcheck source=scripts/ci/libraries/_initialization.sh
 . "${LIBRARIES_DIR}"/_initialization.sh
+# shellcheck source=scripts/ci/libraries/_repeats.sh
+. "${LIBRARIES_DIR}"/_repeats.sh
 # shellcheck source=scripts/ci/libraries/_sanity_checks.sh
 . "${LIBRARIES_DIR}"/_sanity_checks.sh
 # shellcheck source=scripts/ci/libraries/_build_images.sh

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -51,7 +51,8 @@ function kind::make_sure_kubernetes_tools_are_installed() {
     if [[ ! -f "${KIND_BINARY_PATH}"  || ${DOWNLOADED_KIND_VERSION} != "${KIND_VERSION}" ]]; then
         echo
         echo "Downloading Kind version ${KIND_VERSION}"
-        curl --fail --location "${KIND_URL}" --output "${KIND_BINARY_PATH}"
+        repeats::repeat_up_to_n_times 4 \
+            "curl --fail --location '${KIND_URL}' --output '${KIND_BINARY_PATH}'"
         chmod a+x "${KIND_BINARY_PATH}"
     else
         echo "Kind version ok"
@@ -66,7 +67,8 @@ function kind::make_sure_kubernetes_tools_are_installed() {
     if [[ ! -f "${KUBECTL_BINARY_PATH}" || ${DOWNLOADED_KUBECTL_VERSION} != "${KUBECTL_VERSION}" ]]; then
         echo
         echo "Downloading Kubectl version ${KUBECTL_VERSION}"
-        curl --fail --location "${KUBECTL_URL}" --output "${KUBECTL_BINARY_PATH}"
+        repeats::repeat_up_to_n_times 4 \
+            "curl --fail --location '${KUBECTL_URL}' --output '${KUBECTL_BINARY_PATH}'"
         chmod a+x "${KUBECTL_BINARY_PATH}"
     else
         echo "Kubectl version ok"
@@ -81,8 +83,8 @@ function kind::make_sure_kubernetes_tools_are_installed() {
     if [[ ! -f "${HELM_BINARY_PATH}" || ${DOWNLOADED_HELM_VERSION} != "${HELM_VERSION}" ]]; then
         echo
         echo "Downloading Helm version ${HELM_VERSION}"
-        curl     --location "${HELM_URL}" |
-            tar -xvz -O "${SYSTEM}-amd64/helm" >"${HELM_BINARY_PATH}"
+        repeats::repeat_up_to_n_times 4 \
+            "curl --location '${HELM_URL}' | tar -xvz -O '${SYSTEM}-amd64/helm' >'${HELM_BINARY_PATH}'"
         chmod a+x "${HELM_BINARY_PATH}"
     else
         echo "Helm version ok"

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -67,7 +67,7 @@ function kind::make_sure_kubernetes_tools_are_installed() {
     if [[ ! -f "${KUBECTL_BINARY_PATH}" || ${DOWNLOADED_KUBECTL_VERSION} != "${KUBECTL_VERSION}" ]]; then
         echo
         echo "Downloading Kubectl version ${KUBECTL_VERSION}"
-        repeats::repeat_up_to_n_times 4 \
+        repeats::run_with_retry 4 \
             "curl --fail --location '${KUBECTL_URL}' --output '${KUBECTL_BINARY_PATH}'"
         chmod a+x "${KUBECTL_BINARY_PATH}"
     else

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -51,7 +51,7 @@ function kind::make_sure_kubernetes_tools_are_installed() {
     if [[ ! -f "${KIND_BINARY_PATH}"  || ${DOWNLOADED_KIND_VERSION} != "${KIND_VERSION}" ]]; then
         echo
         echo "Downloading Kind version ${KIND_VERSION}"
-        repeats::repeat_up_to_n_times 4 \
+        repeats::run_with_retry 4 \
             "curl --fail --location '${KIND_URL}' --output '${KIND_BINARY_PATH}'"
         chmod a+x "${KIND_BINARY_PATH}"
     else

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -83,7 +83,7 @@ function kind::make_sure_kubernetes_tools_are_installed() {
     if [[ ! -f "${HELM_BINARY_PATH}" || ${DOWNLOADED_HELM_VERSION} != "${HELM_VERSION}" ]]; then
         echo
         echo "Downloading Helm version ${HELM_VERSION}"
-        repeats::repeat_up_to_n_times 4 \
+        repeats::run_with_retry 4 \
             "curl --location '${HELM_URL}' | tar -xvz -O '${SYSTEM}-amd64/helm' >'${HELM_BINARY_PATH}'"
         chmod a+x "${HELM_BINARY_PATH}"
     else

--- a/scripts/ci/libraries/_repeats.sh
+++ b/scripts/ci/libraries/_repeats.sh
@@ -20,7 +20,7 @@
 # Parameters:
 #   $1 - how many times to repeat
 #   $2 - command to repeat (run through bash -c)
-function repeats::repeat_up_to_n_times() {
+function repeats::run_with_retry() {
     local num_repeats="${1}"
     local command="${2}"
     for ((n=0;n<num_repeats;n++));

--- a/scripts/ci/libraries/_repeats.sh
+++ b/scripts/ci/libraries/_repeats.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Repeat the command up to n times in case of failure
+# Parameters:
+#   $1 - how many times to repeat
+#   $2 - command to repeat (run through bash -c)
+function repeats::repeat_up_to_n_times() {
+    local num_repeats="${1}"
+    local command="${2}"
+    for ((n=0;n<num_repeats;n++));
+    do
+        local res
+        echo "Attempt no. ${n} to execute ${command}"
+        set +e
+        bash -c "${command}"
+        res=$?
+        set -e
+        if [[ ${res} == "0" ]]; then
+            return 0
+        fi
+        >&2 echo
+        >&2 echo "Unsuccessful attempt no. ${n}. Result: ${res}"
+        >&2 echo
+    done
+    >&2 echo
+    >&2 echo "Giving up after ${num_repeats} attempts!"
+    >&2 echo
+    return ${res}
+}


### PR DESCRIPTION
The K8S tests on CI are controlled from the host, not from
inside of the CI container image. Therefore it needs virtualenv
to run the tests as well as some tools such as helm, kubectl
and kind. While those tools can bee downloaded and installed
on demand, from time to time the download fails intermittently.

This change introduces the following improvements:

* the commands to download and setup kind, helm, kubectl are
  repeated up to 4 times in case they fail

* the "bin" directory where those binaries are downloaded is
  cached between runs. Only the same combination of
  versions of the tools are sharing the same cache.

This way both cases - regular re-runs of the same jobs and
upgrade of tools will be much more stable.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
