### PR TITLE
Unpin werkzeug & set default cookie_samesite to Lax

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -25,6 +25,7 @@ assists users migrating to a new version.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of contents**
 
+- [Airflow Master](#airflow-master)
 - [Airflow 2.0.0a1](#airflow-200a1)
 - [Airflow 1.10.13](#airflow-11013)
 - [Airflow 1.10.12](#airflow-11012)
@@ -46,6 +47,13 @@ assists users migrating to a new version.
 - [Airflow 1.7.1.2](#airflow-1712)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Airflow Master
+
+### The default `[webserver] cookie_samesite` has been changed to `Lax`
+
+As [recommended](https://flask.palletsprojects.com/en/1.1.x/config/#SESSION_COOKIE_SAMESITE) by Flask, the
+`[webserver] cookie_samesite` has bee changed to `Lax` from `None`.
 
 ## Airflow 2.0.0a1
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1063,7 +1063,7 @@
       version_added: 1.10.3
       type: string
       example: ~
-      default: ""
+      default: "Lax"
     - name: default_wrap
       description: |
         Default setting for wrap toggle on DAG code and TI log views.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -531,7 +531,7 @@ proxy_fix_x_prefix = 1
 cookie_secure = False
 
 # Set samesite policy on session cookie
-cookie_samesite =
+cookie_samesite = Lax
 
 # Default setting for wrap toggle on DAG code and TI log views.
 default_wrap = False

--- a/setup.py
+++ b/setup.py
@@ -737,7 +737,6 @@ INSTALL_REQUIREMENTS = [
     'typing-extensions>=3.7.4;python_version<"3.8"',
     'tzlocal>=1.4,<2.0.0',
     'unicodecsv>=0.14.1',
-    'werkzeug<1.0.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -737,7 +737,7 @@ INSTALL_REQUIREMENTS = [
     'typing-extensions>=3.7.4;python_version<"3.8"',
     'tzlocal>=1.4,<2.0.0',
     'unicodecsv>=0.14.1',
-    'werkzeug~=1.1.0',
+    'werkzeug~=1.0, >=1.0.1',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -737,6 +737,7 @@ INSTALL_REQUIREMENTS = [
     'typing-extensions>=3.7.4;python_version<"3.8"',
     'tzlocal>=1.4,<2.0.0',
     'unicodecsv>=0.14.1',
+    'werkzeug~=1.1.0',
 ]
 
 


### PR DESCRIPTION
As suggested by https://flask.palletsprojects.com/en/1.1.x/config/#SESSION_COOKIE_SAMESITE , set `cookie_samesite` to `Lax`.

This Werkzeug bug prevented using latest version of Werkzeug (1.1.0): https://github.com/pallets/werkzeug/issues/1549 | https://github.com/pallets/werkzeug/pull/1550

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
Detailed explanantion: https://web.dev/samesite-cookies-explained/

Previously https://github.com/apache/airflow/pull/11610 had unpinned Werkzeug but that caused https://github.com/apache/airflow/issues/11871 on 2.0.0a2 so I had to pin it again https://github.com/apache/airflow/pull/11872

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
