### PR TITLE
Enables splitting tests into smaller chunks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,6 +442,7 @@ jobs:
       POSTGRES_VERSION: ${{ matrix.postgres-version }}
       RUN_TESTS: true
       TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
+      TEST_TYPE: ""
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
         (github.repository == 'apache/airflow' || github.event_name != 'schedule')
@@ -494,6 +495,7 @@ jobs:
       MYSQL_VERSION: ${{ matrix.mysql-version }}
       RUN_TESTS: true
       TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
+      TEST_TYPE: ""
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
         (github.repository == 'apache/airflow' || github.event_name != 'schedule')
@@ -543,6 +545,7 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       RUN_TESTS: true
       TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
+      TEST_TYPE: ""
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
         (github.repository == 'apache/airflow' || github.event_name != 'schedule')
@@ -596,6 +599,7 @@ jobs:
       POSTGRES_VERSION: ${{needs.build-info.outputs.defaultPostgresVersion}}
       RUN_TESTS: true
       TEST_TYPES: "Quarantined"
+      TEST_TYPE: ""
       NUM_RUNS: 10
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     if: >

--- a/breeze
+++ b/breeze
@@ -173,6 +173,9 @@ function breeze::setup_default_breeze_constants() {
     export SCREEN_WIDTH
     readonly SCREEN_WIDTH
 
+    # for Breeze default tests executed are "All"
+    export TEST_TYPE=${TEST_TYPE:="All"}
+
     # Update short and long options in the breeze-complete script
     # This way autocomplete will work automatically with all options available
     # shellcheck source=breeze-complete

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -461,7 +461,7 @@ function initialization::initialize_github_variables() {
 }
 
 function initialization::initialize_test_variables() {
-    export TEST_TYPE=${TEST_TYPE:="All"}
+    export TEST_TYPE=${TEST_TYPE:=""}
 }
 
 # Common environment that is initialized by both Breeze and CI scripts

--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -37,7 +37,7 @@ function run_airflow_testing_in_docker() {
         echo "Making sure docker-compose is down"
         echo
         docker-compose --log-level INFO -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
-            down --remove-orphans --timeout 10
+            down --remove-orphans --volumes --timeout 10
         echo
         echo "System-prune docker"
         echo
@@ -53,6 +53,12 @@ function run_airflow_testing_in_docker() {
         echo
         echo "Starting try number ${try_num}"
         echo
+        if [[ " ${ENABLED_INTEGRATIONS} " =~ " kerberos " ]]; then
+            echo "Creating Kerberos network"
+            kerberos::create_kerberos_network
+        else
+            echo "Skip creating kerberos network"
+        fi
         docker-compose --log-level INFO \
           -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
           -f "${SCRIPTS_CI_DIR}/docker-compose/backend-${BACKEND}.yml" \
@@ -60,6 +66,10 @@ function run_airflow_testing_in_docker() {
           "${DOCKER_COMPOSE_LOCAL[@]}" \
              run airflow "${@}"
         exit_code=$?
+        if [[ " ${INTEGRATIONS[*]} " =~ " kerberos " ]]; then
+            echo "Delete kerberos network"
+            kerberos::delete_kerberos_network
+        fi
         if [[ ${exit_code} == 254 ]]; then
             echo
             echo "Failed starting integration on ${try_num} try. Wiping-out docker-compose remnants"
@@ -149,13 +159,6 @@ if [[ ${TEST_TYPE=} != "" ]]; then
 fi
 readonly TEST_TYPES
 
-export RUN_INTEGRATION_TESTS=${RUN_INTEGRATION_TESTS:=""}
-export ENABLED_INTEGRATIONS=${ENABLED_INTEGRATIONS:=""}
-
-if [[ " ${ENABLED_INTEGRATIONS[*]} " =~ " kerberos " ]]; then
-    kerberos::create_kerberos_network
-fi
-
 echo "Running TEST_TYPES: ${TEST_TYPES}"
 
 for TEST_TYPE in ${TEST_TYPES}
@@ -166,6 +169,9 @@ do
     if [[ ${TEST_TYPE:=} == "Integration" ]]; then
         export ENABLED_INTEGRATIONS="${AVAILABLE_INTEGRATIONS}"
         export RUN_INTEGRATION_TESTS="${AVAILABLE_INTEGRATIONS}"
+    else
+        export ENABLED_INTEGRATIONS=""
+        export RUN_INTEGRATION_TESTS=""
     fi
 
     for _INT in ${ENABLED_INTEGRATIONS}
@@ -174,11 +180,11 @@ do
         INTEGRATIONS+=("${SCRIPTS_CI_DIR}/docker-compose/integration-${_INT}.yml")
     done
 
-
     export TEST_TYPE
+
     echo "**********************************************************************************************"
     echo
-    echo "                            TEST_TYPE: ${TEST_TYPE}"
+    echo "      TEST_TYPE: ${TEST_TYPE}, ENABLED INTEGRATIONS: ${ENABLED_INTEGRATIONS}"
     echo
     echo "**********************************************************************************************"
 

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -185,6 +185,7 @@ if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
         # timeouts in seconds for individual tests
         "--setup-timeout=20"
         "--execution-timeout=60"
+        "--with-db-init"
         "--teardown-timeout=20"
         # Only display summary for non-expected case
         # f - failed

--- a/tests/bats/breeze/test_breeze_complete.bats
+++ b/tests/bats/breeze/test_breeze_complete.bats
@@ -255,10 +255,10 @@
   assert_equal "${_breeze_default_postgres_version}" "${POSTGRES_VERSION}"
 }
 
-@test "Test default test type same as TEST_TYPE" {
+@test "Test default test type is empty" {
   load ../bats_utils
   #shellcheck source=breeze-complete
   source "${AIRFLOW_SOURCES}/breeze-complete"
 
-  assert_equal "${_breeze_default_test_type}" "${TEST_TYPE}"
+  assert_equal "" "${TEST_TYPE}"
 }


### PR DESCRIPTION
We've implemented the capability of running the tests in smaller
chunks and selective running only some of those, but this
capability have been disabled by mistake by default setting of
TEST_TYPE to "All" and not removing it when TEST_TYPES are set
to the sets of tests that should be run.

This should speed up many of our tests and also hopefully
lower the chance of EXIT 137 errors.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
