### PR TITLE
Fix bug when marking tasks when DAG Serialization is enabled

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -181,7 +181,7 @@ def get_subdag_runs(dag, session, state, task_ids, commit, confirmed_dates):
                 continue
 
             current_task = current_dag.get_task(task_id)
-            if isinstance(current_task, SubDagOperator):
+            if isinstance(current_task, SubDagOperator) or current_task.task_type == "SubDagOperator":
                 # this works as a kind of integrity check
                 # it creates missing dag runs for subdag operators,
                 # maybe this should be moved to dagrun.verify_integrity


### PR DESCRIPTION
This is because `current_task` is of SerializedBaseOperator type.

tests would be covered in https://github.com/apache/airflow/pull/11335 where we update all the tests to enable DAG Serialization.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
