### PR TITLE
Security scans are also selective now

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,10 +10,36 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
+  selective-checks:
+    name: Selective checks
+    runs-on: ubuntu-latest
+    if: github.repository == 'apache/airflow'
+    outputs:
+      needs-python-scans: ${{ steps.selective-checks.outputs.needs-python-scans }}
+      needs-javascript-scans: ${{ steps.selective-checks.outputs.needs-javascript-scans }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Selective checks
+        id: selective-checks
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INCOMING_COMMIT_SHA: ${{ github.sha }}
+        run: |
+          if [[ ${EVENT_NAME} == "pull_request" ]]; then
+            # Run selective checks
+            ./scripts/ci/selective_ci_checks.sh "${INCOMING_COMMIT_SHA}"
+          else
+            # Run all checks
+            ./scripts/ci/selective_ci_checks.sh
+          fi
+
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-
+    needs: [selective-checks]
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +47,6 @@ jobs:
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language: ['python', 'javascript']
 
-    if: github.repository == 'apache/airflow'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -29,11 +54,19 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
+        if: |
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
 
       # If this run was triggered by a pull request event, then checkout
       # the head of the pull request instead of the merge commit.
       - run: git checkout HEAD^2
-        if: github.event_name == 'pull_request'
+        if: |
+          github.event_name == 'pull_request' &&
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -44,11 +77,23 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        if: |
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
         uses: github/codeql-action/autobuild@v1
+        if: |
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
+        if: |
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')

--- a/CI.rst
+++ b/CI.rst
@@ -691,6 +691,13 @@ delete old artifacts that are > 7 days old. It only runs for the 'apache/airflow
 We also have a script that can help to clean-up the old artifacts:
 `remove_artifacts.sh <dev/remove_artifacts.sh>`_
 
+CodeQL scan
+-----------
+
+The CodeQL security scan uses GitHub security scan framework to scan our code for security violations.
+It is run for javascript and python code.
+
+
 Selective CI Checks
 ===================
 
@@ -774,6 +781,11 @@ The logic implemented for the changes works as follows:
     that require CI image are skipped, and we only run the tests on the files that changed in the incoming
     commit - unlike pylint/flake8/mypy, those static checks are per-file based and they should not miss any
     important change.
+
+Similarly to selective tests we also run selective security scans. In Pull requests,
+the Python scan will only run when there is a python code change and javascript scan will only run if
+there is a javascript or yarn.lock file change. For master builds, all scans are always executed.
+
 
 
 Naming conventions for stored images


### PR DESCRIPTION
The security scans take a long time, especially for python code
- it is about ~18 minutes now. This PR reduces strain on the
GitHub actions by only running the scan in pull requests
when any of python/javascript code changed respectively.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
