### PR TITLE
[AIRFLOW-8664] Postgres to GCS operator - use named cursor

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_postgres_to_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_postgres_to_gcs.py
@@ -18,11 +18,14 @@
 """
 Example DAG using PostgresToGoogleCloudStorageOperator.
 """
+import os
+
 from airflow import models
 from airflow.providers.google.cloud.transfers.postgres_to_gcs import PostgresToGCSOperator
 from airflow.utils.dates import days_ago
 
-GCS_BUCKET = "postgres_to_gcs_example"
+PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
+GCS_BUCKET = os.environ.get("GCP_GCS_BUCKET_NAME", "postgres_to_gcs_example")
 FILENAME = "test_file"
 SQL_QUERY = "select * from test_table;"
 
@@ -34,4 +37,13 @@ with models.DAG(
 ) as dag:
     upload_data = PostgresToGCSOperator(
         task_id="get_data", sql=SQL_QUERY, bucket=GCS_BUCKET, filename=FILENAME, gzip=False
+    )
+
+    upload_data_server_side_cursor = PostgresToGCSOperator(
+        task_id="get_data_with_server_side_cursor",
+        sql=SQL_QUERY,
+        bucket=GCS_BUCKET,
+        filename=FILENAME,
+        gzip=False,
+        use_server_side_cursor=True,
     )

--- a/tests/providers/google/cloud/transfers/test_postgres_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_postgres_to_gcs.py
@@ -81,6 +81,14 @@ class TestPostgresToGoogleCloudStorageOperator(unittest.TestCase):
         self.assertEqual(op.bucket, BUCKET)
         self.assertEqual(op.filename, FILENAME)
 
+    def _assert_uploaded_file_content(self, bucket, obj, tmp_filename, mime_type, gzip):
+        self.assertEqual(BUCKET, bucket)
+        self.assertEqual(FILENAME.format(0), obj)
+        self.assertEqual('application/json', mime_type)
+        self.assertFalse(gzip)
+        with open(tmp_filename, 'rb') as file:
+            self.assertEqual(b''.join(NDJSON_LINES), file.read())
+
     @patch('airflow.providers.google.cloud.transfers.sql_to_gcs.GCSHook')
     def test_exec_success(self, gcs_hook_mock_class):
         """Test the execute function in case where the run is successful."""
@@ -89,17 +97,23 @@ class TestPostgresToGoogleCloudStorageOperator(unittest.TestCase):
         )
 
         gcs_hook_mock = gcs_hook_mock_class.return_value
+        gcs_hook_mock.upload.side_effect = self._assert_uploaded_file_content
+        op.execute(None)
 
-        def _assert_upload(bucket, obj, tmp_filename, mime_type, gzip):
-            self.assertEqual(BUCKET, bucket)
-            self.assertEqual(FILENAME.format(0), obj)
-            self.assertEqual('application/json', mime_type)
-            self.assertFalse(gzip)
-            with open(tmp_filename, 'rb') as file:
-                self.assertEqual(b''.join(NDJSON_LINES), file.read())
-
-        gcs_hook_mock.upload.side_effect = _assert_upload
-
+    @patch('airflow.providers.google.cloud.transfers.sql_to_gcs.GCSHook')
+    def test_exec_success_server_side_cursor(self, gcs_hook_mock_class):
+        """Test the execute in case where the run is successful while using server side cursor."""
+        op = PostgresToGCSOperator(
+            task_id=TASK_ID,
+            postgres_conn_id=POSTGRES_CONN_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=FILENAME,
+            use_server_side_cursor=True,
+            cursor_itersize=100,
+        )
+        gcs_hook_mock = gcs_hook_mock_class.return_value
+        gcs_hook_mock.upload.side_effect = self._assert_uploaded_file_content
         op.execute(None)
 
     @patch('airflow.providers.google.cloud.transfers.sql_to_gcs.GCSHook')

--- a/tests/providers/google/cloud/transfers/test_postgres_to_gcs_system.py
+++ b/tests/providers/google/cloud/transfers/test_postgres_to_gcs_system.py
@@ -18,11 +18,11 @@
 import pytest
 from psycopg2 import ProgrammingError
 
+from airflow.providers.google.cloud.example_dags.example_postgres_to_gcs import GCS_BUCKET
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
 from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTest, provide_gcp_context
 
-GCS_BUCKET = "postgres_to_gcs_example"
 CREATE_QUERY = """
 CREATE TABLE public.test_table
 (
@@ -55,6 +55,7 @@ DELETE_QUERY = "DROP TABLE public.test_table;"
 
 
 @pytest.mark.backend("postgres")
+@pytest.mark.system("google.cloud")
 @pytest.mark.credential_file(GCP_GCS_KEY)
 class PostgresToGCSSystemTest(GoogleSystemTest):
     @staticmethod


### PR DESCRIPTION
Hello!

Implemented feature for postgres_to_gcs operator that allows to use server side cursor. More in the issue https://github.com/apache/airflow/issues/8664

I was thinking about multiple designs to generalize it a bit more, but in the end went with straight forward solution on doing it only for postgres db, while keeping it consistent with presto_to_gcs operator. If there would be more demand for server-side cursors implemented on other dbs as well (mssql, mysql), generalization can be done then.

btw, had great experience with Breeze, absolutely love it! I was sceptic and was counting on "this will help you develop, but it will yield 100 errors anyway" experience, but it was really a breeze - install, read docs, run. nice!

Thanks!