### PR TITLE
Fixes flaky test test_should_response_200_with_reset_dag_run

### DIFF
--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -836,7 +836,8 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
                 'task_id': 'sleep_for_3',
             },
         ]
-        self.assertEqual(expected_response, response.json["task_instances"])
+        for task_instance in expected_response:
+            self.assertIn(task_instance, response.json["task_instances"])
         self.assertEqual(5, len(response.json["task_instances"]))
         self.assertEqual(0, failed_dag_runs, 0)
 


### PR DESCRIPTION
Sometimes the rows were returned in reverse order.

Fixes #11816

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
