### PR TITLE
Stop scheduler from thinking that upstream_failed tasks are running

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -387,7 +387,7 @@ class DagRun(Base, LoggingMixin):
             ti.task = dag.get_task(ti.task_id)
 
         unfinished_tasks = [t for t in tis if t.state in State.unfinished]
-        finished_tasks = [t for t in tis if t.state in State.finished | {State.UPSTREAM_FAILED}]
+        finished_tasks = [t for t in tis if t.state in State.finished]
         none_depends_on_past = all(not t.task.depends_on_past for t in unfinished_tasks)
         none_task_concurrency = all(t.task.task_concurrency is None for t in unfinished_tasks)
         if unfinished_tasks:

--- a/airflow/ti_deps/dep_context.py
+++ b/airflow/ti_deps/dep_context.py
@@ -100,7 +100,7 @@ class DepContext:
             self.finished_tasks = dag.get_task_instances(
                 start_date=execution_date,
                 end_date=execution_date,
-                state=State.finished | {State.UPSTREAM_FAILED},
+                state=State.finished,
                 session=session,
             )
         return self.finished_tasks

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -107,11 +107,15 @@ class State:
         SUCCESS,
         FAILED,
         SKIPPED,
+        UPSTREAM_FAILED,
     ])
     """
-    A list of states indicating that a task started and completed a
-    run attempt. Note that the attempt could have resulted in failure or
-    have been interrupted; in any case, it is no longer running.
+    A list of states indicating a task has reached a terminal state (i.e. it has "finished") and needs no
+    further action.
+
+    Note that the attempt could have resulted in failure or have been
+    interrupted; or perhaps never run at all (skip, or upstream_failed) in any
+    case, it is no longer running.
     """
 
     unfinished = frozenset([

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -547,8 +547,7 @@ class TestTriggerRuleDep(unittest.TestCase):
         finished_tasks = DepContext().ensure_finished_tasks(ti_op2.task.dag, ti_op2.execution_date, session)
         self.assertEqual(get_states_count_upstream_ti(finished_tasks=finished_tasks, ti=ti_op2),
                          (1, 0, 0, 0, 1))
-        finished_tasks = dr.get_task_instances(state=State.finished | {State.UPSTREAM_FAILED},
-                                               session=session)
+        finished_tasks = dr.get_task_instances(state=State.finished, session=session)
         self.assertEqual(get_states_count_upstream_ti(finished_tasks=finished_tasks, ti=ti_op4),
                          (1, 0, 1, 0, 2))
         self.assertEqual(get_states_count_upstream_ti(finished_tasks=finished_tasks, ti=ti_op5),


### PR DESCRIPTION
This was messing up the "max_active_runs" calculation, and this fix is a
"hack" until we add a better approach of adding a queued state to
DagRuns -- at which point we don't even have to do this calculation at
all.

Closes #11633

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).