### PR TITLE
Cache CLI parser objects

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -23,6 +23,7 @@ import json
 import os
 import textwrap
 from argparse import Action, ArgumentError, RawTextHelpFormatter
+from functools import lru_cache
 from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Union
 
 from tabulate import tabulate_formats
@@ -1457,6 +1458,7 @@ class AirflowHelpFormatter(argparse.HelpFormatter):
         return super()._format_action(action)
 
 
+@lru_cache(maxsize=2)
 def get_parser(dag_parser: bool = False) -> argparse.ArgumentParser:
     """Creates and returns command line argument parser"""
     parser = DefaultHelpParser(prog="airflow", formatter_class=AirflowHelpFormatter)

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1458,7 +1458,7 @@ class AirflowHelpFormatter(argparse.HelpFormatter):
         return super()._format_action(action)
 
 
-@lru_cache(maxsize=2)
+@lru_cache(maxsize=None)
 def get_parser(dag_parser: bool = False) -> argparse.ArgumentParser:
     """Creates and returns command line argument parser"""
     parser = DefaultHelpParser(prog="airflow", formatter_class=AirflowHelpFormatter)


### PR DESCRIPTION
Right now, when we are using the CLI parser in LocalTaskJob and executor, having to re-create the parser each time adds a noticeable overhead for quick tasks -- by caching this we save 0.07s

(I know that doesn't sound like much, but for an `echo true` BashOperator task that takes it from 0.25s to 0.19s - i.e. it cuts the time down by about 20%!)

When coupled with #11956 this makes an ungodly difference to task run time for large dags with many short DAGs, more so than it looks like individually -- we've seen total "task lag" for a DAG (time between end date of one task and start date of next) go from 21 seconds down to 0.7 seconds - varies quite a lot based on number of tasks and DAG structure (linear vs binary tree etc.) -- but it always helps.

Using CLI parser inside LocalTaskJob and the Executor is a bit of a hack, but this is a _very_ easy fix for the speed it gives!
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).