### PR TITLE
Constraints generation runs regardless from test status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -885,18 +885,11 @@ jobs:
       fail-fast: false
     needs:
       - build-info
-      - static-checks
-      - static-checks-pylint
-      - tests-sqlite
-      - tests-mysql
-      - tests-postgres
-      - tests-kubernetes
     env:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
     if: >
       needs.build-info.outputs.basic-checks-only == 'false' &&
       (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' ) &&
-      github.event_name != 'pull' &&
       (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -921,11 +914,18 @@ jobs:
     timeout-minutes: 10
     name: "Constraints push"
     runs-on: ubuntu-latest
-    needs: [build-info, constraints]
+    needs:
+      - build-info
+      - constraints
+      - static-checks
+      - static-checks-pylint
+      - tests-sqlite
+      - tests-mysql
+      - tests-postgres
+      - tests-kubernetes
     if: >
       needs.build-info.outputs.basic-checks-only == 'false' &&
       (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' ) &&
-      github.event_name != 'pull' &&
       (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"


### PR DESCRIPTION
Constraints generation did not run when tests were failing
but this was wrong. In case of tests that fail due to constraints
upgrade we neeed to see the output of constraint generation, to
know which constraints failed. Only pushing the constraint
should be limited to the case where everything succeeded.

This should make investigation of problems similar to #11837 much
easier.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
