### PR TITLE
Improve legibility with increased contrast ratio in footer and pagination

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -387,6 +387,7 @@ label[for="timezone-other"],
   bottom: 0;
   width: 100%;
   height: 60px;
+  color: #8e8e8d;
   background-color: #f5f5f5;
 }
 

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -210,7 +210,7 @@
       <div class="col-sm-6">
         {{paging}}
       </div>
-      <div class="col-sm-6 text-right text-muted">
+      <div class="col-sm-6 text-right">
         Showing <strong>{{num_dag_from}}-{{num_dag_to}}</strong> of <strong>{{num_of_all_dags}}</strong> DAGs
       </div>
     </div>

--- a/airflow/www/templates/airflow/master.html
+++ b/airflow/www/templates/airflow/master.html
@@ -62,7 +62,7 @@
   {% if not current_user.is_anonymous %}
     {% set version_label = 'Version' %}
     <footer class="footer">
-      <div class="container text-muted">
+      <div class="container">
         <div>
           {{ version_label }}: {% if airflow_version %}<a href="https://pypi.python.org/pypi/apache-airflow/{{ airflow_version }}" target="_blank">v{{ airflow_version }}</a>{% else %} N/A{% endif %}
           {% if git_version %}<br>Git Version:<strong>{{ git_version }}</strong>{% endif %}


### PR DESCRIPTION
The contrast ratio of the versioning text in the footer and page numbers on the DAGs (home) view were failing accessibility standards. This update increases the contrast rations to acceptable levels.

**Before:**

![image](https://user-images.githubusercontent.com/3267/96597477-e1b74200-12bb-11eb-8e63-d34352312e3b.png)

**After:**

![image](https://user-images.githubusercontent.com/3267/96597371-c2b8b000-12bb-11eb-9234-a8d20f2485c8.png)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
