### PR TITLE
Add test types displayed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,9 @@ jobs:
 
   tests-postgres:
     timeout-minutes: 60
-    name: "Postgres${{matrix.postgres-version}},Py${{matrix.python-version}}"
+    name: >
+      Postgres${{matrix.postgres-version}},Py${{matrix.python-version}}:
+      ${{needs.build-info.outputs.testTypes}}
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     strategy:
@@ -441,7 +443,7 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       POSTGRES_VERSION: ${{ matrix.postgres-version }}
       RUN_TESTS: true
-      TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
+      TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
@@ -457,7 +459,7 @@ jobs:
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
-      - name: "Tests"
+      - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
         run: ./scripts/ci/testing/ci_run_airflow_testing.sh
       - name: "Upload airflow logs"
         uses: actions/upload-artifact@v2
@@ -480,7 +482,8 @@ jobs:
 
   tests-mysql:
     timeout-minutes: 60
-    name: "MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}"
+    name: >
+      MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}: ${{needs.build-info.outputs.testTypes}}
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     strategy:
@@ -494,7 +497,7 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       MYSQL_VERSION: ${{ matrix.mysql-version }}
       RUN_TESTS: true
-      TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
+      TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
@@ -510,7 +513,7 @@ jobs:
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
-      - name: "Tests"
+      - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
         run: ./scripts/ci/testing/ci_run_airflow_testing.sh
       - name: "Upload airflow logs"
         uses: actions/upload-artifact@v2
@@ -532,7 +535,8 @@ jobs:
 
   tests-sqlite:
     timeout-minutes: 60
-    name: "Sqlite Py${{matrix.python-version}}"
+    name: >
+      Sqlite Py${{matrix.python-version}}: ${{needs.build-info.outputs.testTypes}}
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     strategy:
@@ -544,7 +548,7 @@ jobs:
       BACKEND: sqlite
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       RUN_TESTS: true
-      TEST_TYPES: ${{needs.build-info.outputs.testTypes}}
+      TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
         needs.build-info.outputs.run-tests == 'true' &&
@@ -560,7 +564,7 @@ jobs:
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
-      - name: "Tests"
+      - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
         run: ./scripts/ci/testing/ci_run_airflow_testing.sh
       - name: "Upload airflow logs"
         uses: actions/upload-artifact@v2
@@ -628,7 +632,7 @@ jobs:
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
-      - name: "Tests"
+      - name: "Tests: Quarantined"
         run: ./scripts/ci/testing/ci_run_airflow_testing.sh
       - name: "Upload Quarantine test results"
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This is a follow up after #11659. Thanks to this one, it will
be immediately visible in CI which types of tests are run.

This change has been lost during one of the rebases, so it is
brought back now.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
