### PR TITLE
Add missing space to log message in task completion logs

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1087,7 +1087,7 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
             self.refresh_from_db(lock_for_update=True)
             self.state = State.SKIPPED
             self.log.info(
-                'Marking task as SKIPPED.'
+                'Marking task as SKIPPED. '
                 'dag_id=%s, task_id=%s, execution_date=%s, start_date=%s, end_date=%s',
                 self.dag_id,
                 self.task_id,
@@ -1123,7 +1123,7 @@ class TaskInstance(Base, LoggingMixin):     # pylint: disable=R0902,R0904
         # Recording SUCCESS
         self.end_date = timezone.utcnow()
         self.log.info(
-            'Marking task as SUCCESS.'
+            'Marking task as SUCCESS. '
             'dag_id=%s, task_id=%s, execution_date=%s, start_date=%s, end_date=%s',
             self.dag_id,
             self.task_id,

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -318,7 +318,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
         self.assert_log_line("Log from TI Logger", logs_list)
         self.assert_log_line("Log from Print statement", logs_list, expect_from_logging_mixin=True)
 
-        self.assertIn(f"INFO - Marking task as SUCCESS.dag_id={self.dag_id}, "
+        self.assertIn(f"INFO - Marking task as SUCCESS. dag_id={self.dag_id}, "
                       f"task_id={self.task_id}, execution_date=20170101T000000", logs)
 
     @mock.patch("airflow.task.task_runner.standard_task_runner.CAN_FORK", False)
@@ -343,7 +343,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
 
         self.assertIn(f"INFO - Running: ['airflow', 'tasks', 'run', '{self.dag_id}', "
                       f"'{self.task_id}', '{self.execution_date_str}',", logs)
-        self.assertIn(f"INFO - Marking task as SUCCESS.dag_id={self.dag_id}, "
+        self.assertIn(f"INFO - Marking task as SUCCESS. dag_id={self.dag_id}, "
                       f"task_id={self.task_id}, execution_date=20170101T000000", logs)
 
     def test_log_file_template_with_run_task(self):


### PR DESCRIPTION
Previously it looked like this

    INFO - Marking task as SUCCESS.dag_id=scenario1_case1_1_1, ...

Now it looks like

    INFO - Marking task as SUCCESS. dag_id=scenario1_case1_1_1, ...


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).