### PR TITLE
Use PEP 380: Syntax for Delegating to a Subgenerator

### DIFF
--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -128,8 +128,7 @@ class TaskGroup(TaskMixin):
     def __iter__(self):
         for child in self.children.values():
             if isinstance(child, TaskGroup):
-                for inner_task in child:
-                    yield inner_task
+                yield from child
             else:
                 yield child
 

--- a/tests/test_utils/mock_process.py
+++ b/tests/test_utils/mock_process.py
@@ -84,5 +84,4 @@ class MockConnectionCursor:
         return self.iterable
 
     def __iter__(self):
-        for i in self.iterable:
-            yield i
+        yield from self.iterable


### PR DESCRIPTION
Since Master is Py 3.6>= we can use PEP 380 which was introduced in Python 3.3.

https://docs.python.org/3/whatsnew/3.3.html#pep-380

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
