### PR TITLE
Stop running scheduled workflows on Forks again

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -59,6 +59,7 @@ jobs:
       cacheDirective: ${{ steps.cache-directive.outputs.docker-cache }}
       buildImages: ${{ steps.build-images.outputs.buildImages }}
       upgradeToLatestConstraints: ${{ steps.upgrade-constraints.outputs.upgradeToLatestConstraints }}
+    if: github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule'
     steps:
       - name: "Get information about the original trigger of the run"
         uses: potiuk/get-workflow-origin@2ef0b065db6b688a2231f8a7f464df1aac254328  # v1_2
@@ -198,7 +199,8 @@ jobs:
       run-kubernetes-tests: ${{ steps.selective-checks.outputs.run-kubernetes-tests }}
       basic-checks-only: ${{ steps.selective-checks.outputs.basic-checks-only }}
     if: >
-      needs.cancel-workflow-runs.outputs.buildImages == 'true'
+      needs.cancel-workflow-runs.outputs.buildImages == 'true' &&
+      (github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -252,7 +254,8 @@ jobs:
       fail-fast: true
     if: >
       needs.build-info.outputs.basic-checks-only == 'false' &&
-      needs.cancel-workflow-runs.outputs.buildImages == 'true'
+      needs.cancel-workflow-runs.outputs.buildImages == 'true' &&
+      (github.repository == 'apache/airflow' || github.event.workflow_run.event != 'schedule')
     env:
       BACKEND: postgres
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
       needs-api-tests: ${{ steps.selective-checks.outputs.needs-api-tests }}
       pullRequestNumber: ${{ steps.source-run-info.outputs.pullRequestNumber }}
       pullRequestLabels: ${{ steps.source-run-info.outputs.pullRequestLabels }}
+    if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Get information about the PR"
         uses: potiuk/get-workflow-origin@2ef0b065db6b688a2231f8a7f464df1aac254328  # v1_2
@@ -148,7 +149,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     if: >
-      needs.build-info.outputs.needs-helm-tests == 'true'
+      needs.build-info.outputs.needs-helm-tests == 'true' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -160,7 +162,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     if: >
-      needs.build-info.outputs.needs-api-tests == 'true'
+      needs.build-info.outputs.needs-api-tests == 'true' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -173,7 +176,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false'
+      needs.build-info.outputs.basic-checks-only == 'false' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     env:
       BACKEND: sqlite
     steps:
@@ -212,7 +216,8 @@ jobs:
       MOUNT_LOCAL_SOURCES: "true"
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false'
+      needs.build-info.outputs.basic-checks-only == 'false' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -249,7 +254,8 @@ jobs:
       MOUNT_LOCAL_SOURCES: "true"
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: >
-      needs.build-info.outputs.basic-checks-only == 'true'
+      needs.build-info.outputs.basic-checks-only == 'true' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -283,7 +289,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false'
+      needs.build-info.outputs.basic-checks-only == 'false' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     env:
       # We want to make sure we have latest sources as only in_container scripts are added
       # to the image but we want to static-check all of them
@@ -318,7 +325,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info, ci-images]
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false'
+      needs.build-info.outputs.basic-checks-only == 'false' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -341,7 +349,8 @@ jobs:
     env:
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false'
+      needs.build-info.outputs.basic-checks-only == 'false' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -361,7 +370,8 @@ jobs:
       BACKPORT_PACKAGES: "true"
       VERSION_SUFFIX_FOR_SVN: "rc1"
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false'
+      needs.build-info.outputs.basic-checks-only == 'false' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -399,7 +409,8 @@ jobs:
       VERSION_SUFFIX_FOR_PYPI: "a0"
       VERSION_SUFFIX_FOR_SVN: "a0"
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false'
+      needs.build-info.outputs.basic-checks-only == 'false' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -494,7 +505,8 @@ jobs:
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
-        needs.build-info.outputs.run-tests == 'true'
+        needs.build-info.outputs.run-tests == 'true' &&
+        (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -547,7 +559,8 @@ jobs:
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
-        needs.build-info.outputs.run-tests == 'true'
+        needs.build-info.outputs.run-tests == 'true' &&
+        (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -597,7 +610,8 @@ jobs:
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
       TEST_TYPE: ""
     if: >
-        needs.build-info.outputs.run-tests == 'true'
+        needs.build-info.outputs.run-tests == 'true' &&
+        (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -652,7 +666,8 @@ jobs:
       NUM_RUNS: 10
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     if: >
-      needs.build-info.outputs.run-tests == 'true'
+      needs.build-info.outputs.run-tests == 'true' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -713,6 +728,7 @@ jobs:
       - tests-sqlite
       - tests-mysql
       - tests-quarantined
+    if: github.repository == 'apache/airflow' || github.event_name != 'schedule'
     steps:
       - name: "Download all artifacts from the current build"
         uses: actions/download-artifact@v2
@@ -734,7 +750,8 @@ jobs:
       BACKEND: sqlite
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
     if: >
-      needs.build-info.outputs.basic-checks-only == 'false'
+      needs.build-info.outputs.basic-checks-only == 'false' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -779,7 +796,8 @@ jobs:
       KIND_VERSION: "${{ needs.build-info.outputs.defaultKindVersion }}"
       HELM_VERSION: "${{ needs.build-info.outputs.defaultHelmVersion }}"
     if: >
-      needs.build-info.outputs.run-kubernetes-tests == 'true'
+      needs.build-info.outputs.run-kubernetes-tests == 'true' &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -934,7 +952,8 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
     if: >
       needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' )
+      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' ) &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -969,7 +988,8 @@ jobs:
       - tests-kubernetes
     if: >
       needs.build-info.outputs.basic-checks-only == 'false' &&
-      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' )
+      (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v1-10-test' ) &&
+      (github.repository == 'apache/airflow' || github.event_name != 'schedule')
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,6 +30,7 @@ jobs:
   selective-checks:
     name: Selective checks
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/airflow'
     outputs:
       needs-python-scans: ${{ steps.selective-checks.outputs.needs-python-scans }}
       needs-javascript-scans: ${{ steps.selective-checks.outputs.needs-javascript-scans }}
@@ -71,14 +72,16 @@ jobs:
           # a pull request then we can checkout the head.
           fetch-depth: 2
         if: |
-          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
 
       # If this run was triggered by a pull request event, then checkout
       # the head of the pull request instead of the merge commit.
       - run: git checkout HEAD^2
         if: |
           github.event_name == 'pull_request' &&
+          github.repository == 'apache/airflow' &&
           (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
           matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
 
@@ -92,19 +95,22 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
         if: |
-          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
         uses: github/codeql-action/autobuild@v1
         if: |
-          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
         if: |
-          matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
-          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true'
+          github.repository == 'apache/airflow' &&
+          (matrix.language == 'python' && needs.selective-checks.outputs.needs-python-scans == 'true' ||
+          matrix.language == 'javascript' && needs.selective-checks.outputs.needs-javascript-scans == 'true')

--- a/.github/workflows/delete_old_artifacts.yml
+++ b/.github/workflows/delete_old_artifacts.yml
@@ -24,6 +24,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   delete-artifacts:
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/airflow'
     steps:
       - uses: kolpav/purge-artifacts-action@04c636a505f26ebc82f8d070b202fb87ff572b10  # v1.0
         with:

--- a/.github/workflows/scheduled_quarantined.yml
+++ b/.github/workflows/scheduled_quarantined.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-tests: ${{ steps.trigger-tests.outputs.run-tests }}
+    if: github.repository == 'apache/airflow'
     steps:
       - uses: actions/checkout@v2
       - name: "Check if tests should be run"
@@ -76,8 +77,9 @@ jobs:
       TEST_TYPE: Quarantined
       NUM_RUNS: 20
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: |
-      needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request'
+    if: >
+      github.repository == 'apache/airflow' &&
+      (needs.trigger-tests.outputs.run-tests == 'true' || github.event_name != 'pull_request')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
We removed the repo check in https://github.com/apache/airflow/pull/11876 following
 a Github Actions email but seems like the Scheduled workflows are still running on forks.

Example: https://github.com/astronomer/airflow/actions?query=event%3Aschedule

This reverts commit bdd5e0bd7f049e3deee7626af430f4fbe6999737.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
