### PR TITLE
Introduced deterministic order in connection export

### DIFF
--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -154,7 +154,7 @@ def connections_export(args):
                       f"The file must have the extension {', '.join(allowed_formats)}"
                 raise SystemExit(msg)
 
-        connections = session.query(Connection).all()
+        connections = session.query(Connection).order_by(Connection.conn_id).all()
         msg = _format_connections(connections, filetype)
         args.file.write(msg)
 

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -216,9 +216,10 @@ class TestCliExportConnections(unittest.TestCase):
                                                                                       mock_splittext):
         output_filepath = '/tmp/connections.json'
 
-        def my_side_effect():
+        def my_side_effect(_):
             raise Exception("dummy exception")
-        mock_session.return_value.__enter__.return_value.query.return_value.all.side_effect = my_side_effect
+        mock_session.return_value.__enter__.return_value.query.return_value.order_by.side_effect = \
+            my_side_effect
         mock_splittext.return_value = (None, '.json')
 
         args = self.parser.parse_args([


### PR DESCRIPTION
The tests for connection export failed when CLI tests are
run in isolation. The problem was with non-deterministic
sequence of returned rows from connection export query.

Rather than fixing the test to accept the non-deterministic
sequence, it is better idea to return them always in the
connection_id order. This does not change functionality and
is backwards compatible, but at the same time it gives stability
in the export, which might be important if someone uses export
to determine for example if some connections were added/removed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
