### PR TITLE
Remove unused "poke_exception_cache_ttl" param from SmartSensorOperator

### DIFF
--- a/airflow/sensors/smart_sensor_operator.py
+++ b/airflow/sensors/smart_sensor_operator.py
@@ -295,9 +295,6 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
     :type shard_min: int
     :param shard_max: shard code upper bound (exclusive)
     :type shard_max: int
-    :param poke_exception_cache_ttl: Time, in seconds before the current
-        exception expires and being cleaned up.
-    :type poke_exception_cache_ttl: int
     :param poke_timeout: Time, in seconds before the task times out and fails.
     :type poke_timeout: float
     """
@@ -311,7 +308,6 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
                  soft_fail=False,
                  shard_min=0,
                  shard_max=100000,
-                 poke_exception_cache_ttl=600,
                  poke_timeout=6.0,
                  *args,
                  **kwargs):
@@ -330,7 +326,6 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
         self.max_tis_per_query = 50
         self.shard_min = shard_min
         self.shard_max = shard_max
-        self.poke_exception_cache_ttl = poke_exception_cache_ttl
         self.poke_timeout = poke_timeout
 
     def _validate_input_values(self):


### PR DESCRIPTION
These four places are the only places this param appears in the code
base, and is likely left over from open sourcing the original feature.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).