### PR TITLE
Use Python 3 Style Super Class

### DIFF
--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -28,7 +28,7 @@ from airflow.providers.exasol.hooks.exasol import ExasolHook
 
 class TestExasolHookConn(unittest.TestCase):
     def setUp(self):
-        super(TestExasolHookConn, self).setUp()
+        super().setUp()
 
         self.connection = models.Connection(
             login='login',
@@ -67,7 +67,7 @@ class TestExasolHookConn(unittest.TestCase):
 
 class TestExasolHook(unittest.TestCase):
     def setUp(self):
-        super(TestExasolHook, self).setUp()
+        super().setUp()
 
         self.cur = mock.MagicMock()
         self.conn = mock.MagicMock()

--- a/tests/sensors/test_smart_sensor_operator.py
+++ b/tests/sensors/test_smart_sensor_operator.py
@@ -47,9 +47,9 @@ class DummySmartSensor(SmartSensorOperator):
                  shard_max=conf.getint('smart_sensor', 'shard_code_upper_limit'),
                  shard_min=0,
                  **kwargs):
-        super(DummySmartSensor, self).__init__(shard_min=shard_min,
-                                               shard_max=shard_max,
-                                               **kwargs)
+        super().__init__(shard_min=shard_min,
+                         shard_max=shard_max,
+                         **kwargs)
 
 
 class DummySensor(BaseSensorOperator):
@@ -57,7 +57,7 @@ class DummySensor(BaseSensorOperator):
     exec_fields = ('soft_fail', 'execution_timeout', 'timeout')
 
     def __init__(self, input_field='test', return_value=False, **kwargs):
-        super(DummySensor, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.input_field = input_field
         self.return_value = return_value
 

--- a/tests/test_utils/mock_operators.py
+++ b/tests/test_utils/mock_operators.py
@@ -122,7 +122,7 @@ class CustomOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self, bash_command=None, **kwargs):
-        super(CustomOperator, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.bash_command = bash_command
 
     def execute(self, context):


### PR DESCRIPTION
Example: `super(CustomOperator, self).__init__(**kwargs)` instead of `super().__init__(**kwargs)`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
