### PR TITLE
Enhance EmrStepSensor to retrieve all steps if no stepId was provided

### DIFF
--- a/airflow/providers/amazon/aws/sensors/emr_base.py
+++ b/airflow/providers/amazon/aws/sensors/emr_base.py
@@ -65,7 +65,7 @@ class EmrBaseSensor(BaseSensorOperator):
             return False
 
         state = self.state_from_response(response)
-        self.log.info('Job flow currently %s', state)
+        self.log.info('Job flow/step currently %s', state)
 
         if state in self.target_states:
             return True

--- a/tests/providers/amazon/aws/sensors/test_emr_step.py
+++ b/tests/providers/amazon/aws/sensors/test_emr_step.py
@@ -25,6 +25,10 @@ from dateutil.tz import tzlocal
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.sensors.emr_step import EmrStepSensor
 
+from airflow.models import TaskInstance, DAG
+from airflow.utils import timezone
+
+
 DESCRIBE_JOB_STEP_RUNNING_RETURN = {
     'ResponseMetadata': {'HTTPStatusCode': 200, 'RequestId': '8dee8db2-3719-11e6-9e20-35b2f861a2a6'},
     'Step': {
@@ -150,7 +154,7 @@ class TestEmrStepSensor(unittest.TestCase):
             step_id='s-VK57YR1Z9Z5N',
             aws_conn_id='aws_default',
         )
-
+        # raise Exception(self.step_id)
         mock_emr_session = MagicMock()
         mock_emr_session.client.return_value = self.emr_client_mock
 
@@ -199,3 +203,545 @@ class TestEmrStepSensor(unittest.TestCase):
 
         with patch('boto3.session.Session', self.boto3_session_mock):
             self.assertRaises(AirflowException, self.sensor.execute, None)
+
+
+LIST_STEPS_RUNNING_RESPONSES = {
+    'Steps': [
+        {
+            'Id': 's-VK57YR1Z9Z5N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'RUNNING',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z6N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'RUNNING',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z7N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'RUNNING',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z8N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'RUNNING',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+    ],
+    'ResponseMetadata': {'HTTPStatusCode': 200, 'RequestId': 'omitted'},
+}
+
+LIST_STEPS_COMPLETED_RESPONSES = {
+    'Steps': [
+        {
+            'Id': 's-VK57YR1Z9Z5N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'COMPLETED',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z6N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'COMPLETED',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z7N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'COMPLETED',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z8N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'COMPLETED',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+    ],
+    'ResponseMetadata': {'HTTPStatusCode': 200, 'RequestId': 'omitted'},
+}
+
+LIST_STEPS_FAILED_RESPONSES = {
+    'Steps': [
+        {
+            'Id': 's-VK57YR1Z9Z5N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'FAILED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z6N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'FAILED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z7N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'FAILED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z8N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'FAILED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+    ],
+    'ResponseMetadata': {'HTTPStatusCode': 200, 'RequestId': 'omitted'},
+}
+
+LIST_STEPS_INTERRUPTED_RESPONSES = {
+    'Steps': [
+        {
+            'Id': 's-VK57YR1Z9Z5N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'INTERRUPTED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z6N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'INTERRUPTED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z7N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'INTERRUPTED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z8N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'INTERRUPTED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+    ],
+    'ResponseMetadata': {'HTTPStatusCode': 200, 'RequestId': 'omitted'},
+}
+
+LIST_STEPS_MIXED_RESPONSES = {
+    'Steps': [
+        {
+            'Id': 's-VK57YR1Z9Z5N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'INTERRUPTED',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z6N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'FAILED',
+                'StateChangeReason': {},
+                'FailureDetails': {
+                    'LogFile': 's3://fake-log-files/emr-logs/j-8989898989/steps/s-VK57YR1Z9Z5N',
+                    'Reason': 'Unknown Error.',
+                },
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z7N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'CANCELLED',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+        {
+            'Id': 's-VK57YR1Z9Z8N',
+            'Name': 'calculate_pi',
+            'Config': {
+                'Args': ['/usr/lib/spark/bin/run-example', 'SparkPi', '10'],
+                'Jar': 'command-runner.jar',
+                'Properties': {},
+            },
+            'ActionOnFailure': 'CONTINUE',
+            'Status': {
+                'State': 'COMPLETED',
+                'StateChangeReason': {},
+                'Timeline': {
+                    'CreationDateTime': datetime(2016, 6, 20, 19, 0, 18),
+                    'StartDateTime': datetime(2016, 6, 20, 19, 2, 34),
+                },
+            },
+        },
+    ],
+    'ResponseMetadata': {'HTTPStatusCode': 200, 'RequestId': 'omitted'},
+}
+
+
+class TestGetListSteps(unittest.TestCase):
+    def setUp(self):
+        args = {
+            "owner": "airflow",
+            "start_date": timezone.datetime(2018, 1, 1),
+        }
+
+        dag = DAG(
+            'test_dag',
+            default_args=args,
+            schedule_interval="@once",
+        )
+        self.emr_client_mock = MagicMock()
+        self.sensor = EmrStepSensor(
+            task_id='test_task',
+            poke_interval=0,
+            job_flow_id='j-8989898989',
+            step_id=None,
+            aws_conn_id='aws_default',
+            dag=dag,
+        )
+
+        mock_emr_session = MagicMock()
+        mock_emr_session.client.return_value = self.emr_client_mock
+
+        # Mock out the emr_client creator
+        self.boto3_session_mock = MagicMock(return_value=mock_emr_session)
+
+    def test_get_steps_if_no_steps_specified_completed(self):
+        self.emr_client_mock.list_steps.side_effect = [
+            LIST_STEPS_COMPLETED_RESPONSES,
+        ]
+
+        with patch('boto3.session.Session', self.boto3_session_mock):
+            ti = TaskInstance(task=self.sensor, execution_date=timezone.utcnow())
+            ti.run()
+            xcom_result = ti.xcom_pull(task_ids=self.sensor.task_id, key="return_value")
+            calls = [
+                unittest.mock.call(ClusterId='j-8989898989'),
+            ]
+            self.assertEqual(self.emr_client_mock.list_steps.call_count, 1)
+            self.emr_client_mock.list_steps.assert_has_calls(calls)
+            self.assertIsNotNone(xcom_result)
+
+    def test_get_steps_if_no_steps_specified_failed(self):
+        self.emr_client_mock.list_steps.side_effect = [
+            LIST_STEPS_FAILED_RESPONSES,
+        ]
+
+        with patch('boto3.session.Session', self.boto3_session_mock):
+            ti = TaskInstance(task=self.sensor, execution_date=timezone.utcnow())
+            self.assertRaises(AirflowException, ti.run, None)
+            xcom_result = ti.xcom_pull(task_ids=self.sensor.task_id, key="return_value")
+            calls = [
+                unittest.mock.call(ClusterId='j-8989898989'),
+            ]
+            self.assertEqual(self.emr_client_mock.list_steps.call_count, 1)
+            self.emr_client_mock.list_steps.assert_has_calls(calls)
+            self.assertIsNotNone(xcom_result)
+
+    def test_get_steps_if_no_steps_specified_interrupted(self):
+        self.emr_client_mock.list_steps.side_effect = [
+            LIST_STEPS_INTERRUPTED_RESPONSES,
+        ]
+
+        with patch('boto3.session.Session', self.boto3_session_mock):
+            ti = TaskInstance(task=self.sensor, execution_date=timezone.utcnow())
+            self.assertRaises(AirflowException, ti.run, None)
+            xcom_result = ti.xcom_pull(task_ids=self.sensor.task_id, key="return_value")
+            calls = [
+                unittest.mock.call(ClusterId='j-8989898989'),
+            ]
+            self.assertEqual(self.emr_client_mock.list_steps.call_count, 1)
+            self.emr_client_mock.list_steps.assert_has_calls(calls)
+            self.assertIsNotNone(xcom_result)
+
+    def test_get_steps_if_no_steps_specified_running_completed(self):
+        self.emr_client_mock.list_steps.side_effect = [
+            LIST_STEPS_RUNNING_RESPONSES,
+            LIST_STEPS_COMPLETED_RESPONSES,
+        ]
+
+        with patch('boto3.session.Session', self.boto3_session_mock):
+            ti = TaskInstance(task=self.sensor, execution_date=timezone.utcnow())
+            ti.run()
+            xcom_result = ti.xcom_pull(task_ids=self.sensor.task_id, key="return_value")
+            self.assertEqual(self.emr_client_mock.list_steps.call_count, 2)
+            calls = [
+                unittest.mock.call(ClusterId='j-8989898989'),
+                unittest.mock.call(ClusterId='j-8989898989'),
+            ]
+            self.emr_client_mock.list_steps.assert_has_calls(calls)
+            self.assertIsNotNone(xcom_result)
+
+    def test_get_steps_if_no_steps_specified_running_failed(self):
+        self.emr_client_mock.list_steps.side_effect = [
+            LIST_STEPS_RUNNING_RESPONSES,
+            LIST_STEPS_RUNNING_RESPONSES,
+            LIST_STEPS_FAILED_RESPONSES,
+        ]
+
+        with patch('boto3.session.Session', self.boto3_session_mock):
+            ti = TaskInstance(task=self.sensor, execution_date=timezone.utcnow())
+            self.assertRaises(AirflowException, ti.run, None)
+            xcom_result = ti.xcom_pull(task_ids=self.sensor.task_id, key="return_value")
+            self.assertEqual(self.emr_client_mock.list_steps.call_count, 3)
+            calls = [
+                unittest.mock.call(ClusterId='j-8989898989'),
+                unittest.mock.call(ClusterId='j-8989898989'),
+                unittest.mock.call(ClusterId='j-8989898989'),
+            ]
+            self.emr_client_mock.list_steps.assert_has_calls(calls)
+            self.assertIsNotNone(xcom_result)


### PR DESCRIPTION
Currently the EmrStepSensor only looks at one step at a time. Enhancing the EmrStepSensor to retrieve all steps on a specified cluster if no stepId was provided.