### PR TITLE
Make TaskInstances pid and task duration nullable in API specification

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1724,6 +1724,7 @@ components:
           format: datetime
         duration:
           type: number
+          nullable: true
         state:
           $ref: '#/components/schemas/TaskState'
         try_number:
@@ -1749,6 +1750,7 @@ components:
           nullable: true
         pid:
           type: integer
+          nullable: true
         executor_config:
           type: string
         sla_miss:


### PR DESCRIPTION
Task instances pid and duration can be 'none' at times but it's not nullable in API specification.
Skipped task instance duration is None.
Currently, to get the task instances of skipped tasks or tasks that the PID is none through the REST API raises an error. 
This PR fixes it

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
