### PR TITLE
Fix helm chart worker deployment without kerberos

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -207,9 +207,11 @@ spec:
 {{- if .Values.workers.extraVolumes }}
 {{ toYaml .Values.workers.extraVolumes | indent 8 }}
 {{- end }}
+        {{- if .Values.kerberos.enabled }}
         - name: kerberos-keytab
           secret:
             secretName: {{ include "kerberos_keytab_secret" . | quote }}
+        {{- end }}
         - name: config
           configMap:
             name: {{ template "airflow_config" . }}

--- a/chart/tests/test_celery_kubernetes_executor.py
+++ b/chart/tests/test_celery_kubernetes_executor.py
@@ -31,8 +31,8 @@ class CeleryKubernetesExecutorTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        self.assertEqual("config", jmespath.search("spec.template.spec.volumes[1].name", docs[0]))
-        self.assertEqual("dags", jmespath.search("spec.template.spec.volumes[2].name", docs[0]))
+        self.assertEqual("config", jmespath.search("spec.template.spec.volumes[0].name", docs[0]))
+        self.assertEqual("dags", jmespath.search("spec.template.spec.volumes[1].name", docs[0]))
 
     def test_should_create_a_worker_deployment_with_the_celery_kubernetes_executor(self):
         docs = render_chart(
@@ -43,5 +43,5 @@ class CeleryKubernetesExecutorTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        self.assertEqual("config", jmespath.search("spec.template.spec.volumes[1].name", docs[0]))
-        self.assertEqual("dags", jmespath.search("spec.template.spec.volumes[2].name", docs[0]))
+        self.assertEqual("config", jmespath.search("spec.template.spec.volumes[0].name", docs[0]))
+        self.assertEqual("dags", jmespath.search("spec.template.spec.volumes[1].name", docs[0]))

--- a/chart/tests/test_git_sync_worker.py
+++ b/chart/tests/test_git_sync_worker.py
@@ -31,8 +31,8 @@ class GitSyncWorkerTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        self.assertEqual("config", jmespath.search("spec.template.spec.volumes[1].name", docs[0]))
-        self.assertEqual("dags", jmespath.search("spec.template.spec.volumes[2].name", docs[0]))
+        self.assertEqual("config", jmespath.search("spec.template.spec.volumes[0].name", docs[0]))
+        self.assertEqual("dags", jmespath.search("spec.template.spec.volumes[1].name", docs[0]))
 
     def test_should_add_dags_volume_to_the_worker_if_git_sync_is_enabled_and_peristence_is_disabled(self):
         docs = render_chart(
@@ -43,8 +43,8 @@ class GitSyncWorkerTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        self.assertEqual("config", jmespath.search("spec.template.spec.volumes[1].name", docs[0]))
-        self.assertEqual("dags", jmespath.search("spec.template.spec.volumes[2].name", docs[0]))
+        self.assertEqual("config", jmespath.search("spec.template.spec.volumes[0].name", docs[0]))
+        self.assertEqual("dags", jmespath.search("spec.template.spec.volumes[1].name", docs[0]))
 
     def test_should_add_git_sync_container_to_worker_if_persistence_is_not_enabled_but_git_sync_is(self):
         docs = render_chart(

--- a/chart/tests/test_kerberos.py
+++ b/chart/tests/test_kerberos.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import unittest
+
+from tests.helm_template_generator import render_chart
+
+
+class KerberosTest(unittest.TestCase):
+    def test_kerberos_not_mentioned_in_render_if_disabled(self):
+        k8s_objects = render_chart(name="NO-KERBEROS", values={"kerberos": {'enabled': False}})
+        # ignore airflow config map
+        k8s_objects_to_consider = [
+            obj for obj in k8s_objects if obj["metadata"]["name"] != "NO-KERBEROS-airflow-config"
+        ]
+        k8s_objects_to_consider_str = json.dumps(k8s_objects_to_consider)
+        self.assertNotIn("kerberos", k8s_objects_to_consider_str)


### PR DESCRIPTION
Hello,

A small follow up to #11130 after some tests on the new chart : we shouldn't mount the `kerberos-keytab` volume
in the worker deployment if we are not using
kerberos in the first place.
(the previous behavior is breaking the chart)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
