### PR TITLE
Fix issue rendering k8s V1Pod

### DIFF
--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -54,6 +54,6 @@ class AirflowJsonEncoder(json.JSONEncoder):
             return float(obj)
         elif k8s is not None and isinstance(obj, k8s.V1Pod):
             from airflow.kubernetes.pod_generator import PodGenerator
-            PodGenerator.serialize_pod(obj)
+            return PodGenerator.serialize_pod(obj)
 
         raise TypeError(f"Object of type '{obj.__class__.__name__}' is not JSON serializable")

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -47,6 +47,7 @@ from pygments.formatters import HtmlFormatter  # noqa pylint: disable=no-name-in
 from sqlalchemy import and_, desc, func, or_, union_all
 from sqlalchemy.orm import joinedload
 from wtforms import SelectField, validators
+from airflow.utils import json as utils_json
 
 import airflow
 from airflow import models, plugins_manager, settings
@@ -2444,7 +2445,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             ti.task_id: alchemy_to_dict(ti)
             for ti in dag.get_task_instances(dttm, dttm)}
 
-        return json.dumps(task_instances)
+        return json.dumps(task_instances, cls=utils_json.AirflowJsonEncoder)
 
 
 class ConfigurationView(AirflowBaseView):

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -76,7 +76,7 @@ class TestAirflowJsonEncoder(unittest.TestCase):
             )
         )
         self.assertEqual(
-            json.dumps(pod, cls=utils_json.AirflowJsonEncoder),
+            json.loads(json.dumps(pod, cls=utils_json.AirflowJsonEncoder)),
             {"metadata": {"name": "foo", "namespace": "bar"},
              "spec": {"containers": [{"image": "bar", "name": "foo"}]}}
         )

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -58,6 +58,29 @@ class TestAirflowJsonEncoder(unittest.TestCase):
             '3.76953125'
         )
 
+    def test_encode_k8s_v1pod(self):
+        from kubernetes.client import models as k8s
+
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(
+                name="foo",
+                namespace="bar",
+            ),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="foo",
+                        image="bar",
+                    )
+                ]
+            )
+        )
+        self.assertEqual(
+            json.dumps(pod, cls=utils_json.AirflowJsonEncoder),
+            {"metadata": {"name": "foo", "namespace": "bar"},
+             "spec": {"containers": [{"image": "bar", "name": "foo"}]}}
+        )
+
     def test_encode_raises(self):
         self.assertRaisesRegex(TypeError,
                                "^.*is not JSON serializable$",


### PR DESCRIPTION
Adds return statement for json serialization of k8s.V1Pod that
previously caused errors in UI

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
