### PR TITLE
Fix backwards compatibility with k8s executor_config resources

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -221,19 +221,22 @@ class PodGenerator:
 
         if resources is None:
             requests = {
-                'cpu': namespaced.get('request_cpu'),
-                'memory': namespaced.get('request_memory'),
-                'ephemeral-storage': namespaced.get('ephemeral-storage')
+                'cpu': namespaced.pop('request_cpu', None),
+                'memory': namespaced.pop('request_memory', None),
+                'ephemeral-storage': namespaced.get('ephemeral-storage')    # We pop this one in limits
             }
             limits = {
-                'cpu': namespaced.get('limit_cpu'),
-                'memory': namespaced.get('limit_memory'),
-                'ephemeral-storage': namespaced.get('ephemeral-storage')
+                'cpu': namespaced.pop('limit_cpu', None),
+                'memory': namespaced.pop('limit_memory', None),
+                'ephemeral-storage': namespaced.pop('ephemeral-storage', None)
             }
             all_resources = list(requests.values()) + list(limits.values())
             if all(r is None for r in all_resources):
                 resources = None
             else:
+                # remove None's so they don't become 0's
+                requests = {k: v for k, v in requests.items() if v is not None}
+                limits = {k: v for k, v in limits.items() if v is not None}
                 resources = k8s.V1ResourceRequirements(
                     requests=requests,
                     limits=limits


### PR DESCRIPTION
Ran across this issue when testing out the Airflow 2.0.0 alpha 1, specifically the backwards compatibility of resources via `executor_config`:

```
PythonOperator(
        task_id="eat",
        python_callable=eat,
        executor_config={
            "KubernetesExecutor": {"request_memory": "128Mi", "limit_memory": "128Mi",},
        },
    )
```

Results in:
```
/some/path/site-packages/airflow/kubernetes/pod_generator.py:202: DeprecationWarning: Using a dictionary for the executor_config is deprecated and will soon be removed.please use a `kubernetes.client.models.V1Pod` class with a "pod_
override" key instead.                                                                    
  category=DeprecationWarning)                                                                                                                       
[2020-10-23 15:21:06,806] {scheduler_job.py:1335} ERROR - Exception when executing SchedulerJob._run_scheduler_loop                                                                                      
Traceback (most recent call last):                                                                                                                                                                       
  File "/some/path/site-packages/airflow/jobs/scheduler_job.py", line 1316, in _execute
    self._run_scheduler_loop()
  File "/some/path/site-packages/airflow/jobs/scheduler_job.py", line 1391, in _run_scheduler_loop
    self.executor.heartbeat()
  File "/some/path/site-packages/airflow/executors/base_executor.py", line 156, in heartbeat
    self.trigger_tasks(open_slots)
  File "/some/path/site-packages/airflow/executors/base_executor.py", line 188, in trigger_tasks
    executor_config=ti.executor_config)
  File "/some/path/site-packages/airflow/executors/kubernetes_executor.py", line 612, in execute_async
    kube_executor_config = PodGenerator.from_obj(executor_config)
  File "/some/path/site-packages/airflow/kubernetes/pod_generator.py", line 203, in from_obj
    return PodGenerator.from_legacy_obj(obj)
  File "/some/path/site-packages/airflow/kubernetes/pod_generator.py", line 244, in from_legacy_obj
    return PodGeneratorDeprecated(**namespaced).gen_pod()
TypeError: __init__() got an unexpected keyword argument 'request_memory'
```

I did look for test coverage for the backwards compatibility layer but came up empty. Did I miss it?