### PR TITLE
Add Template Fields RedshiftToS3Operator & S3ToRedshiftOperator

### DIFF
--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -63,7 +63,7 @@ class RedshiftToS3Operator(BaseOperator):
     :type table_as_file_name: bool
     """
 
-    template_fields = ('s3_key',)
+    template_fields = ('s3_bucket', 's3_key', 'schema', 'table', 'unload_options')
     template_ext = ()
     ui_color = '#ededed'
 

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -60,10 +60,7 @@ class S3ToRedshiftOperator(BaseOperator):
     :type truncate_table: bool
     """
 
-    template_fields = (
-        's3_key',
-        'table',
-    )
+    template_fields = ('s3_bucket', 's3_key', 'schema', 'table', 'copy_options')
     template_ext = ()
     ui_color = '#99e699'
 

--- a/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
@@ -87,3 +87,8 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
 
         assert mock_run.call_count == 1
         assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], unload_query)
+
+    def test_template_fields_overrides(self):
+        self.assertEqual(
+            RedshiftToS3Operator.template_fields, ('s3_bucket', 's3_key', 'schema', 'table', 'unload_options')
+        )

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -109,3 +109,8 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
         assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], transaction)
 
         assert mock_run.call_count == 1
+
+    def test_template_fields_overrides(self):
+        self.assertEqual(
+            S3ToRedshiftOperator.template_fields, ('s3_bucket', 's3_key', 'schema', 'table', 'copy_options')
+        )


### PR DESCRIPTION
Adding template fields to RedshiftToS3 and S3ToRedshift operators.   Our use case includes situations where would like to parameterize bucket, schema, and unload/copy options based on environment. 

Example case is one in which we utilize production redshift for system tests, parameterizing schema/bucket for staging.

Can't think of any negatives with including these fields - I believe this change makes the experience consistent with other PostgresHook based operations where the entire sql being executed can utilize templating.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
