### PR TITLE
Use unittest.mock instead of backported mock library

### DIFF
--- a/tests/api_connexion/endpoints/test_config_endpoint.py
+++ b/tests/api_connexion/endpoints/test_config_endpoint.py
@@ -17,7 +17,7 @@
 
 import textwrap
 
-from mock import patch
+from unittest.mock import patch
 
 from airflow.security import permissions
 from airflow.www import app

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -137,8 +137,9 @@ class TestCeleryStopCommand(unittest.TestCase):
         celery_command.worker(worker_args)
         run_mock = mock_celery_worker.return_value.run
         assert run_mock.call_args
-        assert 'pidfile' in run_mock.call_args.kwargs
-        assert run_mock.call_args.kwargs['pidfile'] == pid_file
+        _, kwargs = run_mock.call_args
+        assert 'pidfile' in kwargs
+        assert kwargs['pidfile'] == pid_file
 
         # Call stop
         stop_args = self.parser.parse_args(['celery', 'stop'])

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -18,8 +18,8 @@
 import unittest
 from argparse import Namespace
 from tempfile import NamedTemporaryFile
+from unittest import mock
 
-import mock
 import pytest
 import sqlalchemy
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -21,8 +21,7 @@ import os
 import tempfile
 import unittest
 from datetime import datetime, timedelta
-
-import mock
+from unittest import mock
 
 from airflow import settings
 from airflow.cli import cli_parser

--- a/tests/core/test_logging_config.py
+++ b/tests/core/test_logging_config.py
@@ -23,8 +23,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
-
-from mock import patch
+from unittest.mock import patch
 
 from airflow.configuration import conf
 from tests.test_utils.config import conf_vars

--- a/tests/core/test_sqlalchemy_config.py
+++ b/tests/core/test_sqlalchemy_config.py
@@ -17,8 +17,8 @@
 # under the License.
 
 import unittest
+from unittest.mock import patch
 
-from mock import patch
 from sqlalchemy.pool import NullPool
 
 from airflow import settings

--- a/tests/executors/test_celery_kubernetes_executor.py
+++ b/tests/executors/test_celery_kubernetes_executor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import mock
+from unittest import mock
 
 from airflow.executors.celery_kubernetes_executor import CeleryKubernetesExecutor
 

--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -16,8 +16,8 @@
 # under the License.
 
 import unittest
+from unittest import mock
 
-import mock
 from parameterized import parameterized
 
 from airflow import plugins_manager

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -20,8 +20,8 @@ import re
 import string
 import unittest
 from datetime import datetime
+from unittest import mock
 
-import mock
 from kubernetes.client import models as k8s
 from urllib3 import HTTPResponse
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -22,10 +22,10 @@ import json
 import logging
 import threading
 import unittest
+from unittest.mock import patch
 
 import pytest
 import sqlalchemy
-from mock import patch
 from parameterized import parameterized
 
 from airflow import settings

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -18,8 +18,8 @@
 #
 
 import datetime
+from unittest.mock import ANY, Mock, patch
 
-from mock import ANY, Mock, patch
 from pytest import raises
 from sqlalchemy.exc import OperationalError
 

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -22,9 +22,9 @@ import time
 import unittest
 import uuid
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 
 from airflow import settings
 from airflow.exceptions import AirflowException

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -23,12 +23,12 @@ import shutil
 import unittest
 from datetime import timedelta
 from tempfile import NamedTemporaryFile, mkdtemp
+from unittest import mock
+from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
 
-import mock
 import psutil
 import pytest
-from mock import MagicMock, patch
 from parameterized import parameterized
 from sqlalchemy import func
 from sqlalchemy.exc import OperationalError

--- a/tests/kubernetes/test_client.py
+++ b/tests/kubernetes/test_client.py
@@ -17,8 +17,8 @@
 
 import socket
 import unittest
+from unittest import mock
 
-import mock
 from urllib3.connection import HTTPConnection, HTTPSConnection
 
 from airflow.kubernetes.kube_client import RefreshConfiguration, _enable_tcp_keepalive, get_kube_client

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from unittest import mock
 
-import mock
 from requests.exceptions import BaseHTTPError
 
 from airflow.exceptions import AirflowException

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -17,8 +17,7 @@
 # under the License.
 import unittest
 from datetime import timedelta
-
-from mock import patch
+from unittest.mock import patch
 
 from airflow import AirflowException, example_dags as example_dags_module
 from airflow.models import DagBag

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -18,8 +18,8 @@
 
 import datetime
 import unittest
+from unittest import mock
 
-import mock
 from parameterized import parameterized
 
 from airflow import models, settings

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1492,7 +1492,7 @@ class TestTaskInstance(unittest.TestCase):
         assert ti.state == State.SUCCESS
 
     def test_handle_failure(self):
-        import mock
+        from unittest import mock
 
         start_date = timezone.datetime(2016, 6, 1)
         dag = models.DAG(dag_id="test_handle_failure", schedule_interval=None, start_date=start_date)

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -17,12 +17,10 @@
 # under the License.
 
 import unittest
-import unittest.mock
 from datetime import datetime, timedelta
 from subprocess import PIPE, STDOUT
 from tempfile import NamedTemporaryFile
-
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.models import DagRun
@@ -76,7 +74,7 @@ class TestBashOperator(unittest.TestCase):
                              'echo $AIRFLOW_CTX_DAG_RUN_ID>> {0};'.format(tmp_file.name)
             )
 
-            with unittest.mock.patch.dict('os.environ', {
+            with mock.patch.dict('os.environ', {
                 'AIRFLOW_HOME': 'MY_PATH_TO_AIRFLOW_HOME',
                 'PYTHONPATH': 'AWESOME_PYTHONPATH'
             }):

--- a/tests/operators/test_sql.py
+++ b/tests/operators/test_sql.py
@@ -18,8 +18,8 @@
 
 import datetime
 import unittest
+from unittest import mock
 
-import mock
 import pytest
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -17,9 +17,9 @@
 # under the License.
 #
 import unittest
+from unittest import mock
 
 import boto3
-import mock
 
 from airflow.models import Connection
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook

--- a/tests/providers/amazon/aws/hooks/test_batch_client.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_client.py
@@ -19,9 +19,9 @@
 # pylint: disable=missing-docstring
 
 import unittest
+from unittest import mock
 
 import botocore.exceptions
-import mock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/amazon/aws/hooks/test_batch_waiters.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_waiters.py
@@ -35,12 +35,12 @@ derived from the moto test suite for testing the batch client.
 import inspect
 import unittest
 from typing import NamedTuple, Optional
+from unittest import mock
 
 import boto3
 import botocore.client
 import botocore.exceptions
 import botocore.waiter
-import mock
 import pytest
 from moto import mock_batch, mock_ec2, mock_ecs, mock_iam, mock_logs
 

--- a/tests/providers/amazon/aws/hooks/test_datasync.py
+++ b/tests/providers/amazon/aws/hooks/test_datasync.py
@@ -17,9 +17,9 @@
 # under the License.
 #
 import unittest
+from unittest import mock
 
 import boto3
-import mock
 
 from airflow.exceptions import AirflowTaskTimeout
 from airflow.providers.amazon.aws.hooks.datasync import AWSDataSyncHook

--- a/tests/providers/amazon/aws/hooks/test_glacier.py
+++ b/tests/providers/amazon/aws/hooks/test_glacier.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from testfixtures import LogCapture
 
 from airflow.providers.amazon.aws.hooks.glacier import GlacierHook

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -18,7 +18,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook
 

--- a/tests/providers/amazon/aws/hooks/test_glue_catalog.py
+++ b/tests/providers/amazon/aws/hooks/test_glue_catalog.py
@@ -17,9 +17,9 @@
 # under the License.
 
 import unittest
+from unittest import mock
 
 import boto3
-import mock
 
 from airflow.providers.amazon.aws.hooks.glue_catalog import AwsGlueCatalogHook
 

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -19,10 +19,10 @@
 import gzip as gz
 import os
 import tempfile
+from unittest import mock
 from unittest.mock import Mock
 
 import boto3
-import mock
 import pytest
 from botocore.exceptions import ClientError, NoCredentialsError
 

--- a/tests/providers/amazon/aws/hooks/test_sagemaker.py
+++ b/tests/providers/amazon/aws/hooks/test_sagemaker.py
@@ -21,7 +21,7 @@ import time
 import unittest
 from datetime import datetime
 
-import mock
+from unittest import mock
 from tzlocal import get_localzone
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.models import DAG, TaskInstance
 from airflow.providers.amazon.aws.hooks.athena import AWSAthenaHook

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -21,7 +21,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -21,7 +21,7 @@ import sys
 import unittest
 from copy import deepcopy
 
-import mock
+from unittest import mock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/amazon/aws/operators/test_glacier.py
+++ b/tests/providers/amazon/aws/operators/test_glacier.py
@@ -18,7 +18,7 @@
 
 from unittest import TestCase
 
-import mock
+from unittest import mock
 
 from airflow.providers.amazon.aws.operators.glacier import (
     GlacierCreateJobOperator,

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow import configuration
 from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook

--- a/tests/providers/amazon/aws/operators/test_s3_bucket.py
+++ b/tests/providers/amazon/aws/operators/test_s3_bucket.py
@@ -18,7 +18,7 @@
 import os
 import unittest
 
-import mock
+from unittest import mock
 from moto import mock_s3
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook

--- a/tests/providers/amazon/aws/operators/test_s3_list.py
+++ b/tests/providers/amazon/aws/operators/test_s3_list.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.amazon.aws.operators.s3_list import S3ListOperator
 

--- a/tests/providers/amazon/aws/operators/test_sagemaker_endpoint.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_endpoint.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from botocore.exceptions import ClientError
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/amazon/aws/operators/test_sagemaker_endpoint_config.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_endpoint_config.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

--- a/tests/providers/amazon/aws/operators/test_sagemaker_model.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_model.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

--- a/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/amazon/aws/operators/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_training.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

--- a/tests/providers/amazon/aws/operators/test_sagemaker_transform.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_transform.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

--- a/tests/providers/amazon/aws/operators/test_sagemaker_tuning.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_tuning.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

--- a/tests/providers/amazon/aws/sensors/test_athena.py
+++ b/tests/providers/amazon/aws/sensors/test_athena.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.athena import AWSAthenaHook

--- a/tests/providers/amazon/aws/sensors/test_cloud_formation.py
+++ b/tests/providers/amazon/aws/sensors/test_cloud_formation.py
@@ -16,9 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from unittest.mock import MagicMock, patch
 
 import boto3
-from mock import MagicMock, patch
 
 from airflow.providers.amazon.aws.sensors.cloud_formation import (
     CloudFormationCreateStackSensor,

--- a/tests/providers/amazon/aws/sensors/test_glacier.py
+++ b/tests/providers/amazon/aws/sensors/test_glacier.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow import AirflowException
 from airflow.providers.amazon.aws.sensors.glacier import GlacierJobOperationSensor, JobStatus

--- a/tests/providers/amazon/aws/sensors/test_glue.py
+++ b/tests/providers/amazon/aws/sensors/test_glue.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow import configuration
 from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook

--- a/tests/providers/amazon/aws/sensors/test_glue_catalog_partition.py
+++ b/tests/providers/amazon/aws/sensors/test_glue_catalog_partition.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.glue_catalog import AwsGlueCatalogHook
 from airflow.providers.amazon.aws.sensors.glue_catalog_partition import AwsGlueCatalogPartitionSensor

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_endpoint.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_endpoint.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_training.py
@@ -19,7 +19,7 @@
 import unittest
 from datetime import datetime
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_transform.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_transform.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_tuning.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_tuning.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook

--- a/tests/providers/amazon/aws/transfers/test_gcs_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_gcs_to_s3.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator

--- a/tests/providers/amazon/aws/transfers/test_gcs_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_gcs_to_s3.py
@@ -271,4 +271,5 @@ class TestGCSToS3Operator(unittest.TestCase):
         operator.execute(None)
 
         # Make sure the acl_policy parameter is passed to the upload method
-        self.assertEqual(mock_load_bytes.call_args.kwargs['acl_policy'], S3_ACL_POLICY)
+        _, kwargs = mock_load_bytes.call_args
+        self.assertEqual(kwargs['acl_policy'], S3_ACL_POLICY)

--- a/tests/providers/amazon/aws/transfers/test_glacier_to_gcs.py
+++ b/tests/providers/amazon/aws/transfers/test_glacier_to_gcs.py
@@ -17,7 +17,7 @@
 # under the License.
 from unittest import TestCase
 
-import mock
+from unittest import mock
 
 from airflow.providers.amazon.aws.transfers.glacier_to_gcs import GlacierToGCSOperator
 

--- a/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
@@ -17,7 +17,7 @@
 # under the License.
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.models import TaskInstance
 from airflow.models.dag import DAG

--- a/tests/providers/apache/cassandra/hooks/test_cassandra.py
+++ b/tests/providers/apache/cassandra/hooks/test_cassandra.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 import pytest
 from cassandra.cluster import Cluster
 from cassandra.policies import (

--- a/tests/providers/apache/druid/operators/test_druid_check.py
+++ b/tests/providers/apache/druid/operators/test_druid_check.py
@@ -20,7 +20,7 @@
 import unittest
 from datetime import datetime
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG

--- a/tests/providers/apache/hive/transfers/test_s3_to_hive.py
+++ b/tests/providers/apache/hive/transfers/test_s3_to_hive.py
@@ -27,7 +27,7 @@ from gzip import GzipFile
 from itertools import product
 from tempfile import NamedTemporaryFile, mkdtemp
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.apache.hive.transfers.s3_to_hive import S3ToHiveOperator

--- a/tests/providers/apache/pig/hooks/test_pig.py
+++ b/tests/providers/apache/pig/hooks/test_pig.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.apache.pig.hooks.pig import PigCliHook
 

--- a/tests/providers/apache/pig/operators/test_pig.py
+++ b/tests/providers/apache/pig/operators/test_pig.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.apache.pig.hooks.pig import PigCliHook
 from airflow.providers.apache.pig.operators.pig import PigOperator

--- a/tests/providers/apache/spark/hooks/test_spark_jdbc_script.py
+++ b/tests/providers/apache/spark/hooks/test_spark_jdbc_script.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import mock
+from unittest import mock
 import pytest
 from pyspark.sql.readwriter import DataFrameReader, DataFrameWriter
 

--- a/tests/providers/cloudant/hooks/test_cloudant.py
+++ b/tests/providers/cloudant/hooks/test_cloudant.py
@@ -17,7 +17,7 @@
 # under the License.
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -21,7 +21,7 @@ import itertools
 import json
 import unittest
 
-import mock
+from unittest import mock
 from requests import exceptions as requests_exceptions
 
 from airflow import __version__

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -19,7 +19,7 @@
 import unittest
 from datetime import datetime
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG

--- a/tests/providers/datadog/sensors/test_datadog.py
+++ b/tests/providers/datadog/sensors/test_datadog.py
@@ -20,7 +20,7 @@ import json
 import unittest
 from typing import List
 
-from mock import patch
+from unittest.mock import patch
 
 from airflow.models import Connection
 from airflow.providers.datadog.sensors.datadog import DatadogSensor

--- a/tests/providers/docker/hooks/test_docker.py
+++ b/tests/providers/docker/hooks/test_docker.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -255,13 +255,13 @@ class TestDockerOperator(unittest.TestCase):
         self.client_mock.create_container.assert_called_once()
         self.assertIn(
             'host_config',
-            self.client_mock.create_container.call_args.kwargs,
+            self.client_mock.create_container.call_args[1],
         )
         self.assertIn(
             'extra_hosts',
-            self.client_mock.create_host_config.call_args.kwargs,
+            self.client_mock.create_host_config.call_args[1],
         )
         self.assertIs(
             hosts_obj,
-            self.client_mock.create_host_config.call_args.kwargs['extra_hosts'],
+            self.client_mock.create_host_config.call_args[1]['extra_hosts'],
         )

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -18,7 +18,7 @@
 import logging
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 import requests
 from docker import APIClient
 

--- a/tests/providers/elasticsearch/log/elasticmock/__init__.py
+++ b/tests/providers/elasticsearch/log/elasticmock/__init__.py
@@ -40,9 +40,9 @@
 """Elastic mock module used for testing"""
 from functools import wraps
 from typing import Dict
+from unittest.mock import patch
 
 from elasticsearch.client import _normalize_hosts
-from mock import patch
 
 from .fake_elasticsearch import FakeElasticsearch
 

--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -20,7 +20,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow import models
 from airflow.providers.exasol.hooks.exasol import ExasolHook

--- a/tests/providers/exasol/operators/test_exasol.py
+++ b/tests/providers/exasol/operators/test_exasol.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.exasol.operators.exasol import ExasolOperator
 

--- a/tests/providers/facebook/ads/hooks/test_ads.py
+++ b/tests/providers/facebook/ads/hooks/test_ads.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import mock
+from unittest import mock
 import pytest
 
 from airflow.providers.facebook.ads.hooks.ads import FacebookAdsReportingHook

--- a/tests/providers/google/ads/hooks/test_ads.py
+++ b/tests/providers/google/ads/hooks/test_ads.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import mock
+from unittest import mock
 import pytest
 
 from airflow.providers.google.ads.hooks.ads import GoogleAdsHook

--- a/tests/providers/google/cloud/hooks/test_automl.py
+++ b/tests/providers/google/cloud/hooks/test_automl.py
@@ -18,7 +18,7 @@
 #
 import unittest
 
-import mock
+from unittest import mock
 from google.cloud.automl_v1beta1 import AutoMlClient, PredictionServiceClient
 
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook

--- a/tests/providers/google/cloud/hooks/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery_dts.py
@@ -19,7 +19,7 @@
 import unittest
 from copy import deepcopy
 
-import mock
+from unittest import mock
 from google.cloud.bigquery_datatransfer_v1 import DataTransferServiceClient
 from google.cloud.bigquery_datatransfer_v1.types import TransferConfig
 from google.protobuf.json_format import ParseDict

--- a/tests/providers/google/cloud/hooks/test_bigtable.py
+++ b/tests/providers/google/cloud/hooks/test_bigtable.py
@@ -17,13 +17,13 @@
 # under the License.
 
 import unittest
+from unittest import mock
+from unittest.mock import PropertyMock
 
 import google
-import mock
 from google.cloud.bigtable import Client
 from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable_admin_v2 import enums
-from mock import PropertyMock
 
 from airflow.providers.google.cloud.hooks.bigtable import BigtableHook
 from tests.providers.google.cloud.utils.base_gcp_mock import (

--- a/tests/providers/google/cloud/hooks/test_cloud_build.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_build.py
@@ -22,7 +22,7 @@ import unittest
 from typing import Optional
 from unittest import mock
 
-from mock import PropertyMock
+from unittest.mock import PropertyMock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_build import CloudBuildHook

--- a/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
@@ -17,12 +17,12 @@
 # under the License.
 from typing import Dict, Sequence, Tuple
 from unittest import TestCase, mock
+from unittest.mock import PropertyMock
 
 from google.api_core.retry import Retry
 from google.cloud.exceptions import NotFound
 from google.cloud.memcache_v1beta2.types import cloud_memcache
 from google.cloud.redis_v1.types import Instance
-from mock import PropertyMock
 
 from airflow import version
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/hooks/test_cloud_sql.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_sql.py
@@ -20,11 +20,11 @@
 
 import json
 import unittest
+from unittest import mock
+from unittest.mock import PropertyMock
 
 import httplib2
-import mock
 from googleapiclient.errors import HttpError
-from mock import PropertyMock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
@@ -21,9 +21,9 @@ import re
 import unittest
 from copy import deepcopy
 
-import mock
+from unittest import mock
+from unittest.mock import MagicMock, PropertyMock
 from googleapiclient.errors import HttpError
-from mock import MagicMock, PropertyMock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/hooks/test_compute.py
+++ b/tests/providers/google/cloud/hooks/test_compute.py
@@ -20,8 +20,8 @@
 
 import unittest
 
-import mock
-from mock import PropertyMock
+from unittest import mock
+from unittest.mock import PropertyMock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.compute import ComputeEngineHook, GceOperationStatus

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -22,8 +22,8 @@ import shlex
 import unittest
 from typing import Any, Dict
 
-import mock
-from mock import MagicMock
+from unittest import mock
+from unittest.mock import MagicMock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/hooks/test_dataprep.py
+++ b/tests/providers/google/cloud/hooks/test_dataprep.py
@@ -18,9 +18,9 @@
 import json
 import unittest
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 from requests import HTTPError
 from tenacity import RetryError
 

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -18,7 +18,7 @@
 #
 import unittest
 
-import mock
+from unittest import mock
 from google.cloud.dataproc_v1beta2.types import JobStatus  # pylint: disable=no-name-in-module
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/hooks/test_datastore.py
+++ b/tests/providers/google/cloud/hooks/test_datastore.py
@@ -20,7 +20,7 @@
 import unittest
 from unittest.mock import call, patch
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.datastore import DatastoreHook

--- a/tests/providers/google/cloud/hooks/test_dlp.py
+++ b/tests/providers/google/cloud/hooks/test_dlp.py
@@ -25,9 +25,9 @@ functions in CloudDLPHook
 import unittest
 from typing import Any, Dict
 
-import mock
+from unittest import mock
+from unittest.mock import PropertyMock
 from google.cloud.dlp_v2.types import DlpJob
-from mock import PropertyMock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dlp import CloudDLPHook

--- a/tests/providers/google/cloud/hooks/test_functions.py
+++ b/tests/providers/google/cloud/hooks/test_functions.py
@@ -18,8 +18,8 @@
 
 import unittest
 
-import mock
-from mock import PropertyMock
+from unittest import mock
+from unittest.mock import PropertyMock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.functions import CloudFunctionsHook

--- a/tests/providers/google/cloud/hooks/test_kms.py
+++ b/tests/providers/google/cloud/hooks/test_kms.py
@@ -20,7 +20,7 @@ import unittest
 from base64 import b64decode, b64encode
 from collections import namedtuple
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.hooks.kms import CloudKMSHook
 

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -18,9 +18,9 @@
 #
 import unittest
 
-import mock
+from unittest import mock
+from unittest.mock import PropertyMock
 from google.cloud.container_v1.types import Cluster
-from mock import PropertyMock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.kubernetes_engine import GKEHook

--- a/tests/providers/google/cloud/hooks/test_life_sciences.py
+++ b/tests/providers/google/cloud/hooks/test_life_sciences.py
@@ -21,7 +21,7 @@ Tests for Google Cloud Life Sciences Hook
 import unittest
 from unittest import mock
 
-from mock import PropertyMock
+from unittest.mock import PropertyMock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.life_sciences import LifeSciencesHook

--- a/tests/providers/google/cloud/hooks/test_natural_language.py
+++ b/tests/providers/google/cloud/hooks/test_natural_language.py
@@ -19,7 +19,7 @@
 import unittest
 from typing import Any, Dict
 
-import mock
+from unittest import mock
 from google.cloud.language_v1.proto.language_service_pb2 import Document
 
 from airflow.providers.google.cloud.hooks.natural_language import CloudNaturalLanguageHook

--- a/tests/providers/google/cloud/hooks/test_pubsub.py
+++ b/tests/providers/google/cloud/hooks/test_pubsub.py
@@ -19,7 +19,7 @@
 import unittest
 from typing import List
 
-import mock
+from unittest import mock
 from google.api_core.exceptions import AlreadyExists, GoogleAPICallError
 from google.cloud.exceptions import NotFound
 from google.cloud.pubsub_v1.types import ReceivedMessage

--- a/tests/providers/google/cloud/hooks/test_secret_manager.py
+++ b/tests/providers/google/cloud/hooks/test_secret_manager.py
@@ -17,10 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from unittest.mock import MagicMock, patch
 
 from google.api_core.exceptions import NotFound
 from google.cloud.secretmanager_v1.proto.service_pb2 import AccessSecretVersionResponse
-from mock import MagicMock, patch
 
 from airflow.providers.google.cloud.hooks.secret_manager import SecretsManagerHook
 from tests.providers.google.cloud.utils.base_gcp_mock import (

--- a/tests/providers/google/cloud/hooks/test_spanner.py
+++ b/tests/providers/google/cloud/hooks/test_spanner.py
@@ -18,8 +18,8 @@
 
 import unittest
 
-import mock
-from mock import PropertyMock
+from unittest import mock
+from unittest.mock import PropertyMock
 
 from airflow.providers.google.cloud.hooks.spanner import SpannerHook
 from tests.providers.google.cloud.utils.base_gcp_mock import (

--- a/tests/providers/google/cloud/hooks/test_speech_to_text.py
+++ b/tests/providers/google/cloud/hooks/test_speech_to_text.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from mock import PropertyMock, patch
+from unittest.mock import PropertyMock, patch
 
 from airflow.providers.google.cloud.hooks.speech_to_text import CloudSpeechToTextHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/test_stackdriver.py
+++ b/tests/providers/google/cloud/hooks/test_stackdriver.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 from google.api_core.gapic_v1.method import DEFAULT
 from google.cloud import monitoring_v3
 from google.protobuf.json_format import ParseDict

--- a/tests/providers/google/cloud/hooks/test_tasks.py
+++ b/tests/providers/google/cloud/hooks/test_tasks.py
@@ -19,7 +19,7 @@
 import unittest
 from typing import Any, Dict
 
-import mock
+from unittest import mock
 from google.cloud.tasks_v2.types import Queue, Task
 
 from airflow.providers.google.cloud.hooks.tasks import CloudTasksHook

--- a/tests/providers/google/cloud/hooks/test_text_to_speech.py
+++ b/tests/providers/google/cloud/hooks/test_text_to_speech.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from mock import PropertyMock, patch
+from unittest.mock import PropertyMock, patch
 
 from airflow.providers.google.cloud.hooks.text_to_speech import CloudTextToSpeechHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/test_translate.py
+++ b/tests/providers/google/cloud/hooks/test_translate.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.hooks.translate import CloudTranslateHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id

--- a/tests/providers/google/cloud/hooks/test_video_intelligence.py
+++ b/tests/providers/google/cloud/hooks/test_video_intelligence.py
@@ -18,7 +18,7 @@
 #
 import unittest
 
-import mock
+from unittest import mock
 from google.cloud.videointelligence_v1 import enums
 
 from airflow.providers.google.cloud.hooks.video_intelligence import CloudVideoIntelligenceHook

--- a/tests/providers/google/cloud/hooks/test_vision.py
+++ b/tests/providers/google/cloud/hooks/test_vision.py
@@ -17,7 +17,7 @@
 # under the License.
 import unittest
 
-import mock
+from unittest import mock
 from google.cloud.vision import enums
 from google.cloud.vision_v1 import ProductSearchClient
 from google.cloud.vision_v1.proto.image_annotator_pb2 import (

--- a/tests/providers/google/cloud/operators/test_automl.py
+++ b/tests/providers/google/cloud/operators/test_automl.py
@@ -19,7 +19,7 @@
 import copy
 import unittest
 
-import mock
+from unittest import mock
 from google.cloud.automl_v1beta1 import AutoMlClient, PredictionServiceClient
 
 from airflow.providers.google.cloud.operators.automl import (

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -20,7 +20,7 @@ import unittest
 from datetime import datetime
 from unittest.mock import MagicMock
 
-import mock
+from unittest import mock
 import pytest
 from google.cloud.exceptions import Conflict
 from parameterized import parameterized

--- a/tests/providers/google/cloud/operators/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/operators/test_bigquery_dts.py
@@ -17,7 +17,7 @@
 # under the License.
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.operators.bigquery_dts import (
     BigQueryCreateDataTransferOperator,

--- a/tests/providers/google/cloud/operators/test_bigtable.py
+++ b/tests/providers/google/cloud/operators/test_bigtable.py
@@ -18,9 +18,9 @@
 
 import unittest
 from typing import Dict, List
+from unittest import mock
 
 import google.api_core.exceptions
-import mock
 from google.cloud.bigtable.column_family import MaxVersionsGCRule
 from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable_admin_v2 import enums

--- a/tests/providers/google/cloud/operators/test_cloud_build.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from datetime import datetime
 from unittest import TestCase
 
-import mock
+from unittest import mock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/operators/test_cloud_sql.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql.py
@@ -21,7 +21,7 @@
 import os
 import unittest
 
-import mock
+from unittest import mock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/operators/test_cloud_storage_transfer_service.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 from datetime import date, time
 from typing import Dict
 
-import mock
+from unittest import mock
 from botocore.credentials import Credentials
 from freezegun import freeze_time
 from parameterized import parameterized

--- a/tests/providers/google/cloud/operators/test_compute.py
+++ b/tests/providers/google/cloud/operators/test_compute.py
@@ -21,9 +21,9 @@
 import ast
 import unittest
 from copy import deepcopy
+from unittest import mock
 
 import httplib2
-import mock
 from googleapiclient.errors import HttpError
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/operators/test_dataflow.py
+++ b/tests/providers/google/cloud/operators/test_dataflow.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.operators.dataflow import (
     CheckJobRunning,

--- a/tests/providers/google/cloud/operators/test_datafusion.py
+++ b/tests/providers/google/cloud/operators/test_datafusion.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import mock
+from unittest import mock
 
 from airflow import DAG
 from airflow.providers.google.cloud.operators.datafusion import (

--- a/tests/providers/google/cloud/operators/test_dlp.py
+++ b/tests/providers/google/cloud/operators/test_dlp.py
@@ -23,7 +23,7 @@ This module contains various unit tests for Google Cloud DLP Operators
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.operators.dlp import (
     CloudDLPCancelDLPJobOperator,

--- a/tests/providers/google/cloud/operators/test_functions.py
+++ b/tests/providers/google/cloud/operators/test_functions.py
@@ -19,7 +19,7 @@
 import unittest
 from copy import deepcopy
 
-import mock
+from unittest import mock
 from googleapiclient.errors import HttpError
 from parameterized import parameterized
 

--- a/tests/providers/google/cloud/operators/test_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.operators.gcs import (
     GCSBucketCreateAclEntryOperator,

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -19,8 +19,8 @@ import json
 import os
 import unittest
 
-import mock
-from mock import PropertyMock
+from unittest import mock
+from unittest.mock import PropertyMock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/operators/test_life_sciences.py
+++ b/tests/providers/google/cloud/operators/test_life_sciences.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.operators.life_sciences import LifeSciencesRunPipelineOperator
 

--- a/tests/providers/google/cloud/operators/test_mlengine_utils.py
+++ b/tests/providers/google/cloud/operators/test_mlengine_utils.py
@@ -19,7 +19,7 @@ import datetime
 import unittest
 from unittest.mock import ANY, patch
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.models.dag import DAG

--- a/tests/providers/google/cloud/operators/test_natural_language.py
+++ b/tests/providers/google/cloud/operators/test_natural_language.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 import unittest
+from unittest.mock import patch
 
 from google.cloud.language_v1.proto.language_service_pb2 import (
     AnalyzeEntitiesResponse,
@@ -25,7 +26,6 @@ from google.cloud.language_v1.proto.language_service_pb2 import (
     ClassifyTextResponse,
     Document,
 )
-from mock import patch
 
 from airflow.providers.google.cloud.operators.natural_language import (
     CloudNaturalLanguageAnalyzeEntitiesOperator,

--- a/tests/providers/google/cloud/operators/test_pubsub.py
+++ b/tests/providers/google/cloud/operators/test_pubsub.py
@@ -19,7 +19,7 @@
 import unittest
 from typing import Any, Dict, List
 
-import mock
+from unittest import mock
 from google.cloud.pubsub_v1.types import ReceivedMessage
 from google.protobuf.json_format import MessageToDict, ParseDict
 

--- a/tests/providers/google/cloud/operators/test_spanner.py
+++ b/tests/providers/google/cloud/operators/test_spanner.py
@@ -17,7 +17,7 @@
 # under the License.
 import unittest
 
-import mock
+from unittest import mock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/operators/test_speech_to_text.py
+++ b/tests/providers/google/cloud/operators/test_speech_to_text.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.operators.speech_to_text import CloudSpeechToTextRecognizeSpeechOperator

--- a/tests/providers/google/cloud/operators/test_stackdriver.py
+++ b/tests/providers/google/cloud/operators/test_stackdriver.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.operators.stackdriver import (

--- a/tests/providers/google/cloud/operators/test_tasks.py
+++ b/tests/providers/google/cloud/operators/test_tasks.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from google.cloud.tasks_v2.types import Queue, Task
 
 from airflow.providers.google.cloud.operators.tasks import (

--- a/tests/providers/google/cloud/operators/test_text_to_speech.py
+++ b/tests/providers/google/cloud/operators/test_text_to_speech.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from mock import ANY, Mock, PropertyMock, patch
+from unittest.mock import ANY, Mock, PropertyMock, patch
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/google/cloud/operators/test_translate.py
+++ b/tests/providers/google/cloud/operators/test_translate.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.operators.translate import CloudTranslateTextOperator
 

--- a/tests/providers/google/cloud/operators/test_translate_speech.py
+++ b/tests/providers/google/cloud/operators/test_translate_speech.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from google.cloud.speech_v1.proto.cloud_speech_pb2 import (
     RecognizeResponse,
     SpeechRecognitionAlternative,

--- a/tests/providers/google/cloud/operators/test_video_intelligence.py
+++ b/tests/providers/google/cloud/operators/test_video_intelligence.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from google.cloud.videointelligence_v1 import enums
 from google.cloud.videointelligence_v1.proto.video_intelligence_pb2 import AnnotateVideoResponse
 

--- a/tests/providers/google/cloud/operators/test_vision.py
+++ b/tests/providers/google/cloud/operators/test_vision.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from google.api_core.exceptions import AlreadyExists
 from google.cloud.vision_v1.types import Product, ProductSet, ReferenceImage
 

--- a/tests/providers/google/cloud/sensors/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/sensors/test_bigquery_dts.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.sensors.bigquery_dts import BigQueryDataTransferServiceTransferRunSensor
 

--- a/tests/providers/google/cloud/sensors/test_bigtable.py
+++ b/tests/providers/google/cloud/sensors/test_bigtable.py
@@ -17,9 +17,9 @@
 # under the License.
 
 import unittest
+from unittest import mock
 
 import google.api_core.exceptions
-import mock
 from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import ClusterState
 from parameterized import parameterized

--- a/tests/providers/google/cloud/sensors/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/sensors/test_cloud_storage_transfer_service.py
@@ -17,7 +17,7 @@
 # under the License.
 import unittest
 
-import mock
+from unittest import mock
 from parameterized import parameterized
 
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import GcpTransferOperationStatus

--- a/tests/providers/google/cloud/sensors/test_pubsub.py
+++ b/tests/providers/google/cloud/sensors/test_pubsub.py
@@ -19,7 +19,7 @@
 import unittest
 from typing import Any, Dict, List
 
-import mock
+from unittest import mock
 from google.cloud.pubsub_v1.types import ReceivedMessage
 from google.protobuf.json_format import MessageToDict, ParseDict
 

--- a/tests/providers/google/cloud/transfers/test_adls_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_adls_to_gcs.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.adls_to_gcs import ADLSToGCSOperator
 

--- a/tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.azure_fileshare_to_gcs import AzureFileShareToGCSOperator
 

--- a/tests/providers/google/cloud/transfers/test_bigquery_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_bigquery_to_bigquery.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.bigquery_to_bigquery import BigQueryToBigQueryOperator
 

--- a/tests/providers/google/cloud/transfers/test_bigquery_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_bigquery_to_gcs.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.bigquery_to_gcs import BigQueryToGCSOperator
 

--- a/tests/providers/google/cloud/transfers/test_bigquery_to_mysql.py
+++ b/tests/providers/google/cloud/transfers/test_bigquery_to_mysql.py
@@ -17,7 +17,7 @@
 # under the License.
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.bigquery_to_mysql import BigQueryToMySqlOperator
 

--- a/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
@@ -19,7 +19,7 @@
 import unittest
 from unittest import mock
 
-from mock import call
+from unittest.mock import call
 
 from airflow.providers.google.cloud.transfers.cassandra_to_gcs import CassandraToGCSOperator
 

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 

--- a/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
@@ -19,7 +19,7 @@
 import unittest
 from datetime import datetime
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.transfers.gcs_to_gcs import WILDCARD, GCSToGCSOperator

--- a/tests/providers/google/cloud/transfers/test_gcs_to_local.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_local.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.gcs_to_local import GCSToLocalFilesystemOperator
 

--- a/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_sftp.py
@@ -20,7 +20,7 @@
 import os
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.transfers.gcs_to_sftp import GCSToSFTPOperator

--- a/tests/providers/google/cloud/transfers/test_local_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_local_to_gcs.py
@@ -22,7 +22,7 @@ import os
 import unittest
 from glob import glob
 
-import mock
+from unittest import mock
 import pytest
 
 from airflow.models.dag import DAG

--- a/tests/providers/google/cloud/transfers/test_mssql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_mssql_to_gcs.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow import PY38
 

--- a/tests/providers/google/cloud/transfers/test_mysql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_mysql_to_gcs.py
@@ -20,7 +20,7 @@ import datetime
 import decimal
 import unittest
 
-import mock
+from unittest import mock
 from _mysql_exceptions import ProgrammingError
 from parameterized import parameterized
 

--- a/tests/providers/google/cloud/transfers/test_postgres_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_postgres_to_gcs.py
@@ -17,9 +17,9 @@
 # under the License.
 
 import unittest
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 
 from airflow.providers.google.cloud.transfers.postgres_to_gcs import PostgresToGCSOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook

--- a/tests/providers/google/cloud/transfers/test_presto_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_presto_to_gcs.py
@@ -16,9 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 
 from airflow.providers.google.cloud.transfers.presto_to_gcs import PrestoToGCSOperator
 

--- a/tests/providers/google/cloud/transfers/test_s3_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_s3_to_gcs.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.s3_to_gcs import S3ToGCSOperator
 

--- a/tests/providers/google/cloud/transfers/test_sftp_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sftp_to_gcs.py
@@ -20,7 +20,7 @@
 import os
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.transfers.sftp_to_gcs import SFTPToGCSOperator

--- a/tests/providers/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sheets_to_gcs.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.cloud.transfers.sheets_to_gcs import GoogleSheetsToGCSOperator
 

--- a/tests/providers/google/cloud/transfers/test_sql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sql_to_gcs.py
@@ -19,7 +19,7 @@ import json
 import unittest
 from unittest.mock import Mock
 
-import mock
+from unittest import mock
 import unicodecsv as csv
 
 from airflow.providers.google.cloud.hooks.gcs import GCSHook

--- a/tests/providers/google/cloud/utils/test_credentials_provider.py
+++ b/tests/providers/google/cloud/utils/test_credentials_provider.py
@@ -22,7 +22,7 @@ import unittest
 from io import StringIO
 from uuid import uuid4
 
-import mock
+from unittest import mock
 from google.auth.environment_vars import CREDENTIALS
 from parameterized import parameterized
 

--- a/tests/providers/google/cloud/utils/test_mlengine_operator_utils.py
+++ b/tests/providers/google/cloud/utils/test_mlengine_operator_utils.py
@@ -19,9 +19,9 @@ import base64
 import json
 import unittest
 from datetime import datetime
+from unittest import mock
 
 import dill
-import mock
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG

--- a/tests/providers/google/cloud/utils/test_mlengine_prediction_summary.py
+++ b/tests/providers/google/cloud/utils/test_mlengine_prediction_summary.py
@@ -18,9 +18,9 @@
 import base64
 import binascii
 import unittest
+from unittest import mock
 
 import dill
-import mock
 
 try:
     from airflow.providers.google.cloud.utils import mlengine_prediction_summary

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -21,9 +21,9 @@ import os
 import re
 import unittest
 from io import StringIO
+from unittest import mock
 
 import google.auth
-import mock
 import tenacity
 from google.auth.environment_vars import CREDENTIALS
 from google.auth.exceptions import GoogleAuthError

--- a/tests/providers/google/firebase/hooks/test_firestore.py
+++ b/tests/providers/google/firebase/hooks/test_firestore.py
@@ -22,7 +22,7 @@ import unittest
 from typing import Optional
 from unittest import mock
 
-from mock import PropertyMock
+from unittest.mock import PropertyMock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.firebase.hooks.firestore import CloudFirestoreHook

--- a/tests/providers/google/suite/hooks/test_drive.py
+++ b/tests/providers/google/suite/hooks/test_drive.py
@@ -18,7 +18,7 @@
 #
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.suite.hooks.drive import GoogleDriveHook
 from tests.providers.google.cloud.utils.base_gcp_mock import GCP_CONNECTION_WITH_PROJECT_ID

--- a/tests/providers/google/suite/hooks/test_sheets.py
+++ b/tests/providers/google/suite/hooks/test_sheets.py
@@ -22,7 +22,7 @@ Unit Tests for the GSheets Hook
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.suite.hooks.sheets import GSheetsHook

--- a/tests/providers/google/suite/operators/test_sheets.py
+++ b/tests/providers/google/suite/operators/test_sheets.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.suite.operators.sheets import GoogleSheetsCreateSpreadsheetOperator
 

--- a/tests/providers/google/suite/transfers/test_gcs_to_sheets.py
+++ b/tests/providers/google/suite/transfers/test_gcs_to_sheets.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import mock
+from unittest import mock
 
 from airflow.providers.google.suite.transfers.gcs_to_sheets import GCSToGoogleSheetsOperator
 

--- a/tests/providers/grpc/hooks/test_grpc.py
+++ b/tests/providers/grpc/hooks/test_grpc.py
@@ -18,7 +18,7 @@
 import unittest
 from io import StringIO
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowConfigException
 from airflow.models import Connection

--- a/tests/providers/grpc/operators/test_grpc.py
+++ b/tests/providers/grpc/operators/test_grpc.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.grpc.operators.grpc import GrpcOperator
 

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -18,9 +18,9 @@
 
 from unittest import mock
 from unittest.case import TestCase
+from unittest.mock import mock_open, patch
 
 from hvac.exceptions import InvalidPath, VaultError
-from mock import mock_open, patch
 
 from airflow.providers.hashicorp._internal_client.vault_client import _VaultClient  # noqa
 

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -18,9 +18,9 @@
 
 from unittest import mock
 from unittest.case import TestCase
+from unittest.mock import PropertyMock, mock_open, patch
 
 from hvac.exceptions import VaultError
-from mock import PropertyMock, mock_open, patch
 from parameterized import parameterized
 
 from airflow.providers.hashicorp.hooks.vault import VaultHook

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -18,7 +18,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 import requests
 import requests_mock
 import tenacity

--- a/tests/providers/http/operators/test_http.py
+++ b/tests/providers/http/operators/test_http.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 import requests_mock
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -18,7 +18,7 @@
 import unittest
 from unittest.mock import patch
 
-import mock
+from unittest import mock
 import requests
 
 from airflow.exceptions import AirflowException, AirflowSensorTimeout

--- a/tests/providers/jenkins/operators/test_jenkins_job_trigger.py
+++ b/tests/providers/jenkins/operators/test_jenkins_job_trigger.py
@@ -17,9 +17,9 @@
 # under the License.
 
 import unittest
+from unittest.mock import Mock, patch
 
 import jenkins
-from mock import Mock, patch
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/microsoft/azure/hooks/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_batch.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 from azure.batch import BatchServiceClient, models as batch_models
 
 from airflow.models import Connection

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -23,7 +23,7 @@ import logging
 import unittest
 import uuid
 
-import mock
+from unittest import mock
 from azure.cosmos.cosmos_client import CosmosClient
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.models import Connection
 from airflow.utils import db

--- a/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
@@ -28,7 +28,7 @@ and password (=Storage account key), or login and SAS token in the extra field
 import json
 import unittest
 
-import mock
+from unittest import mock
 from azure.storage.file import File, Directory
 
 from airflow.models import Connection

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -22,7 +22,7 @@ import json
 import unittest
 from collections import namedtuple
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection

--- a/tests/providers/microsoft/azure/operators/test_adls_list.py
+++ b/tests/providers/microsoft/azure/operators/test_adls_list.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.microsoft.azure.operators.adls_list import AzureDataLakeStorageListOperator
 

--- a/tests/providers/microsoft/azure/operators/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_batch.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection

--- a/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
@@ -21,7 +21,7 @@ import unittest
 from collections import namedtuple
 from unittest.mock import MagicMock
 
-import mock
+from unittest import mock
 from azure.mgmt.containerinstance.models import ContainerState, Event
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/microsoft/azure/operators/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_cosmos.py
@@ -22,7 +22,7 @@ import json
 import unittest
 import uuid
 
-import mock
+from unittest import mock
 
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.operators.azure_cosmos import AzureCosmosInsertDocumentOperator

--- a/tests/providers/microsoft/azure/operators/test_wasb_delete_blob.py
+++ b/tests/providers/microsoft/azure/operators/test_wasb_delete_blob.py
@@ -20,7 +20,7 @@
 import datetime
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.operators.wasb_delete_blob import WasbDeleteBlobOperator

--- a/tests/providers/microsoft/azure/sensors/test_wasb.py
+++ b/tests/providers/microsoft/azure/sensors/test_wasb.py
@@ -20,7 +20,7 @@
 import datetime
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.sensors.wasb import WasbBlobSensor, WasbPrefixSensor

--- a/tests/providers/microsoft/azure/transfers/test_azure_blob_to_gcs.py
+++ b/tests/providers/microsoft/azure/transfers/test_azure_blob_to_gcs.py
@@ -16,7 +16,7 @@
 # under the License.
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.microsoft.azure.transfers.azure_blob_to_gcs import (
     AzureBlobStorageToGCSOperator,

--- a/tests/providers/microsoft/azure/transfers/test_file_to_wasb.py
+++ b/tests/providers/microsoft/azure/transfers/test_file_to_wasb.py
@@ -20,7 +20,7 @@
 import datetime
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.transfers.file_to_wasb import FileToWasbOperator

--- a/tests/providers/microsoft/azure/transfers/test_local_to_adls.py
+++ b/tests/providers/microsoft/azure/transfers/test_local_to_adls.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalToAzureDataLakeStorageOperator

--- a/tests/providers/microsoft/azure/transfers/test_oracle_to_azure_data_lake.py
+++ b/tests/providers/microsoft/azure/transfers/test_oracle_to_azure_data_lake.py
@@ -20,9 +20,9 @@ import os
 import unittest
 from tempfile import TemporaryDirectory
 
-import mock
+from unittest import mock
+from unittest.mock import MagicMock
 import unicodecsv as csv
-from mock import MagicMock
 
 from airflow.providers.microsoft.azure.transfers.oracle_to_azure_data_lake import (
     OracleToAzureDataLakeOperator,

--- a/tests/providers/microsoft/mssql/hooks/test_mssql.py
+++ b/tests/providers/microsoft/mssql/hooks/test_mssql.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow import PY38
 from airflow.models import Connection

--- a/tests/providers/microsoft/mssql/operators/test_mssql.py
+++ b/tests/providers/microsoft/mssql/operators/test_mssql.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow import PY38
 from airflow.models import Connection

--- a/tests/providers/openfaas/hooks/test_openfaas.py
+++ b/tests/providers/openfaas/hooks/test_openfaas.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 import requests_mock
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -20,7 +20,7 @@ import json
 import unittest
 from datetime import datetime
 
-import mock
+from unittest import mock
 import numpy
 
 from airflow.models import Connection

--- a/tests/providers/oracle/operators/test_oracle.py
+++ b/tests/providers/oracle/operators/test_oracle.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.oracle.hooks.oracle import OracleHook
 from airflow.providers.oracle.operators.oracle import OracleOperator

--- a/tests/providers/oracle/transfers/test_oracle_to_oracle.py
+++ b/tests/providers/oracle/transfers/test_oracle_to_oracle.py
@@ -19,7 +19,7 @@
 import unittest
 from unittest import mock
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from airflow.providers.oracle.transfers.oracle_to_oracle import OracleToOracleOperator
 

--- a/tests/providers/plexus/hooks/test_plexus.py
+++ b/tests/providers/plexus/hooks/test_plexus.py
@@ -15,10 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from unittest import mock
+from unittest.mock import Mock
+
 import arrow
-import mock
 import pytest
-from mock import Mock
 from requests.exceptions import Timeout
 from airflow.exceptions import AirflowException
 from airflow.providers.plexus.hooks.plexus import PlexusHook

--- a/tests/providers/plexus/operators/test_job.py
+++ b/tests/providers/plexus/operators/test_job.py
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import mock
+from unittest import mock
+from unittest.mock import Mock
 import pytest
-from mock import Mock
 from requests.exceptions import Timeout
 from airflow.exceptions import AirflowException
 from airflow.providers.plexus.operators.job import PlexusJobOperator

--- a/tests/providers/qubole/operators/test_qubole_check.py
+++ b/tests/providers/qubole/operators/test_qubole_check.py
@@ -19,7 +19,7 @@
 import unittest
 from datetime import datetime
 
-import mock
+from unittest import mock
 from qds_sdk.commands import HiveCommand
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/redis/operators/test_redis_publish.py
+++ b/tests/providers/redis/operators/test_redis_publish.py
@@ -18,9 +18,9 @@
 
 
 import unittest
+from unittest.mock import MagicMock
 
 import pytest
-from mock import MagicMock
 
 from airflow.models.dag import DAG
 from airflow.providers.redis.hooks.redis import RedisHook

--- a/tests/providers/samba/hooks/test_samba.py
+++ b/tests/providers/samba/hooks/test_samba.py
@@ -19,7 +19,7 @@
 import unittest
 from unittest.mock import call
 
-import mock
+from unittest import mock
 import smbclient
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/sendgrid/utils/test_emailer.py
+++ b/tests/providers/sendgrid/utils/test_emailer.py
@@ -22,7 +22,7 @@ import os
 import tempfile
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.sendgrid.utils.emailer import send_email
 

--- a/tests/providers/singularity/operators/test_singularity.py
+++ b/tests/providers/singularity/operators/test_singularity.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from parameterized import parameterized
 from spython.instance import Instance
 

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 from slack.errors import SlackApiError
 
 from airflow.exceptions import AirflowException

--- a/tests/providers/slack/operators/test_slack.py
+++ b/tests/providers/slack/operators/test_slack.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.providers.slack.operators.slack import SlackAPIFileOperator, SlackAPIPostOperator
 

--- a/tests/providers/snowflake/operators/test_snowflake.py
+++ b/tests/providers/snowflake/operators/test_snowflake.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from airflow.models.dag import DAG
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -22,7 +22,7 @@ from io import StringIO
 from typing import Optional
 import random
 import string
-import mock
+from unittest import mock
 import paramiko
 
 from airflow.models import Connection

--- a/tests/sensors/test_date_time_sensor.py
+++ b/tests/sensors/test_date_time_sensor.py
@@ -15,8 +15,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from unittest.mock import patch
+
 import pytest
-from mock import patch
 from parameterized import parameterized
 
 from airflow.models.dag import DAG

--- a/tests/sensors/test_smart_sensor_operator.py
+++ b/tests/sensors/test_smart_sensor_operator.py
@@ -21,9 +21,9 @@ import logging
 import os
 import time
 import unittest
+from unittest.mock import Mock
 
 from freezegun import freeze_time
-from mock import Mock
 
 from airflow import DAG, settings
 from airflow.configuration import conf

--- a/tests/sensors/test_time_sensor.py
+++ b/tests/sensors/test_time_sensor.py
@@ -17,9 +17,9 @@
 # under the License.
 
 from datetime import datetime, time
+from unittest.mock import patch
 
 import pendulum
-from mock import patch
 from parameterized import parameterized
 
 from airflow.models.dag import DAG

--- a/tests/ti_deps/deps/test_dagrun_id_dep.py
+++ b/tests/ti_deps/deps/test_dagrun_id_dep.py
@@ -17,8 +17,7 @@
 # under the License.
 
 import unittest
-
-from mock import Mock
+from unittest.mock import Mock
 
 from airflow.models.dagrun import DagRun
 from airflow.ti_deps.deps.dagrun_id_dep import DagrunIdDep

--- a/tests/ti_deps/deps/test_pool_slots_available_dep.py
+++ b/tests/ti_deps/deps/test_pool_slots_available_dep.py
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
-
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from airflow.models import Pool
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES

--- a/tests/utils/test_dot_renderer.py
+++ b/tests/utils/test_dot_renderer.py
@@ -18,8 +18,7 @@
 # under the License.
 import datetime
 import unittest
-
-import mock
+from unittest import mock
 
 from airflow.models import TaskInstance
 from airflow.models.dag import DAG

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -21,8 +21,7 @@ import unittest
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-
-import mock
+from unittest import mock
 
 from airflow import utils
 from airflow.configuration import conf

--- a/tests/utils/test_python_virtualenv.py
+++ b/tests/utils/test_python_virtualenv.py
@@ -17,8 +17,7 @@
 # under the License.
 #
 import unittest
-
-import mock
+from unittest import mock
 
 from airflow.utils.python_virtualenv import prepare_virtualenv
 


### PR DESCRIPTION
mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.

https://docs.python.org/3/library/unittest.mock.html

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
