### PR TITLE
Remove redundant "UTF-8" in Python 3

### DIFF
--- a/tests/providers/google/cloud/_internal_client/test_secret_manager_client.py
+++ b/tests/providers/google/cloud/_internal_client/test_secret_manager_client.py
@@ -77,7 +77,7 @@ class TestSecretManagerClient(TestCase):
         mock_secrets_client.return_value = mock_client
         mock_client.secret_version_path.return_value = "full-path"
         test_response = AccessSecretVersionResponse()
-        test_response.payload.data = "result".encode("UTF-8")
+        test_response.payload.data = "result".encode()
         mock_client.access_secret_version.return_value = test_response
         secrets_client = _SecretManagerClient(credentials="credentials")
         secret = secrets_client.get_secret(secret_id="existing", project_id="project_id")
@@ -93,7 +93,7 @@ class TestSecretManagerClient(TestCase):
         mock_secrets_client.return_value = mock_client
         mock_client.secret_version_path.return_value = "full-path"
         test_response = AccessSecretVersionResponse()
-        test_response.payload.data = "result".encode("UTF-8")
+        test_response.payload.data = "result".encode()
         mock_client.access_secret_version.return_value = test_response
         secrets_client = _SecretManagerClient(credentials="credentials")
         secret = secrets_client.get_secret(

--- a/tests/providers/google/cloud/hooks/test_secret_manager.py
+++ b/tests/providers/google/cloud/hooks/test_secret_manager.py
@@ -59,7 +59,7 @@ class TestSecretsManagerHook(unittest.TestCase):
     def test_get_existing_key(self, mock_get_credentials, mock_client):
         mock_client.secret_version_path.return_value = "full-path"
         test_response = AccessSecretVersionResponse()
-        test_response.payload.data = "result".encode("UTF-8")
+        test_response.payload.data = "result".encode()
         mock_client.access_secret_version.return_value = test_response
         secrets_manager_hook = SecretsManagerHook(gcp_conn_id='test')
         mock_get_credentials.assert_called_once_with()


### PR DESCRIPTION
```
In [1]: "result".encode("UTF-8")
Out[1]: b'result'

In [2]: "result".encode()
Out[2]: b'result'
```

This will be enforced by PyUpgrade in #11447 -- which will be merged before 2.0 beta since it can cause conflicts for many PRs since it changes format to f-string that touches a large number of files



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
