### PR TITLE
Switch postgres from 10 to 13

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1717,7 +1717,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --postgres-version POSTGRES_VERSION
           Postgres version used. One of:
 
-                 9.6 10
+                 9.6 10 11 12 13
 
   --mysql-version MYSQL_VERSION
           Mysql version used. One of:
@@ -2112,7 +2112,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
   --postgres-version POSTGRES_VERSION
           Postgres version used. One of:
 
-                 9.6 10
+                 9.6 10 11 12 13
 
   --mysql-version MYSQL_VERSION
           Mysql version used. One of:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Apache Airflow is tested with:
 |              | Master version (2.0.0dev) | Stable version (1.10.12) |
 | ------------ | ------------------------- | ------------------------ |
 | Python       | 3.6, 3.7, 3.8             | 2.7, 3.5, 3.6, 3.7, 3.8  |
-| PostgreSQL   | 9.6, 10                   | 9.6, 10                  |
+| PostgreSQL   | 9.6, 10, 11, 12, 13       | 9.6, 10, 11, 12, 13      |
 | MySQL        | 5.7, 8                    | 5.6, 5.7                 |
 | SQLite       | latest stable             | latest stable            |
 | Kubernetes   | 1.16.2, 1.17.0            | 1.16.2, 1.17.0           |

--- a/breeze-complete
+++ b/breeze-complete
@@ -31,7 +31,7 @@ _breeze_allowed_kubernetes_versions="v1.18.6 v1.17.5 v1.16.9"
 _breeze_allowed_helm_versions="v3.2.4"
 _breeze_allowed_kind_versions="v0.8.0"
 _breeze_allowed_mysql_versions="5.7 8"
-_breeze_allowed_postgres_versions="9.6 10"
+_breeze_allowed_postgres_versions="9.6 10 11 12 13"
 _breeze_allowed_kind_operations="start stop restart status deploy test shell"
 _breeze_allowed_test_types="All Core Providers API CLI Integration Other WWW Heisentests Postgres MySQL"
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -94,7 +94,7 @@ function initialization::initialize_base_variables() {
     export CURRENT_PYTHON_MAJOR_MINOR_VERSIONS
 
     # Currently supported versions of Postgres
-    CURRENT_POSTGRES_VERSIONS+=("9.6" "10")
+    CURRENT_POSTGRES_VERSIONS+=("9.6" "13")
     export CURRENT_POSTGRES_VERSIONS
 
     # Currently supported versions of MySQL

--- a/tests/bats/breeze/test_breeze_complete.bats
+++ b/tests/bats/breeze/test_breeze_complete.bats
@@ -244,7 +244,17 @@
   #shellcheck source=breeze-complete
   source "${AIRFLOW_SOURCES}/breeze-complete"
 
-  assert_equal "${_breeze_allowed_postgres_versions}" "${CURRENT_POSTGRES_VERSIONS[*]}"
+  local version
+  for version in  "${CURRENT_POSTGRES_VERSIONS[@]}"
+  do
+      if [[ " ${_breeze_allowed_postgres_versions} " == *" ${version} "* ]]; then
+          continue
+      else
+          echo "${version} missing in ${_breeze_allowed_postgres_versions}"
+          exit 1
+      fi
+  done
+
 }
 
 @test "Test default Postgres version same as POSTGRES_VERSION" {


### PR DESCRIPTION
Seems that postgres is really stable when it comes to upgrades,
so we take the assumption that if we test 9.6 and 13, and they
work, all the versions between will also work.

This PR changes Postgres 10 to 13 in tests  and updates documentation
with all the versions in between.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
