### PR TITLE
fix pod launcher rolebinding in helm chart

### DIFF
--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -42,7 +42,11 @@ metadata:
 {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.multiNamespaceMode }}
   kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
   name: {{ .Release.Name }}-pod-launcher-role
 subjects:
 {{- if $grantScheduler }}


### PR DESCRIPTION
Hello,

This PR is a tiny followup to #11034: if `multiNamespaceMode = False` then we should reference a `Role` and not a `ClusterRole` in the roleRef of `pod-launcher-rolebinding.yaml`.

Also,
with #11034 & this PR, we should be able to close #10190.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
