### PR TITLE
Use LocalExecutor by default with tmux + Breeze

### DIFF
--- a/scripts/in_container/run_tmux.sh
+++ b/scripts/in_container/run_tmux.sh
@@ -21,7 +21,10 @@ if [[ ${START_AIRFLOW:="false"} == "true" ]]; then
 
     export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
     export AIRFLOW__CORE__LOAD_EXAMPLES=${LOAD_EXAMPLES}
-    export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
+
+    if [[ ${BACKEND} != "sqlite"  ]]; then
+        export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
+    fi
 
     #this is because I run docker in WSL - Hi Bill!
     export TMUX_TMPDIR=~/.tmux/tmp

--- a/scripts/in_container/run_tmux.sh
+++ b/scripts/in_container/run_tmux.sh
@@ -22,6 +22,8 @@ if [[ ${START_AIRFLOW:="false"} == "true" ]]; then
     export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
     export AIRFLOW__CORE__LOAD_EXAMPLES=${LOAD_EXAMPLES}
 
+    # Use LocalExecutor if not set and if backend is not sqlite as it gives
+    # better performance
     if [[ ${BACKEND} != "sqlite"  ]]; then
         export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
     fi

--- a/scripts/in_container/run_tmux.sh
+++ b/scripts/in_container/run_tmux.sh
@@ -21,6 +21,7 @@ if [[ ${START_AIRFLOW:="false"} == "true" ]]; then
 
     export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
     export AIRFLOW__CORE__LOAD_EXAMPLES=${LOAD_EXAMPLES}
+    export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
 
     #this is because I run docker in WSL - Hi Bill!
     export TMUX_TMPDIR=~/.tmux/tmp


### PR DESCRIPTION
By default, it would be good to use `LocalExecutor` if not set in env file when started with breeze + tmux using `./breeze start-airflow`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
