### PR TITLE
Revert "Fixed an error introduced in selective checks (#11640)"

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -424,13 +424,13 @@ else
 fi
 
 if [[ ${tests_needed} == "true" ]]; then
-    run_tests "true"
+    run_tests
 else
-    run_tests "false"
+    skip_running_tests
 fi
 
 if [[ ${kubernetes_tests_needed} == "true" ]]; then
-    run_kubernetes_tests "true"
+    run_kubernetes_tests
 else
-    run_kubernetes_tests "false"
+    skip_running_kubernetes_tests
 fi


### PR DESCRIPTION
The static checks are failing, even after the 2 PRs that were merged to fix the issue. For now reverting them is the best option

Example: #11645 (which is rebased on latest master and contains 4fcc71c)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
