### PR TITLE
Consistent use images in Helm Chart

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -104,7 +104,8 @@
 {{/*  Git sync container */}}
 {{- define "git_sync_container"}}
 - name: {{ .Values.dags.gitSync.containerName }}
-  image: "{{ .Values.dags.gitSync.containerRepository }}:{{ .Values.dags.gitSync.containerTag }}"
+  image: {{ template "git_sync_image" . }}
+  imagePullPolicy: {{ .Values.images.gitSync.pullPolicy }}
   securityContext:
     runAsUser: {{ .Values.dags.gitSync.uid }}
   env:
@@ -205,6 +206,10 @@
 
 {{ define "pgbouncer_exporter_image" -}}
 {{ printf "%s:%s" .Values.images.pgbouncerExporter.repository .Values.images.pgbouncerExporter.tag }}
+{{- end }}
+
+{{ define "git_sync_image" -}}
+{{ printf "%s:%s" .Values.images.gitSync.repository .Values.images.gitSync.tag }}
 {{- end }}
 
 {{ define "fernet_key_secret" -}}

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -63,6 +63,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       restartPolicy: Always
+      {{- if or .Values.registry.secretName .Values.registry.connection }}
+      imagePullSecrets:
+        - name: {{ template "registry_secret" . }}
+      {{- end }}
       containers:
         - name: pgbouncer
           image: {{ template "pgbouncer_image" . }}

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -117,6 +117,7 @@ spec:
                 command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
         - name: metrics-exporter
           image: {{ template "pgbouncer_exporter_image" . }}
+          imagePullPolicy: {{ .Values.images.pgbouncerExporter.pullPolicy }}
           env:
             - name: DATABASE_URL
               valueFrom:

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       containers:
         - name: redis
-          image: {{- include "redis_image" . | indent 1 }}
+          image: {{ template "redis_image" . }}
           imagePullPolicy: {{ .Values.images.redis.pullPolicy }}
           command: ["/bin/sh"]
           resources:

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -59,6 +59,10 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+      {{- if or .Values.registry.secretName .Values.registry.connection }}
+      imagePullSecrets:
+        - name: {{ template "registry_secret" . }}
+      {{- end }}
       containers:
         - name: redis
           image: {{ template "redis_image" . }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -172,6 +172,7 @@ spec:
         # we don't have elasticsearch enabled.
         - name: scheduler-logs
           image: {{ template "airflow_image" . }}
+          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["airflow", "serve_logs"]
           ports:
             - name: worker-logs

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -56,6 +56,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       restartPolicy: Always
+      {{- if or .Values.registry.secretName .Values.registry.connection }}
+      imagePullSecrets:
+        - name: {{ template "registry_secret" . }}
+      {{- end }}
       containers:
         - name: statsd
           image: {{ template "statsd_image" . }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: statsd
-          image: {{- include "statsd_image" . | indent 1 }}
+          image: {{ template "statsd_image" . }}
           imagePullPolicy: {{ .Values.images.statsd.pullPolicy }}
           args:
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -152,6 +152,7 @@ spec:
 {{- if $persistence }}
         - name: worker-gc
           image: {{ template "airflow_image" . }}
+          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args: ["bash", "/clean-logs"]
           volumeMounts:
             - name: logs

--- a/chart/tests/git-sync-scheduler_test.yaml
+++ b/chart/tests/git-sync-scheduler_test.yaml
@@ -29,12 +29,15 @@ tests:
           value: dags
   - it: validate the git sync container spec
     set:
+      images:
+        gitSync:
+          repository: test-registry/test-repo
+          tag: test-tag
+          pullPolicy: Allways
       dags:
         gitSync:
           enabled: true
           containerName: git-sync-test
-          containerTag: test-tag
-          containerRepository: test-registry/test-repo
           wait: 66
           maxFailures: 70
           subPath: "path1/path2"
@@ -57,6 +60,7 @@ tests:
             securityContext:
               runAsUser: 65533
             image: test-registry/test-repo:test-tag
+            imagePullPolicy: Allways
             env:
               - name: GIT_SYNC_REV
                 value: HEAD

--- a/chart/tests/pod-template-file_test.yaml
+++ b/chart/tests/pod-template-file_test.yaml
@@ -29,12 +29,15 @@ tests:
           value: base
   - it: should add an initContainer if gitSync is true
     set:
+      images:
+        gitSync:
+          repository: test-registry/test-repo
+          tag: test-tag
+          pullPolicy: Allways
       dags:
         gitSync:
           enabled: true
           containerName: git-sync-test
-          containerTag: test-tag
-          containerRepository: test-registry/test-repo
           wait: 66
           maxFailures: 70
           subPath: "path1/path2"
@@ -57,6 +60,7 @@ tests:
             securityContext:
               runAsUser: 65533
             image: test-registry/test-repo:test-tag
+            imagePullPolicy: Allways
             env:
               - name: GIT_SYNC_REV
                 value: HEAD

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -288,6 +288,24 @@
                             "type": "string"
                         }
                     }
+                },
+                "gitSync": {
+                    "description": "Configuration of the gitSync image.",
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "description": "The gitSync image repository.",
+                            "type": "string"
+                        },
+                        "tag": {
+                            "description": "The gitSync image tag.",
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "description": "The gitSync image pull policy.",
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },
@@ -1107,14 +1125,6 @@
                         "wait": {
                             "description": "Interval between git sync attempts in seconds.",
                             "type": "integer"
-                        },
-                        "containerRepository": {
-                            "description": "Git sync image repository.",
-                            "type": "string"
-                        },
-                        "containerTag": {
-                            "description": "Git sync image tag.",
-                            "type": "string"
                         },
                         "containerName": {
                             "description": "Git sync container name.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -147,6 +147,10 @@ images:
     repository: apache/airflow
     tag: airflow-pgbouncer-exporter-2020.09.25-0.5.0
     pullPolicy: IfNotPresent
+  gitSync:
+    repository: k8s.gcr.io/git-sync
+    tag: v3.1.6
+    pullPolicy: IfNotPresent
 
 # Environment variables for all airflow containers
 env: []
@@ -707,8 +711,5 @@ dags:
     #    <host2>,<ip2> <key2>
     # interval between git sync attempts in seconds
     wait: 60
-    # git sync image details
-    containerRepository: k8s.gcr.io/git-sync
-    containerTag: v3.1.6
     containerName: git-sync
     uid: 65533


### PR DESCRIPTION
- ImagePullPolicy attribute was always set for containers. Previously, the option was in the values.yaml file, but was not used. (`pgbouncerExporter`)
- Image setup for git sync was not in the "images" section. Now all images are in one place.
 - Minor simplifications of the template syntax without changing the behavior. Calling a similar template always uses the same syntax.
- All workloads supports image pull secret.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
