### PR TITLE
Pin `kubernetes` to a max version of 11.0.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ kerberos = [
 ]
 kubernetes = [
     'cryptography>=2.0.0',
-    'kubernetes>=3.0.0',
+    'kubernetes>=3.0.0, <12.0.0',
 ]
 kylin = [
     'kylinpy>=2.6'


### PR DESCRIPTION
12.0.0 introduces `TypeError: cannot serialize '_io.TextIOWrapper'
object` when serializing V1Pod's in `executor_config`.

```
[2020-10-28 22:12:16,440] {kubernetes_executor.py:616} INFO - Add task TaskInstanceKey(dag_id='python-memory-eater', task_id='eat', execution_date=datetime.datetime(2020, 10, 28, 22, 10, 14, 732352, tzinfo=Timezone('UTC')), try_number=1) with command ['airflow', 'tasks', 'run', 'python-memory-eater', 'eat', '2020-10-28T22:10:14.732352+00:00', '--local', '--pool', 'default_pool', '--subdir', '/dags/python-memory-eater.py'] with executor_config {'KubernetesExecutor': {'request_memory': '128Mi', 'limit_memory': '128Mi'}}
[2020-10-28 22:12:16,440] {warnings.py:99} WARNING - /some/path/site-packages/airflow/kubernetes/pod_generator.py:200: DeprecationWarning: Using a dictionary for the executor_config is deprecated and will soon be removed.please use a `kubernetes.client.models.V1Pod` class with a "pod_override" key instead.
  category=DeprecationWarning)
[2020-10-28 22:12:16,443] {scheduler_job.py:1326} ERROR - Exception when executing SchedulerJob._run_scheduler_loop
Traceback (most recent call last):
  File "/some/path/site-packages/airflow/jobs/scheduler_job.py", line 1307, in _execute
    self._run_scheduler_loop()
  File "/some/path/site-packages/airflow/jobs/scheduler_job.py", line 1380, in _run_scheduler_loop
    self.executor.heartbeat()
  File "/some/path/site-packages/airflow/executors/base_executor.py", line 151, in heartbeat
    self.trigger_tasks(open_slots)
  File "/some/path/site-packages/airflow/executors/base_executor.py", line 183, in trigger_tasks
    executor_config=ti.executor_config)
  File "/some/path/site-packages/airflow/executors/kubernetes_executor.py", line 622, in execute_async
    self.task_queue.put((key, command, kube_executor_config))
  File "<string>", line 2, in put 
  File "/usr/lib64/python3.6/multiprocessing/managers.py", line 756, in _callmethod
    conn.send((self._id, methodname, args, kwds))
  File "/usr/lib64/python3.6/multiprocessing/connection.py", line 206, in send
    self._send_bytes(_ForkingPickler.dumps(obj))
  File "/usr/lib64/python3.6/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
TypeError: cannot serialize '_io.TextIOWrapper' object
```

This applies to both the deprecated `executor_config` dict and `pod_override`.
