### PR TITLE
Fix: Override FAB styling

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -432,3 +432,9 @@ label[for="timezone-other"],
   top: 2px;
   border: 0;
 }
+
+/* Overrides undesireable styling rendered by FAB markup */
+.dropdown-menu .filter.btn {
+  border: 0;
+  border-radius: 0;
+}


### PR DESCRIPTION
FAB is going against [Boostrap's Dropdown guidelines](https://getbootstrap.com/docs/3.3/components/#dropdowns) by  adding a `btn` class on the anchors within the drop-down menus. This yields some undesirable styling. This PR offers a simple CSS override to improve the aesthetics.

| Before | After |
|---|---|
| <img width="272" alt="Image 2020-10-22 at 4 31 32 PM" src="https://user-images.githubusercontent.com/3267/96927116-956b2e00-1484-11eb-8836-267c1c6422eb.png">  |  <img width="230" alt="Image 2020-10-22 at 4 30 52 PM" src="https://user-images.githubusercontent.com/3267/96927121-9734f180-1484-11eb-88d7-0f3cba415573.png"> |





---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
