### PR TITLE
Fix Logout Google Auth issue

### DIFF
--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -94,7 +94,13 @@ class GoogleAuthBackend(object):
             'google',
             consumer_key=get_config_param('client_id'),
             consumer_secret=get_config_param('client_secret'),
+            #options for prompt will be the ones in here: https://developers.google.com/identity/protocols/oauth2/web-server#userconsentprompt
+            # consent,select_account, (none existent)
             request_token_params={'scope': [
+                'https://www.googleapis.com/auth/userinfo.profile',
+                'https://www.googleapis.com/auth/userinfo.email'],
+                'prompt': get_config_param('prompt')
+            } if get_config_param('prompt') else {'scope': [
                 'https://www.googleapis.com/auth/userinfo.profile',
                 'https://www.googleapis.com/auth/userinfo.email']},
             base_url='https://www.google.com/accounts/',

--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -94,8 +94,6 @@ class GoogleAuthBackend(object):
             'google',
             consumer_key=get_config_param('client_id'),
             consumer_secret=get_config_param('client_secret'),
-            #options for prompt will be the ones in here: https://developers.google.com/identity/protocols/oauth2/web-server#userconsentprompt
-            # consent,select_account, (none existent)
             request_token_params={'scope': [
                 'https://www.googleapis.com/auth/userinfo.profile',
                 'https://www.googleapis.com/auth/userinfo.email'],

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -387,7 +387,13 @@ Google Authentication
 
 The Google authentication backend can be used to authenticate users
 against Google using OAuth2. You must specify the domains to restrict
-login, separated with a comma, to only members of those domains.
+login, separated with a comma, to only members of those domains. You
+also need to select an option for `user consent prompt behaviour <https://developers.google.com/identity/protocols/oauth2/web-server#userconsentprompt>`_, one of:
+
+consent: Prompt the user for consent.
+select_account: Prompt the user to select an account.
+none: Do not display any authentication or consent screens.
+'': the user will be prompted only the first time your project requests access
 
 .. code-block:: ini
 
@@ -400,6 +406,7 @@ login, separated with a comma, to only members of those domains.
     client_secret = google_client_secret
     oauth_callback_route = /oauth2callback
     domain = example1.com,example2.com
+    prompt = <One of : consent, select_account, none or ''>
 
 To use Google authentication, you must install Airflow with the ``google_auth`` extras group:
 


### PR DESCRIPTION
**WHY?**
- [prompt functionality](https://developers.google.com/identity/protocols/oauth2/web-server#userconsentprompt) is not implemented in Google Auth implementation. Therefore you cannot log out properly from Airflow.

**SOLUTION:**
- Config section for Google Auth backend would look like:

[webserver]
authenticate = True
auth_backend = airflow.contrib.auth.backends.google_auth

[google]
client_id = google_client_id
client_secret = google_client_secret
oauth_callback_route = /oauth2callback
domain = example1.com,example2.com
prompt = <One of : 'consent', 'select_account', 'none' or ''>

closes: #11889

