### PR TITLE
Simplify "scheduled" conditons to follow today's change in GA

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -59,7 +59,6 @@ jobs:
       cacheDirective: ${{ steps.cache-directive.outputs.docker-cache }}
       buildImages: ${{ steps.build-images.outputs.buildImages }}
       upgradeToLatestConstraints: ${{ steps.upgrade-constraints.outputs.upgradeToLatestConstraints }}
-    if: github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule'
     steps:
       - name: "Get information about the original trigger of the run"
         uses: potiuk/get-workflow-origin@e3ba776faee1134e17551924b852bfb374e1703d  # v1_1
@@ -199,8 +198,7 @@ jobs:
       run-kubernetes-tests: ${{ steps.selective-checks.outputs.run-kubernetes-tests }}
       basic-checks-only: ${{ steps.selective-checks.outputs.basic-checks-only }}
     if: >
-      needs.cancel-workflow-runs.outputs.buildImages == 'true' &&
-      (github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule')
+      needs.cancel-workflow-runs.outputs.buildImages == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -250,8 +248,7 @@ jobs:
       fail-fast: true
     if: >
       needs.build-info.outputs.basic-checks-only == 'false' &&
-      needs.cancel-workflow-runs.outputs.buildImages == 'true' &&
-      (github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule')
+      needs.cancel-workflow-runs.outputs.buildImages == 'true'
     env:
       BACKEND: postgres
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
       needs-api-tests: ${{ steps.selective-checks.outputs.needs-api-tests }}
       pullRequestNumber: ${{ steps.source-run-info.outputs.pullRequestNumber }}
       pullRequestLabels: ${{ steps.source-run-info.outputs.pullRequestLabels }}
-    if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Get information about the PR"
         uses: potiuk/get-workflow-origin@e3ba776faee1134e17551924b852bfb374e1703d  # v1_1
@@ -147,8 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     if: >
-      needs.build-info.outputs.needs-helm-tests == 'true' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.needs-helm-tests == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -160,8 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     if: >
-      needs.build-info.outputs.needs-api-tests == 'true' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.needs-api-tests == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -174,8 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'false'
     env:
       BACKEND: sqlite
     steps:
@@ -211,8 +207,7 @@ jobs:
       MOUNT_LOCAL_SOURCES: "true"
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'false'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -249,8 +244,7 @@ jobs:
       MOUNT_LOCAL_SOURCES: "true"
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: >
-      needs.build-info.outputs.basic-checks-only == 'true' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -284,8 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'false'
     env:
       # We want to make sure we have latest sources as only in_container scripts are added
       # to the image but we want to static-check all of them
@@ -320,8 +313,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'false'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -344,8 +336,7 @@ jobs:
     env:
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'false'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -365,8 +356,7 @@ jobs:
       BACKPORT_PACKAGES: "true"
       VERSION_SUFFIX_FOR_SVN: "rc1"
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'false'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -404,8 +394,7 @@ jobs:
       VERSION_SUFFIX_FOR_PYPI: "a0"
       VERSION_SUFFIX_FOR_SVN: "a0"
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'false'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -454,8 +443,7 @@ jobs:
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
-        needs.build-info.outputs.run-tests == 'true' &&
-        (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+        needs.build-info.outputs.run-tests == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -508,8 +496,7 @@ jobs:
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
-        needs.build-info.outputs.run-tests == 'true' &&
-        (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+        needs.build-info.outputs.run-tests == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -559,8 +546,7 @@ jobs:
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
-        needs.build-info.outputs.run-tests == 'true' &&
-        (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+        needs.build-info.outputs.run-tests == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -615,8 +601,7 @@ jobs:
       NUM_RUNS: 10
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     if: >
-      needs.build-info.outputs.run-tests == 'true' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.run-tests == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -677,7 +662,6 @@ jobs:
       - tests-sqlite
       - tests-mysql
       - tests-quarantined
-    if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Download all artifacts from the current build"
         uses: actions/download-artifact@v2
@@ -699,8 +683,7 @@ jobs:
       BACKEND: sqlite
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.basic-checks-only == 'false'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -742,8 +725,7 @@ jobs:
       KIND_VERSION: "${{ needs.build-info.outputs.defaultKindVersion }}"
       HELM_VERSION: "${{ needs.build-info.outputs.defaultHelmVersion }}"
     if: >
-      needs.build-info.outputs.run-kubernetes-tests == 'true' &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      needs.build-info.outputs.run-kubernetes-tests == 'true'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -897,8 +879,7 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
     if: >
       needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' ) &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' )
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -933,8 +914,7 @@ jobs:
       - tests-kubernetes
     if: >
       needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' ) &&
-      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
+      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' )
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,6 @@ jobs:
   selective-checks:
     name: Selective checks
     runs-on: ubuntu-latest
-    if: github.repository == 'apache/airflow'
     outputs:
       needs-python-scans: ${{ steps.selective-checks.outputs.needs-python-scans }}
       needs-javascript-scans: ${{ steps.selective-checks.outputs.needs-javascript-scans }}
@@ -55,18 +54,16 @@ jobs:
           # a pull request then we can checkout the head.
           fetch-depth: 2
         if: |
-          github.repository == 'apache/airflow' &&
-          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
+          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'
 
       # If this run was triggered by a pull request event, then checkout
       # the head of the pull request instead of the merge commit.
       - run: git checkout HEAD^2
         if: |
           github.event_name == 'pull_request' &&
-          github.repository == 'apache/airflow' &&
-          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
+          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -78,22 +75,19 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
         if: |
-          github.repository == 'apache/airflow' &&
-          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
+          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
         uses: github/codeql-action/autobuild@v1
         if: |
-          github.repository == 'apache/airflow' &&
-          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
+          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
         if: |
-          github.repository == 'apache/airflow' &&
-          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
+          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'

--- a/.github/workflows/delete_old_artifacts.yml
+++ b/.github/workflows/delete_old_artifacts.yml
@@ -7,7 +7,6 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   delete-artifacts:
     runs-on: ubuntu-latest
-    if: github.repository == 'apache/airflow'
     steps:
       - uses: kolpav/purge-artifacts-action@04c636a505f26ebc82f8d070b202fb87ff572b10  # v1.0
         with:

--- a/.github/workflows/scheduled_quarantined.yml
+++ b/.github/workflows/scheduled_quarantined.yml
@@ -51,7 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-tests: ${{ steps.trigger-tests.outputs.run-tests }}
-    if: github.repository == 'apache/airflow'
     steps:
       - uses: actions/checkout@v2
       - name: "Check if tests should be run"
@@ -77,9 +76,8 @@ jobs:
       TEST_TYPE: Quarantined
       NUM_RUNS: 20
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: >
-      github.repository == 'apache/airflow' &&
-      (needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request')
+    if: |
+      needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
GitHub Actions policy about runnig scheduled workflows in forks
has changed recently and as of October 27 2020 scheduled workflows
in forks will be disabled. Thanks to that change we can simplify
some of our conditions that disallowed running scheduled workflows
in forks.

The change is active as of today (email from GitHub):

> What will happen to scheduled workflows in forks I already have?

> If you already have scheduled workflows in forks of public
  repositories, they will be disabled on October 27, 2020. Repository
  owners will receive a reminder email 7 days prior and can choose to
  keep the workflows running at that time if they are needed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
