### PR TITLE
Adds newly added fast CI jobs to "fail-fast" cancelling

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -112,8 +112,8 @@ jobs:
           sourceRunId: ${{ github.event.workflow_run.id }}
           notifyPRCancel: true
           jobNameRegexps: >
-            ["^Pylint$", "^Static checks$", "^Build docs$", "^Spell check docs$", "^Backport packages$",
-             "^Checks: Helm tests$", "^Test OpenAPI*"]
+            ["^Pylint$", "^Static checks", "^Build docs$", "^Spell check docs$", "^Backport packages$",
+             "^Provider packages", "^Checks: Helm tests$", "^Test OpenAPI*"]
       - name: "Extract canceled failed runs"
 
         # We use this step to build regexp that will be used to match the Source Run id in


### PR DESCRIPTION
We "fail-fast" the whole workflow run if we the queue is busy and
we notice that there is a failing "fast" job - i.e. job that
probably failed rather fast, and you will have to rerun the build
anyway, so cancelling tests for the build that is going to be
re-pushed again is a nice thing to do for others.

There were two jobs added recently that did not match the
regexp for job names.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
