### PR TITLE
Update flask-caching dep to version that works with Werkzeug 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -700,7 +700,7 @@ INSTALL_REQUIREMENTS = [
     'dill>=0.2.2, <0.4',
     'flask>=1.1.0, <2.0',
     'flask-appbuilder~=3.1.1',
-    'flask-caching>=1.3.3, <2.0.0',
+    'flask-caching>=1.5.0, <2.0.0',
     'flask-login>=0.3, <0.5',
     'flask-swagger==0.2.13',
     'flask-wtf>=0.14.3, <0.15',


### PR DESCRIPTION
Werkzeug 1.0 removed the werkzeug.contrib.caching module, so we need at
least 1.5.0 of flask-caching to deal with this -- see

https://github.com/sh4nks/flask-caching/blob/v1.9.0/CHANGES#L97-L107


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).