### PR TITLE
Replace non-empty sets with set literals

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2073,7 +2073,7 @@ class DagModel(Base):
             .all()
         )
 
-        paused_dag_ids = set(paused_dag_id for paused_dag_id, in paused_dag_ids)
+        paused_dag_ids = {paused_dag_id for paused_dag_id, in paused_dag_ids}
         return paused_dag_ids
 
     def get_default_view(self) -> str:

--- a/airflow/providers/plexus/operators/job.py
+++ b/airflow/providers/plexus/operators/job.py
@@ -50,7 +50,7 @@ class PlexusJobOperator(BaseOperator):
         super().__init__(**kwargs)
 
         self.job_params = job_params
-        self.required_params = set(["name", "app", "queue", "num_cores", "num_nodes"])
+        self.required_params = {"name", "app", "queue", "num_cores", "num_nodes"}
         self.lookups = {
             "app": ("apps/", "id", "name"),
             "billing_account_id": ("users/{}/billingaccounts/", "id", None),

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -271,18 +271,18 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
     def get_readable_dag_ids(self, user) -> Set[str]:
         """Gets the DAG IDs readable by authenticated user."""
-        return set(dag.dag_id for dag in self.get_readable_dags(user))
+        return {dag.dag_id for dag in self.get_readable_dags(user)}
 
     def get_editable_dag_ids(self, user) -> Set[str]:
         """Gets the DAG IDs editable by authenticated user."""
-        return set(dag.dag_id for dag in self.get_editable_dags(user))
+        return {dag.dag_id for dag in self.get_editable_dags(user)}
 
     def get_accessible_dag_ids(self, user) -> Set[str]:
         """Gets the DAG IDs editable or readable by authenticated user."""
         accessible_dags = self.get_accessible_dags(
             [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ], user
         )
-        return set(dag.dag_id for dag in accessible_dags)
+        return {dag.dag_id for dag in accessible_dags}
 
     @provide_session
     def get_accessible_dags(self, user_actions, user, session=None):

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -54,7 +54,7 @@ def get_sensitive_variables_fields():
     sensitive_fields = set(DEFAULT_SENSITIVE_VARIABLE_FIELDS)
     sensitive_variable_fields = conf.get('admin', 'sensitive_variable_fields')
     if sensitive_variable_fields:
-        sensitive_fields.update(set(field.strip() for field in sensitive_variable_fields.split(',')))
+        sensitive_fields.update({field.strip() for field in sensitive_variable_fields.split(',')})
     return sensitive_fields
 
 

--- a/tests/core/test_project_structure.py
+++ b/tests/core/test_project_structure.py
@@ -93,12 +93,12 @@ class TestProjectStructure(unittest.TestCase):
         missing_tests_files = expected_test_files - expected_test_files.intersection(current_test_files)
 
         with self.subTest("Detect missing tests in providers module"):
-            expected_missing_test_modules = set(pair[1] for pair in expected_missing_providers_modules)
+            expected_missing_test_modules = {pair[1] for pair in expected_missing_providers_modules}
             missing_tests_files = missing_tests_files - set(expected_missing_test_modules)
             self.assertEqual(set(), missing_tests_files)
 
         with self.subTest("Verify removed deprecated module also removed from deprecated list"):
-            expected_missing_modules = set(pair[0] for pair in expected_missing_providers_modules)
+            expected_missing_modules = {pair[0] for pair in expected_missing_providers_modules}
             removed_deprecated_module = expected_missing_modules - modules_files
             if removed_deprecated_module:
                 self.fail(
@@ -144,7 +144,7 @@ class TestGoogleProviderProjectStructure(unittest.TestCase):
             return False
 
         with self.subTest("Detect missing example dags"):
-            missing_example = set(s for s in operator_sets if not has_example_dag(s))
+            missing_example = {s for s in operator_sets if not has_example_dag(s)}
             missing_example -= self.MISSING_EXAMPLE_DAGS
             self.assertEqual(set(), missing_example)
 

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -297,8 +297,8 @@ class TestDagFileProcessorManager(unittest.TestCase):
             assert fake_processors[-1]._file_path == test_dag_path
             callback_requests = fake_processors[-1]._callback_requests
             assert (
-                set(zombie.simple_task_instance.key for zombie in expected_failure_callback_requests) ==
-                set(result.simple_task_instance.key for result in callback_requests)
+                {zombie.simple_task_instance.key for zombie in expected_failure_callback_requests} ==
+                {result.simple_task_instance.key for result in callback_requests}
             )
 
             child_pipe.close()


### PR DESCRIPTION
Example:

```python
{paused_dag_id for paused_dag_id, in paused_dag_ids}
```

Instead of

```python
set(paused_dag_id for paused_dag_id, in paused_dag_ids)
```

This will be enforced by PyUpgrade in #11447 -- which will be merged before 2.0 beta since it can cause conflicts for many PRs since it changes format to f-string that touches a large number of files



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
