### PR TITLE
Remove redundant builtins imports

### DIFF
--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import unicode_literals
 
 import os.path
 from typing import Optional

--- a/airflow/smart_sensor_dags/smart_sensor_group.py
+++ b/airflow/smart_sensor_dags/smart_sensor_group.py
@@ -17,7 +17,6 @@
 # under the License.
 
 """Smart sensor DAGs managing all smart sensor tasks."""
-from builtins import range
 from datetime import timedelta
 
 from airflow.configuration import conf


### PR DESCRIPTION
These imports are not needed in Python3

This will be enforced by PyUpgrade in #11447 -- which will be merged before 2.0 beta since it can cause conflicts for many PRs since it changes format to f-string that touches a large number of files



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
