### PR TITLE
Revert "Fixes selective tests in case of missing merge commits (#11641)" 

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -223,11 +223,10 @@ jobs:
         env:
           EVENT_NAME: ${{ needs.cancel-workflow-runs.outputs.sourceEvent }}
           MERGE_COMMIT_SHA: ${{ needs.cancel-workflow-runs.outputs.mergeCommitSha }}
-          COMMIT_SHA: ${{ needs.cancel-workflow-runs.outputs.sourceHeadSha }}
         run: |
           if [[ ${EVENT_NAME} == "pull_request" ]]; then
             # Run selective checks
-            ./scripts/ci/selective_ci_checks.sh "${MERGE_COMMIT_SHA}" "${COMMIT_SHA}"
+            ./scripts/ci/selective_ci_checks.sh "${MERGE_COMMIT_SHA}"
           else
             # Run all checks
             ./scripts/ci/selective_ci_checks.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,6 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 2
         if: github.event_name  == 'pull_request'
-      - name: >
-          Fetch commit ${{ github.ref }} ( ${{ github.sha }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 2
-        if: github.event_name  == 'pull_request'
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} : merge commit ${{ github.merge_commit_sha }} )"
         uses: actions/checkout@v2
       - name: >
@@ -140,7 +133,7 @@ jobs:
         run: |
           if [[ ${EVENT_NAME} == "pull_request" ]]; then
             # Run selective checks
-            ./scripts/ci/selective_ci_checks.sh "${MERGE_COMMIT_SHA}" "${GITHUB_SHA}"
+            ./scripts/ci/selective_ci_checks.sh "${MERGE_COMMIT_SHA}"
           else
             # Run all checks
             ./scripts/ci/selective_ci_checks.sh

--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -24,8 +24,7 @@
 #      sets all the version outputs that determine that all tests should be run. This happens in case
 #      the even triggering the workflow is 'schedule' or 'push'. Merge commit is only
 #      available in case of 'pull_request' triggered runs.
-# $2 - Commit of the change. It might happen that the merge commit is missing (in simple changes)
-#      In which case the change commit is treated as fallback
+#
 declare -a pattern_array
 
 function output_all_basic_variables() {
@@ -394,28 +393,11 @@ if (($# < 1)); then
 fi
 
 MERGE_COMMIT_SHA="${1}"
-
-if (($# > 1)); then
-    COMMIT_SHA="${2}"
-    echo
-    echo "Commit SHA : ${COMMIT_SHA}"
-    echo
-    if [[ ${MERGE_COMMIT_SHA} == "" ]]; then
-       MERGE_COMMIT_SHA=${COMMIT_SHA}
-    fi
-fi
 readonly MERGE_COMMIT_SHA
 
 echo
 echo "Merge commit SHA: ${MERGE_COMMIT_SHA}"
 echo
-
-if [[ ${MERGE_COMMIT_SHA} == "" ]] ; then
-    echo
-    echo "Merge commit SHA empty - running all tests!"
-    echo
-    set_outputs_run_everything_and_exit
-fi
 
 image_build_needed="false"
 tests_needed="false"


### PR DESCRIPTION
The static checks are failing, even after the 2 PRs that were merged to fix the issue. For now reverting them is the best option

Example: https://github.com/apache/airflow/pull/11645  (which is rebased on latest master and contains https://github.com/apache/airflow/commit/4fcc71c2ffbf87585759f49ab7e426ccb9516f87)
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
