### PR TITLE
Refactor "loading" state of DAGs view to remove visual jank

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -18,6 +18,7 @@
 #}
 
 {% extends base_template %}
+{% from 'appbuilder/loading_dots.html' import loading_dots %}
 
 {% block page_title %}
   {% if search_query %}
@@ -80,19 +81,14 @@
             <th>DAG</th>
             <th>Schedule</th>
             <th>Owner</th>
-            <th>
-              Recent Tasks
+            <th>Recent Tasks
               <span class="material-icons text-muted js-tooltip" aria-hidden="true" title="Status of tasks from all active DAG runs or, if not currently active, from most recent run.">info</span>
-              <img class="loading-task-stats" width="15" src="{{ url_for('static', filename='loading.gif') }}">
             </th>
-            <th>
-              Last Run
+            <th style="width:180px;">Last Run
               <span class="material-icons text-muted js-tooltip" aria-hidden="true" title="Execution Date/Time of Highest Dag Run.">info</span>
             </th>
-            <th>
-              DAG Runs
+            <th>DAG Runs
               <span class="material-icons text-muted js-tooltip" aria-hidden="true" title="Status of all previous DAG runs.">info</span>
-              <img class="loading-dag-stats"  width="15" src="{{ url_for('static', filename='loading.gif') }}">
             </th>
             <th class="text-center" style="width:205px;">Links</th>
             <th class="text-center" style="width:140px;">Actions</th>
@@ -141,18 +137,18 @@
               </td>
               {# Column 5: Recent Tasks #}
               <td style="padding:0; width:323px; height:10px;">
+                {{ loading_dots(classes='js-loading-task-stats text-muted') }}
                 <svg height="10" width="10" id='task-run-{{ dag.safe_dag_id }}' style="display: block;"></svg>
               </td>
               {# Column 6: Last Run #}
-              <td class="text-nowrap latest_dag_run">
-                <div height="10" width="10" id='last-run-{{ dag.safe_dag_id }}' style="display: block;">
-                  <a></a>
-                  <img class="loading-last-run" width="15" src="{{ url_for('static', filename='loading.gif') }}">
-                  <span aria-hidden="true" title=" " class="material-icons text-muted js-tooltip" style="display:none">info</span>
-                </div>
+              <td id="last-run-{{ dag.safe_dag_id }}" class="text-nowrap latest_dag_run">
+                {{ loading_dots(classes='js-loading-last-run text-muted') }}
+                <a></a>
+                <span aria-hidden="true" title=" " class="material-icons text-muted js-tooltip" style="display:none">info</span>
               </td>
               {# Column 7: Dag Runs #}
               <td style="padding:0; width:120px;">
+                {{ loading_dots(classes='js-loading-dag-stats text-muted') }}
                 <svg height="10" width="10" id='dag-run-{{ dag.safe_dag_id }}' style="display: block;"></svg>
               </td>
               {# Column 8: Links #}
@@ -372,7 +368,7 @@
         dag_id = json[safe_dag_id].dag_id;
         execution_date = json[safe_dag_id].execution_date;
         start_date = json[safe_dag_id].start_date;
-        g = d3.select('div#last-run-' + safe_dag_id)
+        g = d3.select('#last-run-' + safe_dag_id)
         g.selectAll('a')
           .attr('href', '{{ url_for('Airflow.graph') }}?dag_id=' + encodeURIComponent(dag_id) + '&execution_date=' + encodeURIComponent(execution_date))
           .insert(isoDateToTimeEl.bind(null, execution_date, {title: false}));
@@ -380,9 +376,9 @@
           // We don't translate the timezone in the tooltip, that stays in UTC.
           .attr('data-original-title', 'Start Date: ' + start_date)
           .style('display', null);
-        g.selectAll('.loading-last-run').remove();
+        g.selectAll('.js-loading-last-run').remove();
       }
-      d3.selectAll('.loading-last-run').remove();
+      $('.js-loading-last-run').remove();
     }
 
     function drawDagStatsForDag(dag_id, stats) {
@@ -444,7 +440,7 @@
         .style('opacity', 0)
         .transition().duration(300).delay(function(d, i){return i*50;})
         .style('opacity', 1);
-      d3.select('.loading-dag-stats').remove();
+      d3.select('.js-loading-dag-stats').remove();
 
       g.append('text')
         .attr('fill', '#51504f')
@@ -521,7 +517,7 @@
         .style('opacity', 0)
         .transition().duration(300).delay(function(d, i){return i*50;})
         .style('opacity', 1);
-      d3.select('.loading-task-stats').remove();
+      d3.select('.js-loading-task-stats').remove();
 
       g.append('text')
         .attr('fill', '#51504f')
@@ -555,9 +551,9 @@
         .post(encoded_dag_ids, taskStatsHandler);
     }
     else {
-      // no dags, hide the loading gifs
-      $('.loading-task-stats').remove();
-      $('.loading-dag-stats').remove();
+      // no dags, hide the loading dots
+      $('.js-loading-task-stats').remove();
+      $('.js-loading-dag-stats').remove();
     }
 
     function showSvgTooltip(text, circ) {

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -18,13 +18,13 @@
 #}
 
 {% extends "airflow/dag.html" %}
+{% from 'appbuilder/loading_dots.html' import loading_dots %}
 
 {% block page_title %}{{ dag.dag_id }} - Graph - Airflow{% endblock %}
 
 {% block head_css %}
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('graph.css') }}">
-  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('loadingDots.css') }}">
   <style type="text/css">
     {% for state, state_color in state_color_mapping.items() %}
       g.node.{{state}} rect {
@@ -97,11 +97,7 @@
   </div>
   <br>
   <div class="refresh-actions">
-    <span class="loading-dots refresh-loading" id="loading-dots" >
-      <span class="loading-dot"></span>
-      <span class="loading-dot"></span>
-      <span class="loading-dot"></span>
-    </span>
+    {{ loading_dots(id='loading-dots', classes='refresh-loading') }}
     <label class="switch-label">
       <input class="switch-input" id="auto_refresh" type="checkbox" {% if dag_run_state == 'running' %}checked{% endif %}>
       <span class="switch" aria-hidden="true"></span>

--- a/airflow/www/templates/airflow/master.html
+++ b/airflow/www/templates/airflow/master.html
@@ -28,6 +28,7 @@
   {% endif %}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('materialIcons.css') }}">
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('main.css') }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('loadingDots.css') }}">
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('bootstrap-datetimepicker.min.css') }}">
   <style type="text/css">
     {% for state, state_color in state_color_mapping.items() %}

--- a/airflow/www/templates/appbuilder/loading_dots.html
+++ b/airflow/www/templates/appbuilder/loading_dots.html
@@ -1,0 +1,24 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+{% macro loading_dots(id=None, classes=None) %}
+  <span class="loading-dots{% if classes %} {{ classes }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
+    <span class="loading-dot"></span><span class="loading-dot"></span><span class="loading-dot"></span>
+  </span>
+{% endmacro %}


### PR DESCRIPTION
This fixes the visual "jank" seen when loading the DAGs (home) view. Most of the unwanted shifting was being caused by the loading GIF images being shown briefly in the table header. This caused table cells to shift vertically and horizontally. The implementation was also a bit inconsistent in that it showed a loading state in two column headers ("Recent Tasks", "DAG Runs") and then in the individual cells of another ("Last Run"). I've remedied that by using the same placement for all three.

I've moved the new "loading dots" pattern (CSS only, no images) introduced in #11534 to a macro file so that it could be repurposed here as well. 


**Before:**

![Screen Recording 2020-10-21 at 02 05 15 PM](https://user-images.githubusercontent.com/3267/96759894-9e85cd80-13a6-11eb-95db-dd5d3ce60fa5.gif)

**After:**

![Screen Recording 2020-10-21 at 02 23 09 PM](https://user-images.githubusercontent.com/3267/96766389-01786400-13a9-11eb-8736-c2c31bee4044.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
