### PR TITLE
Improve web server stopping

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import textwrap
 import time
+from contextlib import suppress
 from time import sleep
 from typing import Dict, List, NoReturn
 
@@ -389,7 +390,10 @@ def webserver(args):
         def kill_proc(signum, _):  # pylint: disable=unused-argument
             log.info("Received signal: %s. Closing gunicorn.", signum)
             gunicorn_master_proc.terminate()
-            gunicorn_master_proc.wait()
+            with suppress(TimeoutError):
+                gunicorn_master_proc.wait(timeout=30)
+            if gunicorn_master_proc.poll() is not None:
+                gunicorn_master_proc.kill()
             sys.exit(0)
 
         def monitor_gunicorn(gunicorn_master_pid: int):


### PR DESCRIPTION
If we send signal `SIGTERM - 15`   several times to airflow webserver, then gunicorn can become [defunct process](https://askubuntu.com/questions/201303/what-is-a-defunct-process-and-why-doesnt-it-get-killed) and Airflow will not be able to handle this situation and wait in an endless loop. Re-sending the signal to Airflow will cause it to re-send the signal  `SIGTERM - 15` to gunicorn (but it will not receive it anyway) and then re-enter the endless loop. As a result, Airflow can only be stopped by signal `SIGKILL - -9`.

It is possible that it will fix some of the tests we have in quarantine.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
