### PR TITLE
Add support for setting ciphers for SFTPHook

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -51,6 +51,7 @@ class SFTPHook(SSHHook):
 
         self.conn = None
         self.private_key_pass = None
+        self.ciphers = None
 
         # Fail for unverified hosts, unless this is explicitly allowed
         self.no_host_key_check = False
@@ -80,6 +81,9 @@ class SFTPHook(SSHHook):
 
                 if 'no_host_key_check' in extra_options:
                     self.no_host_key_check = str(extra_options['no_host_key_check']).lower() == 'true'
+                    
+                if 'ciphers' in extra_options:
+                    self.ciphers = extra_options['ciphers']
 
                 if 'private_key' in extra_options:
                     warnings.warn(
@@ -98,6 +102,7 @@ class SFTPHook(SSHHook):
             if self.no_host_key_check:
                 cnopts.hostkeys = None
             cnopts.compression = self.compress
+            cnopts.ciphers = self.ciphers
             conn_params = {
                 'host': self.remote_host,
                 'port': self.port,

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -145,6 +145,14 @@ class TestSFTPHook(unittest.TestCase):
         get_connection.return_value = connection
         hook = SFTPHook()
         self.assertEqual(hook.no_host_key_check, False)
+        
+    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
+    def test_ciphers(self, get_connection):
+        connection = Connection(login='login', host='host', extra='{"ciphers": ["A", "B", "C"]}')
+
+        get_connection.return_value = connection
+        hook = SFTPHook()
+        self.assertEqual(hook.ciphers, ["A", "B", "C"])
 
     @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
     def test_no_host_key_check_disabled_for_all_but_true(self, get_connection):


### PR DESCRIPTION
Adds support for an `extra_dejson["ciphers"]` value to be handed off to `pysftp` -- resolves #11560 