### PR TITLE
Re-introduce refresh_from_db

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -171,6 +171,7 @@ def task_run(args, dag=None):
 
     task = dag.get_task(task_id=args.task_id)
     ti = TaskInstance(task, args.execution_date)
+    ti.refresh_from_db()
     ti.init_run_context(raw=args.raw)
 
     hostname = get_hostname()

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -257,6 +257,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
     def setUp(self) -> None:
         self.dag_id = "test_logging_dag"
         self.task_id = "test_task"
+        self.dag_path = os.path.join(ROOT_FOLDER, "dags", "test_logging_in_dag.py")
         reset(self.dag_id)
         self.execution_date = timezone.make_aware(datetime(2017, 1, 1))
         self.execution_date_str = self.execution_date.isoformat()
@@ -297,7 +298,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
         #  We are not using self.assertLogs as we want to verify what actually is stored in the Log file
         # as that is what gets displayed
 
-        with conf_vars({('core', 'dags_folder'): os.path.join(ROOT_FOLDER, f"tests/dags/{self.dag_id}")}):
+        with conf_vars({('core', 'dags_folder'): self.dag_path}):
             task_command.task_run(self.parser.parse_args([
                 'tasks', 'run', self.dag_id, self.task_id, '--local', self.execution_date_str]))
 
@@ -324,7 +325,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
     def test_logging_with_run_task_subprocess(self):
         # We are not using self.assertLogs as we want to verify what actually is stored in the Log file
         # as that is what gets displayed
-        with conf_vars({('core', 'dags_folder'): os.path.join(ROOT_FOLDER, f"tests/dags/{self.dag_id}")}):
+        with conf_vars({('core', 'dags_folder'): self.dag_path}):
             task_command.task_run(self.parser.parse_args([
                 'tasks', 'run', self.dag_id, self.task_id, '--local', self.execution_date_str]))
 
@@ -349,7 +350,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
         """Verify that the taskinstance has the right context for log_filename_template"""
 
         with mock.patch.object(task_command, "_run_task_by_selected_method"):
-            with conf_vars({('core', 'dags_folder'): os.path.join(ROOT_FOLDER, f"tests/dags/{self.dag_id}")}):
+            with conf_vars({('core', 'dags_folder'): self.dag_path}):
                 # increment the try_number of the task to be run
                 dag = DagBag().get_dag(self.dag_id)
                 task = dag.get_task(self.task_id)

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -31,11 +31,12 @@ from airflow.cli import cli_parser
 from airflow.cli.commands import task_command
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.models import DagBag, TaskInstance
-from airflow.settings import Session
+from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.utils import timezone
 from airflow.utils.cli import get_dag
+from airflow.utils.session import create_session
 from airflow.utils.state import State
+from airflow.utils.types import DagRunType
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_pools, clear_db_runs
 
@@ -46,11 +47,11 @@ ROOT_FOLDER = os.path.realpath(
 
 
 def reset(dag_id):
-    session = Session()
-    tis = session.query(TaskInstance).filter_by(dag_id=dag_id)
-    tis.delete()
-    session.commit()
-    session.close()
+    with create_session() as session:
+        tis = session.query(TaskInstance).filter_by(dag_id=dag_id)
+        tis.delete()
+        runs = session.query(DagRun).filter_by(dag_id=dag_id)
+        runs.delete()
 
 
 class TestCliTasks(unittest.TestCase):
@@ -257,7 +258,8 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
         self.dag_id = "test_logging_dag"
         self.task_id = "test_task"
         reset(self.dag_id)
-        self.execution_date_str = timezone.make_aware(datetime(2017, 1, 1)).isoformat()
+        self.execution_date = timezone.make_aware(datetime(2017, 1, 1))
+        self.execution_date_str = self.execution_date.isoformat()
         self.log_dir = conf.get('logging', 'base_log_folder')
         self.log_filename = f"{self.dag_id}/{self.task_id}/{self.execution_date_str}/1.log"
         self.ti_log_file_path = os.path.join(self.log_dir, self.log_filename)
@@ -342,6 +344,43 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
                       f"'{self.task_id}', '{self.execution_date_str}',", logs)
         self.assertIn(f"INFO - Marking task as SUCCESS.dag_id={self.dag_id}, "
                       f"task_id={self.task_id}, execution_date=20170101T000000", logs)
+
+    def test_log_file_template_with_run_task(self):
+        """Verify that the taskinstance has the right context for log_filename_template"""
+
+        with mock.patch.object(task_command, "_run_task_by_selected_method"):
+            with conf_vars({('core', 'dags_folder'): os.path.join(ROOT_FOLDER, f"tests/dags/{self.dag_id}")}):
+                # increment the try_number of the task to be run
+                dag = DagBag().get_dag(self.dag_id)
+                task = dag.get_task(self.task_id)
+                with create_session() as session:
+                    dag.create_dagrun(
+                        execution_date=self.execution_date,
+                        start_date=timezone.utcnow(),
+                        state=State.RUNNING,
+                        run_type=DagRunType.MANUAL,
+                        session=session,
+                    )
+                    ti = TaskInstance(task, self.execution_date)
+                    ti.refresh_from_db(session=session, lock_for_update=True)
+                    ti.try_number = 1  # not running, so starts at 0
+                    session.merge(ti)
+
+                log_file_path = os.path.join(os.path.dirname(self.ti_log_file_path), "2.log")
+
+                try:
+                    task_command.task_run(
+                        self.parser.parse_args(
+                            ['tasks', 'run', self.dag_id, self.task_id, '--local', self.execution_date_str]
+                        )
+                    )
+
+                    assert os.path.exists(log_file_path)
+                finally:
+                    try:
+                        os.remove(log_file_path)
+                    except OSError:
+                        pass
 
 
 class TestCliTaskBackfill(unittest.TestCase):


### PR DESCRIPTION
The run context (logging context) accesses task instance attributes via the log_filename_template configuration.

Closes #11717.