### PR TITLE
Update download url for Airflow Providers Version

### DIFF
--- a/provider_packages/SETUP_TEMPLATE.py.jinja2
+++ b/provider_packages/SETUP_TEMPLATE.py.jinja2
@@ -79,7 +79,7 @@ def do_setup(version_suffix_for_pypi=''):
         author_email='dev@airflow.apache.org',
         url='http://airflow.apache.org/',
         download_url=(
-            'https://dist.apache.org/repos/dist/release/airflow/{{ PROVIDERS_FOLDER }}' + version),
+            'https://archive.apache.org/dist/airflow/{{ PROVIDERS_FOLDER }}' + version),
         python_requires='~=3.6',
         project_urls={
             'Documentation': 'https://airflow.apache.org/docs/',


### PR DESCRIPTION
All the versions are available at https://archive.apache.org/dist/airflow/ and this link appears in https://pypi.org/project/apache-airflow/

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
