### PR TITLE
Update TIs with a proper lock

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -857,7 +857,8 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         # We need to do this for mysql as well because it can cause deadlocks
         # as discussed in https://issues.apache.org/jira/browse/AIRFLOW-2516
         if self.using_sqlite or self.using_mysql:
-            tis_to_change: List[TI] = with_row_locks(query).all()
+            tis_to_change: List[TI] = with_row_locks(query, of=TI,
+                                                     **skip_locked(session=session)).all()
             for ti in tis_to_change:
                 ti.set_state(new_state, session=session)
                 tis_changed += 1


### PR DESCRIPTION
Was getting the following error when running 2 schedulers and 1 scheduler would die withing seconds after starting 

> Traceback (most recent call last):
  File "/Users/smaheshwari/work/airflow/venv/lib/python3.7/site-packages/airflow/jobs/scheduler_job.py", line 1316, in _execute
    self._run_scheduler_loop()
  File "/Users/smaheshwari/work/airflow/venv/lib/python3.7/site-packages/airflow/jobs/scheduler_job.py", line 1389, in _run_scheduler_loop
    num_queued_tis = self._do_scheduling(session)
  File "/Users/smaheshwari/work/airflow/venv/lib/python3.7/site-packages/airflow/jobs/scheduler_job.py", line 1513, in _do_scheduling
    session=session
  File "/Users/smaheshwari/work/airflow/venv/lib/python3.7/site-packages/airflow/utils/session.py", line 61, in wrapper
    return func(*args, **kwargs)
  File "/Users/smaheshwari/work/airflow/venv/lib/python3.7/site-packages/airflow/jobs/scheduler_job.py", line 860, in _change_state_for_tis_without_dagrun
    tis_to_change: List[TI] = with_row_locks(query).all()
.....
.....
 sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError) (1213, 'Deadlock found when trying to get lock; try restarting 
 transaction')

