### PR TITLE
Add readme for core sensors directory

### DIFF
--- a/airflow/operators/README.md
+++ b/airflow/operators/README.md
@@ -19,6 +19,6 @@
 
 # Airflow Operators
 
-Airflow operators are modules that represent a single, ideally idempotent task. They are arbiters of the logic that executes when your DAG runs.
+Airflow Operators are modules that represent a single, ideally idempotent task. They are arbiters of the logic that executes when your DAG runs.
 
-The operators contained within this directory are core Airflow operators from which others may inherit, including the modules distributed in provider packages. They are included by default in any Airflow implementation.
+The Operators contained within this directory are core Airflow Operators from which others may inherit, including the modules distributed in provider packages. They are included by default in any Airflow implementation.

--- a/airflow/sensors/README.md
+++ b/airflow/sensors/README.md
@@ -17,8 +17,8 @@
  under the License.
  -->
 
-# Airflow Hooks
+# Airflow Sensors
 
-Airflow Hooks are interfaces to external platforms and databases. They implement a common interface and act as building blocks for operators.
+Airflow Sensors are a special kind of Airflow Operator. When they run, they check to see if a certain criteria is met before they complete and let their downstream tasks execute. They are primarily used to enable portions of your DAG to wait for some criteria to be fulfilled by an external system.
 
-The Hooks contained within this directory are core Airflow Hooks from which others may inherit, including the modules distributed in provider packages. They are included by default in any Airflow implementation.
+The Sensors contained within this directory are core Airflow Sensors. They are included by default in any Airflow implementation. For other available sensors that have been built by the community, please see the `providers` directory.


### PR DESCRIPTION
A follow up on https://github.com/apache/airflow/pull/11829- I had noticed that I made two small mistakes:
- Forgot to include a readme for the core sensors directory
- Did not standardize capitalization schema for Hooks, Sensors, and Operators. All of these words are now treated as proper nouns and capitalized.

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
