### PR TITLE
Fix: Removed password if HiveServer2Hook in LDAP or CUSTOM mode

### DIFF
--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -814,6 +814,7 @@ class HiveServer2Hook(DbApiHook):
     def get_conn(self, schema: Optional[str] = None) -> Any:
         """Returns a Hive connection object."""
         username: Optional[str] = None
+        password: Optional[str] = None
         # pylint: disable=no-member
         db = self.get_connection(self.hiveserver2_conn_id)  # type: ignore
 
@@ -834,6 +835,10 @@ class HiveServer2Hook(DbApiHook):
             )
             auth_mechanism = 'KERBEROS'
 
+        # Password should be set if and only if in LDAP or CUSTOM mode
+        if auth_mechanism in ('LDAP', 'CUSTOM'):
+            password = db.password
+
         from pyhive.hive import connect
 
         return connect(
@@ -842,7 +847,7 @@ class HiveServer2Hook(DbApiHook):
             auth=auth_mechanism,
             kerberos_service_name=kerberos_service_name,
             username=db.login or username,
-            password=db.password,
+            password=password,
             database=schema or db.schema or 'default',
         )
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR includes a possible fix for issue https://github.com/apache/airflow/issues/11275 of HiveServer2Hook:

```
  File "/usr/local/lib/python3.7/site-packages/airflow/hooks/hive_hooks.py", line 833, in get_conn
    database=schema or db.schema or 'default')
  File "/usr/local/lib/python3.7/site-packages/pyhive/hive.py", line 94, in connect
    return Connection(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pyhive/hive.py", line 123, in __init__
    raise ValueError("Password should be set if and only if in LDAP or CUSTOM mode; "
ValueError: Password should be set if and only if in LDAP or CUSTOM mode; Remove password or use one of those modes
```

It will set the `password` to `None` for pyhive connect if auth mechanism is not in `LDAP` or `CUSTOM` mode.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
