### PR TITLE
Remove loading DagBag multiple times in test_views.py:TestDecorators

### DIFF
--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2961,6 +2961,9 @@ class TestDecorators(TestBase):
         super().setUpClass()
         dagbag = models.DagBag(include_examples=True)
         DAG.bulk_write_to_db(dagbag.dags.values())
+        cls.bash_dag = dagbag.dags['example_bash_operator']
+        cls.sub_dag = dagbag.dags['example_subdag_operator']
+        cls.xcom_dag = dagbag.dags['example_xcom']
 
     def setUp(self):
         super().setUp()
@@ -2970,11 +2973,6 @@ class TestDecorators(TestBase):
         self.prepare_dagruns()
 
     def prepare_dagruns(self):
-        dagbag = models.DagBag(include_examples=True)
-        self.bash_dag = dagbag.dags['example_bash_operator']
-        self.sub_dag = dagbag.dags['example_subdag_operator']
-        self.xcom_dag = dagbag.dags['example_xcom']
-
         self.bash_dagrun = self.bash_dag.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=self.EXAMPLE_DAG_DEFAULT_DATE,


### PR DESCRIPTION
Previously we were loading DagBag twice, once in `setUpClass` and once in `setUp` (which is called everytime a test in that class is run)

This will be enforced by PyUpgrade in #11447 -- which will be merged before 2.0 beta since it can cause conflicts for many PRs since it changes format to f-string that touches a large number of files

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
