### PR TITLE
Replace io.open with builtin open

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import io
 import logging
 import os
 import re
@@ -83,7 +82,7 @@ def open_maybe_zipped(fileloc, mode='r'):
     if archive and zipfile.is_zipfile(archive):
         return zipfile.ZipFile(archive, mode=mode).open(filename)
     else:
-        return io.open(fileloc, mode=mode)
+        return open(fileloc, mode=mode)
 
 
 def find_path_from_directory(

--- a/provider_packages/SETUP_TEMPLATE.py.jinja2
+++ b/provider_packages/SETUP_TEMPLATE.py.jinja2
@@ -26,7 +26,6 @@
 
 """Setup.py for the {{ PACKAGE_PIP_NAME }} package."""
 
-import io
 import logging
 import os
 import sys
@@ -41,9 +40,7 @@ version = '{{ RELEASE_NO_LEADING_ZEROS }}{{VERSION_SUFFIX }}'
 my_dir = dirname(__file__)
 
 try:
-    with io.open(os.path.join(my_dir,
-                              '{{ PROVIDER_PATH }}/{{ README_FILE }}'),
-                 encoding='utf-8') as f:
+    with open(os.path.join(my_dir, '{{ PROVIDER_PATH }}/{{ README_FILE }}'), encoding='utf-8') as f:
         long_description = f.read()
 except FileNotFoundError:
     long_description = ''

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@
 # under the License.
 """Setup.py for the Airflow project."""
 
-import io
 import logging
 import os
 import subprocess
@@ -43,7 +42,7 @@ PY3 = sys.version_info[0] == 3
 my_dir = dirname(__file__)
 
 try:
-    with io.open(os.path.join(my_dir, 'README.md'), encoding='utf-8') as f:
+    with open(os.path.join(my_dir, 'README.md'), encoding='utf-8') as f:
         long_description = f.read()
 except FileNotFoundError:
     long_description = ''

--- a/tests/build_provider_packages_dependencies.py
+++ b/tests/build_provider_packages_dependencies.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import io
 import json
 import os
 import sys
@@ -152,7 +151,7 @@ def get_imports_from_file(file_name: str) -> List[str]:
     :return: list of import names
     """
     try:
-        with io.open(file_name, "rt", encoding="utf-8") as f:
+        with open(file_name, "rt", encoding="utf-8") as f:
             root = parse(f.read(), file_name)
     except Exception:
         print(f"Error when opening file {file_name}", file=sys.stderr)
@@ -245,7 +244,7 @@ if __name__ == '__main__':
         print(f"Written provider dependencies to the file {provider_dependencies_file_name}")
         print()
     if documentation_file_name:
-        with io.open(documentation_file_name, "r", encoding="utf-8") as documentation_file:
+        with open(documentation_file_name, "r", encoding="utf-8") as documentation_file:
             text = documentation_file.readlines()
         replacing = False
         result: List[str] = []
@@ -258,7 +257,7 @@ if __name__ == '__main__':
                 replacing = False
             if not replacing:
                 result.append(line)
-        with io.open(documentation_file_name, "w", encoding="utf-8") as documentation_file:
+        with open(documentation_file_name, "w", encoding="utf-8") as documentation_file:
             documentation_file.write("".join(result))
         print()
         print(f"Written package extras to the file {documentation_file_name}")

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -542,13 +542,13 @@ class TestCorrectMaybeZipped(unittest.TestCase):
 
 class TestOpenMaybeZipped(unittest.TestCase):
     def test_open_maybe_zipped_normal_file(self):
-        with mock.patch('open', mock.mock_open(read_data="data")) as mock_file:
+        with mock.patch('builtins.open', mock.mock_open(read_data="data")) as mock_file:
             open_maybe_zipped('/path/to/some/file.txt')
             mock_file.assert_called_once_with('/path/to/some/file.txt', mode='r')
 
     def test_open_maybe_zipped_normal_file_with_zip_in_name(self):
         path = '/path/to/fakearchive.zip.other/file.txt'
-        with mock.patch('open', mock.mock_open(read_data="data")) as mock_file:
+        with mock.patch('builtins.open', mock.mock_open(read_data="data")) as mock_file:
             open_maybe_zipped(path)
             mock_file.assert_called_once_with(path, mode='r')
 

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -542,17 +542,13 @@ class TestCorrectMaybeZipped(unittest.TestCase):
 
 class TestOpenMaybeZipped(unittest.TestCase):
     def test_open_maybe_zipped_normal_file(self):
-        with mock.patch(
-            'io.open', mock.mock_open(read_data="data")
-        ) as mock_file:
+        with mock.patch('open', mock.mock_open(read_data="data")) as mock_file:
             open_maybe_zipped('/path/to/some/file.txt')
             mock_file.assert_called_once_with('/path/to/some/file.txt', mode='r')
 
     def test_open_maybe_zipped_normal_file_with_zip_in_name(self):
         path = '/path/to/fakearchive.zip.other/file.txt'
-        with mock.patch(
-            'io.open', mock.mock_open(read_data="data")
-        ) as mock_file:
+        with mock.patch('open', mock.mock_open(read_data="data")) as mock_file:
             open_maybe_zipped(path)
             mock_file.assert_called_once_with(path, mode='r')
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -818,7 +818,7 @@ class TestAirflowBaseViews(TestBase):
         url = 'code?dag_id=example_bash_operator'
         mock_open_patch = mock.mock_open(read_data='')
         mock_open_patch.side_effect = FileNotFoundError
-        with mock.patch('io.open', mock_open_patch):
+        with mock.patch('builtins.open', mock_open_patch):
             resp = self.client.get(url, follow_redirects=True)
             self.check_content_in_response('Failed to load file', resp)
             self.check_content_in_response('example_bash_operator', resp)


### PR DESCRIPTION
From Python 3 `io.open` is an alias for the builtin `open()` function.

Docs: https://docs.python.org/3/library/io.html#io.open

This will be enforced by PyUpgrade in #11447 -- which will be merged before 2.0 beta since it can cause conflicts for many PRs since it changes format to f-string that touches a large number of files

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
