### PR TITLE
Improve the visual presentation of the variable import form

### DIFF
--- a/airflow/www/templates/airflow/variable_list.html
+++ b/airflow/www/templates/airflow/variable_list.html
@@ -20,13 +20,20 @@
 {% extends 'appbuilder/general/model/list.html' %}
 
 {% block content %}
-  <form class="form-inline" action="{{ url_for('VariableModelView.varimport') }}" method=post enctype=multipart/form-data style="margin-top: 50px;">
-    {% if csrf_token %}
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-    {% endif %}
-    <input class="form-control-file" type="file" name="file">
-    <input class="btn btn-default" type="submit" value="Import Variables"/>
-  </form>
-  <hr>
+  <div class="well well-sm pull-left">
+    <form class="form-inline" action="{{ url_for('VariableModelView.varimport') }}" method="post" enctype="multipart/form-data">
+      {% if csrf_token %}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      {% endif %}
+      <div class="form-group">
+        <input class="form-control-file" type="file" name="file">
+      </div>
+      <button type="submit" class="btn">
+        <span class="material-icons">cloud_upload</span>
+        Import Variables
+      </button>
+    </form>
+  </div>
+  <div class="clearfix"></div>
   {{ super() }}
 {% endblock %}


### PR DESCRIPTION
No functional changes, just visual enhancement of the variable import form. This simply refactors the markup slightly to better utilize some Bootstrap styling and add an icon to the button.

**Before:**

<img width="898" alt="Image 2020-10-23 at 10 53 05 AM" src="https://user-images.githubusercontent.com/3267/97019381-407bf600-151e-11eb-8297-3063225089cc.png">

**After:**

<img width="899" alt="Image 2020-10-23 at 10 52 42 AM" src="https://user-images.githubusercontent.com/3267/97019401-45d94080-151e-11eb-8b03-cccd52394875.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
