### PR TITLE
Remove usage of six

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -28,7 +28,6 @@ from zipfile import ZipFile
 import mock
 import psutil
 import pytest
-import six
 from mock import MagicMock, patch
 from parameterized import parameterized
 from sqlalchemy import func
@@ -1648,7 +1647,7 @@ class TestSchedulerJob(unittest.TestCase):
         )
         self.assertEqual(State.RUNNING, ti1.state)
         self.assertEqual(State.RUNNING, ti2.state)
-        six.assertCountEqual(self, [State.QUEUED, State.SCHEDULED], [ti3.state, ti4.state])
+        self.assertCountEqual([State.QUEUED, State.SCHEDULED], [ti3.state, ti4.state])
         self.assertEqual(1, res)
 
     def test_execute_task_instances_limit(self):

--- a/tests/providers/singularity/operators/test_singularity.py
+++ b/tests/providers/singularity/operators/test_singularity.py
@@ -19,7 +19,6 @@
 import unittest
 
 import mock
-import six
 from parameterized import parameterized
 from spython.instance import Instance
 
@@ -62,7 +61,7 @@ class SingularityOperatorTestCase(unittest.TestCase):
     )
     def test_command_is_required(self, command):
         task = SingularityOperator(task_id='task-id', image="docker://busybox", command=command)
-        with six.assertRaisesRegex(self, AirflowException, "You must define a command."):
+        with self.assertRaisesRegex(AirflowException, "You must define a command."):
             task.execute({})
 
     @mock.patch('airflow.providers.singularity.operators.singularity.Client')


### PR DESCRIPTION
Since we support Py 3.6, there is no need of six library

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
