### PR TITLE
Fix: add support for no-menu plugin views (#10788)

### DIFF
--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -111,8 +111,14 @@ def init_plugins(app):
     appbuilder = app.appbuilder
 
     for view in plugins_manager.flask_appbuilder_views:
-        log.debug("Adding view %s", view["name"])
-        appbuilder.add_view(view["view"], view["name"], category=view["category"])
+        name = view.get('name')
+        if name:
+            log.debug("Adding view %s with menu", name)
+            appbuilder.add_view(view["view"], name, category=view["category"])
+        else:
+            # if 'name' key is missing, intent is to add view without menu
+            log.debug("Adding view %s without menu", str(type(view["view"])))
+            appbuilder.add_view_no_menu(view["view"])
 
     for menu_link in sorted(plugins_manager.flask_appbuilder_menu_links, key=lambda x: x["name"]):
         log.debug("Adding menu link %s", menu_link["name"])

--- a/docs/apache-airflow/plugins.rst
+++ b/docs/apache-airflow/plugins.rst
@@ -192,10 +192,23 @@ definitions in Airflow.
         def test(self):
             return self.render("test_plugin/test.html", content="Hello galaxy!")
 
+    # Creating a flask appbuilder BaseView
+    class TestAppBuilderBaseNoMenuView(AppBuilderBaseView):
+        default_view = "test"
+
+        @expose("/")
+        def test(self):
+            return self.render("test_plugin/test.html", content="Hello galaxy!")
+
     v_appbuilder_view = TestAppBuilderBaseView()
     v_appbuilder_package = {"name": "Test View",
                             "category": "Test Plugin",
                             "view": v_appbuilder_view}
+
+    v_appbuilder_nomenu_view = TestAppBuilderBaseNoMenuView()
+    v_appbuilder_nomenu_package = {
+        "view": v_appbuilder_nomenu_view
+    }
 
     # Creating a flask appbuilder Menu Item
     appbuilder_mitem = {"name": "Google",
@@ -233,7 +246,7 @@ definitions in Airflow.
         hooks = [PluginHook]
         macros = [plugin_macro]
         flask_blueprints = [bp]
-        appbuilder_views = [v_appbuilder_package]
+        appbuilder_views = [v_appbuilder_package, v_appbuilder_nomenu_package]
         appbuilder_menu_items = [appbuilder_mitem]
         global_operator_extra_links = [GoogleLink(),]
         operator_extra_links = [S3LogLink(), ]
@@ -245,6 +258,9 @@ Note on role based views
 Airflow 1.10 introduced role based views using FlaskAppBuilder. You can configure which UI is used by setting
 ``rbac = True``. To support plugin views and links for both versions of the UI and maintain backwards compatibility,
 the fields ``appbuilder_views`` and ``appbuilder_menu_items`` were added to the ``AirflowTestPlugin`` class.
+
+``appbuilder_views`` supports both views-with-menu and views-without-menu - to add a view with menu link, add a "name"
+key in view's package dictionary, otherwise the view is added to flask appbuilder without menu item.
 
 Exclude views from CSRF protection
 ----------------------------------

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -75,6 +75,8 @@ class PluginTestAppBuilderBaseView(AppBuilderBaseView):
 v_appbuilder_view = PluginTestAppBuilderBaseView()
 v_appbuilder_package = {"name": "Test View", "category": "Test Plugin", "view": v_appbuilder_view}
 
+v_nomenu_appbuilder_package = {"view": v_appbuilder_view}
+
 # Creating a flask appbuilder Menu Item
 appbuilder_mitem = {
     "name": "Google",

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -59,6 +59,23 @@ class TestPluginsRBAC(unittest.TestCase):
         self.assertEqual(link.name, v_appbuilder_package['category'])
         self.assertEqual(link.childs[0].name, v_appbuilder_package['name'])
 
+    def test_flaskappbuilder_nomenu_views(self):
+        from tests.plugins.test_plugin import v_nomenu_appbuilder_package
+
+        class AirflowNoMenuViewsPlugin(AirflowPlugin):
+            appbuilder_views = [v_nomenu_appbuilder_package]
+
+        appbuilder_class_name = str(v_nomenu_appbuilder_package['view'].__class__.__name__)
+
+        with mock_plugin_manager(plugins=[AirflowNoMenuViewsPlugin()]):
+            appbuilder = application.create_app(testing=True).appbuilder  # pylint: disable=no-member
+
+            plugin_views = [
+                view for view in appbuilder.baseviews if view.blueprint.name == appbuilder_class_name
+            ]
+
+            self.assertTrue(len(plugin_views) == 1)
+
     def test_flaskappbuilder_menu_links(self):
         from tests.plugins.test_plugin import appbuilder_mitem
 


### PR DESCRIPTION
closes: #10788

old PR: #10987

Adds support in Airflow to add custom views from plugins without associating a menu entry. If "name" key is missing in the given plugin view, then it adds the view without menu, otherwise it behaves as usual by adding a view with menu.

Read the Pull Request Guidelines for more information.
In case of fundamental code change, Airflow Improvement Proposal (AIP) is needed.
In case of a new dependency, check compliance with the ASF 3rd Party License Policy.
In case of backwards incompatible changes please leave a note in UPDATING.md.