### PR TITLE
Log more types of errors when loading a DAG file to DB (POC)

### DIFF
--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -21,7 +21,6 @@
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
@@ -30,12 +29,6 @@ args = {
     'owner': 'airflow',
 }
 
-import warnings
-
-import airflow.operators.email_operator
-
-warnings.warn("This module is deprecated. Please use `airflow.operators.bash`.", DeprecationWarning)
-Variable.get("123123", default_var="⚡️")
 
 dag = DAG(
     dag_id='example_bash_operator',

--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -21,13 +21,21 @@
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.operators.bash import BashOperator
+from airflow.models import Variable
+from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
 
 args = {
     'owner': 'airflow',
 }
+
+import warnings
+
+import airflow.operators.email_operator
+
+warnings.warn("This module is deprecated. Please use `airflow.operators.bash`.", DeprecationWarning)
+Variable.get("123123", default_var="⚡️")
 
 dag = DAG(
     dag_id='example_bash_operator',

--- a/airflow/migrations/versions/6baa51abb3d7_support_more_types_of_import_errors.py
+++ b/airflow/migrations/versions/6baa51abb3d7_support_more_types_of_import_errors.py
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""support more types of import errors
+
+Revision ID: 6baa51abb3d7
+Revises: 2c6edca13270
+Create Date: 2020-10-30 02:23:55.723031
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '6baa51abb3d7'
+down_revision = '2c6edca13270'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply support more types of import errors"""
+    with op.batch_alter_table('import_error', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('category', sa.String(length=64), nullable=False))
+        batch_op.add_column(sa.Column('error_hash', sa.BigInteger(), nullable=False))
+        batch_op.create_index(batch_op.f('ix_import_error_error_hash'), ['error_hash'], unique=False)
+
+
+def downgrade():
+    """Unapply support more types of import errors"""
+    with op.batch_alter_table('import_error', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_import_error_error_hash'))
+        batch_op.drop_column('error_hash')
+        batch_op.drop_column('category')

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -28,7 +28,7 @@ from airflow.settings import STORE_DAG_CODE
 from airflow.utils import timezone
 from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
 from airflow.utils.session import provide_session
-from airflow.utils.sqlalchemy import UtcDateTime
+from airflow.utils.sqlalchemy import UtcDateTime, generate_index_hash
 
 log = logging.getLogger(__name__)
 
@@ -192,9 +192,4 @@ class DagCode(Base):
         :param full_filepath: full filepath of DAG file
         :return: hashed full_filepath
         """
-        # Hashing is needed because the length of fileloc is 2000 as an Airflow convention,
-        # which is over the limit of indexing.
-        import hashlib
-
-        # Only 7 bytes because MySQL BigInteger can hold only 8 bytes (signed).
-        return struct.unpack('>Q', hashlib.sha1(full_filepath.encode('utf-8')).digest()[-8:])[0] >> 8
+        return generate_index_hash(full_filepath)

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -17,8 +17,10 @@
 # under the License.
 
 import datetime
+import hashlib
 import json
 import logging
+import struct
 from typing import Any, Dict
 
 import pendulum
@@ -271,3 +273,11 @@ def is_lock_not_available_error(error: OperationalError):
     if db_err_code in ('55P03', 1205, 3572):
         return True
     return False
+
+
+def generate_index_hash(value) -> int:
+    # Hashing is needed because the length of value can be greater than 2000 characters
+    # which is over the limit of indexing.
+
+    # Only 7 bytes because MySQL BigInteger can hold only 8 bytes (signed).
+    return struct.unpack('>Q', hashlib.sha1(value.encode('utf-8')).digest()[-8:])[0] >> 8

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -94,6 +94,11 @@ def init_appbuilder_views(app):
     appbuilder.add_view(
         views.XComModelView, permissions.RESOURCE_XCOM, category=permissions.RESOURCE_ADMIN_MENU
     )
+    appbuilder.add_view(
+        views.ImportViewModelView,
+        permissions.RESOURCE_IMPORT_ERROR,
+        category=permissions.RESOURCE_BROWSE_MENU,
+    )
     # add_view_no_menu to change item position.
     # I added link in extensions.init_appbuilder_links.init_appbuilder_links
     appbuilder.add_view_no_menu(views.RedocView)

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -291,6 +291,16 @@ def dag_link(attr):
     return Markup('<a href="{}">{}</a>').format(url, dag_id)  # noqa  # noqa
 
 
+def multiline_text(attr_key):
+    """."""
+
+    def formatter(attr):
+        text = attr.get(attr_key)
+        return Markup('<pre>{}</pre>').format(text)
+
+    return formatter
+
+
 def dag_run_link(attr):
     """Generates a URL to the Graph View for a DagRun."""
     dag_id = attr.get('dag_id')


### PR DESCRIPTION
Part of: https://github.com/apache/airflow/issues/11925

Hello,

I started working on displaying deprecation warnings in Web UI, so I will explain a bit what it looks like in the context of Airflow 1.10 and 2.0.

In Airflow 1.10.13, we have the `airflow upgrade-check` command with a specific set of rules that are detected and displayed in the CLI for the user. These rules detect breaking changes and things that were deprecated in Airflow 2.0, but that might work. 

For example:
The code below works on Airflow 1.10 and 2.0:
```python
from airflow.operators.jdbc_operator import JdbcOperator
```
In Airflow 2.0, we will display a deprecation warning to the user that this code will not work in the next release, but the user does not have easy access to this warning. This message only appears in CLI, but access to CLI in some environments is limited. Not every user has access, but every user should see this deprecation warning.

This is not based on a specific set of rules, but we are using the standard Python library.
https://docs.python.org/3/library/warnings.html#warning-categories
```python
        if region is None:
            warnings.warn(
                "Default region value `global` will be deprecated. Please, provide region value.",
                DeprecationWarning,
                stacklevel=2,
            )
```
https://github.com/apache/airflow/blob/41bf172c1dc75099f4f9d8b3f3350b4b1f523ef9/airflow/providers/google/cloud/operators/dataproc.py#L482-L487

In the long run, this may mean that users will not have to focus specifically on migrating to the next release but will be able to update each release smoothly.  When users update the provider package, they will have some new warning that they will likely fix during regular maintenance. When they have no errors, they will be able to update to a newer version safely.

We can use this to display DAG writing recommendations. For now, it detects database queries during parsing the DAG so we can suggest a more optimal solution - Jiinja.
For example, the following code is not perfect. 
```python
    email_summary = email_operator.EmailOperator(
        task_id='email_summary',
        to=models.Variable.get('email'),
        subject='Sample BigQuery notify data ready',
        html_content="""
```
https://github.com/GoogleCloudPlatform/python-docs-samples/blob/f89ac82ea18a08398cc54762c638c686c6f938fa/composer/workflows/bq_notify.py#L145-L149
We should use Jinja to limit the number of database queries.
```python
    email_summary = email_operator.EmailOperator(
        task_id='email_summary',
        to='{{ var.value.email }}',
        subject='Sample BigQuery notify data ready',
        html_content="""
```
For now, this is exclusive to Airflow 2.0, and we can think of cherry-picking this change, but it is a separate effort and not necessarily needed because we have the airflow upgrade-check command.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
