### PR TITLE
fix helm scheduler deployment / scheduler logs

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -173,7 +173,7 @@ spec:
         - name: scheduler-logs
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
-          args: ["airflow", "serve_logs"]
+          args: ["serve_logs"]
           ports:
             - name: worker-logs
               containerPort: {{ .Values.ports.workerLogs }}

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import unittest
+from typing import Any, Dict, List, Union
 
 from tests.helm_template_generator import render_chart
 
@@ -64,3 +65,33 @@ class TestBaseChartTest(unittest.TestCase):
         ]
         self.assertNotIn(('Job', 'TEST-BASIC-create-user'), list_of_kind_names_tuples)
         self.assertEqual(OBJECT_COUNT_IN_BASIC_DEPLOYMENT - 1, len(k8s_objects))
+
+    def test_chart_is_consistent_with_official_airflow_image(self):
+        def get_k8s_objs_with_image(obj: Union[List[Any], Dict[str, Any]]) -> List[Dict[str, Any]]:
+            """
+            Recursive helper to retrieve all the k8s objects that have an "image" key
+            inside k8s obj or list of k8s obj
+            """
+            out = []
+            if isinstance(obj, list):
+                for item in obj:
+                    out += get_k8s_objs_with_image(item)
+            if isinstance(obj, dict):
+                if "image" in obj:
+                    out += [obj]
+                # include sub objs, just in case
+                for val in obj.values():
+                    out += get_k8s_objs_with_image(val)
+            return out
+
+        image_repo = "test-airflow-repo/airflow"
+        k8s_objects = render_chart("TEST-BASIC", {"defaultAirflowRepository": image_repo})
+
+        objs_with_image = get_k8s_objs_with_image(k8s_objects)
+        for obj in objs_with_image:
+            image: str = obj["image"]  # pylint: disable=invalid-sequence-index
+            if image.startswith(image_repo):
+                # Make sure that a command is not specified
+                self.assertNotIn("command", obj)
+                # Make sure that the first arg is never airflow
+                self.assertNotEqual(obj["args"][0], "airflow")  # pylint: disable=invalid-sequence-index


### PR DESCRIPTION
Hello again, 
Another very small fix to make the latest chart work.

Based on the airflow image entrypoint, we should use airflow commands directly (just like for everywhere else in the current chart).
The container exists otherwise.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
