### PR TITLE
Fix interaction with Recent Tasks/DAG Runs circles

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -211,7 +211,7 @@
       </div>
     </div>
   </div>
-  <div id="svg-tooltip" class="tooltip top" style="position: fixed; display: none; opacity: 1">
+  <div id="svg-tooltip" class="tooltip top" style="position: fixed; display: none; opacity: 1; pointer-events: none;">
     <div class="tooltip-arrow"></div>
     <div class="tooltip-inner"></div>
   </div>
@@ -448,6 +448,7 @@
         .attr('vertical-align', 'middle')
         .attr('font-size', 8)
         .attr('y', 3)
+        .style('pointer-events', 'none')
         .text(function(d){ return d.count > 0 ? d.count : ''; });
     }
 
@@ -525,6 +526,7 @@
         .attr('vertical-align', 'middle')
         .attr('font-size', 8)
         .attr('y', 3)
+        .style('pointer-events', 'none')
         .text(function(d){ return d.count > 0 ? d.count : ''; });
     }
 


### PR DESCRIPTION
Resolves #11563. With the hover event triggering the tooltips, the tooltip was triggering a mouse-out event when the cursor was at the top of the circle (where the tooltip is presented). This was causing the fluttering behavior due to the looping off these events.

| Before | After |
|---|---|
| ![Screen Recording 2020-10-23 at 12 25 36 PM](https://user-images.githubusercontent.com/3267/97029076-e59ccb80-152a-11eb-86bd-43606ee89530.gif)  | ![Screen Recording 2020-10-23 at 12 23 31 PM](https://user-images.githubusercontent.com/3267/97028805-9e163f80-152a-11eb-9809-7ed72d75e458.gif)  |

Another tangentially related fix that I've included in this PR is ignoring the pointer-events of the inner SVG `<text />` elements where counts are displayed. This was causing the cursor to change when hovered, lose the circle hover styling, and more importantly, it was causing clicks directly on the text to be ignored.

| Before | After |
|---|---|
| ![Screen Recording 2020-10-23 at 12 27 28 PM](https://user-images.githubusercontent.com/3267/97029288-36acbf80-152b-11eb-9190-f2d723b262a4.gif)  |  ![Screen Recording 2020-10-23 at 12 24 20 PM](https://user-images.githubusercontent.com/3267/97028899-b8e8b400-152a-11eb-92d9-925b0df129dd.gif) |


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
