### PR TITLE
Update instruction to only push a single tag while releasing Airflow

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -234,7 +234,7 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
 - Tag your release
 
     ```shell script
-    git tag ${VERSION}
+    git tag -s ${VERSION}
     ```
 
 - Clean the checkout: the sdist step below will
@@ -275,7 +275,10 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
     ```
 
 - Push Tags
-`git push --tags`
+
+    ```shell script
+    git push ${VERSION}
+    ```
 
 - Push the artifacts to ASF dev dist repo
 ```

--- a/dev/README.md
+++ b/dev/README.md
@@ -277,7 +277,7 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
 - Push Tags
 
     ```shell script
-    git push ${VERSION}
+    git push origin ${VERSION}
     ```
 
 - Push the artifacts to ASF dev dist repo


### PR DESCRIPTION
Updated instructions to:

- Push only a single tag
- Signed tag

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
