### PR TITLE
Vault with optional Variables or Connections

### DIFF
--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -48,7 +48,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         (default: 'connections'). If set to None (null), requests for connections will not be sent to Vault.
     :type connections_path: str
     :param variables_path: Specifies the path of the secret to read to get Variable.
-        (default: 'variables'). Note that if set to None (null), requests for variables will not be sent to Vault.
+        (default: 'variables'). If set to None (null), requests for variables will not be sent to Vault.
     :type variables_path: str
     :param config_path: Specifies the path of the secret to read Airflow Configurations
         (default: 'configs').

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -48,7 +48,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         (default: 'connections').
     :type connections_path: str
     :param variables_path: Specifies the path of the secret to read to get Variables
-        (default: 'variables').
+        (default: None).
     :type variables_path: str
     :param config_path: Specifies the path of the secret to read Airflow Configurations
         (default: 'configs').

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -112,7 +112,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         connections_path: str = 'connections',
-        variables_path: str = 'variables',
+        variables_path: Optional[str] = None,
         config_path: str = 'config',
         url: Optional[str] = None,
         auth_type: str = 'token',
@@ -140,7 +140,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     ):
         super().__init__()
         self.connections_path = connections_path.rstrip('/')
-        if variables_path != None:
+        if variables_path is not None:
             self.variables_path = variables_path.rstrip('/')
         else:
             self.variables_path = variables_path
@@ -195,7 +195,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :rtype: str
         :return: Variable Value retrieved from the vault
         """
-        if self.variables_path == None:
+        if self.variables_path is None:
             return None
         else:
             secret_path = self.build_path(self.variables_path, key)

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -45,7 +45,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     conn_id ``smtp_default``.
 
     :param connections_path: Specifies the path of the secret to read to get Connections.
-        (default: 'connections'). Note that if set to None (null), requests for connections will not be sent to Vault.
+        (default: 'connections'). If set to None (null), requests for connections will not be sent to Vault.
     :type connections_path: str
     :param variables_path: Specifies the path of the secret to read to get Variable.
         (default: 'variables'). Note that if set to None (null), requests for variables will not be sent to Vault.

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -140,7 +140,10 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     ):
         super().__init__()
         self.connections_path = connections_path.rstrip('/')
-        self.variables_path = variables_path.rstrip('/')
+        if variables_path != None:
+            self.variables_path = variables_path.rstrip('/')
+        else:
+            self.variables_path = variables_path
         self.config_path = config_path.rstrip('/')
         self.mount_point = mount_point
         self.kv_engine_version = kv_engine_version
@@ -192,9 +195,12 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :rtype: str
         :return: Variable Value retrieved from the vault
         """
-        secret_path = self.build_path(self.variables_path, key)
-        response = self.vault_client.get_secret(secret_path=secret_path)
-        return response.get("value") if response else None
+        if self.variables_path == None:
+            return None
+        else:
+            secret_path = self.build_path(self.variables_path, key)
+            response = self.vault_client.get_secret(secret_path=secret_path)
+            return response.get("value") if response else None
 
     def get_config(self, key: str) -> Optional[str]:
         """

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -51,7 +51,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         (default: 'variables'). If set to None (null), requests for variables will not be sent to Vault.
     :type variables_path: str
     :param config_path: Specifies the path of the secret to read Airflow Configurations
-        (default: 'configs').
+        (default: 'configs'). If set to None (null), requests for configurations will not be sent to Vault.
     :type config_path: str
     :param url: Base URL for the Vault instance being addressed.
     :type url: str
@@ -147,7 +147,10 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
             self.variables_path = variables_path.rstrip('/')
         else:
             self.variables_path = variables_path
-        self.config_path = config_path.rstrip('/')
+        if config_path is not None:
+            self.config_path = config_path.rstrip('/')
+        else:
+            self.config_path = config_path
         self.mount_point = mount_point
         self.kv_engine_version = kv_engine_version
         self.vault_client = _VaultClient(
@@ -217,6 +220,9 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :rtype: str
         :return: Configuration Option Value retrieved from the vault
         """
-        secret_path = self.build_path(self.config_path, key)
-        response = self.vault_client.get_secret(secret_path=secret_path)
-        return response.get("value") if response else None
+        if self.config_path is None:
+            return None
+        else:
+            secret_path = self.build_path(self.config_path, key)
+            response = self.vault_client.get_secret(secret_path=secret_path)
+            return response.get("value") if response else None

--- a/tests/providers/hashicorp/secrets/test_vault.py
+++ b/tests/providers/hashicorp/secrets/test_vault.py
@@ -315,3 +315,37 @@ class TestVaultSecrets(TestCase):
         test_client = VaultBackend(**kwargs)
         returned_uri = test_client.get_config("sql_alchemy_conn")
         self.assertEqual('sqlite:////Users/airflow/airflow/airflow.db', returned_uri)
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_connections_path_none_value(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+
+        kwargs = {
+            "connections_path": None,
+            "mount_point": "airflow",
+            "auth_type": "token",
+            "url": "http://127.0.0.1:8200",
+            "token": "s.FnL7qg0YnHZDpf4zKKuFy0UK",
+        }
+
+        test_client = VaultBackend(**kwargs)
+        self.assertIsNone(test_client.get_conn_uri(conn_id="test"))
+        mock_hvac.Client.assert_not_called()
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_variables_path_none_value(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+
+        kwargs = {
+            "variables_path": None,
+            "mount_point": "airflow",
+            "auth_type": "token",
+            "url": "http://127.0.0.1:8200",
+            "token": "s.FnL7qg0YnHZDpf4zKKuFy0UK",
+        }
+
+        test_client = VaultBackend(**kwargs)
+        self.assertIsNone(test_client.get_variable("hello"))
+        mock_hvac.Client.assert_not_called()

--- a/tests/providers/hashicorp/secrets/test_vault.py
+++ b/tests/providers/hashicorp/secrets/test_vault.py
@@ -349,3 +349,20 @@ class TestVaultSecrets(TestCase):
         test_client = VaultBackend(**kwargs)
         self.assertIsNone(test_client.get_variable("hello"))
         mock_hvac.Client.assert_not_called()
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_config_path_none_value(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+
+        kwargs = {
+            "config_path": None,
+            "mount_point": "airflow",
+            "auth_type": "token",
+            "url": "http://127.0.0.1:8200",
+            "token": "s.FnL7qg0YnHZDpf4zKKuFy0UK",
+        }
+
+        test_client = VaultBackend(**kwargs)
+        self.assertIsNone(test_client.get_config("test"))
+        mock_hvac.Client.assert_not_called()


### PR DESCRIPTION
In some cases organizations may not want to use Vault for Airflow Variable, but instead for Airflow Connections only. The proposed PR makes Variables optional in Vault when using Vault as the Alternative Secrets Backend.

The changes here eliminate Airflow requests to Vault when the `variables_path` parameter is not defined in `backend_kwargs`. Thus reducing the burden on Vault deployments and reduced error messages when only Connection are truly implemented.
