### PR TITLE
Standardize the Airflow CLI help descriptions to all start with a cap…

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1290,7 +1290,7 @@ airflow_commands: List[CLICommand] = [
     ),
     GroupCommand(
         name="kubernetes",
-        help='tools to help run the KubernetesExecutor',
+        help='Tools to help run the KubernetesExecutor',
         subcommands=KUBERNETES_COMMANDS
     ),
     GroupCommand(


### PR DESCRIPTION
…ital letter

Before:

![Screen Shot 2020-10-24 at 3 42 15 am](https://user-images.githubusercontent.com/418747/97037304-75368e80-15ac-11eb-8bd4-856fb25e7e2d.png)

After:

![Screen Shot 2020-10-24 at 3 43 18 am](https://user-images.githubusercontent.com/418747/97037327-7e276000-15ac-11eb-9752-3f72561909d2.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
