### PR TITLE
Fix incorrect typing and move config args out of extra connection config to operator args

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -32,6 +32,9 @@ from airflow.utils import timezone
 class AzureBatchHook(BaseHook):
     """
     Hook for Azure Batch APIs
+
+    Account name and account key should be in login and password parameters.
+    The account url should be in extra parameter as account_url
     """
 
     def __init__(self, azure_batch_conn_id: str = 'azure_batch_default') -> None:
@@ -64,20 +67,23 @@ class AzureBatchHook(BaseHook):
                 )
             return value
 
-        batch_account_name = _get_required_param('account_name')
-        batch_account_key = _get_required_param('account_key')
         batch_account_url = _get_required_param('account_url')
-        credentials = batch_auth.SharedKeyCredentials(batch_account_name, batch_account_key)
+        credentials = batch_auth.SharedKeyCredentials(conn.login, conn.password)
         batch_client = BatchServiceClient(credentials, batch_url=batch_account_url)
         return batch_client
 
-    def configure_pool(
+    def configure_pool(  # pylint: disable=too-many-arguments
         self,
         pool_id: str,
-        vm_size: str,
-        vm_publisher: str,
-        vm_offer: str,
-        sku_starts_with: str,
+        vm_size: Optional[str] = None,
+        vm_publisher: Optional[str] = None,
+        vm_offer: Optional[str] = None,
+        sku_starts_with: Optional[str] = None,
+        vm_sku: Optional[str] = None,
+        vm_version: Optional[str] = None,
+        vm_node_agent_sku_id: Optional[str] = None,
+        os_family: Optional[str] = None,
+        os_version: Optional[str] = None,
         display_name: Optional[str] = None,
         target_dedicated_nodes: Optional[int] = None,
         use_latest_image_and_sku: bool = False,
@@ -111,6 +117,22 @@ class AzureBatchHook(BaseHook):
 
         :param sku_starts_with: The start name of the sku to search
         :type sku_starts_with: Optional[str]
+
+        :param vm_sku: The name of the virtual machine sku to use
+        :type vm_sku: str
+
+        :param vm_version: The version of the virtual machine
+        :param vm_version: str
+
+        :param vm_node_agent_sku_id: The node agent sku id of the virtual machine
+        :type vm_node_agent_sku_id: str
+
+        :param os_family: The Azure Guest OS family to be installed on the virtual machines in the Pool.
+        :type os_family: str
+
+        :param os_version: The OS family version
+        :type os_version: str
+
         """
         if use_latest_image_and_sku:
             self.log.info('Using latest verified virtual machine image with node agent sku')
@@ -128,7 +150,7 @@ class AzureBatchHook(BaseHook):
                 **kwargs,
             )
 
-        elif self.extra.get('os_family'):
+        elif os_family:
             self.log.info(
                 'Using cloud service configuration to create pool, ' 'virtual machine configuration ignored'
             )
@@ -137,7 +159,7 @@ class AzureBatchHook(BaseHook):
                 vm_size=vm_size,
                 display_name=display_name,
                 cloud_service_configuration=batch_models.CloudServiceConfiguration(
-                    os_family=self.extra.get('os_family'), os_version=self.extra.get('os_version')
+                    os_family=os_family, os_version=os_version
                 ),
                 target_dedicated_nodes=target_dedicated_nodes,
                 **kwargs,
@@ -151,12 +173,12 @@ class AzureBatchHook(BaseHook):
                 display_name=display_name,
                 virtual_machine_configuration=batch_models.VirtualMachineConfiguration(
                     image_reference=batch_models.ImageReference(
-                        publisher=self.extra.get('vm_publisher'),
-                        offer=self.extra.get('vm_offer'),
-                        sku=self.extra.get('vm_sku'),
-                        version=self.extra.get("vm_version"),
+                        publisher=vm_publisher,
+                        offer=vm_offer,
+                        sku=vm_sku,
+                        version=vm_version,
                     ),
-                    node_agent_sku_id=self.extra.get('node_agent_sku_id'),
+                    node_agent_sku_id=vm_node_agent_sku_id,
                 ),
                 target_dedicated_nodes=target_dedicated_nodes,
                 **kwargs,
@@ -183,9 +205,9 @@ class AzureBatchHook(BaseHook):
 
     def _get_latest_verified_image_vm_and_sku(
         self,
-        publisher: str,
-        offer: str,
-        sku_starts_with: str,
+        publisher: Optional[str] = None,
+        offer: Optional[str] = None,
+        sku_starts_with: Optional[str] = None,
     ) -> tuple:
         """
         Get latest verified image vm and sku
@@ -205,8 +227,8 @@ class AzureBatchHook(BaseHook):
         skus_to_use = [
             (image.node_agent_sku_id, image.image_reference)
             for image in images
-            if image.image_reference.publisher.lower() == publisher.lower()
-            and image.image_reference.offer.lower() == offer.lower()
+            if image.image_reference.publisher.lower() == publisher
+            and image.image_reference.offer.lower() == offer
             and image.image_reference.sku.startswith(sku_starts_with)
         ]
 

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -119,19 +119,19 @@ class AzureBatchHook(BaseHook):
         :type sku_starts_with: Optional[str]
 
         :param vm_sku: The name of the virtual machine sku to use
-        :type vm_sku: str
+        :type vm_sku: Optional[str]
 
         :param vm_version: The version of the virtual machine
         :param vm_version: str
 
         :param vm_node_agent_sku_id: The node agent sku id of the virtual machine
-        :type vm_node_agent_sku_id: str
+        :type vm_node_agent_sku_id: Optional[str]
 
         :param os_family: The Azure Guest OS family to be installed on the virtual machines in the Pool.
-        :type os_family: str
+        :type os_family: Optional[str]
 
         :param os_version: The OS family version
-        :type os_version: str
+        :type os_version: Optional[str]
 
         """
         if use_latest_image_and_sku:

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -91,10 +91,9 @@ def create_default_connections(session=None):
         Connection(
             conn_id="azure_batch_default",
             conn_type="azure_batch",
-            extra='''{"account_name": "<ACCOUNT_NAME>", "account_key": "<ACCOUNT_KEY>",
-                      "account_url": "<ACCOUNT_URL>", "vm_publisher": "<VM_PUBLISHER>",
-                      "vm_offer": "<VM_OFFER>", "vm_sku": "<VM_SKU>",
-                      "vm_version": "<VM_VERSION>", "node_agent_sku_id": "<NODE_AGENT_SKU_ID>"}'''
+            login="<ACCOUNT_NAME>",
+            password="",
+            extra='''{"account_url": "<ACCOUNT_URL>"}'''
         )
     )
     merge_conn(


### PR DESCRIPTION
The PR #11359 made` vm_publisher`, `vm_sku` and `sku_starts_with` a required argument in AzureBatchOperator.
It's possible to run batch job using cloud service configuration or virtual machine configuration. 
Both are mutually exclusive, making `vm_publisher` etc, a required argument will not allow anyone to run batch job using cloud service configuration.

Also, I moved service configuration argument from connection extra to operator. When I originally wrote this hook, I had very little experience of airflow and passed these arguments through the connection extra parameter. Now, I think it's not Ok, hence asking to correct it through this PR.

cc @turbaszek @mik-laj 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
