### PR TITLE
Improve handling server errors in DataprocSubmitJobOperator

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -24,6 +24,7 @@ import warnings
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from cached_property import cached_property
+from google.api_core.exceptions import ServerError
 from google.api_core.retry import Retry
 from google.cloud.dataproc_v1beta2 import (  # pylint: disable=no-name-in-module
     ClusterControllerClient,
@@ -704,7 +705,9 @@ class DataprocHook(GoogleBaseHook):
         return operation
 
     @GoogleBaseHook.fallback_to_default_project_id
-    def wait_for_job(self, job_id: str, location: str, project_id: str, wait_time: int = 10) -> None:
+    def wait_for_job(
+        self, job_id: str, location: str, project_id: str, wait_time: int = 10, timeout: Optional[int] = None
+    ) -> None:
         """
         Helper method which polls a job to check if it finishes.
 
@@ -716,12 +719,21 @@ class DataprocHook(GoogleBaseHook):
         :type location: str
         :param wait_time: Number of seconds between checks
         :type wait_time: int
+        :param timeout: How many seconds wait for job to be ready. Used only if ``asynchronous`` is False
+        :type timeout: int
         """
         state = None
+        start = time.monotonic()
         while state not in (JobStatus.ERROR, JobStatus.DONE, JobStatus.CANCELLED):
+            if timeout and start + timeout < time.monotonic():
+                raise AirflowException(f"Timeout: dataproc job {job_id} is not ready after {timeout}s")
             time.sleep(wait_time)
-            job = self.get_job(location=location, job_id=job_id, project_id=project_id)
-            state = job.status.state
+            try:
+                job = self.get_job(location=location, job_id=job_id, project_id=project_id)
+                state = job.status.state
+            except ServerError:
+                pass
+
         if state == JobStatus.ERROR:
             raise AirflowException('Job failed:\n{}'.format(job))
         if state == JobStatus.CANCELLED:

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -731,8 +731,8 @@ class DataprocHook(GoogleBaseHook):
             try:
                 job = self.get_job(location=location, job_id=job_id, project_id=project_id)
                 state = job.status.state
-            except ServerError:
-                pass
+            except ServerError as err:
+                self.log.info("Retrying. Dataproc API returned server error when waiting for job: %s", err)
 
         if state == JobStatus.ERROR:
             raise AirflowException('Job failed:\n{}'.format(job))

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -464,7 +464,7 @@ class TestDataprocSubmitJobOperator(unittest.TestCase):
             metadata=METADATA,
         )
         mock_hook.return_value.wait_for_job.assert_called_once_with(
-            job_id=job_id, project_id=GCP_PROJECT, location=GCP_LOCATION
+            job_id=job_id, project_id=GCP_PROJECT, location=GCP_LOCATION, timeout=None
         )
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))


### PR DESCRIPTION
Users report that sometimes Dataproc API can return 5XX response. Is such case we should retry.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
