### PR TITLE
Use Python 3 style super classes

### DIFF
--- a/airflow/api_connexion/exceptions.py
+++ b/airflow/api_connexion/exceptions.py
@@ -78,7 +78,7 @@ class NotFound(ProblemException):
     def __init__(
         self, title: str = 'Not Found', detail: Optional[str] = None, headers: Optional[Dict] = None, **kwargs
     ):
-        super(NotFound, self).__init__(
+        super().__init__(
             status=404, type=EXCEPTIONS_LINK_MAP[404], title=title, detail=detail, headers=headers, **kwargs
         )
 
@@ -93,7 +93,7 @@ class BadRequest(ProblemException):
         headers: Optional[Dict] = None,
         **kwargs,
     ):
-        super(BadRequest, self).__init__(
+        super().__init__(
             status=400, type=EXCEPTIONS_LINK_MAP[400], title=title, detail=detail, headers=headers, **kwargs
         )
 
@@ -108,7 +108,7 @@ class Unauthenticated(ProblemException):
         headers: Optional[Dict] = None,
         **kwargs,
     ):
-        super(Unauthenticated, self).__init__(
+        super().__init__(
             status=401, type=EXCEPTIONS_LINK_MAP[401], title=title, detail=detail, headers=headers, **kwargs
         )
 
@@ -119,7 +119,7 @@ class PermissionDenied(ProblemException):
     def __init__(
         self, title: str = 'Forbidden', detail: Optional[str] = None, headers: Optional[Dict] = None, **kwargs
     ):
-        super(PermissionDenied, self).__init__(
+        super().__init__(
             status=403, type=EXCEPTIONS_LINK_MAP[403], title=title, detail=detail, headers=headers, **kwargs
         )
 
@@ -130,7 +130,7 @@ class AlreadyExists(ProblemException):
     def __init__(
         self, title='Conflict', detail: Optional[str] = None, headers: Optional[Dict] = None, **kwargs
     ):
-        super(AlreadyExists, self).__init__(
+        super().__init__(
             status=409, type=EXCEPTIONS_LINK_MAP[409], title=title, detail=detail, headers=headers, **kwargs
         )
 
@@ -145,6 +145,6 @@ class Unknown(ProblemException):
         headers: Optional[Dict] = None,
         **kwargs,
     ):
-        super(Unknown, self).__init__(
+        super().__init__(
             status=500, type=EXCEPTIONS_LINK_MAP[500], title=title, detail=detail, headers=headers, **kwargs
         )

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -75,7 +75,7 @@ class AwsGlueJobOperator(BaseOperator):
         iam_role_name: Optional[str] = None,
         **kwargs,
     ):  # pylint: disable=too-many-arguments
-        super(AwsGlueJobOperator, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.job_name = job_name
         self.job_desc = job_desc
         self.script_location = script_location

--- a/airflow/providers/apache/livy/hooks/livy.py
+++ b/airflow/providers/apache/livy/hooks/livy.py
@@ -65,7 +65,7 @@ class LivyHook(HttpHook, LoggingMixin):
     _def_headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
 
     def __init__(self, livy_conn_id: str = 'livy_default') -> None:
-        super(LivyHook, self).__init__(http_conn_id=livy_conn_id)
+        super().__init__(http_conn_id=livy_conn_id)
 
     def get_conn(self, headers: Optional[Dict[str, Any]] = None) -> Any:
         """

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -41,7 +41,7 @@ class ExasolHook(DbApiHook):
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:
-        super(ExasolHook, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.schema = kwargs.pop("schema", None)
 
     def get_conn(self) -> ExaConnection:
@@ -167,7 +167,7 @@ class ExasolHook(DbApiHook):
         """
         autocommit = conn.attr.get('autocommit')
         if autocommit is None:
-            autocommit = super(ExasolHook, self).get_autocommit(conn)
+            autocommit = super().get_autocommit(conn)
         return autocommit
 
     @staticmethod

--- a/airflow/providers/exasol/operators/exasol.py
+++ b/airflow/providers/exasol/operators/exasol.py
@@ -56,7 +56,7 @@ class ExasolOperator(BaseOperator):
         schema: Optional[str] = None,
         **kwargs,
     ) -> None:
-        super(ExasolOperator, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.exasol_conn_id = exasol_conn_id
         self.sql = sql
         self.autocommit = autocommit

--- a/airflow/providers/google/cloud/hooks/gdm.py
+++ b/airflow/providers/google/cloud/hooks/gdm.py
@@ -37,7 +37,7 @@ class GoogleDeploymentManagerHook(GoogleBaseHook):  # pylint: disable=abstract-m
         delegate_to: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
     ) -> None:
-        super(GoogleDeploymentManagerHook, self).__init__(
+        super().__init__(
             gcp_conn_id=gcp_conn_id,
             delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,

--- a/airflow/providers/google/marketing_platform/operators/analytics.py
+++ b/airflow/providers/google/marketing_platform/operators/analytics.py
@@ -460,7 +460,7 @@ class GoogleAnalyticsModifyFileHeadersDataImportOperator(BaseOperator):
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
-        super(GoogleAnalyticsModifyFileHeadersDataImportOperator, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.storage_bucket = storage_bucket
         self.storage_name_object = storage_name_object
         self.gcp_conn_id = gcp_conn_id

--- a/airflow/providers/singularity/operators/singularity.py
+++ b/airflow/providers/singularity/operators/singularity.py
@@ -87,7 +87,7 @@ class SingularityOperator(BaseOperator):
         **kwargs,
     ) -> None:
 
-        super(SingularityOperator, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.auto_remove = auto_remove
         self.command = command
         self.start_command = start_command

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -206,7 +206,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         self.filename = filename
         self.filetype = filetype
         self.content = content
-        super(SlackAPIFileOperator, self).__init__(method=self.method, **kwargs)
+        super().__init__(method=self.method, **kwargs)
 
     def construct_api_call_params(self) -> Any:
         self.api_params = {

--- a/airflow/providers/snowflake/transfers/snowflake_to_slack.py
+++ b/airflow/providers/snowflake/transfers/snowflake_to_slack.py
@@ -84,7 +84,7 @@ class SnowflakeToSlackOperator(BaseOperator):
         slack_token: Optional[str] = None,
         **kwargs,
     ) -> None:
-        super(SnowflakeToSlackOperator, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.snowflake_conn_id = snowflake_conn_id
         self.sql = sql

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -46,7 +46,7 @@ class DateTimeWithTimezoneField(Field):
     widget = widgets.TextInput()
 
     def __init__(self, label=None, validators=None, datetime_format='%Y-%m-%d %H:%M:%S%Z', **kwargs):
-        super(DateTimeWithTimezoneField, self).__init__(label, validators, **kwargs)
+        super().__init__(label, validators, **kwargs)
         self.format = datetime_format
         self.data = None
 


### PR DESCRIPTION
example:

```
super().__init__(label, validators, **kwargs)
```

instead of
```
super(DateTimeWithTimezoneField, self).__init__(label, validators, **kwargs)
```

This will be enforced by PyUpgrade in https://github.com/apache/airflow/pull/11447 -- which will be merged before 2.0 beta since it can cause conflicts for many PRs since it changes format to f-string that touches a large number of files

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
