### PR TITLE
BigQuery job_id fix for `BigQueryInsertJobOperator`

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2062,7 +2062,7 @@ class BigQueryInsertJobOperator(BaseOperator):
 
         exec_date = context['execution_date'].isoformat()
         job_id = f"airflow_{self.dag_id}_{self.task_id}_{exec_date}_{uniqueness_suffix}"
-        return re.sub(r"\:|-|\+\.", "_", job_id)
+        return re.sub(r"[:\-+.]", "_", job_id)
 
     def execute(self, context: Any):
         hook = BigQueryHook(


### PR DESCRIPTION
Ensures that the `:`, `-`, `+` and `.` characters are removed from the string that is built to create a BigQuery jobid.

Closes: #11856 
