### PR TITLE
Revert "fix: Override FAB styling (#11752)"

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -432,9 +432,3 @@ label[for="timezone-other"],
   top: 2px;
   border: 0;
 }
-
-/* Overrides undesireable styling rendered by FAB markup */
-.dropdown-menu .filter.btn {
-  border: 0;
-  border-radius: 0;
-}


### PR DESCRIPTION
This reverts commit 2df9d1c4d78d0add5efa18831725ddcc2a93d738.

It removes a patch to override FAB's broken CSS styling. I have since [fixed the issue in FAB](https://github.com/dpgaspar/Flask-AppBuilder/pull/1503) and that fix was released in FAB v3.1.1 and adopted by Airflow in #11884.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
