### PR TITLE
Docs: Typo in Smart sensor

### DIFF
--- a/docs/smart-sensor.rst
+++ b/docs/smart-sensor.rst
@@ -69,12 +69,12 @@ Add the following settings in the ``airflow.cfg``:
 
     # Users can change the following config based on their requirements
     shards = 5
-    sensor_enabled = NamedHivePartitionSensor, MetastorePartitionSensor
+    sensors_enabled = NamedHivePartitionSensor, MetastorePartitionSensor
 
 *   ``use_smart_sensor``: This config indicates if the smart sensor is enabled.
 *   ``shards``: This config indicates the number of concurrently running smart sensor jobs for
     the airflow cluster.
-*   ``sensor_enabled``: This config is a list of sensor class names that will use the smart sensor.
+*   ``sensors_enabled``: This config is a list of sensor class names that will use the smart sensor.
     The users use the same class names (e.g. HivePartitionSensor) in their DAGs and they don’t have
     the control to use smart sensors or not, unless they exclude their tasks explicitly.
 


### PR DESCRIPTION
``sensors_enabled`` config key was mistyped.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
