### PR TITLE
Fix locking issue stopping tasks running with SequentialExecutor

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1542,6 +1542,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                     return 0
                 raise
 
+            guard.commit()
             return num_queued_tis
 
     def _create_dag_runs(self, dag_models: Iterable[DagModel], session: Session) -> None:


### PR DESCRIPTION
Missing a commit means that the the row level lock was not released
before `executor.heartbeat()` was called.  This was only a problem for
the SequentialExecutor, as all the other executors would continue
running the scheduler code so the lock would be released shortly after
tasks are sent to the executor anyway. (Where as SequentialExecutor
doesn't return control until tasks have run!)

Fixes #11788 #11787


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).