### PR TITLE
Fix issue with moving end_date in elastic dag

### DIFF
--- a/tests/test_utils/perf/scheduler_dag_execution_timing.py
+++ b/tests/test_utils/perf/scheduler_dag_execution_timing.py
@@ -22,6 +22,7 @@ import sys
 import textwrap
 import time
 from argparse import Namespace
+from datetime import datetime, timedelta
 from operator import attrgetter
 
 import click
@@ -236,6 +237,7 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
 
     # Set this so that dags can dynamically configure their end_date
     os.environ['AIRFLOW_BENCHMARK_MAX_DAG_RUNS'] = str(num_runs)
+    os.environ['PERF_START_DATE'] = str(datetime.utcnow() - timedelta(hours=1))
     os.environ['PERF_MAX_RUNS'] = str(num_runs)
 
     if pre_create_dag_runs:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
---
This PR addresses an issue in the elastic DAG with moving `end_date` when using "PERF_MAX_RUNS" environment variable. Because `end_date` is derived from `start_date`, and `start_date` being defined as `datetime.now() - parse_time_delta(START_DATE_ENV)` constantly changes, this causes `end_date` to move forward in time as well. While  (from what I understand) the `start_date` is assigned to a DAG only once, the `end_date` is not, so it is constantly updated, which allows scheduler to create more DagRuns than specified by "PERF_MAX_RUNS" (it can be easily observed especially with small "PERF_SCHEDULE_INTERVAL" values like "1m").

I have added option to provide `start_date` as a date string via "PERF_START_DATE" environment variable, which overrides "PERF_START_AGO" and is required when "PERF_MAX_RUNS" is defined. I also had to change the "START_DATE" part of the `dag_id`, which becomes the `start_date` timestamp when "PERF_START_DATE" is defined. We cannot use timestamp when using "PERF_START_AGO", again due to moving nature of `start_date` (it would cause the constant stream of new DAGs being created).

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
