### PR TITLE
Log instead of raise an Error for unregistered OperatorLinks

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -499,7 +499,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                     _operator_link_class_path
                 ]
             else:
-                raise KeyError("Operator Link class %r not registered" % _operator_link_class_path)
+                log.error("Operator Link class %r not registered", _operator_link_class_path)
+                return {}
 
             op_predefined_extra_link: BaseOperatorLink = cattr.structure(
                 data, single_op_link_class)


### PR DESCRIPTION
Currently, if someone uses OperatorLinks that are not registered,
it will break the UI when someone clicks on that DAG.

This commit will instead log an error in the Webserver logs so that
someone can still see the DAG in different Views (graph, tree, etc).


**Before** (When clicking on Graph/tree View for that DAG):

```
Node: fe6f318dbd2a 
------------------------------------------------------------------------------- 
Traceback (most recent call last): 
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2447, in wsgi_app 
response = self.full_dispatch_request() 
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1952, in full_dispatch_request 
rv = self.handle_user_exception(e) 
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1821, in handle_user_exception 
reraise(exc_type, exc_value, tb) 
File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise 
raise value 
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1950, in full_dispatch_request 
rv = self.dispatch_request() 
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1936, in dispatch_request 
return self.view_functions[rule.endpoint](**req.view_args) 
File "/usr/local/lib/python3.7/site-packages/airflow/www_rbac/decorators.py", line 121, in wrapper 
return f(self, *args, **kwargs) 
File "/usr/local/lib/python3.7/site-packages/flask_appbuilder/security/decorators.py", line 109, in wraps 
return f(self, *args, **kwargs) 
File "/usr/local/lib/python3.7/site-packages/airflow/www_rbac/decorators.py", line 92, in view_func 
return f(*args, **kwargs) 
File "/usr/local/lib/python3.7/site-packages/airflow/www_rbac/decorators.py", line 56, in wrapper 
return f(*args, **kwargs) 
File "/usr/local/lib/python3.7/site-packages/airflow/utils/db.py", line 74, in wrapper 
return func(*args, **kwargs) 
File "/usr/local/lib/python3.7/site-packages/airflow/www_rbac/views.py", line 1408, in tree 
dag = dagbag.get_dag(dag_id) 
File "/usr/local/lib/python3.7/site-packages/airflow/models/dagbag.py", line 136, in get_dag 
self._add_dag_from_db(dag_id=dag_id) 
File "/usr/local/lib/python3.7/site-packages/airflow/models/dagbag.py", line 195, in _add_dag_from_db 
dag = row.dag 
File "/usr/local/lib/python3.7/site-packages/airflow/models/serialized_dag.py", line 152, in dag 
dag = SerializedDAG.from_dict(self.data) # type: Any 
File "/usr/local/lib/python3.7/site-packages/airflow/serialization/serialized_objects.py", line 634, in from_dict 
return cls.deserialize_dag(serialized_obj['dag']) 
File "/usr/local/lib/python3.7/site-packages/airflow/serialization/serialized_objects.py", line 573, in deserialize_dag 
task["task_id"]: SerializedBaseOperator.deserialize_operator(task) for task in v 
File "/usr/local/lib/python3.7/site-packages/airflow/serialization/serialized_objects.py", line 573, in <dictcomp> 
task["task_id"]: SerializedBaseOperator.deserialize_operator(task) for task in v 
File "/usr/local/lib/python3.7/site-packages/airflow/serialization/serialized_objects.py", line 408, in deserialize_operator 
op_predefined_extra_links = cls._deserialize_operator_extra_links(v) 
File "/usr/local/lib/python3.7/site-packages/airflow/serialization/serialized_objects.py", line 480, in _deserialize_operator_extra_links 
raise KeyError("Operator Link class %r not registered" % _operator_link_class_path) 
KeyError: "Operator Link class 'include.airflow.watermark_link.TaskStateLink' not registered"
```


**Now:**
![image](https://user-images.githubusercontent.com/8811558/97650121-e4026480-1a50-11eb-8900-f5508695c15d.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
