### PR TITLE
Bump attrs and cattrs dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -690,9 +690,11 @@ EXTRAS_REQUIREMENTS.update(
 INSTALL_REQUIREMENTS = [
     'alembic>=1.2, <2.0',
     'argcomplete~=1.10',
-    'attrs~=20.0',
+    'attrs>=20.0, <21.0',
     'cached_property~=1.5',
-    'cattrs~=1.0',
+    # cattrs >= 1.1.0 dropped support for Python 3.6
+    'cattrs>=1.0, <1.1.0;python_version<="3.6"',
+    'cattrs>=1.0, <2.0;python_version>"3.7"',
     'colorlog==4.0.2',
     'connexion[swagger-ui,flask]>=2.6.0,<3',
     'croniter>=0.3.17, <0.4',


### PR DESCRIPTION
`cattrs` now depends on `attrs >= 20.1.0`, because of `attr.resolve_types`.

Source: https://github.com/Tinche/cattrs/blob/master/HISTORY.rst#110-2020-10-29

Secondly cattrs >= 1.1.0 dropped support for Python 3.6

closes https://github.com/apache/airflow/issues/11965

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
