### PR TITLE
Allow Kubernetes ServiceAccount airflow-webserver to read pod logs

### DIFF
--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -56,6 +56,7 @@ rules:
       - "pods/log"
     verbs:
       - "get"
+      - "list"
   - apiGroups:
       - ""
     resources:

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -59,7 +59,7 @@ subjects:
     name: {{ .Release.Name }}-worker
     namespace: {{ .Release.Namespace }}
 {{- end }}
-- kind: ServiceAccount
-  name: {{ .Release.Name }}-webserver
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-webserver
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -59,4 +59,7 @@ subjects:
     name: {{ .Release.Name }}-worker
     namespace: {{ .Release.Namespace }}
 {{- end }}
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-webserver
+  namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Hello, this is small fix to the helm-chart. 
This is to give the *airflow-webserver* service account access to the pod logs.

related: #11696 