### PR TITLE
Update pod template - only include subPath for dags mount if gitSync is enabled

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -54,7 +54,7 @@ spec:
         - mountPath: {{ include "airflow_dags_mount_path" . }}
           name: dags
           readOnly: true
-{{- if and .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
+{{- if .Values.dags.gitSync.enabled }}
           subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
 {{- end }}

--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -54,7 +54,7 @@ spec:
         - mountPath: {{ include "airflow_dags_mount_path" . }}
           name: dags
           readOnly: true
-{{- if .Values.dags.persistence.enabled }}
+{{- if and .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
           subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Hi together,
I experienced an issue when mounting my **dags folder** from an externally populated PVC like described [here](https://github.com/apache/airflow/tree/master/chart#mounting-dags-from-an-externally-populated-pvc). Problem was that the **subPath** was still set in the dags mount even though gitSync was disabled - so the dag files were not found. 

It's loosely related to #11696 , as I was also experiencing this issue also there but that issue is about access to the pod logs from the WebUI.